### PR TITLE
fix C# Guide label name

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -10,7 +10,7 @@
       "processor-meta-docs": {
         "product": {
           "(?i)dotnet-csharp$": {
-            "labels-add": "books: Area - C# Guide"
+            "labels-add": ":books: Area - C# Guide"
           },
           "(?i)dotnet-visualbasic$": {
             "labels-add": ":books: Area - Visual Basic Guide"


### PR DESCRIPTION
This is causing new C# Guide issues to be placed under a new label, instead of using the existing label.

@Thraka Once this is merged, I'll cleanup the few existing labels with the wrong name.