### PR TITLE
Create fips-compliance.md

### DIFF
--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -12,7 +12,7 @@ ms.author: "riande"
 
 * Does **not** implement any cryptographic primitives.
 * Passes cryptographic primitives calls through to the standard modules the underlying operating system provides.
-* Does **not** enforce FIPS compliance in .NET Core apps.
+* Does **not** enforce the use of FIPS Approved algorithms or key sizes in .NET Core apps.
 * Does **not** stop developers from using non-FIPS compliant algorithms, even on systems configured for FIPS compliance.
 
 The system administrator is responsible for configuring the FIPS compliance for an operating system.

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -1,0 +1,28 @@
+---
+title: .NET Core FIPS compliance
+description: Explains .NET Core FIPS compliance
+ms.date: 11/20/2019
+---
+
+# .NET Core FIPS compliance
+
+.NET Core:
+
+* Does **not** implement any cryptographic primitives.
+* Passes cryptographic primitives calls through to the standard modules the underlying operating system provides.
+* Does **not** enforce FIPS compliance in .NET Core app.
+* Does **not** stop developers using non-FIPS compliant algorithms, even on systems configured for FIPS compliance.
+
+It's the responsibility of the system administrator to configure FIPS compliance for an operating system.
+
+If code is written for a FIPS-compliant environment, it's the responsibility of the developer to:
+
+* Ensure that non-compliant FIPS algorithms are not used.
+* FIPS compliance is met.
+
+For more information on FIPS compliance, see the following articles:
+
+* [Windows FIPS Compliance](/windows/security/threat-protection/fips-140-validation)
+* [Configuring Windows for FIPS Compliance](/windows/security/threat-protection/security-policy-settings/system-cryptography-use-fips-compliant-algorithms-for-encryption-hashing-and-signing)
+* [OpenSSL FIPS Compliance](https://www.openssl.org/docs/fips.html)
+* [Configuring OpenSSL for FIPS Compliance](https://www.openssl.org/docs/fips/UserGuide.pdf)

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -20,7 +20,6 @@ It's the responsibility of the system administrator to configure FIPS compliance
 If code is written for a FIPS-compliant environment, it's the responsibility of the developer to esure that:
 
 * Non-compliant FIPS algorithms are not used.
-* FIPS compliance is met.
 
 For more information on FIPS compliance, see the following articles:
 

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -1,12 +1,12 @@
 ---
 title: FIPS compliance - .NET Core
-description: Explains .NET Core FIPS compliance.
+description: Explains .NET Core Federal Information Processing Standard (FIPS) compliance.
 ms.date: 11/20/2019
 author: "Rick-Anderson"
 ms.author: "riande"
 ---
 
-# .NET Core FIPS compliance
+# .NET Core Federal Information Processing Standard (FIPS) compliance
 
 .NET Core:
 

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -12,7 +12,6 @@ The Federal Information Processing Standard (FIPS) Publication 140-2 is a U.S. g
 
 .NET Core:
 
-* Does **not** implement any cryptographic primitives.
 * Passes cryptographic primitives calls through to the standard modules the underlying operating system provides.
 * Does **not** enforce the use of FIPS Approved algorithms or key sizes in .NET Core apps.
 
@@ -20,10 +19,8 @@ The system administrator is responsible for configuring the FIPS compliance for 
 
 If code is written for a FIPS-compliant environment, the developer is responsible for ensuring that non-compliant FIPS algorithms aren't used.
 
-* Non-compliant FIPS algorithms are not used.
-
 For more information on FIPS compliance, see the following articles:
 
 * [Windows FIPS Compliance](/windows/security/threat-protection/fips-140-validation)
 * [Configuring Windows for FIPS Compliance](/windows/security/threat-protection/security-policy-settings/system-cryptography-use-fips-compliant-algorithms-for-encryption-hashing-and-signing)
-
+* [10.2. FEDERAL INFORMATION PROCESSING STANDARD (FIPS)](https://access.redhat.com/documentation/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-federal_standards_and_regulations-federal_information_processing_standard)

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -2,6 +2,8 @@
 title: .NET Core FIPS compliance
 description: Explains .NET Core FIPS compliance
 ms.date: 11/20/2019
+author: "Rick-Anderson"
+ms.author: "riande"
 ---
 
 # .NET Core FIPS compliance
@@ -15,9 +17,9 @@ ms.date: 11/20/2019
 
 It's the responsibility of the system administrator to configure FIPS compliance for an operating system.
 
-If code is written for a FIPS-compliant environment, it's the responsibility of the developer to:
+If code is written for a FIPS-compliant environment, it's the responsibility of the developer to esure that:
 
-* Ensure that non-compliant FIPS algorithms are not used.
+* Non-compliant FIPS algorithms are not used.
 * FIPS compliance is met.
 
 For more information on FIPS compliance, see the following articles:

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -10,8 +10,8 @@ ms.date: 11/20/2019
 
 * Does **not** implement any cryptographic primitives.
 * Passes cryptographic primitives calls through to the standard modules the underlying operating system provides.
-* Does **not** enforce FIPS compliance in .NET Core app.
-* Does **not** stop developers using non-FIPS compliant algorithms, even on systems configured for FIPS compliance.
+* Does **not** enforce FIPS compliance in .NET Core apps.
+* Does **not** stop developers from using non-FIPS compliant algorithms, even on systems configured for FIPS compliance.
 
 It's the responsibility of the system administrator to configure FIPS compliance for an operating system.
 

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core FIPS compliance
+title: FIPS compliance - .NET Core
 description: Explains .NET Core FIPS compliance.
 ms.date: 11/20/2019
 author: "Rick-Anderson"

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -1,6 +1,6 @@
 ---
 title: .NET Core FIPS compliance
-description: Explains .NET Core FIPS compliance
+description: Explains .NET Core FIPS compliance.
 ms.date: 11/20/2019
 author: "Rick-Anderson"
 ms.author: "riande"
@@ -15,9 +15,9 @@ ms.author: "riande"
 * Does **not** enforce FIPS compliance in .NET Core apps.
 * Does **not** stop developers from using non-FIPS compliant algorithms, even on systems configured for FIPS compliance.
 
-It's the responsibility of the system administrator to configure FIPS compliance for an operating system.
+The system administrator is responsible for configuring the FIPS compliance for an operating system.
 
-If code is written for a FIPS-compliant environment, it's the responsibility of the developer to esure that:
+If code is written for a FIPS-compliant environment, the developer is responsible for ensuring that non-compliant FIPS algorithms aren't used.
 
 * Non-compliant FIPS algorithms are not used.
 

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -13,7 +13,6 @@ ms.author: "riande"
 * Does **not** implement any cryptographic primitives.
 * Passes cryptographic primitives calls through to the standard modules the underlying operating system provides.
 * Does **not** enforce the use of FIPS Approved algorithms or key sizes in .NET Core apps.
-* Does **not** stop developers from using non-FIPS compliant algorithms, even on systems configured for FIPS compliance.
 
 The system administrator is responsible for configuring the FIPS compliance for an operating system.
 

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -8,6 +8,8 @@ ms.author: "riande"
 
 # .NET Core Federal Information Processing Standard (FIPS) compliance
 
+The Federal Information Processing Standard (FIPS) Publication 140-2 is a U.S. government standard that defines minimum security requirements for cryptographic modules in information technology products, as defined in Section 5131 of the Information Technology Management Reform Act of 1996.
+
 .NET Core:
 
 * Does **not** implement any cryptographic primitives.

--- a/docs/standard/security/fips-compliance.md
+++ b/docs/standard/security/fips-compliance.md
@@ -26,5 +26,4 @@ For more information on FIPS compliance, see the following articles:
 
 * [Windows FIPS Compliance](/windows/security/threat-protection/fips-140-validation)
 * [Configuring Windows for FIPS Compliance](/windows/security/threat-protection/security-policy-settings/system-cryptography-use-fips-compliant-algorithms-for-encryption-hashing-and-signing)
-* [OpenSSL FIPS Compliance](https://www.openssl.org/docs/fips.html)
-* [Configuring OpenSSL for FIPS Compliance](https://www.openssl.org/docs/fips/UserGuide.pdf)
+

--- a/docs/standard/security/toc.yml
+++ b/docs/standard/security/toc.yml
@@ -3,6 +3,8 @@
   items:
   - name: Key Security Concepts
     href: key-security-concepts.md
+  - name: .NET Core FIPS compliance
+    href: fips-compliance.md 
   - name: Role-Based Security
     href: role-based-security.md
     items:
@@ -16,8 +18,6 @@
       href: replacing-a-principal-object.md
     - name: Impersonating and Reverting
       href: impersonating-and-reverting.md
-    - name: .NET Core FIPS compliance
-      href: fips-compliance.md 
   - name: Cryptography Model
     href: cryptography-model.md
     items:

--- a/docs/standard/security/toc.yml
+++ b/docs/standard/security/toc.yml
@@ -16,6 +16,8 @@
       href: replacing-a-principal-object.md
     - name: Impersonating and Reverting
       href: impersonating-and-reverting.md
+    - name: .NET Core FIPS compliance
+      href: fips-compliance.md 
   - name: Cryptography Model
     href: cryptography-model.md
     items:


### PR DESCRIPTION
[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/standard/security/fips-compliance?branch=pr-en-us-15870)

Verify:

* meta-data.
* meaning hasn't changed from original.

Original doc:
.NET Core FIPS compliance

.NET Core does not implement any cryptographic primitives but, instead, passes calls rough to the standard modules the underlying operating system provides. 

It is, therefore, the responsibility of the system administrator to configure FIPS compliance for an operating system 

Furthermore, .NET Core does not enforce FIPS compliance in .NET Core nor stop developers using non-FIPS compliant algorithms even on systems configured for FIPS compliance. If code is written for a FIPS compliant environment it is the responsibility of the developer to ensure they do not use non-compliant algorithms.

Further Information
Windows FIPS Compliance 
Configuring Windows for FIPS Compliance
OpenSSL FIPS Compliance
Configuring OpenSSL for FIPS Compliance

