### PR TITLE
Removed double copy command in Dockerfile

### DIFF
--- a/docs/architecture/modern-web-apps-azure/common-web-application-architectures.md
+++ b/docs/architecture/modern-web-apps-azure/common-web-application-architectures.md
@@ -260,7 +260,6 @@ The `docker-compose.yml` file references the `Dockerfile` in the `Web` project. 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /app
 
-COPY *.sln .
 COPY . .
 WORKDIR /app/src/Web
 RUN dotnet restore


### PR DESCRIPTION
## Summary

As asked / answered in issue #15070 the double copy command in the Dockerfile, one for the solution file and one for all the files, is not needed. The copy solution file command is removed because the solution file will copy with the copy all command.

Fixes #15070 
