### PR TITLE
Add include_in_build flag to openpublishing.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -56,12 +56,14 @@
     {
       "path_to_root": "_csharplang",
       "url": "https://github.com/dotnet/csharplang",
-      "branch": "master"
+      "branch": "master",
+      "include_in_build": true
     },
     {
       "path_to_root": "_vblang",
       "url": "https://github.com/dotnet/vblang",
-      "branch": "master"
+      "branch": "master",
+      "include_in_build": true
     },
     {
       "path_to_root": "samples",


### PR DESCRIPTION
## Summary

This pull request is related to docfx v3 migration and won't bring any impact to your current published content page.

This is a change of the current build system, you have to add the flag `include_in_build` if you want to build the files the dependent repository as a content file.

