### PR TITLE
update redirect_document_id to false

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1331,12 +1331,12 @@
         {
             "source_path": "docs/csharp/quick-starts/branches-and-loops.md",
             "redirect_url": "/dotnet/csharp/tutorials/intro-to-csharp/branches-and-loops",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/csharp/quick-starts/hello-world.md",
             "redirect_url": "/dotnet/csharp/tutorials/intro-to-csharp/hello-world",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/csharp/quick-starts/index.md",
@@ -1351,7 +1351,7 @@
         {
             "source_path": "docs/csharp/quick-starts/interpolated-strings.md",
             "redirect_url": "/dotnet/csharp/tutorials/exploration/interpolated-strings",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/csharp/quick-starts/introduction-to-classes.md",
@@ -1361,7 +1361,7 @@
         {
             "source_path": "docs/csharp/quick-starts/list-collection.md",
             "redirect_url": "/dotnet/csharp/tutorials/intro-to-csharp/list-collection",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/csharp/quick-starts/local-environment.md",
@@ -1376,7 +1376,7 @@
         {
             "source_path": "docs/csharp/quick-starts/numbers-in-csharp.md",
             "redirect_url": "/dotnet/csharp/tutorials/intro-to-csharp/numbers-in-csharp",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/csharp/reference-semantics-with-value-types.md",
@@ -2988,7 +2988,7 @@
         {
             "source_path": "docs/standard/guidance-architecture.md",
             "redirect_url": "/dotnet/architecture/index",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/standard/library.md",


### PR DESCRIPTION
## Summary

There is a known issue in the current build system: if the redirect target is a yaml file, the redirection flag `redirect_document_id` will not work, so to unblock the migration of docfx v3, please turn off this flag, this won't bring any impact to your current published page, after migrating to docfx v3, you can turn on this flag for those redirection rules, that will become effective.
