### PR TITLE
Language reference for readonly members

### DIFF
--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -15,23 +15,23 @@ The `readonly` keyword is a modifier that can be used in four contexts:
 
 - In a [field declaration](#readonly-field-example), `readonly` indicates that assignment to the field can only occur as part of the declaration or in a constructor in the same class. A readonly field can be assigned and reassigned multiple times within the field declaration and constructor. 
   
-  A `readonly` field cannot be assigned after the constructor exits. That has different implications for value types and reference types:
+  A `readonly` field can't be assigned after the constructor exits. This rule has different implications for value types and reference types:
   
   - Because value types directly contain their data, a field that is a  `readonly` value type is immutable. 
-  - Because reference types contain a reference to their data, a field that is a `readonly` reference type must always refer to the same object. That object is not immutable. The `readonly` modifier prevents the field from being replaced by a different instance of the reference type. However, the modifier does not prevent the instance data of the field from being modified through the read-only field.
+  - Because reference types contain a reference to their data, a field that is a `readonly` reference type must always refer to the same object. That object isn't immutable. The `readonly` modifier prevents the field from being replaced by a different instance of the reference type. However, the modifier doesn't prevent the instance data of the field from being modified through the read-only field.
 
   > [!WARNING]
   > An externally visible type that contains an externally visible read-only field that is a mutable reference type may be a security vulnerability and may trigger warning [CA2104](/visualstudio/code-quality/ca2104-do-not-declare-read-only-mutable-reference-types) : "Do not declare read only mutable reference types."
 
 - In a [`readonly struct` definition](#readonly-struct-example), `readonly` indicates that the `struct` is immutable.
-- In a [`readonly` member definition](#readonly-member-examples), `readonly` indicates that a member of a `struct` does not mutate the struct's internal state.
-- In a [`ref readonly` method return](#ref-readonly-return-example), the `readonly` modifier indicates that method returns a reference and writes are not allowed to that reference.
+- In a [`readonly` member definition](#readonly-member-examples), `readonly` indicates that a member of a `struct` doesn't mutate the struct's internal state.
+- In a [`ref readonly` method return](#ref-readonly-return-example), the `readonly` modifier indicates that method returns a reference and writes aren't allowed to that reference.
 
 The `readonly sturct` and `ref readonly` contexts were added in C# 7.2. `readonly` struct members were added in C# 8.0
 
 ## Readonly field example
 
-In this example, the value of the field `year` cannot be changed in the method `ChangeYear`, even though it is assigned a value in the class constructor:
+In this example, the value of the field `year` can't be changed in the method `ChangeYear`, even though it's assigned a value in the class constructor:
 
 [!code-csharp[Readonly Field example](~/samples/snippets/csharp/keywords/ReadonlyKeywordExamples.cs#ReadonlyField)]
 
@@ -46,7 +46,7 @@ You can assign a value to a `readonly` field only in the following contexts:
 - In an instance constructor of the class that contains the instance field declaration.
 - In the static constructor of the class that contains the static field declaration.
 
-These constructor contexts are also the only contexts in which it is valid to pass a `readonly` field as an [out](out-parameter-modifier.md) or [ref](ref.md) parameter.
+These constructor contexts are also the only contexts in which it's valid to pass a `readonly` field as an [out](out-parameter-modifier.md) or [ref](ref.md) parameter.
 
 > [!NOTE]
 > The `readonly` keyword is different from the [const](const.md) keyword. A `const` field can only be initialized at the declaration of the field. A `readonly` field can be assigned multiple times in the field declaration and in any constructor. Therefore, `readonly` fields can have different values depending on the constructor used. Also, while a `const` field is a compile-time constant, the `readonly` field can be used for runtime constants as in the following example:
@@ -63,7 +63,7 @@ In the preceding example, if you use a statement like the following example:
 p2.y = 66;        // Error
 ```
 
-you will get the compiler error message:
+you'll get the compiler error message:
 
 `A readonly field cannot be assigned to (except in a constructor or a variable initializer)`
 
@@ -97,8 +97,8 @@ You gain two advantages by applying the `readonly` modifier to applicable `struc
 
 The `readonly` modifier is valid on most members of a `struct`, including methods that override methods declared in <xref:System.Object?displayProperty=nameWithType>. There are some restrictions:
 
-- You cannot declare `readonly` static members.
-- You cannot declare `readonly` constructors.
+- You can't declare `readonly` static members.
+- You can't declare `readonly` constructors.
 
 You can add the `readonly` modifier to a property or indexer declaration:
 
@@ -123,7 +123,7 @@ int _counter;
 
 You may not add the `readonly` modifier to both a property and one or more of that same property's accessors. That same restriction applies to indexers.
 
-The compiler implicitly applies the `readonly` modifier to auto-implemented properties where the compiler implemented code does not modify state. It is equivalent to the following declarations:
+The compiler implicitly applies the `readonly` modifier to auto-implemented properties where the compiler implemented code doesn't modify state. It's equivalent to the following declarations:
 
 ```csharp
 public readonly int Index { get; }
@@ -136,7 +136,7 @@ You may add the `readonly` modifier in those locations, but it will have no mean
 
 ## Ref readonly return example
 
-The `readonly` modifier on a `ref return` indicates that the returned reference cannot be modified. The following example returns a reference to the origin. It uses the `readonly` modifier to indicate that callers cannot modify the origin:
+The `readonly` modifier on a `ref return` indicates that the returned reference can't be modified. The following example returns a reference to the origin. It uses the `readonly` modifier to indicate that callers can't modify the origin:
 
 [!code-csharp[readonly struct example](~/samples/snippets/csharp/keywords/ReadonlyKeywordExamples.cs#ReadonlyReturn)]
 The type returned doesn't need to be a `readonly struct`. Any type that can be returned by `ref` can be returned by `ref readonly`.

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -91,7 +91,7 @@ Adding a field not marked `readonly` generates compiler error `CS8340`: "Instanc
 
 ## Readonly member examples
 
-Other times, you may create a struct that supports mutation. In those cases, several of the instance members likely won't modify the internal state of the struct. You can declare those instance members with the `readonly` modifier. The compiler enforces your intent. If that member modifies state directly, or accesses a member that isn't also declared with the `readonly` modifier, the result is a compile-time error. The `readonly` modifier is valid on `struct` members, not `class` or `interface` member declarations.
+Other times, you may create a struct that supports mutation. In those cases, several of the instance members likely won't modify the internal state of the struct. You can declare those instance members with the `readonly` modifier. The compiler enforces your intent. If that member modifies state directly or accesses a member that isn't also declared with the `readonly` modifier, the result is a compile-time error. The `readonly` modifier is valid on `struct` members, not `class` or `interface` member declarations.
 
 You gain two advantages by applying the `readonly` modifier to applicable `struct` methods. Most importantly, the compiler enforces your intent. Code that modifies state isn't valid in a `readonly` method. The compiler may also make use of the `readonly` modifier to enable performance optimizations. When large `struct` types are passed by `in` reference, the compiler must generate a defensive copy if the state of the struct might be modified. If only `readonly` members are accessed, the compiler may not create the defensive copy.
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -91,7 +91,7 @@ Adding a field not marked `readonly` generates compiler error `CS8340`: "Instanc
 
 ## Readonly member examples
 
-Other times, you may create a struct that supports mutation. In those cases, several of the instance members likely won't modify the internal state of the struct. You can declare those instance members with the `readonly` modifier. The compiler enforces your intent. If that member modifies state directly, or accesses a member that isn't also declared with the `readonly` modifier, the result is a compile time error. The `readonly` modifier is valid on `struct` members, not `class` or `interface` member declarations.
+Other times, you may create a struct that supports mutation. In those cases, several of the instance members likely won't modify the internal state of the struct. You can declare those instance members with the `readonly` modifier. The compiler enforces your intent. If that member modifies state directly, or accesses a member that isn't also declared with the `readonly` modifier, the result is a compile-time error. The `readonly` modifier is valid on `struct` members, not `class` or `interface` member declarations.
 
 You gain two advantages by applying the `readonly` modifier to applicable `struct` methods. Most importantly, the compiler enforces your intent. Code that modifies state isn't valid in a `readonly` method. The compiler may also make use of the `readonly` modifier to enable performance optimizations. When large `struct` types are passed by `in` reference, the compiler must generate a defensive copy if the state of the struct might be modified. If only `readonly` members are accessed, the compiler may not create the defensive copy.
 
@@ -132,7 +132,7 @@ public int Number { readonly get; }
 public string Message { readonly get; set; }
 ``` 
 
-You may add the `readonly` modifier in those locations, but it will have no meaningful effect. You may not add the `readonly` modifier to an auto-implemented property setter, or to a read / write auto-implemented property.
+You may add the `readonly` modifier in those locations, but it will have no meaningful effect. You may not add the `readonly` modifier to an auto-implemented property setter, or to a read/write auto-implemented property.
 
 ## Ref readonly return example
 
@@ -146,6 +146,7 @@ The type returned doesn't need to be a `readonly struct`. Any type that can be r
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
 
 You can also see the language specification proposals:
+
 - [readonly ref and readonly struct](~/_csharplang/proposals/csharp-7.2/readonly-ref.md)
 - [readonly struct members](~/csharplang/proposals/csharp-8.0/readonly-instance-members.md)
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -148,7 +148,7 @@ The type returned doesn't need to be a `readonly struct`. Any type that can be r
 You can also see the language specification proposals:
 
 - [readonly ref and readonly struct](~/_csharplang/proposals/csharp-7.2/readonly-ref.md)
-- [readonly struct members](~/csharplang/proposals/csharp-8.0/readonly-instance-members.md)
+- [readonly struct members](~/_csharplang/proposals/csharp-8.0/readonly-instance-members.md)
 
 ## See also
 

--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -34,7 +34,7 @@ The remainder of this article briefly describes these features. Where in-depth a
 
 ## Readonly members
 
-You can apply the `readonly` modifier to any member of a struct. It indicates that the member does not modify state. It's more granular than applying the `readonly` modifier to a `struct` declaration.  Consider the following mutable struct:
+You can apply the `readonly` modifier to members of a struct. It indicates that the member does not modify state. It's more granular than applying the `readonly` modifier to a `struct` declaration.  Consider the following mutable struct:
 
 ```csharp
 public struct Point

--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -79,7 +79,7 @@ public readonly void Translate(int xOffset, int yOffset)
 }
 ```
 
-This feature lets you specify your design intent so the compiler can enforce it, and make optimizations based on that intent.
+This feature lets you specify your design intent so the compiler can enforce it, and make optimizations based on that intent. You can learn more about readonly members in the language reference article on [`readonly`](../language-reference/keywords/readonly.md#readonly-member-examples).
 
 ## Default interface methods
 

--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -34,7 +34,7 @@ The remainder of this article briefly describes these features. Where in-depth a
 
 ## Readonly members
 
-You can apply the `readonly` modifier to members of a struct. It indicates that the member does not modify state. It's more granular than applying the `readonly` modifier to a `struct` declaration.  Consider the following mutable struct:
+You can apply the `readonly` modifier to members of a struct. It indicates that the member doesn't modify state. It's more granular than applying the `readonly` modifier to a `struct` declaration.  Consider the following mutable struct:
 
 ```csharp
 public struct Point
@@ -48,28 +48,28 @@ public struct Point
 }
 ```
 
-Like most structs, the `ToString()` method does not modify state. You could indicate that by adding the `readonly` modifier to the declaration of `ToString()`:
+Like most structs, the `ToString()` method doesn't modify state. You could indicate that by adding the `readonly` modifier to the declaration of `ToString()`:
 
 ```csharp
 public readonly override string ToString() =>
     $"({X}, {Y}) is {Distance} from the origin";
 ```
 
-The preceding change generates a compiler warning, because `ToString` accesses the `Distance` property, which is not marked `readonly`:
+The preceding change generates a compiler warning, because `ToString` accesses the `Distance` property, which isn't marked `readonly`:
 
 ```console
 warning CS8656: Call to non-readonly member 'Point.Distance.get' from a 'readonly' member results in an implicit copy of 'this'
 ```
 
-The compiler warns you when it needs to create a defensive copy.  The `Distance` property does not change state, so you can fix this warning by adding the `readonly` modifier to the declaration:
+The compiler warns you when it needs to create a defensive copy.  The `Distance` property doesn't change state, so you can fix this warning by adding the `readonly` modifier to the declaration:
 
 ```csharp
 public readonly double Distance => Math.Sqrt(X * X + Y * Y);
 ```
 
-Notice that the `readonly` modifier is necessary on a read only property. The compiler doesn't assume `get` accessors do not modify state; you must declare `readonly` explicitly. Auto-implemented properties are an exception; the compiler will treat all auto-implemented getters as readonly, so here there is no need to add the `readonly` modifier to the `X` and `Y` properties.
+Notice that the `readonly` modifier is necessary on a read-only property. The compiler doesn't assume `get` accessors don't modify state; you must declare `readonly` explicitly. Auto-implemented properties are an exception; the compiler will treat all auto-implemented getters as readonly, so here there's no need to add the `readonly` modifier to the `X` and `Y` properties.
 
-The compiler does enforce the rule that `readonly` members do not modify state. The following method will not compile unless you remove the `readonly` modifier:
+The compiler does enforce the rule that `readonly` members don't modify state. The following method won't compile unless you remove the `readonly` modifier:
 
 ```csharp
 public readonly void Translate(int xOffset, int yOffset)
@@ -165,7 +165,7 @@ public static RGBColor FromRainbowClassic(Rainbow colorBand)
 
 ### Property patterns
 
-The **property pattern** enables you to match on properties of the object examined. Consider an eCommerce site that must compute sales tax based on the buyer's address. That computation is not a core responsibility of an `Address` class. It will change over time, likely more often than address format changes. The amount of sales tax depends on the `State` property of the address. The following method uses the property pattern to compute the sales tax from the address and the price:
+The **property pattern** enables you to match on properties of the object examined. Consider an eCommerce site that must compute sales tax based on the buyer's address. That computation isn't a core responsibility of an `Address` class. It will change over time, likely more often than address format changes. The amount of sales tax depends on the `State` property of the address. The following method uses the property pattern to compute the sales tax from the address and the price:
 
 ```csharp
 public static decimal ComputeSalesTax(Address location, decimal salePrice) =>
@@ -248,7 +248,7 @@ static Quadrant GetQuadrant(Point point) => point switch
 };
 ```
 
-The discard pattern in the preceding switch matches when either `x` or `y` is 0, but not both. A switch expression must either produce a value or throw an exception. If none of the cases match, the switch expression throws an exception. The compiler generates a warning for you if you do not cover all possible cases in your switch expression.
+The discard pattern in the preceding switch matches when either `x` or `y` is 0, but not both. A switch expression must either produce a value or throw an exception. If none of the cases match, the switch expression throws an exception. The compiler generates a warning for you if you don't cover all possible cases in your switch expression.
 
 You can explore pattern matching techniques in this [advanced tutorial on pattern matching](../tutorials/pattern-matching.md).
 
@@ -307,7 +307,7 @@ static int WriteLinesToFile(IEnumerable<string> lines)
 
 In the preceding example, the file is disposed when the closing brace associated with the `using` statement is reached.
 
-In both cases, the compiler generates the call to `Dispose()`. The compiler generates an error if the expression in the `using` statement is not disposable.
+In both cases, the compiler generates the call to `Dispose()`. The compiler generates an error if the expression in the `using` statement isn't disposable.
 
 ## Static local functions
 
@@ -341,13 +341,13 @@ int M()
 
 ## Disposable ref structs
 
-A `struct` declared with the `ref` modifier may not implement any interfaces and so cannot implement <xref:System.IDisposable>. Therefore, to enable a `ref struct` to be disposed, it must have an accessible `void Dispose()` method. This also applies to `readonly ref struct` declarations.
+A `struct` declared with the `ref` modifier may not implement any interfaces and so can't implement <xref:System.IDisposable>. Therefore, to enable a `ref struct` to be disposed, it must have an accessible `void Dispose()` method. This feature also applies to `readonly ref struct` declarations.
 
 ## Nullable reference types
 
 Inside a nullable annotation context, any variable of a reference type is considered to be a **nonnullable reference type**. If you want to indicate that a variable may be null, you must append the type name with the `?` to declare the variable as a **nullable reference type**.
 
-For nonnullable reference types, the compiler uses flow analysis to ensure that local variables are initialized to a non-null value when declared. Fields must be initialized during construction. The compiler generates a warning if the variable is not set by a call to any of the available constructors or by an initializer. Furthermore, nonnullable reference types can't be assigned a value that could be null.
+For nonnullable reference types, the compiler uses flow analysis to ensure that local variables are initialized to a non-null value when declared. Fields must be initialized during construction. The compiler generates a warning if the variable isn't set by a call to any of the available constructors or by an initializer. Furthermore, nonnullable reference types can't be assigned a value that could be null.
 
 Nullable reference types aren't checked to ensure they aren't assigned or initialized to null. However, the compiler uses flow analysis to ensure that any variable of a nullable reference type is checked against null before it's accessed or assigned to a nonnullable reference type.
 
@@ -398,7 +398,7 @@ This language support relies on two new types, and two new operators:
 
 Let's start with the rules for indexes. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. Note that `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
 
-A range specifies the *start* and *end* of a range. The start of the range is inclusive, but the end of the range is exclusive, meaning the *start* is included in the range but the *end* is not included in the range. The range `[0..^0]` represents the entire range, just as `[0..sequence.Length]` represents the entire range.
+A range specifies the *start* and *end* of a range. The start of the range is inclusive, but the end of the range is exclusive, meaning the *start* is included in the range but the *end* isn't included in the range. The range `[0..^0]` represents the entire range, just as `[0..sequence.Length]` represents the entire range.
 
 Let's look at a few examples. Consider the following array, annotated with its index from the start and from the end:
 
@@ -425,13 +425,13 @@ Console.WriteLine($"The last word is {words[^1]}");
 // writes "dog"
 ```
 
-The following code creates a subrange with the words "quick", "brown", and "fox". It includes `words[1]` through `words[3]`. The element `words[4]` is not in the range.
+The following code creates a subrange with the words "quick", "brown", and "fox". It includes `words[1]` through `words[3]`. The element `words[4]` isn't in the range.
 
 ```csharp
 var quickBrownFox = words[1..4];
 ```
 
-The following code creates a subrange with "lazy" and "dog". It includes `words[^2]` and `words[^1]`. The end index `words[^0]` is not included:
+The following code creates a subrange with "lazy" and "dog". It includes `words[^2]` and `words[^1]`. The end index `words[^0]` isn't included:
 
 ```csharp
 var lazyDog = words[^2..^0];
@@ -481,7 +481,7 @@ For more information, see the [?? and ??= operators](../language-reference/opera
 
 ## Unmanaged constructed types
 
-In C# 7.3 and earlier, a constructed type (a type that includes at least one type argument) cannot be an [unmanaged type](../language-reference/builtin-types/unmanaged-types.md). Starting with C# 8.0, a constructed value type is unmanaged if it contains fields of unmanaged types only.
+In C# 7.3 and earlier, a constructed type (a type that includes at least one type argument) can't be an [unmanaged type](../language-reference/builtin-types/unmanaged-types.md). Starting with C# 8.0, a constructed value type is unmanaged if it contains fields of unmanaged types only.
 
 For example, given the following definition of the generic `Coords<T>` type:
 

--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -16,9 +16,10 @@ This article focuses on techniques for efficient resource management. One advant
 This article focuses on the following resource management techniques:
 
 - Declare a [`readonly struct`](language-reference/keywords/readonly.md#readonly-struct-example) to express that a type is **immutable** and enables the compiler to save copies when using [`in`](language-reference/keywords/in-parameter-modifier.md) parameters.
+- If a type cannot be immutable, declare `struct` members `readonly` to indicate that the member does not modify state.
 - Use a [`ref readonly`](language-reference/keywords/ref.md#reference-return-values) return when the return value is a `struct` larger than <xref:System.IntPtr.Size?displayProperty=nameWithType> and the storage lifetime is greater than the method returning the value.
 - When the size of a `readonly struct` is bigger than <xref:System.IntPtr.Size?displayProperty=nameWithType>, you should pass it as an `in` parameter for performance reasons.
-- Never pass a `struct` as an `in` parameter unless it's declared with the `readonly` modifier because it may negatively affect performance and could lead to an obscure behavior.
+- Never pass a `struct` as an `in` parameter unless it's declared with the `readonly` modifier or the method calls only `readonly` members of the struct. Violating this guidance may negatively affect performance and could lead to an obscure behavior.
 - Use a [`ref struct`](language-reference/keywords/ref.md#ref-struct-types), or a `readonly ref struct` such as <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> to work with memory as a sequence of bytes.
 
 These techniques force you to balance two competing goals with regard to **references** and **values**. Variables that are [reference types](programming-guide/types/index.md#reference-types) hold a reference to the location in memory. Variables that are [value types](programming-guide/types/index.md#value-types) directly contain their value. These differences highlight the key differences that are important for managing memory resources. **Value types** are typically copied when passed to a method or returned from a method. This behavior includes copying the value of `this` when calling members of a value type. The cost of the copy is related to the size of the type. **Reference types** are allocated on the managed heap. Each new object requires a new allocation, and subsequently must be reclaimed. Both these operations take time. The reference is copied when a reference type is passed as an argument to a method or returned from a method.
@@ -62,6 +63,49 @@ readonly public struct ReadonlyPoint3D
 ```
 
 Follow this recommendation whenever your design intent is to create an immutable value type. Any performance improvements are an added benefit. The `readonly struct` clearly expresses your design intent.
+
+## Declare readonly members when a struct can't be immutable
+
+When a struct type is mutable, you should declare members that don't cause mutation to be `readonly`. For example, the following is a mutable variation of the 3D point structure:
+
+```csharp
+public struct Point3D
+{
+    public Point3D(double x, double y, double z)
+    {
+        this.X = x;
+        this.Y = y;
+        this.Z = z;
+    }
+
+    private double _x;
+    public double X 
+    { 
+        readonly get { return _x;}; 
+        set { _x = value; }
+    }
+    
+    private double _y;
+    public double Y 
+    { 
+        readonly get { return _y;}; 
+        set { _y = value; }
+    }
+
+    private double _z;
+    public double Z 
+    { 
+        readonly get { return _z;}; 
+        set { _z = value; }
+    }
+
+    public readonly double Distance => Math.Sqrt(X * X + Y * Y + Z * Z);
+
+    public readonly override string ToString() => $"{X, Y, Z }";
+}
+```
+
+The preceding sample shows many of the different locations where you can apply the `readonly` modifier: methods, properties, and property accessors. If you use auto-implemented properties, the compiler adds the `readonly` modifier to the `get` accessor for read-write properties. The compiler adds the `readonly` modifier to the property declaration for properties with only a `get` accessor.
 
 ## Use `ref readonly return` statements for large structures when possible
 

--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -16,7 +16,7 @@ This article focuses on techniques for efficient resource management. One advant
 This article focuses on the following resource management techniques:
 
 - Declare a [`readonly struct`](language-reference/keywords/readonly.md#readonly-struct-example) to express that a type is **immutable** and enables the compiler to save copies when using [`in`](language-reference/keywords/in-parameter-modifier.md) parameters.
-- If a type cannot be immutable, declare `struct` members `readonly` to indicate that the member does not modify state.
+- If a type can't be immutable, declare `struct` members `readonly` to indicate that the member doesn't modify state.
 - Use a [`ref readonly`](language-reference/keywords/ref.md#reference-return-values) return when the return value is a `struct` larger than <xref:System.IntPtr.Size?displayProperty=nameWithType> and the storage lifetime is greater than the method returning the value.
 - When the size of a `readonly struct` is bigger than <xref:System.IntPtr.Size?displayProperty=nameWithType>, you should pass it as an `in` parameter for performance reasons.
 - Never pass a `struct` as an `in` parameter unless it's declared with the `readonly` modifier or the method calls only `readonly` members of the struct. Violating this guidance may negatively affect performance and could lead to an obscure behavior.
@@ -107,7 +107,7 @@ public struct Point3D
 
 The preceding sample shows many of the locations where you can apply the `readonly` modifier: methods, properties, and property accessors. If you use auto-implemented properties, the compiler adds the `readonly` modifier to the `get` accessor for read-write properties. The compiler adds the `readonly` modifier to the auto-implemented property declarations for properties with only a `get` accessor.
 
-Adding the `readonly` modifier to members that do not mutate state provides two related benefits. First, the compiler enforces your intent. That member cannot mutate the struct's state, nor can it access a member that is not also marked `readonly`. Second, the compiler will not create defensive copies of `in` parameters when accessing a `readonly` member. The compiler can make this optimization safely because it guarantees that the `struct` is not modified by a `readonly` member.
+Adding the `readonly` modifier to members that don't mutate state provides two related benefits. First, the compiler enforces your intent. That member can't mutate the struct's state, nor can it access a member that isn't also marked `readonly`. Second, the compiler won't create defensive copies of `in` parameters when accessing a `readonly` member. The compiler can make this optimization safely because it guarantees that the `struct` is not modified by a `readonly` member.
 
 ## Use `ref readonly return` statements for large structures when possible
 
@@ -270,7 +270,7 @@ The techniques described above explain how to avoid copies by returning referenc
 
 The `Point3D` structure is *not* a readonly struct. There are six different property access calls in the body of this method. On first examination, you may have thought these accesses were safe. After all, a `get` accessor shouldn't modify the state of the object. But there's no language rule that enforces that. It's only a common convention. Any type could implement a `get` accessor that modified the internal state. Without some language guarantee, the compiler must create a temporary copy of the argument before calling any member. The temporary storage is created on the stack, the values of the argument are copied to the temporary storage, and the value is copied to the stack for each member access as the `this` argument. In many situations, these copies harm performance enough that pass-by-value is faster than pass-by-readonly-reference when the argument type isn't a `readonly struct`.
 
-Instead, if the distance calculation uses the immutable struct, `ReadonlyPoint3D`, temporary objects are not needed:
+Instead, if the distance calculation uses the immutable struct, `ReadonlyPoint3D`, temporary objects aren't needed:
 
 [!code-csharp[readonlyInArgument](../../samples/csharp/safe-efficient-code/ref-readonly-struct/Program.cs#ReadOnlyInArgument "Specifying a readonly in argument")]
 
@@ -279,7 +279,7 @@ The compiler generates more efficient code when you call members of a
 is always an `in` parameter passed by reference to the member method. This optimization
 saves copying when you use a `readonly struct` as an `in` argument.
 
-You should not pass a nullable value type as an `in` argument. The <xref:System.Nullable%601> type is not declared as a read-only struct. That means the compiler must generate defensive copies for any nullable value type argument passed to a method using the `in` modifier on the parameter declaration.
+You shouldn't pass a nullable value type as an `in` argument. The <xref:System.Nullable%601> type isn't declared as a read-only struct. That means the compiler must generate defensive copies for any nullable value type argument passed to a method using the `in` modifier on the parameter declaration.
 
 You can see an example program that demonstrates the performance differences using [Benchmark.net](https://www.nuget.org/packages/BenchmarkDotNet/) in our [samples repository](https://github.com/dotnet/samples/tree/master/csharp/safe-efficient-code/benchmark) on GitHub. It compares passing a mutable struct by value and by reference with passing an immutable struct by value and by reference. The use of the immutable struct and pass by reference is fastest.
 

--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -66,7 +66,7 @@ Follow this recommendation whenever your design intent is to create an immutable
 
 ## Declare readonly members when a struct can't be immutable
 
-When a struct type is mutable, you should declare members that don't cause mutation to be `readonly`. For example, the following is a mutable variation of the 3D point structure:
+In C# 8.0 and later, when a struct type is mutable, you should declare members that don't cause mutation to be `readonly`. For example, the following is a mutable variation of the 3D point structure:
 
 ```csharp
 public struct Point3D

--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -105,7 +105,9 @@ public struct Point3D
 }
 ```
 
-The preceding sample shows many of the different locations where you can apply the `readonly` modifier: methods, properties, and property accessors. If you use auto-implemented properties, the compiler adds the `readonly` modifier to the `get` accessor for read-write properties. The compiler adds the `readonly` modifier to the property declaration for properties with only a `get` accessor.
+The preceding sample shows many of the locations where you can apply the `readonly` modifier: methods, properties, and property accessors. If you use auto-implemented properties, the compiler adds the `readonly` modifier to the `get` accessor for read-write properties. The compiler adds the `readonly` modifier to the auto-implemented property declarations for properties with only a `get` accessor.
+
+Adding the `readonly` modifier to members that do not mutate state provides two related benefits. First, the compiler enforces your intent. That member cannot mutate the struct's state, nor can it access a member that is not also marked `readonly`. Second, the compiler will not create defensive copies of `in` parameters when accessing a `readonly` member. The compiler can make this optimization safely because it guarantees that the `struct` is not modified by a `readonly` member.
 
 ## Use `ref readonly return` statements for large structures when possible
 


### PR DESCRIPTION
Fixes #13838 

- Update "What's new" with links.
- Update recommendations for safe and efficient code
- Update `readonly` keyword page.

I did not see other reference areas that were affected.
