### PR TITLE
Fix Spacing Between Comma Placement

### DIFF
--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -95,7 +95,7 @@ HousingData[] housingData = new HousingData[]
     new HousingData
     {
         Size = 850f,
-        HistoricalPrices = new float[] { 150000f,175000f,210000f }
+        HistoricalPrices = new float[] { 150000f, 175000f, 210000f }
     },
     new HousingData
     {


### PR DESCRIPTION
## Summary

Fix spacing between comma placement in the first HousingData.HistoricalPrices field to match other declarations of HousingData.

Fixes #Issue_Number (if available)
