### PR TITLE
Correct wrong wording

### DIFF
--- a/docs/framework/mef/attributed-programming-model-overview-mef.md
+++ b/docs/framework/mef/attributed-programming-model-overview-mef.md
@@ -784,7 +784,7 @@ public class MyAttribute : ExportAttribute
 }
 ```
 
-This class defines a custom attribute named `MyAttribute` with contract type `IMyData` and some metadata named `MyMetadata`. All properties in a class marked with the `MetadataAttribute` attribute are considered to be metadata defined in the custom attribute. The following two declarations are equivalent.
+This class defines a custom attribute named `MyAttribute` with contract type `IMyAddin` and some metadata named `MyMetadata`. All properties in a class marked with the `MetadataAttribute` attribute are considered to be metadata defined in the custom attribute. The following two declarations are equivalent.
 
 ```vb
 <Export(GetType(IMyAddin))>


### PR DESCRIPTION
## Summary

In "Custom Export Attributes," the contract type should be "IMyAddin" not "IMyData" in the sentence:
"This class defines a custom attribute named MyAttribute with contract type IMyData"

Fixes #16272
