### PR TITLE
Improve description for Create a Publisher Policy

### DIFF
--- a/docs/framework/configure-apps/how-to-create-a-publisher-policy.md
+++ b/docs/framework/configure-apps/how-to-create-a-publisher-policy.md
@@ -99,7 +99,7 @@ gacutil /i policy.1.0.myAssembly.dll
 ```
 
 > [!IMPORTANT]
-> The publisher policy assembly cannot be added to the global assembly cache unless the original publisher policy file is located in the same directory as the assembly.
+> The publisher policy assembly cannot be added to the global assembly cache unless the original publisher policy file specified in the `/link` argument is located in the same directory as the assembly.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Clarify that "original publisher policy file" means the .config file specified in the /link argument

Fixes #15978
