### PR TITLE
Correct notes on default DateTimeOffset serialization

### DIFF
--- a/docs/standard/datetime/system-text-json-support.md
+++ b/docs/standard/datetime/system-text-json-support.md
@@ -208,11 +208,11 @@ The following levels of granularity are defined for formatting:
 2. 'Date time'
     1. "yyyy'-'MM'-'dd'T'HH':'mm':'ssZ"
 
-        Used to format a <xref:System.DateTime> or <xref:System.DateTimeOffset> without fractional seconds but with a UTC offset.
+        Used to format a <xref:System.DateTime> without fractional seconds but with a UTC offset.
 
     2. "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'FFFFFFFZ"
 
-        Used to format a <xref:System.DateTime> or <xref:System.DateTimeOffset> with fractional seconds and with a UTC offset.
+        Used to format a <xref:System.DateTime> with fractional seconds and with a UTC offset.
 
     3. "yyyy'-'MM'-'dd'T'HH':'mm':'ss('+'/'-')HH':'mm"
 


### PR DESCRIPTION
Utf8Formatter (with "O" standard format) and the Utf8JsonWriter will only write `DateTimeOffset` types with "+-hh:mm" offset representations e.g. "2019-07-26T16:59:57`+00:00`". They will not write "2019-07-26T16:59:57`Z`".

cc @ahsonkhan @tdykstra @mairaw 