### PR TITLE
Fix titles in Formatting Types articles

### DIFF
--- a/docs/standard/base-types/composite-formatting.md
+++ b/docs/standard/base-types/composite-formatting.md
@@ -1,5 +1,5 @@
 ---
-title: "Composite Formatting"
+title: "Composite formatting"
 ms.date: "10/26/2018"
 ms.technology: dotnet-standard
 dev_langs: 
@@ -14,7 +14,7 @@ helpviewer_keywords:
   - "objects [.NET Framework], formatting multiple objects"
 ms.assetid: 87b7d528-73f6-43c6-b71a-f23043039a49
 ---
-# Composite Formatting
+# Composite formatting
 
 The .NET composite formatting feature takes a list of objects and a composite format string as input. A composite format string consists of fixed text intermixed with indexed placeholders, called format items, that correspond to the objects in the list. The formatting operation yields a result string that consists of the original fixed text intermixed with the string representation of the objects in the list.  
   

--- a/docs/standard/base-types/custom-date-and-time-format-strings.md
+++ b/docs/standard/base-types/custom-date-and-time-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Custom date and time format strings - .NET"
+title: "Custom date and time format strings"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 dev_langs: 

--- a/docs/standard/base-types/custom-numeric-format-strings.md
+++ b/docs/standard/base-types/custom-numeric-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Custom Numeric Format Strings"
+title: "Custom numeric format strings"
 ms.date: "06/25/2018"
 ms.technology: dotnet-standard
 dev_langs:

--- a/docs/standard/base-types/custom-timespan-format-strings.md
+++ b/docs/standard/base-types/custom-timespan-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Custom TimeSpan format strings - .NET"
+title: "Custom TimeSpan format strings"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 dev_langs:
@@ -17,7 +17,7 @@ ms.assetid: a63ebf55-7269-416b-b4f5-286f6c03bf0e
 
 # Custom TimeSpan format strings
 
-A <xref:System.TimeSpan> format string defines the string representation of a <xref:System.TimeSpan> value that results from a formatting operation. A custom format string consists of one or more custom <xref:System.TimeSpan> format specifiers along with any number of literal characters. Any string that isn't a [standard TimeSpan format string](standard-timespan-format-strings.md) is interpreted as a custom <xref:System.TimeSpan> format string.
+A <xref:System.TimeSpan> format string defines the string representation of a <xref:System.TimeSpan> value that results from a formatting operation. A custom format string consists of one or more custom <xref:System.TimeSpan> format specifiers along with any number of literal characters. Any string that isn't a [Standard TimeSpan format string](standard-timespan-format-strings.md) is interpreted as a custom <xref:System.TimeSpan> format string.
 
 > [!IMPORTANT]
 > The custom <xref:System.TimeSpan> format specifiers don't include placeholder separator symbols, such as the symbols that separate days from hours, hours from minutes, or seconds from fractional seconds. Instead, these symbols must be included in the custom format string as string literals. For example, `"dd\.hh\:mm"` defines a period (.) as the separator between days and hours, and a colon (:) as the separator between hours and minutes.

--- a/docs/standard/base-types/enumeration-format-strings.md
+++ b/docs/standard/base-types/enumeration-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Enumeration format strings - .NET"
+title: "Enumeration format strings"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 dev_langs: 

--- a/docs/standard/base-types/formatting-types.md
+++ b/docs/standard/base-types/formatting-types.md
@@ -1,5 +1,5 @@
 ---
-title: "Formatting Types in .NET"
+title: "Formatting types in .NET"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 dev_langs:

--- a/docs/standard/base-types/standard-date-and-time-format-strings.md
+++ b/docs/standard/base-types/standard-date-and-time-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Standard Date and Time Format Strings"
+title: "Standard date and time format strings"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 dev_langs:
@@ -15,9 +15,9 @@ helpviewer_keywords:
   - "date and time strings"
 ms.assetid: bb79761a-ca08-44ee-b142-b06b3e2fc22b
 ---
-# Standard Date and Time Format Strings
+# Standard date and time format strings
 
-A standard date and time format string uses a single format specifier to define the text representation of a date and time value. Any date and time format string that contains more than one character, including white space, is interpreted as a custom date and time format string; for more information, see [Custom Date and Time Format Strings](../../../docs/standard/base-types/custom-date-and-time-format-strings.md). A standard or custom format string can be used in two ways:
+A standard date and time format string uses a single format specifier to define the text representation of a date and time value. Any date and time format string that contains more than one character, including white space, is interpreted as a custom date and time format string; for more information, see [Custom date and time format strings](../../../docs/standard/base-types/custom-date-and-time-format-strings.md). A standard or custom format string can be used in two ways:
 
 - To define the string that results from a formatting operation.
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Standard Numeric Format Strings"
+title: "Standard numeric format strings"
 ms.date: "06/10/2018"
 ms.technology: dotnet-standard
 dev_langs:
@@ -17,7 +17,7 @@ helpviewer_keywords:
   - "formatting numbers [.NET Framework]"
   - "format specifiers, standard numeric format strings"
 ---
-# Standard Numeric Format Strings
+# Standard numeric format strings
 
 Standard numeric format strings are used to format common numeric types. A standard numeric format string takes the form `Axx`, where:
 

--- a/docs/standard/base-types/standard-timespan-format-strings.md
+++ b/docs/standard/base-types/standard-timespan-format-strings.md
@@ -1,5 +1,5 @@
 ---
-title: "Standard TimeSpan Format Strings"
+title: "Standard TimeSpan format strings"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 dev_langs: 
@@ -18,9 +18,9 @@ helpviewer_keywords:
   - "formatting [.NET Framework], time intervals"
 ms.assetid: 9f6c95eb-63ae-4dcc-9c32-f81985c75794
 ---
-# Standard TimeSpan Format Strings
+# Standard TimeSpan format strings
 
-A standard <xref:System.TimeSpan> format string uses a single format specifier to define the text representation of a <xref:System.TimeSpan> value that results from a formatting operation. Any format string that contains more than one character, including white space, is interpreted as a custom <xref:System.TimeSpan> format string. For more information, see [Custom TimeSpan Format Strings](../../../docs/standard/base-types/custom-timespan-format-strings.md) .  
+A standard <xref:System.TimeSpan> format string uses a single format specifier to define the text representation of a <xref:System.TimeSpan> value that results from a formatting operation. Any format string that contains more than one character, including white space, is interpreted as a custom <xref:System.TimeSpan> format string. For more information, see [Custom TimeSpan format strings](../../../docs/standard/base-types/custom-timespan-format-strings.md) .  
   
  The string representations of <xref:System.TimeSpan> values are produced by calls to the overloads of the <xref:System.TimeSpan.ToString%2A?displayProperty=nameWithType> method, as well as by methods that support composite formatting, such as <xref:System.String.Format%2A?displayProperty=nameWithType>. For more information, see [Formatting Types](../../../docs/standard/base-types/formatting-types.md) and [Composite Formatting](../../../docs/standard/base-types/composite-formatting.md). The following example illustrates the use of standard format strings in formatting operations.  
   


### PR DESCRIPTION
Apply sentence-style to "Formatting Types" articles
(official guide: https://docs.microsoft.com/en-us/style-guide/capitalization#sentence-style-capitalization-in-titles-and-headings)