### PR TITLE
🚧 Add reference to VS Test Explorer doc

### DIFF
--- a/docs/core/tutorials/using-on-mac-vs-full-solution.md
+++ b/docs/core/tutorials/using-on-mac-vs-full-solution.md
@@ -188,4 +188,4 @@ Unit tests provide automated software testing during your development and publis
 ## See also
 
 - [Visual Studio 2017 for Mac Release Notes](/visualstudio/releasenotes/vs2017-mac-relnotes)
-- [Run unit tests with Test Explorer](visualstudio/test/run-unit-tests-with-test-explorer)
+- [Run unit tests with Test Explorer](/visualstudio/test/run-unit-tests-with-test-explorer)

--- a/docs/core/tutorials/using-on-mac-vs-full-solution.md
+++ b/docs/core/tutorials/using-on-mac-vs-full-solution.md
@@ -188,3 +188,4 @@ Unit tests provide automated software testing during your development and publis
 ## See also
 
 - [Visual Studio 2017 for Mac Release Notes](/visualstudio/releasenotes/vs2017-mac-relnotes)
+- [Run and debug unit tests with Test Explorer](visualstudio/test/run-unit-tests-with-test-explorer)

--- a/docs/core/tutorials/using-on-mac-vs-full-solution.md
+++ b/docs/core/tutorials/using-on-mac-vs-full-solution.md
@@ -188,4 +188,4 @@ Unit tests provide automated software testing during your development and publis
 ## See also
 
 - [Visual Studio 2017 for Mac Release Notes](/visualstudio/releasenotes/vs2017-mac-relnotes)
-- [Run and debug unit tests with Test Explorer](visualstudio/test/run-unit-tests-with-test-explorer)
+- [Run unit tests with Test Explorer](visualstudio/test/run-unit-tests-with-test-explorer)


### PR DESCRIPTION
Fixes #12762

Debugging unit tests is not specific to .NET Core projects and is covered in VS docs.