### PR TITLE
Fix redirects for prereqs articles

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -141,15 +141,15 @@
         },
         {
             "source_path": "docs/core/linux-prerequisites.md",
-            "redirect_url": "/dotnet/core/setup/dependencies"
+            "redirect_url": "/dotnet/core/install/dependencies"
         },
         {
               "source_path": "docs/core/macos-prerequisites.md",
-              "redirect_url": "/dotnet/core/setup/dependencies"
+              "redirect_url": "/dotnet/core/install/dependencies"
         },
         {
             "source_path": "docs/core/windows-prerequisites.md",
-            "redirect_url": "/dotnet/core/setup/dependencies",
+            "redirect_url": "/dotnet/core/install/dependencies",
             "redirect_document_id": true
         },
         {


### PR DESCRIPTION
## Summary

Redirect should point to install directory not setup directory.

Fixes dotnet/core#3937
