### PR TITLE
Add links to Core, standard, asp.net core

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -251,6 +251,15 @@ additionalContent:
       - title: ".NET for Apache Spark API reference"
         summary: API reference documentation for .NET for Apache Spark
         url: https://docs.microsoft.com/dotnet/api/?view=spark-dotnet
+      - title: ".NET Core"
+        summary: ".NET Core documentation"
+        url: core/index.md
+      - title: ".NET Standard"
+        summary: ".NET Standard documentation"
+        url: standard/index.md
+      - title: "ASP.NET Core"
+        summary: ASP.NET Core documentation"
+        url: /aspnet/core/
       # Card
       - title: "C# language reference"
         summary: C# language reference and specification

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -73,6 +73,12 @@ conceptualContent:
         - url: standard/net-standard.md
           itemType: overview
           text: .NET Standard
+        - url: /aspnet/core/
+          itemType: overview
+          text: ASP.NET Core
+        - url: /ef/core/
+          itemType: overview
+          text: Entity Framework Core
         - url: standard/get-started.md
           itemType: get-started
           text: Get started
@@ -251,15 +257,6 @@ additionalContent:
       - title: ".NET for Apache Spark API reference"
         summary: API reference documentation for .NET for Apache Spark
         url: https://docs.microsoft.com/dotnet/api/?view=spark-dotnet
-      - title: ".NET Core"
-        summary: ".NET Core documentation"
-        url: core/index.md
-      - title: ".NET Standard"
-        summary: ".NET Standard documentation"
-        url: standard/index.md
-      - title: "ASP.NET Core"
-        summary: ASP.NET Core documentation
-        url: /aspnet/core/
       # Card
       - title: "C# language reference"
         summary: C# language reference and specification

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -258,7 +258,7 @@ additionalContent:
         summary: ".NET Standard documentation"
         url: standard/index.md
       - title: "ASP.NET Core"
-        summary: ASP.NET Core documentation"
+        summary: ASP.NET Core documentation
         url: /aspnet/core/
       # Card
       - title: "C# language reference"


### PR DESCRIPTION
Fixes MicrosoftDocs/Feedback#2271

We still want to optimize for the net-new developer, but we need to include the important links for our current .NET community.

