### PR TITLE
Add clarification on package managers x64 support;add manual install …

### DIFF
--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -15,4 +15,4 @@
 > - [SLES 12 - x64](../linux-package-manager-sles12.md)
 > - [SLES 15 - x64](../linux-package-manager-sles15.md)
 
-_Package manager installs are only supported on **64-bit** CPUs_. Other CPUs must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).
+_Package manager installs are only supported on **x32-64** architectures_. Other architectures, such as ARM, must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).

--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -15,4 +15,4 @@
 > - [SLES 12 - x64](../linux-package-manager-sles12.md)
 > - [SLES 15 - x64](../linux-package-manager-sles15.md)
 
-_Package manager installs are only supported on **x64** architectures_. Other architectures, such as **ARM**, must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).
+_Package manager installs are only supported on the **x64** architecture_. Other architectures, such as **ARM**, must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).

--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -14,3 +14,5 @@
 > - [OpenSUSE 15 - x64](../linux-package-manager-opensuse15.md)
 > - [SLES 12 - x64](../linux-package-manager-sles12.md)
 > - [SLES 15 - x64](../linux-package-manager-sles15.md)
+
+_Package manager installs are only supported on **64-bit** CPUs_. For more information, see [.NET Core dependencies and requirements](../dependencies.md), [Manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install), and [Manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install).

--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -15,4 +15,4 @@
 > - [SLES 12 - x64](../linux-package-manager-sles12.md)
 > - [SLES 15 - x64](../linux-package-manager-sles15.md)
 
-_Package manager installs are only supported on **x32-64** architectures_. Other architectures, such as ARM, must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).
+_Package manager installs are only supported on **x64** architectures_. Other architectures, such as **ARM**, must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).

--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -15,4 +15,4 @@
 > - [SLES 12 - x64](../linux-package-manager-sles12.md)
 > - [SLES 15 - x64](../linux-package-manager-sles15.md)
 
-_Package manager installs are only supported on **64-bit** CPUs_. For more information, see [.NET Core dependencies and requirements](../dependencies.md), [Manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install), and [Manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install).
+_Package manager installs are only supported on **64-bit** CPUs_. Other CPUs must [manually install the .NET Core SDK](../sdk.md?pivots=os-linux#download-and-manually-install) or [manually install the .NET Core Runtime](../runtime.md?pivots=os-linux#download-and-manually-install). For more information, see [.NET Core dependencies and requirements](../dependencies.md).

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported on the x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
+Installing it with a package manager is only supported on the x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the instructions on the [Download and manually install](#download-and-manually-install) section. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 
@@ -52,7 +52,7 @@ export PATH=$PATH:$HOME/dotnet
 ```
 
 > [!TIP]
-> The above `export` commands will only make the .NET Core commands available for the terminal session in which it was run.
+> The preceding `export` commands only make the .NET Core commands available for the terminal session in which it was run.
 >
 > You can edit your shell profile to permanently add the commands. There are a number of different shells available for Linux and each has a different profile. For example:
 >

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -43,7 +43,7 @@ Installing it with a package manager is only supported on the x64 architecture. 
 
 ## Download and manually install
 
-To extract the runtime and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
+To extract the runtime and make the .NET Core CLI commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf aspnetcore-runtime-3.1.0-linux-x64.tar.gz -C $HOME/dotnet
@@ -52,7 +52,7 @@ export PATH=$PATH:$HOME/dotnet
 ```
 
 > [!TIP]
-> The preceding `export` commands only make the .NET Core commands available for the terminal session in which it was run.
+> The preceding `export` commands only make the .NET Core CLI commands available for the terminal session in which it was run.
 >
 > You can edit your shell profile to permanently add the commands. There are a number of different shells available for Linux and each has a different profile. For example:
 >

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -39,6 +39,29 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-manager-rhel7.md).
 
+## Download and manually install
+
+To extract the SDK and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
+
+```bash
+mkdir -p $HOME/dotnet && tar zxf aspnetcore-runtime-3.1.0-linux-x64.tar.gz -C $HOME/dotnet
+export DOTNET_ROOT=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
+```
+
+> [!TIP]
+> The above `export` commands will only make the .NET Core commands available for the terminal session in which it was run.
+>
+> You can edit your shell profile to permanently add the commands. There are a number of different shells available for Linux and each has a different profile. For example:
+>
+> - **Bash Shell**: *~/.bash_profile*, *~/.bashrc*
+> - **Korn Shell**: *~/.kshrc* or *.profile*
+> - **Z Shell**: *~/.zshrc* or *.zprofile*
+> 
+> Edit the appropriate source file for your shell and add `:$HOME/dotnet` to the end of the existing `PATH` statement. If no `PATH` statement is included, add a new line with `export PATH=$PATH:$HOME/dotnet`.
+>
+> Also, add `export DOTNET_ROOT=$HOME/dotnet` to the end of the file.
+
 ::: zone-end
 
 ::: zone pivot="os-windows"

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported for x32-64 architectures. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
+Installing with a package manager is only supported on an x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -43,7 +43,7 @@ Installing with a package manager is only supported on the x64 architecture. If 
 
 ## Download and manually install
 
-To extract the SDK and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
+To extract the runtime and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf aspnetcore-runtime-3.1.0-linux-x64.tar.gz -C $HOME/dotnet

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported on an x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
+Installing with a package manager is only supported on the x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported for 64-bit CPUs. If you're installing the .NET Core Runtime with a 32-bit CPU, follow the [Download and manually install](#download-and-manually-install) instructions below.
+Installing with a package manager is only supported for x32-64 architectures. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -37,7 +37,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 ## Install with a package manager
 
-You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-manager-rhel7.md).
+You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
 Installing with a package manager is only supported for 64-bit CPUs. If you're installing the .NET Core Runtime with a 32-bit CPU, follow the [Download and manually install](#download-and-manually-install) instructions below.
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -39,6 +39,8 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 ru
 
 You can install the .NET Core Runtime with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-manager-rhel7.md).
 
+Installing with a package manager is only supported for 64-bit CPUs. If you're installing the .NET Core Runtime with a 32-bit CPU, follow the [Download and manually install](#download-and-manually-install) instructions below.
+
 ## Download and manually install
 
 To extract the SDK and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -43,7 +43,7 @@ Installing with a package manager is only supported on the x64 architecture. If 
 
 ## Download and manually install
 
-To extract the SDK and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
+To extract the SDK and make the .NET Core CLI commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet-sdk-3.1.100-linux-x64.tar.gz -C $HOME/dotnet
@@ -52,7 +52,7 @@ export PATH=$PATH:$HOME/dotnet
 ```
 
 > [!TIP]
-> The preceding `export` commands only make the .NET Core SDK commands available for the terminal session in which it was run.
+> The preceding `export` commands only make the .NET Core CLI commands available for the terminal session in which it was run.
 >
 > You can edit your shell profile to permanently add the commands. There are a number of different shells available for Linux and each has a different profile. For example:
 >

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 SD
 
 You can install the .NET Core SDK with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported on the x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
+Installing with a package manager is only supported on the x64 architecture. If you're installing the .NET Core SDK with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -50,7 +50,7 @@ export PATH=$PATH:$HOME/dotnet
 ```
 
 > [!TIP]
-> The above commands will only make the .NET SDK commands available for the terminal session in which it was run.
+> The above `export` commands will only make the .NET SDK commands available for the terminal session in which it was run.
 >
 > You can edit your shell profile to permanently add the commands. There are a number of different shells available for Linux and each has a different profile. For example:
 >

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -52,7 +52,7 @@ export PATH=$PATH:$HOME/dotnet
 ```
 
 > [!TIP]
-> The above `export` commands will only make the .NET SDK commands available for the terminal session in which it was run.
+> The preceding `export` commands only make the .NET Core SDK commands available for the terminal session in which it was run.
 >
 > You can edit your shell profile to permanently add the commands. There are a number of different shells available for Linux and each has a different profile. For example:
 >

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 SD
 
 You can install the .NET Core SDK with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported for x32-64 architectures. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
+Installing with a package manager is only supported on the x64 architecture. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -39,6 +39,8 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 SD
 
 You can install the .NET Core SDK with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
+Installing with a package manager is only supported for 64-bit CPUs. If you're installing the .NET Core Runtime with a 32-bit CPU, follow the [Download and manually install](#download-and-manually-install) instructions below.
+
 ## Download and manually install
 
 To extract the SDK and make the commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, open a terminal and run the following commands.

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -39,7 +39,7 @@ macOS has standalone installers that can be used to install the .NET Core 3.1 SD
 
 You can install the .NET Core SDK with many of the common Linux package managers. For more information, see [Linux Package Manager - Install .NET Core](linux-package-managers.md).
 
-Installing with a package manager is only supported for 64-bit CPUs. If you're installing the .NET Core Runtime with a 32-bit CPU, follow the [Download and manually install](#download-and-manually-install) instructions below.
+Installing with a package manager is only supported for x32-64 architectures. If you're installing the .NET Core Runtime with a different architecture, such as ARM, follow the [Download and manually install](#download-and-manually-install) instructions below. For more information about what architectures are supported, see [.NET Core dependencies and requirements](dependencies.md).
 
 ## Download and manually install
 


### PR DESCRIPTION
## Summary

- Added a note to the include page that indicates these instructions are only for x64 architecture/64-bit cpus.
- Added links back to the dependencies and manual install instructions
- Copied manual install instructions from SDK article to RUNTIME article.

Fixes #16245
