### PR TITLE
Update multiple docs for .NET Core 3.1

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -2,7 +2,7 @@
 title: .NET Core Guide
 description: .NET Core is a modular, high-performance implementation of .NET for creating Windows, Linux, and Mac apps. Learn about .NET Core to get started.
 author: richlander
-ms.date: 09/23/2019
+ms.date: 12/04/2019
 ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
@@ -19,9 +19,9 @@ Download the [.NET Core SDK](https://www.microsoft.com/net/download) to try .NET
 
 All .NET Core versions are available at [.NET Core Downloads](https://dotnet.microsoft.com/download/dotnet-core) if you're looking for another .NET Core version.
 
-## .NET Core 3.0
+## .NET Core 3.1
 
-The latest version is .NET Core 3.0. New features include Windows Desktop support with Windows Presentation Foundation (WPF) and Windows Forms, full stack C# web development with Blazor, new enhancements to SignalR and Azure SignalR Service, new C# language features with C# 8, and much more. For a full listing of the new features in .NET Core 3.0, see [What's new in .NET Core 3.0](./whats-new/dotnet-core-3-0.md).
+The latest version is .NET Core 3.1. Which includes minor improvements over .NET Core 3.0. However, .NET Core 3.1 is a long-term supported release. For more information about the .NET Core 3.1 release, see [What's new in .NET Core 3.1](./whats-new/dotnet-core-3-1.md).
 
 ## Create your first application
 

--- a/docs/core/install/dependencies.md
+++ b/docs/core/install/dependencies.md
@@ -3,7 +3,7 @@ title: .NET Core SDK and runtime dependencies - .NET Core
 description: Details the operating system and CPU architecture prerequisites to install the .NET Core SDK and runtime on Windows, Linux, and macOS.
 author: leecow
 ms.author: leecow
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 zone_pivot_groups: operating-systems-set-one
 ---
 
@@ -17,6 +17,22 @@ This article details which operating systems and CPU architecture are supported 
 
 <!-- markdownlint-disable MD025 -->
 <!-- markdownlint-disable MD024 -->
+
+# [.NET Core 3.1](#tab/netcore31)
+
+The following Windows versions are supported with .NET Core 3.1:
+
+> [!NOTE]
+> A `+` symbol represents the minimum version.
+
+| OS                            | Version                        | Architectures   |
+| ----------------------------- | ------------------------------ | --------------- |
+| Windows Client                | 7 SP1+, 8.1                    | x64, x86        |
+| Windows 10 Client             | Version 1607+                  | x64, x86        |
+| Windows Server                | 2012 R2+                       | x64, x86        |
+| Nano Server                   | Version 1803+                  | x64, ARM32      |
+
+For more information about .NET Core 3.1 supported operating systems, distributions, and lifecycle policy, see [.NET Core 3.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md).
 
 # [.NET Core 3.0](#tab/netcore30)
 
@@ -96,6 +112,35 @@ The requirements above are also required if you come across one of the following
 ::: zone-end
 
 ::: zone pivot="os-linux"
+
+# [.NET Core 3.1](#tab/netcore31)
+
+.NET Core 3.1 treats Linux as a single operating system. There's a single Linux build (per chip architecture) for supported Linux distributions.
+
+.NET Core 3.1 is supported on the following Linux distributions/versions:
+
+> [!NOTE]
+> A `+` symbol represents the minimum version.
+
+| OS                             | Version               | Architectures    |
+| ------------------------------ | --------------------- | ---------------- |
+| Red Hat Enterprise Linux       | 6, 7, 8               | x64 |
+| CentOS                         | 7+                    | x64 |
+| Oracle Linux                   | 7+                    | x64 |
+| Fedora                         | 29+                   | x64 |
+| Debian                         | 9+                    | x64, ARM32, ARM64 |
+| Ubuntu                         | 16.04+                | x64, ARM32, ARM64 |
+| Linux Mint                     | 18+                   | x64 |
+| openSUSE                       | 15+                   | x64 |
+| SUSE Enterprise Linux (SLES)   | 12 SP2+               | x64 |
+| Alpine Linux                   | 3.10+                 | x64, ARM64 |
+
+For more information about .NET Core 3.1 supported operating systems, distributions, and lifecycle policy, see [.NET Core 3.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md).
+
+For more information about how to install .NET Core 3.1 on ARM64 (kernel 4.14+), see [Installing .NET Core 3.0 on Linux ARM64](https://gist.github.com/richlander/467813274cea8abc624553ee72b28213).
+
+> [!IMPORTANT]
+> ARM64 support requires Linux kernel 4.14 or higher. Some linux distributions satisfy this requirement while others don't. For example, Ubuntu 18.04 is supported but Ubuntu 16.04 doesn't.
 
 # [.NET Core 3.0](#tab/netcore30)
 
@@ -244,6 +289,7 @@ For .NET Core apps that use the *System.Drawing.Common* assembly, you'll also ne
 
 | .NET Core Version | macOS                 | Architectures |     |
 | ----------------- | --------------------- | --------------| --- |
+| 3.1               | High Sierra (10.13+)  | x64 | [More information](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) |
 | 3.0               | High Sierra (10.13+)  | x64 | [More information](https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md) |
 | 2.2               | Sierra (10.12+)       | x64 | [More information](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2-supported-os.md) |
 | 2.1               | Sierra (10.12+)       | x64 | [More information](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) |

--- a/docs/core/install/how-to-detect-installed-versions.md
+++ b/docs/core/install/how-to-detect-installed-versions.md
@@ -3,7 +3,7 @@ title: Check installed .NET Core versions on Windows, Linux, and macOS - .NET Co
 description: Learn how to list which versions of .NET Core are installed on your computer. This includes the .NET Core runtime and SDK.
 author: thraka
 ms.author: adegeo
-ms.date: 11/01/2019
+ms.date: 12/04/2019
 ms.custom: "updateeachrelease"
 zone_pivot_groups: operating-systems-set-one
 ---
@@ -32,6 +32,7 @@ dotnet --list-sdks
 2.1.602 [C:\program files\dotnet\sdk]
 2.2.101 [C:\program files\dotnet\sdk]
 3.0.100 [C:\program files\dotnet\sdk]
+3.1.100 [C:\program files\dotnet\sdk]
 ```
 
 ::: zone-end
@@ -48,6 +49,7 @@ dotnet --list-sdks
 2.1.602 [/home/user/dotnet/sdk]
 2.2.101 [/home/user/dotnet/sdk]
 3.0.100 [/home/user/dotnet/sdk]
+3.1.100 [/home/user/dotnet/sdk]
 ```
 
 ::: zone-end
@@ -64,6 +66,7 @@ dotnet --list-sdks
 2.1.602 [/usr/local/share/dotnet/sdk]
 2.2.101 [/usr/local/share/dotnet/sdk]
 3.0.100 [/usr/local/share/dotnet/sdk]
+3.1.100 [/usr/local/share/dotnet/sdk]
 ```
 
 ::: zone-end
@@ -88,13 +91,16 @@ Microsoft.AspNetCore.App 2.1.13 [c:\program files\dotnet\shared\Microsoft.AspNet
 Microsoft.AspNetCore.App 2.2.0 [c:\program files\dotnet\shared\Microsoft.AspNetCore.App]
 Microsoft.AspNetCore.App 2.2.7 [c:\program files\dotnet\shared\Microsoft.AspNetCore.App]
 Microsoft.AspNetCore.App 3.0.0 [c:\program files\dotnet\shared\Microsoft.AspNetCore.App]
+Microsoft.AspNetCore.App 3.1.0 [c:\program files\dotnet\shared\Microsoft.AspNetCore.App]
 Microsoft.NETCore.App 2.1.7 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.1.13 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.0 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.3 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.7 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
 Microsoft.NETCore.App 3.0.0 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
+Microsoft.NETCore.App 3.1.0 [c:\program files\dotnet\shared\Microsoft.NETCore.App]
 Microsoft.WindowsDesktop.App 3.0.0 [c:\program files\dotnet\shared\Microsoft.WindowsDesktop.App]
+Microsoft.WindowsDesktop.App 3.1.0 [c:\program files\dotnet\shared\Microsoft.WindowsDesktop.App]
 ```
 
 ::: zone-end
@@ -115,12 +121,14 @@ Microsoft.AspNetCore.App 2.1.13 [/home/user/dotnet/shared/Microsoft.AspNetCore.A
 Microsoft.AspNetCore.App 2.2.0 [/home/user/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.AspNetCore.App 2.2.7 [/home/user/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.AspNetCore.App 3.0.0 [/home/user/dotnet/shared/Microsoft.AspNetCore.App]
+Microsoft.AspNetCore.App 3.1.0 [/home/user/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.NETCore.App 2.1.7 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.1.13 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.0 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.3 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.7 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 3.0.0 [/home/user/dotnet/shared/Microsoft.NETCore.App]
+Microsoft.NETCore.App 3.1.0 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 ```
 
 ::: zone-end
@@ -141,12 +149,14 @@ Microsoft.AspNetCore.App 2.1.13 [/usr/local/share/dotnet/shared/Microsoft.AspNet
 Microsoft.AspNetCore.App 2.2.0 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.AspNetCore.App 2.2.7 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.AspNetCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
+Microsoft.AspNetCore.App 3.1.0 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.NETCore.App 2.1.7 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.1.13 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.2.7 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
+Microsoft.NETCore.App 3.1.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 ```
 
 ::: zone-end

--- a/docs/core/install/index.md
+++ b/docs/core/install/index.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Windows, Linux, and macOS - .NET Core
 description: Learn where and what to install for .NET Core on Windows, Linux, and macOS versions. Discover the dependencies required to develop, deploy, and run .NET Core apps.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Download and install .NET Core

--- a/docs/core/install/linux-package-manager-centos7.md
+++ b/docs/core/install/linux-package-manager-centos7.md
@@ -3,7 +3,7 @@ title: Install .NET Core on CentOS 7 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on CentOS 7.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # CentOS 7 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-centos7.md
+++ b/docs/core/install/linux-package-manager-centos7.md
@@ -33,7 +33,7 @@ sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
-sudo yum install dotnet-sdk-3.0
+sudo yum install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -41,7 +41,7 @@ sudo yum install dotnet-sdk-3.0
 Update the products available for installation, then install the ASP.NET runtime. In your terminal, run the following command.
 
 ```bash
-sudo yum install aspnetcore-runtime-3.0
+sudo yum install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -49,7 +49,7 @@ sudo yum install aspnetcore-runtime-3.0
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
 
 ```bash
-sudo yum install dotnet-runtime-3.0
+sudo yum install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-debian10.md
+++ b/docs/core/install/linux-package-manager-debian10.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Debian 10 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Debian 10.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Debian 10 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-debian10.md
+++ b/docs/core/install/linux-package-manager-debian10.md
@@ -41,7 +41,7 @@ Update the products available for installation, then install the .NET Core SDK. 
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-sdk-3.0
+sudo apt-get install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -52,7 +52,7 @@ Update the products available for installation, then install the ASP.NET runtime
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install aspnetcore-runtime-3.0
+sudo apt-get install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -63,7 +63,7 @@ Update the products available for installation, then install the .NET Core runti
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-runtime-3.0
+sudo apt-get install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-debian9.md
+++ b/docs/core/install/linux-package-manager-debian9.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Debian 9 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Debian 9.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Debian 9 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-debian9.md
+++ b/docs/core/install/linux-package-manager-debian9.md
@@ -41,7 +41,7 @@ Update the products available for installation, then install the .NET Core SDK. 
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-sdk-3.0
+sudo apt-get install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -52,7 +52,7 @@ Update the products available for installation, then install the ASP.NET runtime
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install aspnetcore-runtime-3.0
+sudo apt-get install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -63,7 +63,7 @@ Update the products available for installation, then install the .NET Core runti
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-runtime-3.0
+sudo apt-get install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-fedora29.md
+++ b/docs/core/install/linux-package-manager-fedora29.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Fedora 29 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Fedora 29.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Fedora 29 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-fedora29.md
+++ b/docs/core/install/linux-package-manager-fedora29.md
@@ -34,7 +34,7 @@ sudo wget -q -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
-sudo dnf install dotnet-sdk-3.0
+sudo dnf install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -42,7 +42,7 @@ sudo dnf install dotnet-sdk-3.0
 Update the products available for installation, then install the ASP.NET runtime. In your terminal, run the following command.
 
 ```bash
-sudo dnf install aspnetcore-runtime-3.0
+sudo dnf install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -50,7 +50,7 @@ sudo dnf install aspnetcore-runtime-3.0
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
 
 ```bash
-sudo dnf install dotnet-runtime-3.0
+sudo dnf install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-fedora30.md
+++ b/docs/core/install/linux-package-manager-fedora30.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Fedora 30 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Fedora 30.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Fedora 30 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-fedora30.md
+++ b/docs/core/install/linux-package-manager-fedora30.md
@@ -34,7 +34,7 @@ sudo wget -q -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
-sudo dnf install dotnet-sdk-3.0
+sudo dnf install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -42,7 +42,7 @@ sudo dnf install dotnet-sdk-3.0
 Update the products available for installation, then install the ASP.NET runtime. In your terminal, run the following command.
 
 ```bash
-sudo dnf install aspnetcore-runtime-3.0
+sudo dnf install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -50,7 +50,7 @@ sudo dnf install aspnetcore-runtime-3.0
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
 
 ```bash
-sudo dnf install dotnet-runtime-3.0
+sudo dnf install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-opensuse15.md
+++ b/docs/core/install/linux-package-manager-opensuse15.md
@@ -37,7 +37,7 @@ sudo chown root:root /etc/zypp/repos.d/microsoft-prod.repo
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
-sudo zypper install dotnet-sdk-3.0
+sudo zypper install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -45,7 +45,7 @@ sudo zypper install dotnet-sdk-3.0
 Update the products available for installation, then install the ASP.NET runtime. In your terminal, run the following command.
 
 ```bash
-sudo zypper install aspnetcore-runtime-3.0
+sudo zypper install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -53,7 +53,7 @@ sudo zypper install aspnetcore-runtime-3.0
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
 
 ```bash
-sudo zypper install dotnet-runtime-3.0
+sudo zypper install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-opensuse15.md
+++ b/docs/core/install/linux-package-manager-opensuse15.md
@@ -3,7 +3,7 @@ title: Install .NET Core on openSUSE 15 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on openSUSE 15.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # openSUSE 15 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-rhel7.md
+++ b/docs/core/install/linux-package-manager-rhel7.md
@@ -10,7 +10,7 @@ ms.date: 12/03/2019
 
 [!INCLUDE [package-manager-switcher](includes/package-manager-switcher.md)]
 
-This article describes how to use a package manager to install .NET Core on RHEL 7.
+This article describes how to use a package manager to install .NET Core on RHEL 7. .NET Core 3.1 is not yet available for RHEL 7.
 
 ## Register your Red Hat subscription
 

--- a/docs/core/install/linux-package-manager-rhel81.md
+++ b/docs/core/install/linux-package-manager-rhel81.md
@@ -10,7 +10,7 @@ ms.date: 12/03/2019
 
 [!INCLUDE [package-manager-switcher](includes/package-manager-switcher.md)]
 
-This article describes how to use a package manager to install .NET Core on RHEL 8.1.
+This article describes how to use a package manager to install .NET Core on RHEL 8.1. .NET Core 3.1 is not yet available for RHEL 8.1.
 
 > [!NOTE]
 > RHEL 8.0 does not include .NET Core 3.0. Use the command `yum upgrade` to update to RHEL 8.1.

--- a/docs/core/install/linux-package-manager-sles12.md
+++ b/docs/core/install/linux-package-manager-sles12.md
@@ -3,7 +3,7 @@ title: Install .NET Core on SLES 12 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on SLES 12.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # SLES 12 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-sles12.md
+++ b/docs/core/install/linux-package-manager-sles12.md
@@ -33,7 +33,7 @@ sudo rpm -Uvh https://packages.microsoft.com/config/sles/12/packages-microsoft-p
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
-sudo zypper install dotnet-sdk-3.0
+sudo zypper install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -41,7 +41,7 @@ sudo zypper install dotnet-sdk-3.0
 Update the products available for installation, then install the ASP.NET runtime. In your terminal, run the following command.
 
 ```bash
-sudo zypper install aspnetcore-runtime-3.0
+sudo zypper install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -49,7 +49,7 @@ sudo zypper install aspnetcore-runtime-3.0
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
 
 ```bash
-sudo zypper install dotnet-runtime-3.0
+sudo zypper install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-sles15.md
+++ b/docs/core/install/linux-package-manager-sles15.md
@@ -3,7 +3,7 @@ title: Install .NET Core on SLES 15 - package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on SLES 15.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # SLES 15 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-sles15.md
+++ b/docs/core/install/linux-package-manager-sles15.md
@@ -33,7 +33,7 @@ sudo rpm -Uvh https://packages.microsoft.com/config/sles/15/packages-microsoft-p
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
-sudo zypper install dotnet-sdk-3.0
+sudo zypper install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core runtime
@@ -41,7 +41,7 @@ sudo zypper install dotnet-sdk-3.0
 Update the products available for installation, then install the ASP.NET runtime. In your terminal, run the following command.
 
 ```bash
-sudo zypper install aspnetcore-runtime-3.0
+sudo zypper install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core runtime
@@ -49,7 +49,7 @@ sudo zypper install aspnetcore-runtime-3.0
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
 
 ```bash
-sudo zypper install dotnet-runtime-3.0
+sudo zypper install dotnet-runtime-3.1
 ```
 
 ## How to install other versions

--- a/docs/core/install/linux-package-manager-ubuntu-1604.md
+++ b/docs/core/install/linux-package-manager-ubuntu-1604.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Ubuntu 16.04 package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Ubuntu 16.04.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Ubuntu 16.04 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-ubuntu-1604.md
+++ b/docs/core/install/linux-package-manager-ubuntu-1604.md
@@ -37,11 +37,11 @@ Update the products available for installation, then install the .NET Core SDK. 
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-sdk-3.0
+sudo apt-get install dotnet-sdk-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-sdk-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package dotnet-sdk-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## Install the ASP.NET Core runtime
 
@@ -51,11 +51,11 @@ Update the products available for installation, then install the ASP.NET Core ru
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install aspnetcore-runtime-3.0
+sudo apt-get install aspnetcore-runtime-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## Install the .NET Core runtime
 
@@ -65,11 +65,11 @@ Update the products available for installation, then install the .NET Core runti
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-runtime-3.0
+sudo apt-get install dotnet-runtime-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-runtime-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package dotnet-runtime-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## How to install other versions
 

--- a/docs/core/install/linux-package-manager-ubuntu-1804.md
+++ b/docs/core/install/linux-package-manager-ubuntu-1804.md
@@ -38,11 +38,11 @@ sudo add-apt-repository universe
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-sdk-3.0
+sudo apt-get install dotnet-sdk-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-sdk-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package dotnet-sdk-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## Install the ASP.NET Core runtime
 
@@ -53,11 +53,11 @@ sudo add-apt-repository universe
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install aspnetcore-runtime-3.0
+sudo apt-get install aspnetcore-runtime-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## Install the .NET Core runtime
 
@@ -68,11 +68,11 @@ sudo add-apt-repository universe
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-runtime-3.0
+sudo apt-get install dotnet-runtime-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-runtime-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package dotnet-runtime-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## How to install other versions
 

--- a/docs/core/install/linux-package-manager-ubuntu-1804.md
+++ b/docs/core/install/linux-package-manager-ubuntu-1804.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Ubuntu 18.04 package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Ubuntu 18.04.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Ubuntu 18.04 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-ubuntu-1904.md
+++ b/docs/core/install/linux-package-manager-ubuntu-1904.md
@@ -3,7 +3,7 @@ title: Install .NET Core on Ubuntu 19.04 package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on Ubuntu 19.04.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ---
 
 # Ubuntu 19.04 Package Manager - Install .NET Core

--- a/docs/core/install/linux-package-manager-ubuntu-1904.md
+++ b/docs/core/install/linux-package-manager-ubuntu-1904.md
@@ -37,11 +37,11 @@ Update the products available for installation, then install the .NET Core SDK. 
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-sdk-3.0
+sudo apt-get install dotnet-sdk-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-sdk-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package dotnet-sdk-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## Install the ASP.NET Core runtime
 
@@ -51,11 +51,11 @@ Update the products available for installation, then install the ASP.NET Core ru
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install aspnetcore-runtime-3.0
+sudo apt-get install aspnetcore-runtime-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## Install the .NET Core runtime
 
@@ -65,11 +65,11 @@ Update the products available for installation, then install the .NET Core runti
 sudo apt-get update
 sudo apt-get install apt-transport-https
 sudo apt-get update
-sudo apt-get install dotnet-runtime-3.0
+sudo apt-get install dotnet-runtime-3.1
 ```
 
 > [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-runtime-3.0**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
+> If you receive an error message similar to **Unable to locate package dotnet-runtime-3.1**, see the [Troubleshoot the package manager](#troubleshoot-the-package-manager) section.
 
 ## How to install other versions
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -3,7 +3,7 @@ title: Install .NET Core runtime on Windows, Linux, and macOS - .NET Core
 description: Learn how to install .NET Core on Windows, Linux, and macOS. Discover the dependencies required to run .NET Core apps.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ms.custom: "updateeachrelease"
 zone_pivot_groups: operating-systems-set-one
 ---

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -47,7 +47,7 @@ You can install the .NET Core Runtime with many of the common Linux package mana
 
 The [dotnet-install scripts](../tools/dotnet-install-script.md) are used for automation and non-admin installs of the runtime. You can download the script from the [dotnet-install script reference page](../tools/dotnet-install-script.md).
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `Channel` switch. Include the `Runtime` switch to install a runtime. Otherwise, the script will install the [SDK](sdk.md).
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `Channel` switch. Include the `Runtime` switch to install a runtime. Otherwise, the script installs the [SDK](sdk.md).
 
 ```powershell
 dotnet-install.ps1 -Channel 3.1 -Runtime aspnetcore

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -37,7 +37,7 @@ You can install the .NET Core Runtime with many of the common Linux package mana
 
 The [dotnet-install scripts](../tools/dotnet-install-script.md) are used for automation and non-admin installs of the runtime. You can download the script from the [dotnet-install script reference page](../tools/dotnet-install-script.md).
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 2.1. To install the current release of .NET Core (3.0), run the script with the following switch:
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `Channel` switch.
 
 ```powershell
 dotnet-install.ps1 -Channel 3.0
@@ -51,10 +51,10 @@ dotnet-install.ps1 -Channel 3.0
 
 The [dotnet-install scripts](../tools/dotnet-install-script.md) are used for automation and non-admin installs of the runtime. You can download the script from the [dotnet-install script reference page](../tools/dotnet-install-script.md).
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 2.1. To install the current release of .NET Core (3.0), run the script with the following switch:
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `current` switch.
 
 ```bash
-./dotnet-install.sh -c Current
+./dotnet-install.sh --current 3.0
 ```
 
 ::: zone-end
@@ -63,7 +63,7 @@ The script defaults to installing the latest [long term support (LTS)](https://d
 
 You can download and install .NET Core directly with one of the following links:
 
-- [.NET Core 3.1 Preview downloads](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+- [.NET Core 3.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 - [.NET Core 3.0 downloads](https://dotnet.microsoft.com/download/dotnet-core/3.0)
 - [.NET Core 2.2 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.2)
 - [.NET Core 2.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.1)

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -64,7 +64,7 @@ dotnet-install.ps1 -Channel 3.1 -Runtime aspnetcore
 
 The [dotnet-install scripts](../tools/dotnet-install-script.md) are used for automation and non-admin installs of the runtime. You can download the script from the [dotnet-install script reference page](../tools/dotnet-install-script.md).
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `current` switch. Include the `runtime` switch to install a runtime. Otherwise, the script will install the [SDK](sdk.md).
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `current` switch. Include the `runtime` switch to install a runtime. Otherwise, the script installs the [SDK](sdk.md).
 
 ```bash
 ./dotnet-install.sh --current 3.1 --runtime aspnetcore

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -12,14 +12,24 @@ zone_pivot_groups: operating-systems-set-one
 
 In this article, you'll learn how to download and install the .NET Core runtime. The .NET Core runtime is used to run apps created with .NET Core.
 
-::: zone pivot="os-windows,os-macos"
+::: zone pivot="os-windows"
 
 ## Install with an installer
 
-Both Windows and macOS have standalone installers that can be used to install the .NET Core 3.0 runtime.
+Windows has standalone installers that can be used to install the .NET Core 3.1 runtime:
 
-- Windows [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.0) | [x86 (32-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.0)
-- macOS [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+- [x86 (32-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+
+::: zone-end
+
+::: zone pivot="os-macos"
+
+## Install with an installer
+
+macOS has standalone installers that can be used to install the .NET Core 3.1 runtime:
+
+- [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 
 ::: zone-end
 
@@ -37,11 +47,14 @@ You can install the .NET Core Runtime with many of the common Linux package mana
 
 The [dotnet-install scripts](../tools/dotnet-install-script.md) are used for automation and non-admin installs of the runtime. You can download the script from the [dotnet-install script reference page](../tools/dotnet-install-script.md).
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `Channel` switch.
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `Channel` switch. Include the `Runtime` switch to install a runtime. Otherwise, the script will install the [SDK](sdk.md).
 
 ```powershell
-dotnet-install.ps1 -Channel 3.0
+dotnet-install.ps1 -Channel 3.1 -Runtime aspnetcore
 ```
+
+> [!NOTE]
+> The command above installs the ASP.NET Core runtime for maximum compatability. The ASP.NET Core runtime also includes the standard .NET Core runtime.
 
 ::: zone-end
 
@@ -51,11 +64,14 @@ dotnet-install.ps1 -Channel 3.0
 
 The [dotnet-install scripts](../tools/dotnet-install-script.md) are used for automation and non-admin installs of the runtime. You can download the script from the [dotnet-install script reference page](../tools/dotnet-install-script.md).
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `current` switch.
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) version, which is .NET Core 3.1. You can choose a specific release by specifying the `current` switch. Include the `runtime` switch to install a runtime. Otherwise, the script will install the [SDK](sdk.md).
 
 ```bash
-./dotnet-install.sh --current 3.0
+./dotnet-install.sh --current 3.1 --runtime aspnetcore
 ```
+
+> [!NOTE]
+> The command above installs the ASP.NET Core runtime for maximum compatability. The ASP.NET Core runtime also includes the standard .NET Core runtime.
 
 ::: zone-end
 

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -16,10 +16,10 @@ In this article, you'll learn how to install the .NET Core SDK. The .NET Core SD
 
 ## Install with an installer
 
-Windows has standalone installers that can be used to install the .NET Core 3.0 SDK:
+Windows has standalone installers that can be used to install the .NET Core 3.1 SDK:
 
-- [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.0) 
-- [x86 (32-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+- [x86 (32-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 
 ::: zone-end
 
@@ -27,9 +27,9 @@ Windows has standalone installers that can be used to install the .NET Core 3.0 
 
 ## Install with an installer
 
-macOS has standalone installers that can be used to install the .NET Core 3.0 SDK:
+macOS has standalone installers that can be used to install the .NET Core 3.1 SDK:
 
-- [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- [x64 (64-bit) CPUs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 
 ::: zone-end
 
@@ -44,7 +44,7 @@ You can install the .NET Core SDK with many of the common Linux package managers
 To extract the SDK and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
 
 ```bash
-mkdir -p $HOME/dotnet && tar zxf dotnet-sdk-3.0.101-linux-musl-x64.tar.gz -C $HOME/dotnet
+mkdir -p $HOME/dotnet && tar zxf dotnet-sdk-3.1.101-linux-musl-x64.tar.gz -C $HOME/dotnet
 export DOTNET_ROOT=$HOME/dotnet
 export PATH=$PATH:$HOME/dotnet
 ```
@@ -72,7 +72,7 @@ If you're using Visual Studio to develop .NET Core apps, the following table des
 
 | .NET Core SDK version | Visual Studio version                      |
 | --------------------- | ------------------------------------------ |
-| 3.1 Preview           | Visual Studio 2019 version 16.4 preview or higher. |
+| 3.1                   | Visual Studio 2019 version 16.4 or higher. |
 | 3.0                   | Visual Studio 2019 version 16.3 or higher. |
 | 2.2                   | Visual Studio 2017 version 15.9 or higher. |
 | 2.1                   | Visual Studio 2017 version 15.7 or higher. |
@@ -104,7 +104,7 @@ When installing or modifying Visual Studio, select one of the following workload
 
 ## Install with Visual Studio for Mac
 
-Visual Studio for Mac installs the .NET Core SDK when the **.NET Core** workload is selected. To get started with .NET Core development on macOS, see [Install Visual Studio 2019 for Mac](/visualstudio/mac/installation).
+Visual Studio for Mac installs the .NET Core SDK when the **.NET Core** workload is selected. To get started with .NET Core development on macOS, see [Install Visual Studio 2019 for Mac](/visualstudio/mac/installation). For the latest release, .NET Core 3.1, you must use the Visual Studio for Mac 8.4 Preview.
 
 [![macOS Visual Studio 2019 for Mac with .NET Core workload feature](media/install-sdk/mac-install-selection.png)](media/install-sdk/mac-install-selection.png#lightbox)
 
@@ -173,7 +173,7 @@ For more information about using .NET Core in a Docker container, see [Introduct
 
 - [Tutorial: C# Hello World tutorial](../tutorials/with-visual-studio.md).
 - [Tutorial: Visual Basic Hello World tutorial](../tutorials/vb-with-visual-studio.md).
-- [Tutorial: Create a new app with Visual Studio Code](https://code.visualstudio.com/docs/languages/dotnet).
+- [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.md).
 - [Tutorial: Containerize a .NET Core app](../docker/build-container.md).
 
 ::: zone-end
@@ -181,7 +181,14 @@ For more information about using .NET Core in a Docker container, see [Introduct
 ::: zone pivot="os-macos"
 
 - [Tutorial: Get started on macOS](../tutorials/using-on-mac-vs.md).
-- [Tutorial: Create a new app with Visual Studio Code](https://code.visualstudio.com/docs/languages/dotnet).
+- [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.md).
+- [Tutorial: Containerize a .NET Core app](../docker/build-container.md).
+
+::: zone-end
+
+::: zone pivot="os-linux"
+
+- [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.mdt).
 - [Tutorial: Containerize a .NET Core app](../docker/build-container.md).
 
 ::: zone-end

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -3,7 +3,7 @@ title: Install .NET Core SDK on Windows, Linux, and macOS - .NET Core
 description: Learn how to install .NET Core on Windows, Linux, and macOS. Discover the dependencies required to develop .NET Core apps.
 author: thraka
 ms.author: adegeo
-ms.date: 11/06/2019
+ms.date: 12/04/2019
 ms.custom: "updateeachrelease"
 zone_pivot_groups: operating-systems-set-one
 ---

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -188,7 +188,7 @@ For more information about using .NET Core in a Docker container, see [Introduct
 
 ::: zone pivot="os-linux"
 
-- [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.mdt).
+- [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.md).
 - [Tutorial: Containerize a .NET Core app](../docker/build-container.md).
 
 ::: zone-end

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -65,6 +65,8 @@
     href: tutorials/consuming-library-with-visual-studio.md
 - name: What's new in .NET Core
   items:
+  - name: What's new in .NET Core 3.1
+    href: whats-new/dotnet-core-3-1.md
   - name: What's new in .NET Core 3.0
     href: whats-new/dotnet-core-3-0.md
   - name: What's new in .NET Core 2.2

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -38,7 +38,7 @@ The following example shows the contents of a *global.json* file:
 ```json
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "2.2.100"
   }
 }
 ```

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -38,7 +38,7 @@ The following example shows the contents of a *global.json* file:
 ```json
 {
   "sdk": {
-    "version": "2.2.100"
+    "version": "3.1.100"
   }
 }
 ```

--- a/docs/core/whats-new/dotnet-core-3-1.md
+++ b/docs/core/whats-new/dotnet-core-3-1.md
@@ -43,13 +43,13 @@ Legacy controls were included in Windows Forms that have been unavailable in the
 
 | Removed control | Recommended replacement | Associated APIs removed |
 | --------------- | ----------------------- | ----------------------- |
-| DataGrid        | DataGridView            | DataGridCell<br/>DataGridRow<br/>DataGridTableCollection<br/>DataGridColumnCollection<br/>DataGridTableStyle<br/>DataGridColumnStyle<br/>DataGridLineStyle<br/>DataGridParentRowsLabel<br/>DataGridParentRowsLabelStyle<br/>DataGridBoolColumn<br/>DataGridTextBox<br/>GridColumnStylesCollection<br/>GridTableStylesCollection<br/>HitTestType |
-| ToolBar         | ToolStrip               | ToolBarAppearance |
-| ToolBarButton   | ToolStripButton         | ToolBarButtonClickEventArgs<br/>ToolBarButtonClickEventHandler<br/>ToolBarButtonStyle<br/>ToolBarTextAlign |
-| ContextMenu     | ContextMenuStrip        |  |
-| :::no-loc text="Menu":::            | ToolStripDropDown<br/>ToolStripDropDownMenu | MenuItemCollection |
-| MainMenu        | MenuStrip               |  |
-| MenuItem        | ToolStripMenuItem       |  |
+| DataGrid        | <xref:System.Windows.Forms.DataGridView>      | DataGridCell<br/>DataGridRow<br/>DataGridTableCollection<br/>DataGridColumnCollection<br/>DataGridTableStyle<br/>DataGridColumnStyle<br/>DataGridLineStyle<br/>DataGridParentRowsLabel<br/>DataGridParentRowsLabelStyle<br/>DataGridBoolColumn<br/>DataGridTextBox<br/>GridColumnStylesCollection<br/>GridTableStylesCollection<br/>HitTestType |
+| ToolBar         | <xref:System.Windows.Forms.ToolStrip>         | ToolBarAppearance |
+| ToolBarButton   | <xref:System.Windows.Forms.ToolStripButton>   | ToolBarButtonClickEventArgs<br/>ToolBarButtonClickEventHandler<br/>ToolBarButtonStyle<br/>ToolBarTextAlign |
+| ContextMenu     | <xref:System.Windows.Forms.ContextMenuStrip>  |  |
+| :::no-loc text="Menu"::: | <xref:System.Windows.Forms.ToolStripDropDown><br/><xref:System.Windows.Forms.ToolStripDropDownMenu> | MenuItemCollection |
+| MainMenu        | <xref:System.Windows.Forms.MenuStrip>         |  |
+| MenuItem        | <xref:System.Windows.Forms.ToolStripMenuItem> |  |
 
 We recommend you update your applications to .NET Core 3.1 and move to the replacement controls. Replacing the controls is a straightforward process, essentially "find and replace" on the type.
 
@@ -59,7 +59,7 @@ We recommend you update your applications to .NET Core 3.1 and move to the repla
 
 Support has been added for creating C++/CLI (also known as "managed C++") projects. Binaries produced from these projects are compatible with .NET Core 3.0 and later versions.
 
-To add support for C++/CLI in Visual Studio 2019 16.4, install the **Desktop development with C++** workload. This workload adds two templates to Visual Studio:
+To add support for C++/CLI in Visual Studio 2019 16.4, install the [Desktop development with C++ workload](https://docs.microsoft.com/cpp/build/vscpp-step-0-installation?view=vs-2019#step-4---choose-workloads). This workload adds two templates to Visual Studio:
 
 - CLR Class Library (.NET Core)
 - CLR Empty Project (.NET Core)

--- a/docs/core/whats-new/dotnet-core-3-1.md
+++ b/docs/core/whats-new/dotnet-core-3-1.md
@@ -1,0 +1,70 @@
+---
+title: What's new in .NET Core 3.1
+description: Learn about the new features found in .NET Core 3.1.
+dev_langs:
+  - "csharp"
+author: thraka
+ms.author: adegeo
+ms.date: 12/04/2019
+---
+
+# What's new in .NET Core 3.1
+
+This article describes what is new in .NET Core 3.1. This release contains minor improvements to .NET Core 3.0, focusing on small, but important, fixes. The most important feature about .NET Core 3.1 is that it's a long-term supported (LTS) release. For more information, see the [.NET Core support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+
+If you're using Visual Studio 2019, you must update to [Visual Studio 2019 16.4](https://visualstudio.microsoft.com/downloads/) to work with .NET Core 3.1 projects. For more information on what is new in Visual Studio, see the [Visual Studio Blog](https://devblogs.microsoft.com/visualstudio/tis-the-season-visual-studio-2019/).
+
+Visual Studio for Mac also supports and includes .NET Core 3.1, in the Visual Studio for Mac 8.4 Preview channel. You'll need to opt into the Preview channel to use .NET Core 3.1.
+
+For more information about the release, see the [.NET Core 3.1 announcement](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-1/).
+
+- [Download and get started with .NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.1) on Windows, macOS, or Linux.
+
+## Long-term support
+
+.NET Core 3.1 is an LTS release with support from Microsoft for the next three years. It's highly recommended that you move your apps to .NET Core 3.1. The current lifecycle of other major releases is as follows:
+
+| Release | Note |
+| ------- | ---- |
+| .NET Core 3.0 | End of life on March 3, 2020.     |
+| .NET Core 2.2 | End of life on December 23, 2019. |
+| .NET Core 2.1 | End of life on August 21, 2021    |
+
+For more information, see the [.NET Core support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+
+## Windows Forms
+
+*Windows only*
+
+> [!WARNING]
+> There are breaking changes in Windows Forms.
+
+Legacy controls were included in Windows Forms that have been unavailable in the Visual Studio Designer Toolbox for some time. These were replaced with new controls back in .NET Framework 2.0. These have been removed from the Desktop SDK for .NET Core 3.1
+
+| Removed control | Recommended replacement | Associated APIs removed |
+| --------------- | ----------------------- | ----------------------- |
+| DataGrid        | DataGridView            | DataGridCell<br/>DataGridRow<br/>DataGridTableCollection<br/>DataGridColumnCollection<br/>DataGridTableStyle<br/>DataGridColumnStyle<br/>DataGridLineStyle<br/>DataGridParentRowsLabel<br/>DataGridParentRowsLabelStyle<br/>DataGridBoolColumn<br/>DataGridTextBox<br/>GridColumnStylesCollection<br/>GridTableStylesCollection<br/>HitTestType |
+| ToolBar         | ToolStrip               | ToolBarAppearance |
+| ToolBarButton   | ToolStripButton         | ToolBarButtonClickEventArgs<br/>ToolBarButtonClickEventHandler<br/>ToolBarButtonStyle<br/>ToolBarTextAlign |
+| ContextMenu     | ContextMenuStrip        |  |
+| :::no-loc text="Menu":::            | ToolStripDropDown<br/>ToolStripDropDownMenu | MenuItemCollection |
+| MainMenu        | MenuStrip               |  |
+| MenuItem        | ToolStripMenuItem       |  |
+
+We recommend you update your applications to .NET Core 3.1 and move to the replacement controls. Replacing the controls is a straight-forward process, essentially "find and replace" on the type.
+
+## C++/CLI
+
+*Windows only*
+
+Support has been added for creating C++/CLI (also known as "managed C++") projects. Binaries produced from these projects are compatible with .NET Core 3.0 and above.
+
+To add support for C++/CLI in Visual Studio 2019 16.4, install the **Desktop development with C++** workload. This workload adds two templates to Visual Studio:
+
+- CLR Class Library (.NET Core)
+- CLR Empty Project (.NET Core)
+
+## Next steps
+
+- [Review the breaking changes between .NET Core 3.0 and 3.1.](../compatibility/3.0-3.1.md)
+- [Review the breaking changes between .NET Framework and .NET Core 3.0 for Windows Forms apps.](../porting/winforms-breaking-changes.md)

--- a/docs/core/whats-new/dotnet-core-3-1.md
+++ b/docs/core/whats-new/dotnet-core-3-1.md
@@ -10,7 +10,7 @@ ms.date: 12/04/2019
 
 # What's new in .NET Core 3.1
 
-This article describes what is new in .NET Core 3.1. This release contains minor improvements to .NET Core 3.0, focusing on small, but important, fixes. The most important feature about .NET Core 3.1 is that it's a long-term supported (LTS) release. For more information, see the [.NET Core support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+This article describes what is new in .NET Core 3.1. This release contains minor improvements to .NET Core 3.0, focusing on small, but important, fixes. The most important feature about .NET Core 3.1 is that it's a [long-term support (LTS)](#long-term-support) release.
 
 If you're using Visual Studio 2019, you must update to [Visual Studio 2019 16.4](https://visualstudio.microsoft.com/downloads/) to work with .NET Core 3.1 projects. For more information on what is new in Visual Studio, see the [Visual Studio Blog](https://devblogs.microsoft.com/visualstudio/tis-the-season-visual-studio-2019/).
 
@@ -18,7 +18,7 @@ Visual Studio for Mac also supports and includes .NET Core 3.1, in the Visual St
 
 For more information about the release, see the [.NET Core 3.1 announcement](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-1/).
 
-- [Download and get started with .NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.1) on Windows, macOS, or Linux.
+- [Download and get started with .NET Core 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1) on Windows, macOS, or Linux.
 
 ## Long-term support
 
@@ -28,7 +28,7 @@ For more information about the release, see the [.NET Core 3.1 announcement](htt
 | ------- | ---- |
 | .NET Core 3.0 | End of life on March 3, 2020.     |
 | .NET Core 2.2 | End of life on December 23, 2019. |
-| .NET Core 2.1 | End of life on August 21, 2021    |
+| .NET Core 2.1 | End of life on August 21, 2021.    |
 
 For more information, see the [.NET Core support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
 
@@ -39,7 +39,7 @@ For more information, see the [.NET Core support policy](https://dotnet.microsof
 > [!WARNING]
 > There are breaking changes in Windows Forms.
 
-Legacy controls were included in Windows Forms that have been unavailable in the Visual Studio Designer Toolbox for some time. These were replaced with new controls back in .NET Framework 2.0. These have been removed from the Desktop SDK for .NET Core 3.1
+Legacy controls were included in Windows Forms that have been unavailable in the Visual Studio Designer Toolbox for some time. These were replaced with new controls back in .NET Framework 2.0. These have been removed from the Desktop SDK for .NET Core 3.1.
 
 | Removed control | Recommended replacement | Associated APIs removed |
 | --------------- | ----------------------- | ----------------------- |
@@ -51,7 +51,7 @@ Legacy controls were included in Windows Forms that have been unavailable in the
 | MainMenu        | MenuStrip               |  |
 | MenuItem        | ToolStripMenuItem       |  |
 
-We recommend you update your applications to .NET Core 3.1 and move to the replacement controls. Replacing the controls is a straight-forward process, essentially "find and replace" on the type.
+We recommend you update your applications to .NET Core 3.1 and move to the replacement controls. Replacing the controls is a straightforward process, essentially "find and replace" on the type.
 
 ## C++/CLI
 

--- a/docs/core/whats-new/dotnet-core-3-1.md
+++ b/docs/core/whats-new/dotnet-core-3-1.md
@@ -57,7 +57,7 @@ We recommend you update your applications to .NET Core 3.1 and move to the repla
 
 *Windows only*
 
-Support has been added for creating C++/CLI (also known as "managed C++") projects. Binaries produced from these projects are compatible with .NET Core 3.0 and above.
+Support has been added for creating C++/CLI (also known as "managed C++") projects. Binaries produced from these projects are compatible with .NET Core 3.0 and later versions.
 
 To add support for C++/CLI in Visual Studio 2019 16.4, install the **Desktop development with C++** workload. This workload adds two templates to Visual Studio:
 

--- a/docs/core/whats-new/index.md
+++ b/docs/core/whats-new/index.md
@@ -1,4 +1,4 @@
 ---
-redirect_url: dotnet-core-3-0
+redirect_url: dotnet-core-3-1
 ms.custom: updateeachrelease
 ---

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ ms.date: "09/30/2019"
                 </a>
             </li>
             <li>
-                <a href="/dotnet/api/?view=netcore-3.0">
+                <a href="/dotnet/api/?view=netcore-3.1">
                     <div class="cardSize">
                         <div class="cardPadding">
                             <div class="card">

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ ms.date: "09/30/2019"
                 </a>
             </li>
             <li>
-                <a href="/dotnet/api/?view=netcore-3.1">
+                <a href="/dotnet/api/?view=netcore-3.0">
                     <div class="cardSize">
                         <div class="cardPadding">
                             <div class="card">


### PR DESCRIPTION
## Summary

- Updated the linux package managers.
- Added "what's new in 3.1" topic
- Updated default pointer to 3.1 topics
- Updated SDK/Runtime topcis
- Updated powershell/bash scripts
- Clarified 3.0 versions are the latest available for RHEL

Fixes #16091
