### PR TITLE
Update cloud-native link to the new architecture guide

### DIFF
--- a/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
+++ b/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
@@ -36,7 +36,10 @@ The [Twelve-Factor App](https://12factor.net/) (a collection of patterns that ar
 
 The [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) is a primary promoter of cloud-native principles. Microsoft is a [member of the CNCF](https://azure.microsoft.com/blog/announcing-cncf/).
 
-For a sample definition and for more information about the characteristics of cloud-native applications, see the section [Introduction to cloud-native applications](https://docs.microsoft.com/dotnet/architecture/cloud-native/introduction) from the [Architecting Cloud Native .NET Applications for Azure](https://docs.microsoft.com/dotnet/architecture/cloud-native/). For specific guidance from Microsoft about how to implement a cloud-native application, see [.NET microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
+For detailed guidance on how to design and develop cloud-native applications, read the following free e-Books:
+
+*  [Architecting Cloud-Native .NET Applications for Azure](https://docs.microsoft.com/dotnet/architecture/cloud-native/introduction)
+*  [.NET Microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
 
 The most important factor to consider if you migrate a full application to the cloud-native model is that you must rearchitect to a microservices-based architecture. This clearly requires a significant investment in development because of the large refactoring process involved. This option usually is chosen for mission-critical applications that need new levels of scalability and long-term agility. But, you could start moving toward cloud-native by adding microservices for just a few new scenarios, and eventually refactor the application fully as microservices. This is an incremental approach that is the best option for some scenarios.
 

--- a/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
+++ b/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
@@ -14,7 +14,7 @@ Figure 4-3 positions Cloud-Native apps in the application modernization maturity
 
 **Figure 4-3.** Positioning Cloud-Native applications
 
-The Cloud-Native modernization maturity level usually requires new development investments. Moving to the Cloud- Native level typically is driven by business need to modernize applications as much as possible to drastically improve scale in large applications by creating autonomous subsystems (microservices) that can be deployed and scale independently from other areas of the application while lowering costs in the long term and increase evolution agility of those autonomous app’s parts that provide significant compete advantages.
+The Cloud-Native modernization maturity level usually requires new development investments. Moving to the Cloud-Native level typically is driven by business need to modernize applications as much as possible to drastically improve scale in large applications by creating autonomous subsystems (microservices) that can be deployed and scale independently from other areas of the application while lowering costs in the long term and increase evolution agility of those autonomous app’s parts that provide significant compete advantages.
 
 The main pillars of Cloud-Native applications are based on microservices architecture approaches, which can evolve with agility and scale to limits that would be difficult to achieve in a monolithic architecture, deployed to either on-premises or cloud environment.
 
@@ -36,7 +36,7 @@ The [Twelve-Factor App](https://12factor.net/) (a collection of patterns that ar
 
 The [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) is a primary promoter of cloud-native principles. Microsoft is a [member of the CNCF](https://azure.microsoft.com/blog/announcing-cncf/).
 
-For a sample definition and for more information about the characteristics of cloud-native applications, see the Gartner article [How to architect and design cloud-native applications](https://www.gartner.com/doc/3181919/architect-design-cloudnative-applications). For specific guidance from Microsoft about how to implement a cloud-native application, see [.NET microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
+For a sample definition and for more information about the characteristics of cloud-native applications, see the section [Introduction to cloud-native applications](https://docs.microsoft.com/dotnet/architecture/cloud-native/introduction) from the [Architecting Cloud Native .NET Applications for Azure](https://docs.microsoft.com/dotnet/architecture/cloud-native/). For specific guidance from Microsoft about how to implement a cloud-native application, see [.NET microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
 
 The most important factor to consider if you migrate a full application to the cloud-native model is that you must rearchitect to a microservices-based architecture. This clearly requires a significant investment in development because of the large refactoring process involved. This option usually is chosen for mission-critical applications that need new levels of scalability and long-term agility. But, you could start moving toward cloud-native by adding microservices for just a few new scenarios, and eventually refactor the application fully as microservices. This is an incremental approach that is the best option for some scenarios.
 

--- a/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
+++ b/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
@@ -36,9 +36,9 @@ The [Twelve-Factor App](https://12factor.net/) (a collection of patterns that ar
 
 The [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) is a primary promoter of cloud-native principles. Microsoft is a [member of the CNCF](https://azure.microsoft.com/blog/announcing-cncf/).
 
-For detailed guidance on how to design and develop cloud-native applications, read the following free e-Books:
+For detailed guidance on how to design and develop cloud-native applications, read the following free e-books:
 
-*  [Architecting Cloud-Native .NET Applications for Azure](https://docs.microsoft.com/dotnet/architecture/cloud-native/introduction)
+* [Architecting Cloud-Native .NET Applications for Azure](../../cloud-native/introduction.md)
 *  [.NET Microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
 
 The most important factor to consider if you migrate a full application to the cloud-native model is that you must rearchitect to a microservices-based architecture. This clearly requires a significant investment in development because of the large refactoring process involved. This option usually is chosen for mission-critical applications that need new levels of scalability and long-term agility. But, you could start moving toward cloud-native by adding microservices for just a few new scenarios, and eventually refactor the application fully as microservices. This is an incremental approach that is the best option for some scenarios.

--- a/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
+++ b/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
@@ -39,7 +39,7 @@ The [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) is a primar
 For detailed guidance on how to design and develop cloud-native applications, read the following free e-books:
 
 * [Architecting Cloud-Native .NET Applications for Azure](../../cloud-native/introduction.md)
-*  [.NET Microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
+* [.NET Microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
 
 The most important factor to consider if you migrate a full application to the cloud-native model is that you must rearchitect to a microservices-based architecture. This clearly requires a significant investment in development because of the large refactoring process involved. This option usually is chosen for mission-critical applications that need new levels of scalability and long-term agility. But, you could start moving toward cloud-native by adding microservices for just a few new scenarios, and eventually refactor the application fully as microservices. This is an incremental approach that is the best option for some scenarios.
 

--- a/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
+++ b/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/what-about-cloud-native-applications.md
@@ -39,7 +39,7 @@ The [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) is a primar
 For detailed guidance on how to design and develop cloud-native applications, read the following free e-books:
 
 * [Architecting Cloud-Native .NET Applications for Azure](../../cloud-native/introduction.md)
-* [.NET Microservices: Architecture for containerized .NET applications](https://aka.ms/microservicesebook).
+* [.NET Microservices: Architecture for containerized .NET applications](../../microservices/index.md).
 
 The most important factor to consider if you migrate a full application to the cloud-native model is that you must rearchitect to a microservices-based architecture. This clearly requires a significant investment in development because of the large refactoring process involved. This option usually is chosen for mission-critical applications that need new levels of scalability and long-term agility. But, you could start moving toward cloud-native by adding microservices for just a few new scenarios, and eventually refactor the application fully as microservices. This is an incremental approach that is the best option for some scenarios.
 


### PR DESCRIPTION
## Summary

Change a link from a subscription-restricted Gartner article to the recently released Cloud-Native architecture guide.

Fixes https://github.com/dotnet/docs/issues/12344

