### PR TITLE
Unnecessary parenthesis removed

### DIFF
--- a/docs/csharp/nullable-attributes.md
+++ b/docs/csharp/nullable-attributes.md
@@ -223,7 +223,7 @@ That informs the compiler that any code where the return value is `false` need n
 
 ```csharp
 string? userInput = GetUserInput();
-if (!(string.IsNullOrEmpty(userInput))
+if (!string.IsNullOrEmpty(userInput))
 {
    int messageLength = userInput.Length; // no null check needed.
 }


### PR DESCRIPTION
## Summary

Removed an unnecessary parenthesis in a C# code example.