### PR TITLE
Small fix in write-safe-efficient-code.md

### DIFF
--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -281,7 +281,7 @@ saves copying when you use a `readonly struct` as an `in` argument.
 
 You shouldn't pass a nullable value type as an `in` argument. The <xref:System.Nullable%601> type isn't declared as a read-only struct. That means the compiler must generate defensive copies for any nullable value type argument passed to a method using the `in` modifier on the parameter declaration.
 
-You can see an example program that demonstrates the performance differences using [Benchmark.net](https://www.nuget.org/packages/BenchmarkDotNet/) in our [samples repository](https://github.com/dotnet/samples/tree/master/csharp/safe-efficient-code/benchmark) on GitHub. It compares passing a mutable struct by value and by reference with passing an immutable struct by value and by reference. The use of the immutable struct and pass by reference is fastest.
+You can see an example program that demonstrates the performance differences using [BenchmarkDotNet](https://www.nuget.org/packages/BenchmarkDotNet/) in our [samples repository](https://github.com/dotnet/samples/tree/master/csharp/safe-efficient-code/benchmark) on GitHub. It compares passing a mutable struct by value and by reference with passing an immutable struct by value and by reference. The use of the immutable struct and pass by reference is fastest.
 
 ## Use `ref struct` types to work with blocks or memory on a single stack frame
 


### PR DESCRIPTION
Change the title of BenchmarkDotNet from "Benchmark.net" (an incorrect title) to "BenchmarkDotNet" (the correct official title)

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
