### PR TITLE
move installer area to win/mac only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 # Deployment
 /docs/core/deploying/** @Thraka
 # Install
-/docs/core/install/**": @Thraka
+/docs/core/install/** @Thraka
 # Breaking changes
 /docs/core/compatibility/** @gewarren
 # Tools

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,8 @@
 /docs/core/whats-new/** @Thraka
 # Deployment
 /docs/core/deploying/** @Thraka
+# Install
+/docs/core/install/**": @Thraka
 # Breaking changes
 /docs/core/compatibility/** @gewarren
 # Tools

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -19,12 +19,16 @@ You can download and install .NET Core directly with one of the following links:
 - [.NET Core 2.2 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.2)
 - [.NET Core 2.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.1)
 
+::: zone pivot="os-windows,os-macos"
+
 ## Install with an installer
 
 Both Windows and macOS have standalone installers that can be used to install the .NET Core 3.0 runtime.
 
 - Windows [x64 CPUs](https://dotnet.microsoft.com/download/thank-you/dotnet-runtime-3.0.0-windows-x64-installer) | [x32 CPUs](https://dotnet.microsoft.com/download/thank-you/dotnet-runtime-3.0.0-windows-x86-installer)
 - macOS [x64 CPUs](https://dotnet.microsoft.com/download/thank-you/dotnet-runtime-3.0.0-macos-x64-installer)
+
+::: zone-end
 
 ::: zone pivot="os-linux"
 

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -21,12 +21,16 @@ You can download and install .NET Core directly with one of the following links:
 
 You can also install .NET Core as part of an integrated development environment (IDE), detailed in the sections below.
 
+::: zone pivot="os-windows,os-macos"
+
 ## Install with an installer
 
 Both Windows and macOS have standalone installers that can be used to install the .NET Core 3.0 SDK.
 
 - Windows [x64 CPUs](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-windows-x64-installer) | [x32 CPUs](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-windows-x86-installer)
 - macOS [x64 CPUs](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-macos-x64-installer)
+
+::: zone-end
 
 ::: zone pivot="os-linux"
 


### PR DESCRIPTION
Minor fix for the install guide. The "install with an installer" sections were appearing on linux which is not applicable.

Also, add myself as codeowner for this area.