### PR TITLE
update for C# 8 syntax

### DIFF
--- a/docs/csharp/language-reference/keywords/using-statement.md
+++ b/docs/csharp/language-reference/keywords/using-statement.md
@@ -16,7 +16,7 @@ The following example shows how to use the `using` statement.
 
 [!code-csharp[csrefKeywordsNamespace#4](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#4)]
 
-Beginning with C# 8.0, you can use the following alternative syntax for the `using` statement:
+Beginning with C# 8.0, you can use the following alternative syntax for the `using` statement that doesn't require braces:
 
 [!code-csharp[csrefKeywordsNamespace#New](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#ModernUsing)]
 
@@ -30,7 +30,7 @@ The `using` statement ensures that <xref:System.IDisposable.Dispose%2A> is calle
 
 [!code-csharp[csrefKeywordsNamespace#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#5)]
 
-The newer `using` statement translates to very similar code. The `try` block opens where the variable is declared. The `finally` block is added at the close of the enclosing block, typically at the end of a method.
+The newer `using` statement syntax translates to very similar code. The `try` block opens where the variable is declared. The `finally` block is added at the close of the enclosing block, typically at the end of a method.
 
 For more information about the `try`-`finally` statement, see the [try-finally](try-finally.md) topic.
 

--- a/docs/csharp/language-reference/keywords/using-statement.md
+++ b/docs/csharp/language-reference/keywords/using-statement.md
@@ -1,7 +1,7 @@
 ---
 title: "using statement - C# Reference"
 ms.custom: seodec18
-ms.date: 07/20/2015
+ms.date: 10/15/2019
 helpviewer_keywords:
   - "using statement [C#]"
 ms.assetid: afc355e6-f0b9-4240-94dd-0d93f17d9fc3
@@ -16,6 +16,10 @@ The following example shows how to use the `using` statement.
 
 [!code-csharp[csrefKeywordsNamespace#4](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#4)]
 
+Beginning with C# 8.0, you can use the following alternative syntax for the `using` statement:
+
+[!code-csharp[csrefKeywordsNamespace#New](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#ModernUsing)]
+
 ## Remarks
 
 <xref:System.IO.File> and <xref:System.Drawing.Font> are examples of managed types that access unmanaged resources (in this case file handles and device contexts). There are many other kinds of unmanaged resources and class library types that encapsulate them. All such types must implement the <xref:System.IDisposable> interface.
@@ -26,11 +30,17 @@ The `using` statement ensures that <xref:System.IDisposable.Dispose%2A> is calle
 
 [!code-csharp[csrefKeywordsNamespace#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#5)]
 
+The newer `using` statement translates to very similar code. The `try` block opens where the variable is declared. The `finally` block is added at the close of the enclosing block, typically the method close.
+
 For more information about the `try`-`finally` statement, see the [try-finally](try-finally.md) topic.
 
 Multiple instances of a type can be declared in the `using` statement, as shown in the following example:
 
 [!code-csharp[csrefKeywordsNamespace#6](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#6)]
+
+You can combine multiple declarations of the same type using the new C# 8.0 syntax as well. This is shown in the following example:
+
+[!code-csharp[csrefKeywordsNamespace#6](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#MultipleUsing)]
 
 You can instantiate the resource object and then pass the variable to the `using` statement, but this is not a best practice. In this case, after control leaves the `using` block, the object remains in scope but probably has no access to its unmanaged resources. In other words, it's not fully initialized anymore. If you try to use the object outside the `using` block, you risk causing an exception to be thrown. For this reason, it's generally better to instantiate the object in the `using` statement and limit its scope to the `using` block.
 
@@ -51,3 +61,4 @@ For more information, see [The using statement](~/_csharplang/spec/statements.md
 - [Garbage Collection](../../../standard/garbage-collection/index.md)
 - [Using objects that implement IDisposable](../../../standard/garbage-collection/using-objects.md)
 - [IDisposable interface](xref:System.IDisposable)
+- [using statement in C# 8.0](~/_csharplang/proposals/csharp-8.0/using.md)

--- a/docs/csharp/language-reference/keywords/using-statement.md
+++ b/docs/csharp/language-reference/keywords/using-statement.md
@@ -30,7 +30,7 @@ The `using` statement ensures that <xref:System.IDisposable.Dispose%2A> is calle
 
 [!code-csharp[csrefKeywordsNamespace#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#5)]
 
-The newer `using` statement translates to very similar code. The `try` block opens where the variable is declared. The `finally` block is added at the close of the enclosing block, typically the method close.
+The newer `using` statement translates to very similar code. The `try` block opens where the variable is declared. The `finally` block is added at the close of the enclosing block, typically at the end of a method.
 
 For more information about the `try`-`finally` statement, see the [try-finally](try-finally.md) topic.
 
@@ -38,7 +38,7 @@ Multiple instances of a type can be declared in the `using` statement, as shown 
 
 [!code-csharp[csrefKeywordsNamespace#6](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#6)]
 
-You can combine multiple declarations of the same type using the new C# 8.0 syntax as well. This is shown in the following example:
+You can combine multiple declarations of the same type using the new syntax introduced with C# 8 as well. This is shown in the following example:
 
 [!code-csharp[csrefKeywordsNamespace#6](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs#MultipleUsing)]
 


### PR DESCRIPTION
Fixes #13200
Depends on dotnet/samples#1646

Add description of the C# 8.0 syntax. Show the new syntax, and provide a link to the 8.0 proposal.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
