### PR TITLE
chore: Run Markdownlint with GitHub Actions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,19 @@
+name: Markdownlint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Run Markdownlint
+      run: |
+        npm i -g markdownlint-cli
+        markdownlint "**/*.md"


### PR DESCRIPTION
## Summary
More as a discussion point, since this is something i'm sure there is a policy on using/not using GitHub Actions. General idea was that you could ignore these failures if you don't care about them, but can help outside of the OpenPublishing builds.

