### PR TITLE
Fixing sample for runtimes list - Mac OS case

### DIFF
--- a/docs/core/install/how-to-detect-installed-versions.md
+++ b/docs/core/install/how-to-detect-installed-versions.md
@@ -136,7 +136,7 @@ Microsoft.NETCore.App 3.1.0 [/home/user/dotnet/shared/Microsoft.NETCore.App]
 ::: zone pivot="os-macos"
 
 ```bash
-dotnet --list-sdks
+dotnet --list-runtimes
 
 Microsoft.AspNetCore.All 2.1.7 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.All]
 Microsoft.AspNetCore.All 2.1.13 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.All]


### PR DESCRIPTION
The sample had the command for SDK, not runtimes

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
