### PR TITLE
Added the missing link to the Accessibility section

### DIFF
--- a/docs/standard/application-essentials.md
+++ b/docs/standard/application-essentials.md
@@ -48,7 +48,7 @@ This section of the .NET Framework documentation provides information about basi
  [Globalization and Localization](../../docs/standard/globalization-localization/index.md)  
  Provides information to help you design and develop world-ready applications.  
   
- Accessibility  
+ [Accessibility](../../docs/framework/ui-automation/index.md)
  Provides information about Microsoft UI Automation, which is an accessibility framework that addresses the needs of assistive technology products and automated test frameworks by providing programmatic access to information about the user interface (UI).  
   
  [Attributes](../../docs/standard/attributes/index.md)  


### PR DESCRIPTION
## Summary

As far as I understand, the Accessibility section should be completely removed from this list or linked to the closest match that we have in the .NET documentation. UI-Automation section includes accessibility best practices etc so I think it's suitable here.
