### PR TITLE
add CODEOWNERS and label rules

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -43,7 +43,7 @@
             "labels-add": ":books: Area - Roslyn API Reference,:file_folder: Repo - roslyn-api-docs"
           },
           "(?i)dotnet-whats-new$": {
-            "labels-add": ":bookmark_tabs: Information Architecture"
+            "labels-add": ":star2: What's New"
           },
           "(?i)dotnet-architecture$": {
             "labels-add": ":books: Area - .NET Architecture Guide"
@@ -128,7 +128,7 @@
             "labels-add": ":book: guide - Framework Design Guidelines"
           },
           "(?i).*docs\/whats-new\/.*": {
-            "labels-add": ":bookmark_tabs: Information Architecture"
+            "labels-add": ":star2: What's New"
           }
     }
       },
@@ -260,7 +260,7 @@
                 "labels-add": ":books: Area - Visual Basic Guide"
               },
               "(?i).*docs\/whats-new\/.*": {
-                "labels-add": ":bookmark_tabs: Information Architecture"
+                "labels-add": ":star2: What's New"
               }
             }
           }

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -42,6 +42,9 @@
           "(?i)dotnet-roslyn-api$": {
             "labels-add": ":books: Area - Roslyn API Reference,:file_folder: Repo - roslyn-api-docs"
           },
+          "(?i)dotnet-whats-new$": {
+            "labels-add": ":bookmark_tabs: Information Architecture"
+          },
           "(?i)dotnet-architecture$": {
             "labels-add": ":books: Area - .NET Architecture Guide"
           }
@@ -123,8 +126,11 @@
           },
           "(?i).*master\/docs\/standard\/standard\/design-guidelines\/.*": {
             "labels-add": ":book: guide - Framework Design Guidelines"
+          },
+          "(?i).*docs\/whats-new\/.*": {
+            "labels-add": ":bookmark_tabs: Information Architecture"
           }
-        }
+    }
       },
       "processor-meta-custom": {
         "issuetype": {
@@ -252,6 +258,9 @@
               },
               "(?i).*docs\/visual-basic.*": {
                 "labels-add": ":books: Area - Visual Basic Guide"
+              },
+              "(?i).*docs\/whats-new\/.*": {
+                "labels-add": ":bookmark_tabs: Information Architecture"
               }
             }
           }

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 # In each subsection folders are order first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
+############ WHATS NEW ###############
+/docs/whats-new/** @mairaw @billwagner
+
 ############  GUIDES  ################
 # .NET Core
 /docs/core/** @mairaw


### PR DESCRIPTION
I missed these in the .NET What's new page.

I checked the metadata defaults for the files and folders, and those should be fine.

I chose the "Information Architecture" label for "what's new". That seemed the most reasonable for this area. I'm open to other ideas (or leaving it blank)