### PR TITLE
Correct information about System namespace

### DIFF
--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -37,7 +37,7 @@ Let's do a quick walkthrough:
 
    *Hello.csproj*:
 
-   [!code-xml[Hello.csproj](../../../samples/core/console-apps/HelloMsBuild/Hello.csproj)]
+   [!code-xml[Hello.csproj](~/samples/core/console-apps/HelloMsBuild/Hello.csproj)]
 
    The project file specifies everything that's needed to restore dependencies and build the program.
 
@@ -46,9 +46,9 @@ Let's do a quick walkthrough:
 
    *Program.cs*:
 
-   [!code-csharp[Program.cs](../../../samples/core/console-apps/HelloMsBuild/Program.cs)]
+   [!code-csharp[Program.cs](~/samples/core/console-apps/HelloMsBuild/Program.cs)]
 
-   The program starts by `using System`, which means "bring everything in the `System` namespace into scope for this file". The `System` namespace includes basic constructs such as `string`, or numeric types.
+   The program starts by `using System`, which means "bring everything in the `System` namespace into scope for this file". The `System` namespace includes basic constructs such as `Console` class and `Console.WriteLine` method.
 
    We then define a namespace called `Hello`. You can change this to anything you want. A class named `Program` is defined within that namespace, with a `Main` method that takes an array of strings as its argument. This array contains the list of arguments passed in when the compiled program is called. As it is, this array is not used: all the program is doing is to write "Hello World!" to the console. Later, we'll make changes to the code that will make use of this argument.
 
@@ -110,7 +110,7 @@ Let's change the program a bit. Fibonacci numbers are fun, so let's add that in 
    15: 377
    ```
 
-And that's it!  You can augment `Program.cs` any way you like.
+And that's it!  You can augment *Program.cs* any way you like.
 
 ## Working with multiple files
 
@@ -119,11 +119,11 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 1. Add a new file inside the *Hello* directory named *FibonacciGenerator.cs* with the following code:
 
-   [!code-csharp[Fibonacci Generator](../../../samples/core/console-apps/FibonacciBetterMsBuild/FibonacciGenerator.cs)]
+   [!code-csharp[Fibonacci Generator](~/samples/core/console-apps/FibonacciBetterMsBuild/FibonacciGenerator.cs)]
 
 2. Change the `Main` method in your *Program.cs* file to instantiate the new class and call its method as in the following example:
 
-   [!code-csharp[New Program.cs](../../../samples/core/console-apps/FibonacciBetterMsBuild/Program.cs)]
+   [!code-csharp[New Program.cs](~/samples/core/console-apps/FibonacciBetterMsBuild/Program.cs)]
 
 3. Execute [`dotnet build`](../tools/dotnet-build.md) to compile the changes.
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -48,7 +48,7 @@ Let's do a quick walkthrough:
 
    [!code-csharp[Program.cs](~/samples/core/console-apps/HelloMsBuild/Program.cs)]
 
-   The program starts by `using System`, which means "bring everything in the `System` namespace into scope for this file". The `System` namespace includes basic constructs such as `Console` class and `Console.WriteLine` method.
+   The program starts by `using System`, which means "bring everything in the `System` namespace into scope for this file". The `System` namespace includes the `Console` class.
 
    We then define a namespace called `Hello`. You can change this to anything you want. A class named `Program` is defined within that namespace, with a `Main` method that takes an array of strings as its argument. This array contains the list of arguments passed in when the compiled program is called. As it is, this array is not used: all the program is doing is to write "Hello World!" to the console. Later, we'll make changes to the code that will make use of this argument.
 


### PR DESCRIPTION
`string` with small `s` is the C# alias for the CLR type `System.String`, the code snippet above this statement requires `using System` for the `Console.WriteLine` method.