### PR TITLE
Change example code formatting

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
+++ b/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
@@ -24,13 +24,13 @@ The `var` keyword may be used in the following contexts:
 - In a [for](../../language-reference/keywords/for.md) initialization statement.
 
     ```csharp
-    for(var x = 1; x < 10; x++)
+    for (var x = 1; x < 10; x++)
     ```
 
 - In a [foreach](../../language-reference/keywords/foreach-in.md) initialization statement.
 
     ```csharp
-    foreach(var item in list){...}
+    foreach (var item in list) {...}
     ```
 
 - In a [using](../../language-reference/keywords/using-statement.md) statement.
@@ -57,7 +57,7 @@ The following restrictions apply to implicitly-typed variable declarations:
 
 - `var` cannot be used on fields at class scope.
 
-- Variables declared by using `var` cannot be used in the initialization expression. In other words, this expression is legal`: int i = (i = 20);` but this expression produces a compile-time error: `var i = (i = 20);`
+- Variables declared by using `var` cannot be used in the initialization expression. In other words, this expression is legal: `int i = (i = 20);` but this expression produces a compile-time error: `var i = (i = 20);`
 
 - Multiple implicitly-typed variables cannot be initialized in the same statement.
 


### PR DESCRIPTION
## Summary
Added spaces to example code to be consistent with rest of document, moved a colon out of a code block.
