### PR TITLE
CC177472, Adding missing breakline

### DIFF
--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -50,7 +50,8 @@ Multiple frameworks have been built on top of .NET Core:
 
 .NET Core is composed of the following parts:
 
-- The [.NET Core runtime](https://github.com/dotnet/runtime/tree/master/src/coreclr), which provides a type system, assembly loading, a garbage collector, native interop, and other basic services. [.NET Core framework libraries](https://github.com/dotnet/runtime/tree/master/src/libraries) provide primitive data types, app composition types, and fundamental utilities.
+- The [.NET Core runtime](https://github.com/dotnet/runtime/tree/master/src/coreclr), which provides a type system, assembly loading, a garbage collector, native interop, and other basic services.
+- [.NET Core framework libraries](https://github.com/dotnet/runtime/tree/master/src/libraries) provide primitive data types, app composition types, and fundamental utilities.
 - The [ASP.NET runtime](https://github.com/aspnet/home), which provides a framework for building modern cloud-based internet connected applications, such as web apps, IoT apps, and mobile backends.
 - The [.NET Core CLI tools](https://github.com/dotnet/cli) and language compilers ([Roslyn](https://github.com/dotnet/roslyn) and [F#](https://github.com/microsoft/visualfsharp)) that enable the .NET Core developer experience.
 - The [dotnet tool](https://github.com/dotnet/core-setup), which is used to launch .NET Core apps and CLI tools. It selects the runtime and hosts the runtime, provides an assembly loading policy, and launches apps and tools.


### PR DESCRIPTION
This proposed file change comes from https://github.com/dotnet/docs.zh-cn/pull/508/files.
Description: Missing breaklin for link