### PR TITLE
Update index.md

### DIFF
--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -9,7 +9,7 @@ ms.assetid: 2feda177-ce11-432d-81b4-d50f5f35fd37
 ---
 # Interfaces (C# Programming Guide)
 
-An interface contains definitions for a group of related functionalities that a [class](../../language-reference/keywords/class.md) or a [struct](../../language-reference/keywords/struct.md) can implement.
+An interface contains definitions for a group of related functionalities that a [class](../../language-reference/keywords/class.md) or a [struct](../../language-reference/keywords/struct.md) must implement.
   
 By using interfaces, you can, for example, include behavior from multiple sources in a class. That capability is important in C# because the language doesn't support multiple inheritance of classes. In addition, you must use an interface if you want to simulate inheritance for structs, because they can't actually inherit from another struct or class.  
   

--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -9,7 +9,7 @@ ms.assetid: 2feda177-ce11-432d-81b4-d50f5f35fd37
 ---
 # Interfaces (C# Programming Guide)
 
-An interface contains definitions for a group of related functionalities that a [class](../../language-reference/keywords/class.md) or a [struct](../../language-reference/keywords/struct.md) must implement.
+An interface contains definitions for a group of related functionalities that a non-abstrat [class](../../language-reference/keywords/class.md) or a [struct](../../language-reference/keywords/struct.md) must implement.
   
 By using interfaces, you can, for example, include behavior from multiple sources in a class. That capability is important in C# because the language doesn't support multiple inheritance of classes. In addition, you must use an interface if you want to simulate inheritance for structs, because they can't actually inherit from another struct or class.  
   


### PR DESCRIPTION
Just switching 'can' to 'must' in the opening statement.  It implies that it is an imperative to implement all of the methods.  It also is representative of what is documented here: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/interface

## Summary

same explanation as above.  simply changing the wording. 

Fixes #Issue_Number (if available)
