### PR TITLE
C154710: using HTML entity instaead of escaping symbol

### DIFF
--- a/docs/standard/base-types/details-of-regular-expression-behavior.md
+++ b/docs/standard/base-types/details-of-regular-expression-behavior.md
@@ -127,7 +127,7 @@ The .NET Framework regular expression engine is a backtracking regular expressio
     |-------------|-----------------|  
     |`^`|Begin the match at the beginning of the string.|  
     |`[A-Z0-9]`|Match any numeric or alphanumeric character. (The comparison is case-insensitive.)|  
-    |<code>([-!#$%&'.*+/=?^\`{}&#124;~\w])\*</code>|Match zero or more occurrences of any word character, or any of the following characters:  -, !, #, $, %, &, ', ., \*, +, /, =, ?, ^, \`, {, }, &#124;, or ~.|  
+    |<code>([-!#$%&'.*+/=?^\`{}&#124;~\w])\*</code>|Match zero or more occurrences of any word character, or any of the following characters:  -, !, #, $, %, &, ', ., \*, +, /, =, ?, ^, &#96;, {, }, &#124;, or ~.|  
     |`(?<=[A-Z0-9])`|Look behind to the previous character, which must be numeric or alphanumeric. (The comparison is case-insensitive.)|  
     |`$`|End the match at the end of the string.|  
   


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: there is ```` \` ```` which breaks formatting on LOC pages and causes unloc strings. Please replace it with HTML code - `&#96;`
