### PR TITLE
update tab completion

### DIFF
--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -3,7 +3,7 @@ title: Enable tab completion
 description: This article teaches you how to enable tab completion for the .NET Core CLI for PowerShell, Bash, and zsh.
 author: thraka
 ms.author: adegeo
-ms.date: 12/17/2018
+ms.date: 11/03/2019
 ---
 
 # How to enable TAB completion for .NET Core CLI
@@ -53,7 +53,7 @@ Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
  }
 ```
 
-## Bash
+## bash
 
 To add tab completion to your **bash** shell for the .NET Core CLI, add the following code to your `.bashrc` file:
 
@@ -65,7 +65,10 @@ _dotnet_bash_complete()
   local word=${COMP_WORDS[COMP_CWORD]}
 
   local completions
-  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}")"
+  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)"
+  if [ $? -ne 0 ]; then
+    completions=""
+  fi
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }
@@ -73,7 +76,7 @@ _dotnet_bash_complete()
 complete -f -F _dotnet_bash_complete dotnet
 ```
 
-## Zsh
+## zsh
 
 To add tab completion to your **zsh** shell for the .NET Core CLI, add the following code to your `.zshrc` file:
 


### PR DESCRIPTION
I've noticed the scripts have changed in https://github.com/dotnet/cli/blob/master/Documentation/general/tab-completion.md

It's a bit hard to keep two locations up to date. Can we just maintain the one in docs now @KathleenDollard @dsplaisted? Thoughts?