### PR TITLE
Revised the sections about C# numeric literals

### DIFF
--- a/docs/csharp/language-reference/builtin-types/floating-point-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/floating-point-numeric-types.md
@@ -1,7 +1,7 @@
 ---
 title: "Floating-point numeric types - C# reference"
 description: "Overview of the built-in C# floating-point types"
-ms.date: 06/30/2019
+ms.date: 10/18/2019
 f1_keywords:
   - "float"
   - "float_CSharpKeyword"
@@ -21,7 +21,7 @@ helpviewer_keywords:
 ---
 # Floating-point numeric types (C# reference)
 
-The **floating-point types** are a subset of the **simple types** and can be initialized with [*literals*](#floating-point-literals). All floating-point types are also value types. All floating-point numeric types support [arithmetic](../operators/arithmetic-operators.md), [comparison, and equality](../operators/equality-operators.md) operators.
+The **floating-point types** are a subset of the **simple types** and can be initialized with [*literals*](#real-literals). All floating-point types are also value types. All floating-point numeric types support [arithmetic](../operators/arithmetic-operators.md), [comparison](../operators/comparison-operators.md), and [equality](../operators/equality-operators.md) operators.
 
 ## Characteristics of the floating-point types
 
@@ -46,8 +46,8 @@ Because the `decimal` type has more precision and a smaller range than both `flo
 
 You can mix [integral](integral-numeric-types.md) types and floating-point types in an expression. In this case, the integral types are converted to floating-point types. The evaluation of the expression is performed according to the following rules:
 
-- If one of the floating-point types is `double`, the expression evaluates to `double`, or to [bool](../keywords/bool.md) in relational comparisons or comparisons for equality.
-- If there is no `double` type in the expression, the expression evaluates to `float`, or to [bool](../keywords/bool.md) in relational comparisons or comparisons for equality.
+- If one of the floating-point types is `double`, the expression evaluates to `double`, or to [bool](../keywords/bool.md) in relational and equality comparisons.
+- If there is no `double` type in the expression, the expression evaluates to `float`, or to [bool](../keywords/bool.md) in relational and equality comparisons.
 
 A floating-point expression can contain the following sets of values:
 
@@ -60,23 +60,41 @@ For more information about these values, see IEEE Standard for Binary Floating-P
 
 You can use either [standard numeric format strings](../../../standard/base-types/standard-numeric-format-strings.md) or [custom numeric format strings](../../../standard/base-types/custom-numeric-format-strings.md) to format a floating-point value.
 
-## Floating-point literals
+## Real literals
 
-By default, a floating-point numeric literal on the right side of the assignment operator is treated as `double`. You can use suffixes to convert a floating-point or integral literal to a specific type:
+The type of a real literal is determined by its suffix as follows:
 
-- The `d` or `D` suffix converts a literal to a `double`.
-- The `f` or `F` suffix converts a literal to a `float`.
-- The `m` or `M` suffix converts a literal to a `decimal`.
+- The literal without suffix or with the `d` or `D` suffix is of type `double`
+- The literal with the `f` or `F` suffix is of type `float`
+- The literal with the `m` or `M` suffix is of type `decimal`
 
-The following examples show each suffix:
+The following code demonstrates an example of each:
 
 ```csharp
 double d = 3D;
 d = 4d;
-float f = 3.5F;
+d = 3.934_001;
+
+float f = 3_000.5F;
 f = 5.4f;
-decimal myMoney = 300.5m;
+
+decimal myMoney = 3_000.5m;
 myMoney = 400.75M;
+```
+
+The preceding example also shows the use of `_` as a *digit separator*, which is supported starting with C# 7.0. You can use the digit separator with all kinds of numeric literals.
+
+You also can use scientific notation, that is, specify an exponent part of a real literal, as the following example shows:
+
+```csharp-interactive
+double d = 0.42e2;
+Console.WriteLine(d);  // output 42;
+
+float f = 134.45E-2f;
+Console.WriteLine(f);  // output: 1.3445
+
+decimal m = 1.5E6m;
+Console.WriteLine(m);  // output: 1500000
 ```
 
 ## Conversions
@@ -89,15 +107,21 @@ For more information about implicit numeric conversions, see [Implicit Numeric C
 
 For more information about explicit numeric conversions, see [Explicit Numeric Conversions Table](../keywords/explicit-numeric-conversions-table.md).
 
+## C# language specification
+
+For more information, see the following sections of the [C# language specification](~/_csharplang/spec/introduction.md):
+
+- [Floating-point types](~/_csharplang/spec/types.md#floating-point-types)
+- [The decimal type](~/_csharplang/spec/types.md#the-decimal-type)
+- [Real literals](~/_csharplang/spec/lexical-structure.md#real-literals)
+
 ## See also
 
-- [C# Reference](../index.md)
+- [C# reference](../index.md)
 - [Integral types](integral-numeric-types.md)
 - [Built-in types table](../keywords/built-in-types-table.md)
 - [Numerics in .NET](../../../standard/numerics.md)
 - [Casting and Type Conversions](../../programming-guide/types/casting-and-type-conversions.md)
-- [Implicit Numeric Conversions Table](../keywords/implicit-numeric-conversions-table.md)
-- [Explicit Numeric Conversions Table](../keywords/explicit-numeric-conversions-table.md)
 - <xref:System.Numerics.Complex?displayProperty=nameWithType>
 - [Formatting numeric results table](../keywords/formatting-numeric-results-table.md)
-- [Standard Numeric Format Strings](../../../standard/base-types/standard-numeric-format-strings.md)
+- [Standard numeric format strings](../../../standard/base-types/standard-numeric-format-strings.md)

--- a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
@@ -1,7 +1,7 @@
 ---
 title: "Integral numeric types - C# reference"
 description: "Learn the range, storage size, and uses for each of the integral numeric types."
-ms.date: 06/25/2019
+ms.date: 10/18/2019
 f1_keywords:
   - "byte"
   - "byte_CSharpKeyword"
@@ -35,7 +35,7 @@ helpviewer_keywords:
 ---
 # Integral numeric types  (C# reference)
 
-The **integral numeric types** are a subset of the **simple types** and can be initialized with [*literals*](#integral-literals). All integral types are also value types. All integral numeric types support [arithmetic](../operators/arithmetic-operators.md), [bitwise logical](../operators/bitwise-and-shift-operators.md), [comparison, and equality](../operators/equality-operators.md) operators.
+The **integral numeric types** are a subset of the **simple types** and can be initialized with [*literals*](#integer-literals). All integral types are also value types. All integral numeric types support [arithmetic](../operators/arithmetic-operators.md), [bitwise logical](../operators/bitwise-and-shift-operators.md), [comparison](../operators/comparison-operators.md), and [equality](../operators/equality-operators.md) operators.
 
 ## Characteristics of the integral types
 
@@ -63,9 +63,15 @@ The default value of each integral type is zero, `0`. Each of the integral types
 
 Use the <xref:System.Numerics.BigInteger?displayProperty=nameWithType> structure to represent a signed integer with no upper or lower bounds.
 
-## Integral literals
+## Integer literals
 
-Integral literals can be specified as *decimal literals*, *hexadecimal literals*, or *binary literals*. An example of each is shown below:
+Integer literals can be
+
+- *decimal*: without any prefix
+- *hexadecimal*: with the `0x` or `0X` prefix
+- *binary*: with the `0b` or `0B` prefix (available in C# 7.0 and later)
+
+The following code demonstrates an example of each:
 
 ```csharp
 var decimalLiteral = 42;
@@ -73,38 +79,35 @@ var hexLiteral = 0x2A;
 var binaryLiteral = 0b_0010_1010;
 ```
 
-Decimal literals don't require any prefix. The `x` or `X` prefix signifies a *hexadecimal literal*. The `b` or `B` prefix signifies a *binary literal*. The declaration of `binaryLiteral` demonstrates the use of `_` as a *digit separator*. The digit separator can be used with all numeric literals. Binary literals and the digit separator `_` are supported starting with C# 7.0.
+The preceding example also shows the use of `_` as a *digit separator*, which is supported starting with C# 7.0. You can use the digit separator with all kinds of numeric literals.
 
-### Literal suffixes
+The type of an integer literal is determined by its suffix as follows:
 
-The `l` or `L` suffix specifies that the integral literal should be of the `long` type. The `ul` or `UL` suffix specifies the `ulong` type. If the `L` suffix is used on a literal that is greater than 9,223,372,036,854,775,807 (the maximum value of `long`), the value is converted to the `ulong` type. If the value represented by an integral literal exceeds <xref:System.UInt64.MaxValue?displayProperty=nameWithType>, a compiler error [CS1021](../../misc/cs1021.md) occurs. 
+- If the literal has no suffix, its type is the first of the following types in which its value can be represented: `int`, `uint`, `long`, `ulong`.
+- If the literal is suffixed by `U` or `u`, its type is the first of the following types in which its value can be represented: `uint`, `ulong`.
+- If the literal is suffixed by `L` or `l`, its type is the first of the following types in which its value can be represented: `long`, `ulong`.
 
-> [!NOTE]
-> You can use the lowercase letter "l" as a suffix. However, this generates a compiler warning because the letter "l" is easily confused with the digit "1." Use "L" for clarity.
+  > [!NOTE]
+  > You can use the lowercase letter `l` as a suffix. However, this generates a compiler warning because the letter `l` can be confused with the digit `1`. Use `L` for clarity.
 
-### Type of an integral literal
+- If the literal is suffixed by `UL`, `Ul`, `uL`, `ul`, `LU`, `Lu`, `lU`, or `lu`, its type is `ulong`.
 
-If an integral literal has no suffix, its type is the first of the following types in which its value can be represented:
+If the value represented by an integer literal exceeds <xref:System.UInt64.MaxValue?displayProperty=nameWithType>, a compiler error [CS1021](../../misc/cs1021.md) occurs.
 
-1. `int`
-1. `uint`
-1. `long`
-1. `ulong`
-
-You can convert an integral literal to a type with a smaller range than the default using either an assignment or a cast:
+The value represented by an integer literal can be implicitly converted to a type with a smaller range than the determined type of the literal. That's possible when the value is within the range of the destination type:
 
 ```csharp
-byte byteVariable = 42; // type is byte
-var signedByte = (sbyte)42; // type is sbyte.
+byte a = 17;
+byte b = 300;   // CS0031: Constant value '300' cannot be converted to a 'byte'
 ```
 
-You can convert an integral literal to a type with a larger range than the default using either assignment, a cast, or a suffix on the literal:
+As the preceding example shows, if the literal's value is not within the range of the destination type, a compiler error [CS0031](../../misc/cs0031.md) occurs.
+
+You also can use a cast to convert the value represented by an integer literal to the type other than the determined type of the literal:
 
 ```csharp
-var unsignedLong = 42UL;
-var longVariable = 42L;
-ulong anotherUnsignedLong = 42;
-var anotherLong = (long)42;
+var signedByte = (sbyte)42;
+var longVariable = (long)42;
 ```
 
 ## Conversions
@@ -113,9 +116,15 @@ There's an implicit conversion (called a *widening conversion*) between any two 
 
 You must use an explicit cast to convert one integral type to another integral type when an implicit conversion is not defined from the source type to the destination type. This is called a *narrowing conversion*. The explicit case is required because the conversion can result in data loss.
 
+## C# language specification
+
+For more information, see the following sections of the [C# language specification](~/_csharplang/spec/introduction.md):
+
+- [Integral types](~/_csharplang/spec/types.md#integral-types)
+- [Integer literals](~/_csharplang/spec/lexical-structure.md#integer-literals)
+
 ## See also
 
-- [C# language specification - Integral types](~/_csharplang/spec/types.md#integral-types)
 - [C# reference](../index.md)
 - [Floating-point types](floating-point-numeric-types.md)
 - [Default values table](../keywords/default-values-table.md)


### PR DESCRIPTION
- Renamed literals to "integer" and "real" to match the spec.
- Mentioned `u`, `U` and all possible `ulong` suffixes for integer literals
- Combined "Literal suffixes" and "Type of a literal" sections about integer literals, as those two sections talk about the same.
- Added examples of the scientific notation (`1.2e-3`) for real literals: Fixes #7782
