### PR TITLE
Add yml to supported languages in template.md

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -326,6 +326,7 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |VBScript|vbscript|
 |XAML|xaml|
 |XML|xml|
+|yml|yml|
 
 The `csharp-interactive` name specifies the C# language, and the ability to run the samples from the browser. These snippets are compiled and executed in a Docker container, and the results of that program execution are displayed in the user's browser window.
 


### PR DESCRIPTION
It seems that yml is a supported identifier. It's getting proper highlighting. Example from [Common web application architectures](https://docs.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/common-web-application-architectures#docker-support):

![image](https://user-images.githubusercontent.com/31348972/68581366-f458b280-0480-11ea-98b4-de17deb0d4bc.png)

