### PR TITLE
Try to resolve yaml duplicate keys

### DIFF
--- a/docs/framework/unmanaged-api/profiling/toc.yml
+++ b/docs/framework/unmanaged-api/profiling/toc.yml
@@ -468,15 +468,15 @@
       - name: EnumerateObjectReferences Method
         href: icorprofilerinfo10-enumerateobjectreferences-method.md
       - name: IsFrozenObject Method
+        href: icorprofilerinfo10-isfrozenobject-method.md
       - name: GetLOHObjectSizeThreshold Method
         href: icorprofilerinfo10-getlohobjectsizethreshold-method.md
-        href: icorprofilerinfo10-isfrozenobject-method.md
       - name: RequestReJITWithInliners Method
         href: icorprofilerinfo10-requestrejitwithinliners-method.md
-        href: icorprofilerinfo10-suspendruntime-method.md
       - name: ResumeRuntime Method
-      - name: SuspendRuntime Method
         href: icorprofilerinfo10-resumeruntime-method.md
+      - name: SuspendRuntime Method
+        href: icorprofilerinfo10-suspendruntime-method.md
     - name: ICorProfilerModuleEnum Interface
       href: icorprofilermoduleenum-interface.md
       items:

--- a/docs/fsharp/toc.yml
+++ b/docs/fsharp/toc.yml
@@ -6,11 +6,11 @@
   - name: Install F#
     href: get-started/install-fsharp.md
   - name: Get Started with F# in Visual Studio
+    href: get-started/get-started-visual-studio.md
   - name: Get Started with F# in Visual Studio Code
     href: get-started/get-started-vscode.md
   - name: Get Started with F# with the .NET Core CLI
     href: get-started/get-started-command-line.md
-    href: get-started/get-started-visual-studio.md
   - name: Get Started with F# in Visual Studio for Mac
     href: get-started/get-started-with-visual-studio-for-mac.md
 - name: What is F#


### PR DESCRIPTION
## Summary

We created this pull request to fix yaml duplicate keys and unblock docfx v3 migration. **Please help review if this is expected fix or not**

If there is yaml duplicate key, only the value of the last key will be kept on published page by default, which can cause toc doesn't work as expected, It's better to avoid that. 

### Details
We find there are duplicate `href` for some toc items and there are some toc item without `href`, we try to resolve them by adjusting the line of duplicate `href` based on the `href` article name and toc name. 


  


