### PR TITLE
 Typo in links for certain types

### DIFF
--- a/docs/standard/serialization/binary-serialization.md
+++ b/docs/standard/serialization/binary-serialization.md
@@ -82,7 +82,7 @@ As the nature of binary serialization allows the modification of private members
 - <xref:System.Collections.Specialized.StringCollection?displayProperty=nameWithType>
 - <xref:System.Collections.Specialized.StringDictionary?displayProperty=nameWithType>
 - <xref:System.Collections.Stack?displayProperty=nameWithType>
-- `System.Collections.Generic.NonRandomizedStringEqualityComparer` (available in .NET Core 2.0.4 and later versions)
+- <xref:System.Collections.Generic.NonRandomizedStringEqualityComparer?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.ComponentModel.BindingList%601?displayProperty=nameWithType>
 - <xref:System.ComponentModel.DataAnnotations.ValidationException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.ComponentModel.Design.CheckoutException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
@@ -140,7 +140,7 @@ As the nature of binary serialization allows the modification of private members
 - <xref:System.DateTime?displayProperty=nameWithType>
 - <xref:System.DateTimeOffset?displayProperty=nameWithType>
 - <xref:System.Decimal?displayProperty=nameWithType>
-- `System.Diagnostics.Contracts.ContractException` (available in .NET Core 2.0.4 and later versions)
+- <xref:System.Diagnostics.Contracts.ContractException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Diagnostics.Tracing.EventSourceException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.IO.DirectoryNotFoundException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.DirectoryServices.AccountManagement.MultipleMatchesException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
@@ -184,7 +184,7 @@ As the nature of binary serialization allows the modification of private members
 - <xref:System.Globalization.CultureNotFoundException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Globalization.SortVersion?displayProperty=nameWithType>
 - <xref:System.Guid?displayProperty=nameWithType>
-- `System.IO.Compression.ZLibException` (available in .NET Core 2.0.4 and later versions)
+- <xref:System.IO.Compression.ZLibException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.IO.DriveNotFoundException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.IO.EndOfStreamException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.IO.FileFormatException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
@@ -266,7 +266,7 @@ As the nature of binary serialization allows the modification of private members
 - <xref:System.Security.Authentication.InvalidCredentialException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Security.Cryptography.CryptographicException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Security.Cryptography.CryptographicUnexpectedOperationException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
-- `System.Security.Cryptography.Xml.CryptoSignedXmlRecursionException` (available in .NET Core 2.0.4 and later versions)
+- <xref:System.Security.Cryptography.Xml.CryptoSignedXmlRecursionException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Security.HostProtectionException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Security.Policy.PolicyException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)
 - <xref:System.Security.Principal.IdentityNotMappedException?displayProperty=nameWithType> (available in .NET Core 2.0.4 and later versions)


### PR DESCRIPTION
## Summary
Currently, there are some broken links (not links at all, only marked with `<code>` tag in HTML.
This commit fixes that (via xref) that will be converted to anchor tag.