### PR TITLE
Document libgdiplus dependency

### DIFF
--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites for .NET Core on Linux
 description: Supported Linux versions and .NET Core dependencies to develop, deploy, and run .NET Core applications on Linux machines.
 author: leecow
 ms.author: leecow
-ms.date: 09/25/2019
+ms.date: 10/11/2019
 ---
 # Prerequisites for .NET Core on Linux
 

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -122,14 +122,14 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 * libunwind8
 * libuuid1
 
-For .NET Core applications which use the System.Drawing.Common assembly, you will also need the following dependencies:
+For .NET Core applications that use the *System.Drawing.Common* assembly, you also need the following dependency:
 
-* libgdiplus (version 6.0.1 or later)
+* libgdiplus (version 6.0.1 or later) - required by applications that use the *System.Drawing.Common* assembly.
 
 > [!NOTE]
 > Most versions of Ubuntu include an earlier version of libgdiplus. You can install a recent version
-> of libgdiplus by adding the Mono repository to your system. See https://www.mono-project.com/download/stable/
-> for more information.
+> of libgdiplus by adding the Mono repository to your system. For more information,
+> see <https://www.mono-project.com/download/stable/>.
 
 ### CentOS and Fedora
 
@@ -151,14 +151,14 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 
 For more information about the dependencies, see [Self-contained Linux applications](https://github.com/dotnet/core/blob/master/Documentation/self-contained-linux-apps.md).
 
-For .NET Core applications which use the System.Drawing.Common assembly, you will also need the following dependencies:
+For .NET Core applications that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
 
 * libgdiplus (version 6.0.1 or later)
 
 > [!NOTE]
 > Most versions of CentOS and Fedora include an earlier version of libgdiplus. You can install a recent version
-> of libgdiplus by adding the Mono repository to your system. See https://www.mono-project.com/download/stable/
-> for more information.
+> of libgdiplus by adding the Mono repository to your system. For more information,
+> see <https://www.mono-project.com/download/stable/>.
 
 ## Installing .NET Core dependencies with the native installers
 

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -124,7 +124,7 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 
 For .NET Core applications that use the *System.Drawing.Common* assembly, you also need the following dependency:
 
-* libgdiplus (version 6.0.1 or later) - required by applications that use the *System.Drawing.Common* assembly.
+* libgdiplus (version 6.0.1 or later)
 
 > [!NOTE]
 > Most versions of Ubuntu include an earlier version of libgdiplus. You can install a recent version

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -122,7 +122,7 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 * libunwind8
 * libuuid1
 
-If your code uses the System.Drawing.Common assembly, you will also need the following dependencies:
+For .NET Core applications which use the System.Drawing.Common assembly, you will also need the following dependencies:
 
 * libgdiplus (version 6.0.1 or later)
 
@@ -151,7 +151,7 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 
 For more information about the dependencies, see [Self-contained Linux applications](https://github.com/dotnet/core/blob/master/Documentation/self-contained-linux-apps.md).
 
-If your code uses the System.Drawing.Common assembly, you will also need the following dependencies:
+For .NET Core applications which use the System.Drawing.Common assembly, you will also need the following dependencies:
 
 * libgdiplus (version 6.0.1 or later)
 

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -122,6 +122,15 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 * libunwind8
 * libuuid1
 
+If your code uses the System.Drawing.Common assembly, you will also need the following dependencies:
+
+* libgdiplus (version 6.0.1 or later)
+
+> [!NOTE]
+> Most versions of Ubuntu include an earlier version of libgdiplus. You can install a recent version
+> of libgdiplus by adding the Mono repository to your system. See https://www.mono-project.com/download/stable/
+> for more information.
+
 ### CentOS and Fedora
 
 CentOS distributions require the following libraries installed:
@@ -141,6 +150,15 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 * libuuid
 
 For more information about the dependencies, see [Self-contained Linux applications](https://github.com/dotnet/core/blob/master/Documentation/self-contained-linux-apps.md).
+
+If your code uses the System.Drawing.Common assembly, you will also need the following dependencies:
+
+* libgdiplus (version 6.0.1 or later)
+
+> [!NOTE]
+> Most versions of CentOS and Fedora include an earlier version of libgdiplus. You can install a recent version
+> of libgdiplus by adding the Mono repository to your system. See https://www.mono-project.com/download/stable/
+> for more information.
 
 ## Installing .NET Core dependencies with the native installers
 

--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -4,7 +4,7 @@ description: Supported macOS versions and .NET Core dependencies to develop, dep
 author: thraka
 ms.author: adegeo
 ms.custom: "updateeachvsrelease"
-ms.date: 09/27/2019
+ms.date: 10/11/2019
 ---
 # Prerequisites for .NET Core on macOS
 

--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -40,6 +40,19 @@ For a list of known issues, see [.NET Core known issues](https://github.com/dotn
 
 ---
 
+## libgdiplus
+
+.NET Core applications which use the System.Drawing.Common assembly require libgdiplus to be installed.
+
+An easy way to obtain libgdiplus is by using the [Homebrew ("brew")](https://brew.sh/) package manager for macOS. After installing *brew*, install libgdiplus by executing the following commands at a Terminal (command) prompt:
+
+```console
+brew update
+brew install libgdiplus
+```
+
+---
+
 ## Visual Studio for Mac
 
 You can use any editor to develop .NET Core applications using the .NET Core SDK. However, if you want to develop .NET Core applications on a Mac in an integrated development environment, you can use [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link).

--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -42,7 +42,7 @@ For a list of known issues, see [.NET Core known issues](https://github.com/dotn
 
 ## libgdiplus
 
-.NET Core applications which use the System.Drawing.Common assembly require libgdiplus to be installed.
+.NET Core applications that use the *System.Drawing.Common* assembly require libgdiplus to be installed.
 
 An easy way to obtain libgdiplus is by using the [Homebrew ("brew")](https://brew.sh/) package manager for macOS. After installing *brew*, install libgdiplus by executing the following commands at a Terminal (command) prompt:
 
@@ -50,8 +50,6 @@ An easy way to obtain libgdiplus is by using the [Homebrew ("brew")](https://bre
 brew update
 brew install libgdiplus
 ```
-
----
 
 ## Visual Studio for Mac
 


### PR DESCRIPTION
## Summary

System.Drawing.Common depends on a native library, libgdiplus, on Linux and macOS.
You'll need a recent version of libgdiplus, too. An easy way to get a recent version of libgdiplus is via the Mono package repositories (Linux) or Homebrew (macOS).

Document this in the prerequisites section.

Related to https://github.com/dotnet/corefx/issues/24525#issuecomment-539912651
