### PR TITLE
Prevent statically defined enums from being changed at runtime

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -63,9 +63,9 @@ You can use this class as a type in any entity or value object, as for the follo
 ```csharp
 public class CardType : Enumeration
 {
-    public static CardType Amex = new CardType(1, "Amex");
-    public static CardType Visa = new CardType(2, "Visa");
-    public static CardType MasterCard = new CardType(3, "MasterCard");
+    public static readonly CardType Amex = new CardType(1, "Amex");
+    public static readonly CardType Visa = new CardType(2, "Visa");
+    public static readonly CardType MasterCard = new CardType(3, "MasterCard");
 
     public CardType(int id, string name)
         : base(id, name)


### PR DESCRIPTION
In the example code, the `CardType` is immutable, but the static reference to the pre-defined enums are not. This corrects that and removes the ability for them to be redefined by client code.

## Summary

Static `CardType` objects are marked as readonly.

Fixes #16192
