### PR TITLE
CC176301: Fixing ubuntu version name

### DIFF
--- a/docs/spark/tutorials/databricks-deployment.md
+++ b/docs/spark/tutorials/databricks-deployment.md
@@ -127,7 +127,7 @@ Next, you publish the *mySparkApp* created in the [.NET for Apache Spark - Get S
 
    ```console
    cd mySparkApp
-   dotnet publish -c Release -f netcoreapp3.0 -r ubuntu.16.04-x6
+   dotnet publish -c Release -f netcoreapp3.0 -r ubuntu.16.04-x64
    ```
 
    **On Linux:**


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: wrong ubuntu version name