### PR TITLE
Update how-to-compare-the-contents-of-two-folders-linq.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-compare-the-contents-of-two-folders-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-compare-the-contents-of-two-folders-linq.md
@@ -62,7 +62,7 @@ namespace QueryCompareTwoDirs
             // execute until the foreach statement.  
             var queryCommonFiles = list1.Intersect(list2, myFileCompare);  
   
-            if (queryCommonFiles.Count() > 0)  
+            if (queryCommonFiles.Any())  
             {  
                 Console.WriteLine("The following files are in both folders:");  
                 foreach (var v in queryCommonFiles)  


### PR DESCRIPTION
## Summary

Change Count() to Any(). Improves performance for large file structures since it doesn't require a full enumeration.

