### PR TITLE
C# operators reference: nit picks

### DIFF
--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -17,13 +17,13 @@ ms.assetid: 93e56486-bb42-43c1-bd43-60af11e64e67
 ---
 # + and += operators (C# reference)
 
-The `+` operator is supported by the built-in numeric types, [string](../keywords/string.md) type, and [delegate](../keywords/delegate.md) types.
+The `+` and `+=` operators are supported by the built-in [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types, the [string](../builtin-types/reference-types.md#the-string-type) type, and [delegate](../builtin-types/reference-types.md#the-delegate-type) types.
 
 For information about the arithmetic `+` operator, see the [Unary plus and minus operators](arithmetic-operators.md#unary-plus-and-minus-operators) and [Addition operator +](arithmetic-operators.md#addition-operator-) sections of the [Arithmetic operators](arithmetic-operators.md) article.
 
 ## String concatenation
 
-When one or both operands are of type [string](../keywords/string.md), the `+` operator concatenates the string representations of its operands:
+When one or both operands are of type [string](../builtin-types/reference-types.md#the-string-type), the `+` operator concatenates the string representations of its operands:
 
 [!code-csharp-interactive[string concatenation](~/samples/csharp/language-reference/operators/AdditionOperator.cs#AddStrings)]
 
@@ -33,7 +33,7 @@ Starting with C# 6, [string interpolation](../tokens/interpolated.md) provides a
 
 ## Delegate combination
 
-For operands of the same [delegate](../keywords/delegate.md) type, the `+` operator returns a new delegate instance that, when invoked, invokes the left-hand operand and then invokes the right-hand operand. If any of the operands is `null`, the `+` operator returns the value of another operand (which also might be `null`). The following example shows how delegates can be combined with the `+` operator:
+For operands of the same [delegate](../builtin-types/reference-types.md#the-delegate-type) type, the `+` operator returns a new delegate instance that, when invoked, invokes the left-hand operand and then invokes the right-hand operand. If any of the operands is `null`, the `+` operator returns the value of another operand (which also might be `null`). The following example shows how delegates can be combined with the `+` operator:
 
 [!code-csharp-interactive[delegate combination](~/samples/csharp/language-reference/operators/AdditionOperator.cs#AddDelegates)]
 
@@ -56,7 +56,7 @@ x = x + y
 ```
 
 except that `x` is only evaluated once.
-  
+
 The following example demonstrates the usage of the `+=` operator:
 
 [!code-csharp-interactive[+= examples](~/samples/csharp/language-reference/operators/AdditionOperator.cs#AddAndAssign)]
@@ -75,9 +75,7 @@ For more information, see the [Unary plus operator](~/_csharplang/spec/expressio
 
 - [C# reference](../index.md)
 - [C# operators](index.md)
-- [String interpolation](../tokens/interpolated.md)
 - [How to: concatenate multiple strings](../../how-to/concatenate-multiple-strings.md)
-- [Delegates](../../programming-guide/delegates/index.md)
 - [Events](../../programming-guide/events/index.md)
 - [Arithmetic operators](arithmetic-operators.md)
 - [- and -= operators](subtraction-operator.md)

--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -27,7 +27,7 @@ When one or both operands are of type [string](../builtin-types/reference-types.
 
 [!code-csharp-interactive[string concatenation](~/samples/csharp/language-reference/operators/AdditionOperator.cs#AddStrings)]
 
-Starting with C# 6, [string interpolation](../tokens/interpolated.md) provides a more convenient way to format strings:
+Beginning with C# 6, [string interpolation](../tokens/interpolated.md) provides a more convenient way to format strings:
 
 [!code-csharp-interactive[string interpolation](~/samples/csharp/language-reference/operators/AdditionOperator.cs#UseStringInterpolation)]
 

--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -30,7 +30,7 @@ helpviewer_keywords:
 ---
 # Arithmetic operators (C# reference)
 
-The following operators perform arithmetic operations with the operands of numeric types:
+The following operators perform arithmetic operations with operands of numeric types:
 
 - Unary [`++` (increment)](#increment-operator-), [`--` (decrement)](#decrement-operator---), [`+` (plus)](#unary-plus-and-minus-operators), and [`-` (minus)](#unary-plus-and-minus-operators) operators
 - Binary [`*` (multiplication)](#multiplication-operator-), [`/` (division)](#division-operator-), [`%` (remainder)](#remainder-operator-), [`+` (addition)](#addition-operator-), and [`-` (subtraction)](#subtraction-operator--) operators

--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -229,7 +229,7 @@ For the operands of the `decimal` type, arithmetic overflow always throws an <xr
 
 ## Round-off errors
 
-Because of general limitations of the floating-point representation of real numbers and the floating-point arithmetic, the round-off errors might occur in calculations with floating-point types. That is, the produced result of an expression might differ from the expected mathematical result. The following example demonstrates several such cases:
+Because of general limitations of the floating-point representation of real numbers and floating-point arithmetic, round-off errors might occur in calculations with floating-point types. That is, the produced result of an expression might differ from the expected mathematical result. The following example demonstrates several such cases:
 
 [!code-csharp-interactive[round-off errors](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#RoundOffErrors)]
 

--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -30,12 +30,12 @@ helpviewer_keywords:
 ---
 # Arithmetic operators (C# reference)
 
-The following operators perform arithmetic operations with numeric types:
+The following operators perform arithmetic operations with the operands of numeric types:
 
 - Unary [`++` (increment)](#increment-operator-), [`--` (decrement)](#decrement-operator---), [`+` (plus)](#unary-plus-and-minus-operators), and [`-` (minus)](#unary-plus-and-minus-operators) operators
 - Binary [`*` (multiplication)](#multiplication-operator-), [`/` (division)](#division-operator-), [`%` (remainder)](#remainder-operator-), [`+` (addition)](#addition-operator-), and [`-` (subtraction)](#subtraction-operator--) operators
 
-Those operators support all [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types.
+Those operators are supported by all [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types.
 
 ## Increment operator ++
 
@@ -79,7 +79,7 @@ The unary `+` operator returns the value of its operand. The unary `-` operator 
 
 [!code-csharp-interactive[unary plus and minus](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#UnaryPlusAndMinus)]
 
-The unary `-` operator doesn't support the [ulong](../builtin-types/integral-numeric-types.md) type.
+The [ulong](../builtin-types/integral-numeric-types.md) type doesn't support the unary `-` operator.
 
 ## Multiplication operator *
 
@@ -116,7 +116,7 @@ If one of the operands is `decimal`, another operand can be neither `float` nor 
 The remainder operator `%` computes the remainder after dividing its left-hand operand by its right-hand operand.
 
 ### Integer remainder
-  
+
 For the operands of integer types, the result of `a % b` is the value produced by `a - (a / b) * b`. The sign of the non-zero remainder is the same as that of the left-hand operand, as the following example shows:
 
 [!code-csharp-interactive[integer remainder](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#IntegerRemainder)]
@@ -131,7 +131,7 @@ For the `float` and `double` operands, the result of `x % y` for the finite `x` 
 - The absolute value of `z` is the value produced by `|x| - n * |y|` where `n` is the largest possible integer that is less than or equal to `|x| / |y|` and `|x|` and `|y|` are the absolute values of `x` and `y`, respectively.
 
 > [!NOTE]
-> This method of computing the remainder is analogous to that used for integer operands, but differs from the IEEE 754. If you need the remainder operation that complies with the IEEE 754, use the <xref:System.Math.IEEERemainder%2A?displayProperty=nameWithType> method.
+> This method of computing the remainder is analogous to that used for integer operands, but different from the IEEE 754 specification. If you need the remainder operation that complies with the IEEE 754 specification, use the <xref:System.Math.IEEERemainder%2A?displayProperty=nameWithType> method.
 
 For information about the behavior of the `%` operator with non-finite operands, see the [Remainder operator](~/_csharplang/spec/expressions.md#remainder-operator) section of the [C# language specification](~/_csharplang/spec/introduction.md).
 
@@ -155,7 +155,7 @@ The subtraction operator `-` subtracts its right-hand operand from its left-hand
 
 [!code-csharp-interactive[subtraction operator](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#Subtraction)]
 
-You also can use the `-` operator for delegate removal. For more information, see the [`-` operator](subtraction-operator.md) article.
+You also can use the `-` operator for delegate removal. For more information, see the [`-` and `-=` operators](subtraction-operator.md) article.
 
 ## Compound assignment
 
@@ -181,7 +181,7 @@ Because of [numeric promotions](~/_csharplang/spec/expressions.md#numeric-promot
 
 [!code-csharp-interactive[compound assignment with cast](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#CompoundAssignmentWithCast)]
 
-You also use the `+=` and `-=` operators to subscribe to and unsubscribe from [events](../keywords/event.md). For more information, see [How to: subscribe to and unsubscribe from events](../../programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md).
+You also use the `+=` and `-=` operators to subscribe to and unsubscribe from an [event](../keywords/event.md), respectively. For more information, see [How to: subscribe to and unsubscribe from events](../../programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md).
 
 ## Operator precedence and associativity
 
@@ -198,7 +198,7 @@ Use parentheses, `()`, to change the order of evaluation imposed by operator pre
 
 [!code-csharp-interactive[precedence and associativity](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#PrecedenceAndAssociativity)]
 
-For the complete list of C# operators ordered by precedence level, see [C# operators](index.md).
+For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
 ## Arithmetic overflow and division by zero
 
@@ -229,11 +229,11 @@ For the operands of the `decimal` type, arithmetic overflow always throws an <xr
 
 ## Round-off errors
 
-Because of general limitations of the floating-point representation of real numbers and floating-point arithmetic, the round-off errors might occur in calculations with floating-point types. That is, the produced result of an expression might differ from the expected mathematical result. The following example demonstrates several such cases:
+Because of general limitations of the floating-point representation of real numbers and the floating-point arithmetic, the round-off errors might occur in calculations with floating-point types. That is, the produced result of an expression might differ from the expected mathematical result. The following example demonstrates several such cases:
 
 [!code-csharp-interactive[round-off errors](~/samples/csharp/language-reference/operators/ArithmeticOperators.cs#RoundOffErrors)]
 
-For more information, see remarks at [System.Double](/dotnet/api/system.double#remarks), [System.Single](/dotnet/api/system.single#remarks), or [System.Decimal](/dotnet/api/system.decimal#remarks) reference pages.
+For more information, see remarks at the [System.Double](/dotnet/api/system.double#remarks), [System.Single](/dotnet/api/system.single#remarks), or [System.Decimal](/dotnet/api/system.decimal#remarks) reference pages.
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "= operator - C# reference"
+title: "Assignment operators - C# reference"
 ms.custom: seodec18
 ms.date: 09/10/2019
 f1_keywords: 
@@ -8,11 +8,11 @@ helpviewer_keywords:
   - "= operator [C#]"
 ms.assetid: d802a6d5-32f0-42b8-b180-12f5a081bfc1
 ---
-# = operator (C# reference)
+# Assignment operators (C# reference)
 
 The assignment operator `=` assigns the value of its right-hand operand to a variable, a [property](../../programming-guide/classes-and-structs/properties.md), or an [indexer](../../programming-guide/indexers/index.md) element given by its left-hand operand. The result of an assignment expression is the value assigned to the left-hand operand. The type of the right-hand operand must be the same as the type of the left-hand operand or implicitly convertible to it.
 
-The assignment operator is right-associative, that is, an expression of the form
+The `=` operator is right-associative, that is, an expression of the form
 
 ```csharp
 a = b = c
@@ -34,9 +34,7 @@ Beginning with C# 7.3, you can use the ref assignment operator `= ref` to reassi
 
 [!code-csharp[ref assignment operator](~/samples/csharp/language-reference/operators/AssignmentOperator.cs#RefAssignment)]
 
-In the case of the ref assignment operator, the type of both its operands must be the same.
-
-For more information, see the [feature proposal note](~/_csharplang/proposals/csharp-7.3/ref-local-reassignment.md).
+In the case of the ref assignment operator, the both of its operands must be of the same type.
 
 ## Compound assignment
 
@@ -62,11 +60,15 @@ Beginning with C# 8.0, you can use the null-coalescing assignment operator `??=`
 
 ## Operator overloadability
 
-A user-defined type cannot overload the assignment operator. However, a user-defined type can define an implicit conversion to another type. That way, the value of a user-defined type can be assigned to a variable, a property, or an indexer element of another type. For more information, see [User-defined conversion operators](user-defined-conversion-operators.md).
+A user-defined type cannot [overload](operator-overloading.md) the assignment operator. However, a user-defined type can define an implicit conversion to another type. That way, the value of a user-defined type can be assigned to a variable, a property, or an indexer element of another type. For more information, see [User-defined conversion operators](user-defined-conversion-operators.md).
+
+A user-defined type cannot explicitly overload a compound assignment operator. However, if a user-defined type overloads a binary operator `op`, the `op=` operator, if it exists, is also implicitly overloaded.
 
 ## C# language specification
 
-For more information, see the [Assignment operators](~/_csharplang/spec/expressions.md#assignment-operators) section of the [C# language specification](../language-specification/index.md).
+For more information, see the [Assignment operators](~/_csharplang/spec/expressions.md#assignment-operators) section of the [C# language specification](~/_csharplang/spec/introduction.md).
+
+For more information about the ref assignment operator `= ref`, see the [feature proposal note](~/_csharplang/proposals/csharp-7.3/ref-local-reassignment.md).
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -12,7 +12,7 @@ ms.assetid: d802a6d5-32f0-42b8-b180-12f5a081bfc1
 
 The assignment operator `=` assigns the value of its right-hand operand to a variable, a [property](../../programming-guide/classes-and-structs/properties.md), or an [indexer](../../programming-guide/indexers/index.md) element given by its left-hand operand. The result of an assignment expression is the value assigned to the left-hand operand. The type of the right-hand operand must be the same as the type of the left-hand operand or implicitly convertible to it.
 
-The assignment operator (`=`) is right-associative, that is, an expression of the form
+The assignment operator `=` is right-associative, that is, an expression of the form
 
 ```csharp
 a = b = c

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -12,7 +12,7 @@ ms.assetid: d802a6d5-32f0-42b8-b180-12f5a081bfc1
 
 The assignment operator `=` assigns the value of its right-hand operand to a variable, a [property](../../programming-guide/classes-and-structs/properties.md), or an [indexer](../../programming-guide/indexers/index.md) element given by its left-hand operand. The result of an assignment expression is the value assigned to the left-hand operand. The type of the right-hand operand must be the same as the type of the left-hand operand or implicitly convertible to it.
 
-The `=` operator is right-associative, that is, an expression of the form
+The assignment operator (`=`) is right-associative, that is, an expression of the form
 
 ```csharp
 a = b = c

--- a/docs/csharp/language-reference/operators/await.md
+++ b/docs/csharp/language-reference/operators/await.md
@@ -11,7 +11,7 @@ ms.assetid: 50725c24-ac76-4ca7-bca1-dd57642ffedb
 ---
 # await operator (C# reference)
 
-The `await` operator suspends evaluation of the enclosing [async](../keywords/async.md) method until the asynchronous operation represented by its operand completes. When the asynchronous operation completes, the `await` operator returns the result of the operation, if any. When the `await` operator is applied to the operand that represents already completed operation, it returns the result of the operation immediately without suspension of the enclosing method. The `await` operator doesn't block the thread that evaluates the async method. When the `await` operator suspends the enclosing method, the control returns to the caller of the method.
+The `await` operator suspends evaluation of the enclosing [async](../keywords/async.md) method until the asynchronous operation represented by its operand completes. When the asynchronous operation completes, the `await` operator returns the result of the operation, if any. When the `await` operator is applied to the operand that represents already completed operation, it returns the result of the operation immediately without suspension of the enclosing method. The `await` operator doesn't block the thread that evaluates the async method. When the `await` operator suspends the enclosing async method, the control returns to the caller of the method.
 
 In the following example, the <xref:System.Net.Http.HttpClient.GetByteArrayAsync%2A?displayProperty=nameWithType> method returns the `Task<byte[]>` instance, which represents an asynchronous operation that produces a byte array when it completes. Until the operation completes, the `await` operator suspends the `DownloadDocsMainPageAsync` method. When `DownloadDocsMainPageAsync` gets suspended, control is returned to the `Main` method, which is the caller of `DownloadDocsMainPageAsync`. The `Main` method executes until it needs the result of the asynchronous operation performed by the `DownloadDocsMainPageAsync` method. When <xref:System.Net.Http.HttpClient.GetByteArrayAsync%2A> gets all the bytes, the rest of the `DownloadDocsMainPageAsync` method is evaluated. After that, the rest of the `Main` method is evaluated.
 
@@ -23,7 +23,7 @@ The preceding example uses the [async `Main` method](../../programming-guide/mai
 > For an introduction to asynchronous programming, see [Asynchronous programming with async and await](../../programming-guide/concepts/async/index.md). Asynchronous programming with `async` and `await` follows the [task-based asynchronous pattern](../../../standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md).
 
 You can use the `await` operator only in a method, [lambda expression](../../programming-guide/statements-expressions-operators/lambda-expressions.md), or [anonymous method](delegate-operator.md) that is modified by the [async](../keywords/async.md) keyword. Within an async method, you cannot use the `await` operator in the body of a synchronous function, inside the block of a [lock statement](../keywords/lock-statement.md), and in an [unsafe](../keywords/unsafe.md) context.
-  
+
 The operand of the `await` operator is usually of one of the following .NET types: <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task%601>, <xref:System.Threading.Tasks.ValueTask>, or <xref:System.Threading.Tasks.ValueTask%601>. However, any awaitable expression can be the operand of the `await` operator. For more information, see the [Awaitable expressions](~/_csharplang/spec/expressions.md#awaitable-expressions) section of the [C# language specification](~/_csharplang/spec/introduction.md).
 
 The type of expression `await t` is `TResult` if the type of expression `t` is <xref:System.Threading.Tasks.Task%601> or <xref:System.Threading.Tasks.ValueTask%601>. If the type of `t` is <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.ValueTask>, the type of `await t` is `void`. In both cases, if `t` throws an exception, `await t` rethrows the exception. For more information about exception handling, see the [Exceptions in async methods](../keywords/try-catch.md#exceptions-in-async-methods) section of the [try-catch statement](../keywords/try-catch.md) article.
@@ -32,7 +32,7 @@ The `async` and `await` keywords are available starting with C# 5.
 
 ## await operator in the Main method
 
-Starting with C# 7.1, the [`Main` method](../../programming-guide/main-and-command-args/index.md), which is the application entry point, can return `Task` or `Task<int>`, enabling it to be async so you can use the `await` operator in its body. In earlier C# versions, to ensure that the `Main` method waits for the completion of an asynchronous operation, you can retrieve the value of the <xref:System.Threading.Tasks.Task%601.Result?displayProperty=nameWithType> property of the <xref:System.Threading.Tasks.Task%601> instance that is returned by the corresponding async method. For asynchronous operations that don't produce a value, you can call the <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> method. For information about how to select the language version, see [Select the C# language version](../configure-language-version.md).
+Starting with C# 7.1, the [`Main` method](../../programming-guide/main-and-command-args/index.md), which is the application entry point, can return `Task` or `Task<int>`, enabling it to be async so you can use the `await` operator in its body. In earlier C# versions, to ensure that the `Main` method waits for the completion of an asynchronous operation, you can retrieve the value of the <xref:System.Threading.Tasks.Task%601.Result?displayProperty=nameWithType> property of the <xref:System.Threading.Tasks.Task%601> instance that is returned by the corresponding async method. For asynchronous operations that don't produce a value, you can call the <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> method. For information about how to select the language version, see [C# language versioning](../configure-language-version.md).
 
 ## C# language specification
 
@@ -43,9 +43,7 @@ For more information, see the [Await expressions](~/_csharplang/spec/expressions
 - [C# reference](../index.md)
 - [C# operators](index.md)
 - [async](../keywords/async.md)
-- [Asynchronous programming with async and await](../../programming-guide/concepts/async/index.md)
 - [Task asynchronous programming model](../../programming-guide/concepts/async/task-asynchronous-programming-model.md)
 - [Asynchronous programming](../../async.md)
-- [Task-based asynchronous pattern](../../../standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md)
 - [Async in depth](../../../standard/async-in-depth.md)
 - [Walkthrough: accessing the Web by using async and await](../../programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md)

--- a/docs/csharp/language-reference/operators/await.md
+++ b/docs/csharp/language-reference/operators/await.md
@@ -17,7 +17,7 @@ In the following example, the <xref:System.Net.Http.HttpClient.GetByteArrayAsync
 
 [!code-csharp[await example](~/samples/csharp/language-reference/operators/AwaitOperator.cs)]
 
-The preceding example uses the [async `Main` method](../../programming-guide/main-and-command-args/index.md), which is possible starting with C# 7.1. For more information, see the [await operator in the Main method](#await-operator-in-the-main-method) section.
+The preceding example uses the [async `Main` method](../../programming-guide/main-and-command-args/index.md), which is possible beginning with C# 7.1. For more information, see the [await operator in the Main method](#await-operator-in-the-main-method) section.
 
 > [!NOTE]
 > For an introduction to asynchronous programming, see [Asynchronous programming with async and await](../../programming-guide/concepts/async/index.md). Asynchronous programming with `async` and `await` follows the [task-based asynchronous pattern](../../../standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md).
@@ -28,11 +28,11 @@ The operand of the `await` operator is usually of one of the following .NET type
 
 The type of expression `await t` is `TResult` if the type of expression `t` is <xref:System.Threading.Tasks.Task%601> or <xref:System.Threading.Tasks.ValueTask%601>. If the type of `t` is <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.ValueTask>, the type of `await t` is `void`. In both cases, if `t` throws an exception, `await t` rethrows the exception. For more information about exception handling, see the [Exceptions in async methods](../keywords/try-catch.md#exceptions-in-async-methods) section of the [try-catch statement](../keywords/try-catch.md) article.
 
-The `async` and `await` keywords are available starting with C# 5.
+The `async` and `await` keywords are available in C# 5 and later.
 
 ## await operator in the Main method
 
-Starting with C# 7.1, the [`Main` method](../../programming-guide/main-and-command-args/index.md), which is the application entry point, can return `Task` or `Task<int>`, enabling it to be async so you can use the `await` operator in its body. In earlier C# versions, to ensure that the `Main` method waits for the completion of an asynchronous operation, you can retrieve the value of the <xref:System.Threading.Tasks.Task%601.Result?displayProperty=nameWithType> property of the <xref:System.Threading.Tasks.Task%601> instance that is returned by the corresponding async method. For asynchronous operations that don't produce a value, you can call the <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> method. For information about how to select the language version, see [C# language versioning](../configure-language-version.md).
+Beginning with C# 7.1, the [`Main` method](../../programming-guide/main-and-command-args/index.md), which is the application entry point, can return `Task` or `Task<int>`, enabling it to be async so you can use the `await` operator in its body. In earlier C# versions, to ensure that the `Main` method waits for the completion of an asynchronous operation, you can retrieve the value of the <xref:System.Threading.Tasks.Task%601.Result?displayProperty=nameWithType> property of the <xref:System.Threading.Tasks.Task%601> instance that is returned by the corresponding async method. For asynchronous operations that don't produce a value, you can call the <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> method. For information about how to select the language version, see [C# language versioning](../configure-language-version.md).
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -32,7 +32,7 @@ helpviewer_keywords:
 ---
 # Bitwise and shift operators (C# reference)
 
-The following operators perform bitwise or shift operations with operands of the [integral types](../builtin-types/integral-numeric-types.md):
+The following operators perform bitwise or shift operations with the operands of [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../keywords/char.md) type:
 
 - Unary [`~` (bitwise complement)](#bitwise-complement-operator-) operator
 - Binary [`<<` (left shift)](#left-shift-operator-) and [`>>` (right shift)](#right-shift-operator-) shift operators
@@ -76,11 +76,11 @@ The right-shift operation discards the low-order bits, as the following example 
 
 The high-order empty bit positions are set based on the type of the left-hand operand as follows:
 
-- If the left-hand operand is of type [int](../builtin-types/integral-numeric-types.md) or [long](../builtin-types/integral-numeric-types.md), the right-shift operator performs an *arithmetic* shift: the value of the most significant bit (the sign bit) of the left-hand operand is propagated to the high-order empty bit positions. That is, the high-order empty bit positions are set to zero if the left-hand operand is non-negative and set to one if it's negative.
+- If the left-hand operand is of type `int` or `long`, the right-shift operator performs an *arithmetic* shift: the value of the most significant bit (the sign bit) of the left-hand operand is propagated to the high-order empty bit positions. That is, the high-order empty bit positions are set to zero if the left-hand operand is non-negative and set to one if it's negative.
 
   [!code-csharp-interactive[arithmetic right shift](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#ArithmeticRightShift)]
 
-- If the left-hand operand is of type [uint](../builtin-types/integral-numeric-types.md) or [ulong](../builtin-types/integral-numeric-types.md), the right-shift operator performs a *logical* shift: the high-order empty bit positions are always set to zero.
+- If the left-hand operand is of type `uint` or `ulong`, the right-shift operator performs a *logical* shift: the high-order empty bit positions are always set to zero.
 
   [!code-csharp-interactive[logical right shift](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#LogicalRightShift)]
 
@@ -92,7 +92,7 @@ The `&` operator computes the bitwise logical AND of its operands:
 
 [!code-csharp-interactive[bitwise AND](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#BitwiseAnd)]
 
-For the operands of the `bool` type, the `&` operator computes the [logical AND](boolean-logical-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
+For the `bool` operands, the `&` operator computes the [logical AND](boolean-logical-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
 ## Logical exclusive OR operator ^
 
@@ -100,7 +100,7 @@ The `^` operator computes the bitwise logical exclusive OR, also known as the bi
 
 [!code-csharp-interactive[bitwise XOR](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#BitwiseXor)]
 
-For the operands of the `bool` type, the `^` operator computes the [logical exclusive OR](boolean-logical-operators.md#logical-exclusive-or-operator-) of its operands.
+For the `bool` operands, the `^` operator computes the [logical exclusive OR](boolean-logical-operators.md#logical-exclusive-or-operator-) of its operands.
 
 ## Logical OR operator |
 
@@ -108,7 +108,7 @@ The `|` operator computes the bitwise logical OR of its operands:
 
 [!code-csharp-interactive[bitwise OR](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#BitwiseOr)]
 
-For the operands of the `bool` type, the `|` operator computes the [logical OR](boolean-logical-operators.md#logical-or-operator-) of its operands.
+For the `bool` operands, the `|` operator computes the [logical OR](boolean-logical-operators.md#logical-or-operator-) of its operands.
 
 ## Compound assignment
 
@@ -148,17 +148,17 @@ Use parentheses, `()`, to change the order of evaluation imposed by operator pre
 
 [!code-csharp-interactive[operator precedence](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#Precedence)]
 
-For the complete list of C# operators ordered by precedence level, see [C# operators](index.md).
+For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
 ## Shift count of the shift operators
 
-For the shift operators `<<` and `>>`, the type of the right-hand operand must be [int](../builtin-types/integral-numeric-types.md) or a type that has a [predefined implicit numeric conversion](../builtin-types/numeric-conversions.md#implicit-numeric-conversions) to `int`.
+For the shift operators `<<` and `>>`, the type of the right-hand operand must be `int` or a type that has a [predefined implicit numeric conversion](../builtin-types/numeric-conversions.md#implicit-numeric-conversions) to `int`.
 
 For the `x << count` and `x >> count` expressions, the actual shift count depends on the type of `x` as follows:
 
-- If the type of `x` is [int](../builtin-types/integral-numeric-types.md) or [uint](../builtin-types/integral-numeric-types.md), the shift count is defined by the low-order *five* bits of the right-hand operand. That is, the shift count is computed from `count & 0x1F` (or `count & 0b_1_1111`).
+- If the type of `x` is `int` or `uint`, the shift count is defined by the low-order *five* bits of the right-hand operand. That is, the shift count is computed from `count & 0x1F` (or `count & 0b_1_1111`).
 
-- If the type of `x` is [long](../builtin-types/integral-numeric-types.md) or [ulong](../builtin-types/integral-numeric-types.md), the shift count is defined by the low-order *six* bits of the right-hand operand. That is, the shift count is computed from `count & 0x3F` (or `count & 0b_11_1111`).
+- If the type of `x` is `long` or `ulong`, the shift count is defined by the low-order *six* bits of the right-hand operand. That is, the shift count is computed from `count & 0x3F` (or `count & 0b_11_1111`).
 
 The following example demonstrates that behavior:
 
@@ -166,7 +166,7 @@ The following example demonstrates that behavior:
 
 ## Enumeration logical operators
 
-The `~`, `&`, `|`, and `^` operators are also defined for any [enumeration](../keywords/enum.md) type. For the operands of the same enumeration type, a logical operation is performed on the corresponding values of the underlying integral type. For example, for any `x` and `y` of an enumeration type `T` with an underlying type `U`, the `x & y` expression produces the same result as the `(T)((U)x & (U)y)` expression.
+The `~`, `&`, `|`, and `^` operators are also supported by any [enumeration](../keywords/enum.md) type. For the operands of the same enumeration type, a logical operation is performed on the corresponding values of the underlying integral type. For example, for any `x` and `y` of an enumeration type `T` with an underlying type `U`, the `x & y` expression produces the same result as the `(T)((U)x & (U)y)` expression.
 
 You typically use bitwise logical operators with an enumeration type which is defined with the [Flags](xref:System.FlagsAttribute) attribute. For more information, see the [Enumeration types as bit flags](../../programming-guide/enumeration-types.md#enumeration-types-as-bit-flags) section of the [Enumeration types](../../programming-guide/enumeration-types.md) article.
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -32,7 +32,7 @@ helpviewer_keywords:
 ---
 # Bitwise and shift operators (C# reference)
 
-The following operators perform bitwise or shift operations with the operands of [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../keywords/char.md) type:
+The following operators perform bitwise or shift operations with operands of the [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../keywords/char.md) type:
 
 - Unary [`~` (bitwise complement)](#bitwise-complement-operator-) operator
 - Binary [`<<` (left shift)](#left-shift-operator-) and [`>>` (right shift)](#right-shift-operator-) shift operators
@@ -92,7 +92,7 @@ The `&` operator computes the bitwise logical AND of its operands:
 
 [!code-csharp-interactive[bitwise AND](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#BitwiseAnd)]
 
-For the `bool` operands, the `&` operator computes the [logical AND](boolean-logical-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
+For `bool` operands, the `&` operator computes the [logical AND](boolean-logical-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
 ## Logical exclusive OR operator ^
 
@@ -100,7 +100,7 @@ The `^` operator computes the bitwise logical exclusive OR, also known as the bi
 
 [!code-csharp-interactive[bitwise XOR](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#BitwiseXor)]
 
-For the `bool` operands, the `^` operator computes the [logical exclusive OR](boolean-logical-operators.md#logical-exclusive-or-operator-) of its operands.
+For `bool` operands, the `^` operator computes the [logical exclusive OR](boolean-logical-operators.md#logical-exclusive-or-operator-) of its operands.
 
 ## Logical OR operator |
 
@@ -108,7 +108,7 @@ The `|` operator computes the bitwise logical OR of its operands:
 
 [!code-csharp-interactive[bitwise OR](~/samples/csharp/language-reference/operators/BitwiseAndShiftOperators.cs#BitwiseOr)]
 
-For the `bool` operands, the `|` operator computes the [logical OR](boolean-logical-operators.md#logical-or-operator-) of its operands.
+For `bool` operands, the `|` operator computes the [logical OR](boolean-logical-operators.md#logical-or-operator-) of its operands.
 
 ## Compound assignment
 
@@ -166,7 +166,7 @@ The following example demonstrates that behavior:
 
 ## Enumeration logical operators
 
-The `~`, `&`, `|`, and `^` operators are also supported by any [enumeration](../keywords/enum.md) type. For the operands of the same enumeration type, a logical operation is performed on the corresponding values of the underlying integral type. For example, for any `x` and `y` of an enumeration type `T` with an underlying type `U`, the `x & y` expression produces the same result as the `(T)((U)x & (U)y)` expression.
+The `~`, `&`, `|`, and `^` operators are also supported by any [enumeration](../keywords/enum.md) type. For operands of the same enumeration type, a logical operation is performed on the corresponding values of the underlying integral type. For example, for any `x` and `y` of an enumeration type `T` with an underlying type `U`, the `x & y` expression produces the same result as the `(T)((U)x & (U)y)` expression.
 
 You typically use bitwise logical operators with an enumeration type which is defined with the [Flags](xref:System.FlagsAttribute) attribute. For more information, see the [Enumeration types as bit flags](../../programming-guide/enumeration-types.md#enumeration-types-as-bit-flags) section of the [Enumeration types](../../programming-guide/enumeration-types.md) article.
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -40,7 +40,7 @@ The following operators perform bitwise or shift operations with operands of the
 
 Those operators are defined for the `int`, `uint`, `long`, and `ulong` types. When both operands are of other integral types (`sbyte`, `byte`, `short`, `ushort`, or `char`), their values are converted to the `int` type, which is also the result type of an operation. When operands are of different integral types, their values are converted to the closest containing integral type. For more information, see the [Numeric promotions](~/_csharplang/spec/expressions.md#numeric-promotions) section of the [C# language specification](~/_csharplang/spec/introduction.md).
 
-The `&`, `|`, and `^` operators are also defined for the operands of the `bool` type. For more information, see [Boolean logical operators](boolean-logical-operators.md).
+The `&`, `|`, and `^` operators are also defined for operands of the `bool` type. For more information, see [Boolean logical operators](boolean-logical-operators.md).
 
 Bitwise and shift operations never cause overflow and produce the same results in [checked and unchecked](../keywords/checked-and-unchecked.md) contexts.
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -35,13 +35,13 @@ helpviewer_keywords:
 ---
 # Boolean logical operators (C# reference)
 
-The following operators perform logical operations with the [bool](../keywords/bool.md) operands:
+The following operators perform logical operations with [bool](../keywords/bool.md) operands:
 
 - Unary [`!` (logical negation)](#logical-negation-operator-) operator.
 - Binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators. Those operators always evaluate both operands.
 - Binary [`&&` (conditional logical AND)](#conditional-logical-and-operator-) and [`||` (conditional logical OR)](#conditional-logical-or-operator-) operators. Those operators evaluate the right-hand operand only if it's necessary.
 
-For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `&`, `|`, and `^` operators perform bitwise logical operations. For more information, see [Bitwise and shift operators](bitwise-and-shift-operators.md).
+For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `&`, `|`, and `^` operators perform bitwise logical operations. For more information, see [Bitwise and shift operators](bitwise-and-shift-operators.md).
 
 ## Logical negation operator !
 
@@ -49,7 +49,7 @@ The unary prefix `!` operator computes logical negation of its operand. That is,
 
 [!code-csharp-interactive[logical negation](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#Negation)]
 
-Starting with C# 8.0, the unary postfix `!` operator is the [null-forgiving operator](null-forgiving.md).
+Beginning with C# 8.0, the unary postfix `!` operator is the [null-forgiving operator](null-forgiving.md).
 
 ## <a name="logical-and-operator-"></a> Logical AND operator &amp;
 
@@ -63,7 +63,7 @@ In the following example, the right-hand operand of the `&` operator is a method
 
 The [conditional logical AND operator](#conditional-logical-and-operator-) `&&` also computes the logical AND of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `false`.
 
-For operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `&` operator computes the [bitwise logical AND](bitwise-and-shift-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
+For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `&` operator computes the [bitwise logical AND](bitwise-and-shift-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
 ## Logical exclusive OR operator ^
 
@@ -71,7 +71,7 @@ The `^` operator computes the logical exclusive OR, also known as the logical XO
 
 [!code-csharp-interactive[logical exclusive OR](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#Xor)]
 
-For operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
+For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
 
 ## Logical OR operator |
 
@@ -85,7 +85,7 @@ In the following example, the right-hand operand of the `|` operator is a method
 
 The [conditional logical OR operator](#conditional-logical-or-operator-) `||` also computes the logical OR of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `true`.
 
-For operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `|` operator computes the [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) of its operands.
+For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `|` operator computes the [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) of its operands.
 
 ## <a name="conditional-logical-and-operator-"></a> Conditional logical AND operator &amp;&amp;
 
@@ -109,7 +109,7 @@ The [logical OR operator](#logical-or-operator-) `|` also computes the logical O
 
 ## Nullable Boolean logical operators
 
-For the `bool?` operands, the `&` and `|` operators support the three-valued logic. The semantics of these operators is defined by the following table:  
+For `bool?` operands, the `&` and `|` operators support the three-valued logic. The semantics of these operators is defined by the following table:  
   
 |x|y|x&y|x&#124;y|  
 |----|----|----|----|  
@@ -125,11 +125,11 @@ For the `bool?` operands, the `&` and `|` operators support the three-valued log
 
 The behavior of those operators differs from the typical operator behavior with nullable value types. Typically, an operator which is defined for operands of a value type can be also used with operands of the corresponding nullable value type. Such an operator produces `null` if any of its operands evaluates to `null`. However, the `&` and `|` operators can produce non-null even if one of the operands evaluates to `null`. For more information about the operator behavior with nullable value types, see the [Operators](../../programming-guide/nullable-types/using-nullable-types.md#operators) section of the [Using nullable value types](../../programming-guide/nullable-types/using-nullable-types.md) article.
 
-You can also use the `!` and `^` operators with the `bool?` operands, as the following example shows:
+You can also use the `!` and `^` operators with `bool?` operands, as the following example shows:
 
 [!code-csharp-interactive[lifted negation and xor](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#WithNullableBoolean)]
 
-The conditional logical operators `&&` and `||` don't support the `bool?` operands.
+The conditional logical operators `&&` and `||` don't support `bool?` operands.
 
 ## Compound assignment
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -63,7 +63,7 @@ In the following example, the right-hand operand of the `&` operator is a method
 
 The [conditional logical AND operator](#conditional-logical-and-operator-) `&&` also computes the logical AND of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `false`.
 
-For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `&` operator computes the [bitwise logical AND](bitwise-and-shift-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
+For operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `&` operator computes the [bitwise logical AND](bitwise-and-shift-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
 ## Logical exclusive OR operator ^
 
@@ -71,7 +71,7 @@ The `^` operator computes the logical exclusive OR, also known as the logical XO
 
 [!code-csharp-interactive[logical exclusive OR](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#Xor)]
 
-For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
+For operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
 
 ## Logical OR operator |
 
@@ -85,7 +85,7 @@ In the following example, the right-hand operand of the `|` operator is a method
 
 The [conditional logical OR operator](#conditional-logical-or-operator-) `||` also computes the logical OR of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `true`.
 
-For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `|` operator computes the [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) of its operands.
+For operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `|` operator computes the [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) of its operands.
 
 ## <a name="conditional-logical-and-operator-"></a> Conditional logical AND operator &amp;&amp;
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -41,7 +41,7 @@ The following operators perform logical operations with the [bool](../keywords/b
 - Binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators. Those operators always evaluate both operands.
 - Binary [`&&` (conditional logical AND)](#conditional-logical-and-operator-) and [`||` (conditional logical OR)](#conditional-logical-or-operator-) operators. Those operators evaluate the right-hand operand only if it's necessary.
 
-For the operands of the [integral](../builtin-types/integral-numeric-types.md) types, the `&`, `|`, and `^` operators perform bitwise logical operations. For more information, see [Bitwise and shift operators](bitwise-and-shift-operators.md).
+For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `&`, `|`, and `^` operators perform bitwise logical operations. For more information, see [Bitwise and shift operators](bitwise-and-shift-operators.md).
 
 ## Logical negation operator !
 
@@ -55,7 +55,7 @@ Starting with C# 8.0, the unary postfix `!` operator is the [null-forgiving oper
 
 The `&` operator computes the logical AND of its operands. The result of `x & y` is `true` if both `x` and `y` evaluate to `true`. Otherwise, the result is `false`.
 
-The `&` operator evaluates both operands even if the left-hand operand evaluates to `false`, so that the result must be `false` regardless of the value of the right-hand operand.
+The `&` operator evaluates both operands even if the left-hand operand evaluates to `false`, so that the operation result is `false` regardless of the value of the right-hand operand.
 
 In the following example, the right-hand operand of the `&` operator is a method call, which is performed regardless of the value of the left-hand operand:
 
@@ -63,7 +63,7 @@ In the following example, the right-hand operand of the `&` operator is a method
 
 The [conditional logical AND operator](#conditional-logical-and-operator-) `&&` also computes the logical AND of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `false`.
 
-For the operands of the integral types, the `&` operator computes the [bitwise logical AND](bitwise-and-shift-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
+For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `&` operator computes the [bitwise logical AND](bitwise-and-shift-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
 ## Logical exclusive OR operator ^
 
@@ -71,13 +71,13 @@ The `^` operator computes the logical exclusive OR, also known as the logical XO
 
 [!code-csharp-interactive[logical exclusive OR](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#Xor)]
 
-For the operands of the integral types, the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
+For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
 
 ## Logical OR operator |
 
 The `|` operator computes the logical OR of its operands. The result of `x | y` is `true` if either `x` or `y` evaluates to `true`. Otherwise, the result is `false`.
 
-The `|` operator evaluates both operands even if the left-hand operand evaluates to `true`, so that the result must be `true` regardless of the value of the right-hand operand.
+The `|` operator evaluates both operands even if the left-hand operand evaluates to `true`, so that the operation result is `true` regardless of the value of the right-hand operand.
 
 In the following example, the right-hand operand of the `|` operator is a method call, which is performed regardless of the value of the left-hand operand:
 
@@ -85,7 +85,7 @@ In the following example, the right-hand operand of the `|` operator is a method
 
 The [conditional logical OR operator](#conditional-logical-or-operator-) `||` also computes the logical OR of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `true`.
 
-For the operands of the integral types, the `|` operator computes the [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) of its operands.
+For the operands of [integral numeric types](../builtin-types/integral-numeric-types.md), the `|` operator computes the [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) of its operands.
 
 ## <a name="conditional-logical-and-operator-"></a> Conditional logical AND operator &amp;&amp;
 
@@ -123,7 +123,7 @@ For the `bool?` operands, the `&` and `|` operators support the three-valued log
 |null|false|false|null|  
 |null|null|null|null|  
 
-The behavior of those operators differs from the typical operator behavior with nullable value types. Typically, an operator which is defined for operands of a value type can be also used with operands of the corresponding nullable value type. Such an operator produces `null` if any of its operands is `null`. However, the `&` and `|` operators can produce non-null even if one of the operands is `null`. For more information about the operator behavior with nullable value types, see the [Operators](../../programming-guide/nullable-types/using-nullable-types.md#operators) section of the [Using nullable value types](../../programming-guide/nullable-types/using-nullable-types.md) article.
+The behavior of those operators differs from the typical operator behavior with nullable value types. Typically, an operator which is defined for operands of a value type can be also used with operands of the corresponding nullable value type. Such an operator produces `null` if any of its operands evaluates to `null`. However, the `&` and `|` operators can produce non-null even if one of the operands evaluates to `null`. For more information about the operator behavior with nullable value types, see the [Operators](../../programming-guide/nullable-types/using-nullable-types.md#operators) section of the [Using nullable value types](../../programming-guide/nullable-types/using-nullable-types.md) article.
 
 You can also use the `!` and `^` operators with the `bool?` operands, as the following example shows:
 
@@ -168,7 +168,7 @@ Use parentheses, `()`, to change the order of evaluation imposed by operator pre
 
 [!code-csharp-interactive[operator precedence](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#Precedence)]
 
-For the complete list of C# operators ordered by precedence level, see [C# operators](index.md).
+For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/comparison-operators.md
+++ b/docs/csharp/language-reference/operators/comparison-operators.md
@@ -27,7 +27,7 @@ The [`<` (less than)](#less-than-operator-), [`>` (greater than)](#greater-than-
 > [!NOTE]
 > For the `==`, `<`, `>`, `<=`, and `>=` operators, if any of the operands is not a number (<xref:System.Double.NaN?displayProperty=nameWithType> or <xref:System.Single.NaN?displayProperty=nameWithType>), the result of operation is `false`. That means that the `NaN` value is neither greater than, less than, nor equal to any other `double` (or `float`) value, including `NaN`. For more information and examples, see the <xref:System.Double.NaN?displayProperty=nameWithType> or <xref:System.Single.NaN?displayProperty=nameWithType> reference article.
 
-Enumeration types also support comparison operators. For the operands of the same [enum](../keywords/enum.md) type, the corresponding values of the underlying integral type are compared.
+Enumeration types also support comparison operators. For operands of the same [enum](../keywords/enum.md) type, the corresponding values of the underlying integral type are compared.
 
 The [`==` and `!=` operators](equality-operators.md) check if their operands are equal or not.
 

--- a/docs/csharp/language-reference/operators/comparison-operators.md
+++ b/docs/csharp/language-reference/operators/comparison-operators.md
@@ -22,12 +22,12 @@ helpviewer_keywords:
 ---
 # Comparison operators (C# reference)
 
-The [`<` (less than)](#less-than-operator-), [`>` (greater than)](#greater-than-operator-), [`<=` (less than or equal)](#less-than-or-equal-operator-), and [`>=` (greater than or equal)](#greater-than-or-equal-operator-) comparison, also known as relational, operators compare their operands. Those operators support all [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types.
+The [`<` (less than)](#less-than-operator-), [`>` (greater than)](#greater-than-operator-), [`<=` (less than or equal)](#less-than-or-equal-operator-), and [`>=` (greater than or equal)](#greater-than-or-equal-operator-) comparison, also known as relational, operators compare their operands. Those operators are supported by all [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types.
 
 > [!NOTE]
 > For the `==`, `<`, `>`, `<=`, and `>=` operators, if any of the operands is not a number (<xref:System.Double.NaN?displayProperty=nameWithType> or <xref:System.Single.NaN?displayProperty=nameWithType>), the result of operation is `false`. That means that the `NaN` value is neither greater than, less than, nor equal to any other `double` (or `float`) value, including `NaN`. For more information and examples, see the <xref:System.Double.NaN?displayProperty=nameWithType> or <xref:System.Single.NaN?displayProperty=nameWithType> reference article.
 
-Enumeration types also support comparison operators. For operands of the same [enum](../keywords/enum.md) type, the corresponding values of the underlying integral type are compared.
+Enumeration types also support comparison operators. For the operands of the same [enum](../keywords/enum.md) type, the corresponding values of the underlying integral type are compared.
 
 The [`==` and `!=` operators](equality-operators.md) check if their operands are equal or not.
 

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -13,7 +13,7 @@ ms.assetid: e83a17f1-7500-48ba-8bee-2fbc4c847af4
 ---
 # ?: operator (C# reference)
 
-The conditional operator `?:`, commonly known as the ternary conditional operator, evaluates a Boolean expression, and returns the result of evaluating one of two expressions, depending on whether the Boolean expression evaluates to `true` or `false`. Beginning with C# 7.2, the [conditional ref expression](#conditional-ref-expression) returns the reference to the result of one of the two expressions.
+The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`. Beginning with C# 7.2, the [conditional ref expression](#conditional-ref-expression) returns the reference to the result of one of the two expressions.
 
 The syntax for the conditional operator is as follows:
 
@@ -23,7 +23,7 @@ condition ? consequent : alternative
 
 The `condition` expression must evaluate to `true` or `false`. If `condition` evaluates to `true`, the `consequent` expression is evaluated, and its result becomes the result of the operation. If `condition` evaluates to `false`, the `alternative` expression is evaluated, and its result becomes the result of the operation. Only `consequent` or `alternative` is evaluated.
 
-The type of `consequent` and `alternative` must be the same, or there must be an implicit conversion from one type to the other.
+The type of `consequent` and `alternative` must be the same, or there must be an implicit conversion from one type to another.
 
 The conditional operator is right-associative, that is, an expression of the form
 
@@ -66,21 +66,21 @@ The following example demonstrates the usage of the conditional ref expression:
 
 [!code-csharp-interactive[conditional ref](~/samples/csharp/language-reference/operators/ConditionalOperator.cs#ConditionalRef)]
 
-For more information, see the [feature proposal note](~/_csharplang/proposals/csharp-7.2/conditional-ref.md).
-
 ## Conditional operator and an `if..else` statement
 
-Use of the conditional operator over an [if-else](../keywords/if-else.md) statement might result in more concise code in cases when you need conditionally to compute a value. The following example demonstrates two ways to classify an integer as negative or nonnegative:
+Use of the conditional operator instead of an [if-else](../keywords/if-else.md) statement might result in more concise code in cases when you need conditionally to compute a value. The following example demonstrates two ways to classify an integer as negative or nonnegative:
 
 [!code-csharp[conditional and if-else](~/samples/csharp/language-reference/operators/ConditionalOperator.cs#CompareWithIf)]
 
 ## Operator overloadability
 
-The conditional operator cannot be overloaded.
+A user-defined type cannot overload the conditional operator.
 
 ## C# language specification
 
 For more information, see the [Conditional operator](~/_csharplang/spec/expressions.md#conditional-operator) section of the [C# language specification](~/_csharplang/spec/introduction.md).
+
+For more information about the conditional ref expression, see the [feature proposal note](~/_csharplang/proposals/csharp-7.2/conditional-ref.md).
 
 ## See also
 
@@ -88,5 +88,5 @@ For more information, see the [Conditional operator](~/_csharplang/spec/expressi
 - [C# operators](index.md)
 - [if-else statement](../keywords/if-else.md)
 - [?. and ?[] operators](member-access-operators.md#null-conditional-operators--and-)
-- [?? operator](null-coalescing-operator.md)
+- [?? and ??= operators](null-coalescing-operator.md)
 - [ref keyword](../keywords/ref.md)

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -23,7 +23,7 @@ condition ? consequent : alternative
 
 The `condition` expression must evaluate to `true` or `false`. If `condition` evaluates to `true`, the `consequent` expression is evaluated, and its result becomes the result of the operation. If `condition` evaluates to `false`, the `alternative` expression is evaluated, and its result becomes the result of the operation. Only `consequent` or `alternative` is evaluated.
 
-The type of `consequent` and `alternative` must be the same, or there must be an implicit conversion from one type to another.
+The type of `consequent` and `alternative` must be the same, or there must be an implicit conversion from one type to the other.
 
 The conditional operator is right-associative, that is, an expression of the form
 

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -1,7 +1,7 @@
 ---
 title: "default operator - C# reference"
 ms.custom: seodec18
-description: "Use default operator to produce the default value of a type"
+description: "Use the default operator to produce the default value of a type"
 ms.date: 08/01/2019
 helpviewer_keywords: 
   - "default keyword [C#]"
@@ -14,16 +14,16 @@ The following example shows the usage of the `default` operator:
 
 [!code-csharp-interactive[default of T](~/samples/csharp/language-reference/operators/DefaultOperator.cs#WithOperand)]
 
-You also use the `default` keyword as the default case label within the [`switch` statement](../keywords/switch.md).
+You also use the `default` keyword as the default case label within a [`switch` statement](../keywords/switch.md).
 
 ## default literal
 
 Beginning with C# 7.1, you can use the `default` literal to produce the default value of a type when the compiler can infer the expression type. The `default` literal expression produces the same value as the `default(T)` expression where `T` is the inferred type. You can use the `default` literal in any of the following cases:
 
 - In the assignment or initialization of a variable.
-- In the declaration of the default value for an optional method parameter.
+- In the declaration of the default value for an [optional method parameter](../../methods.md#optional-parameters-and-arguments).
 - In a method call to provide an argument value.
-- In a `return` statement or as an expression in an expression-bodied member.
+- In a [`return` statement](../keywords/return.md) or as an expression in an [expression-bodied member](../../programming-guide/statements-expressions-operators/expression-bodied-members.md).
 
 The following example shows the usage of the `default` literal:
 
@@ -40,3 +40,4 @@ For more information about the `default` literal, see the [feature proposal note
 - [C# reference](../index.md)
 - [C# operators](index.md)
 - [Default values table](../keywords/default-values-table.md)
+- [Generics in .NET](../../../standard/generics/index.md)

--- a/docs/csharp/language-reference/operators/delegate-operator.md
+++ b/docs/csharp/language-reference/operators/delegate-operator.md
@@ -11,15 +11,18 @@ The `delegate` operator creates an anonymous method that can be converted to a d
 
 [!code-csharp-interactive[anonymous method](~/samples/csharp/language-reference/operators/DelegateOperator.cs#AnonymousMethod)]
 
-Beginning with C# 3, [lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md) provide a more concise and expressive way to create an anonymous function. Use the [=> operator](lambda-operator.md) to construct a lambda expression:
-
-[!code-csharp-interactive[lambda expression](~/samples/csharp/language-reference/operators/DelegateOperator.cs#Lambda)]
+> [!NOTE]
+> Beginning with C# 3, lambda expressions provide a more concise and expressive way to create an anonymous function. Use the [=> operator](lambda-operator.md) to construct a lambda expression:
+>
+> [!code-csharp-interactive[lambda expression](~/samples/csharp/language-reference/operators/DelegateOperator.cs#Lambda)]
+>
+> For more information about features of lambda expressions, for example, capturing outer variables, see [Lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md).
 
 When you use the `delegate` operator, you might omit the parameter list. If you do that, the created anonymous method can be converted to a delegate type with any list of  parameters, as the following example shows:
 
 [!code-csharp-interactive[no parameter list](~/samples/csharp/language-reference/operators/DelegateOperator.cs#WithoutParameterList)]
 
-That's the only functionality of anonymous methods that is not supported by lambda expressions. In all other cases, a lambda expression is a preferred way to write inline code. For more information about features of lambda expressions, for example, capturing outer variables, see [Lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md).
+That's the only functionality of anonymous methods that is not supported by lambda expressions. In all other cases, a lambda expression is a preferred way to write inline code.
 
 You also use the `delegate` keyword to declare a [delegate type](../builtin-types/reference-types.md#the-delegate-type).
 
@@ -31,3 +34,4 @@ For more information, see the [Anonymous function expressions](~/_csharplang/spe
 
 - [C# reference](../index.md)
 - [C# operators](index.md)
+- [=> operator](lambda-operator.md)

--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -35,7 +35,7 @@ Operands of the [built-in value types](../keywords/value-types-table.md) are equ
 
 Two operands of the same [enum](../keywords/enum.md) type are equal if the corresponding values of the underlying integral type are equal.
 
-User-defined [struct](../keywords/struct.md) types don't support the `==` operator by default. To support the `==` operator, a user-defined struct must [overload](#operator-overloadability) it.
+User-defined [struct](../keywords/struct.md) types don't support the `==` operator by default. To support the `==` operator, a user-defined struct must [overload](operator-overloading.md) it.
 
 Beginning with C# 7.3, the `==` and `!=` operators are supported by C# [tuples](../../tuples.md). For more information, see the [Equality and tuples](../../tuples.md#equality-and-tuples) section of the [C# tuple types](../../tuples.md) article.
 
@@ -49,7 +49,7 @@ As the example shows, user-defined reference types support the `==` operator by 
 
 ### String equality
 
-Two [string](../keywords/string.md) operands are equal when both of them are `null` or both string instances are of the same length and have identical characters in each character position:
+Two [string](../builtin-types/reference-types.md#the-string-type) operands are equal when both of them are `null` or both string instances are of the same length and have identical characters in each character position:
 
 [!code-csharp-interactive[string equality](~/samples/csharp/language-reference/operators/EqualityOperators.cs#StringEquality)]
 

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -79,7 +79,7 @@ Unrelated to operator precedence and associativity, operands in an expression ar
 |`a / b + c * d`|a, b, /, c, d, *, +|
 |`a / (b + c) * d`|a, b, c, +, /, d, *|
 
-Typically, all operator operands are evaluated. Some operators evaluate operands conditionally. That is, the value of the first operand of such an operator defines if (or which) other operands should be evaluated. These operators are the conditional logical [AND (`&&`)](boolean-logical-operators.md#conditional-logical-and-operator-) and [OR (`||`)](boolean-logical-operators.md#conditional-logical-or-operator-) operators, the [null-coalescing operators `??` and `??=`](null-coalescing-operator.md), the [null-conditional operators `?.` and `?[]`](member-access-operators.md#null-conditional-operators--and-), and the [conditional operator `?:`](conditional-operator.md). See the description of each operator for more details.
+Typically, all operator operands are evaluated. However, some operators evaluate operands conditionally. That is, the value of the leftmost operand of such an operator defines if (or which) other operands should be evaluated. These operators are the conditional logical [AND (`&&`)](boolean-logical-operators.md#conditional-logical-and-operator-) and [OR (`||`)](boolean-logical-operators.md#conditional-logical-or-operator-) operators, the [null-coalescing operators `??` and `??=`](null-coalescing-operator.md), the [null-conditional operators `?.` and `?[]`](member-access-operators.md#null-conditional-operators--and-), and the [conditional operator `?:`](conditional-operator.md). For more information, see the description of each operator.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -11,21 +11,21 @@ helpviewer_keywords:
 ---
 # => operator (C# reference)
 
-The `=>` token is supported in two forms: as the lambda operator and as a separator of a member name and the member implementation in an expression body definition.
+The `=>` token is supported in two forms: as the [lambda operator](#lambda-operator) and as a separator of a member name and the member implementation in an [expression body definition](#expression-body-definition).
 
 ## Lambda operator
 
-In [lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md), the lambda operator `=>` separates the input variables on the left side from the lambda body on the right side.
+In [lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md), the lambda operator `=>` separates the input parameters on the left side from the lambda body on the right side.
 
 The following example uses the [LINQ](../../programming-guide/concepts/linq/index.md) feature with method syntax to demonstrate the usage of lambda expressions:
 
 [!code-csharp-interactive[infer types of input variables](~/samples/csharp/language-reference/operators/LambdaOperator.cs#InferredTypes)]
 
-Input variables of lambda expressions are strongly typed at compile time. When the compiler can infer the types of input variables, like in the preceding example, you may omit type declarations. If you need to specify the type of input variables, you must do that for each variable, as the following example shows:
+Input parameters of a lambda expression are strongly typed at compile time. When the compiler can infer the types of input parameters, like in the preceding example, you may omit type declarations. If you need to specify the type of input parameters, you must do that for each parameter, as the following example shows:
 
 [!code-csharp-interactive[specify types of input variables](~/samples/csharp/language-reference/operators/LambdaOperator.cs#ExplicitTypes)]
 
-The following example shows how to define a lambda expression without input variables:
+The following example shows how to define a lambda expression without input parameters:
 
 [!code-csharp-interactive[without input variables](~/samples/csharp/language-reference/operators/LambdaOperator.cs#WithoutInput)]
 
@@ -39,7 +39,7 @@ An expression body definition has the following general syntax:
 member => expression;
 ```
 
-where `expression` is a valid expression. The return type of `expression` must be implicitly convertible to the member's return type. If the member's return type is `void` or if the member is a constructor, a finalizer, or a property `set` accessor, `expression` must be a [*statement expression*](~/_csharplang/spec/statements.md#expression-statements); it can be of any type then.
+where `expression` is a valid expression. The return type of `expression` must be implicitly convertible to the member's return type. If the member's return type is `void` or if the member is a constructor, a finalizer, or a property `set` accessor, `expression` must be a [*statement expression*](~/_csharplang/spec/statements.md#expression-statements), which can be of any type.
 
 The following example shows an expression body definition for a `Person.ToString` method:
 
@@ -56,7 +56,7 @@ public override string ToString()
 }
 ```
 
-Expression body definitions for methods and read-only properties are supported starting with C# 6. Expression body definitions for constructors, finalizers, property accessors, and indexers are supported starting with C# 7.0.
+Expression body definitions for methods, operators, and read-only properties are supported beginning with C# 6. Expression body definitions for constructors, finalizers, and property and indexer accessors are supported beginning with C# 7.0.
 
 For more information, see [Expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md).
 
@@ -66,11 +66,9 @@ The `=>` operator cannot be overloaded.
 
 ## C# language specification
 
-For more information, see the [Anonymous function expressions](~/_csharplang/spec/expressions.md#anonymous-function-expressions) section of the [C# language specification](../language-specification/index.md).
+For more information about the lambda operator, see the [Anonymous function expressions](~/_csharplang/spec/expressions.md#anonymous-function-expressions) section of the [C# language specification](~/_csharplang/spec/introduction.md).
 
 ## See also
 
 - [C# reference](../index.md)
 - [C# operators](index.md)
-- [Lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md)
-- [Expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -35,7 +35,7 @@ helpviewer_keywords:
 ---
 # Member access operators (C# reference)
 
-You might use the following operators when you access a type member:
+You can use the following operators when you access a type member:
 
 - [`.` (member access)](#member-access-operator-): to access a member of a namespace or a type
 - [`[]` (array element or indexer access)](#indexer-operator-): to access an array element or a type indexer
@@ -82,11 +82,11 @@ For more information about arrays, see [Arrays](../../programming-guide/arrays/i
 
 ### Indexer access
 
-The following example uses .NET <xref:System.Collections.Generic.Dictionary%602> type to demonstrate indexer access:
+The following example uses the .NET <xref:System.Collections.Generic.Dictionary%602> type to demonstrate indexer access:
 
 [!code-csharp-interactive[indexer access](~/samples/csharp/language-reference/operators/MemberAccessOperators.cs#Indexers)]
 
-Indexers allow you to index instances of a user-defined type in the similar way as array indexing. Unlike array indices, which must be integer, the indexer arguments can be declared to be of any type.
+Indexers allow you to index instances of a user-defined type in the similar way as array indexing. Unlike array indices, which must be integer, the indexer parameters can be declared to be of any type.
 
 For more information about indexers, see [Indexers](../../programming-guide/indexers/index.md).
 
@@ -116,7 +116,7 @@ The following example demonstrates the usage of the `?.` and `?[]` operators:
 
 [!code-csharp-interactive[null-conditional operators](~/samples/csharp/language-reference/operators/MemberAccessOperators.cs#NullConditional)]
 
-The preceding example also shows the usage of the [null-coalescing operator](null-coalescing-operator.md). You might use the null-coalescing operator to provide an alternative expression to evaluate in case the result of the null-conditional operation is `null`.
+The preceding example also uses the [null-coalescing operator `??`](null-coalescing-operator.md) to specify an alternative expression to evaluate in case the result of a null-conditional operation is `null`.
 
 ### Thread-safe delegate invocation
 
@@ -192,6 +192,8 @@ For more information, see the following sections of the [C# language specificati
 - [Element access](~/_csharplang/spec/expressions.md#element-access)
 - [Null-conditional operator](~/_csharplang/spec/expressions.md#null-conditional-operator)
 - [Invocation expressions](~/_csharplang/spec/expressions.md#invocation-expressions)
+
+For more information about indices and ranges, see the [feature proposal note](~/_csharplang/proposals/csharp-8.0/ranges.md).
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -17,7 +17,7 @@ The `nameof` operator obtains the name of a variable, type, or member as the str
 
 As the preceding example shows, in the case of a type and a namespace, the produced name is usually not [fully qualified](~/_csharplang/spec/basic-concepts.md#fully-qualified-names).
 
-The `nameof` operator is evaluated at compile time, and has no effect at run time.
+The `nameof` operator is evaluated at compile time and has no effect at run time.
 
 You can use the `nameof` operator to make the argument-checking code more maintainable:
 

--- a/docs/csharp/language-reference/operators/namespace-alias-qualifier.md
+++ b/docs/csharp/language-reference/operators/namespace-alias-qualifier.md
@@ -14,10 +14,10 @@ ms.assetid: 698b5a73-85cf-4e0e-9e8e-6496887f8527
 ---
 # :: operator (C# reference)
 
-Use the namespace alias qualifier `::` to access members of an aliased namespace. You use the `::` qualifier between two identifiers. The left-hand identifier can be any of the following aliases:
+Use the namespace alias qualifier `::` to access a member of an aliased namespace. You can use the `::` qualifier only between two identifiers. The left-hand identifier can be any of the following aliases:
 
-- A namespace alias created with the [using alias directive](../keywords/using-directive.md):
-  
+- A namespace alias created with a [using alias directive](../keywords/using-directive.md):
+
   ```csharp
   using forwinforms = System.Drawing;
   using forwpf = System.Windows;
@@ -30,7 +30,7 @@ Use the namespace alias qualifier `::` to access members of an aliased namespace
 
 - An [extern alias](../keywords/extern-alias.md).
 - The `global` alias, which is the global namespace alias. The global namespace is the namespace that contains namespaces and types that are not declared inside a named namespace. When used with the `::` qualifier, the `global` alias always references the global namespace, even if there is the user-defined `global` namespace alias.
-  
+
   The following example uses the `global` alias to access the .NET <xref:System> namespace, which is a member of the global namespace. Without the `global` alias, the user-defined `System` namespace, which is a member of the `MyCompany.MyProduct` namespace, would be accessed:
 
   ```csharp
@@ -40,18 +40,18 @@ Use the namespace alias qualifier `::` to access members of an aliased namespace
       {
           static void Main() => global::System.Console.WriteLine("Using global alias");
       }
-  
+
       class Console
       {
           string Suggestion => "Consider renaming this class";
       }
   }
   ```
-  
+
   > [!NOTE]
   > The `global` keyword is the global namespace alias only when it's the left-hand identifier of the `::` qualifier.
 
-You can also use the [member access `.` operator](member-access-operators.md#member-access-operator-) to access members of an aliased namespace. However, the `.` operator is also used to access members of a type. The `::` qualifier ensures that its left-hand identifier always references a namespace alias, even if there exists a type or namespace with the same name.
+You can also use the [member access `.` operator](member-access-operators.md#member-access-operator-) to access a member of an aliased namespace. However, the `.` operator is also used to access a type member. The `::` qualifier ensures that its left-hand identifier always references a namespace alias, even if there exists a type or namespace with the same name.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/new-operator.md
+++ b/docs/csharp/language-reference/operators/new-operator.md
@@ -44,7 +44,7 @@ To create an instance of an [anonymous type](../../programming-guide/classes-and
 
 You don't have to destroy earlier created type instances. Instances of both reference and value types are destroyed automatically. Instances of value types are destroyed as soon as the context that contains them is destroyed. Instances of reference types are destroyed by the [garbage collector](../../../standard/garbage-collection/index.md) at unspecified time after the last reference to them is removed.
 
-For types that contain unmanaged resources, for example, a file handle, it's recommended to employ deterministic clean-up to ensure that the resources they contain are released as soon as possible. For more information, see the <xref:System.IDisposable?displayProperty=nameWithType> API reference and the [using statement](../keywords/using-statement.md) article.
+For type instances that contain unmanaged resources, for example, a file handle, it's recommended to employ deterministic clean-up to ensure that the resources they contain are released as soon as possible. For more information, see the <xref:System.IDisposable?displayProperty=nameWithType> API reference and the [using statement](../keywords/using-statement.md) article.
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/null-coalescing-operator.md
+++ b/docs/csharp/language-reference/operators/null-coalescing-operator.md
@@ -20,9 +20,9 @@ Available in C# 8.0 and later, the null-coalescing assignment operator `??=` ass
 
 [!code-csharp[null-coalescing assignment](~/samples/csharp/language-reference/operators/NullCoalescingOperator.cs#Assignment)]
 
-The left-hand operand of the `??=` operator must be a variable, a [property](../../programming-guide/classes-and-structs/properties.md), or an [indexer](../../programming-guide/indexers/index.md) element. For more information about null-coalescing assignment, see the [feature proposal note](~/_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md).
+The left-hand operand of the `??=` operator must be a variable, a [property](../../programming-guide/classes-and-structs/properties.md), or an [indexer](../../programming-guide/indexers/index.md) element.
 
-In C# 7.3 and earlier, the type of the left-hand operand of the `??` operator must be either a reference type or a [nullable value type](../../programming-guide/nullable-types/index.md). Beginning with C# 8.0, that requirement is replaced with the following: the type of the left-hand operand of the `??` and `??=` operators cannot be a non-nullable value type. In particular, you can use the null-coalescing operators with unconstrained type parameters in C# 8.0 and later:
+In C# 7.3 and earlier, the type of the left-hand operand of the `??` operator must be either a reference type or a [nullable value type](../../programming-guide/nullable-types/index.md). Beginning with C# 8.0, that requirement is replaced with the following: the type of the left-hand operand of the `??` and `??=` operators cannot be a non-nullable value type. In particular, beginning with C# 8.0, you can use the null-coalescing operators with unconstrained type parameters:
 
 [!code-csharp[unconstrained type parameter](~/samples/csharp/language-reference/operators/NullCoalescingOperator.cs#UnconstrainedType)]
 
@@ -44,23 +44,23 @@ d ??= (e ??= f)
 
 The `??` and `??=` operators can be useful in the following scenarios:
 
-- In expressions with the [null-conditional operators ?. and ?[]](member-access-operators.md#null-conditional-operators--and-), you can use the null-coalescing operator to provide an alternative expression to evaluate in case the result of the expression with null-conditional operations is `null`:
+- In expressions with the [null-conditional operators ?. and ?[]](member-access-operators.md#null-conditional-operators--and-), you can use the `??` operator to provide an alternative expression to evaluate in case the result of the expression with null-conditional operations is `null`:
 
   [!code-csharp-interactive[with null-conditional](~/samples/csharp/language-reference/operators/NullCoalescingOperator.cs#WithNullConditional)]
 
-- When you work with [nullable value types](../../programming-guide/nullable-types/index.md) and need to provide a value of an underlying value type, use the null-coalescing operator to specify the value to provide in case a nullable type value is `null`:
+- When you work with [nullable value types](../../programming-guide/nullable-types/index.md) and need to provide a value of an underlying value type, use the `??` operator to specify the value to provide in case a nullable type value is `null`:
 
   [!code-csharp-interactive[with nullable types](~/samples/csharp/language-reference/operators/NullCoalescingOperator.cs#WithNullableTypes)]
 
   Use the <xref:System.Nullable%601.GetValueOrDefault?displayProperty=nameWithType> method if the value to be used when a nullable type value is `null` should be the default value of the underlying value type.
 
-- Starting with C# 7.0, you can use a [`throw` expression](../keywords/throw.md#the-throw-expression) as the right-hand operand of the null-coalescing operator to make the argument-checking code more concise:
+- Beginning with C# 7.0, you can use a [`throw` expression](../keywords/throw.md#the-throw-expression) as the right-hand operand of the `??` operator to make the argument-checking code more concise:
 
   [!code-csharp[with throw expression](~/samples/csharp/language-reference/operators/NullCoalescingOperator.cs#WithThrowExpression)]
 
   The preceding example also demonstrates how to use [expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md) to define a property.
 
-- Starting with C# 8.0, you can use the `??=` operator to replace the code of the form
+- Beginning with C# 8.0, you can use the `??=` operator to replace the code of the form
 
   ```csharp
   if (variable is null)
@@ -82,6 +82,8 @@ The operators `??` and `??=` cannot be overloaded.
 ## C# language specification
 
 For more information about the `??` operator, see [The null coalescing operator](~/_csharplang/spec/expressions.md#the-null-coalescing-operator) section of the [C# language specification](~/_csharplang/spec/introduction.md).
+
+For more information about the `??=` operator, see the [feature proposal note](~/_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md).
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # ! (null-forgiving) operator (C# reference)
 
-Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiving operator. In an enabled [nullable annotation context](../../nullable-references.md#nullable-annotation-context), you use the null-forgiving operator to declare that expression `x` of a reference type isn't null: `x!`. The unary prefix `!` operator is the [logical negation operator](boolean-logical-operators.md#logical-negation-operator-).
+Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiving operator. In an enabled [nullable annotation context](../../nullable-references.md#nullable-annotation-context), you use the null-forgiving operator to declare that expression `x` of a reference type isn't `null`: `x!`. The unary prefix `!` operator is the [logical negation operator](boolean-logical-operators.md#logical-negation-operator-).
 
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
@@ -25,7 +25,7 @@ Using the [MSTest test framework](../../../core/testing/unit-testing-with-mstest
 
 [!code-csharp[Person test](~/samples/csharp/language-reference/operators/NullForgivingOperator.cs#TestPerson)]
 
-Without the null-forgiving operator, the compiler generates the following warning for the preceding code: `Warning CS8625: Cannot convert null literal to non-nullable reference type`. With the use of the null-forgiving operator, you let the compiler know that passing `null` is expected and shouldn't be warned about.
+Without the null-forgiving operator, the compiler generates the following warning for the preceding code: `Warning CS8625: Cannot convert null literal to non-nullable reference type`. By using the null-forgiving operator, you inform the compiler that passing `null` is expected and shouldn't be warned about.
 
 You also can use the null-forgiving operator when you definitely know that an expression cannot be `null` but the compiler doesn't manage to recognize that. In the following example, if the `IsValid` method returns `true`, its argument is not `null` and you can safely dereference it:
 
@@ -33,11 +33,11 @@ You also can use the null-forgiving operator when you definitely know that an ex
 
 Without the null-forgiving operator, the compiler generates the following warning for the `p.Name` code: `Warning CS8602: Dereference of a possibly null reference`.
 
-If you can modify the `IsValid` method, you can use the [NotNullWhen](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute to let the compiler know that an argument of the `IsValid` method cannot be `null` when the method returns `true`:
+If you can modify the `IsValid` method, you can use the [NotNullWhen](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute to inform the compiler that an argument of the `IsValid` method cannot be `null` when the method returns `true`:
 
 [!code-csharp[Use an attribute](~/samples/csharp/language-reference/operators/NullForgivingOperator.cs#UseAttribute)]
 
-In the preceding example, you don't need to use the null-forgiving operator because the compiler has enough information to find out that `p` cannot be `null` inside the `if` statement. For more information about the attributes that allow you to specify additional information about the null state of a variable, see [Upgrade APIs with attributes to define null expectations](../../nullable-attributes.md).
+In the preceding example, you don't need to use the null-forgiving operator because the compiler has enough information to find out that `p` cannot be `null` inside the `if` statement. For more information about the attributes that allow you to provide additional information about the null state of a variable, see [Upgrade APIs with attributes to define null expectations](../../nullable-attributes.md).
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/operator-overloading.md
+++ b/docs/csharp/language-reference/operators/operator-overloading.md
@@ -10,18 +10,18 @@ helpviewer_keywords:
 ---
 # Operator overloading (C# reference)
 
-A user-defined type can overload a predefined C# operator. That is, a type can provide the custom implementation of an operation when one or both of the operands are of that type. The [Overloadable operators](#overloadable-operators) section shows which C# operators can be overloaded.
+A user-defined type can overload a predefined C# operator. That is, a type can provide the custom implementation of an operation in case one or both of the operands are of that type. The [Overloadable operators](#overloadable-operators) section shows which C# operators can be overloaded.
 
 Use the `operator` keyword to declare an operator. An operator declaration must satisfy the following rules:
 
 - It includes both a `public` and a `static` modifier.
-- A unary operator takes one parameter. A binary operator takes two parameters. In each case, at least one parameter must have type `T` or `T?` where `T` is the type that contains the operator declaration.
+- A unary operator has one input parameter. A binary operator has two input parameters. In each case, at least one parameter must have type `T` or `T?` where `T` is the type that contains the operator declaration.
 
 The following example defines a simplified structure to represent a rational number. The structure overloads some of the [arithmetic operators](arithmetic-operators.md):
 
 [!code-csharp[fraction example](~/samples/csharp/language-reference/operators/OperatorOverloading.cs)]
 
-You could extend the preceding example by defining an implicit conversion from `int` to `Fraction`. Then, overloaded operators would support arguments of those two types. That is, it would become possible to add an integer to a fraction and obtain a fraction as a result.
+You could extend the preceding example by [defining an implicit conversion](user-defined-conversion-operators.md) from `int` to `Fraction`. Then, overloaded operators would support arguments of those two types. That is, it would become possible to add an integer to a fraction and obtain a fraction as a result.
 
 You also use the `operator` keyword to define a custom type conversion. For more information, see [User-defined conversion operators](user-defined-conversion-operators.md).
 

--- a/docs/csharp/language-reference/operators/pointer-related-operators.md
+++ b/docs/csharp/language-reference/operators/pointer-related-operators.md
@@ -42,7 +42,7 @@ The unary `&` operator returns the address of its operand:
 
 [!code-csharp[address of local](~/samples/csharp/language-reference/operators/PointerOperators.cs#AddressOf)]
 
-The operand of the `&` operator must be a fixed variable. *Fixed* variables are variables that reside in storage locations that are unaffected by operation of the [garbage collector](../../../standard/garbage-collection/index.md). In the preceding example, the local variable `number` is a fixed variable, because it resides on the stack. Variables that reside in storage locations that can be affected by the garbage collector (for example, relocated) are called *movable* variables. Object fields and array elements are examples of movable variables. You can get the address of a movable variable if you "fix", or "pin", it with the [fixed](../keywords/fixed-statement.md) statement. The obtained address is valid only for the duration of the `fixed` statement block. The following example shows how to use the `fixed` statement and the `&` operator:
+The operand of the `&` operator must be a fixed variable. *Fixed* variables are variables that reside in storage locations that are unaffected by operation of the [garbage collector](../../../standard/garbage-collection/index.md). In the preceding example, the local variable `number` is a fixed variable, because it resides on the stack. Variables that reside in storage locations that can be affected by the garbage collector (for example, relocated) are called *movable* variables. Object fields and array elements are examples of movable variables. You can get the address of a movable variable if you "fix", or "pin", it with a [`fixed` statement](../keywords/fixed-statement.md). The obtained address is valid only inside the block of a `fixed` statement. The following example shows how to use a `fixed` statement and the `&` operator:
 
 [!code-csharp[address of fixed](~/samples/csharp/language-reference/operators/PointerOperators.cs#AddressOfFixed)]
 
@@ -64,7 +64,7 @@ The binary `*` operator computes the [product](arithmetic-operators.md#multiplic
 
 ## Pointer member access operator ->
 
-The `->` operator combines [pointer indirection](#pointer-indirection-operator-) and [member access](member-access-operators.md#member-access-operator-). That is, if `x` is a pointer of type `T*` and `y` is an accessible member of `T`, an expression of the form
+The `->` operator combines [pointer indirection](#pointer-indirection-operator-) and [member access](member-access-operators.md#member-access-operator-). That is, if `x` is a pointer of type `T*` and `y` is an accessible member of type `T`, an expression of the form
 
 ```csharp
 x->y
@@ -160,7 +160,7 @@ The following list orders pointer related operators starting from the highest pr
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence.
 
-For the complete list of C# operators ordered by precedence level, see [C# operators](index.md).
+For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -50,3 +50,4 @@ For more information, see [The sizeof operator](~/_csharplang/spec/unsafe-code.m
 - [Pointer related operators](pointer-related-operators.md)
 - [Pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md)
 - [Memory and span-related types](../../../standard/memory-and-spans/index.md)
+- [Generics in .NET](../../../standard/generics/index.md)

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -9,13 +9,13 @@ helpviewer_keywords:
 ---
 # stackalloc operator (C# reference)
 
-The `stackalloc` operator allocates a block of memory on the stack. A stack allocated memory block created during the method execution is automatically discarded when that method returns. You cannot explicitly free memory allocated with the `stackalloc` operator. A stack allocated memory block is not subject to [garbage collection](../../../standard/garbage-collection/index.md) and doesn't have to be pinned with the [`fixed` statement](../keywords/fixed-statement.md).
+The `stackalloc` operator allocates a block of memory on the stack. A stack allocated memory block created during the method execution is automatically discarded when that method returns. You cannot explicitly free memory allocated with the `stackalloc` operator. A stack allocated memory block is not subject to [garbage collection](../../../standard/garbage-collection/index.md) and doesn't have to be pinned with a [`fixed` statement](../keywords/fixed-statement.md).
 
 In expression `stackalloc T[E]`, `T` must be an [unmanaged type](../builtin-types/unmanaged-types.md) and `E` must be an expression of type `int`.
 
 You can assign the result of the `stackalloc` operator to a variable of one of the following types:
 
-- Starting with C# 7.2, <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as the following example shows:
+- Beginning with C# 7.2, <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as the following example shows:
 
   [!code-csharp[stackalloc span](~/samples/csharp/language-reference/operators/StackallocOperator.cs#AssignToSpan)]
 
@@ -25,7 +25,7 @@ You can assign the result of the `stackalloc` operator to a variable of one of t
 
   [!code-csharp[stackalloc expression](~/samples/csharp/language-reference/operators/StackallocOperator.cs#AsExpression)]
 
-  Starting with C# 8.0, you can use a `stackalloc` expression inside other expressions whenever a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable is allowed, as the following example shows:
+  Beginning with C# 8.0, you can use a `stackalloc` expression inside other expressions whenever a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable is allowed, as the following example shows:
 
   [!code-csharp[stackalloc in nested expressions](~/samples/csharp/language-reference/operators/StackallocOperator.cs#Nested)]
 
@@ -40,7 +40,7 @@ You can assign the result of the `stackalloc` operator to a variable of one of t
 
   In the case of pointer types, you can use a `stackalloc` expression only in a local variable declaration to initialize the variable.
 
-The content of the newly allocated memory is undefined. Starting with C# 7.3, you can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
+The content of the newly allocated memory is undefined. Beginning with C# 7.3, you can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 
 [!code-csharp[stackalloc initialization](~/samples/csharp/language-reference/operators/StackallocOperator.cs#StackallocInit)]
 

--- a/docs/csharp/language-reference/operators/subtraction-operator.md
+++ b/docs/csharp/language-reference/operators/subtraction-operator.md
@@ -16,13 +16,13 @@ ms.assetid: 4de7a4fa-c69d-48e6-aff1-3130af970b2d
 ---
 # - and -= operators (C# reference)
 
-The `-` operator is supported by the built-in numeric types and [delegate](../keywords/delegate.md) types.
+The `-` and `-=` operators are supported by the built-in [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types and [delegate](../builtin-types/reference-types.md#the-delegate-type) types.
 
 For information about the arithmetic `-` operator, see the [Unary plus and minus operators](arithmetic-operators.md#unary-plus-and-minus-operators) and [Subtraction operator -](arithmetic-operators.md#subtraction-operator--) sections of the [Arithmetic operators](arithmetic-operators.md) article.
 
 ## Delegate removal
 
-For operands of the same [delegate](../keywords/delegate.md) type, the `-` operator returns a delegate instance that is calculated as follows:
+For operands of the same [delegate](../builtin-types/reference-types.md#the-delegate-type) type, the `-` operator returns a delegate instance that is calculated as follows:
 
 - If both operands are non-null and the invocation list of the right-hand operand is a proper contiguous sublist of the invocation list of the left-hand operand, the result of the operation is a new invocation list that is obtained by removing the right-hand operand's entries from the invocation list of the left-hand operand. If the right-hand operand's list matches multiple contiguous sublists in the left-hand operand's list, only the right-most matching sublist is removed. If removal results in an empty list, the result is `null`.
 
@@ -32,7 +32,7 @@ For operands of the same [delegate](../keywords/delegate.md) type, the `-` opera
 
   [!code-csharp-interactive[delegate removal with no effect](~/samples/csharp/language-reference/operators/SubtractionOperator.cs#DelegateRemovalNoChange)]
 
-  The preceding example also demonstrates that during delegate removal delegate instances are compared. For example, delegates that are produced from evaluation of identical [lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md) are not equal. For more information about delegate equality, see the [Delegate equality operators](~/_csharplang/spec/expressions.md#delegate-equality-operators) section of the [C# language specification](../language-specification/index.md).
+  The preceding example also demonstrates that during delegate removal delegate instances are compared. For example, delegates that are produced from evaluation of identical [lambda expressions](../../programming-guide/statements-expressions-operators/lambda-expressions.md) are not equal. For more information about delegate equality, see the [Delegate equality operators](~/_csharplang/spec/expressions.md#delegate-equality-operators) section of the [C# language specification](~/_csharplang/spec/introduction.md).
 
 - If the left-hand operand is `null`, the result of the operation is `null`. If the right-hand operand is `null`, the result of the operation is the left-hand operand.
 
@@ -57,7 +57,7 @@ x = x - y
 ```
 
 except that `x` is only evaluated once.
-  
+
 The following example demonstrates the usage of the `-=` operator:
 
 [!code-csharp-interactive[-= examples](~/samples/csharp/language-reference/operators/SubtractionOperator.cs#SubtractAndAssign)]
@@ -76,7 +76,6 @@ For more information, see the [Unary minus operator](~/_csharplang/spec/expressi
 
 - [C# reference](../index.md)
 - [C# operators](index.md)
-- [Delegates](../../programming-guide/delegates/index.md)
 - [Events](../../programming-guide/events/index.md)
 - [Arithmetic operators](arithmetic-operators.md)
 - [+ and += operators](addition-operator.md)

--- a/docs/csharp/language-reference/operators/true-false-operators.md
+++ b/docs/csharp/language-reference/operators/true-false-operators.md
@@ -9,10 +9,10 @@ ms.assetid: 81a888fd-011e-4589-b242-6c261fea505e
 ---
 # true and false operators (C# reference)
 
-The `true` operator returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely true. The `false` operator returns the `bool` value `true` to indicate that an operand is definitely false. The `true` and `false` operators are not guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
+The `true` operator returns the [bool](../keywords/bool.md) value `true` to indicate that its operand is definitely true. The `false` operator returns the `bool` value `true` to indicate that its operand is definitely false. The `true` and `false` operators are not guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
 
 > [!TIP]
-> Use the `bool?` type, if you need to support the three-valued logic, for example, when you work with databases that support a three-valued Boolean type. C# provides the `&` and `|` operators that support the three-valued logic with the `bool?` operands. For more information, see the [Nullable Boolean logical operators](boolean-logical-operators.md#nullable-boolean-logical-operators) section of the [Boolean logical operators](boolean-logical-operators.md) article.
+> Use the `bool?` type, if you need to support the three-valued logic (for example, when you work with databases that support a three-valued Boolean type). C# provides the `&` and `|` operators that support the three-valued logic with the `bool?` operands. For more information, see the [Nullable Boolean logical operators](boolean-logical-operators.md#nullable-boolean-logical-operators) section of the [Boolean logical operators](boolean-logical-operators.md) article.
 
 ## Boolean expressions
 
@@ -24,7 +24,7 @@ If a type with the defined `true` and `false` operators [overloads](operator-ove
 
 ## Example
 
-The following example presents the type that defines both `true` and `false` operators. The type also overloads the logical AND operator `&` in such a way that the operator `&&` also can be evaluated for the operands of that type.
+The following example presents the type that defines both `true` and `false` operators. The type also overloads the logical AND operator `&` in such a way that the `&&` operator also can be evaluated for the operands of that type.
 
 [!code-csharp[true and false operators example](~/samples/csharp/language-reference/operators/TrueFalseOperators.cs)]
 

--- a/docs/csharp/language-reference/operators/type-testing-and-cast.md
+++ b/docs/csharp/language-reference/operators/type-testing-and-cast.md
@@ -30,7 +30,7 @@ You can use the following operators to perform type checking or type conversion:
 
 ## is operator
 
-The `is` operator checks if the runtime type of an expression result is compatible with a given type. Starting with C# 7.0, the `is` operator also tests an expression result against a pattern.
+The `is` operator checks if the runtime type of an expression result is compatible with a given type. Beginning with C# 7.0, the `is` operator also tests an expression result against a pattern.
 
 The expression with the type-testing `is` operator has the following form
 
@@ -46,7 +46,7 @@ The following example demonstrates that the `is` operator returns `true` if the 
 
 [!code-csharp[is with reference conversion](~/samples/csharp/language-reference/operators/TypeTestingAndConversionOperators.cs#IsWithReferenceConversion)]
 
-The next example shows that the `is` operator takes into account boxing and unboxing conversions but doesn't consider numeric conversions:
+The next example shows that the `is` operator takes into account boxing and unboxing conversions but doesn't consider [numeric conversions](../builtin-types/numeric-conversions.md):
 
 [!code-csharp-interactive[is with int](~/samples/csharp/language-reference/operators/TypeTestingAndConversionOperators.cs#IsWithInt)]
 
@@ -54,7 +54,7 @@ For information about C# conversions, see the [Conversions](~/_csharplang/spec/c
 
 ### Type testing with pattern matching
 
-Starting with C# 7.0, the `is` operator also tests an expression result against a pattern. In particular, it supports the type pattern in the following form:
+Beginning with C# 7.0, the `is` operator also tests an expression result against a pattern. In particular, it supports the type pattern in the following form:
 
 ```csharp
 E is T v
@@ -93,7 +93,7 @@ The following example demonstrates the usage of the `as` operator:
 [!code-csharp-interactive[as operator](~/samples/csharp/language-reference/operators/TypeTestingAndConversionOperators.cs#AsOperator)]
 
 > [!NOTE]
-> As the preceding example shows, you need to compare the result of the `as` expression with `null` to check if the conversion is successful. Starting with C# 7.0, you can use the [is operator](#type-testing-with-pattern-matching) both to test if the conversion succeeds and, if it succeeds, assign its result to a new variable.
+> As the preceding example shows, you need to compare the result of the `as` expression with `null` to check if the conversion is successful. Beginning with C# 7.0, you can use the [is operator](#type-testing-with-pattern-matching) both to test if the conversion succeeds and, if it succeeds, assign its result to a new variable.
 
 ## Cast operator ()
 
@@ -121,7 +121,7 @@ You also can use the `typeof` operator with unbound generic types. The name of a
 
 [!code-csharp-interactive[typeof unbound generic](~/samples/csharp/language-reference/operators/TypeTestingAndConversionOperators.cs#TypeOfUnboundGeneric)]
 
-An expression cannot be an argument of the `typeof` operator. To get the <xref:System.Type?displayProperty=nameWithType> instance for the runtime type of the expression result, use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method.
+An expression cannot be an argument of the `typeof` operator. To get the <xref:System.Type?displayProperty=nameWithType> instance for the runtime type of an expression result, use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method.
 
 ### Type testing with the `typeof` operator
 
@@ -131,7 +131,7 @@ Use the `typeof` operator to check if the runtime type of the expression result 
 
 ## Operator overloadability
 
-The `is`, `as`, and `typeof` operators are not overloadable.
+The `is`, `as`, and `typeof` operators cannot be overloaded.
 
 A user-defined type cannot overload the `()` operator, but can define custom type conversions that can be performed by a cast expression. For more information, see [User-defined conversion operators](user-defined-conversion-operators.md).
 
@@ -149,3 +149,4 @@ For more information, see the following sections of the [C# language specificati
 - [C# reference](../index.md)
 - [C# operators](index.md)
 - [How to: safely cast by using pattern matching and the is and as operators](../../how-to/safely-cast-using-pattern-matching-is-and-as-operators.md)
+- [Generics in .NET](../../../standard/generics/index.md)

--- a/docs/csharp/language-reference/operators/user-defined-conversion-operators.md
+++ b/docs/csharp/language-reference/operators/user-defined-conversion-operators.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 
 A user-defined type can define a custom implicit or explicit conversion from or to another type.
 
-Implicit conversions don't require special syntax to be invoked and can occur in a variety of situations, for example, in assignments and methods invocations. Predefined C# implicit conversions always succeed and never throw an exception or lose information. User-defined implicit conversions should behave in that way as well. If a custom conversion can throw an exception or lose information, define it as an explicit conversion.
+Implicit conversions don't require special syntax to be invoked and can occur in a variety of situations, for example, in assignments and methods invocations. Predefined C# implicit conversions always succeed and never throw an exception. User-defined implicit conversions should behave in that way as well. If a custom conversion can throw an exception or lose information, define it as an explicit conversion.
 
 User-defined conversions are not considered by the [is](type-testing-and-cast.md#is-operator) and [as](type-testing-and-cast.md#as-operator) operators. Use the [cast operator ()](type-testing-and-cast.md#cast-operator-) to invoke a user-defined explicit conversion.
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1621,7 +1621,7 @@
       displayName: conditional, ternary, ref
     - name: "! (null-forgiving) operator"
       href: language-reference/operators/null-forgiving.md
-      displayName: nullable reference, null-forgiveness, damn-it
+      displayName: nullable reference, null-forgiveness
     - name: "?? and ??= operators"
       href: language-reference/operators/null-coalescing-operator.md
       displayName: null-coalescing, assignment

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1579,15 +1579,16 @@
     items:
     - name: Overview
       href: language-reference/operators/index.md
+      displayName: operator precedence, operator associativity
     - name: Arithmetic operators
       href: language-reference/operators/arithmetic-operators.md
       displayName: ++, --, +, -, *, /, %, +=, -=, *=, /=, %=, checked, unchecked
     - name: Boolean logical operators
       href: language-reference/operators/boolean-logical-operators.md
-      displayName: "!, &&, ||, &, |, ^, &=, |=, ^="
+      displayName: "!, &&, ||, &, |, ^, &=, |=, ^=, AND, XOR, OR"
     - name: Bitwise and shift operators
       href: language-reference/operators/bitwise-and-shift-operators.md
-      displayName: "~, &, |, ^, <<, >>, &=, |=, ^=, <<=, >>="
+      displayName: "~, &, |, ^, <<, >>, &=, |=, ^=, <<=, >>=, AND, XOR, OR"
     - name: Equality operators
       href: language-reference/operators/equality-operators.md
       displayName: ==, !=
@@ -1599,16 +1600,16 @@
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation, ^, index from end, hat, .., range"
     - name: Type-testing and cast operators
       href: language-reference/operators/type-testing-and-cast.md
-      displayName: "is operator, is keyword, as operator, as keyword, typeof, (), conversion"
+      displayName: "is operator, is keyword, as operator, as keyword, typeof, (), explicit, conversion"
     - name: User-defined conversion operators
       href: language-reference/operators/user-defined-conversion-operators.md
       displayName: implicit, explicit
     - name: Pointer related operators
       href: language-reference/operators/pointer-related-operators.md
       displayName: "&, *, ->, [], +, -, ++, --, ==, !=, <, >, <=, >=, dereference, address-of, indirection"
-    - name: "= operator"
+    - name: Assignment operators
       href: language-reference/operators/assignment-operator.md
-      displayName: "assignment, ref"
+      displayName: "=, ref, compound"
     - name: + and += operators
       href: language-reference/operators/addition-operator.md
       displayName: string concatenation, delegate combination, event subscription
@@ -1620,13 +1621,13 @@
       displayName: conditional, ternary, ref
     - name: "! (null-forgiving) operator"
       href: language-reference/operators/null-forgiving.md
-      displayName: nullable reference, null-forgiveness
+      displayName: nullable reference, null-forgiveness, damn-it
     - name: "?? and ??= operators"
       href: language-reference/operators/null-coalescing-operator.md
       displayName: null-coalescing, assignment
     - name: => operator
       href: language-reference/operators/lambda-operator.md
-      displayName: lambda
+      displayName: lambda, expression body definition
     - name: ":: operator"
       href: language-reference/operators/namespace-alias-qualifier.md
       displayName: "namespace alias qualifier, global namespace"
@@ -1643,6 +1644,7 @@
       href: language-reference/operators/nameof.md
     - name: new operator
       href: language-reference/operators/new-operator.md
+      displayName: constructor
     - name: sizeof operator
       href: language-reference/operators/sizeof.md
     - name: stackalloc operator


### PR DESCRIPTION
To finalize the consolidation project of the C# operators reference, I've gone through all the articles in the same mood and time to ensure they are as consistent as possible. 
