### PR TITLE
Consume a new snippet demonstrating tuples as out parameters

### DIFF
--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -430,7 +430,7 @@ The `Deconstruct` method could convert the `Person` object `p` to a tuple contai
 
 Tuples can be used as out parameters _themselves_. Not to be confused with any ambiguity previously mentioned in the [Deconstruction](#deconstruction) section. In a method call, you need only describe the tuple's shape:
 
-[!code-csharp[TuplesAsOutParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
+[!code-csharp[TuplesAsOutParameters](~/samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
 
 Alternatively, you could use an [_unnamed_](#named-and-unnamed-tuples) tuple and refer to its fields as `Item1` and `Item2`:
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -430,7 +430,7 @@ The `Deconstruct` method could convert the `Person` object `p` to a tuple contai
 
 Tuples can be used as out parameters _themselves_. Not to be confused with any ambiguity previously mentioned in the [Deconstruction](#deconstruction) section. In a method call, you need only describe the tuple's shape:
 
-!code-csharp[TuplesAsOutParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
+[!code-csharp[TuplesAsOutParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
 
 Alternatively, you could use an [_unnamed_](#named-and-unnamed-tuples) tuple, and refer to its fields as `Item1` and `Item2`:
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -428,7 +428,7 @@ The `Deconstruct` method could convert the `Person` object `p` to a tuple contai
 
 ## Tuples as out parameters
 
-Tuples can be used as out parameters _themselves_. Not to be confused with any ambiguity previously mentioned in the [Deconstruction](#deconstruction) section. In a method call, you need only describe the tuple's shape:
+Tuples can be used as out parameters *themselves*. Not to be confused with any ambiguity previously mentioned in the [Deconstruction](#deconstruction) section. In a method call, you need only describe the tuple's shape:
 
 [!code-csharp[TuplesAsOutParameters](~/samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -430,7 +430,7 @@ The `Deconstruct` method could convert the `Person` object `p` to a tuple contai
 
 Tuples can be used as out parameters _themselves_, not to be confused with any ambiguity mentioned above in **[Deconstruction](#Deconstruction)**. In a method call, you need only describe the tuple's shape.
 
-!code-csharp[TuplesAsOurParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
+!code-csharp[TuplesAsOutParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
 
 Alternatively, you could use an [_unnamed_](#named-and-unnamed-tuples) tuple, and refer to its fields as `Item1` and `Item2`:
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -432,7 +432,7 @@ Tuples can be used as out parameters _themselves_. Not to be confused with any a
 
 [!code-csharp[TuplesAsOutParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
 
-Alternatively, you could use an [_unnamed_](#named-and-unnamed-tuples) tuple, and refer to its fields as `Item1` and `Item2`:
+Alternatively, you could use an [_unnamed_](#named-and-unnamed-tuples) tuple and refer to its fields as `Item1` and `Item2`:
 
 ```csharp
 dict.TryGetValue(2, out (int, string) pair);

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -426,6 +426,20 @@ if (("Althea", "Goodwin") == p)
 
 The `Deconstruct` method could convert the `Person` object `p` to a tuple containing two strings, but it is not applicable in the context of equality tests.
 
+## Tuples as out parameters
+
+Tuples can be used as out parameters _themselves_, not to be confused with any ambiguity mentioned above in **[Deconstruction](#Deconstruction)**. In a method call, you need only describe the tuple's shape.
+
+!code-csharp[TuplesAsOurParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
+
+Alternatively, you could use an [_unnamed_](#named-and-unnamed-tuples) tuple, and refer to its fields as `Item1` and `Item2`:
+
+```csharp
+dict.TryGetValue(2, out (int, string) pair);
+// ...
+Console.WriteLine($"{pair.Item1}: {pair.Item2}");
+```
+
 ## Conclusion 
 
 The new language and library support for named tuples makes it much easier

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -428,7 +428,7 @@ The `Deconstruct` method could convert the `Person` object `p` to a tuple contai
 
 ## Tuples as out parameters
 
-Tuples can be used as out parameters _themselves_, not to be confused with any ambiguity mentioned above in **[Deconstruction](#Deconstruction)**. In a method call, you need only describe the tuple's shape.
+Tuples can be used as out parameters _themselves_. Not to be confused with any ambiguity previously mentioned in the [Deconstruction](#deconstruction) section. In a method call, you need only describe the tuple's shape:
 
 !code-csharp[TuplesAsOutParameters](../../samples/snippets/csharp/tuples/program.cs#01_TupleAsOutVariable "Tuples as out parameters")]
 


### PR DESCRIPTION
## Summary

Is there a standardization doc for linking to 1) snippets and 2) other anchors within a doc? I'm not 100% sure how to _test_ my snippets e.g.

- `[_unnamed_](#named-and-unnamed-tuples)`
- `**[Deconstruction](#Deconstruction)**`

Happy to discuss/revise this further.

#### Update:
I was able to confirm the linked anchors' behavior (though there were build _warnings_) simply by viewing tuple.md in the browser at Github.com--still not 100% convinced

Fixes #11874
