### PR TITLE
Fix Comma Placement

### DIFF
--- a/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md
+++ b/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md
@@ -20,7 +20,7 @@ HousingData[] housingData = new HousingData[]
     new HousingData
     {
         Size = 600f,
-        HistoricalPrices = new float[] { 100000f ,125000f ,122000f },
+        HistoricalPrices = new float[] { 100000f, 125000f, 122000f },
         CurrentPrice = 170000f
     },
     new HousingData


### PR DESCRIPTION
Fix comma placement in the first HousingData.HistoricalPrices field to match other declarations of HousingData.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
