### PR TITLE
Add System.EnterpriseServices in article intro

### DIFF
--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -7,7 +7,7 @@ ms.date: 04/30/2019
 
 # .NET Framework technologies unavailable on .NET Core
 
-Several technologies available to .NET Framework libraries aren't available for use with .NET Core, such as AppDomains, Remoting, Code Access Security (CAS), and Security Transparency. If your libraries rely on one or more of these technologies, consider the alternative approaches outlined below. For more information on API compatibility, see the [.NET Core breaking changes](../compatibility/breaking-changes.md) article.
+Several technologies available to .NET Framework libraries aren't available for use with .NET Core, such as AppDomains, Remoting, Code Access Security (CAS), System.EnterpriseServices, and Security Transparency. If your libraries rely on one or more of these technologies, consider the alternative approaches outlined below. For more information on API compatibility, see the [.NET Core breaking changes](../compatibility/breaking-changes.md) article.
 
 Just because an API or technology isn't currently implemented doesn't imply it's intentionally unsupported. You should first search the GitHub repositories for .NET Core to see if a particular issue you encounter is by design, but if you cannot find such an indicator, please file an issue in the [dotnet/corefx repository issues](https://github.com/dotnet/corefx/issues) at GitHub to ask for specific APIs and technologies. [Porting requests in the issues](https://github.com/dotnet/corefx/labels/port-to-core) are marked with the `port-to-core` label.
 

--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -7,7 +7,7 @@ ms.date: 04/30/2019
 
 # .NET Framework technologies unavailable on .NET Core
 
-Several technologies available to .NET Framework libraries aren't available for use with .NET Core, such as AppDomains, Remoting, Code Access Security (CAS), System.EnterpriseServices, and Security Transparency. If your libraries rely on one or more of these technologies, consider the alternative approaches outlined below. For more information on API compatibility, see the [.NET Core breaking changes](../compatibility/breaking-changes.md) article.
+Several technologies available to .NET Framework libraries aren't available for use with .NET Core, such as AppDomains, Remoting, Code Access Security (CAS), Security Transparency, and System.EnterpriseServices. If your libraries rely on one or more of these technologies, consider the alternative approaches outlined below. For more information on API compatibility, see the [.NET Core breaking changes](../compatibility/breaking-changes.md) article.
 
 Just because an API or technology isn't currently implemented doesn't imply it's intentionally unsupported. You should first search the GitHub repositories for .NET Core to see if a particular issue you encounter is by design, but if you cannot find such an indicator, please file an issue in the [dotnet/corefx repository issues](https://github.com/dotnet/corefx/issues) at GitHub to ask for specific APIs and technologies. [Porting requests in the issues](https://github.com/dotnet/corefx/labels/port-to-core) are marked with the `port-to-core` label.
 


### PR DESCRIPTION
In a previous PR, System.EnterpriseServices was added  in the bottom of the article but it was missing from the article intro.