### PR TITLE
Add wording for types used by DBLoader in Load Data How-To

### DIFF
--- a/docs/machine-learning/how-to-guides/load-data-ml-net.md
+++ b/docs/machine-learning/how-to-guides/load-data-ml-net.md
@@ -112,9 +112,10 @@ Given a database with a table named `House` and the following schema:
 
 ```SQL
 CREATE TABLE [House] (
-    [HouseId] int NOT NULL IDENTITY,
-    [Size] real NOT NULL,
-    [Price] real NOT NULL
+    [HouseId] INT NOT NULL IDENTITY,
+    [Size] INT NOT NULL,
+    [NumBed] INT NOT NULL,
+    [Price] REAL NOT NULL
     CONSTRAINT [PK_House] PRIMARY KEY ([HouseId])
 );
 ```
@@ -125,6 +126,8 @@ The data can be modeled by a class like `HouseData`.
 public class HouseData
 {
     public float Size { get; set; }
+    
+    public float NumBed { get; set; }
 
     public float Price { get; set; }
 }
@@ -143,12 +146,14 @@ Define your connection string as well as the SQL command to be executed on the d
 ```csharp
 string connectionString = @"Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=<YOUR-DB-FILEPATH>;Database=<YOUR-DB-NAME>;Integrated Security=True;Connect Timeout=30";
 
-string sqlCommand = "SELECT Size,Price FROM House";
+string sqlCommand = "SELECT Size, CAST(NumBed as REAL) as NumBed, Price FROM House";
 
-DatabaseSource dbSource = new DatabaseSource(SqlClientFactory.Instance,connectionString,sqlCommand);
+DatabaseSource dbSource = new DatabaseSource(SqlClientFactory.Instance, connectionString, sqlCommand);
 ```
 
-Finally, use the `Load` method to load the data into an [`IDataView`](xref:Microsoft.ML.IDataView).
+Numerical data that is not of type [`Real`](xref:System.Data.SqlDbType) has to be converted to [`Real`](xref:System.Data.SqlDbType). The [`Real`](xref:System.Data.SqlDbType) type is represented as a single-precision floating-point value or [`Single`](xref:System.Single), the input type expected by ML.NET algorithms. In this sample, the `NumBed` column is an integer in the database. Using the `CAST` built-in function, it's converted to [`Real`](xref:System.Data.SqlDbType). Because the `Price` property is already of type [`Real`](xref:System.Data.SqlDbType) it is loaded as is.
+
+Use the `Load` method to load the data into an [`IDataView`](xref:Microsoft.ML.IDataView).
 
 ```csharp
 IDataView data = loader.Load(dbSource);


### PR DESCRIPTION
To load numerical data from a database using ML.NET DatabaseLoader, it has to be of type REAL. If it's not already in this type, it needs to be cast. Added wording for this in the How-To.

[Preview Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/load-data-ml-net?branch=pr-en-us-15468#load-data-from-a-relational-database)

[AB#1617680](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1617680)
