### PR TITLE
Update predict-prices-with-model-builder.md

### DIFF
--- a/docs/machine-learning/tutorials/predict-prices-with-model-builder.md
+++ b/docs/machine-learning/tutorials/predict-prices-with-model-builder.md
@@ -79,8 +79,8 @@ Model Builder accepts data from two sources, a SQL Server database or a local fi
 
 1. In the data step of the Model Builder tool, select *File* from the data source dropdown.
 1. Select the button next to the *Select a file* text box and use File Explorer to browse and select the *taxi-fare-test.csv* in the *Data* directory
-1. Choose *fare_amount* in the *Column to Predict (Label)* dropdown and navigate to the train step of the Model Builder tool.
-1. Expand the *Input Columns (Features)* dropdown and uncheck the *trip_time_in_secs* column to exclude it as a feature during training.
+1. Choose *fare_amount* in the *Column to Predict (Label)* dropdown.
+1. Expand the *Input Columns (Features)* dropdown and uncheck the *trip_time_in_secs* column to exclude it as a feature during training.  Navigate to the train step of the Model Builder tool.
 
 ## Train the model
 


### PR DESCRIPTION
## Summary

Comments:
- In the "Train the Model" section, sentence: "Best accuracy displays the accuracy of the best performing model found by Model Builder so far. Higher accuracy means the model predicted more correctly on test data."
  -- The label in the wizard is "Best Quality(R squared)".  I was expecting it to be "Best accuracy" based on the above sentence.  Maybe the text is just out of date with the wizard?

- In the "Evaluate the Model" section, sentence: "Additionally, a summary table containing top five models and their metrics."
 -- This sentence feels incomplete to me.  Maybe something like" "A summary table that contains the top five models and their metrics is also provided" ??


