### PR TITLE
fix: MD009/no-trailing-spaces

### DIFF
--- a/docs/visual-basic/developing-apps/accessing-data.md
+++ b/docs/visual-basic/developing-apps/accessing-data.md
@@ -1,53 +1,55 @@
 ---
 title: "Accessing data in Visual Basic applications"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "data [Visual Basic]"
   - "Visual Basic, data access"
 ms.assetid: 3086ab38-3be5-4b22-9385-7d0e16b04f6a
 ---
 # Accessing data in Visual Basic applications
-Visual Basic includes several new features to assist in developing applications that access data. Data-bound forms for Windows applications are created by dragging items from the [Data Sources Window](/visualstudio/data-tools/add-new-data-sources) onto the form. You bind controls to data by dragging items from the **Data Sources Window** onto existing controls.  
-  
-## Related sections  
- [Accessing Data in Visual Studio](/visualstudio/data-tools/)  
- Provides links to pages that discuss incorporating data access functionality into your applications.
 
- [Visual Studio data tools for .NET](/visualstudio/data-tools/visual-studio-data-tools-for-dotnet)  
- Provides links to pages on creating applications that work with data, using Visual Studio.  
-  
- [LINQ](../../visual-basic/programming-guide/language-features/linq/index.md)  
- Provides links to topics that describe how to use LINQ with Visual Basic.  
-  
- [LINQ to SQL](../../framework/data/adonet/sql/linq/index.md)  
- Provides information about [!INCLUDE[vbtecdlinq](~/includes/vbtecdlinq-md.md)]. Includes programming examples.  
-  
- [LINQ to SQL Tools in Visual Studio](/visualstudio/data-tools/linq-to-sql-tools-in-visual-studio2)  
- Provides links to topics about how to create a [LINQ to SQL](../../framework/data/adonet/sql/linq/index.md) object model in applications.  
-  
- [Work with datasets in n-tier applications](/visualstudio/data-tools/work-with-datasets-in-n-tier-applications)  
- Provides links to topics about how to create multitiered data applications.  
-     
- [Add new connections](/visualstudio/data-tools/add-new-connections)  
- Provides links to pages on connecting your application to data with design-time tools and ADO.NET connection objects, using Visual Studio.  
+Visual Basic includes several new features to assist in developing applications that access data. Data-bound forms for Windows applications are created by dragging items from the [Data Sources Window](/visualstudio/data-tools/add-new-data-sources) onto the form. You bind controls to data by dragging items from the **Data Sources Window** onto existing controls.
 
- [Dataset Tools in Visual Studio](/visualstudio/data-tools/dataset-tools-in-visual-studio)  
- Provides links to pages describing how to load data into datasets and how to execute SQL statements and stored procedures.  
-  
- [Bind controls to data in Visual Studio](/visualstudio/data-tools/bind-controls-to-data-in-visual-studio)  
- Provides links to pages that explain how to display data on Windows Forms through data-bound controls.  
-  
- [Edit Data in Datasets](/visualstudio/data-tools/edit-data-in-datasets)  
- Provides links to pages describing how to manipulate the data in the data tables of a dataset.  
-  
- [Validate data in datasets](/visualstudio/data-tools/validate-data-in-datasets)  
- Provides links to pages describing how to add validation to a dataset during column and row changes.  
-  
- [Save data back to the database](/visualstudio/data-tools/save-data-back-to-the-database)  
- Provides links to pages explaining how to send updated data from an application to the database.  
-  
- [ADO.NET](../../framework/data/adonet/index.md)  
- Describes the ADO.NET classes, which expose data-access services to the .NET Framework programmer.
+## Related sections
 
- [Data in Office Solutions](/visualstudio/vsto/data-in-office-solutions)
- Contains links to pages that explain how data works in Office solutions, including information about schema-oriented programming, data caching, and server-side data access.
+[Accessing Data in Visual Studio](/visualstudio/data-tools/)  
+Provides links to pages that discuss incorporating data access functionality into your applications.
+
+[Visual Studio data tools for .NET](/visualstudio/data-tools/visual-studio-data-tools-for-dotnet)  
+Provides links to pages on creating applications that work with data, using Visual Studio.
+
+[LINQ](../../visual-basic/programming-guide/language-features/linq/index.md)  
+Provides links to topics that describe how to use LINQ with Visual Basic.
+
+[LINQ to SQL](../../framework/data/adonet/sql/linq/index.md)  
+Provides information about [!INCLUDE[vbtecdlinq](~/includes/vbtecdlinq-md.md)]. Includes programming examples.  
+
+[LINQ to SQL Tools in Visual Studio](/visualstudio/data-tools/linq-to-sql-tools-in-visual-studio2)  
+Provides links to topics about how to create a [LINQ to SQL](../../framework/data/adonet/sql/linq/index.md) object model in applications.
+
+[Work with datasets in n-tier applications](/visualstudio/data-tools/work-with-datasets-in-n-tier-applications)  
+Provides links to topics about how to create multitiered data applications.
+
+[Add new connections](/visualstudio/data-tools/add-new-connections)  
+Provides links to pages on connecting your application to data with design-time tools and ADO.NET connection objects, using Visual Studio.
+
+[Dataset Tools in Visual Studio](/visualstudio/data-tools/dataset-tools-in-visual-studio)  
+Provides links to pages describing how to load data into datasets and how to execute SQL statements and stored procedures.  
+
+[Bind controls to data in Visual Studio](/visualstudio/data-tools/bind-controls-to-data-in-visual-studio)  
+Provides links to pages that explain how to display data on Windows Forms through data-bound controls.
+
+[Edit Data in Datasets](/visualstudio/data-tools/edit-data-in-datasets)  
+Provides links to pages describing how to manipulate the data in the data tables of a dataset.  
+
+[Validate data in datasets](/visualstudio/data-tools/validate-data-in-datasets)  
+Provides links to pages describing how to add validation to a dataset during column and row changes.
+
+[Save data back to the database](/visualstudio/data-tools/save-data-back-to-the-database)  
+Provides links to pages explaining how to send updated data from an application to the database.
+
+[ADO.NET](../../framework/data/adonet/index.md)  
+Describes the ADO.NET classes, which expose data-access services to the .NET Framework programmer.
+
+[Data in Office Solutions](/visualstudio/vsto/data-in-office-solutions)  
+Contains links to pages that explain how data works in Office solutions, including information about schema-oriented programming, data caching, and server-side data access.

--- a/docs/visual-basic/developing-apps/programming/computer-resources/index.md
+++ b/docs/visual-basic/developing-apps/programming/computer-resources/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Accessing computer resources (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "computer resources [Visual Basic]"
   - "My.Computer object [Visual Basic], tasks"
   - "computer resources [Visual Basic], accessing"
@@ -10,8 +10,8 @@ ms.assetid: 75b81c88-f7c0-46e0-95c8-0c006d2120f9
 
 # Accessing computer resources (Visual Basic)
 
-The `My.Computer` object is one of the three central objects in `My`, providing access to information and commonly used functionality. `My.Computer` provides methods, properties, and events for accessing the computer on which the application is running. Its objects include:  
-  
+The `My.Computer` object is one of the three central objects in `My`, providing access to information and commonly used functionality. `My.Computer` provides methods, properties, and events for accessing the computer on which the application is running. Its objects include:
+
 - <xref:Microsoft.VisualBasic.Devices.Audio>
 - Clipboard (<xref:Microsoft.VisualBasic.MyServices.ClipboardProxy>)
 - <xref:Microsoft.VisualBasic.Devices.Clock>
@@ -22,29 +22,29 @@ The `My.Computer` object is one of the three central objects in `My`, providing 
 - <xref:Microsoft.VisualBasic.Devices.Network>
 - <xref:Microsoft.VisualBasic.Devices.Ports>
 - Registry (<xref:Microsoft.VisualBasic.MyServices.RegistryProxy>)
-  
+
 ## In this section
 
-[Playing Sounds](../../../../visual-basic/developing-apps/programming/computer-resources/playing-sounds.md)   
+[Playing Sounds](../../../../visual-basic/developing-apps/programming/computer-resources/playing-sounds.md)  
 Lists tasks associated with `My.Computer.Audio`, such as playing a sound in the background.
 
-[Storing Data to and Reading from the Clipboard](../../../../visual-basic/developing-apps/programming/computer-resources/storing-data-to-and-reading-from-the-clipboard.md)   
+[Storing Data to and Reading from the Clipboard](../../../../visual-basic/developing-apps/programming/computer-resources/storing-data-to-and-reading-from-the-clipboard.md)  
 Lists tasks associated with `My.Computer.Clipboard`, such as reading data from or writing data to the Clipboard.
 
-[Getting Information about the Computer](../../../../visual-basic/developing-apps/programming/computer-resources/getting-information-about-the-computer.md)   
+[Getting Information about the Computer](../../../../visual-basic/developing-apps/programming/computer-resources/getting-information-about-the-computer.md)  
 Lists tasks associated with `My.Computer.Info`, such as determining a computer's full name or IP addresses.
 
-[Accessing the Keyboard](../../../../visual-basic/developing-apps/programming/computer-resources/accessing-the-keyboard.md)   
+[Accessing the Keyboard](../../../../visual-basic/developing-apps/programming/computer-resources/accessing-the-keyboard.md)  
 Lists tasks associated with `My.Computer.Keyboard`, such as determining whether CAPS LOCK is on.
 
-[Accessing the Mouse](../../../../visual-basic/developing-apps/programming/computer-resources/accessing-the-mouse.md)   
+[Accessing the Mouse](../../../../visual-basic/developing-apps/programming/computer-resources/accessing-the-mouse.md)  
 Lists tasks associated with `My.Computer.Mouse`, such as determining whether a mouse is present.
 
-[Performing Network Operations](../../../../visual-basic/developing-apps/programming/computer-resources/performing-network-operations.md)   
+[Performing Network Operations](../../../../visual-basic/developing-apps/programming/computer-resources/performing-network-operations.md)  
 Lists tasks associated with `My.Computer.Network`, such as uploading or downloading files.
 
-[Accessing the Computer's Ports](../../../../visual-basic/developing-apps/programming/computer-resources/accessing-the-computer-s-ports.md)   
+[Accessing the Computer's Ports](../../../../visual-basic/developing-apps/programming/computer-resources/accessing-the-computer-s-ports.md)  
 Lists tasks associated with `My.Computer.Ports`, such as showing available serial ports or sending strings to serial ports.
 
-[Reading from and Writing to the Registry](../../../../visual-basic/developing-apps/programming/computer-resources/reading-from-and-writing-to-the-registry.md)   
+[Reading from and Writing to the Registry](../../../../visual-basic/developing-apps/programming/computer-resources/reading-from-and-writing-to-the-registry.md)  
 Lists tasks associated with `My.Computer.Registry`, such as reading data from or writing data to registry keys.

--- a/docs/visual-basic/developing-apps/programming/computer-resources/port-operations-in-the-net-framework.md
+++ b/docs/visual-basic/developing-apps/programming/computer-resources/port-operations-in-the-net-framework.md
@@ -1,30 +1,32 @@
 ---
 title: "Port Operations in the .NET Framework with Visual Basic"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ports, Visual Basic"
 ms.assetid: 1eba223b-7bd3-401a-b097-982bce96df1b
 ---
 # Port Operations in the .NET Framework with Visual Basic
-You can access your computer's serial ports through the .NET Framework classes in the <xref:System.IO.Ports?displayProperty=nameWithType> namespace. The most important class, <xref:System.IO.Ports.SerialPort>, provides a framework for synchronous and event-driven I/O, access to pin and break states, and access to serial driver properties. It can be wrapped in a <xref:System.IO.Stream> object, accessible through the <xref:System.IO.Ports.SerialPort.BaseStream> property. Wrapping <xref:System.IO.Ports.SerialPort> in a <xref:System.IO.Stream> object allows the serial port to be accessed by classes that use streams. The namespace includes enumerations that simplify the control of serial ports.  
-  
- The simplest way to create a <xref:System.IO.Ports.SerialPort> object is through the <xref:Microsoft.VisualBasic.Devices.Ports.OpenSerialPort%2A> method.  
-  
+
+You can access your computer's serial ports through the .NET Framework classes in the <xref:System.IO.Ports?displayProperty=nameWithType> namespace. The most important class, <xref:System.IO.Ports.SerialPort>, provides a framework for synchronous and event-driven I/O, access to pin and break states, and access to serial driver properties. It can be wrapped in a <xref:System.IO.Stream> object, accessible through the <xref:System.IO.Ports.SerialPort.BaseStream> property. Wrapping <xref:System.IO.Ports.SerialPort> in a <xref:System.IO.Stream> object allows the serial port to be accessed by classes that use streams. The namespace includes enumerations that simplify the control of serial ports.
+
+The simplest way to create a <xref:System.IO.Ports.SerialPort> object is through the <xref:Microsoft.VisualBasic.Devices.Ports.OpenSerialPort%2A> method.
+
 > [!NOTE]
-> You cannot use .NET Framework classes to directly access other types of ports, such as parallel ports, USB ports, and so on.  
-  
-## Enumerations  
- This table lists and describes the main enumerations used for accessing a serial port:  
-  
-|Enumeration|Description|  
-|---|---|   
-|<xref:System.IO.Ports.Handshake>|Specifies the control protocol used in establishing a serial port communication for a <xref:System.IO.Ports.SerialPort> object.|  
-|<xref:System.IO.Ports.Parity>|Specifies the parity bit for a <xref:System.IO.Ports.SerialPort> object.|  
-|<xref:System.IO.Ports.SerialData>|Specifies the type of character that was received on the serial port of the <xref:System.IO.Ports.SerialPort> object.|  
-|<xref:System.IO.Ports.SerialError>|Specifies errors that occur on the <xref:System.IO.Ports.SerialPort> object|  
-|<xref:System.IO.Ports.SerialPinChange>|Specifies the type of change that occurred on the <xref:System.IO.Ports.SerialPort> object.|  
-|<xref:System.IO.Ports.StopBits>|Specifies the number of stop bits used on the <xref:System.IO.Ports.SerialPort> object.|  
-  
+> You cannot use .NET Framework classes to directly access other types of ports, such as parallel ports, USB ports, and so on.
+
+## Enumerations
+
+This table lists and describes the main enumerations used for accessing a serial port:
+
+|Enumeration|Description|
+|---|---|
+|<xref:System.IO.Ports.Handshake>|Specifies the control protocol used in establishing a serial port communication for a <xref:System.IO.Ports.SerialPort> object.|
+|<xref:System.IO.Ports.Parity>|Specifies the parity bit for a <xref:System.IO.Ports.SerialPort> object.|
+|<xref:System.IO.Ports.SerialData>|Specifies the type of character that was received on the serial port of the <xref:System.IO.Ports.SerialPort> object.|
+|<xref:System.IO.Ports.SerialError>|Specifies errors that occur on the <xref:System.IO.Ports.SerialPort> object|
+|<xref:System.IO.Ports.SerialPinChange>|Specifies the type of change that occurred on the <xref:System.IO.Ports.SerialPort> object.|
+|<xref:System.IO.Ports.StopBits>|Specifies the number of stop bits used on the <xref:System.IO.Ports.SerialPort> object.|
+
 ## See also
 
 - <xref:Microsoft.VisualBasic.Devices.Ports>

--- a/docs/visual-basic/developing-apps/programming/log-info/walkthrough-changing-where-my-application-log-writes-information.md
+++ b/docs/visual-basic/developing-apps/programming/log-info/walkthrough-changing-where-my-application-log-writes-information.md
@@ -1,180 +1,182 @@
 ---
 title: "Changing Where My.Application.Log Writes Information (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "My.Application.Log object, walkthroughs"
   - "event logs, changing output location"
 ms.assetid: ecc74f95-743c-450d-93f6-09a30db0fe4a
 ---
 # Walkthrough: Changing Where My.Application.Log Writes Information (Visual Basic)
-You can use the `My.Application.Log` and `My.Log` objects to log information about events that occur in your application. This walkthrough shows how to override the default settings and cause the `Log` object to write to other log listeners.  
-  
-## Prerequisites  
- The `Log` object can write information to several log listeners. You need to determine the current configuration of the log listeners before changing the configurations. For more information, see [Walkthrough: Determining Where My.Application.Log Writes Information](../../../../visual-basic/developing-apps/programming/log-info/walkthrough-determining-where-my-application-log-writes-information.md).  
-  
- You may want to review [How to: Write Event Information to a Text File](../../../../visual-basic/developing-apps/programming/log-info/how-to-write-event-information-to-a-text-file.md) or [How to: Write to an Application Event Log](../../../../visual-basic/developing-apps/programming/log-info/how-to-write-to-an-application-event-log.md).  
-  
-### To add listeners  
-  
-1. Right-click app.config in **Solution Explorer** and choose **Open**.  
-  
-     \- or -  
-  
-     If there is no app.config file:  
-  
-    1. On the **Project** menu, choose **Add New Item**.  
-  
-    2. From the **Add New Item** dialog box, select **Application Configuration File**.  
-  
-    3. Click **Add**.  
-  
-2. Locate the `<listeners>` section, under the `<source>` section with the `name` attribute "DefaultSource", in the `<sources>` section. The `<sources>` section is in the `<system.diagnostics>` section, in the top-level `<configuration>` section.  
-  
-3. Add these elements to that `<listeners>` section.  
-  
-    ```xml  
-    <!-- Uncomment to connect the application file log. -->  
-    <!-- <add name="FileLog" /> -->  
-    <!-- Uncomment to connect the event log. -->  
-    <!-- <add name="EventLog" /> -->  
-    <!-- Uncomment to connect the event log. -->  
-    <!-- <add name="Delimited" /> -->  
-    <!-- Uncomment to connect the XML log. -->  
-    <!-- <add name="XmlWriter" /> -->  
-    <!-- Uncomment to connect the console log. -->  
-    <!-- <add name="Console" /> -->  
-    ```  
-  
-4. Uncomment the log listeners that you want to receive `Log` messages.  
-  
-5. Locate the `<sharedListeners>` section, in the `<system.diagnostics>` section, in the top-level `<configuration>` section.  
-  
-6. Add these elements to that `<sharedListeners>` section.  
-  
-    ```xml  
-    <add name="FileLog"  
-         type="Microsoft.VisualBasic.Logging.FileLogTraceListener,   
-               Microsoft.VisualBasic, Version=8.0.0.0,   
-               Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"  
-         initializeData="FileLogWriter" />  
-    <add name="EventLog"  
-         type="System.Diagnostics.EventLogTraceListener,   
-               System, Version=2.0.0.0,   
-               Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-         initializeData="sample application"/>  
-    <add name="Delimited"   
-         type="System.Diagnostics.DelimitedListTraceListener,   
-               System, Version=2.0.0.0,   
-               Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-         initializeData="c:\temp\sampleDelimitedFile.txt"  
-         traceOutputOptions="DateTime" />  
-    <add name="XmlWriter"  
-         type="System.Diagnostics.XmlWriterTraceListener,   
-               System, Version=2.0.0.0,   
-               Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-         initializeData="c:\temp\sampleLogFile.xml" />  
-    <add name="Console"  
-         type="System.Diagnostics.ConsoleTraceListener,   
-               System, Version=2.0.0.0,   
-               Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-         initializeData="true" />  
-    ```  
-  
-7. The content of the app.config file should be similar to the following XML:  
-  
-    ```xml  
-    <?xml version="1.0" encoding="utf-8" ?>  
-    <configuration>  
-      <system.diagnostics>  
-        <sources>  
-          <!-- This section configures My.Application.Log -->  
-          <source name="DefaultSource" switchName="DefaultSwitch">  
-            <listeners>  
-              <add name="FileLog"/>  
-              <!-- Uncomment to connect the application file log. -->  
-              <!-- <add name="FileLog" /> -->  
-              <!-- Uncomment to connect the event log. -->  
-              <!-- <add name="EventLog" /> -->  
-              <!-- Uncomment to connect the event log. -->  
-              <!-- <add name="Delimited" /> -->  
-              <!-- Uncomment to connect the XML log. -->  
-              <!-- <add name="XmlWriter" /> -->  
-              <!-- Uncomment to connect the console log. -->  
-              <!-- <add name="Console" /> -->  
-            </listeners>  
-          </source>  
-        </sources>  
-        <switches>  
-          <add name="DefaultSwitch" value="Information" />  
-        </switches>  
-        <sharedListeners>  
-          <add name="FileLog"  
-               type="Microsoft.VisualBasic.Logging.FileLogTraceListener,   
-                     Microsoft.VisualBasic, Version=8.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"  
-               initializeData="FileLogWriter" />  
-          <add name="EventLog"  
-               type="System.Diagnostics.EventLogTraceListener,   
-                     System, Version=2.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-               initializeData="sample application"/>  
-          <add name="Delimited"   
-               type="System.Diagnostics.DelimitedListTraceListener,   
-                     System, Version=2.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-               initializeData="c:\temp\sampleDelimitedFile.txt"  
-               traceOutputOptions="DateTime" />  
-          <add name="XmlWriter"  
-               type="System.Diagnostics.XmlWriterTraceListener,   
-                     System, Version=2.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-               initializeData="c:\temp\sampleLogFile.xml" />  
-          <add name="Console"  
-               type="System.Diagnostics.ConsoleTraceListener,   
-                     System, Version=2.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b77a5c561934e089"  
-               initializeData="true" />  
-        </sharedListeners>  
-      </system.diagnostics>  
-    </configuration>  
-    ```  
-  
-### To reconfigure a listener  
-  
-1. Locate the listener's `<add>` element from the `<sharedListeners>` section.  
-  
-2. The `type` attribute gives the name of the listener type. This type must inherit from the <xref:System.Diagnostics.TraceListener> class. Use the strongly named type name to ensure that the right type is used. For more information, see the "To reference a strongly named type" section below.  
-  
-     Some types that you can use are:  
-  
-    - A <xref:Microsoft.VisualBasic.Logging.FileLogTraceListener?displayProperty=nameWithType> listener, which writes to a file log.  
-  
-    - A <xref:System.Diagnostics.EventLogTraceListener?displayProperty=nameWithType> listener, which writes information to the computer event log specified by the `initializeData` parameter.  
-  
-    - The <xref:System.Diagnostics.DelimitedListTraceListener?displayProperty=nameWithType> and <xref:System.Diagnostics.XmlWriterTraceListener?displayProperty=nameWithType> listeners, which write to the file specified in the `initializeData` parameter.  
-  
-    - A <xref:System.Diagnostics.ConsoleTraceListener?displayProperty=nameWithType> listener, which writes to the command-line console.  
-  
-     For information about where other types of log listeners write information, consult that type's documentation.  
-  
-3. When the application creates the log-listener object, it passes the `initializeData` attribute as the constructor parameter. The meaning of the `initializeData` attribute depends on the trace listener.  
-  
-4. After creating the log listener, the application sets the listener's properties. These properties are defined by the other attributes in the `<add>` element. For more information on the properties for a particular listener, see the documentation for that listener's type.  
-  
-### To reference a strongly named type  
-  
-1. To ensure that the right type is used for your log listener, make sure to use the fully qualified type name and the strongly named assembly name. The syntax of a strongly named type is as follows:  
-  
-     \<*type name*>, \<*assembly name*>, \<*version number*>, \<*culture*>, \<*strong name*>  
-  
-2. This code example shows how to determine the strongly named type name for a fully qualified type—"System.Diagnostics.FileLogTraceListener" in this case.  
-  
-     [!code-vb[VbVbalrMyApplicationLog#15](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrMyApplicationLog/VB/Form1.vb#15)]  
-  
-     This is the output, and it can be used to uniquely reference a strongly named type, as in the "To add listeners" procedure above.  
-  
-     `Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`  
-  
+
+You can use the `My.Application.Log` and `My.Log` objects to log information about events that occur in your application. This walkthrough shows how to override the default settings and cause the `Log` object to write to other log listeners.
+
+## Prerequisites
+
+The `Log` object can write information to several log listeners. You need to determine the current configuration of the log listeners before changing the configurations. For more information, see [Walkthrough: Determining Where My.Application.Log Writes Information](../../../../visual-basic/developing-apps/programming/log-info/walkthrough-determining-where-my-application-log-writes-information.md).
+
+You may want to review [How to: Write Event Information to a Text File](../../../../visual-basic/developing-apps/programming/log-info/how-to-write-event-information-to-a-text-file.md) or [How to: Write to an Application Event Log](../../../../visual-basic/developing-apps/programming/log-info/how-to-write-to-an-application-event-log.md).
+
+### To add listeners
+
+1. Right-click app.config in **Solution Explorer** and choose **Open**.
+
+     \- or -
+
+     If there is no app.config file:
+
+    1. On the **Project** menu, choose **Add New Item**.
+
+    2. From the **Add New Item** dialog box, select **Application Configuration File**.
+
+    3. Click **Add**.
+
+2. Locate the `<listeners>` section, under the `<source>` section with the `name` attribute "DefaultSource", in the `<sources>` section. The `<sources>` section is in the `<system.diagnostics>` section, in the top-level `<configuration>` section.
+
+3. Add these elements to that `<listeners>` section.
+
+    ```xml
+    <!-- Uncomment to connect the application file log. -->
+    <!-- <add name="FileLog" /> -->
+    <!-- Uncomment to connect the event log. -->
+    <!-- <add name="EventLog" /> -->
+    <!-- Uncomment to connect the event log. -->
+    <!-- <add name="Delimited" /> -->
+    <!-- Uncomment to connect the XML log. -->
+    <!-- <add name="XmlWriter" /> -->
+    <!-- Uncomment to connect the console log. -->
+    <!-- <add name="Console" /> -->
+    ```
+
+4. Uncomment the log listeners that you want to receive `Log` messages.
+
+5. Locate the `<sharedListeners>` section, in the `<system.diagnostics>` section, in the top-level `<configuration>` section.
+
+6. Add these elements to that `<sharedListeners>` section.
+
+    ```xml
+    <add name="FileLog"
+         type="Microsoft.VisualBasic.Logging.FileLogTraceListener,
+               Microsoft.VisualBasic, Version=8.0.0.0,
+               Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+         initializeData="FileLogWriter" />
+    <add name="EventLog"
+         type="System.Diagnostics.EventLogTraceListener,
+               System, Version=2.0.0.0,
+               Culture=neutral, PublicKeyToken=b77a5c561934e089"
+         initializeData="sample application"/>
+    <add name="Delimited"
+         type="System.Diagnostics.DelimitedListTraceListener,
+               System, Version=2.0.0.0,
+               Culture=neutral, PublicKeyToken=b77a5c561934e089"
+         initializeData="c:\temp\sampleDelimitedFile.txt"
+         traceOutputOptions="DateTime" />
+    <add name="XmlWriter"
+         type="System.Diagnostics.XmlWriterTraceListener,
+               System, Version=2.0.0.0,
+               Culture=neutral, PublicKeyToken=b77a5c561934e089"
+         initializeData="c:\temp\sampleLogFile.xml" />
+    <add name="Console"
+         type="System.Diagnostics.ConsoleTraceListener,
+               System, Version=2.0.0.0,
+               Culture=neutral, PublicKeyToken=b77a5c561934e089"
+         initializeData="true" />
+    ```
+
+7. The content of the app.config file should be similar to the following XML:
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8" ?>
+    <configuration>
+      <system.diagnostics>
+        <sources>
+          <!-- This section configures My.Application.Log -->
+          <source name="DefaultSource" switchName="DefaultSwitch">
+            <listeners>
+              <add name="FileLog"/>
+              <!-- Uncomment to connect the application file log. -->
+              <!-- <add name="FileLog" /> -->
+              <!-- Uncomment to connect the event log. -->
+              <!-- <add name="EventLog" /> -->
+              <!-- Uncomment to connect the event log. -->
+              <!-- <add name="Delimited" /> -->
+              <!-- Uncomment to connect the XML log. -->
+              <!-- <add name="XmlWriter" /> -->
+              <!-- Uncomment to connect the console log. -->
+              <!-- <add name="Console" /> -->
+            </listeners>
+          </source>
+        </sources>
+        <switches>
+          <add name="DefaultSwitch" value="Information" />
+        </switches>
+        <sharedListeners>
+          <add name="FileLog"
+               type="Microsoft.VisualBasic.Logging.FileLogTraceListener,
+                     Microsoft.VisualBasic, Version=8.0.0.0,
+                     Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+               initializeData="FileLogWriter" />
+          <add name="EventLog"
+               type="System.Diagnostics.EventLogTraceListener,
+                     System, Version=2.0.0.0,
+                     Culture=neutral, PublicKeyToken=b77a5c561934e089"
+               initializeData="sample application"/>
+          <add name="Delimited"
+               type="System.Diagnostics.DelimitedListTraceListener,
+                     System, Version=2.0.0.0,
+                     Culture=neutral, PublicKeyToken=b77a5c561934e089"
+               initializeData="c:\temp\sampleDelimitedFile.txt"
+               traceOutputOptions="DateTime" />
+          <add name="XmlWriter"
+               type="System.Diagnostics.XmlWriterTraceListener,
+                     System, Version=2.0.0.0,
+                     Culture=neutral, PublicKeyToken=b77a5c561934e089"
+               initializeData="c:\temp\sampleLogFile.xml" />
+          <add name="Console"
+               type="System.Diagnostics.ConsoleTraceListener,
+                     System, Version=2.0.0.0,
+                     Culture=neutral, PublicKeyToken=b77a5c561934e089"
+               initializeData="true" />
+        </sharedListeners>
+      </system.diagnostics>
+    </configuration>
+    ```
+
+### To reconfigure a listener
+
+1. Locate the listener's `<add>` element from the `<sharedListeners>` section.
+
+2. The `type` attribute gives the name of the listener type. This type must inherit from the <xref:System.Diagnostics.TraceListener> class. Use the strongly named type name to ensure that the right type is used. For more information, see the "To reference a strongly named type" section below.
+
+     Some types that you can use are:
+
+    - A <xref:Microsoft.VisualBasic.Logging.FileLogTraceListener?displayProperty=nameWithType> listener, which writes to a file log.
+
+    - A <xref:System.Diagnostics.EventLogTraceListener?displayProperty=nameWithType> listener, which writes information to the computer event log specified by the `initializeData` parameter.
+
+    - The <xref:System.Diagnostics.DelimitedListTraceListener?displayProperty=nameWithType> and <xref:System.Diagnostics.XmlWriterTraceListener?displayProperty=nameWithType> listeners, which write to the file specified in the `initializeData` parameter.
+
+    - A <xref:System.Diagnostics.ConsoleTraceListener?displayProperty=nameWithType> listener, which writes to the command-line console.
+
+     For information about where other types of log listeners write information, consult that type's documentation.
+
+3. When the application creates the log-listener object, it passes the `initializeData` attribute as the constructor parameter. The meaning of the `initializeData` attribute depends on the trace listener.
+
+4. After creating the log listener, the application sets the listener's properties. These properties are defined by the other attributes in the `<add>` element. For more information on the properties for a particular listener, see the documentation for that listener's type.
+
+### To reference a strongly named type
+
+1. To ensure that the right type is used for your log listener, make sure to use the fully qualified type name and the strongly named assembly name. The syntax of a strongly named type is as follows:
+
+     \<*type name*>, \<*assembly name*>, \<*version number*>, \<*culture*>, \<*strong name*>
+
+2. This code example shows how to determine the strongly named type name for a fully qualified type—"System.Diagnostics.FileLogTraceListener" in this case.
+
+     [!code-vb[VbVbalrMyApplicationLog#15](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrMyApplicationLog/VB/Form1.vb#15)]
+
+     This is the output, and it can be used to uniquely reference a strongly named type, as in the "To add listeners" procedure above.
+
+     `Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`
+
 ## See also
 
 - <xref:Microsoft.VisualBasic.Logging.Log?displayProperty=nameWithType>

--- a/docs/visual-basic/developing-apps/programming/log-info/walkthrough-filtering-my-application-log-output.md
+++ b/docs/visual-basic/developing-apps/programming/log-info/walkthrough-filtering-my-application-log-output.md
@@ -1,246 +1,250 @@
 ---
 title: "Filtering My.Application.Log Output (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "My.Log object, filtering output"
   - "My.Application.Log object, filtering output"
   - "application event logs, output filtering"
 ms.assetid: 2c0a457a-38a4-49e1-934d-a51320b7b4ca
 ---
 # Walkthrough: Filtering My.Application.Log Output (Visual Basic)
-This walkthrough demonstrates how to change the default log filtering for the `My.Application.Log` object, to control what information is passed from the `Log` object to the listeners and what information is written by the listeners. You can change the logging behavior even after building the application, because the configuration information is stored in the application's configuration file.  
-  
-## Getting Started  
- Each message that `My.Application.Log` writes has an associated severity level, which filtering mechanisms use to control the log output. This sample application uses `My.Application.Log` methods to write several log messages with different severity levels.  
-  
-#### To build the sample application  
-  
-1. Open a new Visual Basic Windows Application project.  
-  
-2. Add a button named Button1 to Form1.  
-  
-3. In the <xref:System.Windows.Forms.Control.Click> event handler for Button1, add the following code:  
-  
-     [!code-vb[VbVbcnMyApplicationLogFiltering#1](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnMyApplicationLogFiltering/VB/Form1.vb#1)]  
-  
-4. Run the application in the debugger.  
-  
-5. Press **Button1**.  
-  
-     The application writes the following information to the application's debug output and log file.  
-  
-     `DefaultSource Information: 0 : In Button1_Click`  
-  
-     `DefaultSource Error: 2 : Error in the application.`  
-  
-6. Close the application.  
-  
-     For information on how to view the application's debug output window, see [Output Window](/visualstudio/ide/reference/output-window). For information on the location of the application's log file, see [Walkthrough: Determining Where My.Application.Log Writes Information](../../../../visual-basic/developing-apps/programming/log-info/walkthrough-determining-where-my-application-log-writes-information.md).  
-  
+
+This walkthrough demonstrates how to change the default log filtering for the `My.Application.Log` object, to control what information is passed from the `Log` object to the listeners and what information is written by the listeners. You can change the logging behavior even after building the application, because the configuration information is stored in the application's configuration file.
+
+## Getting Started
+
+Each message that `My.Application.Log` writes has an associated severity level, which filtering mechanisms use to control the log output. This sample application uses `My.Application.Log` methods to write several log messages with different severity levels.
+
+#### To build the sample application
+
+1. Open a new Visual Basic Windows Application project.
+
+2. Add a button named Button1 to Form1.
+
+3. In the <xref:System.Windows.Forms.Control.Click> event handler for Button1, add the following code:
+
+     [!code-vb[VbVbcnMyApplicationLogFiltering#1](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnMyApplicationLogFiltering/VB/Form1.vb#1)]
+
+4. Run the application in the debugger.
+
+5. Press **Button1**.
+
+     The application writes the following information to the application's debug output and log file.
+
+     `DefaultSource Information: 0 : In Button1_Click`
+
+     `DefaultSource Error: 2 : Error in the application.`
+
+6. Close the application.
+
+     For information on how to view the application's debug output window, see [Output Window](/visualstudio/ide/reference/output-window). For information on the location of the application's log file, see [Walkthrough: Determining Where My.Application.Log Writes Information](../../../../visual-basic/developing-apps/programming/log-info/walkthrough-determining-where-my-application-log-writes-information.md).
+
     > [!NOTE]
-    > By default, the application flushes the log-file output when the application closes.  
-  
-     In the example above, the second call to the <xref:Microsoft.VisualBasic.Logging.Log.WriteEntry%2A> method and the call to the <xref:Microsoft.VisualBasic.Logging.Log.WriteException%2A> method produces log output, while the first and last calls to the `WriteEntry` method do not. This is because the severity levels of `WriteEntry` and `WriteException` are "Information" and "Error", both of which are allowed by the `My.Application.Log` object's default log filtering. However, events with "Start" and "Stop" severity levels are prevented from producing log output.  
-  
-## Filtering for All My.Application.Log Listeners  
- The `My.Application.Log` object uses a <xref:System.Diagnostics.SourceSwitch> named `DefaultSwitch` to control which messages it passes from the `WriteEntry` and `WriteException` methods to the log listeners. You can configure `DefaultSwitch` in the application's configuration file by setting its value to one of the <xref:System.Diagnostics.SourceLevels> enumeration values. By default, its value is "Information".  
-  
- This table shows the severity level required for Log to write a message to the listeners, given a particular `DefaultSwitch` setting.  
-  
-|DefaultSwitch Value|Message severity required for output|  
-|---|---| 
-|`Critical`|`Critical`|  
-|`Error`|`Critical` or `Error`|  
-|`Warning`|`Critical`, `Error`, or `Warning`|  
-|`Information`|`Critical`, `Error`, `Warning`, or `Information`|  
-|`Verbose`|`Critical`, `Error`, `Warning`, `Information`, or `Verbose`|  
-|`ActivityTracing`|`Start`, `Stop`, `Suspend`, `Resume`, or `Transfer`|  
-|`All`|All messages are allowed.|  
-|`Off`|All messages are blocked.|  
-  
+    > By default, the application flushes the log-file output when the application closes.
+
+     In the example above, the second call to the <xref:Microsoft.VisualBasic.Logging.Log.WriteEntry%2A> method and the call to the <xref:Microsoft.VisualBasic.Logging.Log.WriteException%2A> method produces log output, while the first and last calls to the `WriteEntry` method do not. This is because the severity levels of `WriteEntry` and `WriteException` are "Information" and "Error", both of which are allowed by the `My.Application.Log` object's default log filtering. However, events with "Start" and "Stop" severity levels are prevented from producing log output.
+
+## Filtering for All My.Application.Log Listeners
+
+The `My.Application.Log` object uses a <xref:System.Diagnostics.SourceSwitch> named `DefaultSwitch` to control which messages it passes from the `WriteEntry` and `WriteException` methods to the log listeners. You can configure `DefaultSwitch` in the application's configuration file by setting its value to one of the <xref:System.Diagnostics.SourceLevels> enumeration values. By default, its value is "Information".
+
+This table shows the severity level required for Log to write a message to the listeners, given a particular `DefaultSwitch` setting.
+
+|DefaultSwitch Value|Message severity required for output|
+|---|---|
+|`Critical`|`Critical`|
+|`Error`|`Critical` or `Error`|
+|`Warning`|`Critical`, `Error`, or `Warning`|
+|`Information`|`Critical`, `Error`, `Warning`, or `Information`|
+|`Verbose`|`Critical`, `Error`, `Warning`, `Information`, or `Verbose`|
+|`ActivityTracing`|`Start`, `Stop`, `Suspend`, `Resume`, or `Transfer`|
+|`All`|All messages are allowed.|
+|`Off`|All messages are blocked.|
+
 > [!NOTE]
-> The `WriteEntry` and `WriteException` methods each have an overload that does not specify a severity level. The implicit severity level for the `WriteEntry` overload is "Information", and the implicit severity level for the `WriteException` overload is "Error".  
-  
- This table explains the log output shown in the previous example: with the default `DefaultSwitch` setting of "Information", only the second call to the `WriteEntry` method and the call to the `WriteException` method produce log output.  
-  
-#### To log only activity tracing events  
-  
-1. Right-click app.config in the **Solution Explorer** and select **Open**.  
-  
-     -or-  
-  
-     If there is no app.config file:  
-  
-    1. On the **Project** menu, choose **Add New Item**.  
-  
-    2. From the **Add New Item** dialog box, choose **Application Configuration File**.  
-  
-    3. Click **Add**.  
-  
-2. Locate the `<switches>` section, which is in the `<system.diagnostics>` section, which is in the top-level `<configuration>` section.  
-  
-3. Find the element that adds `DefaultSwitch` to the collection of switches. It should look similar to this element:  
-  
-     `<add name="DefaultSwitch" value="Information" />`  
-  
-4. Change the value of the `value` attribute to "ActivityTracing".  
-  
-5. The content of the app.config file should be similar to the following XML:  
-  
-    ```xml  
-    <?xml version="1.0" encoding="utf-8" ?>  
-    <configuration>  
-      <system.diagnostics>  
-        <sources>  
-          <!-- This section configures My.Application.Log -->  
-          <source name="DefaultSource" switchName="DefaultSwitch">  
-            <listeners>  
-              <add name="FileLog"/>  
-            </listeners>  
-          </source>  
-        </sources>  
-        <switches>  
-          <add name="DefaultSwitch" value="ActivityTracing" />  
-        </switches>  
-        <sharedListeners>  
-          <add name="FileLog"  
-               type="Microsoft.VisualBasic.Logging.FileLogTraceListener,   
-                     Microsoft.VisualBasic, Version=8.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a,   
-                     processorArchitecture=MSIL"   
-               initializeData="FileLogWriter"/>  
-        </sharedListeners>  
-      </system.diagnostics>  
-    </configuration>  
-    ```  
-  
-6. Run the application in the debugger.  
-  
-7. Press **Button1**.  
-  
-     The application writes the following information to the application's debug output and log file:  
-  
-     `DefaultSource Start: 4 : Entering Button1_Click`  
-  
-     `DefaultSource Stop: 5 : Leaving Button1_Click`  
-  
-8. Close the application.  
-  
-9. Change the value of the `value` attribute back to "Information".  
-  
+> The `WriteEntry` and `WriteException` methods each have an overload that does not specify a severity level. The implicit severity level for the `WriteEntry` overload is "Information", and the implicit severity level for the `WriteException` overload is "Error".
+
+This table explains the log output shown in the previous example: with the default `DefaultSwitch` setting of "Information", only the second call to the `WriteEntry` method and the call to the `WriteException` method produce log output.
+
+#### To log only activity tracing events
+
+1. Right-click app.config in the **Solution Explorer** and select **Open**.
+
+     -or-
+
+     If there is no app.config file:
+
+    1. On the **Project** menu, choose **Add New Item**.
+
+    2. From the **Add New Item** dialog box, choose **Application Configuration File**.
+
+    3. Click **Add**.
+
+2. Locate the `<switches>` section, which is in the `<system.diagnostics>` section, which is in the top-level `<configuration>` section.
+
+3. Find the element that adds `DefaultSwitch` to the collection of switches. It should look similar to this element:
+
+     `<add name="DefaultSwitch" value="Information" />`
+
+4. Change the value of the `value` attribute to "ActivityTracing".
+
+5. The content of the app.config file should be similar to the following XML:
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8" ?>
+    <configuration>
+      <system.diagnostics>
+        <sources>
+          <!-- This section configures My.Application.Log -->
+          <source name="DefaultSource" switchName="DefaultSwitch">
+            <listeners>
+              <add name="FileLog"/>
+            </listeners>
+          </source>
+        </sources>
+        <switches>
+          <add name="DefaultSwitch" value="ActivityTracing" />
+        </switches>
+        <sharedListeners>
+          <add name="FileLog"
+               type="Microsoft.VisualBasic.Logging.FileLogTraceListener,
+                     Microsoft.VisualBasic, Version=8.0.0.0,
+                     Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a,
+                     processorArchitecture=MSIL"
+               initializeData="FileLogWriter"/>
+        </sharedListeners>
+      </system.diagnostics>
+    </configuration>
+    ```
+
+6. Run the application in the debugger.
+
+7. Press **Button1**.
+
+     The application writes the following information to the application's debug output and log file:
+
+     `DefaultSource Start: 4 : Entering Button1_Click`
+
+     `DefaultSource Stop: 5 : Leaving Button1_Click`
+
+8. Close the application.
+
+9. Change the value of the `value` attribute back to "Information".
+
     > [!NOTE]
-    > The `DefaultSwitch` switch setting controls only `My.Application.Log`. It does not change how the .NET Framework <xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> classes behave.  
-  
-## Individual Filtering For My.Application.Log Listeners  
- The previous example shows how to change the filtering for all `My.Application.Log` output. This example demonstrates how to filter an individual log listener. By default, an application has two listeners that write to the application's debug output and the log file.  
-  
- The configuration file controls the behavior of the log listeners by allowing each one to have a filter, which is similar to a switch for `My.Application.Log`. A log listener will output a message only if the message's severity is allowed by both the log's `DefaultSwitch` and the log listener's filter.  
-  
- This example demonstrates how to configure filtering for a new debug listener and add it to the `Log` object. The default debug listener should be removed from the `Log` object, so it is clear that the debug messages come from the new debug listener.  
-  
-#### To log only activity-tracing events  
-  
-1. Right-click app.config in the **Solution Explorer** and choose **Open**.  
-  
-     -or-  
-  
-     If there is no app.config file:  
-  
-    1. On the **Project** menu, choose **Add New Item**.  
-  
-    2. From the **Add New Item** dialog box, choose **Application Configuration File**.  
-  
-    3. Click **Add**.  
-  
-2. Right-click app.config in **Solution Explorer**. Choose **Open**.  
-  
-3. Locate the `<listeners>` section, in the `<source>` section with the `name` attribute "DefaultSource", which is under the `<sources>` section. The `<sources>` section is under the `<system.diagnostics>` section, in the top-level `<configuration>` section.  
-  
-4. Add this element to the `<listeners>` section:  
-  
-    ```xml  
-    <!-- Remove the default debug listener. -->  
-    <remove name="Default"/>  
-    <!-- Add a filterable debug listener. -->  
-    <add name="NewDefault"/>  
-    ```  
-  
-5. Locate the `<sharedListeners>` section, in the `<system.diagnostics>` section, in the top-level `<configuration>` section.  
-  
-6. Add this element to that `<sharedListeners>` section:  
-  
-    ```xml  
-    <add name="NewDefault"   
-         type="System.Diagnostics.DefaultTraceListener,   
-               System, Version=2.0.0.0, Culture=neutral,   
-               PublicKeyToken=b77a5c561934e089,   
-               processorArchitecture=MSIL">  
-        <filter type="System.Diagnostics.EventTypeFilter"   
-                initializeData="Error" />  
-    </add>  
-    ```  
-  
-     The <xref:System.Diagnostics.EventTypeFilter> filter takes one of the <xref:System.Diagnostics.SourceLevels> enumeration values as its `initializeData` attribute.  
-  
-7. The content of the app.config file should be similar to the following XML:  
-  
-    ```xml  
-    <?xml version="1.0" encoding="utf-8" ?>  
-    <configuration>  
-      <system.diagnostics>  
-        <sources>  
-          <!-- This section configures My.Application.Log -->  
-          <source name="DefaultSource" switchName="DefaultSwitch">  
-            <listeners>  
-              <add name="FileLog"/>  
-              <!-- Remove the default debug listener. -->  
-              <remove name="Default"/>  
-              <!-- Add a filterable debug listener. -->  
-              <add name="NewDefault"/>  
-            </listeners>  
-          </source>  
-        </sources>  
-        <switches>  
-          <add name="DefaultSwitch" value="Information" />  
-        </switches>  
-        <sharedListeners>  
-          <add name="FileLog"  
-               type="Microsoft.VisualBasic.Logging.FileLogTraceListener,   
-                     Microsoft.VisualBasic, Version=8.0.0.0,   
-                     Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a,   
-                     processorArchitecture=MSIL"   
-               initializeData="FileLogWriter"/>  
-          <add name="NewDefault"   
-               type="System.Diagnostics.DefaultTraceListener,   
-                     System, Version=2.0.0.0, Culture=neutral,   
-                     PublicKeyToken=b77a5c561934e089,   
-                     processorArchitecture=MSIL">  
-            <filter type="System.Diagnostics.EventTypeFilter"   
-                    initializeData="Error" />  
-          </add>  
-        </sharedListeners>  
-      </system.diagnostics>  
-    </configuration>  
-    ```  
-  
-8. Run the application in the debugger.  
-  
-9. Press **Button1**.  
-  
-     The application writes the following information to the application's log file:  
-  
-     `Default Information: 0 : In Button1_Click`  
-  
-     `Default Error: 2 : Error in the application.`  
-  
-     The application writes less information to the application's debug output because of the more restrictive filtering.  
-  
-     `Default Error   2   Error`  
-  
-10. Close the application.  
-  
- For more information about changing log settings after deployment, see [Working with Application Logs](../../../../visual-basic/developing-apps/programming/log-info/working-with-application-logs.md).  
-  
+    > The `DefaultSwitch` switch setting controls only `My.Application.Log`. It does not change how the .NET Framework <xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> classes behave.
+
+## Individual Filtering For My.Application.Log Listeners
+
+The previous example shows how to change the filtering for all `My.Application.Log` output. This example demonstrates how to filter an individual log listener. By default, an application has two listeners that write to the application's debug output and the log file.
+
+The configuration file controls the behavior of the log listeners by allowing each one to have a filter, which is similar to a switch for `My.Application.Log`. A log listener will output a message only if the message's severity is allowed by both the log's `DefaultSwitch` and the log listener's filter.
+
+This example demonstrates how to configure filtering for a new debug listener and add it to the `Log` object. The default debug listener should be removed from the `Log` object, so it is clear that the debug messages come from the new debug listener.
+
+#### To log only activity-tracing events
+
+1. Right-click app.config in the **Solution Explorer** and choose **Open**.
+
+     \-or-
+
+     If there is no app.config file:
+
+    1. On the **Project** menu, choose **Add New Item**.
+
+    2. From the **Add New Item** dialog box, choose **Application Configuration File**.
+
+    3. Click **Add**.
+
+2. Right-click app.config in **Solution Explorer**. Choose **Open**.
+
+3. Locate the `<listeners>` section, in the `<source>` section with the `name` attribute "DefaultSource", which is under the `<sources>` section. The `<sources>` section is under the `<system.diagnostics>` section, in the top-level `<configuration>` section.
+
+4. Add this element to the `<listeners>` section:
+
+    ```xml
+    <!-- Remove the default debug listener. -->
+    <remove name="Default"/>
+    <!-- Add a filterable debug listener. -->
+    <add name="NewDefault"/>
+    ```
+
+5. Locate the `<sharedListeners>` section, in the `<system.diagnostics>` section, in the top-level `<configuration>` section.
+
+6. Add this element to that `<sharedListeners>` section:
+
+    ```xml
+    <add name="NewDefault"
+         type="System.Diagnostics.DefaultTraceListener,
+               System, Version=2.0.0.0, Culture=neutral,
+               PublicKeyToken=b77a5c561934e089,
+               processorArchitecture=MSIL">
+        <filter type="System.Diagnostics.EventTypeFilter"
+                initializeData="Error" />
+    </add>
+    ```
+
+     The <xref:System.Diagnostics.EventTypeFilter> filter takes one of the <xref:System.Diagnostics.SourceLevels> enumeration values as its `initializeData` attribute.
+
+7. The content of the app.config file should be similar to the following XML:
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8" ?>
+    <configuration>
+      <system.diagnostics>
+        <sources>
+          <!-- This section configures My.Application.Log -->
+          <source name="DefaultSource" switchName="DefaultSwitch">
+            <listeners>
+              <add name="FileLog"/>
+              <!-- Remove the default debug listener. -->
+              <remove name="Default"/>
+              <!-- Add a filterable debug listener. -->
+              <add name="NewDefault"/>
+            </listeners>
+          </source>
+        </sources>
+        <switches>
+          <add name="DefaultSwitch" value="Information" />
+        </switches>
+        <sharedListeners>
+          <add name="FileLog"
+               type="Microsoft.VisualBasic.Logging.FileLogTraceListener,
+                     Microsoft.VisualBasic, Version=8.0.0.0,
+                     Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a,
+                     processorArchitecture=MSIL"
+               initializeData="FileLogWriter"/>
+          <add name="NewDefault"
+               type="System.Diagnostics.DefaultTraceListener,
+                     System, Version=2.0.0.0, Culture=neutral,
+                     PublicKeyToken=b77a5c561934e089,
+                     processorArchitecture=MSIL">
+            <filter type="System.Diagnostics.EventTypeFilter"
+                    initializeData="Error" />
+          </add>
+        </sharedListeners>
+      </system.diagnostics>
+    </configuration>
+    ```
+
+8. Run the application in the debugger.
+
+9. Press **Button1**.
+
+     The application writes the following information to the application's log file:
+
+     `Default Information: 0 : In Button1_Click`
+
+     `Default Error: 2 : Error in the application.`
+
+     The application writes less information to the application's debug output because of the more restrictive filtering.
+
+     `Default Error   2   Error`
+
+10. Close the application.
+
+For more information about changing log settings after deployment, see [Working with Application Logs](../../../../visual-basic/developing-apps/programming/log-info/working-with-application-logs.md).
+
 ## See also
 
 - [Walkthrough: Determining Where My.Application.Log Writes Information](../../../../visual-basic/developing-apps/programming/log-info/walkthrough-determining-where-my-application-log-writes-information.md)

--- a/docs/visual-basic/developing-apps/windows-forms/index.md
+++ b/docs/visual-basic/developing-apps/windows-forms/index.md
@@ -7,88 +7,99 @@ helpviewer_keywords:
 ms.assetid: 0b919d30-7fd6-42db-85c8-543d15312441
 ---
 # Windows Forms Application Basics (Visual Basic)
-An important part of Visual Basic is the ability to create Windows Forms applications that run locally on users' computers. You can use Visual Studio to create the application and user interface using Windows Forms. A Windows Forms application is built on classes from the <xref:System.Windows.Forms> namespace.  
-  
-## Designing Windows Forms Applications  
- You can create Windows Forms and Windows service applications with Visual Studio. For more information, see the following topics:  
-  
-- [Getting Started with Windows Forms](../../../framework/winforms/getting-started-with-windows-forms.md). Provides information on how to create and program Windows Forms.  
-   
-- [Windows Forms Controls](../../../framework/winforms/controls/index.md). Collection of topics detailing the use of Windows Forms controls.  
-  
-- [Windows Service Applications](../../../framework/windows-services/index.md). Lists topics that explain how to create Windows services.  
-  
-## Building Rich, Interactive User Interfaces  
- Windows Forms is the smart-client component of the .NET Framework, a set of managed libraries that enable common application tasks such as reading and writing to the file system. Using a development environment like Visual Studio, you can create Windows Forms applications that display information, request input from users, and communicate with remote computers over a network.  
-  
- In Windows Forms, a form is a visual surface on which you display information to the user. You commonly build Windows Forms applications by placing controls on forms and developing responses to user actions, such as mouse clicks or key presses. A *control* is a discrete user interface (UI) element that displays data or accepts data input.  
-  
-### Events  
- When a user does something to your form or one of its controls, it generates an event. Your application reacts to these events by using code, and processes the events when they occur. For more information, see [Creating Event Handlers in Windows Forms](../../../framework/winforms/creating-event-handlers-in-windows-forms.md).  
-  
-### Controls  
- Windows Forms contains a variety of controls that you can place on forms: controls that display text boxes, buttons, drop-down boxes, radio buttons, and even Web pages. For a list of all the controls you can use on a form, see [Controls to Use on Windows Forms](../../../framework/winforms/controls/controls-to-use-on-windows-forms.md). If an existing control does not meet your needs, Windows Forms also supports creating your own custom controls using the <xref:System.Windows.Forms.UserControl> class.  
-  
- Windows Forms has rich UI controls that emulate features in high-end applications like Microsoft Office. Using the <xref:System.Windows.Forms.ToolStrip> and <xref:System.Windows.Forms.MenuStrip> control, you can create toolbars and menus that contain text and images, display submenus, and host other controls such as text boxes and combo boxes.  
-  
- With the Visual Studio drag-and-drop forms designer, you can easily create Windows Forms applications: just select the controls with your cursor and place them where you want on the form. The designer provides tools such as grid lines and "snap lines" to take the hassle out of aligning controls. And whether you use Visual Studio or compile at the command line, you can use the <xref:System.Windows.Forms.FlowLayoutPanel>, <xref:System.Windows.Forms.TableLayoutPanel> and <xref:System.Windows.Forms.SplitContainer> controls to create advanced form layouts with minimal time and effort.  
-  
-### Custom UI Elements  
- Finally, if you must create your own custom UI elements, the <xref:System.Drawing> namespace contains all of the classes you need to render lines, circles, and other shapes directly on a form.  
-  
- For step-by-step information about using these features, see the following Help topics.  
-  
-|To|See|  
-|--------|---------|  
-|Create a new Windows Forms application with Visual Studio|[Tutorial 1: Create a picture viewer](/visualstudio/ide/tutorial-1-create-a-picture-viewer)|  
-|Use controls on forms|[How to: Add Controls to Windows Forms](../../../framework/winforms/controls/how-to-add-controls-to-windows-forms.md)|   
-|Create graphics with <xref:System.Drawing>|[Getting Started with Graphics Programming](../../../framework/winforms/advanced/getting-started-with-graphics-programming.md)|  
-|Create custom controls|[How to: Inherit from the UserControl Class](../../../framework/winforms/controls/how-to-inherit-from-the-usercontrol-class.md)|  
-  
-## Displaying and Manipulating Data  
- Many applications must display data from a database, XML file, XML Web service, or other data source. Windows Forms provides a flexible control called the <xref:System.Windows.Forms.DataGridView> control for rendering such tabular data in a traditional row and column format, so that every piece of data occupies its own cell. Using <xref:System.Windows.Forms.DataGridView> you can customize the appearance of individual cells, lock arbitrary rows and columns in place, and display complex controls inside cells, among other features.  
-  
- Connecting to data sources over a network is a simple task with Windows Forms smart clients. The <xref:System.Windows.Forms.BindingSource> component, new with Windows Forms in Visual Studio 2005 and the .NET Framework 2.0, represents a connection to a data source, and exposes methods for binding data to controls, navigating to the previous and next records, editing records, and saving changes back to the original source. The <xref:System.Windows.Forms.BindingNavigator> control provides a simple interface over the <xref:System.Windows.Forms.BindingSource> component for users to navigate between records.  
-  
-### Data-Bound Controls  
- You can create data-bound controls easily using the Data Sources window, which displays data sources such as databases, Web services, and objects in your project. You can create data-bound controls by dragging items from this window onto forms in your project. You can also data-bind existing controls to data by dragging objects from the Data Sources window onto existing controls.  
-  
-### Settings  
- Another type of data binding you can manage in Windows Forms is settings. Most smart-client applications must retain some information about their run-time state, such as the last-known size of forms, and retain user-preference data, such as default locations for saved files. The application-settings feature addresses these requirements by providing an easy way to store both types of settings on the client computer. Once defined using either Visual Studio or a code editor, these settings are persisted as XML and automatically read back into memory at run time.  
-  
- For step-by-step information about using these features, see the following Help topics.  
-  
-|To|See|  
-|--------|---------|  
-|Use the <xref:System.Windows.Forms.BindingSource> component|[How to: Bind Windows Forms Controls with the BindingSource Component Using the Designer](../../../framework/winforms/controls/bind-wf-controls-with-the-bindingsource.md)|  
+
+An important part of Visual Basic is the ability to create Windows Forms applications that run locally on users' computers. You can use Visual Studio to create the application and user interface using Windows Forms. A Windows Forms application is built on classes from the <xref:System.Windows.Forms> namespace.
+
+## Designing Windows Forms Applications
+
+You can create Windows Forms and Windows service applications with Visual Studio. For more information, see the following topics:
+
+- [Getting Started with Windows Forms](../../../framework/winforms/getting-started-with-windows-forms.md). Provides information on how to create and program Windows Forms.
+
+- [Windows Forms Controls](../../../framework/winforms/controls/index.md). Collection of topics detailing the use of Windows Forms controls.
+
+- [Windows Service Applications](../../../framework/windows-services/index.md). Lists topics that explain how to create Windows services.
+
+## Building Rich, Interactive User Interfaces
+
+Windows Forms is the smart-client component of the .NET Framework, a set of managed libraries that enable common application tasks such as reading and writing to the file system. Using a development environment like Visual Studio, you can create Windows Forms applications that display information, request input from users, and communicate with remote computers over a network.
+
+In Windows Forms, a form is a visual surface on which you display information to the user. You commonly build Windows Forms applications by placing controls on forms and developing responses to user actions, such as mouse clicks or key presses. A *control* is a discrete user interface (UI) element that displays data or accepts data input.
+
+### Events
+
+When a user does something to your form or one of its controls, it generates an event. Your application reacts to these events by using code, and processes the events when they occur. For more information, see [Creating Event Handlers in Windows Forms](../../../framework/winforms/creating-event-handlers-in-windows-forms.md).
+
+### Controls
+
+Windows Forms contains a variety of controls that you can place on forms: controls that display text boxes, buttons, drop-down boxes, radio buttons, and even Web pages. For a list of all the controls you can use on a form, see [Controls to Use on Windows Forms](../../../framework/winforms/controls/controls-to-use-on-windows-forms.md). If an existing control does not meet your needs, Windows Forms also supports creating your own custom controls using the <xref:System.Windows.Forms.UserControl> class.
+
+Windows Forms has rich UI controls that emulate features in high-end applications like Microsoft Office. Using the <xref:System.Windows.Forms.ToolStrip> and <xref:System.Windows.Forms.MenuStrip> control, you can create toolbars and menus that contain text and images, display submenus, and host other controls such as text boxes and combo boxes.
+
+With the Visual Studio drag-and-drop forms designer, you can easily create Windows Forms applications: just select the controls with your cursor and place them where you want on the form. The designer provides tools such as grid lines and "snap lines" to take the hassle out of aligning controls. And whether you use Visual Studio or compile at the command line, you can use the <xref:System.Windows.Forms.FlowLayoutPanel>, <xref:System.Windows.Forms.TableLayoutPanel> and <xref:System.Windows.Forms.SplitContainer> controls to create advanced form layouts with minimal time and effort.
+
+### Custom UI Elements
+
+Finally, if you must create your own custom UI elements, the <xref:System.Drawing> namespace contains all of the classes you need to render lines, circles, and other shapes directly on a form.
+
+For step-by-step information about using these features, see the following Help topics.
+
+|To|See|
+|--------|---------|
+|Create a new Windows Forms application with Visual Studio|[Tutorial 1: Create a picture viewer](/visualstudio/ide/tutorial-1-create-a-picture-viewer)|
+|Use controls on forms|[How to: Add Controls to Windows Forms](../../../framework/winforms/controls/how-to-add-controls-to-windows-forms.md)|
+|Create graphics with <xref:System.Drawing>|[Getting Started with Graphics Programming](../../../framework/winforms/advanced/getting-started-with-graphics-programming.md)|
+|Create custom controls|[How to: Inherit from the UserControl Class](../../../framework/winforms/controls/how-to-inherit-from-the-usercontrol-class.md)|
+
+## Displaying and Manipulating Data
+
+Many applications must display data from a database, XML file, XML Web service, or other data source. Windows Forms provides a flexible control called the <xref:System.Windows.Forms.DataGridView> control for rendering such tabular data in a traditional row and column format, so that every piece of data occupies its own cell. Using <xref:System.Windows.Forms.DataGridView> you can customize the appearance of individual cells, lock arbitrary rows and columns in place, and display complex controls inside cells, among other features.
+
+Connecting to data sources over a network is a simple task with Windows Forms smart clients. The <xref:System.Windows.Forms.BindingSource> component, new with Windows Forms in Visual Studio 2005 and the .NET Framework 2.0, represents a connection to a data source, and exposes methods for binding data to controls, navigating to the previous and next records, editing records, and saving changes back to the original source. The <xref:System.Windows.Forms.BindingNavigator> control provides a simple interface over the <xref:System.Windows.Forms.BindingSource> component for users to navigate between records.
+
+### Data-Bound Controls
+
+You can create data-bound controls easily using the Data Sources window, which displays data sources such as databases, Web services, and objects in your project. You can create data-bound controls by dragging items from this window onto forms in your project. You can also data-bind existing controls to data by dragging objects from the Data Sources window onto existing controls.
+
+### Settings
+
+Another type of data binding you can manage in Windows Forms is settings. Most smart-client applications must retain some information about their run-time state, such as the last-known size of forms, and retain user-preference data, such as default locations for saved files. The application-settings feature addresses these requirements by providing an easy way to store both types of settings on the client computer. Once defined using either Visual Studio or a code editor, these settings are persisted as XML and automatically read back into memory at run time.
+
+For step-by-step information about using these features, see the following Help topics.
+
+|To|See|
+|--------|---------|
+|Use the <xref:System.Windows.Forms.BindingSource> component|[How to: Bind Windows Forms Controls with the BindingSource Component Using the Designer](../../../framework/winforms/controls/bind-wf-controls-with-the-bindingsource.md)|
 |Work with ADO.NET data sources|[How to: Sort and Filter ADO.NET Data with the Windows Forms BindingSource Component](../../../framework/winforms/controls/sort-and-filter-ado-net-data-with-wf-bindingsource-component.md)|
-|Use the Data Sources window|[Walkthrough: Displaying Data on a Windows Form](/visualstudio/data-tools/accessing-data-in-visual-studio)|  
-  
-## Deploying Applications to Client Computers  
- Once you have written your application, you must send it to your users so that they can install and run it on their own client computers. Using the ClickOnce technology, you can deploy your applications from within Visual Studio by using just a few clicks and provide users with a URL pointing to your application on the Web. ClickOnce manages all of the elements and dependencies in your application and ensures that the application is properly installed on the client computer.  
-  
- ClickOnce applications can be configured to run only when the user is connected to the network, or to run both online and offline. When you specify that an application should support offline operation, ClickOnce adds a link to your application in the user's **Start** menu, so that the user can open it without using the URL.  
-  
- When you update your application, you publish a new deployment manifest and a new copy of your application to your Web server. ClickOnce detects that there is an update available and upgrades the user's installation; no custom programming is required to update old assemblies.  
-  
- For a full introduction to ClickOnce, see [ClickOnce Security and Deployment](/visualstudio/deployment/clickonce-security-and-deployment). For step-by-step information about using these features, see the following Help topics:  
-  
-|To|See|  
-|--------|---------|  
-|Deploy an application with ClickOnce|[How to: Publish a ClickOnce Application using the Publish Wizard](/visualstudio/deployment/how-to-publish-a-clickonce-application-using-the-publish-wizard)<br /><br /> [Walkthrough: Manually Deploying a ClickOnce Application](/visualstudio/deployment/walkthrough-manually-deploying-a-clickonce-application)|  
-|Update a ClickOnce deployment|[How to: Manage Updates for a ClickOnce Application](/visualstudio/deployment/how-to-manage-updates-for-a-clickonce-application)|  
-|Manage security with ClickOnce|[How to: Enable ClickOnce Security Settings](/visualstudio/deployment/how-to-enable-clickonce-security-settings)|  
-  
-## Other Controls and Features  
- There are many other features in Windows Forms that make implementing common tasks fast and easy, such as support for creating dialog boxes, printing, adding Help and documentation, and localizing your application to multiple languages. In addition, Windows Forms relies on the robust security system of the .NET Framework, enabling you to release more secure applications to your customers.  
-  
- For step-by-step information about using these features, see the following Help topics:  
-  
-|To|See|  
-|--------|---------|  
-|Print the contents of a form|[How to: Print Graphics in Windows Forms](../../../framework/winforms/advanced/how-to-print-graphics-in-windows-forms.md)<br /><br /> [How to: Print a Multi-Page Text File in Windows Forms](../../../framework/winforms/advanced/how-to-print-a-multi-page-text-file-in-windows-forms.md)|   
-|Learn more about Windows Forms security|[Security in Windows Forms Overview](../../../framework/winforms/security-in-windows-forms-overview.md)|  
-  
+|Use the Data Sources window|[Walkthrough: Displaying Data on a Windows Form](/visualstudio/data-tools/accessing-data-in-visual-studio)|
+
+## Deploying Applications to Client Computers
+
+Once you have written your application, you must send it to your users so that they can install and run it on their own client computers. Using the ClickOnce technology, you can deploy your applications from within Visual Studio by using just a few clicks and provide users with a URL pointing to your application on the Web. ClickOnce manages all of the elements and dependencies in your application and ensures that the application is properly installed on the client computer.
+
+ClickOnce applications can be configured to run only when the user is connected to the network, or to run both online and offline. When you specify that an application should support offline operation, ClickOnce adds a link to your application in the user's **Start** menu, so that the user can open it without using the URL.
+
+When you update your application, you publish a new deployment manifest and a new copy of your application to your Web server. ClickOnce detects that there is an update available and upgrades the user's installation; no custom programming is required to update old assemblies.
+
+For a full introduction to ClickOnce, see [ClickOnce Security and Deployment](/visualstudio/deployment/clickonce-security-and-deployment). For step-by-step information about using these features, see the following Help topics:
+
+|To|See|
+|--------|---------|
+|Deploy an application with ClickOnce|[How to: Publish a ClickOnce Application using the Publish Wizard](/visualstudio/deployment/how-to-publish-a-clickonce-application-using-the-publish-wizard)<br /><br /> [Walkthrough: Manually Deploying a ClickOnce Application](/visualstudio/deployment/walkthrough-manually-deploying-a-clickonce-application)|
+|Update a ClickOnce deployment|[How to: Manage Updates for a ClickOnce Application](/visualstudio/deployment/how-to-manage-updates-for-a-clickonce-application)|
+|Manage security with ClickOnce|[How to: Enable ClickOnce Security Settings](/visualstudio/deployment/how-to-enable-clickonce-security-settings)|
+
+## Other Controls and Features
+
+There are many other features in Windows Forms that make implementing common tasks fast and easy, such as support for creating dialog boxes, printing, adding Help and documentation, and localizing your application to multiple languages. In addition, Windows Forms relies on the robust security system of the .NET Framework, enabling you to release more secure applications to your customers.
+
+For step-by-step information about using these features, see the following Help topics:
+
+|To|See|
+|--------|---------|
+|Print the contents of a form|[How to: Print Graphics in Windows Forms](../../../framework/winforms/advanced/how-to-print-graphics-in-windows-forms.md)<br /><br /> [How to: Print a Multi-Page Text File in Windows Forms](../../../framework/winforms/advanced/how-to-print-a-multi-page-text-file-in-windows-forms.md)|
+|Learn more about Windows Forms security|[Security in Windows Forms Overview](../../../framework/winforms/security-in-windows-forms-overview.md)|
+
 ## See also
 
 - <xref:Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase>

--- a/docs/visual-basic/language-reference/error-messages/because-this-call-is-not-awaited-the-current-method-continues-to-run.md
+++ b/docs/visual-basic/language-reference/error-messages/because-this-call-is-not-awaited-the-current-method-continues-to-run.md
@@ -1,202 +1,204 @@
 ---
 title: "Because this call is not awaited, the current method continues to run before the call is completed"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "bc42358"
   - "vbc42358"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BC42358"
 ms.assetid: 43342515-c3c8-4155-9263-c302afabcbc2
 ---
 # Because this call is not awaited, the current method continues to run before the call is completed
-Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'Await' operator to the result of the call.  
-  
- The current method calls an async method that returns a <xref:System.Threading.Tasks.Task> or a <xref:System.Threading.Tasks.Task%601> and doesn’t apply the [Await](../../../visual-basic/language-reference/operators/await-operator.md) operator to the result. The call to the async method starts an asynchronous task. However, because no `Await` operator is applied, the program continues without waiting for the task to complete. In most cases, that behavior isn't expected. Usually other aspects of the calling method depend on the results of the call or, minimally, the called method is expected to complete before you return from the method that contains the call.  
-  
- An equally important issue is what happens with exceptions that are raised in the called async method. An exception that’s raised in a method that returns a <xref:System.Threading.Tasks.Task> or  <xref:System.Threading.Tasks.Task%601> is stored in the returned task. If you don't await the task or explicitly check for exceptions, the exception is lost. If you await the task, its exception is rethrown.  
-  
- As a best practice, you should always await the call.  
-  
- By default, this message is a warning. For more information about hiding warnings or treating warnings as errors, see [Configuring Warnings in Visual Basic](/visualstudio/ide/configuring-warnings-in-visual-basic).  
-  
- **Error ID:** BC42358  
-  
-### To address this warning  
-  
-- You should consider suppressing the warning only if you're sure that you don't want to wait for the asynchronous call to complete and that the called method won't raise any exceptions. In that case, you can suppress the warning by assigning the task result of the call to a variable.  
-  
-     The following example shows how to cause the warning, how to suppress it, and how to await the call.  
-  
-    ```vb  
-    Async Function CallingMethodAsync() As Task  
-  
-        ResultsTextBox.Text &= vbCrLf & "  Entering calling method."  
-  
-        ' Variable delay is used to slow down the called method so that you  
-        ' can distinguish between awaiting and not awaiting in the program's output.   
-        ' You can adjust the value to produce the output that this topic shows   
-        ' after the code.  
-        Dim delay = 5000  
-  
-        ' Call #1.  
-        ' Call an async method. Because you don't await it, its completion isn't   
-        ' coordinated with the current method, CallingMethodAsync.  
-        ' The following line causes the warning.  
-        CalledMethodAsync(delay)  
-  
-        ' Call #2.  
-        ' To suppress the warning without awaiting, you can assign the   
-        ' returned task to a variable. The assignment doesn't change how  
-        ' the program runs. However, the recommended practice is always to  
-        ' await a call to an async method.  
-        ' Replace Call #1 with the following line.  
-        'Task delayTask = CalledMethodAsync(delay)  
-  
-        ' Call #3  
-        ' To contrast with an awaited call, replace the unawaited call   
-        ' (Call #1 or Call #2) with the following awaited call. The best   
-        ' practice is to await the call.  
-  
-        'Await CalledMethodAsync(delay)  
-  
-        ' If the call to CalledMethodAsync isn't awaited, CallingMethodAsync  
-        ' continues to run and, in this example, finishes its work and returns  
-        ' to its caller.  
-        ResultsTextBox.Text &= vbCrLf & "  Returning from calling method."  
-    End Function  
-  
-    Async Function CalledMethodAsync(howLong As Integer) As Task  
-  
-        ResultsTextBox.Text &= vbCrLf & "    Entering called method, starting and awaiting Task.Delay."  
-        ' Slow the process down a little so you can distinguish between awaiting  
-        ' and not awaiting. Adjust the value for howLong if necessary.  
-        Await Task.Delay(howLong)  
-        ResultsTextBox.Text &= vbCrLf & "    Task.Delay is finished--returning from called method."  
-    End Function  
-    ```  
-  
-     In the example, if you choose Call #1 or Call #2, the unawaited async method (`CalledMethodAsync`) finishes after both its caller (`CallingMethodAsync`) and the caller's caller (`StartButton_Click`) are complete. The last line in the following output shows you when the called method finishes. Entry to and exit from the event handler that calls `CallingMethodAsync` in the full example are marked in the output.  
-  
-    ```console  
-    Entering the Click event handler.  
-      Entering calling method.  
-        Entering called method, starting and awaiting Task.Delay.  
-      Returning from calling method.  
-    Exiting the Click event handler.  
-        Task.Delay is finished--returning from called method.  
-    ```  
-  
-## Example  
- The following Windows Presentation Foundation (WPF) application contains the methods from the previous example. The following steps set up the application.  
-  
-1. Create a WPF application, and name it `AsyncWarning`.  
-  
-2. In the Visual Studio Code Editor, choose the **MainWindow.xaml** tab.  
-  
-     If the tab isn't visible, open the shortcut menu for MainWindow.xaml in **Solution Explorer**, and then choose **View Code**.  
-  
-3. Replace the code in the **XAML** view of MainWindow.xaml with the following code.  
-  
-    ```vb  
-    <Window x:Class="MainWindow"  
-            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"  
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"  
-            Title="MainWindow" Height="350" Width="525">  
-        <Grid>  
-            <Button x:Name="StartButton" Content="Start" HorizontalAlignment="Left" Margin="214,28,0,0" VerticalAlignment="Top" Width="75" HorizontalContentAlignment="Center" FontWeight="Bold" FontFamily="Aharoni" Click="StartButton_Click" />  
-            <TextBox x:Name="ResultsTextBox" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Lucida Console"/>  
-        </Grid>  
-    </Window>  
-    ```  
-  
-     A simple window that contains a button and a text box appears in the **Design** view of MainWindow.xaml.  
-  
-     For more information about the XAML Designer, see [Creating a UI by using XAML Designer](/visualstudio/designers/creating-a-ui-by-using-xaml-designer-in-visual-studio). For information about how to build your own simple UI, see the "To create a WPF application" and "To design a simple WPF MainWindow" sections of [Walkthrough: Accessing the Web by Using Async and Await](../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md).  
-  
-4. Replace the code in MainWindow.xaml.vb with the following code.  
-  
-    ```vb  
-    Class MainWindow   
-  
-        Private Async Sub StartButton_Click(sender As Object, e As RoutedEventArgs)  
-  
-            ResultsTextBox.Text &= vbCrLf & "Entering the Click event handler."  
-            Await CallingMethodAsync()  
-            ResultsTextBox.Text &= vbCrLf & "Exiting the Click event handler."  
-        End Sub  
-  
-        Async Function CallingMethodAsync() As Task  
-  
-            ResultsTextBox.Text &= vbCrLf & "  Entering calling method."  
-  
-            ' Variable delay is used to slow down the called method so that you  
-            ' can distinguish between awaiting and not awaiting in the program's output.   
-            ' You can adjust the value to produce the output that this topic shows   
-            ' after the code.  
-            Dim delay = 5000  
-  
-            ' Call #1.  
-            ' Call an async method. Because you don't await it, its completion isn't   
-            ' coordinated with the current method, CallingMethodAsync.  
-            ' The following line causes the warning.  
-            CalledMethodAsync(delay)  
-  
-            ' Call #2.  
-            ' To suppress the warning without awaiting, you can assign the   
-            ' returned task to a variable. The assignment doesn't change how  
-            ' the program runs. However, the recommended practice is always to  
-            ' await a call to an async method.  
-  
-            ' Replace Call #1 with the following line.  
-            'Task delayTask = CalledMethodAsync(delay)  
-  
-            ' Call #3  
-            ' To contrast with an awaited call, replace the unawaited call   
-            ' (Call #1 or Call #2) with the following awaited call. The best   
-            ' practice is to await the call.  
-  
-            'Await CalledMethodAsync(delay)  
-  
-            ' If the call to CalledMethodAsync isn't awaited, CallingMethodAsync  
-            ' continues to run and, in this example, finishes its work and returns  
-            ' to its caller.  
-            ResultsTextBox.Text &= vbCrLf & "  Returning from calling method."  
-        End Function  
-  
-        Async Function CalledMethodAsync(howLong As Integer) As Task  
-  
-            ResultsTextBox.Text &= vbCrLf & "    Entering called method, starting and awaiting Task.Delay."  
-            ' Slow the process down a little so you can distinguish between awaiting  
-            ' and not awaiting. Adjust the value for howLong if necessary.  
-            Await Task.Delay(howLong)  
-            ResultsTextBox.Text &= vbCrLf & "    Task.Delay is finished--returning from called method."  
-        End Function  
-  
-    End Class  
-  
-    ' Output  
-  
-    ' Entering the Click event handler.  
-    '   Entering calling method.  
-    '     Entering called method, starting and awaiting Task.Delay.  
-    '   Returning from calling method.  
-    ' Exiting the Click event handler.  
-    '     Task.Delay is finished--returning from called method.  
-  
-    ' Output  
-  
-    ' Entering the Click event handler.  
-    '   Entering calling method.  
-    '     Entering called method, starting and awaiting Task.Delay.  
-    '     Task.Delay is finished--returning from called method.  
-    '   Returning from calling method.  
-    ' Exiting the Click event handler.  
-    ```  
-  
-5. Choose the F5 key to run the program, and then choose the **Start** button.  
-  
-     The expected output appears at the end of the code.  
-  
+
+Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'Await' operator to the result of the call.
+
+The current method calls an async method that returns a <xref:System.Threading.Tasks.Task> or a <xref:System.Threading.Tasks.Task%601> and doesn’t apply the [Await](../../../visual-basic/language-reference/operators/await-operator.md) operator to the result. The call to the async method starts an asynchronous task. However, because no `Await` operator is applied, the program continues without waiting for the task to complete. In most cases, that behavior isn't expected. Usually other aspects of the calling method depend on the results of the call or, minimally, the called method is expected to complete before you return from the method that contains the call.
+
+An equally important issue is what happens with exceptions that are raised in the called async method. An exception that’s raised in a method that returns a <xref:System.Threading.Tasks.Task> or  <xref:System.Threading.Tasks.Task%601> is stored in the returned task. If you don't await the task or explicitly check for exceptions, the exception is lost. If you await the task, its exception is rethrown.
+
+As a best practice, you should always await the call.
+
+By default, this message is a warning. For more information about hiding warnings or treating warnings as errors, see [Configuring Warnings in Visual Basic](/visualstudio/ide/configuring-warnings-in-visual-basic).
+
+**Error ID:** BC42358
+
+### To address this warning
+
+- You should consider suppressing the warning only if you're sure that you don't want to wait for the asynchronous call to complete and that the called method won't raise any exceptions. In that case, you can suppress the warning by assigning the task result of the call to a variable.
+
+     The following example shows how to cause the warning, how to suppress it, and how to await the call.
+
+    ```vb
+    Async Function CallingMethodAsync() As Task
+
+        ResultsTextBox.Text &= vbCrLf & "  Entering calling method."
+
+        ' Variable delay is used to slow down the called method so that you
+        ' can distinguish between awaiting and not awaiting in the program's output.
+        ' You can adjust the value to produce the output that this topic shows
+        ' after the code.
+        Dim delay = 5000
+
+        ' Call #1.
+        ' Call an async method. Because you don't await it, its completion isn't
+        ' coordinated with the current method, CallingMethodAsync.
+        ' The following line causes the warning.
+        CalledMethodAsync(delay)
+
+        ' Call #2.
+        ' To suppress the warning without awaiting, you can assign the
+        ' returned task to a variable. The assignment doesn't change how
+        ' the program runs. However, the recommended practice is always to
+        ' await a call to an async method.
+        ' Replace Call #1 with the following line.
+        'Task delayTask = CalledMethodAsync(delay)
+
+        ' Call #3
+        ' To contrast with an awaited call, replace the unawaited call
+        ' (Call #1 or Call #2) with the following awaited call. The best
+        ' practice is to await the call.
+
+        'Await CalledMethodAsync(delay)
+
+        ' If the call to CalledMethodAsync isn't awaited, CallingMethodAsync
+        ' continues to run and, in this example, finishes its work and returns
+        ' to its caller.
+        ResultsTextBox.Text &= vbCrLf & "  Returning from calling method."
+    End Function
+
+    Async Function CalledMethodAsync(howLong As Integer) As Task
+
+        ResultsTextBox.Text &= vbCrLf & "    Entering called method, starting and awaiting Task.Delay."
+        ' Slow the process down a little so you can distinguish between awaiting
+        ' and not awaiting. Adjust the value for howLong if necessary.
+        Await Task.Delay(howLong)
+        ResultsTextBox.Text &= vbCrLf & "    Task.Delay is finished--returning from called method."
+    End Function
+    ```
+
+     In the example, if you choose Call #1 or Call #2, the unawaited async method (`CalledMethodAsync`) finishes after both its caller (`CallingMethodAsync`) and the caller's caller (`StartButton_Click`) are complete. The last line in the following output shows you when the called method finishes. Entry to and exit from the event handler that calls `CallingMethodAsync` in the full example are marked in the output.
+
+    ```console
+    Entering the Click event handler.
+      Entering calling method.
+        Entering called method, starting and awaiting Task.Delay.
+      Returning from calling method.
+    Exiting the Click event handler.
+        Task.Delay is finished--returning from called method.
+    ```
+
+## Example
+
+The following Windows Presentation Foundation (WPF) application contains the methods from the previous example. The following steps set up the application.
+
+1. Create a WPF application, and name it `AsyncWarning`.
+
+2. In the Visual Studio Code Editor, choose the **MainWindow.xaml** tab.
+
+     If the tab isn't visible, open the shortcut menu for MainWindow.xaml in **Solution Explorer**, and then choose **View Code**.
+
+3. Replace the code in the **XAML** view of MainWindow.xaml with the following code.
+
+    ```vb
+    <Window x:Class="MainWindow"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            Title="MainWindow" Height="350" Width="525">
+        <Grid>
+            <Button x:Name="StartButton" Content="Start" HorizontalAlignment="Left" Margin="214,28,0,0" VerticalAlignment="Top" Width="75" HorizontalContentAlignment="Center" FontWeight="Bold" FontFamily="Aharoni" Click="StartButton_Click" />
+            <TextBox x:Name="ResultsTextBox" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Lucida Console"/>
+        </Grid>
+    </Window>
+    ```
+
+     A simple window that contains a button and a text box appears in the **Design** view of MainWindow.xaml.
+
+     For more information about the XAML Designer, see [Creating a UI by using XAML Designer](/visualstudio/designers/creating-a-ui-by-using-xaml-designer-in-visual-studio). For information about how to build your own simple UI, see the "To create a WPF application" and "To design a simple WPF MainWindow" sections of [Walkthrough: Accessing the Web by Using Async and Await](../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md).
+
+4. Replace the code in MainWindow.xaml.vb with the following code.
+
+    ```vb
+    Class MainWindow
+
+        Private Async Sub StartButton_Click(sender As Object, e As RoutedEventArgs)
+
+            ResultsTextBox.Text &= vbCrLf & "Entering the Click event handler."
+            Await CallingMethodAsync()
+            ResultsTextBox.Text &= vbCrLf & "Exiting the Click event handler."
+        End Sub
+
+        Async Function CallingMethodAsync() As Task
+
+            ResultsTextBox.Text &= vbCrLf & "  Entering calling method."
+
+            ' Variable delay is used to slow down the called method so that you
+            ' can distinguish between awaiting and not awaiting in the program's output.
+            ' You can adjust the value to produce the output that this topic shows
+            ' after the code.
+            Dim delay = 5000
+
+            ' Call #1.
+            ' Call an async method. Because you don't await it, its completion isn't
+            ' coordinated with the current method, CallingMethodAsync.
+            ' The following line causes the warning.
+            CalledMethodAsync(delay)
+
+            ' Call #2.
+            ' To suppress the warning without awaiting, you can assign the
+            ' returned task to a variable. The assignment doesn't change how
+            ' the program runs. However, the recommended practice is always to
+            ' await a call to an async method.
+
+            ' Replace Call #1 with the following line.
+            'Task delayTask = CalledMethodAsync(delay)
+
+            ' Call #3
+            ' To contrast with an awaited call, replace the unawaited call
+            ' (Call #1 or Call #2) with the following awaited call. The best
+            ' practice is to await the call.
+
+            'Await CalledMethodAsync(delay)
+
+            ' If the call to CalledMethodAsync isn't awaited, CallingMethodAsync
+            ' continues to run and, in this example, finishes its work and returns
+            ' to its caller.
+            ResultsTextBox.Text &= vbCrLf & "  Returning from calling method."
+        End Function
+
+        Async Function CalledMethodAsync(howLong As Integer) As Task
+
+            ResultsTextBox.Text &= vbCrLf & "    Entering called method, starting and awaiting Task.Delay."
+            ' Slow the process down a little so you can distinguish between awaiting
+            ' and not awaiting. Adjust the value for howLong if necessary.
+            Await Task.Delay(howLong)
+            ResultsTextBox.Text &= vbCrLf & "    Task.Delay is finished--returning from called method."
+        End Function
+
+    End Class
+
+    ' Output
+
+    ' Entering the Click event handler.
+    '   Entering calling method.
+    '     Entering called method, starting and awaiting Task.Delay.
+    '   Returning from calling method.
+    ' Exiting the Click event handler.
+    '     Task.Delay is finished--returning from called method.
+
+    ' Output
+
+    ' Entering the Click event handler.
+    '   Entering calling method.
+    '     Entering called method, starting and awaiting Task.Delay.
+    '     Task.Delay is finished--returning from called method.
+    '   Returning from calling method.
+    ' Exiting the Click event handler.
+    ```
+
+5. Choose the F5 key to run the program, and then choose the **Start** button.
+
+     The expected output appears at the end of the code.
+
 ## See also
 
 - [Await Operator](../../../visual-basic/language-reference/operators/await-operator.md)

--- a/docs/visual-basic/language-reference/error-messages/data-type-s-of-the-type-parameter-s-cannot-be-inferred-from-these-arguments.md
+++ b/docs/visual-basic/language-reference/error-messages/data-type-s-of-the-type-parameter-s-cannot-be-inferred-from-these-arguments.md
@@ -1,56 +1,57 @@
 ---
 title: "Data type(s) of the type parameter(s) cannot be inferred from these arguments"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "bc36644"
   - "bc36647"
   - "vbc36647"
   - "vbc36644"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BC36644"
   - "BC36647"
 ms.assetid: 0e0050f2-2039-4311-b260-f0ebfde84189
 ---
 # Data type(s) of the type parameter(s) cannot be inferred from these arguments
-Data type(s) of the type parameter(s) cannot be inferred from these arguments. Specifying the data type(s) explicitly might correct this error.  
-  
- This error occurs when overload resolution has failed. It occurs as a subordinate message that states why a particular overload candidate has been eliminated. The error message explains that the compiler cannot use type inference to find data types for the type parameters.  
-  
+
+Data type(s) of the type parameter(s) cannot be inferred from these arguments. Specifying the data type(s) explicitly might correct this error.
+
+This error occurs when overload resolution has failed. It occurs as a subordinate message that states why a particular overload candidate has been eliminated. The error message explains that the compiler cannot use type inference to find data types for the type parameters.
+
 > [!NOTE]
-> When specifying arguments is not an option (for example, for query operators in query expressions), the error message appears without the second sentence.  
-  
- The following code demonstrates the error.  
-  
-```vb  
-Module Module1  
-  
-    Sub Main()  
-  
-        '' Not Valid.  
-        'OverloadedGenericMethod("Hello", "World")  
-  
-    End Sub  
-  
-    Sub OverloadedGenericMethod(Of T)(ByVal x As String,   
-                                      ByVal y As InterfaceExample(Of T))  
-    End Sub  
-  
-    Sub OverloadedGenericMethod(Of T, R)(ByVal x As T,   
-                                         ByVal y As InterfaceExample(Of R))  
-    End Sub  
-  
-End Module  
-  
-Interface InterfaceExample(Of T)  
-End Interface  
-```  
-  
- **Error ID:** BC36647 and BC36644  
-  
-## To correct this error  
-  
-- You may be able to specify a data type for the type parameter or parameters instead of relying on type inference.  
-  
+> When specifying arguments is not an option (for example, for query operators in query expressions), the error message appears without the second sentence.
+
+The following code demonstrates the error.
+
+```vb
+Module Module1
+
+    Sub Main()
+
+        '' Not Valid.
+        'OverloadedGenericMethod("Hello", "World")
+
+    End Sub
+
+    Sub OverloadedGenericMethod(Of T)(ByVal x As String,
+                                      ByVal y As InterfaceExample(Of T))
+    End Sub
+
+    Sub OverloadedGenericMethod(Of T, R)(ByVal x As T,
+                                         ByVal y As InterfaceExample(Of R))
+    End Sub
+
+End Module
+
+Interface InterfaceExample(Of T)
+End Interface
+```
+
+**Error ID:** BC36647 and BC36644
+
+## To correct this error
+
+You may be able to specify a data type for the type parameter or parameters instead of relying on type inference.
+
 ## See also
 
 - [Relaxed Delegate Conversion](../../../visual-basic/programming-guide/language-features/delegates/relaxed-delegate-conversion.md)

--- a/docs/visual-basic/language-reference/error-messages/isnot-operand-of-type-can-only-be-compared-to-nothing.md
+++ b/docs/visual-basic/language-reference/error-messages/isnot-operand-of-type-can-only-be-compared-to-nothing.md
@@ -1,32 +1,33 @@
 ---
 title: "'IsNot' operand of type 'typename' can only be compared to 'Nothing', because 'typename' is a nullable type"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "bc32128"
   - "vbc32128"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BC32128"
 ms.assetid: 1155b23a-ad75-4bab-b9da-73f35c767a36
 ---
 # 'IsNot' operand of type 'typename' can only be compared to 'Nothing', because 'typename' is a nullable type
-A variable declared as nullable has been compared to an expression other than `Nothing` using the `IsNot` operator.  
-  
- **Error ID:** BC32128  
-  
-## To correct this error  
-  
-1. To compare a nullable type to an expression other than `Nothing` by using the `IsNot` operator, call the `GetType` method on the nullable type and compare the result to the expression, as shown in the following example.  
-  
-```vb  
-Dim number? As Integer = 5  
-  
-If number IsNot Nothing Then  
-  If number.GetType() IsNot Type.GetType("System.Int32") Then   
-  
-  End If  
-End If  
-```  
-  
+
+A variable declared as nullable has been compared to an expression other than `Nothing` using the `IsNot` operator.
+
+**Error ID:** BC32128
+
+## To correct this error
+
+To compare a nullable type to an expression other than `Nothing` by using the `IsNot` operator, call the `GetType` method on the nullable type and compare the result to the expression, as shown in the following example.
+
+```vb
+Dim number? As Integer = 5
+
+If number IsNot Nothing Then
+  If number.GetType() IsNot Type.GetType("System.Int32") Then
+
+  End If
+End If
+```
+
 ## See also
 
 - [Nullable Value Types](../../../visual-basic/programming-guide/language-features/data-types/nullable-value-types.md)

--- a/docs/visual-basic/language-reference/functions/conversion-functions.md
+++ b/docs/visual-basic/language-reference/functions/conversion-functions.md
@@ -1,7 +1,7 @@
 ---
 title: "Conversion functions (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "conversions [Visual Basic], conversion functions"
   - "conversion functions"
   - "string conversion [Visual Basic], conversion functions"
@@ -16,32 +16,32 @@ ms.assetid: 8a8fb553-a8ac-424e-8103-26eea25eaa71
 
 # Conversion functions (Visual Basic)
 
-<xref:Microsoft.VisualBasic.Strings.Asc%2A>   
-<xref:Microsoft.VisualBasic.Strings.AscW%2A>   
-[CBool Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CByte Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CChar Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CDate Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CDbl Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CDec Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-<xref:Microsoft.VisualBasic.Strings.Chr%2A>   
-<xref:Microsoft.VisualBasic.Strings.ChrW%2A>   
-[CInt Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CLng Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CObj Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CSByte Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CShort Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CSng Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CStr Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CType Function](../../../visual-basic/language-reference/functions/ctype-function.md)   
-[CUInt Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CULng Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-[CUShort Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)   
-<xref:Microsoft.VisualBasic.Strings.Format%2A>   
-<xref:Microsoft.VisualBasic.Conversion.Hex%2A>   
-<xref:Microsoft.VisualBasic.Conversion.Oct%2A>   
-<xref:Microsoft.VisualBasic.Conversion.Str%2A>   
-<xref:Microsoft.VisualBasic.Conversion.Val%2A>
+- <xref:Microsoft.VisualBasic.Strings.Asc%2A>
+- <xref:Microsoft.VisualBasic.Strings.AscW%2A>
+- [CBool Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CByte Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CChar Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CDate Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CDbl Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CDec Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- <xref:Microsoft.VisualBasic.Strings.Chr%2A>
+- <xref:Microsoft.VisualBasic.Strings.ChrW%2A>
+- [CInt Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CLng Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CObj Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CSByte Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CShort Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CSng Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CStr Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CType Function](../../../visual-basic/language-reference/functions/ctype-function.md)
+- [CUInt Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CULng Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- [CUShort Function](../../../visual-basic/language-reference/functions/type-conversion-functions.md)
+- <xref:Microsoft.VisualBasic.Strings.Format%2A>
+- <xref:Microsoft.VisualBasic.Conversion.Hex%2A>
+- <xref:Microsoft.VisualBasic.Conversion.Oct%2A>
+- <xref:Microsoft.VisualBasic.Conversion.Str%2A>
+- <xref:Microsoft.VisualBasic.Conversion.Val%2A>
 
 ## See also
 

--- a/docs/visual-basic/language-reference/modifiers/async.md
+++ b/docs/visual-basic/language-reference/modifiers/async.md
@@ -1,102 +1,105 @@
 ---
 title: "Async (Visual Basic)"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "vb.Async"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Async [Visual Basic]"
   - "Async keyword [Visual Basic]"
 ms.assetid: 1be8b4b5-9689-41b5-bd33-b906bfd53bc5
 ---
 # Async (Visual Basic)
-The `Async` modifier indicates that the method or [lambda expression](../../../visual-basic/programming-guide/language-features/procedures/lambda-expressions.md) that it modifies is asynchronous. Such methods are referred to as *async methods*.  
-  
- An async method provides a convenient way to do potentially long-running work without blocking the caller's thread. The caller of an async method can resume its work without waiting for the async method to finish.  
-  
+
+The `Async` modifier indicates that the method or [lambda expression](../../../visual-basic/programming-guide/language-features/procedures/lambda-expressions.md) that it modifies is asynchronous. Such methods are referred to as *async methods*.
+
+An async method provides a convenient way to do potentially long-running work without blocking the caller's thread. The caller of an async method can resume its work without waiting for the async method to finish.
+
 > [!NOTE]
-> The `Async` and `Await` keywords were introduced in Visual Studio 2012. For an introduction to async programming, see [Asynchronous Programming with Async and Await](../../../visual-basic/programming-guide/concepts/async/index.md).  
-  
- The following example shows the structure of an async method. By convention, async method names end in "Async."  
-  
-```vb  
-Public Async Function ExampleMethodAsync() As Task(Of Integer)  
-    ' . . .  
-  
-    ' At the Await expression, execution in this method is suspended and,  
-    ' if AwaitedProcessAsync has not already finished, control returns  
-    ' to the caller of ExampleMethodAsync. When the awaited task is   
-    ' completed, this method resumes execution.   
-    Dim exampleInt As Integer = Await AwaitedProcessAsync()  
-  
-    ' . . .  
-  
-    ' The return statement completes the task. Any method that is   
-    ' awaiting ExampleMethodAsync can now get the integer result.  
-    Return exampleInt  
-End Function  
-```  
-  
- Typically, a method modified by the `Async` keyword contains at least one [Await](../../../visual-basic/language-reference/modifiers/async.md) expression or statement. The method runs synchronously until it reaches the first `Await`, at which point it suspends until the awaited task completes. In the meantime, control is returned to the caller of the method. If the method doesn’t contain an `Await` expression or statement, the method isn’t suspended and executes as a synchronous method does. A compiler warning alerts you to any async methods that don't contain `Await` because that situation might indicate an error. For more information, see the [compiler error](../../../visual-basic/language-reference/error-messages/because-this-call-is-not-awaited-the-current-method-continues-to-run.md).  
-  
- The `Async` keyword is an unreserved keyword. It is a keyword when it modifies a method or a lambda expression. In all other contexts, it is interpreted as an identifier.  
-  
-## Return Types  
- An async method is either a [Sub](../../../visual-basic/programming-guide/language-features/procedures/sub-procedures.md) procedure, or a [Function](../../../visual-basic/programming-guide/language-features/procedures/function-procedures.md) procedure that has a return type of <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601>. The method cannot declare any [ByRef](../../../visual-basic/language-reference/modifiers/byref.md) parameters.  
-  
- You specify `Task(Of TResult)` for the return type of an async method if the [Return](../../../visual-basic/language-reference/statements/return-statement.md) statement of the method has an operand of type TResult. You use `Task` if no meaningful value is returned when the method is completed. That is, a call to the method returns a `Task`, but when the `Task` is completed, any `Await` statement that's awaiting the `Task` doesn’t produce a result value.  
-  
- Async subroutines are used primarily to define event handlers where a `Sub` procedure is required. The caller of an async subroutine can't await it and can't catch exceptions that the method throws.  
-  
- For more information and examples, see [Async Return Types](../../../visual-basic/programming-guide/concepts/async/async-return-types.md).  
-  
-## Example  
- The following examples show an async event handler, an async lambda expression, and an async method. For a full example that uses these elements, see [Walkthrough: Accessing the Web by Using Async and Await](../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can download the walkthrough code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f).  
-  
-```vb  
-' An event handler must be a Sub procedure.  
-Async Sub button1_Click(sender As Object, e As RoutedEventArgs) Handles button1.Click  
-    textBox1.Clear()  
-    ' SumPageSizesAsync is a method that returns a Task.  
-    Await SumPageSizesAsync()  
-    textBox1.Text = vbCrLf & "Control returned to button1_Click."  
-End Sub  
-  
-' The following async lambda expression creates an equivalent anonymous  
-' event handler.  
-AddHandler button1.Click, Async Sub(sender, e)  
-                              textBox1.Clear()  
-                              ' SumPageSizesAsync is a method that returns a Task.  
-                              Await SumPageSizesAsync()  
-                              textBox1.Text = vbCrLf & "Control returned to button1_Click."  
-                          End Sub  
-  
-' The following async method returns a Task(Of T).  
-' A typical call awaits the Byte array result:  
-'      Dim result As Byte() = Await GetURLContents("https://msdn.com")  
-Private Async Function GetURLContentsAsync(url As String) As Task(Of Byte())  
-  
-    ' The downloaded resource ends up in the variable named content.  
-    Dim content = New MemoryStream()  
-  
-    ' Initialize an HttpWebRequest for the current URL.  
-    Dim webReq = CType(WebRequest.Create(url), HttpWebRequest)  
-  
-    ' Send the request to the Internet resource and wait for  
-    ' the response.  
-    Using response As WebResponse = Await webReq.GetResponseAsync()  
-        ' Get the data stream that is associated with the specified URL.  
-        Using responseStream As Stream = response.GetResponseStream()  
-            ' Read the bytes in responseStream and copy them to content.    
-            ' CopyToAsync returns a Task, not a Task<T>.  
-            Await responseStream.CopyToAsync(content)  
-        End Using  
-    End Using  
-  
-    ' Return the result as a byte array.  
-    Return content.ToArray()  
-End Function  
-```  
-  
+> The `Async` and `Await` keywords were introduced in Visual Studio 2012. For an introduction to async programming, see [Asynchronous Programming with Async and Await](../../../visual-basic/programming-guide/concepts/async/index.md).
+
+The following example shows the structure of an async method. By convention, async method names end in "Async."
+
+```vb
+Public Async Function ExampleMethodAsync() As Task(Of Integer)
+    ' . . .
+
+    ' At the Await expression, execution in this method is suspended and,
+    ' if AwaitedProcessAsync has not already finished, control returns
+    ' to the caller of ExampleMethodAsync. When the awaited task is
+    ' completed, this method resumes execution.
+    Dim exampleInt As Integer = Await AwaitedProcessAsync()
+
+    ' . . .
+
+    ' The return statement completes the task. Any method that is
+    ' awaiting ExampleMethodAsync can now get the integer result.
+    Return exampleInt
+End Function
+```
+
+Typically, a method modified by the `Async` keyword contains at least one [Await](../../../visual-basic/language-reference/modifiers/async.md) expression or statement. The method runs synchronously until it reaches the first `Await`, at which point it suspends until the awaited task completes. In the meantime, control is returned to the caller of the method. If the method doesn’t contain an `Await` expression or statement, the method isn’t suspended and executes as a synchronous method does. A compiler warning alerts you to any async methods that don't contain `Await` because that situation might indicate an error. For more information, see the [compiler error](../../../visual-basic/language-reference/error-messages/because-this-call-is-not-awaited-the-current-method-continues-to-run.md).
+
+The `Async` keyword is an unreserved keyword. It is a keyword when it modifies a method or a lambda expression. In all other contexts, it is interpreted as an identifier.
+
+## Return Types
+
+An async method is either a [Sub](../../../visual-basic/programming-guide/language-features/procedures/sub-procedures.md) procedure, or a [Function](../../../visual-basic/programming-guide/language-features/procedures/function-procedures.md) procedure that has a return type of <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601>. The method cannot declare any [ByRef](../../../visual-basic/language-reference/modifiers/byref.md) parameters.
+
+You specify `Task(Of TResult)` for the return type of an async method if the [Return](../../../visual-basic/language-reference/statements/return-statement.md) statement of the method has an operand of type TResult. You use `Task` if no meaningful value is returned when the method is completed. That is, a call to the method returns a `Task`, but when the `Task` is completed, any `Await` statement that's awaiting the `Task` doesn’t produce a result value.
+
+Async subroutines are used primarily to define event handlers where a `Sub` procedure is required. The caller of an async subroutine can't await it and can't catch exceptions that the method throws.
+
+For more information and examples, see [Async Return Types](../../../visual-basic/programming-guide/concepts/async/async-return-types.md).
+
+## Example
+
+The following examples show an async event handler, an async lambda expression, and an async method. For a full example that uses these elements, see [Walkthrough: Accessing the Web by Using Async and Await](../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can download the walkthrough code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f).
+
+```vb
+' An event handler must be a Sub procedure.
+Async Sub button1_Click(sender As Object, e As RoutedEventArgs) Handles button1.Click
+    textBox1.Clear()
+    ' SumPageSizesAsync is a method that returns a Task.
+    Await SumPageSizesAsync()
+    textBox1.Text = vbCrLf & "Control returned to button1_Click."
+End Sub
+
+' The following async lambda expression creates an equivalent anonymous
+' event handler.
+AddHandler button1.Click, Async Sub(sender, e)
+                              textBox1.Clear()
+                              ' SumPageSizesAsync is a method that returns a Task.
+                              Await SumPageSizesAsync()
+                              textBox1.Text = vbCrLf & "Control returned to button1_Click."
+                          End Sub
+
+' The following async method returns a Task(Of T).
+' A typical call awaits the Byte array result:
+'      Dim result As Byte() = Await GetURLContents("https://msdn.com")
+Private Async Function GetURLContentsAsync(url As String) As Task(Of Byte())
+
+    ' The downloaded resource ends up in the variable named content.
+    Dim content = New MemoryStream()
+
+    ' Initialize an HttpWebRequest for the current URL.
+    Dim webReq = CType(WebRequest.Create(url), HttpWebRequest)
+
+    ' Send the request to the Internet resource and wait for
+    ' the response.
+    Using response As WebResponse = Await webReq.GetResponseAsync()
+        ' Get the data stream that is associated with the specified URL.
+        Using responseStream As Stream = response.GetResponseStream()
+            ' Read the bytes in responseStream and copy them to content.
+            ' CopyToAsync returns a Task, not a Task<T>.
+            Await responseStream.CopyToAsync(content)
+        End Using
+    End Using
+
+    ' Return the result as a byte array.
+    Return content.ToArray()
+End Function
+```
+
 ## See also
 
 - <xref:System.Runtime.CompilerServices.AsyncStateMachineAttribute>

--- a/docs/visual-basic/language-reference/modifiers/protected-friend.md
+++ b/docs/visual-basic/language-reference/modifiers/protected-friend.md
@@ -1,7 +1,7 @@
 ---
 title: "Protected Friend (Visual Basic)"
 ms.date: 05/10/2018
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Protected Friend keyword [Visual Basic]"
   - "Protected Friend keyword [Visual Basic], syntax"
 ---
@@ -14,7 +14,7 @@ The `Protected Friend` keyword combination is a member access modifier. It confe
 
 ## Rules
 
-- **Declaration Context.** You can use `Protected Friend` only at the class level. This means the declaration context for a `Protected` element must be a class, and cannot be a source file, namespace, interface, module, structure, or procedure. 
+**Declaration Context.** You can use `Protected Friend` only at the class level. This means the declaration context for a `Protected` element must be a class, and cannot be a source file, namespace, interface, module, structure, or procedure.
 
 ## See also
 

--- a/docs/visual-basic/misc/bc30241.md
+++ b/docs/visual-basic/misc/bc30241.md
@@ -1,31 +1,31 @@
 ---
 title: "Named argument expected"
 ms.date: 02/01/2018
-f1_keywords: 
+f1_keywords:
   - "bc30241"
   - "vbc30241"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BC30241"
 ms.assetid: d21fe832-814c-4a33-aa31-a1e425924881
 ---
 # Named argument expected
 
-An argument list in a method call passes an argument by name and then an argument by position. By default, all positional arguments must precede any argument passed by name in a method call.  
-  
- **Error ID:** BC30241  
-  
-## To correct this error  
-  
-- If you are compiling with any version of Visual Basic earlier than 15.5, rewrite the argument list to place arguments passed by position ahead of arguments passed by name.  
+An argument list in a method call passes an argument by name and then an argument by position. By default, all positional arguments must precede any argument passed by name in a method call.
+
+**Error ID:** BC30241
+
+## To correct this error
+
+- If you are compiling with any version of Visual Basic earlier than 15.5, rewrite the argument list to place arguments passed by position ahead of arguments passed by name.
 
 - If you are compiling with Visual Basic 15.5 or later, add the following `<PropertyGroup>` element to your \*.vbproj project file:
- 
+
    ```xml
    <PropertyGroup>
     <LangVersion>15.5</LangVersion>
    </PropertyGroup>
-   ```  
-  
+   ```
+
 ## See also
 
 - [Passing Arguments by Position and by Name](../../visual-basic/programming-guide/language-features/procedures/passing-arguments-by-position-and-by-name.md)

--- a/docs/visual-basic/programming-guide/concepts/async/async-return-types.md
+++ b/docs/visual-basic/programming-guide/concepts/async/async-return-types.md
@@ -4,288 +4,293 @@ ms.date: 07/20/2015
 ms.assetid: 07890291-ee72-42d3-932a-fa4d312f2c60
 ---
 # Async Return Types (Visual Basic)
-Async methods have three possible return types: <xref:System.Threading.Tasks.Task%601>, <xref:System.Threading.Tasks.Task>, and void. In Visual Basic, the void return type is written as a [Sub](../../../../visual-basic/programming-guide/language-features/procedures/sub-procedures.md) procedure. For more information about async methods, see [Asynchronous Programming with Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/index.md).  
-  
- Each return type is examined in one of the following sections, and you can find a full example that uses all three types at the end of the topic.  
-  
+
+Async methods have three possible return types: <xref:System.Threading.Tasks.Task%601>, <xref:System.Threading.Tasks.Task>, and void. In Visual Basic, the void return type is written as a [Sub](../../../../visual-basic/programming-guide/language-features/procedures/sub-procedures.md) procedure. For more information about async methods, see [Asynchronous Programming with Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/index.md).
+
+Each return type is examined in one of the following sections, and you can find a full example that uses all three types at the end of the topic.
+
 > [!NOTE]
-> To run the example, you must have Visual Studio 2012 or newer and the .NET Framework 4.5 or newer installed on your computer.  
-  
-## <a name="BKMK_TaskTReturnType"></a> Task(T) Return Type  
- The <xref:System.Threading.Tasks.Task%601> return type is used for an async method that contains a [Return](../../../../visual-basic/language-reference/statements/return-statement.md) statement in which the operand has type `TResult`.  
-  
- In the following example, the `TaskOfT_MethodAsync` async method contains a return statement that returns an integer. Therefore, the method declaration must specify a return type of `Task(Of Integer)`.  
-  
-```vb  
-' TASK(OF T) EXAMPLE  
-Async Function TaskOfT_MethodAsync() As Task(Of Integer)  
-  
-    ' The body of an async method is expected to contain an awaited   
-    ' asynchronous call.  
-    ' Task.FromResult is a placeholder for actual work that returns a string.  
-    Dim today As String = Await Task.FromResult(Of String)(DateTime.Now.DayOfWeek.ToString())  
-  
-    ' The method then can process the result in some way.  
-    Dim leisureHours As Integer  
-    If today.First() = "S" Then  
-        leisureHours = 16  
-    Else  
-        leisureHours = 5  
-    End If  
-  
-    ' Because the return statement specifies an operand of type Integer, the   
-    ' method must have a return type of Task(Of Integer).   
-    Return leisureHours  
-End Function  
-```  
-  
- When `TaskOfT_MethodAsync` is called from within an await expression, the await expression retrieves the integer value (the value of `leisureHours`) that's stored in the task that's returned by `TaskOfT_MethodAsync`. For more information about await expressions, see [Await Operator](../../../../visual-basic/language-reference/operators/await-operator.md).  
-  
- The following code calls and awaits method `TaskOfT_MethodAsync`. The result is assigned to the `result1` variable.  
-  
-```vb  
-' Call and await the Task(Of T)-returning async method in the same statement.  
-Dim result1 As Integer = Await TaskOfT_MethodAsync()  
-```  
-  
- You can better understand how this happens by separating the call to `TaskOfT_MethodAsync` from the application of `Await`, as the following code shows. A call to method `TaskOfT_MethodAsync` that isn't immediately awaited returns a `Task(Of Integer)`, as you would expect from the declaration of the method. The task is assigned to the `integerTask` variable in the example. Because `integerTask` is a <xref:System.Threading.Tasks.Task%601>, it contains a <xref:System.Threading.Tasks.Task%601.Result> property of type `TResult`. In this case, TResult represents an integer type. When `Await` is applied to `integerTask`, the await expression evaluates to the contents of the <xref:System.Threading.Tasks.Task%601.Result%2A> property of `integerTask`. The value is assigned to the `result2` variable.  
-  
+> To run the example, you must have Visual Studio 2012 or newer and the .NET Framework 4.5 or newer installed on your computer.
+
+## <a name="BKMK_TaskTReturnType"></a> Task(T) Return Type
+
+The <xref:System.Threading.Tasks.Task%601> return type is used for an async method that contains a [Return](../../../../visual-basic/language-reference/statements/return-statement.md) statement in which the operand has type `TResult`.
+
+In the following example, the `TaskOfT_MethodAsync` async method contains a return statement that returns an integer. Therefore, the method declaration must specify a return type of `Task(Of Integer)`.
+
+```vb
+' TASK(OF T) EXAMPLE
+Async Function TaskOfT_MethodAsync() As Task(Of Integer)
+
+    ' The body of an async method is expected to contain an awaited
+    ' asynchronous call.
+    ' Task.FromResult is a placeholder for actual work that returns a string.
+    Dim today As String = Await Task.FromResult(Of String)(DateTime.Now.DayOfWeek.ToString())
+
+    ' The method then can process the result in some way.
+    Dim leisureHours As Integer
+    If today.First() = "S" Then
+        leisureHours = 16
+    Else
+        leisureHours = 5
+    End If
+
+    ' Because the return statement specifies an operand of type Integer, the
+    ' method must have a return type of Task(Of Integer).
+    Return leisureHours
+End Function
+```
+
+When `TaskOfT_MethodAsync` is called from within an await expression, the await expression retrieves the integer value (the value of `leisureHours`) that's stored in the task that's returned by `TaskOfT_MethodAsync`. For more information about await expressions, see [Await Operator](../../../../visual-basic/language-reference/operators/await-operator.md).
+
+The following code calls and awaits method `TaskOfT_MethodAsync`. The result is assigned to the `result1` variable.
+
+```vb
+' Call and await the Task(Of T)-returning async method in the same statement.
+Dim result1 As Integer = Await TaskOfT_MethodAsync()
+```
+
+You can better understand how this happens by separating the call to `TaskOfT_MethodAsync` from the application of `Await`, as the following code shows. A call to method `TaskOfT_MethodAsync` that isn't immediately awaited returns a `Task(Of Integer)`, as you would expect from the declaration of the method. The task is assigned to the `integerTask` variable in the example. Because `integerTask` is a <xref:System.Threading.Tasks.Task%601>, it contains a <xref:System.Threading.Tasks.Task%601.Result> property of type `TResult`. In this case, TResult represents an integer type. When `Await` is applied to `integerTask`, the await expression evaluates to the contents of the <xref:System.Threading.Tasks.Task%601.Result%2A> property of `integerTask`. The value is assigned to the `result2` variable.
+
 > [!WARNING]
-> The <xref:System.Threading.Tasks.Task%601.Result%2A> property is a blocking property. If you try to access it before its task is finished, the thread that's currently active is blocked until the task completes and the value is available. In most cases, you should access the value by using `Await` instead of accessing the property directly.  
-  
-```vb  
-' Call and await in separate statements.  
-Dim integerTask As Task(Of Integer) = TaskOfT_MethodAsync()  
-  
-' You can do other work that does not rely on resultTask before awaiting.  
-textBox1.Text &= String.Format("Application can continue working while the Task(Of T) runs. . . . " & vbCrLf)  
-  
-Dim result2 As Integer = Await integerTask  
-```  
-  
- The display statements in the following code verify that the values of the `result1` variable, the `result2` variable, and the `Result` property are the same. Remember that the `Result` property is a blocking property and shouldn't be accessed before its task has been awaited.  
-  
-```vb  
-' Display the values of the result1 variable, the result2 variable, and  
-' the resultTask.Result property.  
-textBox1.Text &= String.Format(vbCrLf & "Value of result1 variable:   {0}" & vbCrLf, result1)  
-textBox1.Text &= String.Format("Value of result2 variable:   {0}" & vbCrLf, result2)  
-textBox1.Text &= String.Format("Value of resultTask.Result:  {0}" & vbCrLf, integerTask.Result)  
-```  
-  
-## <a name="BKMK_TaskReturnType"></a> Task Return Type  
- Async methods that don't contain a return statement or that contain a return statement that doesn't return an operand usually have a return type of <xref:System.Threading.Tasks.Task>. Such methods would be [Sub](../../../../visual-basic/programming-guide/language-features/procedures/sub-procedures.md) procedures if they were written to run synchronously. If you use a `Task` return type for an async method, a calling method can use an `Await` operator to suspend the caller's completion until the called async method has finished.  
-  
- In the following example, async method `Task_MethodAsync` doesn't contain a return statement. Therefore, you specify a return type of `Task` for the method, which enables `Task_MethodAsync` to be awaited. The definition of the `Task` type doesn't include a `Result` property to store a return value.  
-  
-```vb  
-' TASK EXAMPLE  
-Async Function Task_MethodAsync() As Task  
-  
-    ' The body of an async method is expected to contain an awaited   
-    ' asynchronous call.  
-    ' Task.Delay is a placeholder for actual work.  
-    Await Task.Delay(2000)  
-    textBox1.Text &= String.Format(vbCrLf & "Sorry for the delay. . . ." & vbCrLf)  
-  
-    ' This method has no return statement, so its return type is Task.   
-End Function  
-```  
-  
- `Task_MethodAsync` is called and awaited by using an await statement instead of an await expression, similar to the calling statement for a synchronous `Sub` or void-returning method. The application of an `Await` operator in this case doesn't produce a value.  
-  
- The following code calls and awaits method `Task_MethodAsync`.  
-  
-```vb  
-' Call and await the Task-returning async method in the same statement.  
-Await Task_MethodAsync()  
-```  
-  
- As in the previous <xref:System.Threading.Tasks.Task%601> example, you can separate the call to `Task_MethodAsync` from the application of an `Await` operator, as the following code shows. However, remember that a `Task` doesn't have a `Result` property, and that no value is produced when an await operator is applied to a `Task`.  
-  
- The following code separates calling `Task_MethodAsync` from awaiting the task that `Task_MethodAsync` returns.  
-  
-```vb  
-' Call and await in separate statements.  
-Dim simpleTask As Task = Task_MethodAsync()  
-  
-' You can do other work that does not rely on simpleTask before awaiting.  
-textBox1.Text &= String.Format(vbCrLf & "Application can continue working while the Task runs. . . ." & vbCrLf)  
-  
-Await simpleTask  
-```  
-  
-## <a name="BKMK_VoidReturnType"></a> Void Return Type  
- The primary use of `Sub` procedures is in event handlers, where there is no return type (referred to as a void return type in other languages). A void return also can be used to override void-returning methods or for methods that perform activities that can be categorized as "fire and forget." However, you should return a `Task` wherever possible, because a void-returning async method can't be awaited. Any caller of such a method must be able to continue to completion without waiting for the called async method to finish, and the caller must be independent of any values or exceptions that the async method generates.  
-  
- The caller of a void-returning async method can't catch exceptions that are thrown from the method, and such unhandled exceptions are likely to cause your application to fail. If an exception occurs in an async method that returns a <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601>, the exception is stored in the returned task, and rethrown when the task is awaited. Therefore, make sure that any async method that can produce an exception has a return type of <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601> and that calls to the method are awaited.  
-  
- For more information about how to catch exceptions in async methods, see [Try...Catch...Finally Statement](../../../../visual-basic/language-reference/statements/try-catch-finally-statement.md).  
-  
- The following code defines an async event handler.  
-  
-```vb  
-' SUB EXAMPLE  
-Async Sub button1_Click(sender As Object, e As RoutedEventArgs) Handles button1.Click  
-  
-    textBox1.Clear()  
-  
-    ' Start the process and await its completion. DriverAsync is a   
-    ' Task-returning async method.  
-    Await DriverAsync()  
-  
-    ' Say goodbye.  
-    textBox1.Text &= vbCrLf & "All done, exiting button-click event handler."  
-End Sub  
-```  
-  
-## <a name="BKMK_Example"></a> Complete Example  
- The following Windows Presentation Foundation (WPF) project contains the code examples from this topic.  
-  
- To run the project, perform the following steps:  
-  
-1. Start Visual Studio.  
-  
-2. On the menu bar, choose **File**, **New**, **Project**.  
-  
-     The **New Project** dialog box opens.  
-  
-3. In the **Installed**, **Templates** category, choose **Visual Basic**, and then choose **Windows**. Choose **WPF Application** from the list of project types.  
-  
-4. Enter `AsyncReturnTypes` as the name of the project, and then choose the **OK** button.  
-  
-     The new project appears in **Solution Explorer**.  
-  
-5. In the Visual Studio Code Editor, choose the **MainWindow.xaml** tab.  
-  
-     If the tab is not visible, open the shortcut menu for MainWindow.xaml in **Solution Explorer**, and then choose **Open**.  
-  
-6. In the **XAML** window of MainWindow.xaml, replace the code with the following code.  
-  
-    ```vb  
-    <Window x:Class="MainWindow"  
-            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"  
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"  
-            Title="MainWindow" Height="350" Width="525">  
-        <Grid>  
-            <Button x:Name="button1" Content="Start" HorizontalAlignment="Left" Margin="214,28,0,0" VerticalAlignment="Top" Width="75" HorizontalContentAlignment="Center" FontWeight="Bold" FontFamily="Aharoni" Click="button1_Click"/>  
-            <TextBox x:Name="textBox1" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Lucida Console"/>  
-  
-        </Grid>  
-    </Window>  
-    ```  
-  
-     A simple window that contains a text box and a button appears in the **Design** window of MainWindow.xaml.  
-  
-7. In **Solution Explorer**, open the shortcut menu for MainWindow.xaml.vb, and then choose **View Code**.  
-  
-8. Replace the code in MainWindow.xaml.vb with the following code.  
-  
-    ```vb  
-    Class MainWindow  
-  
-        ' SUB EXAMPLE  
-        Async Sub button1_Click(sender As Object, e As RoutedEventArgs) Handles button1.Click  
-  
-            textBox1.Clear()  
-  
-            ' Start the process and await its completion. DriverAsync is a   
-            ' Task-returning async method.  
-            Await DriverAsync()  
-  
-            ' Say goodbye.  
-            textBox1.Text &= vbCrLf & "All done, exiting button-click event handler."  
-        End Sub  
-  
-        Async Function DriverAsync() As Task  
-  
-            ' Task(Of T)   
-            ' Call and await the Task(Of T)-returning async method in the same statement.  
-            Dim result1 As Integer = Await TaskOfT_MethodAsync()  
-  
-            ' Call and await in separate statements.  
-            Dim integerTask As Task(Of Integer) = TaskOfT_MethodAsync()  
-  
-            ' You can do other work that does not rely on resultTask before awaiting.  
-            textBox1.Text &= String.Format("Application can continue working while the Task(Of T) runs. . . . " & vbCrLf)  
-  
-            Dim result2 As Integer = Await integerTask  
-  
-            ' Display the values of the result1 variable, the result2 variable, and  
-            ' the resultTask.Result property.  
-            textBox1.Text &= String.Format(vbCrLf & "Value of result1 variable:   {0}" & vbCrLf, result1)  
-            textBox1.Text &= String.Format("Value of result2 variable:   {0}" & vbCrLf, result2)  
-            textBox1.Text &= String.Format("Value of resultTask.Result:  {0}" & vbCrLf, integerTask.Result)  
-  
-            ' Task   
-            ' Call and await the Task-returning async method in the same statement.  
-            Await Task_MethodAsync()  
-  
-            ' Call and await in separate statements.  
-            Dim simpleTask As Task = Task_MethodAsync()  
-  
-            ' You can do other work that does not rely on simpleTask before awaiting.  
-            textBox1.Text &= String.Format(vbCrLf & "Application can continue working while the Task runs. . . ." & vbCrLf)  
-  
-            Await simpleTask  
-        End Function  
-  
-        ' TASK(OF T) EXAMPLE  
-        Async Function TaskOfT_MethodAsync() As Task(Of Integer)  
-  
-            ' The body of an async method is expected to contain an awaited   
-            ' asynchronous call.  
-            ' Task.FromResult is a placeholder for actual work that returns a string.  
-            Dim today As String = Await Task.FromResult(Of String)(DateTime.Now.DayOfWeek.ToString())  
-  
-            ' The method then can process the result in some way.  
-            Dim leisureHours As Integer  
-            If today.First() = "S" Then  
-                leisureHours = 16  
-            Else  
-                leisureHours = 5  
-            End If  
-  
-            ' Because the return statement specifies an operand of type Integer, the   
-            ' method must have a return type of Task(Of Integer).   
-            Return leisureHours  
-        End Function  
-  
-        ' TASK EXAMPLE  
-        Async Function Task_MethodAsync() As Task  
-  
-            ' The body of an async method is expected to contain an awaited   
-            ' asynchronous call.  
-            ' Task.Delay is a placeholder for actual work.  
-            Await Task.Delay(2000)  
-            textBox1.Text &= String.Format(vbCrLf & "Sorry for the delay. . . ." & vbCrLf)  
-  
-            ' This method has no return statement, so its return type is Task.   
-        End Function  
-  
-    End Class  
-    ```  
-  
-9. Choose the F5 key to run the program, and then choose the **Start** button.  
-  
-     The following output should appear:  
-  
-    ```console  
-    Application can continue working while the Task<T> runs. . . .   
-  
-    Value of result1 variable:   5  
-    Value of result2 variable:   5  
-    Value of integerTask.Result: 5  
-  
-    Sorry for the delay. . . .  
-  
-    Application can continue working while the Task runs. . . .  
-  
-    Sorry for the delay. . . .  
-  
-    All done, exiting button-click event handler.  
-    ```  
-  
+> The <xref:System.Threading.Tasks.Task%601.Result%2A> property is a blocking property. If you try to access it before its task is finished, the thread that's currently active is blocked until the task completes and the value is available. In most cases, you should access the value by using `Await` instead of accessing the property directly.
+
+```vb
+' Call and await in separate statements.
+Dim integerTask As Task(Of Integer) = TaskOfT_MethodAsync()
+
+' You can do other work that does not rely on resultTask before awaiting.
+textBox1.Text &= String.Format("Application can continue working while the Task(Of T) runs. . . . " & vbCrLf)
+
+Dim result2 As Integer = Await integerTask
+```
+
+The display statements in the following code verify that the values of the `result1` variable, the `result2` variable, and the `Result` property are the same. Remember that the `Result` property is a blocking property and shouldn't be accessed before its task has been awaited.
+
+```vb
+' Display the values of the result1 variable, the result2 variable, and
+' the resultTask.Result property.
+textBox1.Text &= String.Format(vbCrLf & "Value of result1 variable:   {0}" & vbCrLf, result1)
+textBox1.Text &= String.Format("Value of result2 variable:   {0}" & vbCrLf, result2)
+textBox1.Text &= String.Format("Value of resultTask.Result:  {0}" & vbCrLf, integerTask.Result)
+```
+
+## <a name="BKMK_TaskReturnType"></a> Task Return Type
+
+Async methods that don't contain a return statement or that contain a return statement that doesn't return an operand usually have a return type of <xref:System.Threading.Tasks.Task>. Such methods would be [Sub](../../../../visual-basic/programming-guide/language-features/procedures/sub-procedures.md) procedures if they were written to run synchronously. If you use a `Task` return type for an async method, a calling method can use an `Await` operator to suspend the caller's completion until the called async method has finished.
+
+In the following example, async method `Task_MethodAsync` doesn't contain a return statement. Therefore, you specify a return type of `Task` for the method, which enables `Task_MethodAsync` to be awaited. The definition of the `Task` type doesn't include a `Result` property to store a return value.
+
+```vb
+' TASK EXAMPLE
+Async Function Task_MethodAsync() As Task
+
+    ' The body of an async method is expected to contain an awaited
+    ' asynchronous call.
+    ' Task.Delay is a placeholder for actual work.
+    Await Task.Delay(2000)
+    textBox1.Text &= String.Format(vbCrLf & "Sorry for the delay. . . ." & vbCrLf)
+
+    ' This method has no return statement, so its return type is Task.
+End Function
+```
+
+`Task_MethodAsync` is called and awaited by using an await statement instead of an await expression, similar to the calling statement for a synchronous `Sub` or void-returning method. The application of an `Await` operator in this case doesn't produce a value.
+
+The following code calls and awaits method `Task_MethodAsync`.
+
+```vb
+' Call and await the Task-returning async method in the same statement.
+Await Task_MethodAsync()
+```
+
+As in the previous <xref:System.Threading.Tasks.Task%601> example, you can separate the call to `Task_MethodAsync` from the application of an `Await` operator, as the following code shows. However, remember that a `Task` doesn't have a `Result` property, and that no value is produced when an await operator is applied to a `Task`.
+
+The following code separates calling `Task_MethodAsync` from awaiting the task that `Task_MethodAsync` returns.
+
+```vb
+' Call and await in separate statements.
+Dim simpleTask As Task = Task_MethodAsync()
+
+' You can do other work that does not rely on simpleTask before awaiting.
+textBox1.Text &= String.Format(vbCrLf & "Application can continue working while the Task runs. . . ." & vbCrLf)
+
+Await simpleTask
+```
+
+## <a name="BKMK_VoidReturnType"></a> Void Return Type
+
+The primary use of `Sub` procedures is in event handlers, where there is no return type (referred to as a void return type in other languages). A void return also can be used to override void-returning methods or for methods that perform activities that can be categorized as "fire and forget." However, you should return a `Task` wherever possible, because a void-returning async method can't be awaited. Any caller of such a method must be able to continue to completion without waiting for the called async method to finish, and the caller must be independent of any values or exceptions that the async method generates.
+
+The caller of a void-returning async method can't catch exceptions that are thrown from the method, and such unhandled exceptions are likely to cause your application to fail. If an exception occurs in an async method that returns a <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601>, the exception is stored in the returned task, and rethrown when the task is awaited. Therefore, make sure that any async method that can produce an exception has a return type of <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601> and that calls to the method are awaited.
+
+For more information about how to catch exceptions in async methods, see [Try...Catch...Finally Statement](../../../../visual-basic/language-reference/statements/try-catch-finally-statement.md).
+
+The following code defines an async event handler.
+
+```vb
+' SUB EXAMPLE
+Async Sub button1_Click(sender As Object, e As RoutedEventArgs) Handles button1.Click
+
+    textBox1.Clear()
+
+    ' Start the process and await its completion. DriverAsync is a
+    ' Task-returning async method.
+    Await DriverAsync()
+
+    ' Say goodbye.
+    textBox1.Text &= vbCrLf & "All done, exiting button-click event handler."
+End Sub
+```
+
+## <a name="BKMK_Example"></a> Complete Example
+
+The following Windows Presentation Foundation (WPF) project contains the code examples from this topic.
+
+ To run the project, perform the following steps:
+
+1. Start Visual Studio.
+
+2. On the menu bar, choose **File**, **New**, **Project**.
+
+     The **New Project** dialog box opens.
+
+3. In the **Installed**, **Templates** category, choose **Visual Basic**, and then choose **Windows**. Choose **WPF Application** from the list of project types.
+
+4. Enter `AsyncReturnTypes` as the name of the project, and then choose the **OK** button.
+
+     The new project appears in **Solution Explorer**.
+
+5. In the Visual Studio Code Editor, choose the **MainWindow.xaml** tab.
+
+     If the tab is not visible, open the shortcut menu for MainWindow.xaml in **Solution Explorer**, and then choose **Open**.
+
+6. In the **XAML** window of MainWindow.xaml, replace the code with the following code.
+
+    ```vb
+    <Window x:Class="MainWindow"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            Title="MainWindow" Height="350" Width="525">
+        <Grid>
+            <Button x:Name="button1" Content="Start" HorizontalAlignment="Left" Margin="214,28,0,0" VerticalAlignment="Top" Width="75" HorizontalContentAlignment="Center" FontWeight="Bold" FontFamily="Aharoni" Click="button1_Click"/>
+            <TextBox x:Name="textBox1" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Lucida Console"/>
+
+        </Grid>
+    </Window>
+    ```
+
+     A simple window that contains a text box and a button appears in the **Design** window of MainWindow.xaml.
+
+7. In **Solution Explorer**, open the shortcut menu for MainWindow.xaml.vb, and then choose **View Code**.
+
+8. Replace the code in MainWindow.xaml.vb with the following code.
+
+    ```vb
+    Class MainWindow
+
+        ' SUB EXAMPLE
+        Async Sub button1_Click(sender As Object, e As RoutedEventArgs) Handles button1.Click
+
+            textBox1.Clear()
+
+            ' Start the process and await its completion. DriverAsync is a
+            ' Task-returning async method.
+            Await DriverAsync()
+
+            ' Say goodbye.
+            textBox1.Text &= vbCrLf & "All done, exiting button-click event handler."
+        End Sub
+
+        Async Function DriverAsync() As Task
+
+            ' Task(Of T)
+            ' Call and await the Task(Of T)-returning async method in the same statement.
+            Dim result1 As Integer = Await TaskOfT_MethodAsync()
+
+            ' Call and await in separate statements.
+            Dim integerTask As Task(Of Integer) = TaskOfT_MethodAsync()
+
+            ' You can do other work that does not rely on resultTask before awaiting.
+            textBox1.Text &= String.Format("Application can continue working while the Task(Of T) runs. . . . " & vbCrLf)
+
+            Dim result2 As Integer = Await integerTask
+
+            ' Display the values of the result1 variable, the result2 variable, and
+            ' the resultTask.Result property.
+            textBox1.Text &= String.Format(vbCrLf & "Value of result1 variable:   {0}" & vbCrLf, result1)
+            textBox1.Text &= String.Format("Value of result2 variable:   {0}" & vbCrLf, result2)
+            textBox1.Text &= String.Format("Value of resultTask.Result:  {0}" & vbCrLf, integerTask.Result)
+
+            ' Task
+            ' Call and await the Task-returning async method in the same statement.
+            Await Task_MethodAsync()
+
+            ' Call and await in separate statements.
+            Dim simpleTask As Task = Task_MethodAsync()
+
+            ' You can do other work that does not rely on simpleTask before awaiting.
+            textBox1.Text &= String.Format(vbCrLf & "Application can continue working while the Task runs. . . ." & vbCrLf)
+
+            Await simpleTask
+        End Function
+
+        ' TASK(OF T) EXAMPLE
+        Async Function TaskOfT_MethodAsync() As Task(Of Integer)
+
+            ' The body of an async method is expected to contain an awaited
+            ' asynchronous call.
+            ' Task.FromResult is a placeholder for actual work that returns a string.
+            Dim today As String = Await Task.FromResult(Of String)(DateTime.Now.DayOfWeek.ToString())
+
+            ' The method then can process the result in some way.
+            Dim leisureHours As Integer
+            If today.First() = "S" Then
+                leisureHours = 16
+            Else
+                leisureHours = 5
+            End If
+
+            ' Because the return statement specifies an operand of type Integer, the
+            ' method must have a return type of Task(Of Integer).
+            Return leisureHours
+        End Function
+
+        ' TASK EXAMPLE
+        Async Function Task_MethodAsync() As Task
+
+            ' The body of an async method is expected to contain an awaited
+            ' asynchronous call.
+            ' Task.Delay is a placeholder for actual work.
+            Await Task.Delay(2000)
+            textBox1.Text &= String.Format(vbCrLf & "Sorry for the delay. . . ." & vbCrLf)
+
+            ' This method has no return statement, so its return type is Task.
+        End Function
+
+    End Class
+    ```
+
+9. Choose the F5 key to run the program, and then choose the **Start** button.
+
+     The following output should appear:
+
+    ```console
+    Application can continue working while the Task<T> runs. . . .
+
+    Value of result1 variable:   5
+    Value of result2 variable:   5
+    Value of integerTask.Result: 5
+
+    Sorry for the delay. . . .
+
+    Application can continue working while the Task runs. . . .
+
+    Sorry for the delay. . . .
+
+    All done, exiting button-click event handler.
+    ```
+
 ## See also
 
 - <xref:System.Threading.Tasks.Task.FromResult%2A>

--- a/docs/visual-basic/programming-guide/concepts/async/how-to-extend-the-async-walkthrough-by-using-task-whenall.md
+++ b/docs/visual-basic/programming-guide/concepts/async/how-to-extend-the-async-walkthrough-by-using-task-whenall.md
@@ -4,415 +4,418 @@ ms.date: 07/20/2015
 ms.assetid: c06d386d-e996-4da9-bf3d-05a3b6c0a258
 ---
 # How to: Extend the Async Walkthrough by Using Task.WhenAll (Visual Basic)
-You can improve the performance of the async solution in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md) by using the <xref:System.Threading.Tasks.Task.WhenAll%2A?displayProperty=nameWithType> method. This method asynchronously awaits multiple asynchronous operations, which are represented as a collection of tasks.  
-  
- You might have noticed in the walkthrough that the websites download at different rates. Sometimes one of the websites is very slow, which delays all the remaining downloads. When you run the asynchronous solutions that you build in the walkthrough, you can end the program easily if you don't want to wait, but a better option would be to start all the downloads at the same time and let faster downloads continue without waiting for the one that’s delayed.  
-  
- You apply the `Task.WhenAll` method to a collection of tasks. The application of `WhenAll` returns a single task that isn’t complete until every task in the collection is completed. The tasks appear to run in parallel, but no additional threads are created. The tasks can complete in any order.  
-  
+
+You can improve the performance of the async solution in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md) by using the <xref:System.Threading.Tasks.Task.WhenAll%2A?displayProperty=nameWithType> method. This method asynchronously awaits multiple asynchronous operations, which are represented as a collection of tasks.
+
+You might have noticed in the walkthrough that the websites download at different rates. Sometimes one of the websites is very slow, which delays all the remaining downloads. When you run the asynchronous solutions that you build in the walkthrough, you can end the program easily if you don't want to wait, but a better option would be to start all the downloads at the same time and let faster downloads continue without waiting for the one that’s delayed.
+
+You apply the `Task.WhenAll` method to a collection of tasks. The application of `WhenAll` returns a single task that isn’t complete until every task in the collection is completed. The tasks appear to run in parallel, but no additional threads are created. The tasks can complete in any order.
+
 > [!IMPORTANT]
-> The following procedures describe extensions to the async applications that are developed in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can develop the applications by either completing the walkthrough or downloading the code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f).  
->   
-> To run the example, you must have Visual Studio 2012 or later installed on your computer.  
-  
-### To add Task.WhenAll to your GetURLContentsAsync solution  
-  
-1. Add the `ProcessURLAsync` method to the first application that's developed in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md).  
-  
-    - If you downloaded the code from  [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f), open the AsyncWalkthrough project, and then add `ProcessURLAsync` to the MainWindow.xaml.vb file.  
-  
-    - If you developed the code by completing the walkthrough, add `ProcessURLAsync` to the application that includes the `GetURLContentsAsync` method. The MainWindow.xaml.vb file for this application is the first example in the "Complete Code Examples from the Walkthrough" section.  
-  
-     The `ProcessURLAsync` method consolidates the actions in the body of the `For Each` loop in `SumPageSizesAsync` in the original walkthrough. The method asynchronously downloads the contents of a specified website as a byte array, and then displays and returns the length of the byte array.  
-  
-    ```vb  
-    Private Async Function ProcessURLAsync(url As String) As Task(Of Integer)  
-  
-        Dim byteArray = Await GetURLContentsAsync(url)  
-        DisplayResults(url, byteArray)  
-        Return byteArray.Length  
-    End Function  
-    ```  
-  
-2. Comment out or delete the `For Each` loop in `SumPageSizesAsync`, as the following code shows.  
-  
-    ```vb  
-    'Dim total = 0  
-    'For Each url In urlList  
-  
-    '    Dim urlContents As Byte() = Await GetURLContentsAsync(url)  
-  
-    '    ' The previous line abbreviates the following two assignment statements.  
-  
-    '    ' GetURLContentsAsync returns a task. At completion, the task  
-    '    ' produces a byte array.  
-    '    'Dim getContentsTask As Task(Of Byte()) = GetURLContentsAsync(url)  
-    '    'Dim urlContents As Byte() = Await getContentsTask  
-  
-    '    DisplayResults(url, urlContents)  
-  
-    '    ' Update the total.  
-    '    total += urlContents.Length  
-    'Next  
-    ```  
-  
-3. Create a collection of tasks. The following code defines a [query](../../../../visual-basic/programming-guide/concepts/linq/index.md) that, when executed by the <xref:System.Linq.Enumerable.ToArray%2A> method, creates a collection of tasks that download the contents of each website. The tasks are started when the query is evaluated.  
-  
-     Add the following code to method `SumPageSizesAsync` after the declaration of `urlList`.  
-  
-    ```vb  
-    ' Create a query.   
-    Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =  
-        From url In urlList Select ProcessURLAsync(url)  
-  
-    ' Use ToArray to execute the query and start the download tasks.  
-    Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()  
-    ```  
-  
-4. Apply `Task.WhenAll` to the collection of tasks, `downloadTasks`. `Task.WhenAll` returns a single task that finishes when all the tasks in the collection of tasks have completed.  
-  
-     In the following example, the `Await` expression awaits the completion of the single task that `WhenAll` returns. The expression evaluates to an array of integers, where each integer is the length of a downloaded website. Add the following code to `SumPageSizesAsync`, just after the code that you added in the previous step.  
-  
-    ```vb  
-    ' Await the completion of all the running tasks.  
-    Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)  
-  
-    '' The previous line is equivalent to the following two statements.  
-    'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)  
-    'Dim lengths As Integer() = Await whenAllTask  
-    ```  
-  
-5. Finally, use the <xref:System.Linq.Enumerable.Sum%2A> method to calculate the sum of the lengths of all the websites. Add the following line to `SumPageSizesAsync`.  
-  
-    ```vb  
-    Dim total = lengths.Sum()  
-    ```  
-  
-### To add Task.WhenAll to the HttpClient.GetByteArrayAsync solution  
-  
-1. Add the following version of `ProcessURLAsync` to the second application that's developed in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md).  
-  
-    - If you downloaded the code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f), open the AsyncWalkthrough_HttpClient project, and then add `ProcessURLAsync` to the MainWindow.xaml.vb file.  
-  
-    - If you developed the code by completing the walkthrough, add `ProcessURLAsync` to the application that uses the `HttpClient.GetByteArrayAsync` method. The MainWindow.xaml.vb file for this application is the second example in the "Complete Code Examples from the Walkthrough" section.  
-  
-     The `ProcessURLAsync` method consolidates the actions in the body of the `For Each` loop in `SumPageSizesAsync` in the original walkthrough. The method asynchronously downloads the contents of a specified website as a byte array, and then displays and returns the length of the byte array.  
-  
-     The only difference from the `ProcessURLAsync` method in the previous procedure is the use of the <xref:System.Net.Http.HttpClient> instance, `client`.  
-  
-    ```vb  
-    Private Async Function ProcessURLAsync(url As String, client As HttpClient) As Task(Of Integer)  
-  
-        Dim byteArray = Await client.GetByteArrayAsync(url)  
-        DisplayResults(url, byteArray)  
-        Return byteArray.Length  
-    End Function  
-    ```  
-  
-2. Comment out or delete the `For Each` loop in `SumPageSizesAsync`, as the following code shows.  
-  
-    ```vb  
-    'Dim total = 0   
-    'For Each url In urlList   
-    '    ' GetByteArrayAsync returns a task. At completion, the task   
-    '    ' produces a byte array.   
-    '    Dim urlContents As Byte() = Await client.GetByteArrayAsync(url)   
-  
-    '    ' The following two lines can replace the previous assignment statement.   
-    '    'Dim getContentsTask As Task(Of Byte()) = client.GetByteArrayAsync(url)   
-    '    'Dim urlContents As Byte() = Await getContentsTask   
-  
-    '    DisplayResults(url, urlContents)   
-  
-    '    ' Update the total.   
-    '    total += urlContents.Length   
-    'Next  
-    ```  
-  
-3. Define a [query](../../../../visual-basic/programming-guide/concepts/linq/index.md) that, when executed by the <xref:System.Linq.Enumerable.ToArray%2A> method, creates a collection of tasks that download the contents of each website. The tasks are started when the query is evaluated.  
-  
-     Add the following code to method `SumPageSizesAsync` after the declaration of `client` and `urlList`.  
-  
-    ```vb  
-    ' Create a query.  
-    Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =  
-        From url In urlList Select ProcessURLAsync(url, client)  
-  
-    ' Use ToArray to execute the query and start the download tasks.  
-    Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()  
-    ```  
-  
-4. Next, apply `Task.WhenAll` to the collection of tasks, `downloadTasks`. `Task.WhenAll` returns a single task that finishes when all the tasks in the collection of tasks have completed.  
-  
-     In the following example, the `Await` expression awaits the completion of the single task that `WhenAll` returns. When complete, the `Await` expression evaluates to an array of integers, where each integer is the length of a downloaded website. Add the following code to `SumPageSizesAsync`, just after the code that you added in the previous step.  
-  
-    ```vb  
-    ' Await the completion of all the running tasks.  
-    Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)  
-  
-    '' The previous line is equivalent to the following two statements.  
-    'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)  
-    'Dim lengths As Integer() = Await whenAllTask  
-    ```  
-  
-5. Finally, use the <xref:System.Linq.Enumerable.Sum%2A> method to get the sum of the lengths of all the websites. Add the following line to `SumPageSizesAsync`.  
-  
-    ```vb  
-    Dim total = lengths.Sum()  
-    ```  
-  
-### To test the Task.WhenAll solutions  
-  
-- For either solution, choose the F5 key to run the program, and then choose the **Start** button. The output should resemble the output from the async solutions in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). However, notice that the websites appear in a different order each time.  
-  
-## Example  
- The following code shows the extensions to the project that uses the `GetURLContentsAsync` method to download content from the web.  
-  
-```vb  
-' Add the following Imports statements, and add a reference for System.Net.Http.  
-Imports System.Net.Http  
-Imports System.Net  
-Imports System.IO  
-  
-Class MainWindow  
-  
-    Async Sub startButton_Click(sender As Object, e As RoutedEventArgs) Handles startButton.Click  
-  
-        resultsTextBox.Clear()  
-  
-        ' One-step async call.  
-        Await SumPageSizesAsync()  
-  
-        '' Two-step async call.  
-        'Dim sumTask As Task = SumPageSizesAsync()  
-        'Await sumTask  
-  
-        resultsTextBox.Text &= vbCrLf & "Control returned to button1_Click."  
-    End Sub  
-  
-    Private Async Function SumPageSizesAsync() As Task  
-  
-        ' Make a list of web addresses.  
-        Dim urlList As List(Of String) = SetUpURLList()  
-  
-        ' Create a query.   
-        Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =  
-            From url In urlList Select ProcessURLAsync(url)  
-  
-        ' Use ToArray to execute the query and start the download tasks.  
-        Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()  
-  
-        ' You can do other work here before awaiting.  
-  
-        ' Await the completion of all the running tasks.  
-        Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)  
-  
-        '' The previous line is equivalent to the following two statements.  
-        'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)  
-        'Dim lengths As Integer() = Await whenAllTask  
-  
-        Dim total = lengths.Sum()  
-  
-        'Dim total = 0  
-        'For Each url In urlList  
-  
-        '    Dim urlContents As Byte() = Await GetURLContentsAsync(url)  
-  
-        '    ' The previous line abbreviates the following two assignment statements.  
-  
-        '    ' GetURLContentsAsync returns a task. At completion, the task  
-        '    ' produces a byte array.  
-        '    'Dim getContentsTask As Task(Of Byte()) = GetURLContentsAsync(url)  
-        '    'Dim urlContents As Byte() = Await getContentsTask  
-  
-        '    DisplayResults(url, urlContents)  
-  
-        '    ' Update the total.  
-        '    total += urlContents.Length  
-        'NextNext  
-  
-        ' Display the total count for all of the web addresses.  
-        resultsTextBox.Text &= String.Format(vbCrLf & vbCrLf &  
-                                             "Total bytes returned:  {0}" & vbCrLf, total)  
-    End Function  
-  
-    Private Function SetUpURLList() As List(Of String)  
-  
-        Dim urls = New List(Of String) From  
-            {  
-                "https://msdn.microsoft.com",  
-                "https://msdn.microsoft.com/library/hh290136.aspx",  
-                "https://msdn.microsoft.com/library/ee256749.aspx",  
-                "https://msdn.microsoft.com/library/hh290138.aspx",  
-                "https://msdn.microsoft.com/library/hh290140.aspx",  
-                "https://msdn.microsoft.com/library/dd470362.aspx",  
-                "https://msdn.microsoft.com/library/aa578028.aspx",  
-                "https://msdn.microsoft.com/library/ms404677.aspx",  
-                "https://msdn.microsoft.com/library/ff730837.aspx"  
-            }  
-        Return urls  
-    End Function  
-  
-    ' The actions from the foreach loop are moved to this async method.  
-    Private Async Function ProcessURLAsync(url As String) As Task(Of Integer)  
-  
-        Dim byteArray = Await GetURLContentsAsync(url)  
-        DisplayResults(url, byteArray)  
-        Return byteArray.Length  
-    End Function  
-  
-    Private Async Function GetURLContentsAsync(url As String) As Task(Of Byte())  
-  
-        ' The downloaded resource ends up in the variable named content.  
-        Dim content = New MemoryStream()  
-  
-        ' Initialize an HttpWebRequest for the current URL.  
-        Dim webReq = CType(WebRequest.Create(url), HttpWebRequest)  
-  
-        ' Send the request to the Internet resource and wait for  
-        ' the response.  
-        Using response As WebResponse = Await webReq.GetResponseAsync()  
-            ' Get the data stream that is associated with the specified URL.  
-            Using responseStream As Stream = response.GetResponseStream()  
-                ' Read the bytes in responseStream and copy them to content.    
-                ' CopyToAsync returns a Task, not a Task<T>.  
-                Await responseStream.CopyToAsync(content)  
-            End Using  
-        End Using  
-  
-        ' Return the result as a byte array.  
-        Return content.ToArray()  
-    End Function  
-  
-    Private Sub DisplayResults(url As String, content As Byte())  
-  
-        ' Display the length of each website. The string format   
-        ' is designed to be used with a monospaced font, such as  
-        ' Lucida Console or Global Monospace.  
-        Dim bytes = content.Length  
-        ' Strip off the "https://".  
-        Dim displayURL = url.Replace("https://", "")  
-        resultsTextBox.Text &= String.Format(vbCrLf & "{0,-58} {1,8}", displayURL, bytes)  
-    End Sub  
-  
-End Class  
-```  
-  
-## Example  
- The following code shows the extensions to the project that uses method `HttpClient.GetByteArrayAsync` to download content from the web.  
-  
-```vb  
-' Add the following Imports statements, and add a reference for System.Net.Http.  
-Imports System.Net.Http  
-Imports System.Net  
-Imports System.IO  
-  
-Class MainWindow  
-  
-    Async Sub startButton_Click(sender As Object, e As RoutedEventArgs) Handles startButton.Click  
-  
-        resultsTextBox.Clear()  
-  
-        '' One-step async call.  
-        Await SumPageSizesAsync()  
-  
-        '' Two-step async call.  
-        'Dim sumTask As Task = SumPageSizesAsync()  
-        'Await sumTask  
-  
-        resultsTextBox.Text &= vbCrLf & "Control returned to button1_Click."  
-    End Sub  
-  
-    Private Async Function SumPageSizesAsync() As Task  
-  
-        ' Declare an HttpClient object and increase the buffer size. The  
-        ' default buffer size is 65,536.  
-        Dim client As HttpClient =  
-            New HttpClient() With {.MaxResponseContentBufferSize = 1000000}  
-  
-        ' Make a list of web addresses.  
-        Dim urlList As List(Of String) = SetUpURLList()  
-  
-        ' Create a query.  
-        Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =  
-            From url In urlList Select ProcessURLAsync(url, client)  
-  
-        ' Use ToArray to execute the query and start the download tasks.  
-        Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()  
-  
-        ' You can do other work here before awaiting.  
-  
-        ' Await the completion of all the running tasks.  
-        Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)  
-  
-        '' The previous line is equivalent to the following two statements.  
-        'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)  
-        'Dim lengths As Integer() = Await whenAllTask  
-  
-        Dim total = lengths.Sum()  
-  
-        ''<snippet7>  
-        'Dim total = 0  
-        'For Each url In urlList  
-        '    ' GetByteArrayAsync returns a task. At completion, the task  
-        '    ' produces a byte array.  
-        '    '<snippet31>  
-        '    Dim urlContents As Byte() = Await client.GetByteArrayAsync(url)  
-        '    '</snippet31>  
-  
-        '    ' The following two lines can replace the previous assignment statement.  
-        '    'Dim getContentsTask As Task(Of Byte()) = client.GetByteArrayAsync(url)  
-        '    'Dim urlContents As Byte() = Await getContentsTask  
-  
-        '    DisplayResults(url, urlContents)  
-  
-        '    ' Update the total.  
-        '    total += urlContents.Length  
-        'NextNext  
-  
-        ' Display the total count for all of the web addresses.  
-        resultsTextBox.Text &= String.Format(vbCrLf & vbCrLf &  
-                                             "Total bytes returned:  {0}" & vbCrLf, total)  
-    End Function  
-  
-    Private Function SetUpURLList() As List(Of String)  
-  
-        Dim urls = New List(Of String) From  
-            {  
-                "https://www.msdn.com",  
-                "https://msdn.microsoft.com/library/hh290136.aspx",  
-                "https://msdn.microsoft.com/library/ee256749.aspx",  
-                "https://msdn.microsoft.com/library/hh290138.aspx",  
-                "https://msdn.microsoft.com/library/hh290140.aspx",  
-                "https://msdn.microsoft.com/library/dd470362.aspx",  
-                "https://msdn.microsoft.com/library/aa578028.aspx",  
-                "https://msdn.microsoft.com/library/ms404677.aspx",  
-                "https://msdn.microsoft.com/library/ff730837.aspx"  
-            }  
-        Return urls  
-    End Function  
-  
-    Private Async Function ProcessURLAsync(url As String, client As HttpClient) As Task(Of Integer)  
-  
-        Dim byteArray = Await client.GetByteArrayAsync(url)  
-        DisplayResults(url, byteArray)  
-        Return byteArray.Length  
-    End Function  
-  
-    Private Sub DisplayResults(url As String, content As Byte())  
-  
-        ' Display the length of each website. The string format   
-        ' is designed to be used with a monospaced font, such as  
-        ' Lucida Console or Global Monospace.  
-        Dim bytes = content.Length  
-        ' Strip off the "https://".  
-        Dim displayURL = url.Replace("https://", "")  
-        resultsTextBox.Text &= String.Format(vbCrLf & "{0,-58} {1,8}", displayURL, bytes)  
-    End Sub  
-  
-End Class  
-```  
-  
+> The following procedures describe extensions to the async applications that are developed in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can develop the applications by either completing the walkthrough or downloading the code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f).
+>
+> To run the example, you must have Visual Studio 2012 or later installed on your computer.
+
+### To add Task.WhenAll to your GetURLContentsAsync solution
+
+1. Add the `ProcessURLAsync` method to the first application that's developed in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md).
+
+    - If you downloaded the code from  [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f), open the AsyncWalkthrough project, and then add `ProcessURLAsync` to the MainWindow.xaml.vb file.
+
+    - If you developed the code by completing the walkthrough, add `ProcessURLAsync` to the application that includes the `GetURLContentsAsync` method. The MainWindow.xaml.vb file for this application is the first example in the "Complete Code Examples from the Walkthrough" section.
+
+     The `ProcessURLAsync` method consolidates the actions in the body of the `For Each` loop in `SumPageSizesAsync` in the original walkthrough. The method asynchronously downloads the contents of a specified website as a byte array, and then displays and returns the length of the byte array.
+
+    ```vb
+    Private Async Function ProcessURLAsync(url As String) As Task(Of Integer)
+
+        Dim byteArray = Await GetURLContentsAsync(url)
+        DisplayResults(url, byteArray)
+        Return byteArray.Length
+    End Function
+    ```
+
+2. Comment out or delete the `For Each` loop in `SumPageSizesAsync`, as the following code shows.
+
+    ```vb
+    'Dim total = 0
+    'For Each url In urlList
+
+    '    Dim urlContents As Byte() = Await GetURLContentsAsync(url)
+
+    '    ' The previous line abbreviates the following two assignment statements.
+
+    '    ' GetURLContentsAsync returns a task. At completion, the task
+    '    ' produces a byte array.
+    '    'Dim getContentsTask As Task(Of Byte()) = GetURLContentsAsync(url)
+    '    'Dim urlContents As Byte() = Await getContentsTask
+
+    '    DisplayResults(url, urlContents)
+
+    '    ' Update the total.
+    '    total += urlContents.Length
+    'Next
+    ```
+
+3. Create a collection of tasks. The following code defines a [query](../../../../visual-basic/programming-guide/concepts/linq/index.md) that, when executed by the <xref:System.Linq.Enumerable.ToArray%2A> method, creates a collection of tasks that download the contents of each website. The tasks are started when the query is evaluated.
+
+     Add the following code to method `SumPageSizesAsync` after the declaration of `urlList`.
+
+    ```vb
+    ' Create a query.
+    Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =
+        From url In urlList Select ProcessURLAsync(url)
+
+    ' Use ToArray to execute the query and start the download tasks.
+    Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()
+    ```
+
+4. Apply `Task.WhenAll` to the collection of tasks, `downloadTasks`. `Task.WhenAll` returns a single task that finishes when all the tasks in the collection of tasks have completed.
+
+     In the following example, the `Await` expression awaits the completion of the single task that `WhenAll` returns. The expression evaluates to an array of integers, where each integer is the length of a downloaded website. Add the following code to `SumPageSizesAsync`, just after the code that you added in the previous step.
+
+    ```vb
+    ' Await the completion of all the running tasks.
+    Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)
+
+    '' The previous line is equivalent to the following two statements.
+    'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)
+    'Dim lengths As Integer() = Await whenAllTask
+    ```
+
+5. Finally, use the <xref:System.Linq.Enumerable.Sum%2A> method to calculate the sum of the lengths of all the websites. Add the following line to `SumPageSizesAsync`.
+
+    ```vb
+    Dim total = lengths.Sum()
+    ```
+
+### To add Task.WhenAll to the HttpClient.GetByteArrayAsync solution
+
+1. Add the following version of `ProcessURLAsync` to the second application that's developed in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md).
+
+    - If you downloaded the code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f), open the AsyncWalkthrough_HttpClient project, and then add `ProcessURLAsync` to the MainWindow.xaml.vb file.
+
+    - If you developed the code by completing the walkthrough, add `ProcessURLAsync` to the application that uses the `HttpClient.GetByteArrayAsync` method. The MainWindow.xaml.vb file for this application is the second example in the "Complete Code Examples from the Walkthrough" section.
+
+     The `ProcessURLAsync` method consolidates the actions in the body of the `For Each` loop in `SumPageSizesAsync` in the original walkthrough. The method asynchronously downloads the contents of a specified website as a byte array, and then displays and returns the length of the byte array.
+
+     The only difference from the `ProcessURLAsync` method in the previous procedure is the use of the <xref:System.Net.Http.HttpClient> instance, `client`.
+
+    ```vb
+    Private Async Function ProcessURLAsync(url As String, client As HttpClient) As Task(Of Integer)
+
+        Dim byteArray = Await client.GetByteArrayAsync(url)
+        DisplayResults(url, byteArray)
+        Return byteArray.Length
+    End Function
+    ```
+
+2. Comment out or delete the `For Each` loop in `SumPageSizesAsync`, as the following code shows.
+
+    ```vb
+    'Dim total = 0
+    'For Each url In urlList
+    '    ' GetByteArrayAsync returns a task. At completion, the task
+    '    ' produces a byte array.
+    '    Dim urlContents As Byte() = Await client.GetByteArrayAsync(url)
+
+    '    ' The following two lines can replace the previous assignment statement.
+    '    'Dim getContentsTask As Task(Of Byte()) = client.GetByteArrayAsync(url)
+    '    'Dim urlContents As Byte() = Await getContentsTask
+
+    '    DisplayResults(url, urlContents)
+
+    '    ' Update the total.
+    '    total += urlContents.Length
+    'Next
+    ```
+
+3. Define a [query](../../../../visual-basic/programming-guide/concepts/linq/index.md) that, when executed by the <xref:System.Linq.Enumerable.ToArray%2A> method, creates a collection of tasks that download the contents of each website. The tasks are started when the query is evaluated.
+
+     Add the following code to method `SumPageSizesAsync` after the declaration of `client` and `urlList`.
+
+    ```vb
+    ' Create a query.
+    Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =
+        From url In urlList Select ProcessURLAsync(url, client)
+
+    ' Use ToArray to execute the query and start the download tasks.
+    Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()
+    ```
+
+4. Next, apply `Task.WhenAll` to the collection of tasks, `downloadTasks`. `Task.WhenAll` returns a single task that finishes when all the tasks in the collection of tasks have completed.
+
+     In the following example, the `Await` expression awaits the completion of the single task that `WhenAll` returns. When complete, the `Await` expression evaluates to an array of integers, where each integer is the length of a downloaded website. Add the following code to `SumPageSizesAsync`, just after the code that you added in the previous step.
+
+    ```vb
+    ' Await the completion of all the running tasks.
+    Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)
+
+    '' The previous line is equivalent to the following two statements.
+    'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)
+    'Dim lengths As Integer() = Await whenAllTask
+    ```
+
+5. Finally, use the <xref:System.Linq.Enumerable.Sum%2A> method to get the sum of the lengths of all the websites. Add the following line to `SumPageSizesAsync`.
+
+    ```vb
+    Dim total = lengths.Sum()
+    ```
+
+### To test the Task.WhenAll solutions
+
+For either solution, choose the F5 key to run the program, and then choose the **Start** button. The output should resemble the output from the async solutions in [Walkthrough: Accessing the Web by Using Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). However, notice that the websites appear in a different order each time.
+
+## Example
+
+The following code shows the extensions to the project that uses the `GetURLContentsAsync` method to download content from the web.
+
+```vb
+' Add the following Imports statements, and add a reference for System.Net.Http.
+Imports System.Net.Http
+Imports System.Net
+Imports System.IO
+
+Class MainWindow
+
+    Async Sub startButton_Click(sender As Object, e As RoutedEventArgs) Handles startButton.Click
+
+        resultsTextBox.Clear()
+
+        ' One-step async call.
+        Await SumPageSizesAsync()
+
+        '' Two-step async call.
+        'Dim sumTask As Task = SumPageSizesAsync()
+        'Await sumTask
+
+        resultsTextBox.Text &= vbCrLf & "Control returned to button1_Click."
+    End Sub
+
+    Private Async Function SumPageSizesAsync() As Task
+
+        ' Make a list of web addresses.
+        Dim urlList As List(Of String) = SetUpURLList()
+
+        ' Create a query.
+        Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =
+            From url In urlList Select ProcessURLAsync(url)
+
+        ' Use ToArray to execute the query and start the download tasks.
+        Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()
+
+        ' You can do other work here before awaiting.
+
+        ' Await the completion of all the running tasks.
+        Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)
+
+        '' The previous line is equivalent to the following two statements.
+        'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)
+        'Dim lengths As Integer() = Await whenAllTask
+
+        Dim total = lengths.Sum()
+
+        'Dim total = 0
+        'For Each url In urlList
+
+        '    Dim urlContents As Byte() = Await GetURLContentsAsync(url)
+
+        '    ' The previous line abbreviates the following two assignment statements.
+
+        '    ' GetURLContentsAsync returns a task. At completion, the task
+        '    ' produces a byte array.
+        '    'Dim getContentsTask As Task(Of Byte()) = GetURLContentsAsync(url)
+        '    'Dim urlContents As Byte() = Await getContentsTask
+
+        '    DisplayResults(url, urlContents)
+
+        '    ' Update the total.
+        '    total += urlContents.Length
+        'NextNext
+
+        ' Display the total count for all of the web addresses.
+        resultsTextBox.Text &= String.Format(vbCrLf & vbCrLf &
+                                             "Total bytes returned:  {0}" & vbCrLf, total)
+    End Function
+
+    Private Function SetUpURLList() As List(Of String)
+
+        Dim urls = New List(Of String) From
+            {
+                "https://msdn.microsoft.com",
+                "https://msdn.microsoft.com/library/hh290136.aspx",
+                "https://msdn.microsoft.com/library/ee256749.aspx",
+                "https://msdn.microsoft.com/library/hh290138.aspx",
+                "https://msdn.microsoft.com/library/hh290140.aspx",
+                "https://msdn.microsoft.com/library/dd470362.aspx",
+                "https://msdn.microsoft.com/library/aa578028.aspx",
+                "https://msdn.microsoft.com/library/ms404677.aspx",
+                "https://msdn.microsoft.com/library/ff730837.aspx"
+            }
+        Return urls
+    End Function
+
+    ' The actions from the foreach loop are moved to this async method.
+    Private Async Function ProcessURLAsync(url As String) As Task(Of Integer)
+
+        Dim byteArray = Await GetURLContentsAsync(url)
+        DisplayResults(url, byteArray)
+        Return byteArray.Length
+    End Function
+
+    Private Async Function GetURLContentsAsync(url As String) As Task(Of Byte())
+
+        ' The downloaded resource ends up in the variable named content.
+        Dim content = New MemoryStream()
+
+        ' Initialize an HttpWebRequest for the current URL.
+        Dim webReq = CType(WebRequest.Create(url), HttpWebRequest)
+
+        ' Send the request to the Internet resource and wait for
+        ' the response.
+        Using response As WebResponse = Await webReq.GetResponseAsync()
+            ' Get the data stream that is associated with the specified URL.
+            Using responseStream As Stream = response.GetResponseStream()
+                ' Read the bytes in responseStream and copy them to content.
+                ' CopyToAsync returns a Task, not a Task<T>.
+                Await responseStream.CopyToAsync(content)
+            End Using
+        End Using
+
+        ' Return the result as a byte array.
+        Return content.ToArray()
+    End Function
+
+    Private Sub DisplayResults(url As String, content As Byte())
+
+        ' Display the length of each website. The string format
+        ' is designed to be used with a monospaced font, such as
+        ' Lucida Console or Global Monospace.
+        Dim bytes = content.Length
+        ' Strip off the "https://".
+        Dim displayURL = url.Replace("https://", "")
+        resultsTextBox.Text &= String.Format(vbCrLf & "{0,-58} {1,8}", displayURL, bytes)
+    End Sub
+
+End Class
+```
+
+## Example
+
+The following code shows the extensions to the project that uses method `HttpClient.GetByteArrayAsync` to download content from the web.
+
+```vb
+' Add the following Imports statements, and add a reference for System.Net.Http.
+Imports System.Net.Http
+Imports System.Net
+Imports System.IO
+
+Class MainWindow
+
+    Async Sub startButton_Click(sender As Object, e As RoutedEventArgs) Handles startButton.Click
+
+        resultsTextBox.Clear()
+
+        '' One-step async call.
+        Await SumPageSizesAsync()
+
+        '' Two-step async call.
+        'Dim sumTask As Task = SumPageSizesAsync()
+        'Await sumTask
+
+        resultsTextBox.Text &= vbCrLf & "Control returned to button1_Click."
+    End Sub
+
+    Private Async Function SumPageSizesAsync() As Task
+
+        ' Declare an HttpClient object and increase the buffer size. The
+        ' default buffer size is 65,536.
+        Dim client As HttpClient =
+            New HttpClient() With {.MaxResponseContentBufferSize = 1000000}
+
+        ' Make a list of web addresses.
+        Dim urlList As List(Of String) = SetUpURLList()
+
+        ' Create a query.
+        Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =
+            From url In urlList Select ProcessURLAsync(url, client)
+
+        ' Use ToArray to execute the query and start the download tasks.
+        Dim downloadTasks As Task(Of Integer)() = downloadTasksQuery.ToArray()
+
+        ' You can do other work here before awaiting.
+
+        ' Await the completion of all the running tasks.
+        Dim lengths As Integer() = Await Task.WhenAll(downloadTasks)
+
+        '' The previous line is equivalent to the following two statements.
+        'Dim whenAllTask As Task(Of Integer()) = Task.WhenAll(downloadTasks)
+        'Dim lengths As Integer() = Await whenAllTask
+
+        Dim total = lengths.Sum()
+
+        ''<snippet7>
+        'Dim total = 0
+        'For Each url In urlList
+        '    ' GetByteArrayAsync returns a task. At completion, the task
+        '    ' produces a byte array.
+        '    '<snippet31>
+        '    Dim urlContents As Byte() = Await client.GetByteArrayAsync(url)
+        '    '</snippet31>
+
+        '    ' The following two lines can replace the previous assignment statement.
+        '    'Dim getContentsTask As Task(Of Byte()) = client.GetByteArrayAsync(url)
+        '    'Dim urlContents As Byte() = Await getContentsTask
+
+        '    DisplayResults(url, urlContents)
+
+        '    ' Update the total.
+        '    total += urlContents.Length
+        'NextNext
+
+        ' Display the total count for all of the web addresses.
+        resultsTextBox.Text &= String.Format(vbCrLf & vbCrLf &
+                                             "Total bytes returned:  {0}" & vbCrLf, total)
+    End Function
+
+    Private Function SetUpURLList() As List(Of String)
+
+        Dim urls = New List(Of String) From
+            {
+                "https://www.msdn.com",
+                "https://msdn.microsoft.com/library/hh290136.aspx",
+                "https://msdn.microsoft.com/library/ee256749.aspx",
+                "https://msdn.microsoft.com/library/hh290138.aspx",
+                "https://msdn.microsoft.com/library/hh290140.aspx",
+                "https://msdn.microsoft.com/library/dd470362.aspx",
+                "https://msdn.microsoft.com/library/aa578028.aspx",
+                "https://msdn.microsoft.com/library/ms404677.aspx",
+                "https://msdn.microsoft.com/library/ff730837.aspx"
+            }
+        Return urls
+    End Function
+
+    Private Async Function ProcessURLAsync(url As String, client As HttpClient) As Task(Of Integer)
+
+        Dim byteArray = Await client.GetByteArrayAsync(url)
+        DisplayResults(url, byteArray)
+        Return byteArray.Length
+    End Function
+
+    Private Sub DisplayResults(url As String, content As Byte())
+
+        ' Display the length of each website. The string format
+        ' is designed to be used with a monospaced font, such as
+        ' Lucida Console or Global Monospace.
+        Dim bytes = content.Length
+        ' Strip off the "https://".
+        Dim displayURL = url.Replace("https://", "")
+        resultsTextBox.Text &= String.Format(vbCrLf & "{0,-58} {1,8}", displayURL, bytes)
+    End Sub
+
+End Class
+```
+
 ## See also
 
 - <xref:System.Threading.Tasks.Task.WhenAll%2A?displayProperty=nameWithType>

--- a/docs/visual-basic/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md
+++ b/docs/visual-basic/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md
@@ -4,95 +4,97 @@ ms.date: 07/20/2015
 ms.assetid: c56e41da-5433-464f-a7bf-2a722e78bc9f
 ---
 # Accessing Attributes by Using Reflection (Visual Basic)
-The fact that you can define custom attributes and place them in your source code would be of little value without some way of retrieving that information and acting on it. By using reflection, you can retrieve the information that was defined with custom attributes. The key method is `GetCustomAttributes`, which returns an array of objects that are the run-time equivalents of the source code attributes. This method has several overloaded versions. For more information, see <xref:System.Attribute>.  
-  
- An attribute specification such as:  
-  
-```vb  
-<Author("P. Ackerman", Version:=1.1)>   
-Class SampleClass  
-    ' P. Ackerman's code goes here...  
-End Class  
-```  
-  
- is conceptually equivalent to this:  
-  
-```vb  
-Dim anonymousAuthorObject As Author = New Author("P. Ackerman")  
-anonymousAuthorObject.version = 1.1  
-```  
-  
- However, the code is not executed until `SampleClass` is queried for attributes. Calling `GetCustomAttributes` on `SampleClass` causes an `Author` object to be constructed and initialized as above. If the class has other attributes, other attribute objects are constructed similarly. `GetCustomAttributes` then returns the `Author` object and any other attribute objects in an array. You can then iterate over this array, determine what attributes were applied based on the type of each array element, and extract information from the attribute objects.  
-  
-## Example  
- Here is a complete example. A custom attribute is defined, applied to several entities, and retrieved via reflection.  
-  
-```vb  
-' Multiuse attribute  
-<System.AttributeUsage(System.AttributeTargets.Class Or   
-                       System.AttributeTargets.Struct,   
-                       AllowMultiple:=True)>   
-Public Class Author  
-    Inherits System.Attribute  
-    Private name As String  
-    Public version As Double  
-    Sub New(ByVal authorName As String)  
-        name = authorName  
-  
-        ' Default value  
-        version = 1.0  
-    End Sub  
-  
-    Function GetName() As String  
-        Return name  
-    End Function          
-End Class  
-  
-' Class with the Author attribute  
-<Author("P. Ackerman")>   
-Public Class FirstClass  
-End Class  
-  
-' Class without the Author attribute  
-Public Class SecondClass  
-End Class  
-  
-' Class with multiple Author attributes.  
-<Author("P. Ackerman"), Author("R. Koch", Version:=2.0)>   
-Public Class ThirdClass  
-End Class  
-  
-Class TestAuthorAttribute  
-    Sub Main()  
-        PrintAuthorInfo(GetType(FirstClass))  
-        PrintAuthorInfo(GetType(SecondClass))  
-        PrintAuthorInfo(GetType(ThirdClass))  
-    End Sub  
-  
-    Private Shared Sub PrintAuthorInfo(ByVal t As System.Type)  
-        System.Console.WriteLine("Author information for {0}", t)  
-  
-        ' Using reflection  
-        Dim attrs() As System.Attribute = System.Attribute.GetCustomAttributes(t)  
-  
-        ' Displaying output  
-        For Each attr In attrs  
-            Dim a As Author = CType(attr, Author)  
-            System.Console.WriteLine("   {0}, version {1:f}", a.GetName(), a.version)  
-        Next              
-    End Sub  
-  
-    ' Output:  
-    '   Author information for FirstClass  
-    '     P. Ackerman, version 1.00  
-    ' Author information for SecondClass  
-    ' Author information for ThirdClass  
-    '  R. Koch, version 2.00  
-    '  P. Ackerman, version 1.00  
-  
-End Class  
-```  
-  
+
+The fact that you can define custom attributes and place them in your source code would be of little value without some way of retrieving that information and acting on it. By using reflection, you can retrieve the information that was defined with custom attributes. The key method is `GetCustomAttributes`, which returns an array of objects that are the run-time equivalents of the source code attributes. This method has several overloaded versions. For more information, see <xref:System.Attribute>.
+
+An attribute specification such as:
+
+```vb
+<Author("P. Ackerman", Version:=1.1)>
+Class SampleClass
+    ' P. Ackerman's code goes here...
+End Class
+```
+
+ is conceptually equivalent to this:
+
+```vb
+Dim anonymousAuthorObject As Author = New Author("P. Ackerman")
+anonymousAuthorObject.version = 1.1
+```
+
+However, the code is not executed until `SampleClass` is queried for attributes. Calling `GetCustomAttributes` on `SampleClass` causes an `Author` object to be constructed and initialized as above. If the class has other attributes, other attribute objects are constructed similarly. `GetCustomAttributes` then returns the `Author` object and any other attribute objects in an array. You can then iterate over this array, determine what attributes were applied based on the type of each array element, and extract information from the attribute objects.
+
+## Example
+
+Here is a complete example. A custom attribute is defined, applied to several entities, and retrieved via reflection.
+
+```vb
+' Multiuse attribute
+<System.AttributeUsage(System.AttributeTargets.Class Or
+                       System.AttributeTargets.Struct,
+                       AllowMultiple:=True)>
+Public Class Author
+    Inherits System.Attribute
+    Private name As String
+    Public version As Double
+    Sub New(ByVal authorName As String)
+        name = authorName
+
+        ' Default value
+        version = 1.0
+    End Sub
+
+    Function GetName() As String
+        Return name
+    End Function
+End Class
+
+' Class with the Author attribute
+<Author("P. Ackerman")>
+Public Class FirstClass
+End Class
+
+' Class without the Author attribute
+Public Class SecondClass
+End Class
+
+' Class with multiple Author attributes.
+<Author("P. Ackerman"), Author("R. Koch", Version:=2.0)>
+Public Class ThirdClass
+End Class
+
+Class TestAuthorAttribute
+    Sub Main()
+        PrintAuthorInfo(GetType(FirstClass))
+        PrintAuthorInfo(GetType(SecondClass))
+        PrintAuthorInfo(GetType(ThirdClass))
+    End Sub
+
+    Private Shared Sub PrintAuthorInfo(ByVal t As System.Type)
+        System.Console.WriteLine("Author information for {0}", t)
+
+        ' Using reflection
+        Dim attrs() As System.Attribute = System.Attribute.GetCustomAttributes(t)
+
+        ' Displaying output
+        For Each attr In attrs
+            Dim a As Author = CType(attr, Author)
+            System.Console.WriteLine("   {0}, version {1:f}", a.GetName(), a.version)
+        Next
+    End Sub
+
+    ' Output:
+    '   Author information for FirstClass
+    '     P. Ackerman, version 1.00
+    ' Author information for SecondClass
+    ' Author information for ThirdClass
+    '  R. Koch, version 2.00
+    '  P. Ackerman, version 1.00
+
+End Class
+```
+
 ## See also
 
 - <xref:System.Reflection>

--- a/docs/visual-basic/programming-guide/concepts/attributes/attributeusage.md
+++ b/docs/visual-basic/programming-guide/concepts/attributes/attributeusage.md
@@ -4,157 +4,160 @@ ms.date: 07/20/2015
 ms.assetid: 48757216-c21d-4051-86d5-8a3e03c39d2c
 ---
 # AttributeUsage (Visual Basic)
-Determines how a custom attribute class can be used. `AttributeUsage` is an attribute that can be applied to custom attribute definitions to control how the new attribute can be applied. The default settings look like this when applied explicitly:  
-  
-```vb  
-<System.AttributeUsage(System.AttributeTargets.All,   
-                   AllowMultiple:=False,   
-                   Inherited:=True)>   
-Class NewAttribute  
-    Inherits System.Attribute  
-End Class  
-```  
-  
- In this example, the `NewAttribute` class can be applied to any attribute-able code entity, but can be applied only once to each entity. It is inherited by derived classes when applied to a base class.  
-  
- The `AllowMultiple` and `Inherited` arguments are optional, so this code has the same effect:  
-  
-```vb  
-<System.AttributeUsage(System.AttributeTargets.All)>   
-Class NewAttribute  
-    Inherits System.Attribute  
-End Class  
-```  
-  
- The first `AttributeUsage` argument must be one or more elements of the <xref:System.AttributeTargets> enumeration. Multiple target types can be linked together with the OR operator, like this:  
-  
-```vb  
-Imports System  
-```  
-  
-```vb  
-<AttributeUsage(AttributeTargets.Property Or AttributeTargets.Field)>   
-Class NewPropertyOrFieldAttribute  
-    Inherits Attribute  
-End Class  
-```  
-  
- If the `AllowMultiple` argument is set to `true`, then the resulting attribute can be applied more than once to a single entity, like this:  
-  
-```vb  
-Imports System  
-```  
-  
-```vb  
-<AttributeUsage(AttributeTargets.Class, AllowMultiple:=True)>   
-Class MultiUseAttr  
-    Inherits Attribute  
-End Class  
-  
-<MultiUseAttr(), MultiUseAttr()>   
-Class Class1  
-End Class  
-```  
-  
- In this case `MultiUseAttr` can be applied repeatedly because `AllowMultiple` is set to `true`. Both formats shown for applying multiple attributes are valid.  
-  
- If `Inherited` is set to `false`, then the attribute is not inherited by classes that are derived from a class that is attributed. For example:  
-  
-```vb  
-Imports System  
-```  
-  
-```vb  
-<AttributeUsage(AttributeTargets.Class, Inherited:=False)>   
-Class Attr1  
-    Inherits Attribute  
-End Class  
-  
-<Attr1()>   
-Class BClass  
-  
-End Class    
-  
-Class DClass  
-    Inherits BClass  
-End Class  
-```  
-  
- In this case `Attr1` is not applied to `DClass` via inheritance.  
-  
-## Remarks  
- The `AttributeUsage` attribute is a single-use attribute--it cannot be applied more than once to the same class. `AttributeUsage` is an alias for <xref:System.AttributeUsageAttribute>.  
-  
- For more information, see [Accessing Attributes by Using Reflection (Visual Basic)](../../../../visual-basic/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md).  
-  
-## Example  
- The following example demonstrates the effect of the `Inherited` and `AllowMultiple` arguments to the `AttributeUsage` attribute, and how the custom attributes applied to a class can be enumerated.  
-  
-```vb  
-Imports System  
-```  
-  
-```vb  
-' Create some custom attributes:  
-<AttributeUsage(System.AttributeTargets.Class, Inherited:=False)>   
-Class A1  
-    Inherits System.Attribute  
-End Class  
-  
-<AttributeUsage(System.AttributeTargets.Class)>   
-Class A2  
-    Inherits System.Attribute  
-End Class      
-  
-<AttributeUsage(System.AttributeTargets.Class, AllowMultiple:=True)>   
-Class A3  
-    Inherits System.Attribute  
-End Class  
-  
-' Apply custom attributes to classes:  
-<A1(), A2()>   
-Class BaseClass  
-  
-End Class  
-  
-<A3(), A3()>   
-Class DerivedClass  
-    Inherits BaseClass  
-End Class  
-  
-Public Class TestAttributeUsage  
-    Sub Main()  
-        Dim b As New BaseClass  
-        Dim d As New DerivedClass  
-        ' Display custom attributes for each class.  
-        Console.WriteLine("Attributes on Base Class:")  
-        Dim attrs() As Object = b.GetType().GetCustomAttributes(True)  
-  
-        For Each attr In attrs  
-            Console.WriteLine(attr)  
-        Next  
-  
-        Console.WriteLine("Attributes on Derived Class:")  
-        attrs = d.GetType().GetCustomAttributes(True)  
-        For Each attr In attrs  
-            Console.WriteLine(attr)  
-        Next              
-    End Sub  
-End Class  
-```  
-  
-## Sample Output  
-  
-```console  
-Attributes on Base Class:  
-A1  
-A2  
-Attributes on Derived Class:  
-A3  
-A3  
-A2  
-```  
-  
+
+Determines how a custom attribute class can be used. `AttributeUsage` is an attribute that can be applied to custom attribute definitions to control how the new attribute can be applied. The default settings look like this when applied explicitly:
+
+```vb
+<System.AttributeUsage(System.AttributeTargets.All,
+                   AllowMultiple:=False,
+                   Inherited:=True)>
+Class NewAttribute
+    Inherits System.Attribute
+End Class
+```
+
+In this example, the `NewAttribute` class can be applied to any attribute-able code entity, but can be applied only once to each entity. It is inherited by derived classes when applied to a base class.
+
+The `AllowMultiple` and `Inherited` arguments are optional, so this code has the same effect:
+
+```vb
+<System.AttributeUsage(System.AttributeTargets.All)>
+Class NewAttribute
+    Inherits System.Attribute
+End Class
+```
+
+The first `AttributeUsage` argument must be one or more elements of the <xref:System.AttributeTargets> enumeration. Multiple target types can be linked together with the OR operator, like this:
+
+```vb
+Imports System
+```
+
+```vb
+<AttributeUsage(AttributeTargets.Property Or AttributeTargets.Field)>
+Class NewPropertyOrFieldAttribute
+    Inherits Attribute
+End Class
+```
+
+If the `AllowMultiple` argument is set to `true`, then the resulting attribute can be applied more than once to a single entity, like this:
+
+```vb
+Imports System
+```
+
+```vb
+<AttributeUsage(AttributeTargets.Class, AllowMultiple:=True)>
+Class MultiUseAttr
+    Inherits Attribute
+End Class
+
+<MultiUseAttr(), MultiUseAttr()>
+Class Class1
+End Class
+```
+
+In this case `MultiUseAttr` can be applied repeatedly because `AllowMultiple` is set to `true`. Both formats shown for applying multiple attributes are valid.
+
+If `Inherited` is set to `false`, then the attribute is not inherited by classes that are derived from a class that is attributed. For example:
+
+```vb
+Imports System
+```
+
+```vb
+<AttributeUsage(AttributeTargets.Class, Inherited:=False)>
+Class Attr1
+    Inherits Attribute
+End Class
+
+<Attr1()>
+Class BClass
+
+End Class
+
+Class DClass
+    Inherits BClass
+End Class
+```
+
+In this case `Attr1` is not applied to `DClass` via inheritance.
+
+## Remarks
+
+The `AttributeUsage` attribute is a single-use attribute--it cannot be applied more than once to the same class. `AttributeUsage` is an alias for <xref:System.AttributeUsageAttribute>.
+
+For more information, see [Accessing Attributes by Using Reflection (Visual Basic)](../../../../visual-basic/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md).
+
+## Example
+
+The following example demonstrates the effect of the `Inherited` and `AllowMultiple` arguments to the `AttributeUsage` attribute, and how the custom attributes applied to a class can be enumerated.
+
+```vb
+Imports System
+```
+
+```vb
+' Create some custom attributes:
+<AttributeUsage(System.AttributeTargets.Class, Inherited:=False)>
+Class A1
+    Inherits System.Attribute
+End Class
+
+<AttributeUsage(System.AttributeTargets.Class)>
+Class A2
+    Inherits System.Attribute
+End Class
+
+<AttributeUsage(System.AttributeTargets.Class, AllowMultiple:=True)>
+Class A3
+    Inherits System.Attribute
+End Class
+
+' Apply custom attributes to classes:
+<A1(), A2()>
+Class BaseClass
+
+End Class
+
+<A3(), A3()>
+Class DerivedClass
+    Inherits BaseClass
+End Class
+
+Public Class TestAttributeUsage
+    Sub Main()
+        Dim b As New BaseClass
+        Dim d As New DerivedClass
+        ' Display custom attributes for each class.
+        Console.WriteLine("Attributes on Base Class:")
+        Dim attrs() As Object = b.GetType().GetCustomAttributes(True)
+
+        For Each attr In attrs
+            Console.WriteLine(attr)
+        Next
+
+        Console.WriteLine("Attributes on Derived Class:")
+        attrs = d.GetType().GetCustomAttributes(True)
+        For Each attr In attrs
+            Console.WriteLine(attr)
+        Next
+    End Sub
+End Class
+```
+
+## Sample Output
+
+```console
+Attributes on Base Class:
+A1
+A2
+Attributes on Derived Class:
+A3
+A3
+A2
+```
+
 ## See also
 
 - <xref:System.Attribute>

--- a/docs/visual-basic/programming-guide/concepts/attributes/common-attributes.md
+++ b/docs/visual-basic/programming-guide/concepts/attributes/common-attributes.md
@@ -4,250 +4,265 @@ ms.date: 07/20/2015
 ms.assetid: 11fe4894-1bf9-4525-a36b-cddcd3a5d22b
 ---
 # Common Attributes (Visual Basic)
-This topic describes the attributes that are most commonly used in Visual Basic programs.  
-  
-- [Global Attributes](#Global)  
-  
-- [Obsolete Attribute](#Obsolete)  
-  
-- [Conditional Attribute](#Conditional)  
-  
-- [Caller Info Attributes](#CallerInfo)  
-  
-- [Visual Basic Attributes](#VB)  
-  
-## <a name="Global"></a> Global Attributes  
- Most attributes are applied to specific language elements such as classes or methods; however, some attributes are global—they apply to an entire assembly or module. For example, the <xref:System.Reflection.AssemblyVersionAttribute> attribute can be used to embed version information into an assembly, like this:  
-  
-```vb  
-<Assembly: AssemblyVersion("1.0.0.0")>  
-```  
-  
- Global attributes appear in the source code after any top-level `Imports` statements and before any type, module, or namespace declarations. Global attributes can appear in multiple source files, but the files must be compiled in a single compilation pass. For Visual Basic projects, global attributes are generally put in the AssemblyInfo.vb file (the file is created automatically when you create a project in Visual Studio).  
-  
- Assembly attributes are values that provide information about an assembly. They fall into the following categories:  
-  
-- Assembly identity attributes  
-  
-- Informational attributes  
-  
-- Assembly manifest attributes  
-  
-### Assembly Identity Attributes  
- Three attributes (with a strong name, if applicable) determine the identity of an assembly: name, version, and culture. These attributes form the full name of the assembly and are required when you reference it in code. You can set an assembly's version and culture using attributes. However, the name value is set by the compiler, the Visual Studio IDE in the [Assembly Information Dialog Box](/visualstudio/ide/reference/assembly-information-dialog-box), or the Assembly Linker (Al.exe) when the assembly is created, based on the file that contains the assembly manifest. The <xref:System.Reflection.AssemblyFlagsAttribute> attribute specifies whether multiple copies of the assembly can coexist.  
-  
- The following table shows the identity attributes.  
-  
-|Attribute|Purpose|  
-|---------------|-------------|  
-|<xref:System.Reflection.AssemblyName>|Fully describes the identity of an assembly.|  
-|<xref:System.Reflection.AssemblyVersionAttribute>|Specifies the version of an assembly.|  
-|<xref:System.Reflection.AssemblyCultureAttribute>|Specifies which culture the assembly supports.|  
-|<xref:System.Reflection.AssemblyFlagsAttribute>|Specifies whether an assembly supports side-by-side execution on the same computer, in the same process, or in the same application domain.|  
-  
-### Informational Attributes  
- You can use informational attributes to provide additional company or product information for an assembly. The following table shows the informational attributes defined in the <xref:System.Reflection?displayProperty=nameWithType> namespace.  
-  
-|Attribute|Purpose|  
-|---------------|-------------|  
-|<xref:System.Reflection.AssemblyProductAttribute>|Defines a custom attribute that specifies a product name for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyTrademarkAttribute>|Defines a custom attribute that specifies a trademark for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyInformationalVersionAttribute>|Defines a custom attribute that specifies an informational version for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyCompanyAttribute>|Defines a custom attribute that specifies a company name for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyCopyrightAttribute>|Defines a custom attribute that specifies a copyright for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyFileVersionAttribute>|Instructs the compiler to use a specific version number for the Win32 file version resource.|  
-|<xref:System.CLSCompliantAttribute>|Indicates whether the assembly is compliant with the Common Language Specification (CLS).|  
-  
-### Assembly Manifest Attributes  
- You can use assembly manifest attributes to provide information in the assembly manifest. This includes title, description, default alias, and configuration. The following table shows the assembly manifest attributes defined in the <xref:System.Reflection?displayProperty=nameWithType> namespace.  
-  
-|Attribute|Purpose|  
-|---------------|-------------|  
-|<xref:System.Reflection.AssemblyTitleAttribute>|Defines a custom attribute that specifies an assembly title for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyDescriptionAttribute>|Defines a custom attribute that specifies an assembly description for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyConfigurationAttribute>|Defines a custom attribute that specifies an assembly configuration (such as retail or debug) for an assembly manifest.|  
-|<xref:System.Reflection.AssemblyDefaultAliasAttribute>|Defines a friendly default alias for an assembly manifest|  
-  
-## <a name="Obsolete"></a> Obsolete Attribute  
- The `Obsolete` attribute marks a program entity as one that is no longer recommended for use. Each use of an entity marked obsolete will subsequently generate a warning or an error, depending on how the attribute is configured. For example:  
-  
-```vb  
-<System.Obsolete("use class B")>   
-Class A  
-    Sub Method()  
-    End Sub  
-End Class  
-  
-Class B  
-    <System.Obsolete("use NewMethod", True)>   
-    Sub OldMethod()  
-    End Sub  
-  
-    Sub NewMethod()  
-    End Sub  
-End Class  
-```  
-  
- In this example the `Obsolete` attribute is applied to class `A` and to method `B.OldMethod`. Because the second argument of the attribute constructor applied to `B.OldMethod` is set to `true`, this method will cause a compiler error, whereas using class `A` will just produce a warning. Calling `B.NewMethod`, however, produces no warning or error.  
-  
- The string provided as the first argument to attribute constructor will be displayed as part of the warning or error. For example, when you use it with the previous definitions, the following code generates two warnings and one error:  
-  
-```vb  
-' Generates 2 warnings:  
-' Dim a As New A  
-' Generate no errors or warnings:  
-  
-Dim b As New B  
-b.NewMethod()  
-  
-' Generates an error, terminating compilation:  
-' b.OldMethod()  
-```  
-  
- Two warnings for class `A` are generated: one for the declaration of the class reference, and one for the class constructor.  
-  
- The `Obsolete` attribute can be used without arguments, but including an explanation of why the item is obsolete and what to use instead is recommended.  
-  
- The `Obsolete` attribute is a single-use attribute and can be applied to any entity that allows attributes. `Obsolete` is an alias for <xref:System.ObsoleteAttribute>.  
-  
-## <a name="Conditional"></a> Conditional Attribute  
- The `Conditional` attribute makes the execution of a method dependent on a preprocessing identifier. The `Conditional` attribute is an alias for <xref:System.Diagnostics.ConditionalAttribute>, and can be applied to a method or an attribute class.  
-  
- In this example, `Conditional` is applied to a method to enable or disable the display of program-specific diagnostic information:  
-  
-```vb  
-#Const TRACE_ON = True  
-Imports System  
-Imports System.Diagnostics  
-Module TestConditionalAttribute  
-    Public Class Trace  
-        <Conditional("TRACE_ON")>   
-        Public Shared Sub Msg(ByVal msg As String)  
-            Console.WriteLine(msg)  
-        End Sub  
-  
-    End Class  
-  
-    Sub Main()  
-        Trace.Msg("Now in Main...")  
-        Console.WriteLine("Done.")  
-    End Sub  
-End Module  
-```  
-  
- If the `TRACE_ON` identifier is not defined, no trace output will be displayed.  
-  
- The `Conditional` attribute is often used with the `DEBUG` identifier to enable trace and logging features for debug builds but not in release builds, like this:  
-  
-```vb  
-<Conditional("DEBUG")>   
-Shared Sub DebugMethod()  
-  
-End Sub  
-```  
-  
- When a method marked as conditional is called, the presence or absence of the specified preprocessing symbol determines whether the call is included or omitted. If the symbol is defined, the call is included; otherwise, the call is omitted. Using `Conditional` is a cleaner, more elegant, and less error-prone alternative to enclosing methods inside `#if…#endif` blocks, like this:  
-  
-```vb  
-#If DEBUG Then  
-    Sub ConditionalMethod()  
-    End Sub  
-#End If  
-```  
-  
- A conditional method must be a method in a class or struct declaration and must not have a return value.  
-  
-### Using Multiple Identifiers  
- If a method has multiple `Conditional` attributes, a call to the method is included if at least one of the conditional symbols is defined (in other words, the symbols are logically linked together by using the OR operator). In this example, the presence of either `A` or `B` will result in a method call:  
-  
-```vb  
-<Conditional("A"), Conditional("B")>   
-Shared Sub DoIfAorB()  
-  
-End Sub  
-```  
-  
- To achieve the effect of logically linking symbols by using the AND operator, you can define serial conditional methods. For example, the second method below will execute only if both `A` and `B` are defined:  
-  
-```vb  
-<Conditional("A")>   
-Shared Sub DoIfA()  
-    DoIfAandB()  
-End Sub  
-  
-<Conditional("B")>   
-Shared Sub DoIfAandB()  
-    ' Code to execute when both A and B are defined...  
-End Sub  
-```  
-  
-### Using Conditional with Attribute Classes  
- The `Conditional` attribute can also be applied to an attribute class definition. In this example, the custom attribute `Documentation` will only add information to the metadata if DEBUG is defined.  
-  
-```vb  
-<Conditional("DEBUG")>   
-Public Class Documentation  
-    Inherits System.Attribute  
-    Private text As String  
-    Sub New(ByVal doc_text As String)  
-        text = doc_text  
-    End Sub  
-End Class  
-  
-Class SampleClass  
-    ' This attribute will only be included if DEBUG is defined.  
-    <Documentation("This method displays an integer.")>   
-    Shared Sub DoWork(ByVal i As Integer)  
-        System.Console.WriteLine(i)  
-    End Sub  
-End Class  
-```  
-  
-## <a name="CallerInfo"></a> Caller Info Attributes  
- By using Caller Info attributes, you can obtain information about the caller to a method. You can obtain the file path of the source code, the line number in the source code, and the member name of the caller.  
-  
- To obtain member caller information, you use attributes that are applied to optional parameters. Each optional parameter specifies a default value. The following table lists the Caller Info attributes that are defined in the <xref:System.Runtime.CompilerServices?displayProperty=nameWithType> namespace:  
-  
-|Attribute|Description|Type|  
-|---|---|---|  
-|<xref:System.Runtime.CompilerServices.CallerFilePathAttribute>|Full path of the source file that contains the caller. This is the path at compile time.|`String`|  
-|<xref:System.Runtime.CompilerServices.CallerLineNumberAttribute>|Line number in the source file from which the method is called.|`Integer`|  
-|<xref:System.Runtime.CompilerServices.CallerMemberNameAttribute>|Method name or property name of the caller. For more information, see [Caller Information (Visual Basic)](../../../../visual-basic/programming-guide/concepts/caller-information.md).|`String`|  
-  
- For more information about the Caller Info attributes, see [Caller Information (Visual Basic)](../../../../visual-basic/programming-guide/concepts/caller-information.md).  
-  
-## <a name="VB"></a> Visual Basic Attributes  
- The following table lists the attributes that are specific to Visual Basic.  
-  
-|Attribute|Purpose|  
-|---------------|-------------|  
-|<xref:Microsoft.VisualBasic.ComClassAttribute>|Indicates to the compiler that the class should be exposed as a COM object.|  
-|<xref:Microsoft.VisualBasic.HideModuleNameAttribute>|Allows module members to be accessed using only the qualification needed for the module.|  
-|<xref:Microsoft.VisualBasic.VBFixedStringAttribute>|Specifies the size of a fixed-length string in a structure for use with file input and output functions.|  
-|<xref:Microsoft.VisualBasic.VBFixedArrayAttribute>|Specifies the size of a fixed array in a structure for use with file input and output functions.|  
-  
-### COMClassAttribute  
- Use `COMClassAttribute` to simplify the process of creating COM components from Visual Basic. COM objects are considerably different from .NET Framework assemblies, and without `COMClassAttribute`, you need to follow a number of steps to generate a COM object from Visual Basic. For classes marked with `COMClassAttribute`, the compiler performs many of these steps automatically.  
-  
-### HideModuleNameAttribute  
- Use `HideModuleNameAttribute` to allow module members to be accessed by using only the qualification needed for the module.  
-  
-### VBFixedStringAttribute  
- Use `VBFixedStringAttribute` to force Visual Basic to create a fixed-length string. Strings are of variable length by default, and this attribute is useful when storing strings to files. The following code demonstrates this:  
-  
-```vb  
-Structure Worker  
-    ' The runtime uses VBFixedString to determine   
-    ' if the field should be written out as a fixed size.  
-    <VBFixedString(10)> Public LastName As String  
-    <VBFixedString(7)> Public Title As String  
-    <VBFixedString(2)> Public Rank As String  
-End Structure  
-```  
-  
-### VBFixedArrayAttribute  
- Use `VBFixedArrayAttribute` to declare arrays that are fixed in size. Like Visual Basic strings, arrays are of variable length by default. This attribute is useful when serializing or writing data to files.  
-  
+
+This topic describes the attributes that are most commonly used in Visual Basic programs.
+
+- [Global Attributes](#Global)
+
+- [Obsolete Attribute](#Obsolete)
+
+- [Conditional Attribute](#Conditional)
+
+- [Caller Info Attributes](#CallerInfo)
+
+- [Visual Basic Attributes](#VB)
+
+## <a name="Global"></a> Global Attributes
+
+Most attributes are applied to specific language elements such as classes or methods; however, some attributes are global—they apply to an entire assembly or module. For example, the <xref:System.Reflection.AssemblyVersionAttribute> attribute can be used to embed version information into an assembly, like this:
+
+```vb
+<Assembly: AssemblyVersion("1.0.0.0")>
+```
+
+Global attributes appear in the source code after any top-level `Imports` statements and before any type, module, or namespace declarations. Global attributes can appear in multiple source files, but the files must be compiled in a single compilation pass. For Visual Basic projects, global attributes are generally put in the AssemblyInfo.vb file (the file is created automatically when you create a project in Visual Studio).
+
+Assembly attributes are values that provide information about an assembly. They fall into the following categories:
+
+- Assembly identity attributes
+
+- Informational attributes
+
+- Assembly manifest attributes
+
+### Assembly Identity Attributes
+
+Three attributes (with a strong name, if applicable) determine the identity of an assembly: name, version, and culture. These attributes form the full name of the assembly and are required when you reference it in code. You can set an assembly's version and culture using attributes. However, the name value is set by the compiler, the Visual Studio IDE in the [Assembly Information Dialog Box](/visualstudio/ide/reference/assembly-information-dialog-box), or the Assembly Linker (Al.exe) when the assembly is created, based on the file that contains the assembly manifest. The <xref:System.Reflection.AssemblyFlagsAttribute> attribute specifies whether multiple copies of the assembly can coexist.
+
+The following table shows the identity attributes.
+
+|Attribute|Purpose|
+|---------------|-------------|
+|<xref:System.Reflection.AssemblyName>|Fully describes the identity of an assembly.|
+|<xref:System.Reflection.AssemblyVersionAttribute>|Specifies the version of an assembly.|
+|<xref:System.Reflection.AssemblyCultureAttribute>|Specifies which culture the assembly supports.|
+|<xref:System.Reflection.AssemblyFlagsAttribute>|Specifies whether an assembly supports side-by-side execution on the same computer, in the same process, or in the same application domain.|
+
+### Informational Attributes
+
+You can use informational attributes to provide additional company or product information for an assembly. The following table shows the informational attributes defined in the <xref:System.Reflection?displayProperty=nameWithType> namespace.
+
+|Attribute|Purpose|
+|---------------|-------------|
+|<xref:System.Reflection.AssemblyProductAttribute>|Defines a custom attribute that specifies a product name for an assembly manifest.|
+|<xref:System.Reflection.AssemblyTrademarkAttribute>|Defines a custom attribute that specifies a trademark for an assembly manifest.|
+|<xref:System.Reflection.AssemblyInformationalVersionAttribute>|Defines a custom attribute that specifies an informational version for an assembly manifest.|
+|<xref:System.Reflection.AssemblyCompanyAttribute>|Defines a custom attribute that specifies a company name for an assembly manifest.|
+|<xref:System.Reflection.AssemblyCopyrightAttribute>|Defines a custom attribute that specifies a copyright for an assembly manifest.|
+|<xref:System.Reflection.AssemblyFileVersionAttribute>|Instructs the compiler to use a specific version number for the Win32 file version resource.|
+|<xref:System.CLSCompliantAttribute>|Indicates whether the assembly is compliant with the Common Language Specification (CLS).|
+
+### Assembly Manifest Attributes
+
+You can use assembly manifest attributes to provide information in the assembly manifest. This includes title, description, default alias, and configuration. The following table shows the assembly manifest attributes defined in the <xref:System.Reflection?displayProperty=nameWithType> namespace.
+
+|Attribute|Purpose|
+|---------------|-------------|
+|<xref:System.Reflection.AssemblyTitleAttribute>|Defines a custom attribute that specifies an assembly title for an assembly manifest.|
+|<xref:System.Reflection.AssemblyDescriptionAttribute>|Defines a custom attribute that specifies an assembly description for an assembly manifest.|
+|<xref:System.Reflection.AssemblyConfigurationAttribute>|Defines a custom attribute that specifies an assembly configuration (such as retail or debug) for an assembly manifest.|
+|<xref:System.Reflection.AssemblyDefaultAliasAttribute>|Defines a friendly default alias for an assembly manifest|
+
+## <a name="Obsolete"></a> Obsolete Attribute
+
+The `Obsolete` attribute marks a program entity as one that is no longer recommended for use. Each use of an entity marked obsolete will subsequently generate a warning or an error, depending on how the attribute is configured. For example:
+
+```vb
+<System.Obsolete("use class B")>
+Class A
+    Sub Method()
+    End Sub
+End Class
+
+Class B
+    <System.Obsolete("use NewMethod", True)>
+    Sub OldMethod()
+    End Sub
+
+    Sub NewMethod()
+    End Sub
+End Class
+```
+
+In this example the `Obsolete` attribute is applied to class `A` and to method `B.OldMethod`. Because the second argument of the attribute constructor applied to `B.OldMethod` is set to `true`, this method will cause a compiler error, whereas using class `A` will just produce a warning. Calling `B.NewMethod`, however, produces no warning or error.
+
+The string provided as the first argument to attribute constructor will be displayed as part of the warning or error. For example, when you use it with the previous definitions, the following code generates two warnings and one error:
+
+```vb
+' Generates 2 warnings:
+' Dim a As New A
+' Generate no errors or warnings:
+
+Dim b As New B
+b.NewMethod()
+
+' Generates an error, terminating compilation:
+' b.OldMethod()
+```
+
+Two warnings for class `A` are generated: one for the declaration of the class reference, and one for the class constructor.
+
+The `Obsolete` attribute can be used without arguments, but including an explanation of why the item is obsolete and what to use instead is recommended.
+
+The `Obsolete` attribute is a single-use attribute and can be applied to any entity that allows attributes. `Obsolete` is an alias for <xref:System.ObsoleteAttribute>.
+
+## <a name="Conditional"></a> Conditional Attribute
+
+The `Conditional` attribute makes the execution of a method dependent on a preprocessing identifier. The `Conditional` attribute is an alias for <xref:System.Diagnostics.ConditionalAttribute>, and can be applied to a method or an attribute class.
+
+In this example, `Conditional` is applied to a method to enable or disable the display of program-specific diagnostic information:
+
+```vb
+#Const TRACE_ON = True
+Imports System
+Imports System.Diagnostics
+Module TestConditionalAttribute
+    Public Class Trace
+        <Conditional("TRACE_ON")>
+        Public Shared Sub Msg(ByVal msg As String)
+            Console.WriteLine(msg)
+        End Sub
+
+    End Class
+
+    Sub Main()
+        Trace.Msg("Now in Main...")
+        Console.WriteLine("Done.")
+    End Sub
+End Module
+```
+
+If the `TRACE_ON` identifier is not defined, no trace output will be displayed.
+
+The `Conditional` attribute is often used with the `DEBUG` identifier to enable trace and logging features for debug builds but not in release builds, like this:
+
+```vb
+<Conditional("DEBUG")>
+Shared Sub DebugMethod()
+
+End Sub
+```
+
+When a method marked as conditional is called, the presence or absence of the specified preprocessing symbol determines whether the call is included or omitted. If the symbol is defined, the call is included; otherwise, the call is omitted. Using `Conditional` is a cleaner, more elegant, and less error-prone alternative to enclosing methods inside `#if…#endif` blocks, like this:
+
+```vb
+#If DEBUG Then
+    Sub ConditionalMethod()
+    End Sub
+#End If
+```
+
+A conditional method must be a method in a class or struct declaration and must not have a return value.
+
+### Using Multiple Identifiers
+
+If a method has multiple `Conditional` attributes, a call to the method is included if at least one of the conditional symbols is defined (in other words, the symbols are logically linked together by using the OR operator). In this example, the presence of either `A` or `B` will result in a method call:
+
+```vb
+<Conditional("A"), Conditional("B")>
+Shared Sub DoIfAorB()
+
+End Sub
+```
+
+To achieve the effect of logically linking symbols by using the AND operator, you can define serial conditional methods. For example, the second method below will execute only if both `A` and `B` are defined:
+
+```vb
+<Conditional("A")>
+Shared Sub DoIfA()
+    DoIfAandB()
+End Sub
+
+<Conditional("B")>
+Shared Sub DoIfAandB()
+    ' Code to execute when both A and B are defined...
+End Sub
+```
+
+### Using Conditional with Attribute Classes
+
+The `Conditional` attribute can also be applied to an attribute class definition. In this example, the custom attribute `Documentation` will only add information to the metadata if DEBUG is defined.
+
+```vb
+<Conditional("DEBUG")>
+Public Class Documentation
+    Inherits System.Attribute
+    Private text As String
+    Sub New(ByVal doc_text As String)
+        text = doc_text
+    End Sub
+End Class
+
+Class SampleClass
+    ' This attribute will only be included if DEBUG is defined.
+    <Documentation("This method displays an integer.")>
+    Shared Sub DoWork(ByVal i As Integer)
+        System.Console.WriteLine(i)
+    End Sub
+End Class
+```
+
+## <a name="CallerInfo"></a> Caller Info Attributes
+
+By using Caller Info attributes, you can obtain information about the caller to a method. You can obtain the file path of the source code, the line number in the source code, and the member name of the caller.
+
+To obtain member caller information, you use attributes that are applied to optional parameters. Each optional parameter specifies a default value. The following table lists the Caller Info attributes that are defined in the <xref:System.Runtime.CompilerServices?displayProperty=nameWithType> namespace:
+
+|Attribute|Description|Type|
+|---|---|---|
+|<xref:System.Runtime.CompilerServices.CallerFilePathAttribute>|Full path of the source file that contains the caller. This is the path at compile time.|`String`|
+|<xref:System.Runtime.CompilerServices.CallerLineNumberAttribute>|Line number in the source file from which the method is called.|`Integer`|
+|<xref:System.Runtime.CompilerServices.CallerMemberNameAttribute>|Method name or property name of the caller. For more information, see [Caller Information (Visual Basic)](../../../../visual-basic/programming-guide/concepts/caller-information.md).|`String`|
+
+For more information about the Caller Info attributes, see [Caller Information (Visual Basic)](../../../../visual-basic/programming-guide/concepts/caller-information.md).
+
+## <a name="VB"></a> Visual Basic Attributes
+
+The following table lists the attributes that are specific to Visual Basic.
+
+|Attribute|Purpose|
+|---------------|-------------|
+|<xref:Microsoft.VisualBasic.ComClassAttribute>|Indicates to the compiler that the class should be exposed as a COM object.|
+|<xref:Microsoft.VisualBasic.HideModuleNameAttribute>|Allows module members to be accessed using only the qualification needed for the module.|
+|<xref:Microsoft.VisualBasic.VBFixedStringAttribute>|Specifies the size of a fixed-length string in a structure for use with file input and output functions.|
+|<xref:Microsoft.VisualBasic.VBFixedArrayAttribute>|Specifies the size of a fixed array in a structure for use with file input and output functions.|
+
+### COMClassAttribute
+
+Use `COMClassAttribute` to simplify the process of creating COM components from Visual Basic. COM objects are considerably different from .NET Framework assemblies, and without `COMClassAttribute`, you need to follow a number of steps to generate a COM object from Visual Basic. For classes marked with `COMClassAttribute`, the compiler performs many of these steps automatically.
+
+### HideModuleNameAttribute
+
+Use `HideModuleNameAttribute` to allow module members to be accessed by using only the qualification needed for the module.
+
+### VBFixedStringAttribute
+
+Use `VBFixedStringAttribute` to force Visual Basic to create a fixed-length string. Strings are of variable length by default, and this attribute is useful when storing strings to files. The following code demonstrates this:
+
+```vb
+Structure Worker
+    ' The runtime uses VBFixedString to determine
+    ' if the field should be written out as a fixed size.
+    <VBFixedString(10)> Public LastName As String
+    <VBFixedString(7)> Public Title As String
+    <VBFixedString(2)> Public Rank As String
+End Structure
+```
+
+### VBFixedArrayAttribute
+
+Use `VBFixedArrayAttribute` to declare arrays that are fixed in size. Like Visual Basic strings, arrays are of variable length by default. This attribute is useful when serializing or writing data to files.
+
 ## See also
 
 - <xref:System.Reflection>

--- a/docs/visual-basic/programming-guide/concepts/attributes/creating-custom-attributes.md
+++ b/docs/visual-basic/programming-guide/concepts/attributes/creating-custom-attributes.md
@@ -4,58 +4,59 @@ ms.date: 07/20/2015
 ms.assetid: 5c9ef584-6c7c-496b-92a9-6e42f8d9ca28
 ---
 # Creating Custom Attributes (Visual Basic)
-You can create your own custom attributes by defining an attribute class, a class that derives directly or indirectly from <xref:System.Attribute>, which makes identifying attribute definitions in metadata fast and easy. Suppose you want to tag types with the name of the programmer who wrote the type. You might define a custom `Author` attribute class:  
-  
-```vb  
-<System.AttributeUsage(System.AttributeTargets.Class Or   
-                       System.AttributeTargets.Struct)>   
-Public Class Author  
-    Inherits System.Attribute  
-    Private name As String  
-    Public version As Double  
-    Sub New(ByVal authorName As String)  
-        name = authorName  
-        version = 1.0  
-    End Sub  
-End Class  
-```  
-  
- The class name is the attribute's name, `Author`. It is derived from `System.Attribute`, so it is a custom attribute class. The constructor's parameters are the custom attribute's positional parameters. In this example, `name` is a positional parameter. Any public read-write fields or properties are named parameters. In this case, `version` is the only named parameter. Note the use of the `AttributeUsage` attribute to make the `Author` attribute valid only on class and `Structure` declarations.  
-  
- You could use this new attribute as follows:  
-  
-```vb  
-<Author("P. Ackerman", Version:=1.1)>   
-Class SampleClass  
-    ' P. Ackerman's code goes here...  
-End Class  
-```  
-  
- `AttributeUsage` has a named parameter, `AllowMultiple`, with which you can make a custom attribute single-use or multiuse. In the following code example, a multiuse attribute is created.  
-  
-```vb  
-' multiuse attribute  
-<System.AttributeUsage(System.AttributeTargets.Class Or   
-                       System.AttributeTargets.Struct,   
-                       AllowMultiple:=True)>   
-Public Class Author  
-    Inherits System.Attribute  
-```  
-  
- In the following code example, multiple attributes of the same type are applied to a class.  
-  
-```vb  
-<Author("P. Ackerman", Version:=1.1),   
-Author("R. Koch", Version:=1.2)>   
-Class SampleClass  
-    ' P. Ackerman's code goes here...  
-    ' R. Koch's code goes here...  
-End Class  
-```  
-  
+
+You can create your own custom attributes by defining an attribute class, a class that derives directly or indirectly from <xref:System.Attribute>, which makes identifying attribute definitions in metadata fast and easy. Suppose you want to tag types with the name of the programmer who wrote the type. You might define a custom `Author` attribute class:
+
+```vb
+<System.AttributeUsage(System.AttributeTargets.Class Or
+                       System.AttributeTargets.Struct)>
+Public Class Author
+    Inherits System.Attribute
+    Private name As String
+    Public version As Double
+    Sub New(ByVal authorName As String)
+        name = authorName
+        version = 1.0
+    End Sub
+End Class
+```
+
+The class name is the attribute's name, `Author`. It is derived from `System.Attribute`, so it is a custom attribute class. The constructor's parameters are the custom attribute's positional parameters. In this example, `name` is a positional parameter. Any public read-write fields or properties are named parameters. In this case, `version` is the only named parameter. Note the use of the `AttributeUsage` attribute to make the `Author` attribute valid only on class and `Structure` declarations.
+
+You could use this new attribute as follows:
+
+```vb
+<Author("P. Ackerman", Version:=1.1)>
+Class SampleClass
+    ' P. Ackerman's code goes here...
+End Class
+```
+
+`AttributeUsage` has a named parameter, `AllowMultiple`, with which you can make a custom attribute single-use or multiuse. In the following code example, a multiuse attribute is created.
+
+```vb
+' multiuse attribute
+<System.AttributeUsage(System.AttributeTargets.Class Or
+                       System.AttributeTargets.Struct,
+                       AllowMultiple:=True)>
+Public Class Author
+    Inherits System.Attribute
+```
+
+In the following code example, multiple attributes of the same type are applied to a class.
+
+```vb
+<Author("P. Ackerman", Version:=1.1),
+Author("R. Koch", Version:=1.2)>
+Class SampleClass
+    ' P. Ackerman's code goes here...
+    ' R. Koch's code goes here...
+End Class
+```
+
 > [!NOTE]
-> If your attribute class contains a property, that property must be read-write.  
-  
+> If your attribute class contains a property, that property must be read-write.
+
 ## See also
 
 - <xref:System.Reflection>

--- a/docs/visual-basic/programming-guide/concepts/attributes/how-to-create-a-c-cpp-union-by-using-attributes.md
+++ b/docs/visual-basic/programming-guide/concepts/attributes/how-to-create-a-c-cpp-union-by-using-attributes.md
@@ -4,62 +4,65 @@ ms.date: 07/20/2015
 ms.assetid: 9352a7e4-c0da-4d07-aa14-55ed43736fcb
 ---
 # How to: Create a C/C++ Union by Using Attributes (Visual Basic)
-By using attributes you can customize how structs are laid out in memory. For example, you can create what is known as a union in C/C++ by using the `StructLayout(LayoutKind.Explicit)` and `FieldOffset` attributes.  
-  
-## Example  
- In this code segment, all of the fields of `TestUnion` start at the same location in memory.  
-  
-```vb  
-' Add an Imports statement for System.Runtime.InteropServices.  
-  
-<System.Runtime.InteropServices.StructLayout(   
-      System.Runtime.InteropServices.LayoutKind.Explicit)>   
-Structure TestUnion  
-    <System.Runtime.InteropServices.FieldOffset(0)>   
-    Public i As Integer  
-  
-    <System.Runtime.InteropServices.FieldOffset(0)>   
-    Public d As Double  
-  
-    <System.Runtime.InteropServices.FieldOffset(0)>   
-    Public c As Char  
-  
-    <System.Runtime.InteropServices.FieldOffset(0)>   
-    Public b As Byte  
-End Structure  
-```  
-  
-## Example  
- The following is another example where fields start at different explicitly set locations.  
-  
-```vb  
-' Add an Imports statement for System.Runtime.InteropServices.  
-  
- <System.Runtime.InteropServices.StructLayout(  
-      System.Runtime.InteropServices.LayoutKind.Explicit)>   
-Structure TestExplicit  
-     <System.Runtime.InteropServices.FieldOffset(0)>   
-     Public lg As Long  
-  
-     <System.Runtime.InteropServices.FieldOffset(0)>   
-     Public i1 As Integer  
-  
-     <System.Runtime.InteropServices.FieldOffset(4)>   
-     Public i2 As Integer  
-  
-     <System.Runtime.InteropServices.FieldOffset(8)>   
-     Public d As Double  
-  
-     <System.Runtime.InteropServices.FieldOffset(12)>   
-     Public c As Char  
-  
-     <System.Runtime.InteropServices.FieldOffset(14)>   
-     Public b As Byte  
- End Structure  
-```  
-  
- The two integer fields, `i1` and `i2`, share the same memory locations as `lg`. This sort of control over struct layout is useful when using platform invocation.  
-  
+
+By using attributes you can customize how structs are laid out in memory. For example, you can create what is known as a union in C/C++ by using the `StructLayout(LayoutKind.Explicit)` and `FieldOffset` attributes.
+
+## Example
+
+In this code segment, all of the fields of `TestUnion` start at the same location in memory.
+
+```vb
+' Add an Imports statement for System.Runtime.InteropServices.
+
+<System.Runtime.InteropServices.StructLayout(
+      System.Runtime.InteropServices.LayoutKind.Explicit)>
+Structure TestUnion
+    <System.Runtime.InteropServices.FieldOffset(0)>
+    Public i As Integer
+
+    <System.Runtime.InteropServices.FieldOffset(0)>
+    Public d As Double
+
+    <System.Runtime.InteropServices.FieldOffset(0)>
+    Public c As Char
+
+    <System.Runtime.InteropServices.FieldOffset(0)>
+    Public b As Byte
+End Structure
+```
+
+## Example
+
+The following is another example where fields start at different explicitly set locations.
+
+```vb
+' Add an Imports statement for System.Runtime.InteropServices.
+
+ <System.Runtime.InteropServices.StructLayout(
+      System.Runtime.InteropServices.LayoutKind.Explicit)>
+Structure TestExplicit
+     <System.Runtime.InteropServices.FieldOffset(0)>
+     Public lg As Long
+
+     <System.Runtime.InteropServices.FieldOffset(0)>
+     Public i1 As Integer
+
+     <System.Runtime.InteropServices.FieldOffset(4)>
+     Public i2 As Integer
+
+     <System.Runtime.InteropServices.FieldOffset(8)>
+     Public d As Double
+
+     <System.Runtime.InteropServices.FieldOffset(12)>
+     Public c As Char
+
+     <System.Runtime.InteropServices.FieldOffset(14)>
+     Public b As Byte
+ End Structure
+```
+
+The two integer fields, `i1` and `i2`, share the same memory locations as `lg`. This sort of control over struct layout is useful when using platform invocation.
+
 ## See also
 
 - <xref:System.Reflection>

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
@@ -4,92 +4,93 @@ ms.date: 07/20/2015
 ms.assetid: 59224c46-9931-466b-8c6e-3648c3e609c6
 ---
 # Covariance and Contravariance (Visual Basic)
-In Visual Basic, covariance and contravariance enable implicit reference conversion for array types, delegate types, and generic type arguments. Covariance preserves assignment compatibility and contravariance reverses it.  
-  
- The following code demonstrates the difference between assignment compatibility, covariance, and contravariance.  
-  
-```vb  
-' Assignment compatibility.   
-Dim str As String = "test"  
-' An object of a more derived type is assigned to an object of a less derived type.   
-Dim obj As Object = str  
-  
-' Covariance.   
-Dim strings As IEnumerable(Of String) = New List(Of String)()  
-' An object that is instantiated with a more derived type argument   
-' is assigned to an object instantiated with a less derived type argument.   
-' Assignment compatibility is preserved.   
-Dim objects As IEnumerable(Of Object) = strings  
-  
-' Contravariance.             
-' Assume that there is the following method in the class:   
-' Shared Sub SetObject(ByVal o As Object)  
-' End Sub  
-Dim actObject As Action(Of Object) = AddressOf SetObject  
-  
-' An object that is instantiated with a less derived type argument   
-' is assigned to an object instantiated with a more derived type argument.   
-' Assignment compatibility is reversed.   
-Dim actString As Action(Of String) = actObject  
-```  
-  
- Covariance for arrays enables implicit conversion of an array of a more derived type to an array of a less derived type. But this operation is not type safe, as shown in the following code example.  
-  
-```vb  
-Dim array() As Object = New String(10) {}  
-' The following statement produces a run-time exception.  
-' array(0) = 10  
-```  
-  
- Covariance and contravariance support for method groups allows for matching method signatures with delegate types. This enables you to assign to delegates not only methods that have matching signatures, but also methods that return more derived types (covariance) or that accept parameters that have less derived types (contravariance) than that specified by the delegate type. For more information, see [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md) and [Using Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md).  
-  
- The following code example shows covariance and contravariance support for method groups.  
-  
-```vb  
-Shared Function GetObject() As Object  
-    Return Nothing  
-End Function  
-  
-Shared Sub SetObject(ByVal obj As Object)  
-End Sub  
-  
-Shared Function GetString() As String  
-    Return ""  
-End Function  
-  
-Shared Sub SetString(ByVal str As String)  
-  
-End Sub  
-  
-Shared Sub Test()  
-    ' Covariance. A delegate specifies a return type as object,  
-    ' but you can assign a method that returns a string.  
-    Dim del As Func(Of Object) = AddressOf GetString  
-  
-    ' Contravariance. A delegate specifies a parameter type as string,  
-    ' but you can assign a method that takes an object.  
-    Dim del2 As Action(Of String) = AddressOf SetObject  
-End Sub  
-```  
-  
- In .NET Framework 4 or later, Visual Basic supports covariance and contravariance in generic interfaces and delegates and allows for implicit conversion of generic type parameters. For more information, see [Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
-  
- The following code example shows implicit reference conversion for generic interfaces.  
-  
-```vb  
-Dim strings As IEnumerable(Of String) = New List(Of String)  
-Dim objects As IEnumerable(Of Object) = strings  
-```  
-  
- A generic interface or delegate is called *variant* if its generic parameters are declared covariant or contravariant. Visual Basic enables you to create your own variant interfaces and delegates. For more information, see [Creating Variant Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
-  
-## Related Topics  
-  
-|Title|Description|  
-|-----------|-----------------|  
-|[Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md)|Discusses covariance and contravariance in generic interfaces and provides a list of variant generic interfaces in the .NET Framework.|  
-|[Creating Variant Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md)|Shows how to create custom variant interfaces.|  
-|[Using Variance in Interfaces for Generic Collections (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md)|Shows how covariance and contravariance support in the <xref:System.Collections.Generic.IEnumerable%601> and <xref:System.IComparable%601> interfaces can help you reuse code.|  
-|[Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md)|Discusses covariance and contravariance in generic and non-generic delegates and provides a list of variant generic delegates in the .NET Framework.|  
-|[Using Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md)|Shows how to use covariance and contravariance support in non-generic delegates to match method signatures with delegate types.|  
+
+In Visual Basic, covariance and contravariance enable implicit reference conversion for array types, delegate types, and generic type arguments. Covariance preserves assignment compatibility and contravariance reverses it.
+
+The following code demonstrates the difference between assignment compatibility, covariance, and contravariance.
+
+```vb
+' Assignment compatibility.
+Dim str As String = "test"
+' An object of a more derived type is assigned to an object of a less derived type.
+Dim obj As Object = str
+
+' Covariance.
+Dim strings As IEnumerable(Of String) = New List(Of String)()
+' An object that is instantiated with a more derived type argument
+' is assigned to an object instantiated with a less derived type argument.
+' Assignment compatibility is preserved.
+Dim objects As IEnumerable(Of Object) = strings
+
+' Contravariance.
+' Assume that there is the following method in the class:
+' Shared Sub SetObject(ByVal o As Object)
+' End Sub
+Dim actObject As Action(Of Object) = AddressOf SetObject
+
+' An object that is instantiated with a less derived type argument
+' is assigned to an object instantiated with a more derived type argument.
+' Assignment compatibility is reversed.
+Dim actString As Action(Of String) = actObject
+```
+
+Covariance for arrays enables implicit conversion of an array of a more derived type to an array of a less derived type. But this operation is not type safe, as shown in the following code example.
+
+```vb
+Dim array() As Object = New String(10) {}
+' The following statement produces a run-time exception.
+' array(0) = 10
+```
+
+Covariance and contravariance support for method groups allows for matching method signatures with delegate types. This enables you to assign to delegates not only methods that have matching signatures, but also methods that return more derived types (covariance) or that accept parameters that have less derived types (contravariance) than that specified by the delegate type. For more information, see [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md) and [Using Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md).
+
+The following code example shows covariance and contravariance support for method groups.
+
+```vb
+Shared Function GetObject() As Object
+    Return Nothing
+End Function
+
+Shared Sub SetObject(ByVal obj As Object)
+End Sub
+
+Shared Function GetString() As String
+    Return ""
+End Function
+
+Shared Sub SetString(ByVal str As String)
+
+End Sub
+
+Shared Sub Test()
+    ' Covariance. A delegate specifies a return type as object,
+    ' but you can assign a method that returns a string.
+    Dim del As Func(Of Object) = AddressOf GetString
+
+    ' Contravariance. A delegate specifies a parameter type as string,
+    ' but you can assign a method that takes an object.
+    Dim del2 As Action(Of String) = AddressOf SetObject
+End Sub
+```
+
+In .NET Framework 4 or later, Visual Basic supports covariance and contravariance in generic interfaces and delegates and allows for implicit conversion of generic type parameters. For more information, see [Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).
+
+The following code example shows implicit reference conversion for generic interfaces.
+
+```vb
+Dim strings As IEnumerable(Of String) = New List(Of String)
+Dim objects As IEnumerable(Of Object) = strings
+```
+
+A generic interface or delegate is called *variant* if its generic parameters are declared covariant or contravariant. Visual Basic enables you to create your own variant interfaces and delegates. For more information, see [Creating Variant Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).
+
+## Related Topics
+
+|Title|Description|
+|-----------|-----------------|
+|[Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md)|Discusses covariance and contravariance in generic interfaces and provides a list of variant generic interfaces in the .NET Framework.|
+|[Creating Variant Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md)|Shows how to create custom variant interfaces.|
+|[Using Variance in Interfaces for Generic Collections (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md)|Shows how covariance and contravariance support in the <xref:System.Collections.Generic.IEnumerable%601> and <xref:System.IComparable%601> interfaces can help you reuse code.|
+|[Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md)|Discusses covariance and contravariance in generic and non-generic delegates and provides a list of variant generic delegates in the .NET Framework.|
+|[Using Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md)|Shows how to use covariance and contravariance support in non-generic delegates to match method signatures with delegate types.|
 |[Using Variance for Func and Action Generic Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md)|Shows how covariance and contravariance support in the `Func` and `Action` delegates can help you reuse code.|

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
@@ -4,85 +4,88 @@ ms.date: 07/20/2015
 ms.assetid: 36c3012f-b39c-493b-b90f-079b5912ac1b
 ---
 # Using Variance for Func and Action Generic Delegates (Visual Basic)
-These examples demonstrate how to use covariance and contravariance in the `Func` and `Action` generic delegates to enable reuse of methods and provide more flexibility in your code.  
-  
- For more information about covariance and contravariance, see [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
-  
-## Using Delegates with Covariant Type Parameters  
- The following example illustrates the benefits of covariance support in the generic `Func` delegates. The `FindByTitle` method takes a parameter of the `String` type and returns an object of the `Employee` type. However, you can assign this method to the `Func(Of String, Person)` delegate because `Employee` inherits `Person`.  
-  
-```vb  
-' Simple hierarchy of classes.  
-Public Class Person  
-End Class  
-  
-Public Class Employee  
-    Inherits Person  
-End Class  
-  
-Class Finder  
-    Public Shared Function FindByTitle(  
-        ByVal title As String) As Employee  
-        ' This is a stub for a method that returns  
-        ' an employee that has the specified title.  
-        Return New Employee  
-    End Function  
-  
-    Sub Test()  
-        ' Create an instance of the delegate without using variance.  
-        Dim findEmployee As Func(Of String, Employee) =  
-            AddressOf FindByTitle  
-  
-        ' The delegate expects a method to return Person,  
-        ' but you can assign it a method that returns Employee.  
-        Dim findPerson As Func(Of String, Person) =  
-            AddressOf FindByTitle  
-  
-        ' You can also assign a delegate   
-        ' that returns a more derived type to a delegate   
-        ' that returns a less derived type.  
-        findPerson = findEmployee  
-    End Sub  
-End Class  
-```  
-  
-## Using Delegates with Contravariant Type Parameters  
- The following example illustrates the benefits of contravariance support in the generic `Action` delegates. The `AddToContacts` method takes a parameter of the `Person` type. However, you can assign this method to the `Action(Of Employee)` delegate because `Employee` inherits `Person`.  
-  
-```vb  
-Public Class Person  
-End Class  
-  
-Public Class Employee  
-    Inherits Person  
-End Class  
-  
-Class AddressBook  
-    Shared Sub AddToContacts(ByVal person As Person)  
-        ' This method adds a Person object  
-        ' to a contact list.  
-    End Sub  
-  
-    Sub Test()  
-        ' Create an instance of the delegate without using variance.  
-        Dim addPersonToContacts As Action(Of Person) =  
-            AddressOf AddToContacts  
-  
-        ' The Action delegate expects   
-        ' a method that has an Employee parameter,  
-        ' but you can assign it a method that has a Person parameter  
-        ' because Employee derives from Person.  
-        Dim addEmployeeToContacts As Action(Of Employee) =  
-            AddressOf AddToContacts  
-  
-        ' You can also assign a delegate   
-        ' that accepts a less derived parameter   
-        ' to a delegate that accepts a more derived parameter.  
-        addEmployeeToContacts = addPersonToContacts  
-    End Sub  
-End Class  
-```  
-  
+
+These examples demonstrate how to use covariance and contravariance in the `Func` and `Action` generic delegates to enable reuse of methods and provide more flexibility in your code.
+
+For more information about covariance and contravariance, see [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).
+
+## Using Delegates with Covariant Type Parameters
+
+The following example illustrates the benefits of covariance support in the generic `Func` delegates. The `FindByTitle` method takes a parameter of the `String` type and returns an object of the `Employee` type. However, you can assign this method to the `Func(Of String, Person)` delegate because `Employee` inherits `Person`.
+
+```vb
+' Simple hierarchy of classes.
+Public Class Person
+End Class
+
+Public Class Employee
+    Inherits Person
+End Class
+
+Class Finder
+    Public Shared Function FindByTitle(
+        ByVal title As String) As Employee
+        ' This is a stub for a method that returns
+        ' an employee that has the specified title.
+        Return New Employee
+    End Function
+
+    Sub Test()
+        ' Create an instance of the delegate without using variance.
+        Dim findEmployee As Func(Of String, Employee) =
+            AddressOf FindByTitle
+
+        ' The delegate expects a method to return Person,
+        ' but you can assign it a method that returns Employee.
+        Dim findPerson As Func(Of String, Person) =
+            AddressOf FindByTitle
+
+        ' You can also assign a delegate
+        ' that returns a more derived type to a delegate
+        ' that returns a less derived type.
+        findPerson = findEmployee
+    End Sub
+End Class
+```
+
+## Using Delegates with Contravariant Type Parameters
+
+The following example illustrates the benefits of contravariance support in the generic `Action` delegates. The `AddToContacts` method takes a parameter of the `Person` type. However, you can assign this method to the `Action(Of Employee)` delegate because `Employee` inherits `Person`.
+
+```vb
+Public Class Person
+End Class
+
+Public Class Employee
+    Inherits Person
+End Class
+
+Class AddressBook
+    Shared Sub AddToContacts(ByVal person As Person)
+        ' This method adds a Person object
+        ' to a contact list.
+    End Sub
+
+    Sub Test()
+        ' Create an instance of the delegate without using variance.
+        Dim addPersonToContacts As Action(Of Person) =
+            AddressOf AddToContacts
+
+        ' The Action delegate expects
+        ' a method that has an Employee parameter,
+        ' but you can assign it a method that has a Person parameter
+        ' because Employee derives from Person.
+        Dim addEmployeeToContacts As Action(Of Employee) =
+            AddressOf AddToContacts
+
+        ' You can also assign a delegate
+        ' that accepts a less derived parameter
+        ' to a delegate that accepts a more derived parameter.
+        addEmployeeToContacts = addPersonToContacts
+    End Sub
+End Class
+```
+
 ## See also
 
 - [Covariance and Contravariance (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/index.md)

--- a/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -4,103 +4,105 @@ ms.date: 07/20/2015
 ms.assetid: 16278787-7532-4b65-98b2-7a412406c4ee
 ---
 # How to: Use Expression Trees to Build Dynamic Queries (Visual Basic)
-In LINQ, expression trees are used to represent structured queries that target sources of data that implement <xref:System.Linq.IQueryable%601>. For example, the LINQ provider implements the <xref:System.Linq.IQueryable%601> interface for querying relational data stores. The Visual Basic compiler compiles queries that target such data sources into code that builds an expression tree at runtime. The query provider can then traverse the expression tree data structure and translate it into a query language appropriate for the data source.  
-  
- Expression trees are also used in LINQ to represent lambda expressions that are assigned to variables of type <xref:System.Linq.Expressions.Expression%601>.  
-  
- This topic describes how to use expression trees to create dynamic LINQ queries. Dynamic queries are useful when the specifics of a query are not known at compile time. For example, an application might provide a user interface that enables the end user to specify one or more predicates to filter the data. In order to use LINQ for querying, this kind of application must use expression trees to create the LINQ query at runtime.  
-  
-## Example  
- The following example shows you how to use expression trees to construct a query against an `IQueryable` data source and then execute it. The code builds an expression tree to represent the following query:  
-  
- `companies.Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16).OrderBy(Function(company) company)`  
-  
- The factory methods in the <xref:System.Linq.Expressions> namespace are used to create expression trees that represent the expressions that make up the overall query. The expressions that represent calls to the standard query operator methods refer to the <xref:System.Linq.Queryable> implementations of these methods. The final expression tree is passed to the <xref:System.Linq.IQueryProvider.CreateQuery%60%601%28System.Linq.Expressions.Expression%29> implementation of the provider of the `IQueryable` data source to create an executable query of type `IQueryable`. The results are obtained by enumerating that query variable.  
-  
-```vb  
-' Add an Imports statement for System.Linq.Expressions.  
-  
-Dim companies =   
-    {"Consolidated Messenger", "Alpine Ski House", "Southridge Video", "City Power & Light",   
-     "Coho Winery", "Wide World Importers", "Graphic Design Institute", "Adventure Works",   
-     "Humongous Insurance", "Woodgrove Bank", "Margie's Travel", "Northwind Traders",   
-     "Blue Yonder Airlines", "Trey Research", "The Phone Company",   
-     "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee"}  
-  
-' The IQueryable data to query.  
-Dim queryableData As IQueryable(Of String) = companies.AsQueryable()  
-  
-' Compose the expression tree that represents the parameter to the predicate.  
-Dim pe As ParameterExpression = Expression.Parameter(GetType(String), "company")  
-  
-' ***** Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16) *****  
-' Create an expression tree that represents the expression: company.ToLower() = "coho winery".  
-Dim left As Expression = Expression.Call(pe, GetType(String).GetMethod("ToLower", System.Type.EmptyTypes))  
-Dim right As Expression = Expression.Constant("coho winery")  
-Dim e1 As Expression = Expression.Equal(left, right)  
-  
-' Create an expression tree that represents the expression: company.Length > 16.  
-left = Expression.Property(pe, GetType(String).GetProperty("Length"))  
-right = Expression.Constant(16, GetType(Integer))  
-Dim e2 As Expression = Expression.GreaterThan(left, right)  
-  
-' Combine the expressions to create an expression tree that represents the  
-' expression: company.ToLower() = "coho winery" OrElse company.Length > 16).  
-Dim predicateBody As Expression = Expression.OrElse(e1, e2)  
-  
-' Create an expression tree that represents the expression:  
-' queryableData.Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16)  
-Dim whereCallExpression As MethodCallExpression = Expression.Call(   
-        GetType(Queryable),   
-        "Where",   
-        New Type() {queryableData.ElementType},   
-        queryableData.Expression,   
-        Expression.Lambda(Of Func(Of String, Boolean))(predicateBody, New ParameterExpression() {pe}))  
-' ***** End Where *****  
-  
-' ***** OrderBy(Function(company) company) *****  
-' Create an expression tree that represents the expression:  
-' whereCallExpression.OrderBy(Function(company) company)  
-Dim orderByCallExpression As MethodCallExpression = Expression.Call(   
-        GetType(Queryable),   
-        "OrderBy",   
-        New Type() {queryableData.ElementType, queryableData.ElementType},   
-        whereCallExpression,   
-        Expression.Lambda(Of Func(Of String, String))(pe, New ParameterExpression() {pe}))  
-' ***** End OrderBy *****  
-  
-' Create an executable query from the expression tree.  
-Dim results As IQueryable(Of String) = queryableData.Provider.CreateQuery(Of String)(orderByCallExpression)  
-  
-' Enumerate the results.  
-For Each company As String In results  
-    Console.WriteLine(company)  
-Next  
-  
-' This code produces the following output:  
-'  
-' Blue Yonder Airlines  
-' City Power & Light  
-' Coho Winery  
-' Consolidated Messenger  
-' Graphic Design Institute  
-' Humongous Insurance  
-' Lucerne Publishing  
-' Northwind Traders  
-' The Phone Company  
-' Wide World Importers  
-```  
-  
- This code uses a fixed number of expressions in the predicate that is passed to the `Queryable.Where` method. However, you can write an application that combines a variable number of predicate expressions that depends on the user input. You can also vary the standard query operators that are called in the query, depending on the input from the user.  
-  
-## Compiling the Code  
-  
-- Create a new **Console Application** project.  
-  
-- Include the System.Linq.Expressions namespace.  
-  
-- Copy the code from the example and paste it into the `Main` `Sub` procedure.  
-  
+
+In LINQ, expression trees are used to represent structured queries that target sources of data that implement <xref:System.Linq.IQueryable%601>. For example, the LINQ provider implements the <xref:System.Linq.IQueryable%601> interface for querying relational data stores. The Visual Basic compiler compiles queries that target such data sources into code that builds an expression tree at runtime. The query provider can then traverse the expression tree data structure and translate it into a query language appropriate for the data source.
+
+Expression trees are also used in LINQ to represent lambda expressions that are assigned to variables of type <xref:System.Linq.Expressions.Expression%601>.
+
+This topic describes how to use expression trees to create dynamic LINQ queries. Dynamic queries are useful when the specifics of a query are not known at compile time. For example, an application might provide a user interface that enables the end user to specify one or more predicates to filter the data. In order to use LINQ for querying, this kind of application must use expression trees to create the LINQ query at runtime.
+
+## Example
+
+The following example shows you how to use expression trees to construct a query against an `IQueryable` data source and then execute it. The code builds an expression tree to represent the following query:
+
+`companies.Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16).OrderBy(Function(company) company)`
+
+The factory methods in the <xref:System.Linq.Expressions> namespace are used to create expression trees that represent the expressions that make up the overall query. The expressions that represent calls to the standard query operator methods refer to the <xref:System.Linq.Queryable> implementations of these methods. The final expression tree is passed to the <xref:System.Linq.IQueryProvider.CreateQuery%60%601%28System.Linq.Expressions.Expression%29> implementation of the provider of the `IQueryable` data source to create an executable query of type `IQueryable`. The results are obtained by enumerating that query variable.
+
+```vb
+' Add an Imports statement for System.Linq.Expressions.
+
+Dim companies =
+    {"Consolidated Messenger", "Alpine Ski House", "Southridge Video", "City Power & Light",
+     "Coho Winery", "Wide World Importers", "Graphic Design Institute", "Adventure Works",
+     "Humongous Insurance", "Woodgrove Bank", "Margie's Travel", "Northwind Traders",
+     "Blue Yonder Airlines", "Trey Research", "The Phone Company",
+     "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee"}
+
+' The IQueryable data to query.
+Dim queryableData As IQueryable(Of String) = companies.AsQueryable()
+
+' Compose the expression tree that represents the parameter to the predicate.
+Dim pe As ParameterExpression = Expression.Parameter(GetType(String), "company")
+
+' ***** Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16) *****
+' Create an expression tree that represents the expression: company.ToLower() = "coho winery".
+Dim left As Expression = Expression.Call(pe, GetType(String).GetMethod("ToLower", System.Type.EmptyTypes))
+Dim right As Expression = Expression.Constant("coho winery")
+Dim e1 As Expression = Expression.Equal(left, right)
+
+' Create an expression tree that represents the expression: company.Length > 16.
+left = Expression.Property(pe, GetType(String).GetProperty("Length"))
+right = Expression.Constant(16, GetType(Integer))
+Dim e2 As Expression = Expression.GreaterThan(left, right)
+
+' Combine the expressions to create an expression tree that represents the
+' expression: company.ToLower() = "coho winery" OrElse company.Length > 16).
+Dim predicateBody As Expression = Expression.OrElse(e1, e2)
+
+' Create an expression tree that represents the expression:
+' queryableData.Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16)
+Dim whereCallExpression As MethodCallExpression = Expression.Call(
+        GetType(Queryable),
+        "Where",
+        New Type() {queryableData.ElementType},
+        queryableData.Expression,
+        Expression.Lambda(Of Func(Of String, Boolean))(predicateBody, New ParameterExpression() {pe}))
+' ***** End Where *****
+
+' ***** OrderBy(Function(company) company) *****
+' Create an expression tree that represents the expression:
+' whereCallExpression.OrderBy(Function(company) company)
+Dim orderByCallExpression As MethodCallExpression = Expression.Call(
+        GetType(Queryable),
+        "OrderBy",
+        New Type() {queryableData.ElementType, queryableData.ElementType},
+        whereCallExpression,
+        Expression.Lambda(Of Func(Of String, String))(pe, New ParameterExpression() {pe}))
+' ***** End OrderBy *****
+
+' Create an executable query from the expression tree.
+Dim results As IQueryable(Of String) = queryableData.Provider.CreateQuery(Of String)(orderByCallExpression)
+
+' Enumerate the results.
+For Each company As String In results
+    Console.WriteLine(company)
+Next
+
+' This code produces the following output:
+'
+' Blue Yonder Airlines
+' City Power & Light
+' Coho Winery
+' Consolidated Messenger
+' Graphic Design Institute
+' Humongous Insurance
+' Lucerne Publishing
+' Northwind Traders
+' The Phone Company
+' Wide World Importers
+```
+
+This code uses a fixed number of expressions in the predicate that is passed to the `Queryable.Where` method. However, you can write an application that combines a variable number of predicate expressions that depends on the user input. You can also vary the standard query operators that are called in the query, depending on the input from the user.
+
+## Compiling the Code
+
+- Create a new **Console Application** project.
+
+- Include the System.Linq.Expressions namespace.
+
+- Copy the code from the example and paste it into the `Main` `Sub` procedure.
+
 ## See also
 
 - [Expression Trees (Visual Basic)](../../../../visual-basic/programming-guide/concepts/expression-trees/index.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/converting-data-types.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/converting-data-types.md
@@ -4,73 +4,76 @@ ms.date: 07/20/2015
 ms.assetid: 9b0cf1ab-de48-4c6e-9f00-05b40fade46e
 ---
 # Converting Data Types (Visual Basic)
-Conversion methods change the type of input objects.  
-  
+
+Conversion methods change the type of input objects.
+
  Conversion operations in LINQ queries are useful in a variety of applications. The following are some examples:
-  
-- The <xref:System.Linq.Enumerable.AsEnumerable%2A?displayProperty=nameWithType> method can be used to hide a type's custom implementation of a standard query operator.  
-  
-- The <xref:System.Linq.Enumerable.OfType%2A?displayProperty=nameWithType> method can be used to enable non-parameterized collections for LINQ querying.  
-  
-- The <xref:System.Linq.Enumerable.ToArray%2A?displayProperty=nameWithType>, <xref:System.Linq.Enumerable.ToDictionary%2A?displayProperty=nameWithType>, <xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType>, and <xref:System.Linq.Enumerable.ToLookup%2A?displayProperty=nameWithType> methods can be used to force immediate query execution instead of deferring it until the query is enumerated.  
-  
-## Methods  
- The following table lists the standard query operator methods that perform data-type conversions.  
-  
- The conversion methods in this table whose names start with "As" change the static type of the source collection but do not enumerate it. The methods whose names start with "To" enumerate the source collection and put the items into the corresponding collection type.  
-  
-|Method Name|Description|Visual Basic Query Expression Syntax|More Information|  
-|-----------------|-----------------|------------------------------------------|----------------------|  
-|AsEnumerable|Returns the input typed as <xref:System.Collections.Generic.IEnumerable%601>.|Not applicable.|<xref:System.Linq.Enumerable.AsEnumerable%2A?displayProperty=nameWithType>|  
-|AsQueryable|Converts a (generic) <xref:System.Collections.IEnumerable> to a (generic) <xref:System.Linq.IQueryable>.|Not applicable.|<xref:System.Linq.Queryable.AsQueryable%2A?displayProperty=nameWithType>|  
-|Cast|Casts the elements of a collection to a specified type.|`From … As …`|<xref:System.Linq.Enumerable.Cast%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Cast%2A?displayProperty=nameWithType>|  
-|OfType|Filters values, depending on their ability to be cast to a specified type.|Not applicable.|<xref:System.Linq.Enumerable.OfType%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.OfType%2A?displayProperty=nameWithType>|  
-|ToArray|Converts a collection to an array. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToArray%2A?displayProperty=nameWithType>|  
-|ToDictionary|Puts elements into a <xref:System.Collections.Generic.Dictionary%602> based on a key selector function. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToDictionary%2A?displayProperty=nameWithType>|  
-|ToList|Converts a collection to a <xref:System.Collections.Generic.List%601>. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType>|  
-|ToLookup|Puts elements into a <xref:System.Linq.Lookup%602> (a one-to-many dictionary) based on a key selector function. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToLookup%2A?displayProperty=nameWithType>|  
-  
-## Query Expression Syntax Example  
- The following code example uses the `From As` clause to cast a type to a subtype before accessing a member that is available only on the subtype.  
-  
-```vb  
-Class Plant  
-    Public Property Name As String  
-End Class  
-  
-Class CarnivorousPlant  
-    Inherits Plant  
-    Public Property TrapType As String  
-End Class  
-  
-Sub Cast()  
-  
-    Dim plants() As Plant = {   
-        New CarnivorousPlant With {.Name = "Venus Fly Trap", .TrapType = "Snap Trap"},   
-        New CarnivorousPlant With {.Name = "Pitcher Plant", .TrapType = "Pitfall Trap"},   
-        New CarnivorousPlant With {.Name = "Sundew", .TrapType = "Flypaper Trap"},   
-        New CarnivorousPlant With {.Name = "Waterwheel Plant", .TrapType = "Snap Trap"}}  
-  
-    Dim query = From plant As CarnivorousPlant In plants   
-                Where plant.TrapType = "Snap Trap"   
-                Select plant  
-  
-    Dim sb As New System.Text.StringBuilder()  
-    For Each plant In query  
-        sb.AppendLine(plant.Name)  
-    Next  
-  
-    ' Display the results.  
-    MsgBox(sb.ToString())  
-  
-    ' This code produces the following output:  
-  
-    ' Venus Fly Trap  
-    ' Waterwheel Plant  
-  
-End Sub  
-```  
-  
+
+- The <xref:System.Linq.Enumerable.AsEnumerable%2A?displayProperty=nameWithType> method can be used to hide a type's custom implementation of a standard query operator.
+
+- The <xref:System.Linq.Enumerable.OfType%2A?displayProperty=nameWithType> method can be used to enable non-parameterized collections for LINQ querying.
+
+- The <xref:System.Linq.Enumerable.ToArray%2A?displayProperty=nameWithType>, <xref:System.Linq.Enumerable.ToDictionary%2A?displayProperty=nameWithType>, <xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType>, and <xref:System.Linq.Enumerable.ToLookup%2A?displayProperty=nameWithType> methods can be used to force immediate query execution instead of deferring it until the query is enumerated.
+
+## Methods
+
+The following table lists the standard query operator methods that perform data-type conversions.
+
+The conversion methods in this table whose names start with "As" change the static type of the source collection but do not enumerate it. The methods whose names start with "To" enumerate the source collection and put the items into the corresponding collection type.
+
+|Method Name|Description|Visual Basic Query Expression Syntax|More Information|
+|-----------------|-----------------|------------------------------------------|----------------------|
+|AsEnumerable|Returns the input typed as <xref:System.Collections.Generic.IEnumerable%601>.|Not applicable.|<xref:System.Linq.Enumerable.AsEnumerable%2A?displayProperty=nameWithType>|
+|AsQueryable|Converts a (generic) <xref:System.Collections.IEnumerable> to a (generic) <xref:System.Linq.IQueryable>.|Not applicable.|<xref:System.Linq.Queryable.AsQueryable%2A?displayProperty=nameWithType>|
+|Cast|Casts the elements of a collection to a specified type.|`From … As …`|<xref:System.Linq.Enumerable.Cast%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Cast%2A?displayProperty=nameWithType>|
+|OfType|Filters values, depending on their ability to be cast to a specified type.|Not applicable.|<xref:System.Linq.Enumerable.OfType%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.OfType%2A?displayProperty=nameWithType>|
+|ToArray|Converts a collection to an array. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToArray%2A?displayProperty=nameWithType>|
+|ToDictionary|Puts elements into a <xref:System.Collections.Generic.Dictionary%602> based on a key selector function. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToDictionary%2A?displayProperty=nameWithType>|
+|ToList|Converts a collection to a <xref:System.Collections.Generic.List%601>. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType>|
+|ToLookup|Puts elements into a <xref:System.Linq.Lookup%602> (a one-to-many dictionary) based on a key selector function. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToLookup%2A?displayProperty=nameWithType>|
+
+## Query Expression Syntax Example
+
+The following code example uses the `From As` clause to cast a type to a subtype before accessing a member that is available only on the subtype.
+
+```vb
+Class Plant
+    Public Property Name As String
+End Class
+
+Class CarnivorousPlant
+    Inherits Plant
+    Public Property TrapType As String
+End Class
+
+Sub Cast()
+
+    Dim plants() As Plant = {
+        New CarnivorousPlant With {.Name = "Venus Fly Trap", .TrapType = "Snap Trap"},
+        New CarnivorousPlant With {.Name = "Pitcher Plant", .TrapType = "Pitfall Trap"},
+        New CarnivorousPlant With {.Name = "Sundew", .TrapType = "Flypaper Trap"},
+        New CarnivorousPlant With {.Name = "Waterwheel Plant", .TrapType = "Snap Trap"}}
+
+    Dim query = From plant As CarnivorousPlant In plants
+                Where plant.TrapType = "Snap Trap"
+                Select plant
+
+    Dim sb As New System.Text.StringBuilder()
+    For Each plant In query
+        sb.AppendLine(plant.Name)
+    Next
+
+    ' Display the results.
+    MsgBox(sb.ToString())
+
+    ' This code produces the following output:
+
+    ' Venus Fly Trap
+    ' Waterwheel Plant
+
+End Sub
+```
+
 ## See also
 
 - <xref:System.Linq>

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-combine-linq-queries-with-regular-expressions.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-combine-linq-queries-with-regular-expressions.md
@@ -4,80 +4,82 @@ ms.date: 07/20/2015
 ms.assetid: 3da1bd10-b0d8-4d5b-a637-966891c13592
 ---
 # How to: Combine LINQ Queries with Regular Expressions (Visual Basic)
-This example shows how to use the <xref:System.Text.RegularExpressions.Regex> class to create a regular expression for more complex matching in text strings. The LINQ query makes it easy to filter on exactly the files that you want to search with the regular expression, and to shape the results.  
-  
-## Example  
-  
-```vb  
-Class LinqRegExVB  
-  
-    Shared Sub Main()  
-  
-        ' Root folder to query, along with all subfolders.  
-        ' Modify this path as necessary so that it accesses your Visual Studio folder.  
+
+This example shows how to use the <xref:System.Text.RegularExpressions.Regex> class to create a regular expression for more complex matching in text strings. The LINQ query makes it easy to filter on exactly the files that you want to search with the regular expression, and to shape the results.
+
+## Example
+
+```vb
+Class LinqRegExVB
+
+    Shared Sub Main()
+
+        ' Root folder to query, along with all subfolders.
+        ' Modify this path as necessary so that it accesses your Visual Studio folder.
         Dim startFolder As String = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\"
-        ' One of the following paths may be more appropriate on your computer.  
+        ' One of the following paths may be more appropriate on your computer.
         'Dim startFolder As String = "C:\Program Files (x86)\Microsoft Visual Studio\2017\"
-  
-        ' Take a snapshot of the file system.  
-        Dim fileList As IEnumerable(Of System.IO.FileInfo) = GetFiles(startFolder)  
-  
-        ' Create a regular expression to find all things "Visual".  
-        Dim searchTerm As System.Text.RegularExpressions.Regex =   
-            New System.Text.RegularExpressions.Regex("Visual (Basic|C#|C\+\+|Studio)")  
-  
-        ' Search the contents of each .htm file.  
-        ' Remove the where clause to find even more matches!  
-        ' This query produces a list of files where a match  
-        ' was found, and a list of the matches in that file.  
-        ' Note: Explicit typing of "Match" in select clause.  
-        ' This is required because MatchCollection is not a   
-        ' generic IEnumerable collection.  
-        Dim queryMatchingFiles = From afile In fileList  
-                                Where afile.Extension = ".htm"  
-                                Let fileText = System.IO.File.ReadAllText(afile.FullName)  
-                                Let matches = searchTerm.Matches(fileText)  
-                                Where (matches.Count > 0)  
-                                Select Name = afile.FullName,  
-                                       Matches = From match As System.Text.RegularExpressions.Match In matches  
-                                                 Select match.Value  
-  
-        ' Execute the query.  
-        Console.WriteLine("The term " & searchTerm.ToString() & " was found in:")  
-  
-        For Each fileMatches In queryMatchingFiles  
-            ' Trim the path a bit, then write   
-            ' the file name in which a match was found.  
-            Dim s = fileMatches.Name.Substring(startFolder.Length - 1)  
-            Console.WriteLine(s)  
-  
-            ' For this file, write out all the matching strings  
-            For Each match In fileMatches.Matches  
-                Console.WriteLine("  " + match)  
-            Next  
-        Next  
-  
-        ' Keep the console window open in debug mode  
-        Console.WriteLine("Press any key to exit")  
-        Console.ReadKey()  
-    End Sub  
-  
-    ' Function to retrieve a list of files. Note that this is a copy  
-    ' of the file information.  
-    Shared Function GetFiles(ByVal root As String) As IEnumerable(Of System.IO.FileInfo)  
-        Return From file In My.Computer.FileSystem.GetFiles(  
-                   root, FileIO.SearchOption.SearchAllSubDirectories, "*.*")   
-               Select New System.IO.FileInfo(file)  
-    End Function  
-  
-End Class  
-```  
-  
- Note that you can also query the <xref:System.Text.RegularExpressions.MatchCollection> object that is returned by a `RegEx` search. In this example only the value of each match is produced in the results. However, it is also possible to use LINQ to perform all kinds of filtering, sorting, and grouping on that collection. Because <xref:System.Text.RegularExpressions.MatchCollection> is a non-generic <xref:System.Collections.IEnumerable> collection, you have to explicitly state the type of the range variable in the query.  
-  
-## Compiling the Code  
+
+        ' Take a snapshot of the file system.
+        Dim fileList As IEnumerable(Of System.IO.FileInfo) = GetFiles(startFolder)
+
+        ' Create a regular expression to find all things "Visual".
+        Dim searchTerm As System.Text.RegularExpressions.Regex =
+            New System.Text.RegularExpressions.Regex("Visual (Basic|C#|C\+\+|Studio)")
+
+        ' Search the contents of each .htm file.
+        ' Remove the where clause to find even more matches!
+        ' This query produces a list of files where a match
+        ' was found, and a list of the matches in that file.
+        ' Note: Explicit typing of "Match" in select clause.
+        ' This is required because MatchCollection is not a
+        ' generic IEnumerable collection.
+        Dim queryMatchingFiles = From afile In fileList
+                                Where afile.Extension = ".htm"
+                                Let fileText = System.IO.File.ReadAllText(afile.FullName)
+                                Let matches = searchTerm.Matches(fileText)
+                                Where (matches.Count > 0)
+                                Select Name = afile.FullName,
+                                       Matches = From match As System.Text.RegularExpressions.Match In matches
+                                                 Select match.Value
+
+        ' Execute the query.
+        Console.WriteLine("The term " & searchTerm.ToString() & " was found in:")
+
+        For Each fileMatches In queryMatchingFiles
+            ' Trim the path a bit, then write
+            ' the file name in which a match was found.
+            Dim s = fileMatches.Name.Substring(startFolder.Length - 1)
+            Console.WriteLine(s)
+
+            ' For this file, write out all the matching strings
+            For Each match In fileMatches.Matches
+                Console.WriteLine("  " + match)
+            Next
+        Next
+
+        ' Keep the console window open in debug mode
+        Console.WriteLine("Press any key to exit")
+        Console.ReadKey()
+    End Sub
+
+    ' Function to retrieve a list of files. Note that this is a copy
+    ' of the file information.
+    Shared Function GetFiles(ByVal root As String) As IEnumerable(Of System.IO.FileInfo)
+        Return From file In My.Computer.FileSystem.GetFiles(
+                   root, FileIO.SearchOption.SearchAllSubDirectories, "*.*")
+               Select New System.IO.FileInfo(file)
+    End Function
+
+End Class
+```
+
+Note that you can also query the <xref:System.Text.RegularExpressions.MatchCollection> object that is returned by a `RegEx` search. In this example only the value of each match is produced in the results. However, it is also possible to use LINQ to perform all kinds of filtering, sorting, and grouping on that collection. Because <xref:System.Text.RegularExpressions.MatchCollection> is a non-generic <xref:System.Collections.IEnumerable> collection, you have to explicitly state the type of the range variable in the query.
+
+## Compiling the Code
+
 Create a VB.NET console application project, with an `Imports` statement for the System.Linq namespace.
-  
+
 ## See also
 
 - [LINQ and Strings (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-and-strings.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-compute-column-values-in-a-csv-text-file-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-compute-column-values-in-a-csv-text-file-linq.md
@@ -4,141 +4,143 @@ ms.date: 07/20/2015
 ms.assetid: 88b2b9f3-c82e-41f3-b1b4-26ede5973a02
 ---
 # How to: Compute Column Values in a CSV Text File (LINQ) (Visual Basic)
-This example shows how to perform aggregate computations such as Sum, Average, Min, and Max on the columns of a .csv file. The example principles that are shown here can be applied to other types of structured text.  
-  
-### To create the source file  
-  
-1. Copy the following lines into a file that is named scores.csv and save it in your project folder. Assume that the first column represents a student ID, and subsequent columns represent scores from four exams.  
-  
-    ```csv  
-    111, 97, 92, 81, 60  
-    112, 75, 84, 91, 39  
-    113, 88, 94, 65, 91  
-    114, 97, 89, 85, 82  
-    115, 35, 72, 91, 70  
-    116, 99, 86, 90, 94  
-    117, 93, 92, 80, 87  
-    118, 92, 90, 83, 78  
-    119, 68, 79, 88, 92  
-    120, 99, 82, 81, 79  
-    121, 96, 85, 91, 60  
-    122, 94, 92, 91, 91  
-    ```  
-  
-## Example  
-  
-```vb  
-Class SumColumns  
-  
-    Public Shared Sub Main()  
-  
-        Dim lines As String() = System.IO.File.ReadAllLines("../../../scores.csv")  
-  
-        ' Specifies the column to compute  
-        ' This value could be passed in at runtime.  
-        Dim exam = 3  
-  
-        ' Spreadsheet format:  
-        ' Student ID    Exam#1  Exam#2  Exam#3  Exam#4  
-        ' 111,          97,     92,     81,     60  
-        ' one is added to skip over the first column  
-        ' which holds the student ID.  
-        SumColumn(lines, exam + 1)  
-        Console.WriteLine()  
-        MultiColumns(lines)  
-  
-        ' Keep the console window open in debug mode.  
-        Console.WriteLine("Press any key to exit...")  
-        Console.ReadKey()  
-  
-    End Sub  
-  
-    Shared Sub SumColumn(ByVal lines As IEnumerable(Of String), ByVal col As Integer)  
-  
-        ' This query performs two steps:  
-        ' split the string into a string array  
-        ' convert the specified element to  
-        ' integer and select it.  
-        Dim columnQuery = From line In lines   
-                           Let x = line.Split(",")   
-                           Select Convert.ToInt32(x(col))  
-  
-        ' Execute and cache the results for performance.  
-        ' Only needed with very large files.  
-        Dim results = columnQuery.ToList()  
-  
-        ' Perform aggregate calculations   
-        ' on the column specified by col.  
-        Dim avgScore = Aggregate score In results Into Average(score)  
-        Dim minScore = Aggregate score In results Into Min(score)  
-        Dim maxScore = Aggregate score In results Into Max(score)  
-  
-        Console.WriteLine("Single Column Query:")  
-        Console.WriteLine("Exam #{0}: Average:{1:##.##} High Score:{2} Low Score:{3}",   
-                     col, avgScore, maxScore, minScore)  
-  
-    End Sub  
-  
-    Shared Sub MultiColumns(ByVal lines As IEnumerable(Of String))  
-  
-        Console.WriteLine("Multi Column Query:")  
-  
-        ' Create the query. It will produce nested sequences.   
-        ' multiColQuery performs these steps:  
-        ' 1) convert the string to a string array  
-        ' 2) skip over the "Student ID" column and take the rest  
-        ' 3) convert each field to an int and select that   
-        '    entire sequence as one row in the results.  
-        Dim multiColQuery = From line In lines   
-                            Let fields = line.Split(",")   
-                            Select From str In fields Skip 1   
-                                        Select Convert.ToInt32(str)  
-  
-        Dim results = multiColQuery.ToList()  
-  
-        ' Find out how many columns we have.  
-        Dim columnCount = results(0).Count()  
-  
-        ' Perform aggregate calculations on each column.              
-        ' One loop for each score column in scores.  
-        ' We can use a for loop because we have already  
-        ' executed the multiColQuery in the call to ToList.  
-  
-        For j As Integer = 0 To columnCount - 1  
-            Dim column = j  
-            Dim res2 = From row In results   
-                       Select row.ElementAt(column)  
-  
-            ' Perform aggregate calculations   
-            ' on the column specified by col.  
-            Dim avgScore = Aggregate score In res2 Into Average(score)  
-            Dim minScore = Aggregate score In res2 Into Min(score)  
-            Dim maxScore = Aggregate score In res2 Into Max(score)  
-  
-            ' Add 1 to column numbers because exams in this course start with #1  
-            Console.WriteLine("Exam #{0} Average: {1:##.##} High Score: {2} Low Score: {3}",   
-                              column + 1, avgScore, maxScore, minScore)  
-  
-        Next  
-    End Sub  
-  
-End Class  
-' Output:  
-' Single Column Query:  
-' Exam #4: Average:76.92 High Score:94 Low Score:39  
-  
-' Multi Column Query:  
-' Exam #1 Average: 86.08 High Score: 99 Low Score: 35  
-' Exam #2 Average: 86.42 High Score: 94 Low Score: 72  
-' Exam #3 Average: 84.75 High Score: 91 Low Score: 65  
-' Exam #4 Average: 76.92 High Score: 94 Low Score: 39  
-```  
-  
- The query works by using the <xref:System.String.Split%2A> method to convert each line of text into an array. Each array element represents a column. Finally, the text in each column is converted to its numeric representation. If your file is a tab-separated file, just update the argument in the `Split` method to `\t`.  
-  
-## Compiling the Code  
+
+This example shows how to perform aggregate computations such as Sum, Average, Min, and Max on the columns of a .csv file. The example principles that are shown here can be applied to other types of structured text.
+
+### To create the source file
+
+1. Copy the following lines into a file that is named scores.csv and save it in your project folder. Assume that the first column represents a student ID, and subsequent columns represent scores from four exams.
+
+    ```csv
+    111, 97, 92, 81, 60
+    112, 75, 84, 91, 39
+    113, 88, 94, 65, 91
+    114, 97, 89, 85, 82
+    115, 35, 72, 91, 70
+    116, 99, 86, 90, 94
+    117, 93, 92, 80, 87
+    118, 92, 90, 83, 78
+    119, 68, 79, 88, 92
+    120, 99, 82, 81, 79
+    121, 96, 85, 91, 60
+    122, 94, 92, 91, 91
+    ```
+
+## Example
+
+```vb
+Class SumColumns
+
+    Public Shared Sub Main()
+
+        Dim lines As String() = System.IO.File.ReadAllLines("../../../scores.csv")
+
+        ' Specifies the column to compute
+        ' This value could be passed in at runtime.
+        Dim exam = 3
+
+        ' Spreadsheet format:
+        ' Student ID    Exam#1  Exam#2  Exam#3  Exam#4
+        ' 111,          97,     92,     81,     60
+        ' one is added to skip over the first column
+        ' which holds the student ID.
+        SumColumn(lines, exam + 1)
+        Console.WriteLine()
+        MultiColumns(lines)
+
+        ' Keep the console window open in debug mode.
+        Console.WriteLine("Press any key to exit...")
+        Console.ReadKey()
+
+    End Sub
+
+    Shared Sub SumColumn(ByVal lines As IEnumerable(Of String), ByVal col As Integer)
+
+        ' This query performs two steps:
+        ' split the string into a string array
+        ' convert the specified element to
+        ' integer and select it.
+        Dim columnQuery = From line In lines
+                           Let x = line.Split(",")
+                           Select Convert.ToInt32(x(col))
+
+        ' Execute and cache the results for performance.
+        ' Only needed with very large files.
+        Dim results = columnQuery.ToList()
+
+        ' Perform aggregate calculations
+        ' on the column specified by col.
+        Dim avgScore = Aggregate score In results Into Average(score)
+        Dim minScore = Aggregate score In results Into Min(score)
+        Dim maxScore = Aggregate score In results Into Max(score)
+
+        Console.WriteLine("Single Column Query:")
+        Console.WriteLine("Exam #{0}: Average:{1:##.##} High Score:{2} Low Score:{3}",
+                     col, avgScore, maxScore, minScore)
+
+    End Sub
+
+    Shared Sub MultiColumns(ByVal lines As IEnumerable(Of String))
+
+        Console.WriteLine("Multi Column Query:")
+
+        ' Create the query. It will produce nested sequences.
+        ' multiColQuery performs these steps:
+        ' 1) convert the string to a string array
+        ' 2) skip over the "Student ID" column and take the rest
+        ' 3) convert each field to an int and select that
+        '    entire sequence as one row in the results.
+        Dim multiColQuery = From line In lines
+                            Let fields = line.Split(",")
+                            Select From str In fields Skip 1
+                                        Select Convert.ToInt32(str)
+
+        Dim results = multiColQuery.ToList()
+
+        ' Find out how many columns we have.
+        Dim columnCount = results(0).Count()
+
+        ' Perform aggregate calculations on each column.
+        ' One loop for each score column in scores.
+        ' We can use a for loop because we have already
+        ' executed the multiColQuery in the call to ToList.
+
+        For j As Integer = 0 To columnCount - 1
+            Dim column = j
+            Dim res2 = From row In results
+                       Select row.ElementAt(column)
+
+            ' Perform aggregate calculations
+            ' on the column specified by col.
+            Dim avgScore = Aggregate score In res2 Into Average(score)
+            Dim minScore = Aggregate score In res2 Into Min(score)
+            Dim maxScore = Aggregate score In res2 Into Max(score)
+
+            ' Add 1 to column numbers because exams in this course start with #1
+            Console.WriteLine("Exam #{0} Average: {1:##.##} High Score: {2} Low Score: {3}",
+                              column + 1, avgScore, maxScore, minScore)
+
+        Next
+    End Sub
+
+End Class
+' Output:
+' Single Column Query:
+' Exam #4: Average:76.92 High Score:94 Low Score:39
+
+' Multi Column Query:
+' Exam #1 Average: 86.08 High Score: 99 Low Score: 35
+' Exam #2 Average: 86.42 High Score: 94 Low Score: 72
+' Exam #3 Average: 84.75 High Score: 91 Low Score: 65
+' Exam #4 Average: 76.92 High Score: 94 Low Score: 39
+```
+
+The query works by using the <xref:System.String.Split%2A> method to convert each line of text into an array. Each array element represents a column. Finally, the text in each column is converted to its numeric representation. If your file is a tab-separated file, just update the argument in the `Split` method to `\t`.
+
+## Compiling the Code
+
 Create a VB.NET console application project, with an `Imports` statement for the System.Linq namespace.
-  
+
 ## See also
 
 - [LINQ and Strings (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-and-strings.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
@@ -4,56 +4,58 @@ ms.date: 07/20/2015
 ms.assetid: bc367e46-f7cc-45f9-936f-754e661b7bb9
 ---
 # How to: Count Occurrences of a Word in a String (LINQ) (Visual Basic)
-This example shows how to use a LINQ query to count the occurrences of a specified word in a string. Note that to perform the count, first the <xref:System.String.Split%2A> method is called to create an array of words. There is a performance cost to the <xref:System.String.Split%2A> method. If the only operation on the string is to count the words, you should consider using the <xref:System.Text.RegularExpressions.Regex.Matches%2A> or <xref:System.String.IndexOf%2A> methods instead. However, if performance is not a critical issue, or you have already split the sentence in order to perform other types of queries over it, then it makes sense to use LINQ to count the words or phrases as well.  
-  
-## Example  
-  
-```vb  
-Class CountWords  
-  
-    Shared Sub Main()  
-  
-        Dim text As String = "Historically, the world of data and the world of objects" &   
-                  " have not been well integrated. Programmers work in C# or Visual Basic" &   
-                  " and also in SQL or XQuery. On the one side are concepts such as classes," &   
-                  " objects, fields, inheritance, and .NET Framework APIs. On the other side" &   
-                  " are tables, columns, rows, nodes, and separate languages for dealing with" &   
-                  " them. Data types often require translation between the two worlds; there are" &   
-                  " different standard functions. Because the object world has no notion of query, a" &   
-                  " query can only be represented as a string without compile-time type checking or" &   
-                  " IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to" &   
-                  " objects in memory is often tedious and error-prone."  
-  
-        Dim searchTerm As String = "data"  
-  
-        ' Convert the string into an array of words.  
-        Dim dataSource As String() = text.Split(New Char() {" ", ",", ".", ";", ":"},   
-                                                 StringSplitOptions.RemoveEmptyEntries)  
-  
-        ' Create and execute the query. It executes immediately   
-        ' because a singleton value is produced.  
-        ' Use ToLower to match "data" and "Data"   
-        Dim matchQuery = From word In dataSource   
-                      Where word.ToLowerInvariant() = searchTerm.ToLowerInvariant()   
-                      Select word  
-  
-        ' Count the matches.  
-        Dim count As Integer = matchQuery.Count()  
-        Console.WriteLine(count & " occurrence(s) of the search term """ &   
-                          searchTerm & """ were found.")  
-  
-        ' Keep console window open in debug mode.  
-        Console.WriteLine("Press any key to exit.")  
-        Console.ReadKey()  
-    End Sub  
-End Class  
-' Output:  
-' 3 occurrence(s) of the search term "data" were found.  
-```  
-  
-## Compiling the Code  
+
+This example shows how to use a LINQ query to count the occurrences of a specified word in a string. Note that to perform the count, first the <xref:System.String.Split%2A> method is called to create an array of words. There is a performance cost to the <xref:System.String.Split%2A> method. If the only operation on the string is to count the words, you should consider using the <xref:System.Text.RegularExpressions.Regex.Matches%2A> or <xref:System.String.IndexOf%2A> methods instead. However, if performance is not a critical issue, or you have already split the sentence in order to perform other types of queries over it, then it makes sense to use LINQ to count the words or phrases as well.
+
+## Example
+
+```vb
+Class CountWords
+
+    Shared Sub Main()
+
+        Dim text As String = "Historically, the world of data and the world of objects" &
+                  " have not been well integrated. Programmers work in C# or Visual Basic" &
+                  " and also in SQL or XQuery. On the one side are concepts such as classes," &
+                  " objects, fields, inheritance, and .NET Framework APIs. On the other side" &
+                  " are tables, columns, rows, nodes, and separate languages for dealing with" &
+                  " them. Data types often require translation between the two worlds; there are" &
+                  " different standard functions. Because the object world has no notion of query, a" &
+                  " query can only be represented as a string without compile-time type checking or" &
+                  " IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to" &
+                  " objects in memory is often tedious and error-prone."
+
+        Dim searchTerm As String = "data"
+
+        ' Convert the string into an array of words.
+        Dim dataSource As String() = text.Split(New Char() {" ", ",", ".", ";", ":"},
+                                                 StringSplitOptions.RemoveEmptyEntries)
+
+        ' Create and execute the query. It executes immediately
+        ' because a singleton value is produced.
+        ' Use ToLower to match "data" and "Data"
+        Dim matchQuery = From word In dataSource
+                      Where word.ToLowerInvariant() = searchTerm.ToLowerInvariant()
+                      Select word
+
+        ' Count the matches.
+        Dim count As Integer = matchQuery.Count()
+        Console.WriteLine(count & " occurrence(s) of the search term """ &
+                          searchTerm & """ were found.")
+
+        ' Keep console window open in debug mode.
+        Console.WriteLine("Press any key to exit.")
+        Console.ReadKey()
+    End Sub
+End Class
+' Output:
+' 3 occurrence(s) of the search term "data" were found.
+```
+
+## Compiling the Code
+
 Create a VB.NET console application project, with an `Imports` statement for the System.Linq namespace.
-  
+
 ## See also
 
 - [LINQ and Strings (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-and-strings.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-join-content-from-dissimilar-files-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-join-content-from-dissimilar-files-linq.md
@@ -5,99 +5,99 @@ ms.assetid: e7530857-c467-41ea-9730-84e6b1065a4d
 ---
 # How to: Join Content from Dissimilar Files (LINQ) (Visual Basic)
 
-This example shows how to join data from two comma-delimited files that share a common value that is used as a matching key. This technique can be useful if you have to combine data from two spreadsheets, or from a spreadsheet and from a file that has another format, into a new file. You can modify the example to work with any kind of structured text.  
-  
+This example shows how to join data from two comma-delimited files that share a common value that is used as a matching key. This technique can be useful if you have to combine data from two spreadsheets, or from a spreadsheet and from a file that has another format, into a new file. You can modify the example to work with any kind of structured text.
+
 ## To create the data files
-  
-1. Copy the following lines into a file that is named scores.csv and save it to your project folder. The file represents spreadsheet data. Column 1 is the student's ID, and columns 2 through 5 are test scores.  
-  
-    ```csv  
-    111, 97, 92, 81, 60  
-    112, 75, 84, 91, 39  
-    113, 88, 94, 65, 91  
-    114, 97, 89, 85, 82  
-    115, 35, 72, 91, 70  
-    116, 99, 86, 90, 94  
-    117, 93, 92, 80, 87  
-    118, 92, 90, 83, 78  
-    119, 68, 79, 88, 92  
-    120, 99, 82, 81, 79  
-    121, 96, 85, 91, 60  
-    122, 94, 92, 91, 91  
-    ```  
-  
-2. Copy the following lines into a file that is named names.csv and save it to your project folder. The file represents a spreadsheet that contains the student's last name, first name, and student ID.  
-  
-    ```csv  
-    Omelchenko,Svetlana,111  
-    O'Donnell,Claire,112  
-    Mortensen,Sven,113  
-    Garcia,Cesar,114  
-    Garcia,Debra,115  
-    Fakhouri,Fadi,116  
-    Feng,Hanying,117  
-    Garcia,Hugo,118  
-    Tucker,Lance,119  
-    Adams,Terry,120  
-    Zabokritski,Eugene,121  
-    Tucker,Michael,122  
-    ```  
-  
-## Example  
+
+1. Copy the following lines into a file that is named scores.csv and save it to your project folder. The file represents spreadsheet data. Column 1 is the student's ID, and columns 2 through 5 are test scores.
+
+    ```csv
+    111, 97, 92, 81, 60
+    112, 75, 84, 91, 39
+    113, 88, 94, 65, 91
+    114, 97, 89, 85, 82
+    115, 35, 72, 91, 70
+    116, 99, 86, 90, 94
+    117, 93, 92, 80, 87
+    118, 92, 90, 83, 78
+    119, 68, 79, 88, 92
+    120, 99, 82, 81, 79
+    121, 96, 85, 91, 60
+    122, 94, 92, 91, 91
+    ```
+
+2. Copy the following lines into a file that is named names.csv and save it to your project folder. The file represents a spreadsheet that contains the student's last name, first name, and student ID.
+
+    ```csv
+    Omelchenko,Svetlana,111
+    O'Donnell,Claire,112
+    Mortensen,Sven,113
+    Garcia,Cesar,114
+    Garcia,Debra,115
+    Fakhouri,Fadi,116
+    Feng,Hanying,117
+    Garcia,Hugo,118
+    Tucker,Lance,119
+    Adams,Terry,120
+    Zabokritski,Eugene,121
+    Tucker,Michael,122
+    ```
+
+## Example
 
 ```vb
 Imports System.Collections.Generic
 Imports System.Linq
 
-Class JoinStrings  
-  
-    Shared Sub Main()  
-  
-        ' Join content from spreadsheet files that contain  
-        ' related information. names.csv contains the student name  
-        ' plus an ID number. scores.csv contains the ID and a   
-        ' set of four test scores. The following query joins  
-        ' the scores to the student names by using ID as a  
-        ' matching key.  
-  
-        Dim names As String() = System.IO.File.ReadAllLines("../../../names.csv")  
-        Dim scores As String() = System.IO.File.ReadAllLines("../../../scores.csv")  
-  
-        ' Name:    Last[0],       First[1],  ID[2],     Grade Level[3]  
-        '          Omelchenko,    Svetlana,  111,       2  
-        ' Score:   StudentID[0],  Exam1[1]   Exam2[2],  Exam3[3],  Exam4[4]  
-        '          111,           97,        92,        81,        60  
-  
-        ' This query joins two dissimilar spreadsheets based on common ID value.  
-        ' Multiple from clauses are used instead of a join clause  
-        ' in order to store results of id.Split.  
-        Dim scoreQuery1 = From name In names   
-                         Let n = name.Split(New Char() {","})   
-                            From id In scores   
-                            Let n2 = id.Split(New Char() {","})   
+Class JoinStrings
+
+    Shared Sub Main()
+
+        ' Join content from spreadsheet files that contain
+        ' related information. names.csv contains the student name
+        ' plus an ID number. scores.csv contains the ID and a
+        ' set of four test scores. The following query joins
+        ' the scores to the student names by using ID as a
+        ' matching key.
+
+        Dim names As String() = System.IO.File.ReadAllLines("../../../names.csv")
+        Dim scores As String() = System.IO.File.ReadAllLines("../../../scores.csv")
+
+        ' Name:    Last[0],       First[1],  ID[2],     Grade Level[3]
+        '          Omelchenko,    Svetlana,  111,       2
+        ' Score:   StudentID[0],  Exam1[1]   Exam2[2],  Exam3[3],  Exam4[4]
+        '          111,           97,        92,        81,        60
+
+        ' This query joins two dissimilar spreadsheets based on common ID value.
+        ' Multiple from clauses are used instead of a join clause
+        ' in order to store results of id.Split.
+        Dim scoreQuery1 = From name In names
+                         Let n = name.Split(New Char() {","})
+                            From id In scores
+                            Let n2 = id.Split(New Char() {","})
                             Where Convert.ToInt32(n(2)) = Convert.ToInt32(n2(0))
                             Select n(0) & "," & n2(1) & "," & n2(2) & "," & n2(3) & "," &  n2(4)
-  
-        ' Pass a query variable to a Sub and execute it there.  
-        ' The query itself is unchanged.  
-        OutputQueryResults(scoreQuery1, "Merge two spreadsheets:")  
-  
-        ' Keep console window open in debug mode.  
-        Console.WriteLine("Press any key to exit.")  
-        Console.ReadKey()  
-    End Sub  
-  
-    Shared Sub OutputQueryResults(ByVal query As IEnumerable(Of String), ByVal message As String)  
-  
-        Console.WriteLine(System.Environment.NewLine & message)  
-        For Each item As String In query  
-            Console.WriteLine(item)  
-        Next  
-        Console.WriteLine(query.Count & " total names in list")  
-  
-    End Sub  
-End Class  
-' Output:  
+
+        ' Pass a query variable to a Sub and execute it there.
+        ' The query itself is unchanged.
+        OutputQueryResults(scoreQuery1, "Merge two spreadsheets:")
+
+        ' Keep console window open in debug mode.
+        Console.WriteLine("Press any key to exit.")
+        Console.ReadKey()
+    End Sub
+
+    Shared Sub OutputQueryResults(ByVal query As IEnumerable(Of String), ByVal message As String)
+
+        Console.WriteLine(System.Environment.NewLine & message)
+        For Each item As String In query
+            Console.WriteLine(item)
+        Next
+        Console.WriteLine(query.Count & " total names in list")
+
+    End Sub
+End Class
+' Output:
 ' Merge two spreadsheets:
 ' Omelchenko, 97, 92, 81, 60
 ' O'Donnell, 75, 84, 91, 39
@@ -111,8 +111,8 @@ End Class
 ' Adams, 99, 82, 81, 79
 ' Zabokritski, 96, 85, 91, 60
 ' Tucker, 94, 92, 91, 91
-' 12 total names in list 
-```  
+' 12 total names in list
+```
 
 ## See also
 

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-query-an-arraylist-with-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-query-an-arraylist-with-linq.md
@@ -4,72 +4,74 @@ ms.date: 07/20/2015
 ms.assetid: 176358a9-d765-4b57-9557-7feb4428138d
 ---
 # How to: Query an ArrayList with LINQ (Visual Basic)
-When using LINQ to query non-generic <xref:System.Collections.IEnumerable> collections such as <xref:System.Collections.ArrayList>, you must explicitly declare the type of the range variable to reflect the specific type of the objects in the collection. For example, if you have an <xref:System.Collections.ArrayList> of `Student` objects, your [From Clause](../../../../visual-basic/language-reference/queries/from-clause.md) should look like this:  
-  
-```vb  
-Dim query = From student As Student In arrList   
-'...  
-```  
-  
- By specifying the type of the range variable, you are casting each item in the <xref:System.Collections.ArrayList> to a `Student`.  
-  
- The use of an explicitly typed range variable in a query expression is equivalent to calling the <xref:System.Linq.Enumerable.Cast%2A> method. <xref:System.Linq.Enumerable.Cast%2A> throws an exception if the specified cast cannot be performed. <xref:System.Linq.Enumerable.Cast%2A> and <xref:System.Linq.Enumerable.OfType%2A> are the two Standard Query Operator methods that operate on non-generic <xref:System.Collections.IEnumerable> types. In Visual Basic, you must explicitly call the <xref:System.Linq.Enumerable.Cast%2A> method on the data source to ensure a specific range variable type. For more information, see [Type Relationships in Query Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/type-relationships-in-query-operations.md).  
-  
-## Example  
- The following example shows a simple query over an <xref:System.Collections.ArrayList>. Note that this example uses object initializers when the code calls the <xref:System.Collections.ArrayList.Add%2A> method, but this is not a requirement.  
-  
-```vb  
-Imports System.Collections  
-Imports System.Linq  
-  
-Module Module1  
-  
-    Public Class Student  
-        Public Property FirstName As String  
-        Public Property LastName As String  
-        Public Property Scores As Integer()  
-    End Class  
-  
-    Sub Main()  
-  
-        Dim student1 As New Student With {.FirstName = "Svetlana",   
-                                     .LastName = "Omelchenko",   
-                                     .Scores = New Integer() {98, 92, 81, 60}}  
-        Dim student2 As New Student With {.FirstName = "Claire",   
-                                    .LastName = "O'Donnell",   
-                                    .Scores = New Integer() {75, 84, 91, 39}}  
-        Dim student3 As New Student With {.FirstName = "Cesar",   
-                                    .LastName = "Garcia",   
-                                    .Scores = New Integer() {97, 89, 85, 82}}  
-        Dim student4 As New Student With {.FirstName = "Sven",   
-                                    .LastName = "Mortensen",   
-                                    .Scores = New Integer() {88, 94, 65, 91}}  
-  
-        Dim arrList As New ArrayList()  
-        arrList.Add(student1)  
-        arrList.Add(student2)  
-        arrList.Add(student3)  
-        arrList.Add(student4)  
-  
-        ' Use an explicit type for non-generic collections  
-        Dim query = From student As Student In arrList   
-                    Where student.Scores(0) > 95   
-                    Select student  
-  
-        For Each student As Student In query  
-            Console.WriteLine(student.LastName & ": " & student.Scores(0))  
-        Next  
-        ' Keep the console window open in debug mode.  
-        Console.WriteLine("Press any key to exit.")  
-        Console.ReadKey()  
-    End Sub  
-  
-End Module  
-' Output:  
-'   Omelchenko: 98  
-'   Garcia: 97  
-```  
-  
+
+When using LINQ to query non-generic <xref:System.Collections.IEnumerable> collections such as <xref:System.Collections.ArrayList>, you must explicitly declare the type of the range variable to reflect the specific type of the objects in the collection. For example, if you have an <xref:System.Collections.ArrayList> of `Student` objects, your [From Clause](../../../../visual-basic/language-reference/queries/from-clause.md) should look like this:
+
+```vb
+Dim query = From student As Student In arrList
+'...
+```
+
+By specifying the type of the range variable, you are casting each item in the <xref:System.Collections.ArrayList> to a `Student`.
+
+The use of an explicitly typed range variable in a query expression is equivalent to calling the <xref:System.Linq.Enumerable.Cast%2A> method. <xref:System.Linq.Enumerable.Cast%2A> throws an exception if the specified cast cannot be performed. <xref:System.Linq.Enumerable.Cast%2A> and <xref:System.Linq.Enumerable.OfType%2A> are the two Standard Query Operator methods that operate on non-generic <xref:System.Collections.IEnumerable> types. In Visual Basic, you must explicitly call the <xref:System.Linq.Enumerable.Cast%2A> method on the data source to ensure a specific range variable type. For more information, see [Type Relationships in Query Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/type-relationships-in-query-operations.md).
+
+## Example
+
+The following example shows a simple query over an <xref:System.Collections.ArrayList>. Note that this example uses object initializers when the code calls the <xref:System.Collections.ArrayList.Add%2A> method, but this is not a requirement.
+
+```vb
+Imports System.Collections
+Imports System.Linq
+
+Module Module1
+
+    Public Class Student
+        Public Property FirstName As String
+        Public Property LastName As String
+        Public Property Scores As Integer()
+    End Class
+
+    Sub Main()
+
+        Dim student1 As New Student With {.FirstName = "Svetlana",
+                                     .LastName = "Omelchenko",
+                                     .Scores = New Integer() {98, 92, 81, 60}}
+        Dim student2 As New Student With {.FirstName = "Claire",
+                                    .LastName = "O'Donnell",
+                                    .Scores = New Integer() {75, 84, 91, 39}}
+        Dim student3 As New Student With {.FirstName = "Cesar",
+                                    .LastName = "Garcia",
+                                    .Scores = New Integer() {97, 89, 85, 82}}
+        Dim student4 As New Student With {.FirstName = "Sven",
+                                    .LastName = "Mortensen",
+                                    .Scores = New Integer() {88, 94, 65, 91}}
+
+        Dim arrList As New ArrayList()
+        arrList.Add(student1)
+        arrList.Add(student2)
+        arrList.Add(student3)
+        arrList.Add(student4)
+
+        ' Use an explicit type for non-generic collections
+        Dim query = From student As Student In arrList
+                    Where student.Scores(0) > 95
+                    Select student
+
+        For Each student As Student In query
+            Console.WriteLine(student.LastName & ": " & student.Scores(0))
+        Next
+        ' Keep the console window open in debug mode.
+        Console.WriteLine("Press any key to exit.")
+        Console.ReadKey()
+    End Sub
+
+End Module
+' Output:
+'   Omelchenko: 98
+'   Garcia: 97
+```
+
 ## See also
 
 - [LINQ to Objects (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-to-objects.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-query-for-sentences-that-contain-a-specified-set-of-words.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-query-for-sentences-that-contain-a-specified-set-of-words.md
@@ -4,61 +4,63 @@ ms.date: 07/20/2015
 ms.assetid: a5ae8ced-61fe-4c10-bb8a-95630e50f603
 ---
 # How to: Query for Sentences that Contain a Specified Set of Words (LINQ) (Visual Basic)
-This example shows how to find sentences in a text file that contain matches for each of a specified set of words. Although the array of search terms is hard-coded in this example, it could also be populated dynamically at runtime. In this example, the query returns the sentences that contain the words "Historically," "data," and "integrated."  
-  
-## Example  
-  
-```vb  
-Class FindSentences  
-  
-    Shared Sub Main()  
-        Dim text As String = "Historically, the world of data and the world of objects " &   
-        "have not been well integrated. Programmers work in C# or Visual Basic " &   
-        "and also in SQL or XQuery. On the one side are concepts such as classes, " &   
-        "objects, fields, inheritance, and .NET Framework APIs. On the other side " &   
-        "are tables, columns, rows, nodes, and separate languages for dealing with " &   
-        "them. Data types often require translation between the two worlds; there are " &   
-        "different standard functions. Because the object world has no notion of query, a " &   
-        "query can only be represented as a string without compile-time type checking or " &   
-        "IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to " &   
-        "objects in memory is often tedious and error-prone."  
-  
-        ' Split the text block into an array of sentences.  
-        Dim sentences As String() = text.Split(New Char() {".", "?", "!"})  
-  
-        ' Define the search terms. This list could also be dynamically populated at runtime  
-        Dim wordsToMatch As String() = {"Historically", "data", "integrated"}  
-  
-        ' Find sentences that contain all the terms in the wordsToMatch array  
-        ' Note that the number of terms to match is not specified at compile time  
-        Dim sentenceQuery = From sentence In sentences   
-                            Let w = sentence.Split(New Char() {" ", ",", ".", ";", ":"},   
-                                                   StringSplitOptions.RemoveEmptyEntries)   
-                            Where w.Distinct().Intersect(wordsToMatch).Count = wordsToMatch.Count()   
-                            Select sentence  
-  
-        ' Execute the query  
-        For Each str As String In sentenceQuery  
-            Console.WriteLine(str)  
-        Next  
-  
-        ' Keep console window open in debug mode.  
-        Console.WriteLine("Press any key to exit.")  
-        Console.ReadKey()  
-    End Sub  
-  
-End Class  
-' Output:  
-' Historically, the world of data and the world of objects have not been well integrated  
-```  
-  
- The query works by first splitting the text into sentences, and then splitting the sentences into an array of strings that hold each word. For each of these arrays, the <xref:System.Linq.Enumerable.Distinct%2A> method removes all duplicate words, and then the query performs an <xref:System.Linq.Enumerable.Intersect%2A> operation on the word array and the `wordsToMatch` array. If the count of the intersection is the same as the count of the `wordsToMatch` array, all words were found in the words and the original sentence is returned.  
-  
- In the call to <xref:System.String.Split%2A>, the punctuation marks are used as separators in order to remove them from the string. If you did not do this, for example you could have a string "Historically," that would not match "Historically" in the `wordsToMatch` array. You may have to use additional separators, depending on the types of punctuation found in the source text.  
-  
-## Compiling the Code  
+
+This example shows how to find sentences in a text file that contain matches for each of a specified set of words. Although the array of search terms is hard-coded in this example, it could also be populated dynamically at runtime. In this example, the query returns the sentences that contain the words "Historically," "data," and "integrated."
+
+## Example
+
+```vb
+Class FindSentences
+
+    Shared Sub Main()
+        Dim text As String = "Historically, the world of data and the world of objects " &
+        "have not been well integrated. Programmers work in C# or Visual Basic " &
+        "and also in SQL or XQuery. On the one side are concepts such as classes, " &
+        "objects, fields, inheritance, and .NET Framework APIs. On the other side " &
+        "are tables, columns, rows, nodes, and separate languages for dealing with " &
+        "them. Data types often require translation between the two worlds; there are " &
+        "different standard functions. Because the object world has no notion of query, a " &
+        "query can only be represented as a string without compile-time type checking or " &
+        "IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to " &
+        "objects in memory is often tedious and error-prone."
+
+        ' Split the text block into an array of sentences.
+        Dim sentences As String() = text.Split(New Char() {".", "?", "!"})
+
+        ' Define the search terms. This list could also be dynamically populated at runtime
+        Dim wordsToMatch As String() = {"Historically", "data", "integrated"}
+
+        ' Find sentences that contain all the terms in the wordsToMatch array
+        ' Note that the number of terms to match is not specified at compile time
+        Dim sentenceQuery = From sentence In sentences
+                            Let w = sentence.Split(New Char() {" ", ",", ".", ";", ":"},
+                                                   StringSplitOptions.RemoveEmptyEntries)
+                            Where w.Distinct().Intersect(wordsToMatch).Count = wordsToMatch.Count()
+                            Select sentence
+
+        ' Execute the query
+        For Each str As String In sentenceQuery
+            Console.WriteLine(str)
+        Next
+
+        ' Keep console window open in debug mode.
+        Console.WriteLine("Press any key to exit.")
+        Console.ReadKey()
+    End Sub
+
+End Class
+' Output:
+' Historically, the world of data and the world of objects have not been well integrated
+```
+
+The query works by first splitting the text into sentences, and then splitting the sentences into an array of strings that hold each word. For each of these arrays, the <xref:System.Linq.Enumerable.Distinct%2A> method removes all duplicate words, and then the query performs an <xref:System.Linq.Enumerable.Intersect%2A> operation on the word array and the `wordsToMatch` array. If the count of the intersection is the same as the count of the `wordsToMatch` array, all words were found in the words and the original sentence is returned.
+
+In the call to <xref:System.String.Split%2A>, the punctuation marks are used as separators in order to remove them from the string. If you did not do this, for example you could have a string "Historically," that would not match "Historically" in the `wordsToMatch` array. You may have to use additional separators, depending on the types of punctuation found in the source text.
+
+## Compiling the Code
+
 Create a VB.NET console application project, with an `Imports` statement for the System.Linq namespace.
-  
+
 ## See also
 
 - [LINQ and Strings (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-and-strings.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-sort-or-filter-text-data-by-any-word-or-field-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-sort-or-filter-text-data-by-any-word-or-field-linq.md
@@ -4,70 +4,72 @@ ms.date: 07/20/2015
 ms.assetid: 9df137fe-335b-46e0-aecf-ea8a9eddd4e3
 ---
 # How to: Sort or Filter Text Data by Any Word or Field (LINQ) (Visual Basic)
-The following example shows how to sort lines of structured text, such as comma-separated values, by any field in the line. The field may be dynamically specified at runtime. Assume that the fields in scores.csv represent a student's ID number, followed by a series of four test scores.  
-  
-### To create a file that contains data  
-  
-1. Copy the scores.csv data from the topic [How to: Join Content from Dissimilar Files (LINQ) (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/how-to-join-content-from-dissimilar-files-linq.md) and save it to your solution folder.  
-  
-## Example  
-  
-```vb  
-Class SortLines  
-  
-    Shared Sub Main()  
-        Dim scores As String() = System.IO.File.ReadAllLines("../../../scores.csv")  
-  
-        ' Change this to any value from 0 to 4  
-        Dim sortField As Integer = 1  
-  
-        Console.WriteLine("Sorted highest to lowest by field " & sortField)  
-  
-        ' Demonstrates how to return query from a method.  
-        ' The query is executed here.  
-        For Each str As String In SortQuery(scores, sortField)  
-            Console.WriteLine(str)  
-        Next  
-  
-        ' Keep console window open in debug mode.  
-        Console.WriteLine("Press any key to exit.")  
-        Console.ReadKey()  
-  
-    End Sub  
-  
-    Shared Function SortQuery(  
-        ByVal source As IEnumerable(Of String),   
-        ByVal num As Integer) As IEnumerable(Of String)  
-  
-        Dim scoreQuery = From line In source   
-                         Let fields = line.Split(New Char() {","})   
-                         Order By fields(num) Descending   
-                         Select line  
-  
-        Return scoreQuery  
-    End Function  
-End Class  
-' Output:  
-' Sorted highest to lowest by field 1  
-' 116, 99, 86, 90, 94  
-' 120, 99, 82, 81, 79  
-' 111, 97, 92, 81, 60  
-' 114, 97, 89, 85, 82  
-' 121, 96, 85, 91, 60  
-' 122, 94, 92, 91, 91  
-' 117, 93, 92, 80, 87  
-' 118, 92, 90, 83, 78  
-' 113, 88, 94, 65, 91  
-' 112, 75, 84, 91, 39  
-' 119, 68, 79, 88, 92  
-' 115, 35, 72, 91, 70  
-```  
-  
- This example also demonstrates how to return a query variable from a Function.  
-  
-## Compiling the Code  
+
+The following example shows how to sort lines of structured text, such as comma-separated values, by any field in the line. The field may be dynamically specified at runtime. Assume that the fields in scores.csv represent a student's ID number, followed by a series of four test scores.
+
+### To create a file that contains data
+
+Copy the scores.csv data from the topic [How to: Join Content from Dissimilar Files (LINQ) (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/how-to-join-content-from-dissimilar-files-linq.md) and save it to your solution folder.
+
+## Example
+
+```vb
+Class SortLines
+
+    Shared Sub Main()
+        Dim scores As String() = System.IO.File.ReadAllLines("../../../scores.csv")
+
+        ' Change this to any value from 0 to 4
+        Dim sortField As Integer = 1
+
+        Console.WriteLine("Sorted highest to lowest by field " & sortField)
+
+        ' Demonstrates how to return query from a method.
+        ' The query is executed here.
+        For Each str As String In SortQuery(scores, sortField)
+            Console.WriteLine(str)
+        Next
+
+        ' Keep console window open in debug mode.
+        Console.WriteLine("Press any key to exit.")
+        Console.ReadKey()
+
+    End Sub
+
+    Shared Function SortQuery(
+        ByVal source As IEnumerable(Of String),
+        ByVal num As Integer) As IEnumerable(Of String)
+
+        Dim scoreQuery = From line In source
+                         Let fields = line.Split(New Char() {","})
+                         Order By fields(num) Descending
+                         Select line
+
+        Return scoreQuery
+    End Function
+End Class
+' Output:
+' Sorted highest to lowest by field 1
+' 116, 99, 86, 90, 94
+' 120, 99, 82, 81, 79
+' 111, 97, 92, 81, 60
+' 114, 97, 89, 85, 82
+' 121, 96, 85, 91, 60
+' 122, 94, 92, 91, 91
+' 117, 93, 92, 80, 87
+' 118, 92, 90, 83, 78
+' 113, 88, 94, 65, 91
+' 112, 75, 84, 91, 39
+' 119, 68, 79, 88, 92
+' 115, 35, 72, 91, 70
+```
+
+This example also demonstrates how to return a query variable from a Function.
+
+## Compiling the Code
+
 Create a VB.NET console application project, with an `Imports` statement for the System.Linq namespace.
-  
+
 ## See also
 
 - [LINQ and Strings (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-and-strings.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-split-a-file-into-many-files-by-using-groups-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-split-a-file-into-many-files-by-using-groups-linq.md
@@ -4,114 +4,116 @@ ms.date: 07/20/2015
 ms.assetid: 5e8b2a2b-0b1d-4933-8a2b-03e91dfaf77f
 ---
 # How to: Split a File Into Many Files by Using Groups (LINQ) (Visual Basic)
-This example shows one way to merge the contents of two files and then create a set of new files that organize the data in a new way.  
-  
-### To create the data files  
-  
-1. Copy these names into a text file that is named names1.txt and save it in your project folder:  
-  
-    ```text  
-    Bankov, Peter  
-    Holm, Michael  
-    Garcia, Hugo  
-    Potra, Cristina  
-    Noriega, Fabricio  
-    Aw, Kam Foo  
-    Beebe, Ann  
-    Toyoshima, Tim  
-    Guy, Wey Yuan  
-    Garcia, Debra  
-    ```  
-  
-2. Copy these names into a text file that is named names2.txt and save it in your project folder: Note that the two files have some names in common.  
-  
-    ```text  
-    Liu, Jinghao  
-    Bankov, Peter  
-    Holm, Michael  
-    Garcia, Hugo  
-    Beebe, Ann  
-    Gilchrist, Beth  
-    Myrcha, Jacek  
-    Giakoumakis, Leo  
-    McLin, Nkenge  
-    El Yassir, Mehdi  
-    ```  
-  
-## Example  
-  
-```vb  
-Class SplitWithGroups  
-  
-    Shared Sub Main()  
-  
-        Dim fileA As String() = System.IO.File.ReadAllLines("../../../names1.txt")  
-        Dim fileB As String() = System.IO.File.ReadAllLines("../../../names2.txt")  
-  
-        ' Concatenate and remove duplicate names based on  
-        Dim mergeQuery As IEnumerable(Of String) = fileA.Union(fileB)  
-  
-        ' Group the names by the first letter in the last name  
-        Dim groupQuery = From name In mergeQuery   
-                     Let n = name.Split(New Char() {","})   
-                     Order By n(0)   
-                     Group By groupKey = n(0)(0)   
-                     Into groupName = Group  
-  
-        ' Create a new file for each group that was created  
-        ' Note that nested foreach loops are required to access  
-        ' individual items with each group.  
-        For Each gGroup In groupQuery  
-            Dim fileName As String = "..'..'..'testFile_" & gGroup.groupKey & ".txt"  
-            Dim sw As New System.IO.StreamWriter(fileName)  
-            Console.WriteLine(gGroup.groupKey)  
-            For Each item In gGroup.groupName  
-                Console.WriteLine("   " & item.name)  
-                sw.WriteLine(item.name)  
-            Next  
-            sw.Close()  
-        Next  
-  
-        ' Keep console window open in debug mode.  
-        Console.WriteLine("Files have been written. Press any key to exit.")  
-        Console.ReadKey()  
-  
-    End Sub  
-End Class  
-' Console Output:  
-' A  
-'    Aw, Kam Foo  
-' B  
-'    Bankov, Peter  
-'    Beebe, Ann  
-' E  
-'    El Yassir, Mehdi  
-' G  
-'    Garcia, Hugo  
-'    Garcia, Debra  
-'    Giakoumakis, Leo  
-'    Gilchrist, Beth  
-'    Guy, Wey Yuan  
-' H  
-'    Holm, Michael  
-' L  
-'    Liu, Jinghao  
-' M  
-'    McLin, Nkenge  
-'    Myrcha, Jacek  
-' N  
-'    Noriega, Fabricio  
-' P  
-'    Potra, Cristina  
-' T  
-'    Toyoshima, Tim  
-```  
-  
- The program writes a separate file for each group in the same folder as the data files.  
-  
-## Compiling the Code  
+
+This example shows one way to merge the contents of two files and then create a set of new files that organize the data in a new way.
+
+### To create the data files
+
+1. Copy these names into a text file that is named names1.txt and save it in your project folder:
+
+    ```text
+    Bankov, Peter
+    Holm, Michael
+    Garcia, Hugo
+    Potra, Cristina
+    Noriega, Fabricio
+    Aw, Kam Foo
+    Beebe, Ann
+    Toyoshima, Tim
+    Guy, Wey Yuan
+    Garcia, Debra
+    ```
+
+2. Copy these names into a text file that is named names2.txt and save it in your project folder: Note that the two files have some names in common.
+
+    ```text
+    Liu, Jinghao
+    Bankov, Peter
+    Holm, Michael
+    Garcia, Hugo
+    Beebe, Ann
+    Gilchrist, Beth
+    Myrcha, Jacek
+    Giakoumakis, Leo
+    McLin, Nkenge
+    El Yassir, Mehdi
+    ```
+
+## Example
+
+```vb
+Class SplitWithGroups
+
+    Shared Sub Main()
+
+        Dim fileA As String() = System.IO.File.ReadAllLines("../../../names1.txt")
+        Dim fileB As String() = System.IO.File.ReadAllLines("../../../names2.txt")
+
+        ' Concatenate and remove duplicate names based on
+        Dim mergeQuery As IEnumerable(Of String) = fileA.Union(fileB)
+
+        ' Group the names by the first letter in the last name
+        Dim groupQuery = From name In mergeQuery
+                     Let n = name.Split(New Char() {","})
+                     Order By n(0)
+                     Group By groupKey = n(0)(0)
+                     Into groupName = Group
+
+        ' Create a new file for each group that was created
+        ' Note that nested foreach loops are required to access
+        ' individual items with each group.
+        For Each gGroup In groupQuery
+            Dim fileName As String = "..'..'..'testFile_" & gGroup.groupKey & ".txt"
+            Dim sw As New System.IO.StreamWriter(fileName)
+            Console.WriteLine(gGroup.groupKey)
+            For Each item In gGroup.groupName
+                Console.WriteLine("   " & item.name)
+                sw.WriteLine(item.name)
+            Next
+            sw.Close()
+        Next
+
+        ' Keep console window open in debug mode.
+        Console.WriteLine("Files have been written. Press any key to exit.")
+        Console.ReadKey()
+
+    End Sub
+End Class
+' Console Output:
+' A
+'    Aw, Kam Foo
+' B
+'    Bankov, Peter
+'    Beebe, Ann
+' E
+'    El Yassir, Mehdi
+' G
+'    Garcia, Hugo
+'    Garcia, Debra
+'    Giakoumakis, Leo
+'    Gilchrist, Beth
+'    Guy, Wey Yuan
+' H
+'    Holm, Michael
+' L
+'    Liu, Jinghao
+' M
+'    McLin, Nkenge
+'    Myrcha, Jacek
+' N
+'    Noriega, Fabricio
+' P
+'    Potra, Cristina
+' T
+'    Toyoshima, Tim
+```
+
+The program writes a separate file for each group in the same folder as the data files.
+
+## Compiling the Code
+
 Create a VB.NET console application project, with an `Imports` statement for the System.Linq namespace.
-  
+
 ## See also
 
 - [LINQ and Strings (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/linq-and-strings.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/projection-operations.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/projection-operations.md
@@ -4,166 +4,171 @@ ms.date: 07/20/2015
 ms.assetid: b8d38e6d-21cf-4619-8dbb-94476f4badc7
 ---
 # Projection Operations (Visual Basic)
-Projection refers to the operation of transforming an object into a new form that often consists only of those properties that will be subsequently used. By using projection, you can construct a new type that is built from each object. You can project a property and perform a mathematical function on it. You can also project the original object without changing it.  
-  
- The standard query operator methods that perform projection are listed in the following section.  
-  
-## Methods  
-  
-|Method Name|Description|Visual Basic Query Expression Syntax|More Information|  
-|-----------------|-----------------|------------------------------------------|----------------------|  
-|Select|Projects values that are based on a transform function.|`Select`|<xref:System.Linq.Enumerable.Select%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Select%2A?displayProperty=nameWithType>|  
-|SelectMany|Projects sequences of values that are based on a transform function and then flattens them into one sequence.|Use multiple `From` clauses|<xref:System.Linq.Enumerable.SelectMany%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.SelectMany%2A?displayProperty=nameWithType>|  
-  
-## Query Expression Syntax Examples  
-  
-### Select  
- The following example uses the `Select` clause to project the first letter from each string in a list of strings.  
-  
-```vb  
-Dim words = New List(Of String) From {"an", "apple", "a", "day"}  
-  
-Dim query = From word In words   
-            Select word.Substring(0, 1)  
-  
-Dim sb As New System.Text.StringBuilder()  
-For Each letter As String In query  
-    sb.AppendLine(letter)  
-Next  
-  
-' Display the output.  
-MsgBox(sb.ToString())  
-  
-' This code produces the following output:  
-  
-' a  
-' a  
-' a  
-' d  
-```  
-  
-### SelectMany  
- The following example uses multiple `From` clauses to project each word from each string in a list of strings.  
-  
-```vb  
-Dim phrases = New List(Of String) From {"an apple a day", "the quick brown fox"}  
-  
-Dim query = From phrase In phrases   
-            From word In phrase.Split(" "c)   
-            Select word  
-  
-Dim sb As New System.Text.StringBuilder()  
-For Each str As String In query  
-    sb.AppendLine(str)  
-Next  
-  
-' Display the output.  
-MsgBox(sb.ToString())  
-  
-' This code produces the following output:  
-  
-' an  
-' apple  
-' a  
-' day  
-' the  
-' quick  
-' brown  
-' fox  
-```  
-  
-## Select versus SelectMany  
- The work of both `Select()` and `SelectMany()` is to produce a result value (or values) from source values. `Select()` produces one result value for every source value. The overall result is therefore a collection that has the same number of elements as the source collection. In contrast, `SelectMany()` produces a single overall result that contains concatenated sub-collections from each source value. The transform function that is passed as an argument to `SelectMany()` must return an enumerable sequence of values for each source value. These enumerable sequences are then concatenated by `SelectMany()` to create one large sequence.  
-  
- The following two illustrations show the conceptual difference between the actions of these two methods. In each case, assume that the selector (transform) function selects the array of flowers from each source value.  
-  
- This illustration depicts how `Select()` returns a collection that has the same number of elements as the source collection.  
-  
- ![Graphic that shows the action of Select&#40;&#41;](./media/projection-operations/select-action-graphic.png)  
-  
- This illustration depicts how `SelectMany()` concatenates the intermediate sequence of arrays into one final result value that contains each value from each intermediate array.  
-  
- ![Graphic showing the action of SelectMany&#40;&#41;.](./media/projection-operations/select-many-action-graphic.png )  
-  
-### Code Example  
- The following example compares the behavior of `Select()` and `SelectMany()`. The code creates a "bouquet" of flowers by taking the first two items from each list of flower names in the source collection. In this example, the "single value" that the transform function <xref:System.Linq.Enumerable.Select%60%602%28System.Collections.Generic.IEnumerable%7B%60%600%7D%2CSystem.Func%7B%60%600%2C%60%601%7D%29> uses is itself a collection of values. This requires the extra `For Each` loop in order to enumerate each string in each sub-sequence.  
-  
-```vb  
-Class Bouquet  
-    Public Flowers As List(Of String)  
-End Class  
-  
-Sub SelectVsSelectMany()  
-    Dim bouquets = New List(Of Bouquet) From {   
-        New Bouquet With {.Flowers = New List(Of String)(New String() {"sunflower", "daisy", "daffodil", "larkspur"})},   
-        New Bouquet With {.Flowers = New List(Of String)(New String() {"tulip", "rose", "orchid"})},   
-        New Bouquet With {.Flowers = New List(Of String)(New String() {"gladiolis", "lily", "snapdragon", "aster", "protea"})},   
-        New Bouquet With {.Flowers = New List(Of String)(New String() {"larkspur", "lilac", "iris", "dahlia"})}}  
-  
-    Dim output As New System.Text.StringBuilder  
-  
-    ' Select()  
-    Dim query1 = bouquets.Select(Function(b) b.Flowers)  
-  
-    output.AppendLine("Using Select():")  
-    For Each flowerList In query1  
-        For Each str As String In flowerList  
-            output.AppendLine(str)  
-        Next  
-    Next  
-  
-    ' SelectMany()  
-    Dim query2 = bouquets.SelectMany(Function(b) b.Flowers)  
-  
-    output.AppendLine(vbCrLf & "Using SelectMany():")  
-    For Each str As String In query2  
-        output.AppendLine(str)  
-    Next  
-  
-    ' Display the output  
-    MsgBox(output.ToString())  
-  
-    ' This code produces the following output:  
-    '  
-    ' Using Select():  
-    ' sunflower  
-    ' daisy  
-    ' daffodil  
-    ' larkspur  
-    ' tulip  
-    ' rose  
-    ' orchid  
-    ' gladiolis  
-    ' lily  
-    ' snapdragon  
-    ' aster  
-    ' protea  
-    ' larkspur  
-    ' lilac  
-    ' iris  
-    ' dahlia  
-  
-    ' Using SelectMany()  
-    ' sunflower  
-    ' daisy  
-    ' daffodil  
-    ' larkspur  
-    ' tulip  
-    ' rose  
-    ' orchid  
-    ' gladiolis  
-    ' lily  
-    ' snapdragon  
-    ' aster  
-    ' protea  
-    ' larkspur  
-    ' lilac  
-    ' iris  
-    ' dahlia  
-  
-End Sub  
-```  
-  
+
+Projection refers to the operation of transforming an object into a new form that often consists only of those properties that will be subsequently used. By using projection, you can construct a new type that is built from each object. You can project a property and perform a mathematical function on it. You can also project the original object without changing it.
+
+The standard query operator methods that perform projection are listed in the following section.
+
+## Methods
+
+|Method Name|Description|Visual Basic Query Expression Syntax|More Information|
+|-----------------|-----------------|------------------------------------------|----------------------|
+|Select|Projects values that are based on a transform function.|`Select`|<xref:System.Linq.Enumerable.Select%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Select%2A?displayProperty=nameWithType>|
+|SelectMany|Projects sequences of values that are based on a transform function and then flattens them into one sequence.|Use multiple `From` clauses|<xref:System.Linq.Enumerable.SelectMany%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.SelectMany%2A?displayProperty=nameWithType>|
+
+## Query Expression Syntax Examples
+
+### Select
+
+The following example uses the `Select` clause to project the first letter from each string in a list of strings.
+
+```vb
+Dim words = New List(Of String) From {"an", "apple", "a", "day"}
+
+Dim query = From word In words
+            Select word.Substring(0, 1)
+
+Dim sb As New System.Text.StringBuilder()
+For Each letter As String In query
+    sb.AppendLine(letter)
+Next
+
+' Display the output.
+MsgBox(sb.ToString())
+
+' This code produces the following output:
+
+' a
+' a
+' a
+' d
+```
+
+### SelectMany
+
+The following example uses multiple `From` clauses to project each word from each string in a list of strings.
+
+```vb
+Dim phrases = New List(Of String) From {"an apple a day", "the quick brown fox"}
+
+Dim query = From phrase In phrases
+            From word In phrase.Split(" "c)
+            Select word
+
+Dim sb As New System.Text.StringBuilder()
+For Each str As String In query
+    sb.AppendLine(str)
+Next
+
+' Display the output.
+MsgBox(sb.ToString())
+
+' This code produces the following output:
+
+' an
+' apple
+' a
+' day
+' the
+' quick
+' brown
+' fox
+```
+
+## Select versus SelectMany
+
+The work of both `Select()` and `SelectMany()` is to produce a result value (or values) from source values. `Select()` produces one result value for every source value. The overall result is therefore a collection that has the same number of elements as the source collection. In contrast, `SelectMany()` produces a single overall result that contains concatenated sub-collections from each source value. The transform function that is passed as an argument to `SelectMany()` must return an enumerable sequence of values for each source value. These enumerable sequences are then concatenated by `SelectMany()` to create one large sequence.
+
+The following two illustrations show the conceptual difference between the actions of these two methods. In each case, assume that the selector (transform) function selects the array of flowers from each source value.
+
+This illustration depicts how `Select()` returns a collection that has the same number of elements as the source collection.
+
+![Graphic that shows the action of Select&#40;&#41;](./media/projection-operations/select-action-graphic.png)
+
+This illustration depicts how `SelectMany()` concatenates the intermediate sequence of arrays into one final result value that contains each value from each intermediate array.
+
+![Graphic showing the action of SelectMany&#40;&#41;.](./media/projection-operations/select-many-action-graphic.png )
+
+### Code Example
+
+The following example compares the behavior of `Select()` and `SelectMany()`. The code creates a "bouquet" of flowers by taking the first two items from each list of flower names in the source collection. In this example, the "single value" that the transform function <xref:System.Linq.Enumerable.Select%60%602%28System.Collections.Generic.IEnumerable%7B%60%600%7D%2CSystem.Func%7B%60%600%2C%60%601%7D%29> uses is itself a collection of values. This requires the extra `For Each` loop in order to enumerate each string in each sub-sequence.
+
+```vb
+Class Bouquet
+    Public Flowers As List(Of String)
+End Class
+
+Sub SelectVsSelectMany()
+    Dim bouquets = New List(Of Bouquet) From {
+        New Bouquet With {.Flowers = New List(Of String)(New String() {"sunflower", "daisy", "daffodil", "larkspur"})},
+        New Bouquet With {.Flowers = New List(Of String)(New String() {"tulip", "rose", "orchid"})},
+        New Bouquet With {.Flowers = New List(Of String)(New String() {"gladiolis", "lily", "snapdragon", "aster", "protea"})},
+        New Bouquet With {.Flowers = New List(Of String)(New String() {"larkspur", "lilac", "iris", "dahlia"})}}
+
+    Dim output As New System.Text.StringBuilder
+
+    ' Select()
+    Dim query1 = bouquets.Select(Function(b) b.Flowers)
+
+    output.AppendLine("Using Select():")
+    For Each flowerList In query1
+        For Each str As String In flowerList
+            output.AppendLine(str)
+        Next
+    Next
+
+    ' SelectMany()
+    Dim query2 = bouquets.SelectMany(Function(b) b.Flowers)
+
+    output.AppendLine(vbCrLf & "Using SelectMany():")
+    For Each str As String In query2
+        output.AppendLine(str)
+    Next
+
+    ' Display the output
+    MsgBox(output.ToString())
+
+    ' This code produces the following output:
+    '
+    ' Using Select():
+    ' sunflower
+    ' daisy
+    ' daffodil
+    ' larkspur
+    ' tulip
+    ' rose
+    ' orchid
+    ' gladiolis
+    ' lily
+    ' snapdragon
+    ' aster
+    ' protea
+    ' larkspur
+    ' lilac
+    ' iris
+    ' dahlia
+
+    ' Using SelectMany()
+    ' sunflower
+    ' daisy
+    ' daffodil
+    ' larkspur
+    ' tulip
+    ' rose
+    ' orchid
+    ' gladiolis
+    ' lily
+    ' snapdragon
+    ' aster
+    ' protea
+    ' larkspur
+    ' lilac
+    ' iris
+    ' dahlia
+
+End Sub
+```
+
 ## See also
 
 - <xref:System.Linq>

--- a/docs/visual-basic/programming-guide/concepts/linq/sample-xml-file-books-linq-to-xml.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/sample-xml-file-books-linq-to-xml.md
@@ -4,35 +4,36 @@ ms.date: 07/20/2015
 ms.assetid: 27ca5847-2289-40c0-8331-ede67ec59d1c
 ---
 # Sample XML File: Books (LINQ to XML)
-The following XML file is used in various examples in the [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] documentation. The file contains information about books.  
-  
-## books.xml  
-  
-```xml  
-<?xml version="1.0"?>  
-<Catalog>  
-   <Book id="bk101">  
-      <Author>Garghentini, Davide</Author>  
-      <Title>XML Developer's Guide</Title>  
-      <Genre>Computer</Genre>  
-      <Price>44.95</Price>  
-      <PublishDate>2000-10-01</PublishDate>  
-      <Description>An in-depth look at creating applications   
-      with XML.</Description>  
-   </Book>  
-   <Book id="bk102">  
-      <Author>Garcia, Debra</Author>  
-      <Title>Midnight Rain</Title>  
-      <Genre>Fantasy</Genre>  
-      <Price>5.95</Price>  
-      <PublishDate>2000-12-16</PublishDate>  
-      <Description>A former architect battles corporate zombies,   
-      an evil sorceress, and her own childhood to become queen   
-      of the world.</Description>  
-   </Book>  
-</Catalog>  
-```  
-  
+
+The following XML file is used in various examples in the [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] documentation. The file contains information about books.
+
+## books.xml
+
+```xml
+<?xml version="1.0"?>
+<Catalog>
+   <Book id="bk101">
+      <Author>Garghentini, Davide</Author>
+      <Title>XML Developer's Guide</Title>
+      <Genre>Computer</Genre>
+      <Price>44.95</Price>
+      <PublishDate>2000-10-01</PublishDate>
+      <Description>An in-depth look at creating applications
+      with XML.</Description>
+   </Book>
+   <Book id="bk102">
+      <Author>Garcia, Debra</Author>
+      <Title>Midnight Rain</Title>
+      <Genre>Fantasy</Genre>
+      <Price>5.95</Price>
+      <PublishDate>2000-12-16</PublishDate>
+      <Description>A former architect battles corporate zombies,
+      an evil sorceress, and her own childhood to become queen
+      of the world.</Description>
+   </Book>
+</Catalog>
+```
+
 ## See also
 
 - [Sample XML Documents (LINQ to XML)](../../../../visual-basic/programming-guide/concepts/linq/sample-xml-documents-linq-to-xml.md)

--- a/docs/visual-basic/programming-guide/concepts/linq/sorting-data.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/sorting-data.md
@@ -4,138 +4,143 @@ ms.date: 07/20/2015
 ms.assetid: 6f81065c-0c89-4bf3-a6d8-442273f8810e
 ---
 # Sorting Data (Visual Basic)
-A sorting operation orders the elements of a sequence based on one or more attributes. The first sort criterion performs a primary sort on the elements. By specifying a second sort criterion, you can sort the elements within each primary sort group.  
-  
- The following illustration shows the results of an alphabetical sort operation on a sequence of characters.  
-  
- ![Graphic that shows an alphabetical sort operation.](./media/sorting-data/alphabetical-sort-operation.png)  
-  
- The standard query operator methods that sort data are listed in the following section.  
-  
-## Methods  
-  
-|Method Name|Description|Visual Basic Query Expression Syntax|More Information|  
-|-----------------|-----------------|------------------------------------------|----------------------|  
-|OrderBy|Sorts values in ascending order.|`Order By`|<xref:System.Linq.Enumerable.OrderBy%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.OrderBy%2A?displayProperty=nameWithType>|  
-|OrderByDescending|Sorts values in descending order.|`Order By … Descending`|<xref:System.Linq.Enumerable.OrderByDescending%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.OrderByDescending%2A?displayProperty=nameWithType>|  
-|ThenBy|Performs a secondary sort in ascending order.|`Order By …, …`|<xref:System.Linq.Enumerable.ThenBy%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.ThenBy%2A?displayProperty=nameWithType>|  
-|ThenByDescending|Performs a secondary sort in descending order.|`Order By …, … Descending`|<xref:System.Linq.Enumerable.ThenByDescending%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.ThenByDescending%2A?displayProperty=nameWithType>|  
-|Reverse|Reverses the order of the elements in a collection.|Not applicable.|<xref:System.Linq.Enumerable.Reverse%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Reverse%2A?displayProperty=nameWithType>|  
-  
-## Query Expression Syntax Examples  
-  
-### Primary Sort Examples  
-  
-#### Primary Ascending Sort  
- The following example demonstrates how to use the `Order By` clause in a LINQ query to sort the strings in an array by string length, in ascending order.  
-  
-```vb  
-Dim words = {"the", "quick", "brown", "fox", "jumps"}  
-  
-Dim sortQuery = From word In words   
-                Order By word.Length   
-                Select word  
-  
-Dim sb As New System.Text.StringBuilder()  
-For Each str As String In sortQuery  
-    sb.AppendLine(str)  
-Next  
-  
-' Display the results.  
-MsgBox(sb.ToString())  
-  
-' This code produces the following output:  
-  
-' the  
-' fox  
-' quick  
-' brown  
-' jumps  
-```  
-  
-#### Primary Descending Sort  
- The next example demonstrates how to use the `Order By Descending` clause in a LINQ query to sort the strings by their first letter, in descending order.  
-  
-```vb  
-Dim words = {"the", "quick", "brown", "fox", "jumps"}  
-  
-Dim sortQuery = From word In words   
-                Order By word.Substring(0, 1) Descending   
-                Select word  
-  
-Dim sb As New System.Text.StringBuilder()  
-For Each str As String In sortQuery  
-    sb.AppendLine(str)  
-Next  
-  
-' Display the results.  
-MsgBox(sb.ToString())  
-  
-' This code produces the following output:  
-  
-' the  
-' quick  
-' jumps  
-' fox  
-' brown  
-```  
-  
-### Secondary Sort Examples  
-  
-#### Secondary Ascending Sort  
- The following example demonstrates how to use the `Order By` clause in a LINQ query to perform a primary and secondary sort of the strings in an array. The strings are sorted primarily by length and secondarily by the first letter of the string, both in ascending order.  
-  
-```vb  
-Dim words = {"the", "quick", "brown", "fox", "jumps"}  
-  
-Dim sortQuery = From word In words   
-                Order By word.Length, word.Substring(0, 1)   
-                Select word  
-  
-Dim sb As New System.Text.StringBuilder()  
-For Each str As String In sortQuery  
-    sb.AppendLine(str)  
-Next  
-  
-' Display the results.  
-MsgBox(sb.ToString())  
-  
-' This code produces the following output:  
-  
-' fox  
-' the  
-' brown  
-' jumps  
-' quick  
-```  
-  
-#### Secondary Descending Sort  
- The next example demonstrates how to use the `Order By Descending` clause in a LINQ query to perform a primary sort, in ascending order, and a secondary sort, in descending order. The strings are sorted primarily by length and secondarily by the first letter of the string.  
-  
-```vb  
-Dim words = {"the", "quick", "brown", "fox", "jumps"}  
-  
-Dim sortQuery = From word In words   
-                Order By word.Length, word.Substring(0, 1) Descending   
-                Select word  
-  
-Dim sb As New System.Text.StringBuilder()  
-For Each str As String In sortQuery  
-    sb.AppendLine(str)  
-Next  
-  
-' Display the results.  
-MsgBox(sb.ToString())  
-  
-' This code produces the following output:  
-  
-' fox  
-' the  
-' quick  
-' jumps  
-' brown  
-```  
-  
+
+A sorting operation orders the elements of a sequence based on one or more attributes. The first sort criterion performs a primary sort on the elements. By specifying a second sort criterion, you can sort the elements within each primary sort group.
+
+The following illustration shows the results of an alphabetical sort operation on a sequence of characters.
+
+![Graphic that shows an alphabetical sort operation.](./media/sorting-data/alphabetical-sort-operation.png)
+
+The standard query operator methods that sort data are listed in the following section.
+
+## Methods
+
+|Method Name|Description|Visual Basic Query Expression Syntax|More Information|
+|-----------------|-----------------|------------------------------------------|----------------------|
+|OrderBy|Sorts values in ascending order.|`Order By`|<xref:System.Linq.Enumerable.OrderBy%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.OrderBy%2A?displayProperty=nameWithType>|
+|OrderByDescending|Sorts values in descending order.|`Order By … Descending`|<xref:System.Linq.Enumerable.OrderByDescending%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.OrderByDescending%2A?displayProperty=nameWithType>|
+|ThenBy|Performs a secondary sort in ascending order.|`Order By …, …`|<xref:System.Linq.Enumerable.ThenBy%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.ThenBy%2A?displayProperty=nameWithType>|
+|ThenByDescending|Performs a secondary sort in descending order.|`Order By …, … Descending`|<xref:System.Linq.Enumerable.ThenByDescending%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.ThenByDescending%2A?displayProperty=nameWithType>|
+|Reverse|Reverses the order of the elements in a collection.|Not applicable.|<xref:System.Linq.Enumerable.Reverse%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Reverse%2A?displayProperty=nameWithType>|
+
+## Query Expression Syntax Examples
+
+### Primary Sort Examples
+
+#### Primary Ascending Sort
+
+The following example demonstrates how to use the `Order By` clause in a LINQ query to sort the strings in an array by string length, in ascending order.
+
+```vb
+Dim words = {"the", "quick", "brown", "fox", "jumps"}
+
+Dim sortQuery = From word In words
+                Order By word.Length
+                Select word
+
+Dim sb As New System.Text.StringBuilder()
+For Each str As String In sortQuery
+    sb.AppendLine(str)
+Next
+
+' Display the results.
+MsgBox(sb.ToString())
+
+' This code produces the following output:
+
+' the
+' fox
+' quick
+' brown
+' jumps
+```
+
+#### Primary Descending Sort
+
+The next example demonstrates how to use the `Order By Descending` clause in a LINQ query to sort the strings by their first letter, in descending order.
+
+```vb
+Dim words = {"the", "quick", "brown", "fox", "jumps"}
+
+Dim sortQuery = From word In words
+                Order By word.Substring(0, 1) Descending
+                Select word
+
+Dim sb As New System.Text.StringBuilder()
+For Each str As String In sortQuery
+    sb.AppendLine(str)
+Next
+
+' Display the results.
+MsgBox(sb.ToString())
+
+' This code produces the following output:
+
+' the
+' quick
+' jumps
+' fox
+' brown
+```
+
+### Secondary Sort Examples
+
+#### Secondary Ascending Sort
+
+The following example demonstrates how to use the `Order By` clause in a LINQ query to perform a primary and secondary sort of the strings in an array. The strings are sorted primarily by length and secondarily by the first letter of the string, both in ascending order.
+
+```vb
+Dim words = {"the", "quick", "brown", "fox", "jumps"}
+
+Dim sortQuery = From word In words
+                Order By word.Length, word.Substring(0, 1)
+                Select word
+
+Dim sb As New System.Text.StringBuilder()
+For Each str As String In sortQuery
+    sb.AppendLine(str)
+Next
+
+' Display the results.
+MsgBox(sb.ToString())
+
+' This code produces the following output:
+
+' fox
+' the
+' brown
+' jumps
+' quick
+```
+
+#### Secondary Descending Sort
+
+The next example demonstrates how to use the `Order By Descending` clause in a LINQ query to perform a primary sort, in ascending order, and a secondary sort, in descending order. The strings are sorted primarily by length and secondarily by the first letter of the string.
+
+```vb
+Dim words = {"the", "quick", "brown", "fox", "jumps"}
+
+Dim sortQuery = From word In words
+                Order By word.Length, word.Substring(0, 1) Descending
+                Select word
+
+Dim sb As New System.Text.StringBuilder()
+For Each str As String In sortQuery
+    sb.AppendLine(str)
+Next
+
+' Display the results.
+MsgBox(sb.ToString())
+
+' This code produces the following output:
+
+' fox
+' the
+' quick
+' jumps
+' brown
+```
+
 ## See also
 
 - <xref:System.Linq>

--- a/docs/visual-basic/programming-guide/concepts/linq/standard-query-operators-overview.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/standard-query-operators-overview.md
@@ -4,96 +4,100 @@ ms.date: 07/20/2015
 ms.assetid: 302bd39e-2ec1-495b-94bf-37d370d6f05f
 ---
 # Standard Query Operators Overview (Visual Basic)
-The *standard query operators* are the methods that form the LINQ pattern. Most of these methods operate on sequences, where a sequence is an object whose type implements the <xref:System.Collections.Generic.IEnumerable%601> interface or the <xref:System.Linq.IQueryable%601> interface. The standard query operators provide query capabilities including filtering, projection, aggregation, sorting and more.  
-  
- There are two sets of LINQ standard query operators, one that operates on objects of type <xref:System.Collections.Generic.IEnumerable%601> and the other that operates on objects of type <xref:System.Linq.IQueryable%601>. The methods that make up each set are static members of the <xref:System.Linq.Enumerable> and <xref:System.Linq.Queryable> classes, respectively. They are defined as *extension methods* of the type that they operate on. This means that they can be called by using either static method syntax or instance method syntax.  
-  
- In addition, several standard query operator methods operate on types other than those based on <xref:System.Collections.Generic.IEnumerable%601> or <xref:System.Linq.IQueryable%601>. The <xref:System.Linq.Enumerable> type defines two such methods that both operate on objects of type <xref:System.Collections.IEnumerable>. These methods, <xref:System.Linq.Enumerable.Cast%60%601%28System.Collections.IEnumerable%29> and <xref:System.Linq.Enumerable.OfType%60%601%28System.Collections.IEnumerable%29>, let you enable a non-parameterized, or non-generic, collection to be queried in the LINQ pattern. They do this by creating a strongly-typed collection of objects. The <xref:System.Linq.Queryable> class defines two similar methods, <xref:System.Linq.Queryable.Cast%60%601%28System.Linq.IQueryable%29> and <xref:System.Linq.Queryable.OfType%60%601%28System.Linq.IQueryable%29>, that operate on objects of type <xref:System.Linq.Queryable>.  
-  
- The standard query operators differ in the timing of their execution, depending on whether they return a singleton value or a sequence of values. Those methods that return a singleton value (for example, <xref:System.Linq.Enumerable.Average%2A> and <xref:System.Linq.Enumerable.Sum%2A>) execute immediately. Methods that return a sequence defer the query execution and return an enumerable object.  
-  
- In the case of the methods that operate on in-memory collections, that is, those methods that extend <xref:System.Collections.Generic.IEnumerable%601>, the returned enumerable object captures the arguments that were passed to the method. When that object is enumerated, the logic of the query operator is employed and the query results are returned.  
-  
- In contrast, methods that extend <xref:System.Linq.IQueryable%601> do not implement any querying behavior, but build an expression tree that represents the query to be performed. The query processing is handled by the source <xref:System.Linq.IQueryable%601> object.  
-  
- Calls to query methods can be chained together in one query, which enables queries to become arbitrarily complex.  
-  
- The following code example demonstrates how the standard query operators can be used to obtain information about a sequence.  
-  
-```vb  
-Dim sentence = "the quick brown fox jumps over the lazy dog"  
-' Split the string into individual words to create a collection.  
-Dim words = sentence.Split(" "c)  
-  
-Dim query = From word In words   
-            Group word.ToUpper() By word.Length Into gr = Group   
-            Order By Length _  
-            Select Length, GroupedWords = gr  
-  
-Dim output As New System.Text.StringBuilder  
-For Each obj In query  
-    output.AppendLine(String.Format("Words of length {0}:", obj.Length))  
-    For Each word As String In obj.GroupedWords  
-        output.AppendLine(word)  
-    Next  
-Next  
-  
-'Display the output  
-MsgBox(output.ToString())  
-  
-' This code example produces the following output:  
-'  
-' Words of length 3:  
-' THE  
-' FOX  
-' THE  
-' DOG  
-' Words of length 4:  
-' OVER  
-' LAZY  
-' Words of length 5:  
-' QUICK  
-' BROWN  
-' JUMPS   
-```  
-  
-## Query Expression Syntax  
- Some of the more frequently used standard query operators have dedicated C# and Visual Basic language keyword syntax that enables them to be called as part of a *query* *expression*. For more information about standard query operators that have dedicated keywords and their corresponding syntaxes, see [Query Expression Syntax for Standard Query Operators (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/query-expression-syntax-for-standard-query-operators.md).  
-  
-## Extending the Standard Query Operators  
- You can augment the set of standard query operators by creating domain-specific methods that are appropriate for your target domain or technology. You can also replace the standard query operators with your own implementations that provide additional services such as remote evaluation, query translation, and optimization. See <xref:System.Linq.Enumerable.AsEnumerable%2A> for an example.  
-  
-## Related Sections  
- The following links take you to topics that provide additional information about the various standard query operators based on functionality.  
-  
- [Sorting Data](../../../../visual-basic/programming-guide/concepts/linq/sorting-data.md)  
-  
- [Set Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/set-operations.md)  
-  
- [Filtering Data (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/filtering-data.md)  
-  
- [Quantifier Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/quantifier-operations.md)  
-  
- [Projection Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/projection-operations.md)  
-  
- [Partitioning Data (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/partitioning-data.md)  
-  
- [Join Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/join-operations.md)  
-  
- [Grouping Data (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/grouping-data.md)  
-  
- [Generation Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/generation-operations.md)  
-  
- [Equality Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/equality-operations.md)  
-  
- [Element Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/element-operations.md)  
-  
- [Converting Data Types (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/converting-data-types.md)  
-  
- [Concatenation Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/concatenation-operations.md)  
-  
- [Aggregation Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/aggregation-operations.md)  
-  
+
+The *standard query operators* are the methods that form the LINQ pattern. Most of these methods operate on sequences, where a sequence is an object whose type implements the <xref:System.Collections.Generic.IEnumerable%601> interface or the <xref:System.Linq.IQueryable%601> interface. The standard query operators provide query capabilities including filtering, projection, aggregation, sorting and more.
+
+There are two sets of LINQ standard query operators, one that operates on objects of type <xref:System.Collections.Generic.IEnumerable%601> and the other that operates on objects of type <xref:System.Linq.IQueryable%601>. The methods that make up each set are static members of the <xref:System.Linq.Enumerable> and <xref:System.Linq.Queryable> classes, respectively. They are defined as *extension methods* of the type that they operate on. This means that they can be called by using either static method syntax or instance method syntax.
+
+In addition, several standard query operator methods operate on types other than those based on <xref:System.Collections.Generic.IEnumerable%601> or <xref:System.Linq.IQueryable%601>. The <xref:System.Linq.Enumerable> type defines two such methods that both operate on objects of type <xref:System.Collections.IEnumerable>. These methods, <xref:System.Linq.Enumerable.Cast%60%601%28System.Collections.IEnumerable%29> and <xref:System.Linq.Enumerable.OfType%60%601%28System.Collections.IEnumerable%29>, let you enable a non-parameterized, or non-generic, collection to be queried in the LINQ pattern. They do this by creating a strongly-typed collection of objects. The <xref:System.Linq.Queryable> class defines two similar methods, <xref:System.Linq.Queryable.Cast%60%601%28System.Linq.IQueryable%29> and <xref:System.Linq.Queryable.OfType%60%601%28System.Linq.IQueryable%29>, that operate on objects of type <xref:System.Linq.Queryable>.
+
+The standard query operators differ in the timing of their execution, depending on whether they return a singleton value or a sequence of values. Those methods that return a singleton value (for example, <xref:System.Linq.Enumerable.Average%2A> and <xref:System.Linq.Enumerable.Sum%2A>) execute immediately. Methods that return a sequence defer the query execution and return an enumerable object.
+
+In the case of the methods that operate on in-memory collections, that is, those methods that extend <xref:System.Collections.Generic.IEnumerable%601>, the returned enumerable object captures the arguments that were passed to the method. When that object is enumerated, the logic of the query operator is employed and the query results are returned.
+
+In contrast, methods that extend <xref:System.Linq.IQueryable%601> do not implement any querying behavior, but build an expression tree that represents the query to be performed. The query processing is handled by the source <xref:System.Linq.IQueryable%601> object.
+
+Calls to query methods can be chained together in one query, which enables queries to become arbitrarily complex.
+
+The following code example demonstrates how the standard query operators can be used to obtain information about a sequence.
+
+```vb
+Dim sentence = "the quick brown fox jumps over the lazy dog"
+' Split the string into individual words to create a collection.
+Dim words = sentence.Split(" "c)
+
+Dim query = From word In words
+            Group word.ToUpper() By word.Length Into gr = Group
+            Order By Length _
+            Select Length, GroupedWords = gr
+
+Dim output As New System.Text.StringBuilder
+For Each obj In query
+    output.AppendLine(String.Format("Words of length {0}:", obj.Length))
+    For Each word As String In obj.GroupedWords
+        output.AppendLine(word)
+    Next
+Next
+
+'Display the output
+MsgBox(output.ToString())
+
+' This code example produces the following output:
+'
+' Words of length 3:
+' THE
+' FOX
+' THE
+' DOG
+' Words of length 4:
+' OVER
+' LAZY
+' Words of length 5:
+' QUICK
+' BROWN
+' JUMPS
+```
+
+## Query Expression Syntax
+
+Some of the more frequently used standard query operators have dedicated C# and Visual Basic language keyword syntax that enables them to be called as part of a *query* *expression*. For more information about standard query operators that have dedicated keywords and their corresponding syntaxes, see [Query Expression Syntax for Standard Query Operators (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/query-expression-syntax-for-standard-query-operators.md).
+
+## Extending the Standard Query Operators
+
+You can augment the set of standard query operators by creating domain-specific methods that are appropriate for your target domain or technology. You can also replace the standard query operators with your own implementations that provide additional services such as remote evaluation, query translation, and optimization. See <xref:System.Linq.Enumerable.AsEnumerable%2A> for an example.
+
+## Related Sections
+
+The following links take you to topics that provide additional information about the various standard query operators based on functionality.
+
+- [Sorting Data](../../../../visual-basic/programming-guide/concepts/linq/sorting-data.md)
+
+- [Set Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/set-operations.md)
+
+- [Filtering Data (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/filtering-data.md)
+
+- [Quantifier Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/quantifier-operations.md)
+
+- [Projection Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/projection-operations.md)
+
+- [Partitioning Data (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/partitioning-data.md)
+
+- [Join Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/join-operations.md)
+
+- [Grouping Data (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/grouping-data.md)
+
+- [Generation Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/generation-operations.md)
+
+- [Equality Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/equality-operations.md)
+
+- [Element Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/element-operations.md)
+
+- [Converting Data Types (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/converting-data-types.md)
+
+- [Concatenation Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/concatenation-operations.md)
+
+- [Aggregation Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/aggregation-operations.md)
+
 ## See also
 
 - <xref:System.Linq.Enumerable>

--- a/docs/visual-basic/programming-guide/concepts/linq/type-relationships-in-query-operations.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/type-relationships-in-query-operations.md
@@ -1,7 +1,7 @@
 ---
 title: "Type Relationships in Query Operations (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "variable relationships [LINQ in Visual Basic]"
   - "type information inferred [LINQ in Visual Basic]"
   - "type relationships [LINQ in Visual Basic]"
@@ -13,103 +13,107 @@ helpviewer_keywords:
 ms.assetid: b5ff4da5-f3fd-4a8e-aaac-1cbf52fa16f6
 ---
 # Type Relationships in Query Operations (Visual Basic)
-Variables used in [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)] query operations are strongly typed and must be compatible with each other. Strong typing is used in the data source, in the query itself, and in the query execution. The following illustration identifies terms used to describe a [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query. For more information about the parts of a query, see [Basic Query Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/basic-query-operations.md).  
-  
- ![Screenshot showing a pseudocode query with elements highlighted.](./media/type-relationships-in-query-operations/linq-query-description-terms.png)  
-  
- The type of the range variable in the query must be compatible with the type of the elements in the data source. The type of the query variable must be compatible with the sequence element defined in the `Select` clause. Finally, the type of the sequence elements also must be compatible with the type of the loop control variable that is used in the `For Each` statement that executes the query. This strong typing facilitates identification of type errors at compile time.  
-  
- Visual Basic makes strong typing convenient by implementing local type inference, also known as *implicit typing*. That feature is used in the previous example, and you will see it used throughout the [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] samples and documentation. In Visual Basic, local type inference is accomplished simply by using a `Dim` statement without an `As` clause. In the following example, `city` is strongly typed as a string.  
-  
- [!code-vb[VbLINQTypeRels#1](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#1)]  
-  
+
+Variables used in [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)] query operations are strongly typed and must be compatible with each other. Strong typing is used in the data source, in the query itself, and in the query execution. The following illustration identifies terms used to describe a [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query. For more information about the parts of a query, see [Basic Query Operations (Visual Basic)](../../../../visual-basic/programming-guide/concepts/linq/basic-query-operations.md).
+
+![Screenshot showing a pseudocode query with elements highlighted.](./media/type-relationships-in-query-operations/linq-query-description-terms.png)
+
+The type of the range variable in the query must be compatible with the type of the elements in the data source. The type of the query variable must be compatible with the sequence element defined in the `Select` clause. Finally, the type of the sequence elements also must be compatible with the type of the loop control variable that is used in the `For Each` statement that executes the query. This strong typing facilitates identification of type errors at compile time.
+
+Visual Basic makes strong typing convenient by implementing local type inference, also known as *implicit typing*. That feature is used in the previous example, and you will see it used throughout the [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] samples and documentation. In Visual Basic, local type inference is accomplished simply by using a `Dim` statement without an `As` clause. In the following example, `city` is strongly typed as a string.
+
+[!code-vb[VbLINQTypeRels#1](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#1)]
+
 > [!NOTE]
-> Local type inference works only when `Option Infer` is set to `On`. For more information, see [Option Infer Statement](../../../../visual-basic/language-reference/statements/option-infer-statement.md).  
-  
- However, even if you use local type inference in a query, the same type relationships are present among the variables in the data source, the query variable, and the query execution loop. It is useful to have a basic understanding of these type relationships when you are writing [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] queries, or working with the samples and code examples in the documentation.  
-  
- You may need to specify an explicit type for a range variable that does not match the type returned from the data source. You can specify the type of the range variable by using an `As` clause. However, this results in an error if the conversion is a [narrowing conversion](../../../../visual-basic/programming-guide/language-features/data-types/widening-and-narrowing-conversions.md) and `Option Strict` is set to `On`. Therefore, we recommend that you perform the conversion on the values retrieved from the data source. You can convert the values from the data source to the explicit range variable type by using the <xref:System.Linq.Enumerable.Cast%2A> method. You can also cast the values selected in the `Select` clause to an explicit type that is different from the type of the range variable. These points are illustrated in the following code.  
-  
- [!code-vb[VbLINQTypeRels#4](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#4)]  
-  
-## Queries That Return Entire Elements of the Source Data  
- The following example shows a [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query operation that returns a sequence of elements selected from the source data. The source, `names`, contains an array of strings, and the query output is a sequence containing strings that start with the letter M.  
-  
- [!code-vb[VbLINQTypeRels#2](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#2)]  
-  
- This is equivalent to the following code, but is much shorter and easier to write. Reliance on local type inference in queries is the preferred style in Visual Basic.  
-  
- [!code-vb[VbLINQTypeRels#3](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#3)]  
-  
- The following relationships exist in both of the previous code examples, whether the types are determined implicitly or explicitly.  
-  
-1. The type of the elements in the data source, `names`, is the type of the range variable, `name`, in the query.  
-  
-2. The type of the object that is selected, `name`, determines the type of the query variable, `mNames`. Here `name` is a string, so the query variable is IEnumerable(Of String) in Visual Basic.  
-  
-3. The query defined in `mNames` is executed in the `For Each` loop. The loop iterates over the result of executing the query. Because `mNames`, when it is executed, will return a sequence of strings, the loop iteration variable, `nm`, also is a string.  
-  
-## Queries That Return One Field from Selected Elements  
- The following example shows a [!INCLUDE[vbtecdlinq](~/includes/vbtecdlinq-md.md)] query operation that returns a sequence containing only one part of each element selected from the data source. The query takes a collection of `Customer` objects as its data source and projects only the `Name` property in the result. Because the customer name is a string, the query produces a sequence of strings as output.  
-  
-```vb  
-' Method GetTable returns a table of Customer objects.  
-Dim customers = db.GetTable(Of Customer)()  
-Dim custNames = From cust In customers   
-                Where cust.City = "London"   
-                Select cust.Name  
-  
-For Each custName In custNames  
-    Console.WriteLine(custName)  
-Next  
-```  
-  
- The relationships between variables are like those in the simpler example.  
-  
-1. The type of the elements in the data source, `customers`, is the type of the range variable, `cust`, in the query. In this example, that type is `Customer`.  
-  
-2. The `Select` statement returns the `Name` property of each `Customer` object instead of the whole object. Because `Name` is a string, the query variable, `custNames`, will again be IEnumerable(Of String), not of `Customer`.  
-  
-3. Because `custNames` represents a sequence of strings, the `For Each` loop's iteration variable, `custName`, must be a string.  
-  
- Without local type inference, the previous example would be more cumbersome to write and to understand, as the following example shows.  
-  
-```vb  
-' Method GetTable returns a table of Customer objects.  
- Dim customers As Table(Of Customer) = db.GetTable(Of Customer)()  
- Dim custNames As IEnumerable(Of String) =  
-     From cust As Customer In customers   
-     Where cust.City = "London"   
-     Select cust.Name  
-  
- For Each custName As String In custNames  
-     Console.WriteLine(custName)  
- Next  
-```  
-  
-## Queries That Require Anonymous Types  
- The following example shows a more complex situation. In the previous example, it was inconvenient to specify types for all the variables explicitly. In this example, it is impossible. Instead of selecting entire `Customer` elements from the data source, or a single field from each element, the `Select` clause in this query returns two properties of the original `Customer` object: `Name` and `City`. In response to the `Select` clause, the compiler defines an anonymous type that contains those two properties. The result of executing `nameCityQuery` in the `For Each` loop is a collection of instances of the new anonymous type. Because the anonymous type has no usable name, you cannot specify the type of `nameCityQuery` or `custInfo` explicitly. That is, with an anonymous type, you have no type name to use in place of `String` in `IEnumerable(Of String)`. For more information, see [Anonymous Types](../../../../visual-basic/programming-guide/language-features/objects-and-classes/anonymous-types.md).  
-  
-```vb  
-' Method GetTable returns a table of Customer objects.  
-Dim customers = db.GetTable(Of Customer)()  
-Dim nameCityQuery = From cust In customers   
-                    Where cust.City = "London"   
-                    Select cust.Name, cust.City  
-  
-For Each custInfo In nameCityQuery  
-    Console.WriteLine(custInfo.Name)  
-Next  
-```  
-  
- Although it is not possible to specify types for all the variables in the previous example, the relationships remain the same.  
-  
-1. The type of the elements in the data source is again the type of the range variable in the query. In this example, `cust` is an instance of `Customer`.  
-  
-2. Because the `Select` statement produces an anonymous type, the query variable, `nameCityQuery`, must be implicitly typed as an anonymous type. An anonymous type has no usable name, and therefore cannot be specified explicitly.  
-  
-3. The type of the iteration variable in the `For Each` loop is the anonymous type created in step 2. Because the type has no usable name, the type of the loop iteration variable must be determined implicitly.  
-  
+> Local type inference works only when `Option Infer` is set to `On`. For more information, see [Option Infer Statement](../../../../visual-basic/language-reference/statements/option-infer-statement.md).
+
+However, even if you use local type inference in a query, the same type relationships are present among the variables in the data source, the query variable, and the query execution loop. It is useful to have a basic understanding of these type relationships when you are writing [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] queries, or working with the samples and code examples in the documentation.
+
+You may need to specify an explicit type for a range variable that does not match the type returned from the data source. You can specify the type of the range variable by using an `As` clause. However, this results in an error if the conversion is a [narrowing conversion](../../../../visual-basic/programming-guide/language-features/data-types/widening-and-narrowing-conversions.md) and `Option Strict` is set to `On`. Therefore, we recommend that you perform the conversion on the values retrieved from the data source. You can convert the values from the data source to the explicit range variable type by using the <xref:System.Linq.Enumerable.Cast%2A> method. You can also cast the values selected in the `Select` clause to an explicit type that is different from the type of the range variable. These points are illustrated in the following code.
+
+[!code-vb[VbLINQTypeRels#4](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#4)]
+
+## Queries That Return Entire Elements of the Source Data
+
+The following example shows a [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query operation that returns a sequence of elements selected from the source data. The source, `names`, contains an array of strings, and the query output is a sequence containing strings that start with the letter M.
+
+[!code-vb[VbLINQTypeRels#2](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#2)]
+
+This is equivalent to the following code, but is much shorter and easier to write. Reliance on local type inference in queries is the preferred style in Visual Basic.
+
+[!code-vb[VbLINQTypeRels#3](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbLINQTypeRels/VB/Class1.vb#3)]
+
+The following relationships exist in both of the previous code examples, whether the types are determined implicitly or explicitly.
+
+1. The type of the elements in the data source, `names`, is the type of the range variable, `name`, in the query.
+
+2. The type of the object that is selected, `name`, determines the type of the query variable, `mNames`. Here `name` is a string, so the query variable is IEnumerable(Of String) in Visual Basic.
+
+3. The query defined in `mNames` is executed in the `For Each` loop. The loop iterates over the result of executing the query. Because `mNames`, when it is executed, will return a sequence of strings, the loop iteration variable, `nm`, also is a string.
+
+## Queries That Return One Field from Selected Elements
+
+The following example shows a [!INCLUDE[vbtecdlinq](~/includes/vbtecdlinq-md.md)] query operation that returns a sequence containing only one part of each element selected from the data source. The query takes a collection of `Customer` objects as its data source and projects only the `Name` property in the result. Because the customer name is a string, the query produces a sequence of strings as output.
+
+```vb
+' Method GetTable returns a table of Customer objects.
+Dim customers = db.GetTable(Of Customer)()
+Dim custNames = From cust In customers
+                Where cust.City = "London"
+                Select cust.Name
+
+For Each custName In custNames
+    Console.WriteLine(custName)
+Next
+```
+
+The relationships between variables are like those in the simpler example.
+
+1. The type of the elements in the data source, `customers`, is the type of the range variable, `cust`, in the query. In this example, that type is `Customer`.
+
+2. The `Select` statement returns the `Name` property of each `Customer` object instead of the whole object. Because `Name` is a string, the query variable, `custNames`, will again be IEnumerable(Of String), not of `Customer`.
+
+3. Because `custNames` represents a sequence of strings, the `For Each` loop's iteration variable, `custName`, must be a string.
+
+Without local type inference, the previous example would be more cumbersome to write and to understand, as the following example shows.
+
+```vb
+' Method GetTable returns a table of Customer objects.
+ Dim customers As Table(Of Customer) = db.GetTable(Of Customer)()
+ Dim custNames As IEnumerable(Of String) =
+     From cust As Customer In customers
+     Where cust.City = "London"
+     Select cust.Name
+
+ For Each custName As String In custNames
+     Console.WriteLine(custName)
+ Next
+```
+
+## Queries That Require Anonymous Types
+
+The following example shows a more complex situation. In the previous example, it was inconvenient to specify types for all the variables explicitly. In this example, it is impossible. Instead of selecting entire `Customer` elements from the data source, or a single field from each element, the `Select` clause in this query returns two properties of the original `Customer` object: `Name` and `City`. In response to the `Select` clause, the compiler defines an anonymous type that contains those two properties. The result of executing `nameCityQuery` in the `For Each` loop is a collection of instances of the new anonymous type. Because the anonymous type has no usable name, you cannot specify the type of `nameCityQuery` or `custInfo` explicitly. That is, with an anonymous type, you have no type name to use in place of `String` in `IEnumerable(Of String)`. For more information, see [Anonymous Types](../../../../visual-basic/programming-guide/language-features/objects-and-classes/anonymous-types.md).
+
+```vb
+' Method GetTable returns a table of Customer objects.
+Dim customers = db.GetTable(Of Customer)()
+Dim nameCityQuery = From cust In customers
+                    Where cust.City = "London"
+                    Select cust.Name, cust.City
+
+For Each custInfo In nameCityQuery
+    Console.WriteLine(custInfo.Name)
+Next
+```
+
+Although it is not possible to specify types for all the variables in the previous example, the relationships remain the same.
+
+1. The type of the elements in the data source is again the type of the range variable in the query. In this example, `cust` is an instance of `Customer`.
+
+2. Because the `Select` statement produces an anonymous type, the query variable, `nameCityQuery`, must be implicitly typed as an anonymous type. An anonymous type has no usable name, and therefore cannot be specified explicitly.
+
+3. The type of the iteration variable in the `For Each` loop is the anonymous type created in step 2. Because the type has no usable name, the type of the loop iteration variable must be determined implicitly.
+
 ## See also
 
 - [Getting Started with LINQ in Visual Basic](../../../../visual-basic/programming-guide/concepts/linq/getting-started-with-linq.md)

--- a/docs/visual-basic/programming-guide/language-features/data-types/tuples.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/tuples.md
@@ -1,7 +1,7 @@
 ---
 title: "Tuples in Visual Basic"
 ms.date: 04/23/2017
-helpviewer_keywords: 
+helpviewer_keywords:
   - "tuples [Visual Basic]"
 ms.assetid: 3e66cd1b-3432-4e1d-8c37-5ebacae8f53f
 ---
@@ -34,22 +34,22 @@ Rather than using default names for a tuple's fields, you can instantiate a *nam
 
 ## Inferred tuple element names
 
-Starting with Visual Basic 15.3, Visual Basic can infer the names of tuple elements; you do not have to assign them explicitly. Inferred tuple names are useful when you initialize a tuple from a set of variables, and you want the tuple element name to be the same as the variable name. 
+Starting with Visual Basic 15.3, Visual Basic can infer the names of tuple elements; you do not have to assign them explicitly. Inferred tuple names are useful when you initialize a tuple from a set of variables, and you want the tuple element name to be the same as the variable name.
 
 The following example creates a `stateInfo` tuple that contains three explicitly named elements, `state`, `stateName`, and `capital`. Note that, in naming the elements, the tuple initialization statement simply assigns the named elements the values of the identically named variables.
 
 [!code-vb[ExplicitlyNamed](../../../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/named-tuples/program.vb#1)]
- 
+
 Because elements and variables have the same name, the Visual Basic compiler can infer the names of the fields, as the following example shows.
 
 [!code-vb[ExplicitlyNamed](../../../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/named-tuples/program.vb#2)]
 
-To enable inferred tuple element names, you must define the version of the Visual Basic compiler to use in your Visual Basic project (\*.vbproj) file: 
+To enable inferred tuple element names, you must define the version of the Visual Basic compiler to use in your Visual Basic project (\*.vbproj) file:
 
-```xml 
-<PropertyGroup> 
-  <LangVersion>15.3</LangVersion> 
-</PropertyGroup> 
+```xml
+<PropertyGroup>
+  <LangVersion>15.3</LangVersion>
+</PropertyGroup>
 ```
 
 The version number can be any version of the Visual Basic compiler starting with 15.3. Rather than hard-coding a specific compiler version, you can also specify "Latest" as the value of `LangVersion` to compile with the most recent version of the Visual Basic compiler installed on your system.
@@ -61,9 +61,9 @@ In some cases, the Visual Basic compiler cannot infer the tuple element name fro
 - The candidate name is the same as the name of a tuple member, such as `Item3`, `Rest`, or `ToString`.
 
 - The candidate name is duplicated in the tuple.
- 
-When field name inference fails, Visual Basic does not generate a compiler error, nor is an exception thrown at runtime. Instead, tuple fields must be referenced by their predefined names, such as `Item1` and `Item2`. 
-  
+
+When field name inference fails, Visual Basic does not generate a compiler error, nor is an exception thrown at runtime. Instead, tuple fields must be referenced by their predefined names, such as `Item1` and `Item2`.
+
 ## Tuples versus structures
 
 A Visual Basic tuple is a value type that is an instance of one of the a **System.ValueTuple** generic types. For example, the `holiday` tuple defined in the previous example is an instance of the <xref:System.ValueTuple%603> structure. It is designed to be a lightweight container for data. Since the tuple aims to make it easy to create an object with multiple data items, it lacks some of the features that a custom structure might have. These include:
@@ -93,7 +93,7 @@ Visual Basic supports assignment between tuple types that have the same number o
 
 - The source and target field are of the same type.
 
-- A widening (or implicit) conversion of the source type to the target type is defined. 
+- A widening (or implicit) conversion of the source type to the target type is defined.
 
 - `Option Strict` is `On`, and a narrowing (or explicit) conversion of the source type to the target type is defined. This conversion can throw an exception if the source value is outside the range of the target type.
 
@@ -139,7 +139,7 @@ For example, the **TryParse** methods in .NET return a `Boolean` value that indi
 
 [!code-vb[Return](../../../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb#1)]
 
-We can return a tuple from the parsing operation if we wrap the call to the <xref:System.Int32.TryParse%2A?displayProperty=nameWithType> method in our own method. In the following example, `NumericLibrary.ParseInteger` calls the <xref:System.Int32.TryParse%2A?displayProperty=nameWithType> method and returns a named tuple with two elements. 
+We can return a tuple from the parsing operation if we wrap the call to the <xref:System.Int32.TryParse%2A?displayProperty=nameWithType> method in our own method. In the following example, `NumericLibrary.ParseInteger` calls the <xref:System.Int32.TryParse%2A?displayProperty=nameWithType> method and returns a named tuple with two elements.
 
 [!code-vb[Return](../../../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb#2)]
 

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-modify-data-in-a-database-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-modify-data-in-a-database-by-using-linq.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Modify Data in a Database by Using LINQ (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "inserting rows [LINQ to SQL]"
   - "deleting rows [LINQ to SQL]"
   - "updating rows [LINQ to SQL]"
@@ -14,146 +14,147 @@ helpviewer_keywords:
 ms.assetid: cf52635f-0c1b-46c3-aff1-bdf181cf19b1
 ---
 # How to: Modify Data in a Database by Using LINQ (Visual Basic)
-Language-Integrated Query (LINQ) queries make it easy to access database information and modify values in the database.  
-  
- The following example shows how to create a new application that retrieves and updates information in a SQL Server database.  
-  
- The examples in this topic use the Northwind sample database. If you do not have this database on your development computer, you can download it from the Microsoft Download Center. For instructions, see [Downloading Sample Databases](../../../../framework/data/adonet/sql/linq/downloading-sample-databases.md).  
-  
-### To create a connection to a database  
-  
-1. In Visual Studio, open **Server Explorer**/**Database Explorer** by clicking the **View** menu, and then select **Server Explorer**/**Database Explorer**.  
-  
-2. Right-click **Data Connections** in **Server Explorer**/**Database Explorer**, and click **Add Connection**.  
-  
-3. Specify a valid connection to the Northwind sample database.  
-  
-### To add a Project with a LINQ to SQL file  
-  
-1. In Visual Studio, on the **File** menu, point to **New** and then click **Project**. Select Visual Basic **Windows Forms Application** as the project type.  
-  
-2. On the **Project** menu, click **Add New Item**. Select the **LINQ to SQL Classes** item template.  
-  
-3. Name the file `northwind.dbml`. Click **Add**. The Object Relational Designer (O/R Designer) is opened for the `northwind.dbml` file.  
-  
-### To add tables to query and modify to the designer  
-  
-1. In **Server Explorer**/**Database Explorer**, expand the connection to the Northwind database. Expand the **Tables** folder.  
-  
-     If you have closed the O/R Designer, you can reopen it by double-clicking the `northwind.dbml` file that you added earlier.  
-  
-2. Click the Customers table and drag it to the left pane of the designer.  
-  
-     The designer creates a new Customer object for your project.  
-  
-3. Save your changes and close the designer.  
-  
-4. Save your project.  
-  
-### To add code to modify the database and display the results  
-  
-1. From the **Toolbox**, drag a <xref:System.Windows.Forms.DataGridView> control onto the default Windows Form for your project, Form1.  
-  
-2. When you added tables to the O/R Designer, the designer added a <xref:System.Data.Linq.DataContext> object to your project. This object contains code that you can use to access the Customers table. It also contains code that defines  a local Customer object and a Customers collection for the table. The <xref:System.Data.Linq.DataContext> object for your project is named based on the name of your .dbml file. For this project, the <xref:System.Data.Linq.DataContext> object is named `northwindDataContext`.  
-  
-     You can create an instance of the <xref:System.Data.Linq.DataContext> object in your code and query and modify the Customers collection specified by the O/R Designer. Changes that you make to the Customers collection are not reflected in the database until you submit them by calling the <xref:System.Data.Linq.DataContext.SubmitChanges%2A> method of the <xref:System.Data.Linq.DataContext> object.  
-  
-     Double-click the Windows Form, Form1, to add code to the <xref:System.Windows.Forms.Form.Load> event to query the Customers table that is exposed as a property of your <xref:System.Data.Linq.DataContext>. Add the following code:  
-  
-    ```vb  
-    Private db As northwindDataContext  
-  
-    Private Sub Form1_Load(ByVal sender As System.Object,   
-                           ByVal e As System.EventArgs  
-                          ) Handles MyBase.Load  
-      db = New northwindDataContext()  
-  
-      RefreshData()  
-    End Sub  
-  
-    Private Sub RefreshData()  
-      Dim customers = From cust In db.Customers   
-                      Where cust.City(0) = "W"   
-                      Select cust  
-  
-      DataGridView1.DataSource = customers  
-    End Sub  
-    ```  
-  
-3. From the **Toolbox**, drag three <xref:System.Windows.Forms.Button> controls onto the form. Select the first `Button` control. In the **Properties** window, set the `Name` of the `Button` control to `AddButton` and the `Text` to `Add`. Select the second button and set the `Name` property to `UpdateButton` and the `Text` property to `Update`. Select the third button and set the `Name` property to `DeleteButton` and the `Text` property to `Delete`.  
-  
-4. Double-click the **Add** button to add code to its `Click` event. Add the following code:  
-  
-    ```vb  
-    Private Sub AddButton_Click(ByVal sender As System.Object,   
-                                ByVal e As System.EventArgs  
-                               ) Handles AddButton.Click  
-      Dim cust As New Customer With {   
-        .City = "Wellington",   
-        .CompanyName = "Blue Yonder Airlines",   
-        .ContactName = "Jill Frank",   
-        .Country = "New Zealand",   
-        .CustomerID = "JILLF"}  
-  
-      db.Customers.InsertOnSubmit(cust)  
-  
-      Try  
-        db.SubmitChanges()  
-      Catch  
-        ' Handle exception.  
-      End Try  
-  
-      RefreshData()  
-    End Sub  
-    ```  
-  
-5. Double-click the **Update** button to add code to its `Click` event. Add the following code:  
-  
-    ```vb  
-    Private Sub UpdateButton_Click(ByVal sender As System.Object, _  
-                                   ByVal e As System.EventArgs  
-                                  ) Handles UpdateButton.Click  
-      Dim updateCust = (From cust In db.Customers   
-                        Where cust.CustomerID = "JILLF").ToList()(0)  
-  
+
+Language-Integrated Query (LINQ) queries make it easy to access database information and modify values in the database.
+
+The following example shows how to create a new application that retrieves and updates information in a SQL Server database.
+
+The examples in this topic use the Northwind sample database. If you do not have this database on your development computer, you can download it from the Microsoft Download Center. For instructions, see [Downloading Sample Databases](../../../../framework/data/adonet/sql/linq/downloading-sample-databases.md).
+
+### To create a connection to a database
+
+1. In Visual Studio, open **Server Explorer**/**Database Explorer** by clicking the **View** menu, and then select **Server Explorer**/**Database Explorer**.
+
+2. Right-click **Data Connections** in **Server Explorer**/**Database Explorer**, and click **Add Connection**.
+
+3. Specify a valid connection to the Northwind sample database.
+
+### To add a Project with a LINQ to SQL file
+
+1. In Visual Studio, on the **File** menu, point to **New** and then click **Project**. Select Visual Basic **Windows Forms Application** as the project type.
+
+2. On the **Project** menu, click **Add New Item**. Select the **LINQ to SQL Classes** item template.
+
+3. Name the file `northwind.dbml`. Click **Add**. The Object Relational Designer (O/R Designer) is opened for the `northwind.dbml` file.
+
+### To add tables to query and modify to the designer
+
+1. In **Server Explorer**/**Database Explorer**, expand the connection to the Northwind database. Expand the **Tables** folder.
+
+     If you have closed the O/R Designer, you can reopen it by double-clicking the `northwind.dbml` file that you added earlier.
+
+2. Click the Customers table and drag it to the left pane of the designer.
+
+     The designer creates a new Customer object for your project.
+
+3. Save your changes and close the designer.
+
+4. Save your project.
+
+### To add code to modify the database and display the results
+
+1. From the **Toolbox**, drag a <xref:System.Windows.Forms.DataGridView> control onto the default Windows Form for your project, Form1.
+
+2. When you added tables to the O/R Designer, the designer added a <xref:System.Data.Linq.DataContext> object to your project. This object contains code that you can use to access the Customers table. It also contains code that defines  a local Customer object and a Customers collection for the table. The <xref:System.Data.Linq.DataContext> object for your project is named based on the name of your .dbml file. For this project, the <xref:System.Data.Linq.DataContext> object is named `northwindDataContext`.
+
+     You can create an instance of the <xref:System.Data.Linq.DataContext> object in your code and query and modify the Customers collection specified by the O/R Designer. Changes that you make to the Customers collection are not reflected in the database until you submit them by calling the <xref:System.Data.Linq.DataContext.SubmitChanges%2A> method of the <xref:System.Data.Linq.DataContext> object.
+
+     Double-click the Windows Form, Form1, to add code to the <xref:System.Windows.Forms.Form.Load> event to query the Customers table that is exposed as a property of your <xref:System.Data.Linq.DataContext>. Add the following code:
+
+    ```vb
+    Private db As northwindDataContext
+
+    Private Sub Form1_Load(ByVal sender As System.Object,
+                           ByVal e As System.EventArgs
+                          ) Handles MyBase.Load
+      db = New northwindDataContext()
+
+      RefreshData()
+    End Sub
+
+    Private Sub RefreshData()
+      Dim customers = From cust In db.Customers
+                      Where cust.City(0) = "W"
+                      Select cust
+
+      DataGridView1.DataSource = customers
+    End Sub
+    ```
+
+3. From the **Toolbox**, drag three <xref:System.Windows.Forms.Button> controls onto the form. Select the first `Button` control. In the **Properties** window, set the `Name` of the `Button` control to `AddButton` and the `Text` to `Add`. Select the second button and set the `Name` property to `UpdateButton` and the `Text` property to `Update`. Select the third button and set the `Name` property to `DeleteButton` and the `Text` property to `Delete`.
+
+4. Double-click the **Add** button to add code to its `Click` event. Add the following code:
+
+    ```vb
+    Private Sub AddButton_Click(ByVal sender As System.Object,
+                                ByVal e As System.EventArgs
+                               ) Handles AddButton.Click
+      Dim cust As New Customer With {
+        .City = "Wellington",
+        .CompanyName = "Blue Yonder Airlines",
+        .ContactName = "Jill Frank",
+        .Country = "New Zealand",
+        .CustomerID = "JILLF"}
+
+      db.Customers.InsertOnSubmit(cust)
+
+      Try
+        db.SubmitChanges()
+      Catch
+        ' Handle exception.
+      End Try
+
+      RefreshData()
+    End Sub
+    ```
+
+5. Double-click the **Update** button to add code to its `Click` event. Add the following code:
+
+    ```vb
+    Private Sub UpdateButton_Click(ByVal sender As System.Object, _
+                                   ByVal e As System.EventArgs
+                                  ) Handles UpdateButton.Click
+      Dim updateCust = (From cust In db.Customers
+                        Where cust.CustomerID = "JILLF").ToList()(0)
+
       updateCust.ContactName = "Jill Shrader"
       updateCust.Country = "Wales"
       updateCust.CompanyName = "Red Yonder Airlines"
       updateCust.City = "Cardiff"
-  
-      Try  
-        db.SubmitChanges()  
-      Catch  
-        ' Handle exception.  
-      End Try  
-  
-      RefreshData()  
-    End Sub  
-    ```  
-  
-6. Double-click the **Delete** button to add code to its `Click` event. Add the following code:  
-  
-    ```vb  
-    Private Sub DeleteButton_Click(ByVal sender As System.Object, _  
-                                   ByVal e As System.EventArgs  
-                                  ) Handles DeleteButton.Click  
-      Dim deleteCust = (From cust In db.Customers   
-                        Where cust.CustomerID = "JILLF").ToList()(0)  
-  
-      db.Customers.DeleteOnSubmit(deleteCust)  
-  
-      Try  
-        db.SubmitChanges()  
-      Catch  
-        ' Handle exception.  
-      End Try  
-  
-      RefreshData()  
-    End Sub  
-    ```  
-  
-7. Press F5 to run your project. Click **Add** to add a new record. Click **Update** to modify the new record. Click **Delete** to delete the new record.  
-  
+
+      Try
+        db.SubmitChanges()
+      Catch
+        ' Handle exception.
+      End Try
+
+      RefreshData()
+    End Sub
+    ```
+
+6. Double-click the **Delete** button to add code to its `Click` event. Add the following code:
+
+    ```vb
+    Private Sub DeleteButton_Click(ByVal sender As System.Object, _
+                                   ByVal e As System.EventArgs
+                                  ) Handles DeleteButton.Click
+      Dim deleteCust = (From cust In db.Customers
+                        Where cust.CustomerID = "JILLF").ToList()(0)
+
+      db.Customers.DeleteOnSubmit(deleteCust)
+
+      Try
+        db.SubmitChanges()
+      Catch
+        ' Handle exception.
+      End Try
+
+      RefreshData()
+    End Sub
+    ```
+
+7. Press F5 to run your project. Click **Add** to add a new record. Click **Update** to modify the new record. Click **Delete** to delete the new record.
+
 ## See also
 
 - [LINQ](../../../../visual-basic/programming-guide/language-features/linq/index.md)

--- a/docs/visual-basic/programming-guide/language-features/procedures/lambda-expressions.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/lambda-expressions.md
@@ -1,9 +1,9 @@
 ---
 title: "Lambda Expressions (Visual Basic)"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "vb.LambdaFunction"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "functions [Visual Basic], lambda expressions"
   - "lambda expressions [Visual Basic]"
   - "expressions [Visual Basic], lambda"
@@ -11,140 +11,145 @@ helpviewer_keywords:
 ms.assetid: 137064b0-3928-4bfa-ba71-c3f9cbd951e2
 ---
 # Lambda Expressions (Visual Basic)
-A *lambda expression* is a function or subroutine without a name that can be used wherever a delegate is valid. Lambda expressions can be functions or subroutines and can be single-line or multi-line. You can pass values from the current scope to a lambda expression.  
-  
+
+A *lambda expression* is a function or subroutine without a name that can be used wherever a delegate is valid. Lambda expressions can be functions or subroutines and can be single-line or multi-line. You can pass values from the current scope to a lambda expression.
+
 > [!NOTE]
-> The `RemoveHandler` statement is an exception. You cannot pass a lambda expression in for the delegate parameter of `RemoveHandler`.  
-  
- You create lambda expressions by using the `Function` or `Sub` keyword, just as you create a standard function or subroutine. However, lambda expressions are included in a statement.  
-  
- The following example is a lambda expression that increments its argument and returns the value. The example shows both the single-line and multi-line lambda expression syntax for a function.  
-  
- [!code-vb[VbVbalrLambdas#14](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#14)]  
-  
- The following example is a lambda expression that writes a value to the console. The example shows both the single-line and multi-line lambda expression syntax for a subroutine.  
-  
- [!code-vb[VbVbalrLambdas#15](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#15)]  
-  
- Notice that in the previous examples the lambda expressions are assigned to a variable name. Whenever you refer to the variable, you invoke the lambda expression. You can also declare and invoke a lambda expression at the same time, as shown in the following example.  
-  
- [!code-vb[VbVbalrLambdas#3](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#3)]  
-  
- A lambda expression can be returned as the value of a function call (as is shown in the example in the [Context](#context) section later in this topic), or passed in as an argument to a parameter that takes a delegate type, as shown in the following example.  
-  
- [!code-vb[VbVbalrLambdas#8](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class2.vb#8)]  
-  
-## Lambda Expression Syntax  
- The syntax of a lambda expression resembles that of a standard function or subroutine. The differences are as follows:  
-  
-- A lambda expression does not have a name.  
-  
-- Lambda expressions cannot have modifiers, such as `Overloads` or `Overrides`.  
-  
-- Single-line lambda functions do not use an `As` clause to designate the return type. Instead, the type is inferred from the value that the body of the lambda expression evaluates to. For example, if the body of the lambda expression is `cust.City = "London"`, its return type is `Boolean`.  
-  
-- In multi-line lambda functions, you can either specify a return type by using an `As` clause, or omit the `As` clause so that the return type is inferred. When the `As` clause is omitted for a multi-line lambda function, the return type is inferred to be the dominant type from all the `Return` statements in the multi-line lambda function. The *dominant type* is a unique type that all other types can widen to. If this unique type cannot be determined, the dominant type is the unique type that all other types in the array can narrow to. If neither of these unique types can be determined, the dominant type is `Object`. In this case, if `Option Strict` is set to `On`, a compiler error occurs.  
-  
-     For example, if the expressions supplied to the `Return` statement contain values of type `Integer`, `Long`, and `Double`, the resulting array is of type `Double`. Both `Integer` and `Long` widen to `Double` and only `Double`. Therefore, `Double` is the dominant type. For more information, see [Widening and Narrowing Conversions](../../../../visual-basic/programming-guide/language-features/data-types/widening-and-narrowing-conversions.md).  
-  
-- The body of a single-line function must be an expression that returns a value, not a statement. There is no `Return` statement for single-line functions. The value returned by the single-line function is the value of the expression in the body of the function.  
-  
-- The body of a single-line subroutine must be single-line statement.  
-  
-- Single-line functions and subroutines do not include an `End Function` or `End Sub` statement.  
-  
-- You can specify the data type of a lambda expression parameter by using the `As` keyword, or the data type of the parameter can be inferred. Either all parameters must have specified data types or all must be inferred.  
-  
-- `Optional` and `Paramarray` parameters are not permitted.  
-  
-- Generic parameters are not permitted.  
-  
-## Async Lambdas  
- You can easily create lambda expressions and statements that incorporate asynchronous processing by using the [Async](../../../../visual-basic/language-reference/modifiers/async.md) and [Await Operator](../../../../visual-basic/language-reference/operators/await-operator.md) keywords. For example, the following Windows Forms example contains an event handler that calls and awaits an async method, `ExampleMethodAsync`.  
-  
-```vb  
-Public Class Form1  
-  
-    Async Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click  
-        ' ExampleMethodAsync returns a Task.  
-        Await ExampleMethodAsync()  
-        TextBox1.Text = vbCrLf & "Control returned to button1_Click."  
-    End Sub  
-  
-    Async Function ExampleMethodAsync() As Task  
-        ' The following line simulates a task-returning asynchronous process.  
-        Await Task.Delay(1000)  
-    End Function  
-  
-End Class  
-```  
-  
- You can add the same event handler by using an async lambda in an [AddHandler Statement](../../../../visual-basic/language-reference/statements/addhandler-statement.md). To add this handler, add an `Async` modifier before the lambda parameter list, as the following example shows.  
-  
-```vb  
-Public Class Form1  
-  
-    Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load  
-        AddHandler Button1.Click,   
-            Async Sub(sender1, e1)  
-                ' ExampleMethodAsync returns a Task.  
-                Await ExampleMethodAsync()  
-                TextBox1.Text = vbCrLf & "Control returned to Button1_ Click."  
-            End Sub  
-    End Sub  
-  
-    Async Function ExampleMethodAsync() As Task  
-        ' The following line simulates a task-returning asynchronous process.  
-        Await Task.Delay(1000)  
-    End Function  
-  
-End Class  
-```  
-  
- For more information about how to create and use async methods, see [Asynchronous Programming with Async and Await](../../../../visual-basic/programming-guide/concepts/async/index.md).  
-  
-## <a name="context"></a> Context  
- A lambda expression shares its context with the scope within which it is defined. It has the same access rights as any code written in the containing scope. This includes access to member variables, functions and subs, `Me`, and parameters and local variables in the containing scope.  
-  
- Access to local variables and parameters in the containing scope can extend beyond the lifetime of that scope. As long as a delegate referring to a lambda expression is not available to garbage collection, access to the variables in the original environment is retained. In the following example, variable `target` is local to `makeTheGame`, the method in which the lambda expression `playTheGame` is defined. Note that the returned lambda expression, assigned to `takeAGuess` in `Main`, still has access to the local variable `target`.  
-  
- [!code-vb[VbVbalrLambdas#12](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class6.vb#12)]  
-  
- The following example demonstrates the wide range of access rights of the nested lambda expression. When the returned lambda expression is executed from `Main` as `aDel`, it accesses these elements:  
-  
-- A field of the class in which it is defined: `aField`  
-  
-- A property of the class in which it is defined: `aProp`  
-  
-- A parameter of method `functionWithNestedLambda`, in which it is defined: `level1`  
-  
-- A local variable of `functionWithNestedLambda`: `localVar`  
-  
-- A parameter of the lambda expression in which it is nested: `level2`  
-  
- [!code-vb[VbVbalrLambdas#9](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class3.vb#9)]  
-  
-## Converting to a Delegate Type  
- A lambda expression can be implicitly converted to a compatible delegate type. For information about the general requirements for compatibility, see [Relaxed Delegate Conversion](../../../../visual-basic/programming-guide/language-features/delegates/relaxed-delegate-conversion.md). For example, the following code example shows a lambda expression that implicitly converts to `Func(Of Integer, Boolean)` or a matching delegate signature.  
-  
- [!code-vb[VbVbalrLambdas#16](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#16)]  
-  
- The following code example shows a lambda expression that implicitly converts to `Sub(Of Double, String, Double)` or a matching delegate signature.  
-  
- [!code-vb[VbVbalrLambdas#23](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/class7.vb#23)]  
-  
- When you assign lambda expressions to delegates or pass them as arguments to procedures, you can specify the parameter names but omit their data types, letting the types be taken from the delegate.  
-  
-## Examples  
-  
-- The following example defines a lambda expression that returns `True` if the nullable argument has an assigned value, and `False` if its value is `Nothing`.  
-  
-     [!code-vb[VbVbalrLambdas#4](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#4)]  
-  
-- The following example defines a lambda expression that returns the index of the last element in an array.  
-  
-     [!code-vb[VbVbalrLambdas#5](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#5)]  
-  
+> The `RemoveHandler` statement is an exception. You cannot pass a lambda expression in for the delegate parameter of `RemoveHandler`.
+
+You create lambda expressions by using the `Function` or `Sub` keyword, just as you create a standard function or subroutine. However, lambda expressions are included in a statement.
+
+The following example is a lambda expression that increments its argument and returns the value. The example shows both the single-line and multi-line lambda expression syntax for a function.
+
+[!code-vb[VbVbalrLambdas#14](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#14)]
+
+The following example is a lambda expression that writes a value to the console. The example shows both the single-line and multi-line lambda expression syntax for a subroutine.
+
+[!code-vb[VbVbalrLambdas#15](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#15)]
+
+Notice that in the previous examples the lambda expressions are assigned to a variable name. Whenever you refer to the variable, you invoke the lambda expression. You can also declare and invoke a lambda expression at the same time, as shown in the following example.
+
+[!code-vb[VbVbalrLambdas#3](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#3)]
+
+A lambda expression can be returned as the value of a function call (as is shown in the example in the [Context](#context) section later in this topic), or passed in as an argument to a parameter that takes a delegate type, as shown in the following example.
+
+[!code-vb[VbVbalrLambdas#8](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class2.vb#8)]
+
+## Lambda Expression Syntax
+
+The syntax of a lambda expression resembles that of a standard function or subroutine. The differences are as follows:
+
+- A lambda expression does not have a name.
+
+- Lambda expressions cannot have modifiers, such as `Overloads` or `Overrides`.
+
+- Single-line lambda functions do not use an `As` clause to designate the return type. Instead, the type is inferred from the value that the body of the lambda expression evaluates to. For example, if the body of the lambda expression is `cust.City = "London"`, its return type is `Boolean`.
+
+- In multi-line lambda functions, you can either specify a return type by using an `As` clause, or omit the `As` clause so that the return type is inferred. When the `As` clause is omitted for a multi-line lambda function, the return type is inferred to be the dominant type from all the `Return` statements in the multi-line lambda function. The *dominant type* is a unique type that all other types can widen to. If this unique type cannot be determined, the dominant type is the unique type that all other types in the array can narrow to. If neither of these unique types can be determined, the dominant type is `Object`. In this case, if `Option Strict` is set to `On`, a compiler error occurs.
+
+     For example, if the expressions supplied to the `Return` statement contain values of type `Integer`, `Long`, and `Double`, the resulting array is of type `Double`. Both `Integer` and `Long` widen to `Double` and only `Double`. Therefore, `Double` is the dominant type. For more information, see [Widening and Narrowing Conversions](../../../../visual-basic/programming-guide/language-features/data-types/widening-and-narrowing-conversions.md).
+
+- The body of a single-line function must be an expression that returns a value, not a statement. There is no `Return` statement for single-line functions. The value returned by the single-line function is the value of the expression in the body of the function.
+
+- The body of a single-line subroutine must be single-line statement.
+
+- Single-line functions and subroutines do not include an `End Function` or `End Sub` statement.
+
+- You can specify the data type of a lambda expression parameter by using the `As` keyword, or the data type of the parameter can be inferred. Either all parameters must have specified data types or all must be inferred.
+
+- `Optional` and `Paramarray` parameters are not permitted.
+
+- Generic parameters are not permitted.
+
+## Async Lambdas
+
+You can easily create lambda expressions and statements that incorporate asynchronous processing by using the [Async](../../../../visual-basic/language-reference/modifiers/async.md) and [Await Operator](../../../../visual-basic/language-reference/operators/await-operator.md) keywords. For example, the following Windows Forms example contains an event handler that calls and awaits an async method, `ExampleMethodAsync`.
+
+```vb
+Public Class Form1
+
+    Async Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
+        ' ExampleMethodAsync returns a Task.
+        Await ExampleMethodAsync()
+        TextBox1.Text = vbCrLf & "Control returned to button1_Click."
+    End Sub
+
+    Async Function ExampleMethodAsync() As Task
+        ' The following line simulates a task-returning asynchronous process.
+        Await Task.Delay(1000)
+    End Function
+
+End Class
+```
+
+You can add the same event handler by using an async lambda in an [AddHandler Statement](../../../../visual-basic/language-reference/statements/addhandler-statement.md). To add this handler, add an `Async` modifier before the lambda parameter list, as the following example shows.
+
+```vb
+Public Class Form1
+
+    Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        AddHandler Button1.Click,
+            Async Sub(sender1, e1)
+                ' ExampleMethodAsync returns a Task.
+                Await ExampleMethodAsync()
+                TextBox1.Text = vbCrLf & "Control returned to Button1_ Click."
+            End Sub
+    End Sub
+
+    Async Function ExampleMethodAsync() As Task
+        ' The following line simulates a task-returning asynchronous process.
+        Await Task.Delay(1000)
+    End Function
+
+End Class
+```
+
+For more information about how to create and use async methods, see [Asynchronous Programming with Async and Await](../../../../visual-basic/programming-guide/concepts/async/index.md).
+
+## Context
+
+A lambda expression shares its context with the scope within which it is defined. It has the same access rights as any code written in the containing scope. This includes access to member variables, functions and subs, `Me`, and parameters and local variables in the containing scope.
+
+Access to local variables and parameters in the containing scope can extend beyond the lifetime of that scope. As long as a delegate referring to a lambda expression is not available to garbage collection, access to the variables in the original environment is retained. In the following example, variable `target` is local to `makeTheGame`, the method in which the lambda expression `playTheGame` is defined. Note that the returned lambda expression, assigned to `takeAGuess` in `Main`, still has access to the local variable `target`.
+
+[!code-vb[VbVbalrLambdas#12](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class6.vb#12)]
+
+The following example demonstrates the wide range of access rights of the nested lambda expression. When the returned lambda expression is executed from `Main` as `aDel`, it accesses these elements:
+
+- A field of the class in which it is defined: `aField`
+
+- A property of the class in which it is defined: `aProp`
+
+- A parameter of method `functionWithNestedLambda`, in which it is defined: `level1`
+
+- A local variable of `functionWithNestedLambda`: `localVar`
+
+- A parameter of the lambda expression in which it is nested: `level2`
+
+ [!code-vb[VbVbalrLambdas#9](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class3.vb#9)]
+
+## Converting to a Delegate Type
+
+A lambda expression can be implicitly converted to a compatible delegate type. For information about the general requirements for compatibility, see [Relaxed Delegate Conversion](../../../../visual-basic/programming-guide/language-features/delegates/relaxed-delegate-conversion.md). For example, the following code example shows a lambda expression that implicitly converts to `Func(Of Integer, Boolean)` or a matching delegate signature.
+
+[!code-vb[VbVbalrLambdas#16](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#16)]
+
+The following code example shows a lambda expression that implicitly converts to `Sub(Of Double, String, Double)` or a matching delegate signature.
+
+[!code-vb[VbVbalrLambdas#23](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/class7.vb#23)]
+
+When you assign lambda expressions to delegates or pass them as arguments to procedures, you can specify the parameter names but omit their data types, letting the types be taken from the delegate.
+
+## Examples
+
+- The following example defines a lambda expression that returns `True` if the nullable argument has an assigned value, and `False` if its value is `Nothing`.
+
+     [!code-vb[VbVbalrLambdas#4](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#4)]
+
+- The following example defines a lambda expression that returns the index of the last element in an array.
+
+     [!code-vb[VbVbalrLambdas#5](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrLambdas/VB/Class1.vb#5)]
+
 ## See also
 
 - [Procedures](./index.md)

--- a/docs/visual-basic/programming-guide/language-features/procedures/operator-procedures.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/operator-procedures.md
@@ -1,7 +1,7 @@
 ---
 title: "Operator Procedures (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Visual Basic code, procedures"
   - "procedures [Visual Basic], operator"
   - "Visual Basic code, operators"
@@ -13,67 +13,74 @@ helpviewer_keywords:
 ms.assetid: 8c513d38-246b-4fb7-8b75-29e1364e555b
 ---
 # Operator Procedures (Visual Basic)
-An operator procedure is a series of Visual Basic statements that define the behavior of a standard operator (such as `*`, `<>`, or `And`) on a class or structure you have defined. This is also called *operator overloading*.  
-  
-## When to Define Operator Procedures  
- When you have defined a class or structure, you can declare variables to be of the type of that class or structure. Sometimes such a variable needs to participate in an operation as part of an expression. To do this, it must be an operand of an operator.  
-  
- Visual Basic defines operators only on its fundamental data types. You can define the behavior of an operator when one or both of the operands are of the type of your class or structure.  
-  
- For more information, see [Operator Statement](../../../../visual-basic/language-reference/statements/operator-statement.md).  
-  
-## Types of Operator Procedure  
- An operator procedure can be one of the following types:  
-  
-- A definition of a unary operator where the argument is of the type of your class or structure.  
-  
-- A definition of a binary operator where at least one of the arguments is of the type of your class or structure.  
-  
-- A definition of a conversion operator where the argument is of the type of your class or structure.  
-  
-- A definition of a conversion operator that returns the type of your class or structure.  
-  
- Conversion operators are always unary, and you always use `CType` as the operator you are defining.  
-  
-## Declaration Syntax  
- The syntax for declaring an operator procedure is as follows:  
- 
- ```vb 
- Public Shared [Widening | Narrowing] Operator operatorsymbol ( operand1 [,  operand2 ]) As datatype  
-  
- ' Statements of the operator procedure.
-  
- End Operator
- ```
- 
- You use the `Widening` or `Narrowing` keyword only on a type conversion operator. The operator symbol is always [CType Function](../../../../visual-basic/language-reference/functions/ctype-function.md) for a type conversion operator.  
-  
- You declare two operands to define a binary operator, and you declare one operand to define a unary operator, including a type conversion operator. All operands must be declared `ByVal`.  
-  
- You declare each operand the same way you declare parameters for [Sub Procedures](./sub-procedures.md).  
-  
-### Data Type  
- Because you are defining an operator on a class or structure you have defined, at least one of the operands must be of the data type of that class or structure. For a type conversion operator, either the operand or the return type must be of the data type of the class or structure.  
-  
- For more details, see [Operator Statement](../../../../visual-basic/language-reference/statements/operator-statement.md).  
-  
-## Calling Syntax  
- You invoke an operator procedure implicitly by using the operator symbol in an expression. You supply the operands the same way you do for predefined operators.  
-  
- The syntax for an implicit call to an operator procedure is as follows:  
-  
- `Dim testStruct As`  *structurename*  
-  
- `Dim testNewStruct As`  *structurename*  `= testStruct`  *operatorsymbol*  `10`  
-  
-### Illustration of Declaration and Call  
- The following structure stores a signed 128-bit integer value as the constituent high-order and low-order parts. It defines the `+` operator to add two `veryLong` values and generate a resulting `veryLong` value.  
-  
- [!code-vb[VbVbcnProcedures#23](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnProcedures/VB/Class1.vb#23)]  
-  
- The following example shows a typical call to the `+` operator defined on `veryLong`.  
-  
- [!code-vb[VbVbcnProcedures#24](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnProcedures/VB/Class1.vb#24)]  
+
+An operator procedure is a series of Visual Basic statements that define the behavior of a standard operator (such as `*`, `<>`, or `And`) on a class or structure you have defined. This is also called *operator overloading*.
+
+## When to Define Operator Procedures
+
+When you have defined a class or structure, you can declare variables to be of the type of that class or structure. Sometimes such a variable needs to participate in an operation as part of an expression. To do this, it must be an operand of an operator.
+
+Visual Basic defines operators only on its fundamental data types. You can define the behavior of an operator when one or both of the operands are of the type of your class or structure.
+
+For more information, see [Operator Statement](../../../../visual-basic/language-reference/statements/operator-statement.md).
+
+## Types of Operator Procedure
+
+An operator procedure can be one of the following types:
+
+- A definition of a unary operator where the argument is of the type of your class or structure.
+
+- A definition of a binary operator where at least one of the arguments is of the type of your class or structure.
+
+- A definition of a conversion operator where the argument is of the type of your class or structure.
+
+- A definition of a conversion operator that returns the type of your class or structure.
+
+ Conversion operators are always unary, and you always use `CType` as the operator you are defining.
+
+## Declaration Syntax
+
+The syntax for declaring an operator procedure is as follows:
+
+```vb
+Public Shared [Widening | Narrowing] Operator operatorsymbol ( operand1 [,  operand2 ]) As datatype
+
+' Statements of the operator procedure.
+
+End Operator
+```
+
+You use the `Widening` or `Narrowing` keyword only on a type conversion operator. The operator symbol is always [CType Function](../../../../visual-basic/language-reference/functions/ctype-function.md) for a type conversion operator.
+
+You declare two operands to define a binary operator, and you declare one operand to define a unary operator, including a type conversion operator. All operands must be declared `ByVal`.
+
+You declare each operand the same way you declare parameters for [Sub Procedures](./sub-procedures.md).
+
+### Data Type
+
+Because you are defining an operator on a class or structure you have defined, at least one of the operands must be of the data type of that class or structure. For a type conversion operator, either the operand or the return type must be of the data type of the class or structure.
+
+For more details, see [Operator Statement](../../../../visual-basic/language-reference/statements/operator-statement.md).
+
+## Calling Syntax
+
+You invoke an operator procedure implicitly by using the operator symbol in an expression. You supply the operands the same way you do for predefined operators.
+
+The syntax for an implicit call to an operator procedure is as follows:
+
+`Dim testStruct As`  *structurename*
+
+`Dim testNewStruct As`  *structurename*  `= testStruct`  *operatorsymbol*  `10`
+
+### Illustration of Declaration and Call
+
+The following structure stores a signed 128-bit integer value as the constituent high-order and low-order parts. It defines the `+` operator to add two `veryLong` values and generate a resulting `veryLong` value.
+
+[!code-vb[VbVbcnProcedures#23](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnProcedures/VB/Class1.vb#23)]
+
+The following example shows a typical call to the `+` operator defined on `veryLong`.
+
+[!code-vb[VbVbcnProcedures#24](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnProcedures/VB/Class1.vb#24)]
 
 ## See also
 

--- a/docs/visual-basic/programming-guide/language-features/procedures/passing-arguments-by-position-and-by-name.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/passing-arguments-by-position-and-by-name.md
@@ -1,7 +1,7 @@
 ---
 title: "Passing Arguments by Position and by Name (Visual Basic)"
 ms.date: 02/01/2018
-helpviewer_keywords: 
+helpviewer_keywords:
   - "arguments [Visual Basic], passing by name"
   - "procedures [Visual Basic], arguments"
   - ":= passing arguments"
@@ -24,53 +24,56 @@ helpviewer_keywords:
 ms.assetid: 1ad7358f-1da9-48da-a95b-f3c7ed41eff3
 ---
 # Passing Arguments by Position and by Name (Visual Basic)
-When you call a `Sub` or `Function` procedure, you can pass arguments *by position* — in the order in which they appear in the procedure's definition — or you can pass them *by name*, without regard to position.  
-  
- When you pass an argument by name, you specify the argument's declared name followed by a colon and an equal sign (`:=`), followed by the argument value. You can supply named arguments in any order.  
-  
- For example, the following `Sub` procedure takes three arguments:  
-  
- [!code-vb[SampleProcedure](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#1)]  
-  
- When you call this procedure, you can supply the arguments by position, by name, or by using a mixture of both.  
-  
-## Passing Arguments by Position  
- You can call the `Display` method with its arguments passed by position and delimited by commas, as shown in the following example:  
-  
-[!code-vb[ByPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#2)] 
-  
- If you omit an optional argument in a positional argument list, you must hold its place with a comma. The following example calls the `Display` method without the `age` argument:  
-  
-[!code-vb[ByPositionWithOptionalArgument](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#3)] 
-  
-## Passing Arguments by Name  
- Alternatively, you can call `Display` with the arguments passed by name, also delimited by commas, as shown in the following example:  
-  
-[!code-vb[ByName](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#4)] 
 
- Passing arguments by name in this way is especially useful when you call a procedure that has more than one optional argument. If you supply arguments by name, you do not have to use consecutive commas to denote missing positional arguments. Passing arguments by name also makes it easier to keep track of which arguments you are passing and which ones you are omitting.  
-  
-## Mixing Arguments by Position and by Name  
+When you call a `Sub` or `Function` procedure, you can pass arguments *by position* — in the order in which they appear in the procedure's definition — or you can pass them *by name*, without regard to position.
 
-You can supply arguments both by position and by name in a single procedure call, as shown in the following example:  
-  
-[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#5)] 
-  
- In the preceding example, no extra comma is necessary to hold the place of the omitted `age` argument, since `birth` is passed by name.  
-  
+When you pass an argument by name, you specify the argument's declared name followed by a colon and an equal sign (`:=`), followed by the argument value. You can supply named arguments in any order.
+
+For example, the following `Sub` procedure takes three arguments:
+
+[!code-vb[SampleProcedure](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#1)]
+
+When you call this procedure, you can supply the arguments by position, by name, or by using a mixture of both.
+
+## Passing Arguments by Position
+
+You can call the `Display` method with its arguments passed by position and delimited by commas, as shown in the following example:
+
+[!code-vb[ByPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#2)]
+
+If you omit an optional argument in a positional argument list, you must hold its place with a comma. The following example calls the `Display` method without the `age` argument:
+
+[!code-vb[ByPositionWithOptionalArgument](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#3)]
+
+## Passing Arguments by Name
+
+Alternatively, you can call `Display` with the arguments passed by name, also delimited by commas, as shown in the following example:
+
+[!code-vb[ByName](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#4)]
+
+Passing arguments by name in this way is especially useful when you call a procedure that has more than one optional argument. If you supply arguments by name, you do not have to use consecutive commas to denote missing positional arguments. Passing arguments by name also makes it easier to keep track of which arguments you are passing and which ones you are omitting.
+
+## Mixing Arguments by Position and by Name
+
+You can supply arguments both by position and by name in a single procedure call, as shown in the following example:
+
+[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#5)]
+
+In the preceding example, no extra comma is necessary to hold the place of the omitted `age` argument, since `birth` is passed by name.
+
 In versions of Visual Basic before 15.5, when you supply arguments by a mixture of position and name, the positional arguments must all come first. Once you supply an argument by name, any remaining arguments must all be passed by name.  For example, the following call to the `Display` method displays compiler error [BC30241: Named argument expected](../../../misc/bc30241.md).
 
-[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#6)] 
+[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#6)]
 
-Starting with Visual Basic 15.5, positional arguments can follow named arguments if the ending positional arguments are in the correct position. If compiled under Visual Basic 15.5, the previous call to the `Display` method compiles successfully and no longer generates compiler error [BC30241](../../../misc/bc30241.md).  
+Starting with Visual Basic 15.5, positional arguments can follow named arguments if the ending positional arguments are in the correct position. If compiled under Visual Basic 15.5, the previous call to the `Display` method compiles successfully and no longer generates compiler error [BC30241](../../../misc/bc30241.md).
 
-This ability to mix and match named and positional arguments in any order is particularly useful when you want to use a named argument to make your code more readable. For example, the following `Person` class constructor requires two arguments of type `Person`, both of which can be `Nothing`. 
+This ability to mix and match named and positional arguments in any order is particularly useful when you want to use a named argument to make your code more readable. For example, the following `Person` class constructor requires two arguments of type `Person`, both of which can be `Nothing`.
 
-[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#7)] 
+[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#7)]
 
 Using mixed named and positional arguments helps to make the intent of the code clear when the value of the `father` and `mother` arguments is `Nothing`:
 
-[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#8)] 
+[!code-vb[ByNameAndPosition](../../../../../samples/snippets/visualbasic/programming-guide/language-features/passing-named-arguments/module1.vb#8)]
 
 To follow positional arguments with named arguments, you must add the following element to your Visual Basic project (\*.vbproj) file:
 
@@ -82,12 +85,12 @@ To follow positional arguments with named arguments, you must add the following 
 
 For more information see [setting the Visual Basic language version](../../../language-reference/configure-language-version.md).
 
-## Restrictions on Supplying Arguments by Name  
+## Restrictions on Supplying Arguments by Name
 
-You cannot pass arguments by name to avoid entering required arguments. You can omit only the optional arguments.  
-  
-You cannot pass a parameter array by name. This is because when you call the procedure, you supply an indefinite number of comma-separated arguments for the parameter array, and the compiler cannot associate more than one argument with a single name.  
-  
+You cannot pass arguments by name to avoid entering required arguments. You can omit only the optional arguments.
+
+You cannot pass a parameter array by name. This is because when you call the procedure, you supply an indefinite number of comma-separated arguments for the parameter array, and the compiler cannot associate more than one argument with a single name.
+
 ## See also
 
 - [Procedures](./index.md)

--- a/docs/visual-basic/programming-guide/language-features/xml/how-to-transform-xml-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/how-to-transform-xml-by-using-linq.md
@@ -1,154 +1,155 @@
 ---
 title: "How to: Transform XML by Using LINQ (Visual Basic)"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "XML [Visual Basic], transforming"
   - "LINQ to XML [Visual Basic], transforming XML"
 ms.assetid: 815687f4-0bc2-4c0b-adc6-d78744aa356f
 ---
 # How to: Transform XML by Using LINQ (Visual Basic)
-[XML Literals](../../../../visual-basic/language-reference/xml-literals/index.md) make it easy to read XML from one source and transform it to a new XML format. You can take advantage of LINQ queries to retrieve the content to transform, or change content in an existing document to a new XML format.  
-  
- The example in this topic transforms content from an XML source document to HTML to be viewed in a browser.  
-  
-[!INCLUDE[note_settings_general](~/includes/note-settings-general-md.md)]  
-  
-### To transform an XML document  
-  
-1. In Visual Studio, create a new Visual Basic project in the **Console Application** project template.  
-  
-2. Double-click the Module1.vb file created in the project to modify the Visual Basic code. Add the following code to the `Sub Main` of the `Module1` module. This code creates the source XML document as an <xref:System.Xml.Linq.XDocument> object.  
-  
-    ```vb  
-    Dim catalog =   
-      <?xml version="1.0"?>  
-        <Catalog>  
-          <Book id="bk101">  
-            <Author>Garghentini, Davide</Author>  
-            <Title>XML Developer's Guide</Title>  
-            <Price>44.95</Price>  
-            <Description>  
-              An in-depth look at creating applications  
-              with <technology>XML</technology>. For   
-              <audience>beginners</audience> or   
-              <audience>advanced</audience> developers.  
-            </Description>  
-          </Book>  
-          <Book id="bk331">  
-            <Author>Spencer, Phil</Author>  
-            <Title>Developing Applications with Visual Basic .NET</Title>  
-            <Price>45.95</Price>  
-            <Description>  
-              Get the expert insights, practical code samples,   
-              and best practices you need   
-              to advance your expertise with <technology>Visual   
-              Basic .NET</technology>.   
-              Learn how to create faster, more reliable applications  
-              based on professional,   
-              pragmatic guidance by today's top <audience>developers</audience>.  
-            </Description>  
-          </Book>  
-        </Catalog>  
-    ```  
-  
-     [How to: Load XML from a File, String, or Stream](../../../../visual-basic/programming-guide/language-features/xml/how-to-load-xml-from-a-file-string-or-stream.md).  
-  
-3. After the code to create the source XML document, add the following code to retrieve all the \<Book> elements from the object and transform them into an HTML document. The list of \<Book> elements is created by using a LINQ query that returns a collection of <xref:System.Xml.Linq.XElement> objects that contain the transformed HTML. You can use embedded expressions to put the values from the source document in the new XML format.  
-  
-     The resulting HTML document is written to a file by using the <xref:System.Xml.Linq.XElement.Save%2A> method.  
-  
-    ```vb  
-    Dim htmlOutput =   
-      <html>  
-        <body>  
-          <%= From book In catalog.<Catalog>.<Book>   
-              Select <div>  
-                       <h1><%= book.<Title>.Value %></h1>  
-                       <h3><%= "By " & book.<Author>.Value %></h3>  
-                        <h3><%= "Price = " & book.<Price>.Value %></h3>  
-                        <h2>Description</h2>  
-                        <%= TransformDescription(book.<Description>(0)) %>  
-                        <hr/>  
-                      </div> %>  
-        </body>  
-      </html>  
-  
-    htmlOutput.Save("BookDescription.html")  
-    ```  
-  
-4. After `Sub Main` of `Module1`, add a new method (`Sub`) to transform a \<Description> node into the specified HTML format. This method is called by the code in the previous step and is used to preserve the format of the \<Description> elements.  
-  
-     This method replaces sub-elements of the \<Description> element with HTML. The `ReplaceWith` method is used to preserve the location of the sub-elements. The transformed content of the \<Description> element is included in an HTML paragraph (\<p>) element. The <xref:System.Xml.Linq.XContainer.Nodes%2A> property is used to retrieve the transformed content of the \<Description> element. This ensures that sub-elements are included in the transformed content.  
-  
-     Add the following code after `Sub Main` of `Module1`.  
-  
-    ```vb  
-    Public Function TransformDescription(ByVal desc As XElement) As XElement  
-  
-      ' Replace <technology> elements with <b>.  
-      Dim content = (From element In desc...<technology>).ToList()  
-  
-      If content.Count > 0 Then  
-        For i = 0 To content.Count - 1  
-          content(i).ReplaceWith(<b><%= content(i).Value %></b>)  
-        Next  
-      End If  
-  
-      ' Replace <audience> elements with <i>.  
-      content = (From element In desc...<audience>).ToList()  
-  
-      If content.Count > 0 Then  
-        For i = 0 To content.Count - 1  
-          content(i).ReplaceWith(<i><%= content(i).Value %></i>)  
-        Next  
-      End If  
-  
-      ' Return the updated contents of the <Description> element.  
-      Return <p><%= desc.Nodes %></p>  
-    End Function  
-    ```  
-  
-5. Save your changes.  
-  
-6. Press F5 to run the code. The resulting saved document will resemble the following:  
-  
-    ```html  
-    <?xml version="1.0"?>  
-    <html>  
-      <body>  
-        <div>  
-          <h1>XML Developer's Guide</h1>  
-          <h3>By Garghentini, Davide</h3>  
-          <h3>Price = 44.95</h3>  
-          <h2>Description</h2>  
-          <p>  
-            An in-depth look at creating applications  
-            with <b>XML</b>. For   
-            <i>beginners</i> or   
-            <i>advanced</i> developers.  
-          </p>  
-          <hr />  
-        </div>  
-        <div>  
-          <h1>Developing Applications with Visual Basic .NET</h1>  
-          <h3>By Spencer, Phil</h3>  
-          <h3>Price = 45.95</h3>  
-          <h2>Description</h2>  
-          <p>  
-            Get the expert insights, practical code   
-            samples, and best practices you need   
-            to advance your expertise with <b>Visual   
-            Basic .NET</b>. Learn how to create faster,  
-            more reliable applications based on  
-            professional, pragmatic guidance by today's   
-            top <i>developers</i>.  
-          </p>  
-          <hr />  
-        </div>  
-      </body>  
-    </html>  
-    ```  
-  
+
+[XML Literals](../../../../visual-basic/language-reference/xml-literals/index.md) make it easy to read XML from one source and transform it to a new XML format. You can take advantage of LINQ queries to retrieve the content to transform, or change content in an existing document to a new XML format.
+
+The example in this topic transforms content from an XML source document to HTML to be viewed in a browser.
+
+[!INCLUDE[note_settings_general](~/includes/note-settings-general-md.md)]
+
+### To transform an XML document
+
+1. In Visual Studio, create a new Visual Basic project in the **Console Application** project template.
+
+2. Double-click the Module1.vb file created in the project to modify the Visual Basic code. Add the following code to the `Sub Main` of the `Module1` module. This code creates the source XML document as an <xref:System.Xml.Linq.XDocument> object.
+
+    ```vb
+    Dim catalog =
+      <?xml version="1.0"?>
+        <Catalog>
+          <Book id="bk101">
+            <Author>Garghentini, Davide</Author>
+            <Title>XML Developer's Guide</Title>
+            <Price>44.95</Price>
+            <Description>
+              An in-depth look at creating applications
+              with <technology>XML</technology>. For
+              <audience>beginners</audience> or
+              <audience>advanced</audience> developers.
+            </Description>
+          </Book>
+          <Book id="bk331">
+            <Author>Spencer, Phil</Author>
+            <Title>Developing Applications with Visual Basic .NET</Title>
+            <Price>45.95</Price>
+            <Description>
+              Get the expert insights, practical code samples,
+              and best practices you need
+              to advance your expertise with <technology>Visual
+              Basic .NET</technology>.
+              Learn how to create faster, more reliable applications
+              based on professional,
+              pragmatic guidance by today's top <audience>developers</audience>.
+            </Description>
+          </Book>
+        </Catalog>
+    ```
+
+     [How to: Load XML from a File, String, or Stream](../../../../visual-basic/programming-guide/language-features/xml/how-to-load-xml-from-a-file-string-or-stream.md).
+
+3. After the code to create the source XML document, add the following code to retrieve all the \<Book> elements from the object and transform them into an HTML document. The list of \<Book> elements is created by using a LINQ query that returns a collection of <xref:System.Xml.Linq.XElement> objects that contain the transformed HTML. You can use embedded expressions to put the values from the source document in the new XML format.
+
+     The resulting HTML document is written to a file by using the <xref:System.Xml.Linq.XElement.Save%2A> method.
+
+    ```vb
+    Dim htmlOutput =
+      <html>
+        <body>
+          <%= From book In catalog.<Catalog>.<Book>
+              Select <div>
+                       <h1><%= book.<Title>.Value %></h1>
+                       <h3><%= "By " & book.<Author>.Value %></h3>
+                        <h3><%= "Price = " & book.<Price>.Value %></h3>
+                        <h2>Description</h2>
+                        <%= TransformDescription(book.<Description>(0)) %>
+                        <hr/>
+                      </div> %>
+        </body>
+      </html>
+
+    htmlOutput.Save("BookDescription.html")
+    ```
+
+4. After `Sub Main` of `Module1`, add a new method (`Sub`) to transform a \<Description> node into the specified HTML format. This method is called by the code in the previous step and is used to preserve the format of the \<Description> elements.
+
+     This method replaces sub-elements of the \<Description> element with HTML. The `ReplaceWith` method is used to preserve the location of the sub-elements. The transformed content of the \<Description> element is included in an HTML paragraph (\<p>) element. The <xref:System.Xml.Linq.XContainer.Nodes%2A> property is used to retrieve the transformed content of the \<Description> element. This ensures that sub-elements are included in the transformed content.
+
+     Add the following code after `Sub Main` of `Module1`.
+
+    ```vb
+    Public Function TransformDescription(ByVal desc As XElement) As XElement
+
+      ' Replace <technology> elements with <b>.
+      Dim content = (From element In desc...<technology>).ToList()
+
+      If content.Count > 0 Then
+        For i = 0 To content.Count - 1
+          content(i).ReplaceWith(<b><%= content(i).Value %></b>)
+        Next
+      End If
+
+      ' Replace <audience> elements with <i>.
+      content = (From element In desc...<audience>).ToList()
+
+      If content.Count > 0 Then
+        For i = 0 To content.Count - 1
+          content(i).ReplaceWith(<i><%= content(i).Value %></i>)
+        Next
+      End If
+
+      ' Return the updated contents of the <Description> element.
+      Return <p><%= desc.Nodes %></p>
+    End Function
+    ```
+
+5. Save your changes.
+
+6. Press F5 to run the code. The resulting saved document will resemble the following:
+
+    ```html
+    <?xml version="1.0"?>
+    <html>
+      <body>
+        <div>
+          <h1>XML Developer's Guide</h1>
+          <h3>By Garghentini, Davide</h3>
+          <h3>Price = 44.95</h3>
+          <h2>Description</h2>
+          <p>
+            An in-depth look at creating applications
+            with <b>XML</b>. For
+            <i>beginners</i> or
+            <i>advanced</i> developers.
+          </p>
+          <hr />
+        </div>
+        <div>
+          <h1>Developing Applications with Visual Basic .NET</h1>
+          <h3>By Spencer, Phil</h3>
+          <h3>Price = 45.95</h3>
+          <h2>Description</h2>
+          <p>
+            Get the expert insights, practical code
+            samples, and best practices you need
+            to advance your expertise with <b>Visual
+            Basic .NET</b>. Learn how to create faster,
+            more reliable applications based on
+            professional, pragmatic guidance by today's
+            top <i>developers</i>.
+          </p>
+          <hr />
+        </div>
+      </body>
+    </html>
+    ```
+
 ## See also
 
 - [XML Literals](../../../../visual-basic/language-reference/xml-literals/index.md)

--- a/includes/core-changes/aspnetcore/3.0/signalr-hubconnectioncontext-ctors.md
+++ b/includes/core-changes/aspnetcore/3.0/signalr-hubconnectioncontext-ctors.md
@@ -33,9 +33,9 @@ Instead of using the following constructor:
 
 ```csharp
 HubConnectionContext connectionContext = new HubConnectionContext(
-    connectionContext, 
-    keepAliveInterval: TimeSpan.FromSeconds(15), 
-    loggerFactory, 
+    connectionContext,
+    keepAliveInterval: TimeSpan.FromSeconds(15),
+    loggerFactory,
     clientTimeoutInterval: TimeSpan.FromSeconds(15));
 ```
 

--- a/includes/core-changes/aspnetcore/3.0/spas-spaservices-nodeservices-fallback.md
+++ b/includes/core-changes/aspnetcore/3.0/spas-spaservices-nodeservices-fallback.md
@@ -8,7 +8,7 @@
 
 #### Old behavior
 
-`Microsoft.AspNetCore.SpaServices` and `Microsoft.AspNetCore.NodeServices` used to automatically create a console logger when logging isn't configured. 
+`Microsoft.AspNetCore.SpaServices` and `Microsoft.AspNetCore.NodeServices` used to automatically create a console logger when logging isn't configured.
 
 #### New behavior
 
@@ -30,7 +30,7 @@ ASP.NET Core
 
 None
 
-<!-- 
+<!--
 
 #### Affected APIs
 

--- a/includes/core-changes/visualbasic/vbnewline-is-obsolete.md
+++ b/includes/core-changes/visualbasic/vbnewline-is-obsolete.md
@@ -11,7 +11,7 @@ The <xref:Microsoft.VisualBasic.Constants.vbNewLine?displayProperty=fullName> co
 Starting with .NET Core 3.0 Preview 8, the [Obsolete](xref:System.ObsoleteAttribute) attribute has been applied to the <xref:Microsoft.VisualBasic.Constants.vbNewLine?displayProperty=fullName> constant. Use of the constant produces a compiler warning. In previous releases of both .NET Core and .NET Framework, it was not marked as obsolete.
 
 This change was made to support Visual Basic as a language for multi-platform development. The `vbNewLine` constant is equivalent to `\r\n`, the newline character sequence on Windows. On Unix-based systems, the newline character is `\n`.
- 
+
 #### Recommended action
 
 The [Obsolete](xref:System.ObsoleteAttribute) attribute message for `vbNewLine` includes the following recommendation:

--- a/includes/core-changes/windowsforms/remove-duplicated-apis.md
+++ b/includes/core-changes/windowsforms/remove-duplicated-apis.md
@@ -1,6 +1,6 @@
 ### Duplicated APIs removed from Windows Forms
 
-A number of APIs accidentally duplicated in the <xref:System.Windows.Forms?displayProperty=fullName> namespace starting in .NET Core 3.0 Preview 4 have been removed in .NET Core 3.0 RC1. 
+A number of APIs accidentally duplicated in the <xref:System.Windows.Forms?displayProperty=fullName> namespace starting in .NET Core 3.0 Preview 4 have been removed in .NET Core 3.0 RC1.
 
 #### Change description
 
@@ -30,7 +30,7 @@ Windows Forms
 
 - Not detectable via API analysis.
 
-<!-- 
+<!--
 
 ### Affected APIs
 

--- a/includes/internalonly-unmanaged.md
+++ b/includes/internalonly-unmanaged.md
@@ -1,3 +1,2 @@
-
-> [!NOTE] 
+> [!NOTE]
 > This API is for internal use only. It's not intended for use from developer code.

--- a/includes/roslyn-installation.md
+++ b/includes/roslyn-installation.md
@@ -6,8 +6,8 @@ There are two different ways to find the **.NET Compiler Platform SDK** in the *
 
 The .NET Compiler Platform SDK is not automatically selected as part of the Visual Studio extension development workload. You must select it as an optional component.
 
-1. Run **Visual Studio Installer** 
-1. Select **Modify** 
+1. Run **Visual Studio Installer**
+1. Select **Modify**
 1. Check the **Visual Studio extension development** workload.
 1. Open the **Visual Studio extension development** node in the summary tree.
 1. Check the box for **.NET Compiler Platform SDK**. You'll find it last under the optional components.
@@ -19,9 +19,9 @@ Optionally, you'll also want the **DGML editor** to display graphs in the visual
 
 ### Install using the Visual Studio Installer - Individual components tab
 
-1. Run **Visual Studio Installer** 
-1. Select **Modify** 
-1. Select the **Individual components** tab 
+1. Run **Visual Studio Installer**
+1. Select **Modify**
+1. Select the **Individual components** tab
 1. Check the box for **.NET Compiler Platform SDK**. You'll find it at the top under the **Compilers, build tools, and runtimes** section.
 
 Optionally, you'll also want the **DGML editor** to display graphs in the visualizer:

--- a/styleguide/voice-tone.md
+++ b/styleguide/voice-tone.md
@@ -19,30 +19,36 @@ when you don't follow our guidelines.
 ## Details on each guideline
 
 ### Use a Conversational Tone
+
 #### Appropriate Style:
+
 We want our documentation to have a conversational tone. You should feel as though you
 are having a conversation with the author as you read any of our tutorials or explanations.
 For you, the experience should be informal, conversational, and informative. Readers should
 feel as though they are listening to the author explain the concepts to them.
 
 #### Inappropriate Style:
+
 One might see the contrast between a conversational style and the style one finds with
 more academic treatments of technical topics. Those resources are very useful, but the authors
 have written those articles in a very different style than our documentation. When one reads
 an academic journal, one finds a very different tone and a very different style of writing.
-One feels that they are reading a dry account of a very dry topic.  
+One feels that they are reading a dry account of a very dry topic.
 
 The first paragraph above follows our recommendation conversational style. The second
-is a more academic style. You see the difference immediately. 
+is a more academic style. You see the difference immediately.
 
 ### Write in second person
+
 #### Appropriate Style:
+
 You should write your articles as though you are speaking directly to the reader. You
 should use second person often (as I just have in these two sentences). 2nd person doesn't
 always mean using the word 'you'. Write directly to the reader. Write imperative sentences.
 Tell your reader what you want them to learn.
 
-#### Inappropriate Style: 
+#### Inappropriate Style:
+
 An author could also choose to write in third person. In that model, an author must find some
 pronoun or noun to use when referring to the reader. A reader might often find this third
 person style less engaging and less enjoyable to read.
@@ -77,11 +83,13 @@ Programming, Class, and Object, Function and Method are familiar terms. However,
 reading your articles has a formal computer science degree. Terms like 'idempotent' probably
 need to be defined if you use it:
 
->The Close() method is idempotent, meaning that you can call it multiple times and the effect is
-the same as if you called it once.
+> The Close() method is idempotent, meaning that you can call it multiple times and the effect is
+> the same as if you called it once.
 
 ### Avoid future tense
+
 In some non-English languages the concept of future tense is not the same as English. Using future tense can make your documents harder to read. Additionally, when using the future tense, the obvious question is when. So if you say 'Learning PowerShell will be good for you" - the obvious question for the reader is when will it be good? Instead, just say "Learning PowerShell is good for you".
 
 ### What is it - so what?
-Whenever you introduce a new concept to the reader, define the concept and only then explain why it's useful. It's important for reader to understand what something is before they can understand the benefits (or otherwise). 
+
+Whenever you introduce a new concept to the reader, define the concept and only then explain why it's useful. It's important for reader to understand what something is before they can understand the benefits (or otherwise).


### PR DESCRIPTION
Ran on primarily the docs/visual-basic directory
- Remove trailing spaces
- Spaces around headers
- Remove single item
- Left meaningful double space