### PR TITLE
Update cli-templates-create-template-pack.md

### DIFF
--- a/docs/core/tutorials/cli-templates-create-item-template.md
+++ b/docs/core/tutorials/cli-templates-create-item-template.md
@@ -28,7 +28,7 @@ In this part of the series, you'll learn how to:
 
   The reference article explains the basics about templates and how they're put together. Some of this information will be reiterated here.
 
-* Open a terminal and navigate to the _working\templates\\_ folder.
+* Open a terminal and navigate to the _working\templates_ folder.
 
 ## Create the required folders
 
@@ -49,7 +49,7 @@ parent_folder
 
 An item template is a specific type of template that contains one or more files. These types of templates are useful when you want to generate something like a config, code, or solution file. In this example, you'll create a class that adds an extension method to the string type.
 
-In your terminal, navigate to the _working\templates\\_ folder and create a new subfolder named _extensions_. Enter the folder.
+In your terminal, navigate to the _working\templates_ folder and create a new subfolder named _extensions_. Enter the folder.
 
 ```console
 working
@@ -80,7 +80,7 @@ Now that you have the content of the template created, you need to create the te
 
 ## Create the template config
 
-Templates are recognized in .NET Core by a special folder and config file that exist at the root of your template. In this tutorial, your template folder is located at _working\templates\extensions\\_.
+Templates are recognized in .NET Core by a special folder and config file that exist at the root of your template. In this tutorial, your template folder is located at _working\templates\extensions_.
 
 When you create a template, all files and folders in the template folder are included as part of the template except for the special config folder. This config folder is named _.template.config_.
 

--- a/docs/core/tutorials/cli-templates-create-project-template.md
+++ b/docs/core/tutorials/cli-templates-create-project-template.md
@@ -24,13 +24,13 @@ In this part of the series you'll learn how to:
 ## Prerequisites
 
 * Complete [part 1](cli-templates-create-item-template.md) of this tutorial series.
-* Open a terminal and navigate to the _working\templates\\_ folder.
+* Open a terminal and navigate to the _working\templates_ folder.
 
 ## Create a project template
 
 Project templates produce ready-to-run projects that make it easy for users to start with a working set of code. .NET Core includes a few project templates such as a console application or a class library. In this example, you'll create a new console project that enables C# 8.0 and produces an `async main` entry point.
 
-In your terminal, navigate to the _working\templates\\_ folder and create a new subfolder named _consoleasync_. Enter the subfolder and run `dotnet new console` to generate the standard console application. You'll be editing the files produced by this template to create a new template.
+In your terminal, navigate to the _working\templates_ folder and create a new subfolder named _consoleasync_. Enter the subfolder and run `dotnet new console` to generate the standard console application. You'll be editing the files produced by this template to create a new template.
 
 ```console
 working
@@ -93,7 +93,7 @@ Now that you have the content of the template created, you need to create the te
 
 ## Create the template config
 
-Templates are recognized in .NET Core by a special folder and config file that exist at the root of your template. In this tutorial, your template folder is located at _working\templates\consoleasync\\_.
+Templates are recognized in .NET Core by a special folder and config file that exist at the root of your template. In this tutorial, your template folder is located at _working\templates\consoleasync_.
 
 When you create a template, all files and folders in the template folder are included as part of the template except for the special config folder. This config folder is named _.template.config_.
 

--- a/docs/core/tutorials/cli-templates-create-template-pack.md
+++ b/docs/core/tutorials/cli-templates-create-template-pack.md
@@ -2,7 +2,7 @@
 title: Create a template pack for dotnet new
 description: Learn how to create a csproj file that will build a template pack for the dotnet new command.
 author: thraka
-ms.date: 06/25/2019
+ms.date: 12/10/2019
 ms.topic: tutorial
 ms.author: adegeo
 ---
@@ -24,9 +24,9 @@ In this part of the series you'll learn how to:
 
 * Complete [part 1](cli-templates-create-item-template.md) and [part 2](cli-templates-create-project-template.md) of this tutorial series.
 
-  This tutorial uses the two templates created in the first two parts of this tutorial. It's possible you can use a different template as long as you copy the template as a folder into the _working\templates\\_ folder.
+  This tutorial uses the two templates created in the first two parts of this tutorial. You can use a different template as long as you copy the template, as a folder, into the _working\templates\\_ folder.
 
-* Open a terminal and navigate to the _working\templates\\_ folder.
+* Open a terminal and navigate to the _working\\_ folder.
 
 ## Create a template pack project
 


### PR DESCRIPTION
Change the starting directory to match the next step.

## Summary

The prerequisites step had the user navigate to the _working/templates//_ folder, the default folder in the last two parts of the tutorial. This tutorial goes on to then tell them to navigate back to the _working//_ folder.

I changed the prerequisites to have them start in the correct folder.

Fixes #16178

EDIT
Setting Tom as the reviewer since he is code owner on the file but I continue to be the author.