### PR TITLE
Remove samples from docfx exclude

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -16,7 +16,6 @@
         "dest": ".",
         "exclude": [
           "api/overwrites/**",
-          "samples/**/*.*",
           "**/includes/**",
           "***/contributing.md"
         ]
@@ -80,7 +79,6 @@
         "dest": ".",
         "exclude": [
           "**/obj/**",
-          "samples/**/*.*",
           "_themes/DocPacker/**"
         ]
       }


### PR DESCRIPTION
I think it's redundant, there is no `samples` directory in the `docs` repo. Please, confirm that my change is correct.