### PR TITLE
Standardise formatting for Corflags

### DIFF
--- a/docs/framework/tools/corflags-exe-corflags-conversion-tool.md
+++ b/docs/framework/tools/corflags-exe-corflags-conversion-tool.md
@@ -29,7 +29,7 @@ CorFlags.exe assembly [options]
 |`assembly`|The name of the assembly for which to configure the CorFlags.|  
   
 |Option|Description|  
-|------------|-----------------|  
+|:------------|-----------------|  
 |`-32BIT[REQ]+`|Sets the 32BITREQUIRED flag.|  
 |`-32BIT[REQ]-`|Clears the 32BITREQUIRED flag.|  
 |`-32BITPREF+`|Sets the 32BITPREFERRED flag. The app runs as a 32-bit process even on 64-bit platforms. Set this flag only on EXE files. If the flag is set on a DLL, the DLL fails to load in 64-bit processes, and a <xref:System.BadImageFormatException> exception is thrown. An EXE file with this flag can be loaded into a 64-bit process.<br /><br /> New in the .NET Framework 4.5.|  

--- a/docs/framework/tools/corflags-exe-corflags-conversion-tool.md
+++ b/docs/framework/tools/corflags-exe-corflags-conversion-tool.md
@@ -30,18 +30,18 @@ CorFlags.exe assembly [options]
   
 |Option|Description|  
 |------------|-----------------|  
-|**/32BIT[REQ]+**|Sets the 32BITREQUIRED flag.|  
-|**/32BIT[REQ]-**|Clears the 32BITREQUIRED flag.|  
-|**/32BITPREF+**|Sets the 32BITPREFERRED flag. The app runs as a 32-bit process even on 64-bit platforms. Set this flag only on EXE files. If the flag is set on a DLL, the DLL fails to load in 64-bit processes, and a <xref:System.BadImageFormatException> exception is thrown. An EXE file with this flag can be loaded into a 64-bit process.<br /><br /> New in the .NET Framework 4.5.|  
-|**/32BITPREF-**|Clears the 32BITPREFERRED flag.<br /><br /> New in the .NET Framework 4.5.|  
-|**/?**|Displays command syntax and options for the tool.|  
-|**/Force**|Forces an update even if the assembly is strong-named. **Important:**  If you update a strong-named assembly, you must sign it again before executing its code.|  
-|**/help**|Displays command syntax and options for the tool.|  
-|**/ILONLY+**|Sets the ILONLY flag.|  
-|**/ILONLY-**|Clears the ILONLY flag.|  
-|**/nologo**|Suppresses the Microsoft startup banner display.|  
-|**/RevertCLRHeader**|Reverts the CLR header version to 2.0.|  
-|**/UpgradeCLRHeader**|Upgrades the CLR header version to 2.5. **Note:**  Assemblies must have a CLR header version of 2.5 or greater to run natively.|  
+|`-32BIT[REQ]+`|Sets the 32BITREQUIRED flag.|  
+|`-32BIT[REQ]-`|Clears the 32BITREQUIRED flag.|  
+|`-32BITPREF+`|Sets the 32BITPREFERRED flag. The app runs as a 32-bit process even on 64-bit platforms. Set this flag only on EXE files. If the flag is set on a DLL, the DLL fails to load in 64-bit processes, and a <xref:System.BadImageFormatException> exception is thrown. An EXE file with this flag can be loaded into a 64-bit process.<br /><br /> New in the .NET Framework 4.5.|  
+|`-32BITPREF-`|Clears the 32BITPREFERRED flag.<br /><br /> New in the .NET Framework 4.5.|  
+|`-?`|Displays command syntax and options for the tool.|  
+|`-Force`|Forces an update even if the assembly is strong-named. **Important:**  If you update a strong-named assembly, you must sign it again before executing its code.|  
+|`-help`|Displays command syntax and options for the tool.|  
+|`-ILONLY+`|Sets the ILONLY flag.|  
+|`-ILONLY-`|Clears the ILONLY flag.|  
+|`-nologo`|Suppresses the Microsoft startup banner display.|  
+|`-RevertCLRHeader`|Reverts the CLR header version to 2.0.|  
+|`-UpgradeCLRHeader`|Upgrades the CLR header version to 2.5. **Note:**  Assemblies must have a CLR header version of 2.5 or greater to run natively.|  
   
 ## Remarks  
  If no options are specified, the CorFlags Conversion tool displays the flags for the specified assembly.  


### PR DESCRIPTION
Relates to #9958

Used this page today - fixed the inconsistent formatting on the command line arguments. (I also checked that  `-` is valid over `/`, as suggested in the issue.)