### PR TITLE
Fix doc to correctly describe code snippet

### DIFF
--- a/docs/standard/io/pipelines.md
+++ b/docs/standard/io/pipelines.md
@@ -306,7 +306,7 @@ The <xref:System.IO.Pipelines.PipeWriter> manages buffers for writing on the cal
 
 The previous code:
 
-* Requests a buffer of at least 5 bytes from the `PipeWriter` using <xref:System.IO.Pipelines.PipeWriter.GetSpan%2A>.
+* Requests a buffer of at least 5 bytes from the `PipeWriter` using <xref:System.IO.Pipelines.PipeWriter.GetMemory%2A>.
 * Writes bytes for the ASCII string `"Hello"` to the returned `Span<byte>`.
 * Calls <xref:System.IO.Pipelines.PipeWriter.Advance%2A> to indicate how many bytes were written to the buffer.
 * Flushes the `PipeWriter`, which sends the bytes to the underlying device.

--- a/docs/standard/io/pipelines.md
+++ b/docs/standard/io/pipelines.md
@@ -307,7 +307,7 @@ The <xref:System.IO.Pipelines.PipeWriter> manages buffers for writing on the cal
 The previous code:
 
 * Requests a buffer of at least 5 bytes from the `PipeWriter` using <xref:System.IO.Pipelines.PipeWriter.GetMemory%2A>.
-* Writes bytes for the ASCII string `"Hello"` to the returned `Span<byte>`.
+* Writes bytes for the ASCII string `"Hello"` to the returned `Memory<byte>`.
 * Calls <xref:System.IO.Pipelines.PipeWriter.Advance%2A> to indicate how many bytes were written to the buffer.
 * Flushes the `PipeWriter`, which sends the bytes to the underlying device.
 


### PR DESCRIPTION
The doc claimed the code snippet used `GetSpan` when in fact it used `GetMemory`.