### PR TITLE
Add links to the C# 101 video series

### DIFF
--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 The C# guide provides many resources about the C# language. This site has many different audiences. Depending on your experience with programming, or with the C# language and .NET, you may wish to explore different sections of this guide.
 
 - For brand-new developers:
-  - Watch [C# 101 video series](https://aka.ms/dotnet3-csharp). It provides an introduction to the important concepts you'll explore in these tutorials.
+  - Watch the [C# 101 video series](https://aka.ms/dotnet3-csharp). It provides an introduction to the important concepts you'll explore in these tutorials.
 
   - Start with the [Introduction to C# tutorials](tutorials/intro-to-csharp/index.md). These tutorials let you explore the C# language interactively in your browser. From there, you can move on to other [tutorials](tutorials/index.md). These tutorials show you how to create C# programs from scratch. The tutorials provide a step-by-step process to create programs. They show the language concepts and how to build C# programs on your own. If you prefer reading overview information first, try the [tour of the C# language](tour-of-csharp/index.md). It explains the concepts of the C# language. After reading this, you'll have a basic understanding of the language, and be ready to try the tutorials, or build something on your own.
 

--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 The C# guide provides many resources about the C# language. This site has many different audiences. Depending on your experience with programming, or with the C# language and .NET, you may wish to explore different sections of this guide.
 
 - For brand-new developers:
-  - Watch this [video series](https://aka.ms/dotnet3-csharp). It provides an introduction to the important concepts you'll explore in these tutorials.
+  - Watch [C# 101 video series](https://aka.ms/dotnet3-csharp). It provides an introduction to the important concepts you'll explore in these tutorials.
 
   - Start with the [Introduction to C# tutorials](tutorials/intro-to-csharp/index.md). These tutorials let you explore the C# language interactively in your browser. From there, you can move on to other [tutorials](tutorials/index.md). These tutorials show you how to create C# programs from scratch. The tutorials provide a step-by-step process to create programs. They show the language concepts and how to build C# programs on your own. If you prefer reading overview information first, try the [tour of the C# language](tour-of-csharp/index.md). It explains the concepts of the C# language. After reading this, you'll have a basic understanding of the language, and be ready to try the tutorials, or build something on your own.
 

--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -14,6 +14,8 @@ helpviewer_keywords:
 The C# guide provides many resources about the C# language. This site has many different audiences. Depending on your experience with programming, or with the C# language and .NET, you may wish to explore different sections of this guide.
 
 - For brand-new developers:
+  - Watch this [video series](https://aka.ms/dotnet3-csharp). It provides an introduction to the important concepts you'll explore in these tutorials.
+
   - Start with the [Introduction to C# tutorials](tutorials/intro-to-csharp/index.md). These tutorials let you explore the C# language interactively in your browser. From there, you can move on to other [tutorials](tutorials/index.md). These tutorials show you how to create C# programs from scratch. The tutorials provide a step-by-step process to create programs. They show the language concepts and how to build C# programs on your own. If you prefer reading overview information first, try the [tour of the C# language](tour-of-csharp/index.md). It explains the concepts of the C# language. After reading this, you'll have a basic understanding of the language, and be ready to try the tutorials, or build something on your own.
 
 - For developers new to C#:

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -9,7 +9,7 @@ Welcome to the C# tutorials. These start with interactive lessons that you can r
 
 ## Introduction to C# interactive tutorials
 
-If you want to start your exploration in video format, [C# 101 video series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in these tutorials.
+If you want to start your exploration in video format, the [C# 101 video series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in these tutorials.
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -9,7 +9,7 @@ Welcome to the C# tutorials. These start with interactive lessons that you can r
 
 ## Introduction to C# interactive tutorials
 
-If you want to start your exploration in video format, [this series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in these tutorials.
+If you want to start your exploration in video format, [C# 101 video series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in these tutorials.
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -9,6 +9,8 @@ Welcome to the C# tutorials. These start with interactive lessons that you can r
 
 ## Introduction to C# interactive tutorials
 
+If you want to start your exploration in video format, [this series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in this tutorials.
+
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,
 numbers, and booleans. It's all interactive, and you'll be writing and running code

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -9,7 +9,7 @@ Welcome to the C# tutorials. These start with interactive lessons that you can r
 
 ## Introduction to C# interactive tutorials
 
-If you want to start your exploration in video format, [this series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in this tutorials.
+If you want to start your exploration in video format, [this series](https://aka.ms/dotnet3-csharp) provides an introduction to C#. You'll learn about concepts you can explore in these tutorials.
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -10,7 +10,7 @@ Welcome to the introduction to C# tutorials. These start with interactive lesson
 that you can run in your browser. You can learn the basics of C# from
 [this video series](https://aka.ms/dotnet3-csharp) before starting these interactive lessons.
 
-[!VIDEO hhttps://channel9.msdn.com/Series/CSharp-101/What-is-C/player]
+[!VIDEO https://channel9.msdn.com/Series/CSharp-101/What-is-C/player]
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -10,7 +10,7 @@ Welcome to the introduction to C# tutorials. These start with interactive lesson
 that you can run in your browser. You can learn the basics of C# from
 [this video series](https://aka.ms/dotnet3-csharp) before starting these interactive lessons.
 
-[!VIDEO https://channel9.msdn.com/Series/CSharp-101/What-is-C/player]
+> [!VIDEO https://channel9.msdn.com/Series/CSharp-101/What-is-C/player]
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -7,7 +7,10 @@ ms.custom: mvc
 # Introduction to C\#
 
 Welcome to the introduction to C# tutorials. These start with interactive lessons
-that you can run in your browser.
+that you can run in your browser. You can learn the basics of C# from
+[this video series](https://aka.ms/dotnet3-csharp) before starting these interactive lessons.
+
+[!VIDEO hhttps://channel9.msdn.com/Series/CSharp-101/What-is-C/player]
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -7,7 +7,7 @@ ms.custom: mvc
 # Introduction to C\#
 
 Welcome to the introduction to C# tutorials. These start with interactive lessons
-that you can run in your browser. You can learn the basics of C# from
+that you can run in your browser. You can learn the basics of C# from the
 [C# 101 video series](https://aka.ms/dotnet3-csharp) before starting these interactive lessons.
 
 > [!VIDEO https://channel9.msdn.com/Series/CSharp-101/What-is-C/player]

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -8,7 +8,7 @@ ms.custom: mvc
 
 Welcome to the introduction to C# tutorials. These start with interactive lessons
 that you can run in your browser. You can learn the basics of C# from
-[this video series](https://aka.ms/dotnet3-csharp) before starting these interactive lessons.
+[C# 101 video series](https://aka.ms/dotnet3-csharp) before starting these interactive lessons.
 
 > [!VIDEO https://channel9.msdn.com/Series/CSharp-101/What-is-C/player]
 


### PR DESCRIPTION
Fixes #15008

Provide links to the C# 101 video series from the C# home page, the tutorials home page, and the intro to C# tutorials home page.

Internal review links:
[C# Guide index page](https://review.docs.microsoft.com/en-us/dotnet/csharp/index?branch=pr-en-us-15605)
[C# Tutorials index page](https://review.docs.microsoft.com/en-us/dotnet/csharp/tutorials/index?branch=pr-en-us-15605)
[Intro to C# tutorial index page](https://review.docs.microsoft.com/en-us/dotnet/csharp/tutorials/intro-to-csharp/index?branch=pr-en-us-15605)

/cc @JaySing @shanselman @kendrahavens 