### PR TITLE
Update docs/standard/security/index.md

### DIFF
--- a/docs/standard/security/index.md
+++ b/docs/standard/security/index.md
@@ -13,31 +13,24 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # Security in .NET
-The common language runtime and the .NET provide many useful classes and services that enable developers to easily write secure code and enable system administrators to customize the permissions granted to code so that it can access protected resources. In addition, the runtime and the .NET provide useful classes and services that facilitate the use of cryptography and role-based security.  
-  
-## In This Section  
 
- [Key Security Concepts](../../../docs/standard/security/key-security-concepts.md)  
- Provides an overview of common language runtime security features. This section is of interest to developers and system administrators.  
-  
- [Role-Based Security](../../../docs/standard/security/role-based-security.md)  
- Describes how to interact with role-based security in your code. This section is of interest to developers.  
-  
- [Cryptography Model](../../../docs/standard/security/cryptography-model.md)  
- Provides an overview of cryptographic services provided by .NET. This section is of interest to developers.  
-  
- [Secure Coding Guidelines](../../../docs/standard/security/secure-coding-guidelines.md)  
- Describes some of the best practices for creating reliable .NET applications. This section is of interest to developers.  
-  
- [Secure Coding Guidelines for Unmanaged Code](../../../docs/framework/security/secure-coding-guidelines-for-unmanaged-code.md)  
- Describes some of the best practices and security concerns when calling unmanaged code.  
-  
- [Windows Identity Foundation](../../../docs/framework/security/index.md)  
- Describes how you can implement claims-based identity in your applications.  
+The common language runtime and the .NET provide many useful classes and services that enable developers to easily write secure code and enable system administrators to customize the permissions granted to code so that it can access protected resources. In addition, the runtime and the .NET provide useful classes and services that facilitate the use of cryptography and role-based security.
 
-[Security Changes](../../../docs/framework/security/security-changes.md)
-Describes important changes to the .NET Framework security system.
+## In this section
 
-## Related Sections  
- [Development Guide](../../../docs/framework/development-guide.md)  
- Provides a guide to all key technology areas and tasks for application development, including creating, configuring, debugging, securing, and deploying your application, and information about dynamic programming, interoperability, extensibility, memory management, and threading.
+- [Key Security Concepts](key-security-concepts.md)  
+Provides an overview of common language runtime security features. This section is of interest to developers and system administrators.
+
+- [Role-Based Security](role-based-security.md)  
+Describes how to interact with role-based security in your code. This section is of interest to developers.
+
+- [Cryptography Model](cryptography-model.md)  
+Provides an overview of cryptographic services provided by .NET. This section is of interest to developers.
+
+- [Secure Coding Guidelines](secure-coding-guidelines.md)  
+Describes some of the best practices for creating reliable .NET applications. This section is of interest to developers.
+
+## Related sections
+
+[Development Guide](../../framework/development-guide.md)  
+Provides a guide to all key technology areas and tasks for application development, including creating, configuring, debugging, securing, and deploying your application, and information about dynamic programming, interoperability, extensibility, memory management, and threading.


### PR DESCRIPTION
- Remove redundant path segments. (Contributes to #10653)
- Remove links from `In this section`. ( The links in the index.md should be a list of the toc. Some links weren't in the toc, so deleted them. Correct me if I'm wrong )

