### PR TITLE
stackalloc: added the link to a feature proposal note

### DIFF
--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -50,7 +50,7 @@ The use of `stackalloc` automatically enables buffer overrun detection features 
 
 ## C# language specification
 
-For more information, see the [Stack allocation](~/_csharplang/spec/unsafe-code.md#stack-allocation) section of the [C# language specification](~/_csharplang/spec/introduction.md).
+For more information, see the [Stack allocation](~/_csharplang/spec/unsafe-code.md#stack-allocation) section of the [C# language specification](~/_csharplang/spec/introduction.md) and the [Permit `stackalloc` in nested contexts](~/_csharplang/proposals/csharp-8.0/nested-stackalloc.md) feature proposal note.
 
 ## See also
 


### PR DESCRIPTION
The article itself already mentions the new features; it only misses the link to the spec updates.
