### PR TITLE
Update reflection.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/reflection.md
+++ b/docs/csharp/programming-guide/concepts/reflection.md
@@ -12,8 +12,8 @@ Here's a simple example of reflection using the <xref:System.Object.GetType> met
 ```csharp
 // Using GetType to obtain type information:
 int i = 42;
-System.Type type = i.GetType();
-System.Console.WriteLine(type);
+Type type = i.GetType();
+Console.WriteLine(type);
 ```
 
 The output is: `System.Int32`.
@@ -22,8 +22,8 @@ The following example uses reflection to obtain the full name of the loaded asse
 
 ```csharp
 // Using Reflection to get information of an Assembly:
-System.Reflection.Assembly info = typeof(System.Int32).Assembly;
-System.Console.WriteLine(info);
+Reflection.Assembly info = typeof(System.Int32).Assembly;
+Console.WriteLine(info);
 ```
 
 The output is: `System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e`.

--- a/docs/csharp/programming-guide/concepts/reflection.md
+++ b/docs/csharp/programming-guide/concepts/reflection.md
@@ -9,6 +9,9 @@ Reflection provides objects (of type <xref:System.Type>) that describe assemblie
 
 Here's a simple example of reflection using the <xref:System.Object.GetType> method - inherited by all types from the `Object` base class - to obtain the type of a variable:
 
+> [!NOTE]
+> Make sure you add `using System;` and `using System.Reflection;` at the top of your *.cs* file.
+
 ```csharp
 // Using GetType to obtain type information:
 int i = 42;
@@ -22,7 +25,7 @@ The following example uses reflection to obtain the full name of the loaded asse
 
 ```csharp
 // Using Reflection to get information of an Assembly:
-Reflection.Assembly info = typeof(int).Assembly;
+Assembly info = typeof(int).Assembly;
 Console.WriteLine(info);
 ```
 

--- a/docs/csharp/programming-guide/concepts/reflection.md
+++ b/docs/csharp/programming-guide/concepts/reflection.md
@@ -22,7 +22,7 @@ The following example uses reflection to obtain the full name of the loaded asse
 
 ```csharp
 // Using Reflection to get information of an Assembly:
-Reflection.Assembly info = typeof(System.Int32).Assembly;
+Reflection.Assembly info = typeof(int).Assembly;
 Console.WriteLine(info);
 ```
 

--- a/docs/csharp/programming-guide/concepts/reflection.md
+++ b/docs/csharp/programming-guide/concepts/reflection.md
@@ -4,60 +4,52 @@ ms.date: 07/20/2015
 ms.assetid: f80a2362-953b-4e8e-9759-cd5f334190d4
 ---
 # Reflection (C#)
-Reflection provides objects (of type <xref:System.Type>) that describe assemblies, modules and types. You can use reflection to dynamically create an instance of a type, bind the type to an existing object, or get the type from an existing object and invoke its methods or access its fields and properties. If you are using attributes in your code, reflection enables you to access them. For more information, see [Attributes](../../../standard/attributes/index.md).  
-  
- Here's a simple example of reflection using the static method `GetType` - inherited by all types from the `Object` base class - to obtain the type of a variable:  
-  
-```csharp  
-// Using GetType to obtain type information:  
-int i = 42;  
-System.Type type = i.GetType();  
-System.Console.WriteLine(type);  
-```  
-  
- The output is:  
-  
- `System.Int32`  
-  
- The following example uses reflection to obtain the full name of the loaded assembly.  
-  
-```csharp  
-// Using Reflection to get information of an Assembly:  
-System.Reflection.Assembly info = typeof(System.Int32).Assembly;  
-System.Console.WriteLine(info);  
-```  
-  
- The output is:  
-  
- `mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089`  
-  
+
+Reflection provides objects (of type <xref:System.Type>) that describe assemblies, modules, and types. You can use reflection to dynamically create an instance of a type, bind the type to an existing object, or get the type from an existing object and invoke its methods or access its fields and properties. If you are using attributes in your code, reflection enables you to access them. For more information, see [Attributes](../../../standard/attributes/index.md).
+
+Here's a simple example of reflection using the <xref:System.Object.GetType> method - inherited by all types from the `Object` base class - to obtain the type of a variable:
+
+```csharp
+// Using GetType to obtain type information:
+int i = 42;
+System.Type type = i.GetType();
+System.Console.WriteLine(type);
+```
+
+The output is: `System.Int32`.
+
+The following example uses reflection to obtain the full name of the loaded assembly.
+
+```csharp
+// Using Reflection to get information of an Assembly:
+System.Reflection.Assembly info = typeof(System.Int32).Assembly;
+System.Console.WriteLine(info);
+```
+
+The output is: `System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e`.
+
 > [!NOTE]
-> The C# keywords `protected` and `internal` have no meaning in IL and are not used in the reflection APIs. The corresponding terms in IL are *Family* and *Assembly*. To identify an `internal` method using reflection, use the <xref:System.Reflection.MethodBase.IsAssembly%2A> property. To identify a `protected internal` method, use the <xref:System.Reflection.MethodBase.IsFamilyOrAssembly%2A>.  
-  
-## Reflection Overview  
- Reflection is useful in the following situations:  
-  
-- When you have to access attributes in your program's metadata. For more information, see [Retrieving Information Stored in Attributes](../../../standard/attributes/retrieving-information-stored-in-attributes.md).  
-  
-- For examining and instantiating types in an assembly.  
-  
-- For building new types at runtime. Use classes in <xref:System.Reflection.Emit>.  
-  
-- For performing late binding, accessing methods on types created at run time. See the topic [Dynamically Loading and Using Types](../../../framework/reflection-and-codedom/dynamically-loading-and-using-types.md).  
-  
-## Related Sections  
- For more information:  
-  
-- [Reflection](../../../framework/reflection-and-codedom/reflection.md)  
-  
-- [Viewing Type Information](../../../framework/reflection-and-codedom/viewing-type-information.md)  
-  
-- [Reflection and Generic Types](../../../framework/reflection-and-codedom/reflection-and-generic-types.md)  
-  
-- <xref:System.Reflection.Emit>  
-  
-- [Retrieving Information Stored in Attributes](../../../standard/attributes/retrieving-information-stored-in-attributes.md)  
-  
+> The C# keywords `protected` and `internal` have no meaning in IL and are not used in the reflection APIs. The corresponding terms in IL are *Family* and *Assembly*. To identify an `internal` method using reflection, use the <xref:System.Reflection.MethodBase.IsAssembly%2A> property. To identify a `protected internal` method, use the <xref:System.Reflection.MethodBase.IsFamilyOrAssembly%2A>.
+
+## Reflection overview
+
+Reflection is useful in the following situations:
+
+- When you have to access attributes in your program's metadata. For more information, see [Retrieving Information Stored in Attributes](../../../standard/attributes/retrieving-information-stored-in-attributes.md).
+- For examining and instantiating types in an assembly.
+- For building new types at runtime. Use classes in <xref:System.Reflection.Emit>.
+- For performing late binding, accessing methods on types created at run time. See the topic [Dynamically Loading and Using Types](../../../framework/reflection-and-codedom/dynamically-loading-and-using-types.md).
+
+## Related sections
+
+For more information:
+
+- [Reflection](../../../framework/reflection-and-codedom/reflection.md)
+- [Viewing Type Information](../../../framework/reflection-and-codedom/viewing-type-information.md)
+- [Reflection and Generic Types](../../../framework/reflection-and-codedom/reflection-and-generic-types.md)
+- <xref:System.Reflection.Emit>
+- [Retrieving Information Stored in Attributes](../../../standard/attributes/retrieving-information-stored-in-attributes.md)
+
 ## See also
 
 - [C# Programming Guide](../index.md)


### PR DESCRIPTION
- used an xref for GetType, and it was referred to as static. I removed the word "static" as I don't think it's a static method.
- Removed the noisy `System.` and `System.Reflection.` prefixes and added a note about add `using System;` and `using System.Reflection;`.
- Inlined outputs.
- Simplified `System.Int32` to just `int`.
- Updated sample output based on the output I'm getting using .NET Core 3.0 and VS 2019.
    
    ![image](https://user-images.githubusercontent.com/31348972/69902389-c981c000-1395-11ea-9781-db89165a2e0a.png)