### PR TITLE
Update interactive instructions

### DIFF
--- a/docs/csharp/tutorials/exploration/csharp-6.yml
+++ b/docs/csharp/tutorials/exploration/csharp-6.yml
@@ -21,7 +21,7 @@ items:
     [!code-csharp[Starter](../../../../samples/csharp/tutorials/exploration/csharp6-starter/Program.cs)]  
 
         
-     Enter Focus mode, copy the preceding code into the C# interactive window. Then, click *Run* to see what the code does. `AllCaps` has the undesirable side effect of modifying the property values along with returning the uppercase string. The author of the `Person` class intended the strings for `FirstName` and `LastName` to be read-only. With C# 6, you can make that intent clear. Remove the `private set` from both properties to create a read-only auto property. Click *Run* to see that the compiler spots the two locations where the `FirstName` and `LastName` properties are changed when they should not have been. You can change the `AllCaps` method to the following code to fix the compiler error:
+     Enter Focus mode, copy the preceding code into the C# interactive window. Then, select *Run* to see what the code does. `AllCaps` has the undesirable side effect of modifying the property values along with returning the uppercase string. The author of the `Person` class intended the strings for `FirstName` and `LastName` to be read-only. With C# 6, you can make that intent clear. Remove the `private set` from both properties to create a read-only auto property. Select *Run* to see that the compiler spots the two locations where the `FirstName` and `LastName` properties are changed when they should not have been. You can change the `AllCaps` method to the following code to fix the compiler error:
 
     ```csharp
     public string AllCaps()

--- a/docs/csharp/tutorials/exploration/interpolated-strings.yml
+++ b/docs/csharp/tutorials/exploration/interpolated-strings.yml
@@ -16,7 +16,7 @@ items:
 - title: Create an interpolated string
   durationInMinutes: 2
   content: |
-    Run the following code in the interactive window. To do that, type the code in the interactive window (replace `<name>` with your name) and select **Run**:
+    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window (replace `<name>` with your name) and select **Run**:
 
     ```csharp
     var name = "<name>";

--- a/docs/csharp/tutorials/exploration/interpolated-strings.yml
+++ b/docs/csharp/tutorials/exploration/interpolated-strings.yml
@@ -16,7 +16,7 @@ items:
 - title: Create an interpolated string
   durationInMinutes: 2
   content: |
-    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window (replace `<name>` with your name) and select **Run**:
+    Run the following code in the interactive window. Select the **Enter focus mode** button. Then, type the following code block in the interactive window (replace `<name>` with your name) and select **Run**:
 
     ```csharp
     var name = "<name>";

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -35,7 +35,7 @@ items:
     int b = 3;
     ```
 
-    Click the **Run** button again. Because the answer is less than 10, nothing is printed. The **condition** you're testing is false. You don't have any code to execute because you've only
+    Select the **Run** button again. Because the answer is less than 10, nothing is printed. The **condition** you're testing is false. You don't have any code to execute because you've only
     written one of the possible branches for an `if` statement: the true branch.
 
     > [!TIP]
@@ -276,7 +276,7 @@ items:
 
 - title: Congratulations!
   content: |
-    You've completed the "branches and loops" interactive tutorial. You can click the **list collection** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
+    You've completed the "branches and loops" interactive tutorial. You can select the **list collection** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     You can learn more about these concepts in these topics:
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -18,7 +18,7 @@ items:
 - title: Make decisions using the if statement
   durationInMinutes: 4
   content: |
-    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window and click the **Run** button:
+    Run the following code in the interactive window. Select the **Enter focus mode** button. Then, type the following code block in the interactive window and select **Run**:
 
     ```csharp
     int a = 5;

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -18,7 +18,7 @@ items:
 - title: Make decisions using the if statement
   durationInMinutes: 4
   content: |
-    Run the following code in the interactive window. To do that, type the following code block in the interactive window and click the **Run** button:
+    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window and click the **Run** button:
 
     ```csharp
     int a = 5;

--- a/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
@@ -77,7 +77,7 @@ items:
     Console.WriteLine("Hello " + aFriend);
     ```
 
-    Click **Run** again to see the results.
+    Select **Run** again to see the results.
 
     You've been using `+` to build strings from **variables** and **constant** strings. There's a better way.
     You can place a variable between `{` and `}` characters to tell C# to replace that text with the value of the variable.
@@ -91,7 +91,7 @@ items:
     Console.WriteLine($"Hello {aFriend}");
     ```
 
-    Click **Run** again to see the results. Instead of "Hello {aFriend}", the message should be "Hello Maira".
+    Select **Run** again to see the results. Instead of "Hello {aFriend}", the message should be "Hello Maira".
 
     > [!NOTE]
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
@@ -221,7 +221,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the "Hello C#" introduction to C# tutorial. You can click the **Numbers in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
+    You've completed the "Hello C#" introduction to C# tutorial. You can select the **Numbers in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     For further reading on the `string` type:
     - [C# Programming Guide](../../programming-guide/index.md) topic on [strings](../../programming-guide/strings/index.md).

--- a/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
@@ -18,7 +18,7 @@ items:
 - title: Run your first C# program
   durationInMinutes: 2
   content: |
-    Run the following code in the interactive window. To do that, type the following code block in the interactive window and click the **Run** button:
+    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window and click the **Run** button:
 
     ```csharp
     Console.WriteLine("Hello World!");

--- a/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
@@ -18,7 +18,7 @@ items:
 - title: Run your first C# program
   durationInMinutes: 2
   content: |
-    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window and click the **Run** button:
+    Run the following code in the interactive window. Select the **Enter focus mode** button. Then, type the following code block in the interactive window and select **Run**:
 
     ```csharp
     Console.WriteLine("Hello World!");

--- a/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
@@ -16,7 +16,7 @@ items:
 - title: Create lists
   durationInMinutes: 2
   content: |
-    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window (replace `<name>` with your name) and click the **Run** button:
+    Run the following code in the interactive window. Select the **Enter focus mode** button. Then, type the following code block in the interactive window (replace `<name>` with your name) and select **Run**:
 
     ```csharp
     var names = new List<string> { "<name>", "Ana", "Felipe" };

--- a/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
@@ -71,7 +71,7 @@ items:
     Console.WriteLine($"The list has {names.Count} people in it");
     ```
 
-    Click **Run** again to see the results. In C#, indices start at 0, so the largest valid index is one less than the number of items in the list.
+    Select **Run** again to see the results. In C#, indices start at 0, so the largest valid index is one less than the number of items in the list.
 
     > [!NOTE]
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).

--- a/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
@@ -16,7 +16,7 @@ items:
 - title: Create lists
   durationInMinutes: 2
   content: |
-    Run the following code in the interactive window. To do that, type the following code block in the interactive window (replace `<name>` with your name) and click the **Run** button:
+    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window (replace `<name>` with your name) and click the **Run** button:
 
     ```csharp
     var names = new List<string> { "<name>", "Ana", "Felipe" };

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
@@ -18,7 +18,7 @@ items:
 - title: Explore integer math
   durationInMinutes: 4
   content: |
-    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window and click the **Run** button:
+    Run the following code in the interactive window. Select the **Enter focus mode** button. Then, type the following code block in the interactive window and select **Run**:
 
     ```csharp
     int a = 18;

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
@@ -38,7 +38,7 @@ items:
     > [!TIP]
     > Throughout this interactive tutorial, you can explore on your own by modifying the code you've written in the interactive window. This tutorial provides examples that you can try at each step.
 
-    Start by exploring those different operations. Modify the third line to try each of these operations. After each edit, click the **Run** button.
+    Start by exploring those different operations. Modify the third line to try each of these operations. After each edit, select the **Run** button.
 
     Subtraction:
 
@@ -120,7 +120,7 @@ items:
     Console.WriteLine(d);
     ```
 
-    Click **Run** again to see the results.
+    Select **Run** again to see the results.
 
     > [!NOTE]
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
@@ -295,7 +295,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the "Numbers in C#" interactive tutorial. You can click the **Branches and Loops** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
+    You've completed the "Numbers in C#" interactive tutorial. You can select the **Branches and Loops** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     You can learn more about numbers in C# in the following topics:
 

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
@@ -18,7 +18,7 @@ items:
 - title: Explore integer math
   durationInMinutes: 4
   content: |
-    Run the following code in the interactive window. To do that, type the following code block in the interactive window and click the **Run** button:
+    Run the following code in the interactive window. Click the **Enter Focus Mode** button. Then, type the following code block in the interactive window and click the **Run** button:
 
     ```csharp
     int a = 18;

--- a/docs/csharp/tutorials/upgrade-to-nullable-references.md
+++ b/docs/csharp/tutorials/upgrade-to-nullable-references.md
@@ -26,7 +26,7 @@ This tutorial assumes you're familiar with C# and .NET, including either Visual 
 
 ## Explore the sample application
 
-The sample application that you'll migrate is an RSS feed reader web app. It reads from a single RSS feed and displays summaries for the most recent articles. You can click on any of the articles to visit the site. The application is relatively new but was written before nullable reference types were available. The design decisions for the application represented sound principles, but don't take advantage of this important language feature.
+The sample application that you'll migrate is an RSS feed reader web app. It reads from a single RSS feed and displays summaries for the most recent articles. You can select any of the articles to visit the site. The application is relatively new but was written before nullable reference types were available. The design decisions for the application represented sound principles, but don't take advantage of this important language feature.
 
 The sample application includes a unit test library that validates the major functionality of the app. That project will make it easier to upgrade safely, if you change any of the implementation based on the warnings generated. You can download the starter code from the [dotnet/samples](https://github.com/dotnet/samples/tree/master/csharp/tutorials/nullable-reference-migration/start) GitHub repository.
 


### PR DESCRIPTION
The instructions for some of our interactive tutorials don't match the latest site updates.
Update the first example instructions to tell users how to enter focus mode, and begin using the interactive window.

Fixes #13345
Fixes #14078
