### PR TITLE
Replace MSDN DevLabs with Visual Studio Marketplace

### DIFF
--- a/docs/framework/debug-trace-profile/code-contracts.md
+++ b/docs/framework/debug-trace-profile/code-contracts.md
@@ -30,7 +30,7 @@ All .NET Framework languages can immediately take advantage of contracts; you do
 
 Most methods in the contract class are conditionally compiled; that is, the compiler emits calls to these methods only when  you define a special symbol, CONTRACTS_FULL, by using the `#define` directive. CONTRACTS_FULL lets you write contracts in your code without using `#ifdef` directives; you can produce different builds, some with contracts, and some without.
 
-For tools and detailed instructions for using code contracts, see [Code Contracts](https://go.microsoft.com/fwlink/?LinkId=152461) on the MSDN DevLabs Web site.
+For tools and detailed instructions for using code contracts, see [Code Contracts](https://go.microsoft.com/fwlink/?LinkId=152461) on the Visual Studio Marketplace.
 
 ## Preconditions
 


### PR DESCRIPTION
## Summary

It does not look like MSDN DevLabs still exists.

Fixes #Issue_Number (if available)
