### PR TITLE
Fixes #14598

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -45,7 +45,7 @@ C# 4 introduces named and optional arguments. *Named arguments* enable you to sp
 
  `PrintOrderDetails(sellerName: "Gift Shop", 31, productName: "Red Mug");`
   
- However, out-of-order named arguments are invalid if they're followed by positional arguments.
+ Positional arguments that follow any out-of-order named arguments are invalid.
 
  ```csharp
  // This generates CS1738: Named argument specifications must appear after all fixed arguments have been specified.


### PR DESCRIPTION
## Updated text regarding out-of-order named arguments

Made the changes suggested by @BillWagner:
> Thanks for writing this @SharunasBielskis The text in this article is misleading. Instead of the sentence:
> 
> However, out-of-order named arguments are invalid if they're followed by positional arguments.
> 
> A better phrasing is:
> 
> Positional arguments that follow any out-of-order named arguments are invalid.
> 
> I've added this to our backlog to address when we next update this article. I've also added the "up-for-grabs" label for community members to submit a PR with the above fix.

Fixes #14598 