### PR TITLE
Escape the dollar sign

### DIFF
--- a/docs/csharp/language-reference/keywords/formatting-numeric-results-table.md
+++ b/docs/csharp/language-reference/keywords/formatting-numeric-results-table.md
@@ -16,7 +16,7 @@ The following table shows supported format specifiers for formatting numeric res
 
 |Format specifier|Description|Examples|Result|  
 |----------------------|-----------------|--------------|------------|  
-|C or c|Currency|`string s = $"{2.5:C}";`<br /><br /> `string s = $"{-2.5:C}";`|$2.50<br /><br /> ($2.50)|  
+|C or c|Currency|`string s = $"{2.5:C}";`<br /><br /> `string s = $"{-2.5:C}";`|\\$2.50<br /><br /> (\\$2.50)|  
 |D or d|Decimal|`string s = $"{25:D5}";`|00025|  
 |E or e|Exponential|`string s = $"{250000:E2}";`|2.50E+005|  
 |F or f|Fixed-point|`string s = $"{2.5:F2}";`<br /><br /> `string s = $"{2.5:F0}";`|2.50<br /><br /> 3|  


### PR DESCRIPTION
[Formatting numeric results table](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/formatting-numeric-results-table)
The dollar sign (visible in the GitHub preview) disappears when published:
![image](https://user-images.githubusercontent.com/15279990/71197738-921a7b00-2292-11ea-9762-1a2242a23f1d.png)

I escape it with `\\`, like the [Standard numeric format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings) page does. However, that way the GitHub preview is not accurate anymore (for the both pages):
![image](https://user-images.githubusercontent.com/15279990/71197914-f1788b00-2292-11ea-8512-ed61ea9a3a74.png)



