### PR TITLE
Update how-to-customize-a-time-based-cache-policy.md

### DIFF
--- a/docs/framework/network-programming/how-to-customize-a-time-based-cache-policy.md
+++ b/docs/framework/network-programming/how-to-customize-a-time-based-cache-policy.md
@@ -1,106 +1,104 @@
 ---
-title: "How to: Customize a Time-Based Cache Policy"
+title: "How to: customize a time-based cache policy"
 ms.date: "03/30/2017"
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "time-based cache policies"
   - "customizing time-based cache policies"
   - "cache [.NET Framework], time-based policies"
 ms.assetid: 8d84f936-2376-4356-9264-03162e0f9279
 ---
-# How to: Customize a Time-Based Cache Policy
-When creating a time-based cache policy, you can customize caching behavior by specifying values for maximum age, minimum freshness, maximum staleness, or cache synchronization date. The <xref:System.Net.Cache.HttpRequestCachePolicy> object provides several constructors that allow you to specify valid combinations of these values.  
-  
-### To create a time-based cache policy that uses a cache synchronization date  
-  
-- Create a time-based cache policy that uses a cache synchronization date by passing a <xref:System.DateTime> object to the <xref:System.Net.Cache.HttpRequestCachePolicy> constructor.  
-  
-    ```csharp  
-    public static HttpRequestCachePolicy CreateLastSyncPolicy(DateTime when)  
-    {  
-        HttpRequestCachePolicy policy =   
-            new HttpRequestCachePolicy(when);  
-        Console.WriteLine("When: {0}", when);  
-        Console.WriteLine(policy.ToString());  
-        return policy;  
-    }  
-    ```  
-  
-    ```vb  
-    Public Shared Function CreateLastSyncPolicy([when] As DateTime) As HttpRequestCachePolicy  
-        Dim policy As New HttpRequestCachePolicy([when])  
-        Console.WriteLine("When: {0}", [when])  
-        Console.WriteLine(policy.ToString())  
-        Return policy  
-    End Function  
-    ```  
-  
- The output is similar to the following:  
-  
-```output
-When: 1/14/2004 8:07:30 AM  
-Level:Default CacheSyncDate:1/14/2004 8:07:30 AM  
-```  
-  
-### To create a time-based cache policy that is based on minimum freshness  
-  
-- Create a time-based cache policy that is based on minimum freshness by specifying <xref:System.Net.Cache.HttpCacheAgeControl.MinFresh> as the `cacheAgeControl` parameter value and passing a <xref:System.TimeSpan> object to the <xref:System.Net.Cache.HttpRequestCachePolicy> constructor.  
-  
-    ```csharp  
-    public static HttpRequestCachePolicy CreateMinFreshPolicy(TimeSpan span)  
-    {  
-        HttpRequestCachePolicy policy =   
-            new HttpRequestCachePolicy(HttpCacheAgeControl.MinFresh, span);  
-        Console.WriteLine(policy.ToString());  
-        return policy;  
-    }  
-    ```  
-  
-    ```vb  
-    Public Shared Function CreateMinFreshPolicy(span As TimeSpan) As HttpRequestCachePolicy  
-        Dim policy As New HttpRequestCachePolicy(HttpCacheAgeControl.MinFresh, span)  
-        Console.WriteLine(policy.ToString())  
-        Return policy  
-    End Function  
-    ```  
-  
- For the following invocation:  
-  
-```csharp
-CreateMinFreshPolicy(new TimeSpan(1,0,0));  
-```  
+# How to: customize a time-based cache policy
 
- The output is:
-  
+When creating a time-based cache policy, you can customize caching behavior by specifying values for maximum age, minimum freshness, maximum staleness, or cache synchronization date. The <xref:System.Net.Cache.HttpRequestCachePolicy> object provides several constructors that allow you to specify valid combinations of these values.
+
+## To create a time-based cache policy that uses a cache synchronization date
+
+Create a time-based cache policy that uses a cache synchronization date by passing a <xref:System.DateTime> object to the <xref:System.Net.Cache.HttpRequestCachePolicy> constructor:
+
+```csharp
+public static HttpRequestCachePolicy CreateLastSyncPolicy(DateTime when)
+{
+    var policy = new HttpRequestCachePolicy(when);
+    Console.WriteLine("When: {0}", when);
+    Console.WriteLine(policy.ToString());
+    return policy;
+}
+```
+
+```vb
+Public Shared Function CreateLastSyncPolicy([when] As DateTime) As HttpRequestCachePolicy
+    Dim policy As New HttpRequestCachePolicy([when])
+    Console.WriteLine("When: {0}", [when])
+    Console.WriteLine(policy.ToString())
+    Return policy
+End Function
+```
+
+The output is similar to the following:
+
 ```output
-Level:Default MinFresh:3600  
-```  
-  
-### To create a time-based cache policy that is based on minimum freshness and maximum age  
-  
-- Create a time-based cache policy that is based on minimum freshness and maximum age by specifying <xref:System.Net.Cache.HttpCacheAgeControl.MaxAgeAndMinFresh> as the `cacheAgeControl` parameter value and passing two <xref:System.TimeSpan> objects to the <xref:System.Net.Cache.HttpRequestCachePolicy> constructor, one to specify the maximum age for resources and a second to specify the minimum freshness permitted for an object returned from the cache.  
-  
-    ```csharp  
-    public static HttpRequestCachePolicy CreateFreshAndAgePolicy(TimeSpan freshMinimum, TimeSpan ageMaximum)  
-    {  
-        HttpRequestCachePolicy policy =   
-        new HttpRequestCachePolicy(HttpCacheAgeControl.MaxAgeAndMinFresh, ageMaximum, freshMinimum);  
-        Console.WriteLine(policy.ToString());  
-        return policy;  
-    }  
-    ```  
-  
-    ```vb  
-    Public Shared Function CreateFreshAndAgePolicy(freshMinimum As TimeSpan, ageMaximum As TimeSpan) As HttpRequestCachePolicy  
-        Dim policy As New HttpRequestCachePolicy(HttpCacheAgeControl.MaxAgeAndMinFresh, ageMaximum, freshMinimum)  
-        Console.WriteLine(policy.ToString())  
-        Return policy  
-    End Function  
-    ```  
-  
- For the following invocation:  
+When: 1/14/2004 8:07:30 AM
+Level:Default CacheSyncDate:1/14/2004 8:07:30 AM
+```
+
+## To create a time-based cache policy that is based on minimum freshness
+
+Create a time-based cache policy that is based on minimum freshness by specifying <xref:System.Net.Cache.HttpCacheAgeControl.MinFresh> as the `cacheAgeControl` parameter value and passing a <xref:System.TimeSpan> object to the <xref:System.Net.Cache.HttpRequestCachePolicy> constructor:
+
+```csharp
+public static HttpRequestCachePolicy CreateMinFreshPolicy(TimeSpan span)
+{
+    var policy = new HttpRequestCachePolicy(HttpCacheAgeControl.MinFresh, span);
+    Console.WriteLine(policy.ToString());
+    return policy;
+}
+```
+
+```vb
+Public Shared Function CreateMinFreshPolicy(span As TimeSpan) As HttpRequestCachePolicy
+    Dim policy As New HttpRequestCachePolicy(HttpCacheAgeControl.MinFresh, span)
+    Console.WriteLine(policy.ToString())
+    Return policy
+End Function
+```
+
+For the following invocation:
+
+```csharp
+CreateMinFreshPolicy(new TimeSpan(1,0,0));
+```
+
+The output is:
+
+```output
+Level:Default MinFresh:3600
+```
+
+## To create a time-based cache policy that is based on minimum freshness and maximum age
+
+Create a time-based cache policy that is based on minimum freshness and maximum age by specifying <xref:System.Net.Cache.HttpCacheAgeControl.MaxAgeAndMinFresh> as the `cacheAgeControl` parameter value and passing two <xref:System.TimeSpan> objects to the <xref:System.Net.Cache.HttpRequestCachePolicy> constructor, one to specify the maximum age for resources and a second to specify the minimum freshness permitted for an object returned from the cache:
+
+```csharp
+public static HttpRequestCachePolicy CreateFreshAndAgePolicy(TimeSpan freshMinimum, TimeSpan ageMaximum)
+{
+    var policy = new HttpRequestCachePolicy(HttpCacheAgeControl.MaxAgeAndMinFresh, ageMaximum, freshMinimum);
+    Console.WriteLine(policy.ToString());
+    return policy;
+}
+```
+
+```vb
+Public Shared Function CreateFreshAndAgePolicy(freshMinimum As TimeSpan, ageMaximum As TimeSpan) As HttpRequestCachePolicy
+    Dim policy As New HttpRequestCachePolicy(HttpCacheAgeControl.MaxAgeAndMinFresh, ageMaximum, freshMinimum)
+    Console.WriteLine(policy.ToString())
+    Return policy
+End Function
+```
+
+For the following invocation:
   
 ```csharp
 CreateFreshAndAgePolicy(new TimeSpan(5,0,0), new TimeSpan(10,0,0));  

--- a/docs/framework/network-programming/toc.yml
+++ b/docs/framework/network-programming/toc.yml
@@ -145,7 +145,7 @@
         href: how-to-set-a-location-based-cache-policy-for-an-application.md
       - name: "How to: Set the Default Time-Based Cache Policy for an Application"
         href: how-to-set-the-default-time-based-cache-policy-for-an-application.md
-      - name: "How to: Customize a Time-Based Cache Policy"
+      - name: "How to: customize a time-based cache policy"
         href: how-to-customize-a-time-based-cache-policy.md
       - name: "How to: Set Cache Policy for a Request"
         href: how-to-set-cache-policy-for-a-request.md


### PR DESCRIPTION
- Fixed header levels from H3 to H2, that was causing the `In this article` side bar to contain only a link to `See also`.
- Used var in C# code.
- Removed bullet lists that has only one item.
- Removed some extra spaces.
- Left blank lines around headers.
- Followed the current convention in headers casing.