### PR TITLE
Fix Microsoft.AspNetCore.App link

### DIFF
--- a/docs/core/packages.md
+++ b/docs/core/packages.md
@@ -67,7 +67,7 @@ The .NET Standard metapackage is:
 The key .NET Core metapackages are:
 
 - [Microsoft.NETCore.App](https://www.nuget.org/packages/Microsoft.NETCore.App) - Describes the libraries that are part of the .NET Core distribution. Establishes the [`.NETCoreApp` framework](https://github.com/dotnet/core-setup/blob/release/1.1.0/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj). Depends on the smaller `NETStandard.Library`.
-- [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App) - Includes all the supported packages from ASP.NET Core and Entity Framework Core except those that contain third-party dependencies. See [Microsoft.AspNetCore.App metapackage for ASP.NET Core](/aspnet/core/fundamentals/metapackage) for more information.
+- [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App) - Includes all the supported packages from ASP.NET Core and Entity Framework Core except those that contain third-party dependencies. See [Microsoft.AspNetCore.App metapackage for ASP.NET Core](/aspnet/core/fundamentals/metapackage-app) for more information.
 - [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All) - Includes all the supported packages from ASP.NET Core, Entity Framework Core, and internal and third-party dependencies used by ASP.NET Core and Entity Framework Core. See [Microsoft.AspNetCore.All metapackage for ASP.NET Core 2.x](/aspnet/core/fundamentals/metapackage) for more information.
 - [Microsoft.NETCore.Portable.Compatibility](https://www.nuget.org/packages/Microsoft.NETCore.Portable.Compatibility) - A set of compatibility facades that enable mscorlib-based Portable Class Libraries (PCLs) to run on .NET Core.
 


### PR DESCRIPTION
## Summary

In the _Metapackages_ section of the [_Packages, metapackages and frameworks_](https://docs.microsoft.com/en-us/dotnet/core/packages) page, the link to details on the `Microsoft.AspNetCore.App` metapackage incidentally points to `Microsoft.AspNetCore.All`. 

This PR fixes the link target to point to the correct location.
