### PR TITLE
#15390 Remove links to outdated tutorials on string interpolation

### DIFF
--- a/docs/csharp/tutorials/exploration/interpolated-strings.yml
+++ b/docs/csharp/tutorials/exploration/interpolated-strings.yml
@@ -114,6 +114,6 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the string interpolation interactive tutorial. You can click the **Collections in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
+    You've completed the string interpolation interactive tutorial. You can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding.
 
     For more information, see [String interpolation](../../language-reference/tokens/interpolated.md).


### PR DESCRIPTION
## Summary

As @BillWagner described on #15390 the references to other tutorials no longer apply since the docs have moved

Fixes #15390 (if available)
