### PR TITLE
Update info on PreBuildEvent / PostBuildEvent

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -225,7 +225,7 @@ The following example specifies the fallbacks only for the `netcoreapp2.1` targe
 
 ## Build events
 
-The way that pre-build and post-build events are specified in the project file has changed. The properties PreBuildEvent and PostBuildEvent are not recommended in the SDK-style project format, because macros such as $(ProjectDir) will not be resolved. For example, the following code is no longer supported:
+The way that pre-build and post-build events are specified in the project file has changed. The properties PreBuildEvent and PostBuildEvent are not recommended in the SDK-style project format, because macros such as $(ProjectDir) are not resolved. For example, the following code is no longer supported:
 
 ```xml
 <PropertyGroup>

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -223,6 +223,24 @@ The following example specifies the fallbacks only for the `netcoreapp2.1` targe
 </PackageTargetFallback >
 ```
 
+## Build events
+
+The way that pre-build and post-build events are specified in the project file has changed. The properties PreBuildEvent and PostBuildEvent are not supported in the SDK-style project format. For example, the following property is not supported:
+
+```xml
+<PropertyGroup>
+    <PreBuildEvent>"$(ProjectDir)PreBuildEvent.bat" "$(ProjectDir)..\" "$(ProjectDir)" "$(TargetDir)" />
+</PropertyGroup>
+```
+
+In SDK-style projects, use an MSBuild target named `PreBuild` or `PostBuild`. For the preceding example, use the following code:
+
+```xml
+<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="&quot;$(ProjectDir)PreBuildEvent.bat&quot; &quot;$(ProjectDir)..\&quot; &quot;$(ProjectDir)&quot; &quot;$(TargetDir)&quot;" />
+</Target>
+```
+
 ## NuGet metadata properties
 
 With the move to MSBuild, we have moved the input metadata that is used when packing a NuGet package from *project.json* to *.csproj* files. The inputs are MSBuild properties so they have to go within a `<PropertyGroup>` group. The following is the list of properties that are used as inputs to the packing process when using the `dotnet pack` command or the `Pack` MSBuild target that is part of the SDK:

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -225,7 +225,7 @@ The following example specifies the fallbacks only for the `netcoreapp2.1` targe
 
 ## Build events
 
-The way that pre-build and post-build events are specified in the project file has changed. The properties PreBuildEvent and PostBuildEvent are not supported in the SDK-style project format. For example, the following property is not supported:
+The way that pre-build and post-build events are specified in the project file has changed. The properties PreBuildEvent and PostBuildEvent are not recommended in the SDK-style project format, because macros such as $(ProjectDir) will not be resolved. For example, the following code is no longer supported:
 
 ```xml
 <PropertyGroup>

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -241,6 +241,9 @@ In SDK-style projects, use an MSBuild target named `PreBuild` or `PostBuild`. Fo
 </Target>
 ```
 
+> [!NOTE]
+>You can use any name for the MSBuild targets, but the Visual Studio IDE recognizes `PreBuild` and `PostBuild` targets, so we recommend using those names so that you can edit the commands in the Visual Studio IDE. 
+
 ## NuGet metadata properties
 
 With the move to MSBuild, we have moved the input metadata that is used when packing a NuGet package from *project.json* to *.csproj* files. The inputs are MSBuild properties so they have to go within a `<PropertyGroup>` group. The following is the list of properties that are used as inputs to the packing process when using the `dotnet pack` command or the `Pack` MSBuild target that is part of the SDK:

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -233,11 +233,15 @@ The way that pre-build and post-build events are specified in the project file h
 </PropertyGroup>
 ```
 
-In SDK-style projects, use an MSBuild target named `PreBuild` or `PostBuild`. For the preceding example, use the following code:
+In SDK-style projects, use an MSBuild target named `PreBuild` or `PostBuild` and set the `BeforeTargets` property for `PreBuild` or the `AfterTargets` property for `PostBuild`. For the preceding example, use the following code:
 
 ```xml
 <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="&quot;$(ProjectDir)PreBuildEvent.bat&quot; &quot;$(ProjectDir)..\&quot; &quot;$(ProjectDir)&quot; &quot;$(TargetDir)&quot;" />
+</Target>
+
+<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+   <Exec Command="echo Output written to $(TargetDir)" />
 </Target>
 ```
 


### PR DESCRIPTION
## Summary

Add a new section "Build events" that shows how the old vs. new project file format encodes pre- and post-build events. This is important for those migrating projects or manually editing project files.

Fixes #15248 
