### PR TITLE
Text/snippet mismatch

### DIFF
--- a/docs/standard/serialization/system-text-json-how-to.md
+++ b/docs/standard/serialization/system-text-json-how-to.md
@@ -455,7 +455,7 @@ To minimize escaping you can use <xref:System.Text.Encodings.Web.JavaScriptEncod
 
 ## Serialize properties of derived classes
 
-Polymorphic serialization isn't supported when you specify at compile time the type to be serialized. For example, suppose you have a `WeatherForecast` class and a derived class `WeatherForecastWithWind`:
+Polymorphic serialization isn't supported when you specify at compile time the type to be serialized. For example, suppose you have a `WeatherForecast` class and a derived class `WeatherForecastDerived`:
 
 [!code-csharp[](~/samples/snippets/core/system-text-json/csharp/WeatherForecast.cs?name=SnippetWF)]
 
@@ -465,7 +465,7 @@ And suppose the type argument of the `Serialize` method at compile time is `Weat
 
 [!code-csharp[](~/samples/snippets/core/system-text-json/csharp/SerializePolymorphic.cs?name=SnippetSerializeDefault)]
 
-In this scenario, the `WindSpeed` property is not serialized even if the `weatherForecast` object is actually a `WeatherForecastWithWind` object. Only the base class properties are serialized:
+In this scenario, the `WindSpeed` property is not serialized even if the `weatherForecast` object is actually a `WeatherForecastDerived` object. Only the base class properties are serialized:
 
 ```json
 {


### PR DESCRIPTION
The quickest update is to make the text match the snippet ... only one file to change due to the snippet name (`SnippetWFDerived`) possibly requiring an update, too. If you want to go the other way and change both files, I understand ... "WithWind" is cool.

Cross-ref to that snippet :point_right: https://github.com/dotnet/samples/blob/master/snippets/core/system-text-json/csharp/WeatherForecast.cs#L82-L87