### PR TITLE
Swap a Decrypt for an Encrypt

### DIFF
--- a/docs/standard/security/how-to-encrypt-xml-elements-with-symmetric-keys.md
+++ b/docs/standard/security/how-to-encrypt-xml-elements-with-symmetric-keys.md
@@ -20,7 +20,7 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # How to: Encrypt XML Elements with Symmetric Keys
-You can use the classes in the <xref:System.Security.Cryptography.Xml> namespace to encrypt an element within an XML document.  XML Encryption allows you to store or transport sensitive XML, without worrying about the data being easily read.  This procedure decrypts an XML element using the Advanced Encryption Standard (AES) algorithm, also known as Rijndael.  
+You can use the classes in the <xref:System.Security.Cryptography.Xml> namespace to encrypt an element within an XML document.  XML Encryption allows you to store or transport sensitive XML, without worrying about the data being easily read.  This procedure encrypts an XML element using the Advanced Encryption Standard (AES) algorithm, also known as Rijndael.  
   
  For information about how to decrypt an XML element that was encrypted using this procedure, see [How to: Decrypt XML Elements with Symmetric Keys](../../../docs/standard/security/how-to-decrypt-xml-elements-with-symmetric-keys.md).  
   


### PR DESCRIPTION
The wrong word was used in the opening paragraph describing what this example reflects

## Summary

I simply replaced the word `decrypts` (the wrong word) with `encrypts` in the opening paragraph


