### PR TITLE
Add ReadOnlySpan and adjust slice call in both

### DIFF
--- a/docs/fsharp/language-reference/slices.md
+++ b/docs/fsharp/language-reference/slices.md
@@ -111,12 +111,19 @@ If you are defining slices for a type that is actually a struct, we recommend th
 ```fsharp
 open System
 
+type ReadOnlySpan<'T> with
+    // Note the 'inline' in the member definition
+    member sp.GetSlice(startIdx, endIdx) =
+        let s = defaultArg startIdx 0
+        let e = defaultArg endIdx sp.Length
+        sp.Slice(s, e - s)
+
 type Span<'T> with
     // Note the 'inline' in the member definition
     member inline sp.GetSlice(startIdx, endIdx) =
         let s = defaultArg startIdx 0
         let e = defaultArg endIdx sp.Length
-        sp.Slice(s, e)
+        sp.Slice(s, e - s)
 
 let printSpan (sp: Span<int>) =
     let arr = sp.ToArray()


### PR DESCRIPTION
without `e-s`, we're quite prone to IndexOutOfRange exceptions