### PR TITLE
Update streaming-versus-repeated.md

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/streaming-versus-repeated.md
+++ b/docs/architecture/grpc-for-wcf-developers/streaming-versus-repeated.md
@@ -1,6 +1,6 @@
 ---
-title: gRPC streaming services versus repeated fields - gRPC for WCF Developers
-description: Comparing repeated fields to streaming services as ways of passing collections of data with gRPC.
+title: Streaming services vs. repeated fields - gRPC for WCF Developers
+description: Compare repeated fields to streaming services as ways of passing collections of data with gRPC.
 ms.date: 09/02/2019
 ---
 


### PR DESCRIPTION
Shortening title as per 1656875
It currently truncates in Google, and has the duplicate word gRPC. Not sure if we need to lead with that term gRPC though. 

![image](https://user-images.githubusercontent.com/5067358/71222111-0d286500-2284-11ea-8f89-29ab958c66de.png)
