### PR TITLE
add title for static local functions

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -314,6 +314,7 @@
         "_csharplang/proposals/csharp-8.0/using.md": "Pattern based using and using declarations",
         "_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md": "Null coalescing assignment",
         "_csharplang/proposals/csharp-8.0/readonly-instance-members.md": "Readonly instance members",
+        "_csharplang/proposals/csharp-8.0/static-local-functions.md": "Static local functions",
 
         "_vblang/spec/introduction.md": "Introduction",
         "_vblang/spec/lexical-grammar.md": "Lexical grammar",


### PR DESCRIPTION
From recent build reports, the title metadata was not added to the static local functions speclet.

This PR fixes that.
