### PR TITLE
Fixing Environment variable name for spark getting started

### DIFF
--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -63,7 +63,7 @@ Double check that you can run `dotnet`, `java`, `mvn`, `spark-shell` from your c
 
 1. Download the [Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases) release from the .NET for Apache Spark GitHub Releases page to your local machine. For example, you might download it to the path, `c:\bin\Microsoft.Spark.Worker\`.
 
-2. Create a [new environment variable](https://www.java.com/en/download/help/path.xml) called `DotnetWorkerPath` and set it to the directory where you downloaded and extracted the **Microsoft.Spark.Worker**. For example, `c:\bin\Microsoft.Spark.Worker`.
+2. Create a [new environment variable](https://www.java.com/en/download/help/path.xml) called `DOTNET_WORKER_DIR` and set it to the directory where you downloaded and extracted the **Microsoft.Spark.Worker**. For example, `c:\bin\Microsoft.Spark.Worker`.
 
 ## Clone the .NET for Apache Spark GitHub repo
 


### PR DESCRIPTION
FYI @rapoth @imback82 
Fixing the environment variable on the getting started tutorial that shows on docs.microsoft.com to the right one. Seems like we changed this in our dotnet/spark docs, but not here.

