### PR TITLE
Update the WCF Web service reference guide

### DIFF
--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -75,13 +75,13 @@ When these processes complete, you can create an instance of the generated WCF c
 
 ### See also
 
-- [Get started with Windows Communication Foundation applications](https://docs.microsoft.com/en-us/dotnet/framework/wcf/getting-started-tutorial)
-- [Windows Communication Foundation Services and WCF data services in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/data-tools/windows-communication-foundation-services-and-wcf-data-services-in-visual-studio)
-- [WCF Supported features on .NET Core](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md)
+- [Get started with Windows Communication Foundation applications](../../../framework/wcf/getting-started-tutorial.md)
+- [Windows Communication Foundation services and WCF data services in Visual Studio](/visualstudio/data-tools/windows-communication-foundation-services-and-wcf-data-services-in-visual-studio)
+- [WCF supported features on .NET Core](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md)
 
 ### Feedback & questions
 
-If you have any questions or feedback, report it at [Visual Studio's developer community](https://developercommunity.visualstudio.com/).
+If you have any questions or feedback, report it at [Developer Community](https://developercommunity.visualstudio.com/) using the [Report a problem](/visualstudio/ide/how-to-report-a-problem-with-visual-studio) tool.
 
 ### Release notes
 

--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -1,8 +1,8 @@
 ---
 title: Add WCF Web Service Reference
 description: An overview of the Microsoft WCF Web Service Reference Provider Tool that adds functionality for .NET Core and ASP.NET Core projects, similar to Add Service Reference for .NET Framework projects.
-author: mlacouture
-ms.date: 04/19/2018
+author: dasetser
+ms.date: 10/29/2019
 ms.custom: "mvc, seodec18"
 ---
 
@@ -73,9 +73,15 @@ When these processes complete, you can create an instance of the generated WCF c
 
 ## Next steps
 
+### See also
+
+- [Get started with Windows Communication Foundation applications](https://docs.microsoft.com/en-us/dotnet/framework/wcf/getting-started-tutorial)
+- [Windows Communication Foundation Services and WCF data services in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/data-tools/windows-communication-foundation-services-and-wcf-data-services-in-visual-studio)
+- [WCF Supported features on .NET Core](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md)
+
 ### Feedback & questions
 
-If you have any questions or feedback, [open an issue on GitHub](https://github.com/dotnet/wcf/issues/new). You can also review any existing questions or issues [at the WCF repo on GitHub](https://github.com/dotnet/wcf/issues?utf8=%E2%9C%93&q=is:issue%20label:tooling).
+If you have any questions or feedback, report it at [Visual Studio's developer community](https://developercommunity.visualstudio.com/).
 
 ### Release notes
 

--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -73,7 +73,7 @@ When these processes complete, you can create an instance of the generated WCF c
 
 ## See also
 
-- [Get started with Windows Communication Foundation applications](../../framework/wcf/getting-started-tutorial.md)
+- [Get started with Windows Communication Foundation applications](../../../framework/wcf/getting-started-tutorial.md)
 - [Windows Communication Foundation services and WCF data services in Visual Studio](/visualstudio/data-tools/windows-communication-foundation-services-and-wcf-data-services-in-visual-studio)
 - [WCF supported features on .NET Core](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md)
 

--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -71,18 +71,16 @@ While displaying progress, the tool:
 
 When these processes complete, you can create an instance of the generated WCF client type and invoke the service operations.
 
-## Next steps
+## See also
 
-### See also
-
-- [Get started with Windows Communication Foundation applications](../../../framework/wcf/getting-started-tutorial.md)
+- [Get started with Windows Communication Foundation applications](../../framework/wcf/getting-started-tutorial.md)
 - [Windows Communication Foundation services and WCF data services in Visual Studio](/visualstudio/data-tools/windows-communication-foundation-services-and-wcf-data-services-in-visual-studio)
 - [WCF supported features on .NET Core](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md)
 
-### Feedback & questions
+## Feedback & questions
 
 If you have any questions or feedback, report it at [Developer Community](https://developercommunity.visualstudio.com/) using the [Report a problem](/visualstudio/ide/how-to-report-a-problem-with-visual-studio) tool.
 
-### Release notes
+## Release notes
 
 - Refer to the [Release notes](https://github.com/dotnet/wcf/blob/master/release-notes/WCF-Web-Service-Reference-notes.md) for updated release information, including known issues.

--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -73,7 +73,7 @@ When these processes complete, you can create an instance of the generated WCF c
 
 ## See also
 
-- [Get started with Windows Communication Foundation applications](../../../framework/wcf/getting-started-tutorial.md)
+- [Get started with Windows Communication Foundation applications](../../framework/wcf/getting-started-tutorial.md)
 - [Windows Communication Foundation services and WCF data services in Visual Studio](/visualstudio/data-tools/windows-communication-foundation-services-and-wcf-data-services-in-visual-studio)
 - [WCF supported features on .NET Core](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md)
 


### PR DESCRIPTION
## Summary
Include links to documentation that gives some guidance on using WCF. The current next steps section without this is confusing

Fixes https://github.com/dotnet/docs/issues/6655