### PR TITLE
Delete dev_langs in consuming-library-with-visual-studio.md

### DIFF
--- a/docs/core/tutorials/consuming-library-with-visual-studio.md
+++ b/docs/core/tutorials/consuming-library-with-visual-studio.md
@@ -4,9 +4,6 @@ description: Build a .NET Core application that calls members of another class l
 author: BillWagner
 ms.author: wiwagn
 ms.date: 06/05/2018
-dev_langs: 
-  - "csharp"
-  - "vb"
 ms.custom: "vs-dotnet, seodec18"
 ---
 


### PR DESCRIPTION
The problem with the dev_langs in this article is that it adds language selector at the top of article.

![image](https://user-images.githubusercontent.com/31348972/67996667-0d7b8b00-fc59-11e9-9983-bd6fbea222bb.png)

This selector is useless, because the article itself has a C# and VB tabs.

The other solution would be trying to remove the tabs from the article and combining the information together and keep the dev_langs.