### PR TITLE
Add contextual understanding for logging delegates example

### DIFF
--- a/docs/csharp/delegates-patterns.md
+++ b/docs/csharp/delegates-patterns.md
@@ -84,7 +84,7 @@ The static class above is the simplest thing that can work. We need to
 write the single implementation for the method that writes messages
 to the console: 
 
-[!code-csharp[LogToConsole](../../samples/csharp/delegates-and-events/Program.cs#LogToConsole "A Console logger.")]
+[!code-csharp[LogToConsole](../../samples/csharp/delegates-and-events/LoggingMethods.cs#LogToConsole "A Console logger.")]
 
 Finally, you need to hook up the delegate by attaching it to
 the WriteMessage delegate declared in the logger:

--- a/docs/csharp/delegates-patterns.md
+++ b/docs/csharp/delegates-patterns.md
@@ -157,14 +157,14 @@ methods and generate messages to the console and a file:
 
 ```csharp
 var fileOutput = new FileLogger("log.txt");
-Logger.WriteMessage += LogToConsole;
+Logger.WriteMessage += LogginMethods.LogToConsole;
 ```
 
 Later, even in the same application, you can remove one of the
 delegates without any other issues to the system:
 
 ```csharp
-Logger.WriteMessage -= LogToConsole;
+Logger.WriteMessage -= LoggingMethods.LogToConsole;
 ```
 
 ## Practices

--- a/docs/csharp/delegates-patterns.md
+++ b/docs/csharp/delegates-patterns.md
@@ -157,7 +157,7 @@ methods and generate messages to the console and a file:
 
 ```csharp
 var fileOutput = new FileLogger("log.txt");
-Logger.WriteMessage += LogginMethods.LogToConsole;
+Logger.WriteMessage += LoggingMethods.LogToConsole; // LoggingMethods is the static class we utilized earlier
 ```
 
 Later, even in the same application, you can remove one of the


### PR DESCRIPTION
## Note: this will be in conjunction with a fix in the samples
We'll be creating a new file here and changing some pointers, so this PR will be linked to another PR in that repo and both should be merged at the same time.

Link to the samples PR: https://github.com/dotnet/samples/pull/1686

## The Issue
The logging delegates example uses `+= LogToConsole`, but the documentation does not provide context as to where that static method exists (it's housed in `Program.cs` in the example, but that's not evident in the docs or the region that's selected for display.)

## Proposed Solution
Creating a separate static class, e.g `LoggingMethods`, to house this example should mean that the docs can be updated to explicitly show the contents of the class and where it's being used, as well as a clearer conceptual understanding of what's going on.

Fixes https://github.com/dotnet/docs/issues/14103