### PR TITLE
Hub page layout

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -28,92 +28,13 @@ highlightedContent:
       itemType: download
       url: https://dotnet.microsoft.com/download
     # Card
-    - title: "Create your first desktop app. Learn how to build a .NET Core console app."
+    - title: "Create your first console app."
       itemType: get-started
       url: core/get-started.md
     # Card
-    - title: "Create your first web app. Learn how to build an ASP.NET Core web app."
+    - title: "Create your first web app."
       itemType: learn
       url: https://dotnet.microsoft.com/learn/aspnet/hello-world-tutorial/intro
-
-# productDirectory section (optional)
-productDirectory:
-  title: Create your application # < 60 chars (optional)
-  summary: "You can choose web, mobile, desktop, gaming, IoT, and more." # < 160 chars (optional)
-  items:
-    # Card
-    - title: Web
-      # imageSrc should be square in ratio with no whitespace
-      imageSrc: ./media/hub/net_small_purple.png
-      links:
-        - url: https://dotnet.microsoft.com/learn/aspnet/hello-world-tutorial/intro
-          text: Create your first web app
-        - url: /aspnet/core/tutorials
-          text: ASP.NET Core tutorials
-        - url: /aspnet/core
-          text: What is ASP.NET Core?
-        - url: /aspnet/core/tutorials/first-mvc-app/start-mvc
-          text: ASP.NET Core in Visual Studio
-        - url: /aspnet/mvc/overview/deployment/docker-aspnetmvc
-          text: ASP.NET MVC apps in Windows containers
-    # Card
-    - title: Cloud
-      imageSrc: ./media/hub/net_small_purple.png
-      links:
-        - url: /dotnet/azure/
-          text: Azure for .NET documentation
-        - url: /azure/storage
-          text: Storage
-        - url: /dotnet/fsharp/using-fsharp-on-azure/
-          text: Using F# on Azure
-    # Card
-    - title: Mobile
-      imageSrc: ./media/hub/net_small_purple.png
-      links:
-        - url: /xamarin/ios/
-          text: Xamarin.iOS
-        - url: /xamarin/android
-          text: Xamarin.Android
-        - url: /xamarin/xamarin-forms
-          text: Xamarin.Forms
-    # Card
-    - title: Desktop
-      imageSrc: ./media/hub/net_small_purple.png
-      links:
-        - url: /uwp
-          text: Universal Windows apps
-        - url: /desktop-wpf/index.md
-          text: Windows Presentation Foundation (.NET Core)
-        - url: /framework/wpf/index.md
-          text: Windows Presentation Foundation (.NET Framework)
-        - url: /framework/winforms/index.md
-          text: Windows Forms
-        - url: /xamarin/mac
-          text: Xamarin for macOS
-    # Card
-    - title: Gaming
-      imageSrc: ./media/hub/net_small_purple.png
-      links:
-        - url: https://visualstudio.microsoft.com/vs/features/game-development/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link
-          text: Game development with Visual Studio
-        - url: https://docs.cryengine.com/display/CEPROG/C%23+Programming
-          text: Learn how to use CRYENGINE to build games with C#
-        - url: http://www.monogame.net/documentation/?page=main
-          text: Build games with C# using the MonoGame library
-        - url: https://docs.unity3d.com/Manual/index.html
-          text: Learn how to use Unity to build 2D and 3D games with C#
-    # Card
-    - title: Machine learning and AI
-      imageSrc: ./media/hub/net_small_purple.png
-      links:
-        - url: machine-learning/index.yml
-          text: Build custom AI solutions with ML.NET
-        - url: /azure/cognitive-services/
-          text: Azure Cognitive Services
-        - url: /azure/machine-learning
-          text: Azure machine learning
-        - url: spark/index.yml
-          text: .NET for Apache Spark
 
 # conceptualContent section (optional)
 ## Sections:
@@ -121,6 +42,40 @@ productDirectory:
 ## .NET Core Guide
 ## .NET Standard Guide
 ## Architecture
+# From Maira:
+# Remove "guide"
+### Get Started
+## .NET Fundamentals (standard, core, framework landing pages)
+## drive people to the cross-platform / open source content?
+## Drive to port from framework
+## New application model (deployment, docker, CLI, etc)
+## Tutorials 
+
+## Another model:
+## Fundamentals / Architecture (fundamentals is the wrong word)
+## Deployment / versioning / sdk
+## 
+
+## .NET Core
+## .NET Framework
+## Architecture guides
+
+## What to highlight:
+## The .NET STandard thing
+## The .NET Core App model.
+## Deployments / docker / cloud
+## Unit testing and software dev practices
+## Port from framework o Core
+## The setup / install / etc (Andy's work)
+## .NET Core Desktop development (for existing .NET devs)
+
+## Card titles:  .NET Environment (1)  || Tools and Deployments (2)   || .NET Software Development (3)  || (existing architecture guids)
+
+# Cards:
+## .NET Core
+## .NET Concepts / Primer / Ecosystem / Achirectural components / tools & sdks / Environment
+## Architectural guides
+
 conceptualContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
   title: ".NET: Free. Cross-platform. Open source." # < 60 chars (optional)
@@ -175,6 +130,7 @@ conceptualContent:
         url: framework/index.md
         text: See more
     # Card
+    ## Add https://docs.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/
     - title: .NET architectural guides
       links:
         - url: architecture/microservices/index.md
@@ -210,9 +166,78 @@ tools:
       imageSrc: https://docs.microsoft.com/media/logos/logo_VB.svg
       url: visual-basic/index.md
 
-# additionalContent section (optional)
+additionalContent:
+  title: Create your application # < 60 chars (optional)
+  summary: "You can choose web, mobile, desktop, gaming, IoT, and more." # < 160 chars (optional)
+  items:
+    # Card
+    - title: Web
+      links:
+        - url: /aspnet/core/getting-started
+          text: Create your first web app
+        - url: /aspnet/core/tutorials
+          text: ASP.NET Core tutorials
+        - url: /aspnet/core
+          text: What is ASP.NET Core?
+        - url: /aspnet/core/tutorials/first-mvc-app/start-mvc
+          text: ASP.NET Core in Visual Studio
+        - url: /aspnet/mvc/overview/deployment/docker-aspnetmvc
+          text: ASP.NET MVC apps in Windows containers
+    # Card
+    - title: Cloud
+      links:
+        - url: /dotnet/azure/
+          text: Azure for .NET documentation
+        - url: /azure/storage
+          text: Storage
+        - url: /dotnet/fsharp/using-fsharp-on-azure/
+          text: Using F# on Azure
+    # Card
+    - title: Mobile
+      links:
+        - url: /xamarin/ios/
+          text: Xamarin.iOS
+        - url: /xamarin/android
+          text: Xamarin.Android
+        - url: /xamarin/xamarin-forms
+          text: Xamarin.Forms
+    # Card
+    - title: Desktop
+      links:
+        - url: /uwp
+          text: Universal Windows apps
+        - url: /desktop-wpf/index.md
+          text: Windows Presentation Foundation (.NET Core)
+        - url: /framework/wpf/index.md
+          text: Windows Presentation Foundation (.NET Framework)
+        - url: /framework/winforms/index.md
+          text: Windows Forms
+        - url: /xamarin/mac
+          text: Xamarin for macOS
+    # Card
+    - title: Gaming
+      links:
+        - url: https://visualstudio.microsoft.com/vs/features/game-development/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link
+          text: Game development with Visual Studio
+        - url: https://docs.cryengine.com/display/CEPROG/C%23+Programming
+          text: Learn how to use CRYENGINE to build games with C#
+        - url: http://www.monogame.net/documentation/?page=main
+          text: Build games with C# using the MonoGame library
+        - url: https://docs.unity3d.com/Manual/index.html
+          text: Learn how to use Unity to build 2D and 3D games with C#
+    # Card
+    - title: Machine learning and AI
+      links:
+        - url: machine-learning/index.yml
+          text: Build custom AI solutions with ML.NET
+        - url: /azure/cognitive-services/
+          text: Azure Cognitive Services
+        - url: /azure/machine-learning
+          text: Azure machine learning
+        - url: spark/index.yml
+          text: .NET for Apache Spark
+
 # Card with summary style
-## Workloads (Web, Cloud, Mobile, Desktop, Gaming, ML & AI)
 additionalContent:
   # Supports up to 3 sections
   sections: 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -37,29 +37,6 @@ highlightedContent:
       url: https://dotnet.microsoft.com/learn/aspnet/hello-world-tutorial/intro
 
 # conceptualContent section (optional)
-## Sections:
-## .NET Guide
-## .NET Core Guide
-## .NET Standard Guide
-## Architecture
-# From Maira:
-# Remove "guide"
-### Get Started
-## .NET Fundamentals (standard, core, framework landing pages)
-## drive people to the cross-platform / open source content?
-## Drive to port from framework
-## New application model (deployment, docker, CLI, etc)
-## Tutorials 
-
-## Another model:
-## Fundamentals / Architecture (fundamentals is the wrong word)
-## Deployment / versioning / sdk
-## 
-
-## .NET Core
-## .NET Framework
-## Architecture guides
-
 ## What to highlight:
 ## The .NET STandard thing
 ## The .NET Core App model.
@@ -69,36 +46,13 @@ highlightedContent:
 ## The setup / install / etc (Andy's work)
 ## .NET Core Desktop development (for existing .NET devs)
 
-## Card titles:  .NET Environment (1)  || Tools and Deployments (2)   || .NET Software Development (3)  || (existing architecture guids)
-
-# Cards:
-## .NET Core
-## .NET Concepts / Primer / Ecosystem / Achirectural components / tools & sdks / Environment
-## Architectural guides
-
 conceptualContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
   title: ".NET: Free. Cross-platform. Open source." # < 60 chars (optional)
   summary: "A developer platform for building all your apps: web, mobile, desktop, gaming, IoT, and more. Supported on Windows, Linux, and macOS."
   items:
     # Card
-    - title: .NET guide
-      links:
-        - url: standard/get-started.md
-          itemType: get-started
-          text: Get started
-        - url: standard/tour.md
-          itemType: overview
-          text: Tour of .NET
-        - url: standard/components.md
-          itemType: concept
-          text: .NET architectural components
-      # footerLink (optional)
-      footerLink:
-        url: standard/index.md
-        text: See more
-    # Card
-    - title: .NET Core guide
+    - title: .NET Core
       links:
         - url: core/get-started.md
           itemType: get-started
@@ -114,8 +68,17 @@ conceptualContent:
         url: core/index.md
         text: See more
     # Card
-    - title: .NET Framework guide
+    - title: .NET Concepts
       links:
+        - url: standard/get-started.md
+          itemType: get-started
+          text: Get started
+        - url: standard/tour.md
+          itemType: overview
+          text: Tour of .NET
+        - url: standard/components.md
+          itemType: concept
+          text: .NET architectural components
         - url: framework/get-started/index.md
           itemType: get-started
           text: Get started
@@ -127,15 +90,17 @@ conceptualContent:
           text: Develop client apps
       # footerLink (optional)
       footerLink:
-        url: framework/index.md
+        url: standard/index.md
         text: See more
     # Card
-    ## Add https://docs.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/
     - title: .NET architectural guides
       links:
         - url: architecture/microservices/index.md
           itemType: architecture
           text: ".NET Microservices: Architecture for containerized .NET apps"
+        - url: architecture/modern-web-apps-azure/index.md
+          itemType: architecture
+          text: Architect Modern Web Applications with ASP.NET Core and Azure
         - url: architecture/containerized-lifecycle/index.md
           itemType: architecture
           text: "Containerized Docker application lifecycle with Microsoft platform and tools"

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -62,7 +62,7 @@ conceptualContent:
           text: Tutorials
         - url: core/porting/index.md
           itemType: how-to-guide
-          text: Port  apps from .NET Framework
+          text: Port apps from .NET Framework
       # footerLink (optional)
       footerLink:
         url: core/index.md
@@ -109,10 +109,10 @@ conceptualContent:
           text: Porting from .NET Framework to .NET Core
         - url: desktop-wpf/overview/index.md
           itemType: overview
-          text: Create .NET Core desktop apps
+          text: Create .NET Core desktop apps for Windows
         - url: standard/library-guidance/index.md
           itemType: concept
-          text: Open Source library guidance
+          text: Open source library guidance
     # Card
     - title: .NET architectural guides
       links:
@@ -121,7 +121,7 @@ conceptualContent:
           text: ".NET Microservices: Architecture for containerized .NET apps"
         - url: architecture/modern-web-apps-azure/index.md
           itemType: architecture
-          text: Architect Modern Web Applications with ASP.NET Core and Azure
+          text: Architect modern web applications with ASP.NET Core and Azure
         - url: architecture/containerized-lifecycle/index.md
           itemType: architecture
           text: "Containerized Docker application lifecycle with Microsoft platform and tools"

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -70,6 +70,9 @@ conceptualContent:
     # Card
     - title: .NET Concepts
       links:
+        - url: https://channel9.msdn.com/Series/NET-Core-101/What-is-NET
+          itemType: video
+          text: What is .NET?
         - url: standard/get-started.md
           itemType: get-started
           text: Get started

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -37,15 +37,6 @@ highlightedContent:
       url: https://dotnet.microsoft.com/learn/aspnet/hello-world-tutorial/intro
 
 # conceptualContent section (optional)
-## What to highlight:
-## The .NET STandard thing
-## The .NET Core App model.
-## Deployments / docker / cloud
-## Unit testing and software dev practices
-## Port from framework o Core
-## The setup / install / etc (Andy's work)
-## .NET Core Desktop development (for existing .NET devs)
-
 conceptualContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
   title: ".NET: Free. Cross-platform. Open source." # < 60 chars (optional)
@@ -57,6 +48,15 @@ conceptualContent:
         - url: core/get-started.md
           itemType: get-started
           text: Get started
+        - url: core/whats-new/dotnet-core-3-0
+          itemType: whats-new
+          text: What's new in .NET Core 3.0
+        - url: core/deploying/index.md
+          itemType: deploy
+          text: Deploying .NET Core apps
+        - url: core/docker/build-container.md
+          itemType: tutorial
+          text: Containerize .NET Core apps with Docker
         - url: core/tutorials/index.md
           itemType: tutorial
           text: Tutorials
@@ -79,19 +79,37 @@ conceptualContent:
         - url: standard/components.md
           itemType: concept
           text: .NET architectural components
-        - url: framework/get-started/index.md
-          itemType: get-started
-          text: Get started
-        - url: framework/development-guide.md
+        - url: standard/net-standard/index.md
           itemType: overview
-          text: Development guide
-        - url: framework/develop-client-apps.md
-          itemType: concept
-          text: Develop client apps
+          text: .NET Standard
+        - url: framework/index.md
+          itemType: overview
+          text: .NET Framework (Windows) apps
       # footerLink (optional)
       footerLink:
         url: standard/index.md
         text: See more
+    # Card
+    - title: Develop .NET apps
+      links:
+        - url: core/sdk/index.md
+          itemType: download
+          text: Download the .NET Core SDK
+        - url: dotnet/core/tools/index.md
+          itemType: overview
+          text: .NET Core CLI overview
+        - url: core/testing/index.md
+          itemType: tutorial
+          text: Unit testing with .NET Core apps
+        - url: core/porting/index.md
+          itemType: how-to-guide
+          text: Porting from .NET Framework to .NET Core
+        - url: desktop-wpf/overview/index.md
+          itemType: overview
+          text: Create .NET Core desktop apps
+        - url: standard/library-guidance/index.md
+          itemType: concept
+          text: Open Source library guidance
     # Card
     - title: .NET architectural guides
       links:


### PR DESCRIPTION
This PR includes the work we (me, @mairaw @mcleblanc) did in our working session Thursday:

- Move the "build any kind of app" to below the languages and above the reference section.
- Tighten the language on the highlights section.
- Re-work the conceptual section. 

On *Re-work the conceptual section*: 

From our notes, I looked at page views for key areas of .NET Core, .NET Standard, and .NET Framework areas. That suggested the three left-most cards in the conceptual section. 

Open questions:

- Where should a "See more" link direct to in "Develop .NET Apps"?
- All four cards include ".NET". Good or bad repetition?
- Are important links missing?

This is ready for a complete general review. [Internal review link](https://review.docs.microsoft.com/en-us/dotnet/index?branch=pr-en-us-15932)