### PR TITLE
Emphasize that HttpClientFactory depends on M.E.DI

### DIFF
--- a/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
+++ b/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
@@ -187,7 +187,7 @@ Up to this point, the code shown is just performing regular Http requests, but t
   <http://www.thepollyproject.org/>
   
 - **Using HttpClientFactory without dependency injection (GitHub issue)**  
-  <https://github.com/dotnet/docs/issues/13850>
+  <https://github.com/aspnet/Extensions/issues/1345>
 
 >[!div class="step-by-step"]
 >[Previous](explore-custom-http-call-retries-exponential-backoff.md)

--- a/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
+++ b/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
@@ -31,7 +31,7 @@ To address those mentioned issues and make the management of `HttpClient` instan
 - Manage the lifetime of `HttpClientMessageHandlers` to avoid the mentioned problems/issues that can occur when managing `HttpClient` lifetimes yourself.
 
 > [!NOTE]
-> `HttpClientFactory` is tightly tied to the `Microsoft.Extensions.DependencyInjection` implementation. For more information about using other dependency injection containers, see this [GitHub discussion](https://github.com/aspnet/Extensions/issues/1345).
+> `HttpClientFactory` is tightly tied to the dependency injection (DI) implementation in the `Microsoft.Extensions.DependencyInjection` NuGet package. For more information about using other dependency injection containers, see this [GitHub discussion](https://github.com/aspnet/Extensions/issues/1345).
 
 ## Multiple ways to use HttpClientFactory
 
@@ -180,7 +180,7 @@ Up to this point, the code shown is just performing regular Http requests, but t
 - **Using HttpClientFactory in .NET Core**  
   [https://docs.microsoft.com/aspnet/core/fundamentals/http-requests](/aspnet/core/fundamentals/http-requests)
 
-- **HttpClientFactory GitHub repository**  
+- **HttpClientFactory source code in the .NET Extensions GitHub repository**  
   <https://github.com/aspnet/Extensions/tree/master/src/HttpClientFactory>
 
 - **Polly (.NET resilience and transient-fault-handling library)**  

--- a/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
+++ b/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
@@ -30,6 +30,9 @@ To address those mentioned issues and make the management of `HttpClient` instan
 - `HttpClient` already has the concept of delegating handlers that could be linked together for outgoing HTTP requests. You register HTTP clients into the factory and you can use a Polly handler to use Polly policies for Retry, CircuitBreakers, and so on.
 - Manage the lifetime of `HttpClientMessageHandlers` to avoid the mentioned problems/issues that can occur when managing `HttpClient` lifetimes yourself.
 
+> [!NOTE]
+> `HttpClientFactory` is tightly tied to the Microsoft.Extensions.DependencyInjection implementation. You might want to read this [GitHub discussion]((https://github.com/aspnet/Extensions/issues/1345)) about using other dependency injection containers.
+
 ## Multiple ways to use HttpClientFactory
 
 There are several ways that you can use `HttpClientFactory` in your application:
@@ -174,14 +177,17 @@ Up to this point, the code shown is just performing regular Http requests, but t
 
 ## Additional resources
 
-- **Using HttpClientFactory in .NET Core** \
+- **Using HttpClientFactory in .NET Core**  
   [https://docs.microsoft.com/aspnet/core/fundamentals/http-requests](/aspnet/core/fundamentals/http-requests)
 
-- **HttpClientFactory GitHub repo** \
+- **HttpClientFactory GitHub repo**  
   <https://github.com/aspnet/Extensions/tree/master/src/HttpClientFactory>
 
-- **Polly (.NET resilience and transient-fault-handling library)** \
+- **Polly (.NET resilience and transient-fault-handling library)**  
   <http://www.thepollyproject.org/>
+  
+- **Using HttpClientFactory without dependency injection (GitHub issue)**  
+  <https://github.com/dotnet/docs/issues/13850>
 
 >[!div class="step-by-step"]
 >[Previous](explore-custom-http-call-retries-exponential-backoff.md)

--- a/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
+++ b/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
@@ -31,7 +31,7 @@ To address those mentioned issues and make the management of `HttpClient` instan
 - Manage the lifetime of `HttpClientMessageHandlers` to avoid the mentioned problems/issues that can occur when managing `HttpClient` lifetimes yourself.
 
 > [!NOTE]
-> `HttpClientFactory` is tightly tied to the Microsoft.Extensions.DependencyInjection implementation. You might want to read this [GitHub discussion]((https://github.com/aspnet/Extensions/issues/1345)) about using other dependency injection containers.
+> `HttpClientFactory` is tightly tied to the `Microsoft.Extensions.DependencyInjection` implementation. For more information about using other dependency injection containers, see this [GitHub discussion](https://github.com/aspnet/Extensions/issues/1345).
 
 ## Multiple ways to use HttpClientFactory
 
@@ -180,7 +180,7 @@ Up to this point, the code shown is just performing regular Http requests, but t
 - **Using HttpClientFactory in .NET Core**  
   [https://docs.microsoft.com/aspnet/core/fundamentals/http-requests](/aspnet/core/fundamentals/http-requests)
 
-- **HttpClientFactory GitHub repo**  
+- **HttpClientFactory GitHub repository**  
   <https://github.com/aspnet/Extensions/tree/master/src/HttpClientFactory>
 
 - **Polly (.NET resilience and transient-fault-handling library)**  

--- a/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
+++ b/docs/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests.md
@@ -180,7 +180,7 @@ Up to this point, the code shown is just performing regular Http requests, but t
 - **Using HttpClientFactory in .NET Core**  
   [https://docs.microsoft.com/aspnet/core/fundamentals/http-requests](/aspnet/core/fundamentals/http-requests)
 
-- **HttpClientFactory source code in the .NET Extensions GitHub repository**  
+- **HttpClientFactory source code in the `aspnet/Extensions` GitHub repository**  
   <https://github.com/aspnet/Extensions/tree/master/src/HttpClientFactory>
 
 - **Polly (.NET resilience and transient-fault-handling library)**  


### PR DESCRIPTION
## Summary

And a note to emphasize that `HttpClientFactory` is tied to `Microsoft.Extensions.DependencyInjection`

Fixes https://github.com/dotnet/docs/issues/13850
