### PR TITLE
Increase SEO for nullable article

### DIFF
--- a/docs/csharp/nullable-attributes.md
+++ b/docs/csharp/nullable-attributes.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrade APIs with attributes to define null expectations
-description: This article explains the motivations and techniques for adding descriptive attributes to describe the null state of arguments and return values from APIs
+title: Upgrade APIs for nullable reference types with attributes that define null expectations
+description: Learn to use the descriptive attributes AllowNull, DisallowNull, MaybeNull, NotNull and more to fully describe the null state of your APIs.
 ms.technology: csharp-null-safety
 ms.date: 07/31/2019
 ---
 # Update libraries to use nullable reference types and communicate nullable rules to callers
 
-The addition of [nullable reference types](nullable-references.md) means you can declare whether or not a `null` value is allowed or expected for every variable. That provides a great experience as you write code. You get warnings if a non-nullable variable might be set to `null`. You get warnings if a nullable variable isn't null-checked before you dereference it. Updating your libraries can take time, but the payoffs are worth it. The more information you provide to the compiler about *when* a `null` value is allowed or prohibited, the better warnings users of your API will get. Let's start with a familiar example. Imagine your library has the following API to retrieve a resource string:
+The addition of [nullable reference types](nullable-references.md) means you can declare whether or not a `null` value is allowed or expected for every variable. In addition, you can apply a number of attributes: `AllowNull`, `DisallowNull`, `MaybeNull`, `NotNull`, `NotNullWhen`, `MaybeNullWhen`, and `NotNullWhenNotNull` to completely describe the null states of argument and return values. That provides a great experience as you write code. You get warnings if a non-nullable variable might be set to `null`. You get warnings if a nullable variable isn't null-checked before you dereference it. Updating your libraries can take time, but the payoffs are worth it. The more information you provide to the compiler about *when* a `null` value is allowed or prohibited, the better warnings users of your API will get. Let's start with a familiar example. Imagine your library has the following API to retrieve a resource string:
 
 ```csharp
 bool TryGetMessage(string key, out string message)

--- a/docs/csharp/nullable-attributes.md
+++ b/docs/csharp/nullable-attributes.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade APIs for nullable reference types with attributes that define null expectations
+title: Upgrade APIs for nullable reference types with attributes that define expectations for null values
 description: Learn to use the descriptive attributes AllowNull, DisallowNull, MaybeNull, NotNull and more to fully describe the null state of your APIs.
 ms.technology: csharp-null-safety
 ms.date: 07/31/2019


### PR DESCRIPTION
This article was not as prominient as it should have been for key terms related to nullable reference types and the attributes to describe those API contracts. Update the title, description, and opening paragraph to increase its findability.

/cc @jaredpar @cartermp 