### PR TITLE
Note to escape exclamation mark in *nix

### DIFF
--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -10,6 +10,11 @@ ms.custom: seodec18
 
 With the `dotnet test` command in .NET Core, you can use a filter expression to run selective tests. This article demonstrates how to filter which test are run. The following examples use `dotnet test`. If you're using `vstest.console.exe`, replace `--filter` with `--testcasefilter:`.
 
+> [!NOTE]
+> Using filters that include exclamation mark (!) on `*nix` requires escaping since `!` is reserverd. For example, this filter
+> skips all tests if name space contains IntegrationTests `dotnet test --filter FullyQualifiedName\!~IntegrationTests`.
+> Note the backslash that preceds the exclamation mark 
+
 ## MSTest
 
 ```csharp

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -11,9 +11,9 @@ ms.custom: seodec18
 With the `dotnet test` command in .NET Core, you can use a filter expression to run selective tests. This article demonstrates how to filter which test are run. The following examples use `dotnet test`. If you're using `vstest.console.exe`, replace `--filter` with `--testcasefilter:`.
 
 > [!NOTE]
-> Using filters that include exclamation mark (!) on `*nix` requires escaping since `!` is reserverd. For example, this filter
+> Using filters that include exclamation mark (!) on `*nix` requires escaping since `!` is reserved. For example, this filter
 > skips all tests if name space contains IntegrationTests `dotnet test --filter FullyQualifiedName\!~IntegrationTests`.
-> Note the backslash that preceds the exclamation mark 
+> Note the backslash that precedes the exclamation mark.
 
 ## MSTest
 

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -12,7 +12,7 @@ With the `dotnet test` command in .NET Core, you can use a filter expression to 
 
 > [!NOTE]
 > Using filters that include exclamation mark (!) on `*nix` requires escaping since `!` is reserved. For example, this filter
-> skips all tests if name space contains IntegrationTests `dotnet test --filter FullyQualifiedName\!~IntegrationTests`.
+> skips all tests if the namespace contains IntegrationTests: `dotnet test --filter FullyQualifiedName\!~IntegrationTests`.
 > Note the backslash that precedes the exclamation mark.
 
 ## MSTest


### PR DESCRIPTION
## Summary

Add note that exclamation mark need to be escaped on *nix.

~Fixes #Issue_Number (if available)~
