### PR TITLE
Update structure marshaling guidance for .NET Core 3.0

### DIFF
--- a/docs/standard/native-interop/customize-struct-marshaling.md
+++ b/docs/standard/native-interop/customize-struct-marshaling.md
@@ -21,7 +21,7 @@ Sometimes the default marshaling rules for structures aren't exactly what you ne
 
 **✔️ DO** only use `LayoutKind.Explicit` in marshaling when your native struct is also has an explicit layout, such as a union.
 
-**❌ AVOID** using `LayoutKind.Explicit` when marshaling structures on non-Windows platforms. The .NET Core runtime doesn't support passing explicit structures by value to native functions on Intel or AMD 64-bit non-Windows systems. However, the runtime supports passing explicit structures by reference on all platforms.
+**❌ AVOID** using `LayoutKind.Explicit` when marshaling structures on non-Windows platforms if you need to target runtimes before .NET Core 3.0. The .NET Core runtime before 3.0 Preview 4 doesn't support passing explicit structures by value to native functions on Intel or AMD 64-bit non-Windows systems. However, the runtime supports passing explicit structures by reference on all platforms.
 
 ## Customizing boolean field marshaling
 

--- a/docs/standard/native-interop/customize-struct-marshaling.md
+++ b/docs/standard/native-interop/customize-struct-marshaling.md
@@ -21,7 +21,7 @@ Sometimes the default marshaling rules for structures aren't exactly what you ne
 
 **✔️ DO** only use `LayoutKind.Explicit` in marshaling when your native struct is also has an explicit layout, such as a union.
 
-**❌ AVOID** using `LayoutKind.Explicit` when marshaling structures on non-Windows platforms if you need to target runtimes before .NET Core 3.0. The .NET Core runtime before 3.0 Preview 4 doesn't support passing explicit structures by value to native functions on Intel or AMD 64-bit non-Windows systems. However, the runtime supports passing explicit structures by reference on all platforms.
+**❌ AVOID** using `LayoutKind.Explicit` when marshaling structures on non-Windows platforms if you need to target runtimes before .NET Core 3.0. The .NET Core runtime before 3.0 doesn't support passing explicit structures by value to native functions on Intel or AMD 64-bit non-Windows systems. However, the runtime supports passing explicit structures by reference on all platforms.
 
 ## Customizing boolean field marshaling
 


### PR DESCRIPTION
Contributes to #11396 

Continued from #12101

> dotnet/coreclr#22041 fixed marshaling explicit-layout structures on non-Windows platforms.

/cc @jkoritzinsky 