### PR TITLE
Removed Parenthetical Reference

### DIFF
--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -65,7 +65,7 @@ The type of the event (`EventHandler<FileListArgs>` in this example) must be a
 delegate type. There are a number of conventions that you should follow
 when declaring an event. Typically, the event delegate type has a void return.
 Event declarations should be a verb, or a verb phrase.
-Use past tense (as in this example) when
+Use past tense when
 the event reports something that has happened. Use a present tense verb (for
 example, `Closing`) to report something that is about to happen. Often, using
 present tense indicates that your class supports some kind of customization


### PR DESCRIPTION
## Removed parenthetical reference from past tense event naming suggesting

Made change suggested by @BillWagner and @rpetrusha in the issue:

> Adding the "up for grabs" label. I think the correct fix is in the previous comment:
> 
> I do think, though, that the text becomes less confusing by remove the parenthetical reference to the example.

Fixes #9288