### PR TITLE
Remove title suffix from markdown files

### DIFF
--- a/docs/core/additional-tools/dotnet-svcutil.xmlserializer-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil.xmlserializer-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Using dotnet-svcutil.xmlserializer on .NET Core
+title: Using dotnet-svcutil.xmlserializer
 description: Learn how you can use the `dotnet-svcutil.xmlserializer` NuGet package to pre-generate a serialization assembly for .NET Core projects.
 author: huanwu
 ms.date: 11/27/2018

--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core additional CLI tools
+title: Additional CLI tools
 description: An overview of the additional tools you can install that support and extend .NET Core functionality.
 author: mlacouture
 ms.date: 12/02/2019

--- a/docs/core/additional-tools/uninstall-tool.md
+++ b/docs/core/additional-tools/uninstall-tool.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core Uninstall Tool
+title: Uninstall Tool
 description: An overview of the .NET Core Uninstall Tool, a guided tool that enables the controlled clean-up of .NET Core SDKs and runtimes.
 author: sfoslund
 ms.date: 12/17/2019

--- a/docs/framework/wcf/feature-details/configuring-http-and-https.md
+++ b/docs/framework/wcf/feature-details/configuring-http-and-https.md
@@ -1,5 +1,5 @@
 ---
-title: "Configuring HTTP and HTTPS - WCF"
+title: "Configuring HTTP and HTTPS"
 ms.date: "04/08/2019"
 helpviewer_keywords: 
   - "configuring HTTP [WCF]"

--- a/docs/framework/wcf/feature-details/messaging-activities.md
+++ b/docs/framework/wcf/feature-details/messaging-activities.md
@@ -1,5 +1,5 @@
 ---
-title: "Messaging activities - WCF"
+title: "Messaging activities"
 ms.date: "03/30/2017"
 ms.assetid: 8498f215-1823-4aba-a6e1-391407f8c273
 ---

--- a/docs/framework/wcf/feature-details/security-overview.md
+++ b/docs/framework/wcf/feature-details/security-overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Security Overview - WCF"
+title: "Security Overview"
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Windows Communication Foundation, security"

--- a/docs/framework/wcf/feature-details/supported-deployment-scenarios.md
+++ b/docs/framework/wcf/feature-details/supported-deployment-scenarios.md
@@ -1,5 +1,5 @@
 ---
-title: "Supported deployment scenarios - WCF"
+title: "Supported deployment scenarios"
 ms.date: "03/30/2017"
 ms.assetid: 3399f208-3504-4c70-a22e-a7c02a8b94a6
 ---

--- a/docs/framework/wcf/feature-details/transport-security-with-an-anonymous-client.md
+++ b/docs/framework/wcf/feature-details/transport-security-with-an-anonymous-client.md
@@ -1,5 +1,5 @@
 ---
-title: "Transport security with an anonymous client - WCF"
+title: "Transport security with an anonymous client"
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/docs/framework/wcf/feature-details/workflow-services-overview.md
+++ b/docs/framework/wcf/feature-details/workflow-services-overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Workflow services overview - WCF"
+title: "Workflow services overview"
 ms.date: "03/30/2017"
 ms.assetid: e536dda3-e286-441e-99a7-49ddc004b646
 ---

--- a/docs/framework/wcf/samples/custom-message-encoder-custom-text-encoder.md
+++ b/docs/framework/wcf/samples/custom-message-encoder-custom-text-encoder.md
@@ -1,5 +1,5 @@
 ---
-title: "Custom Message Encoder: Custom Text Encoder - WCF"
+title: "Custom Message Encoder: Custom Text Encoder"
 ms.date: "03/30/2017"
 ms.assetid: 68ff5c74-3d33-4b44-bcae-e1d2f5dea0de
 ---

--- a/docs/framework/wcf/samples/findprivatekey.md
+++ b/docs/framework/wcf/samples/findprivatekey.md
@@ -1,5 +1,5 @@
 ---
-title: "FindPrivateKey sample - WCF"
+title: "FindPrivateKey sample"
 ms.date: "12/04/2017"
 helpviewer_keywords: 
   - "FindPrivateKey"

--- a/docs/framework/wcf/samples/services.md
+++ b/docs/framework/wcf/samples/services.md
@@ -1,5 +1,5 @@
 ---
-title: "Services samples - WCF"
+title: "Services samples"
 ms.date: "03/30/2017"
 ms.assetid: 462a2218-f8c6-4fb7-95bc-64765459c429
 ---

--- a/docs/framework/wcf/samples/setting-the-use-and-style-properties.md
+++ b/docs/framework/wcf/samples/setting-the-use-and-style-properties.md
@@ -1,5 +1,5 @@
 ---
-title: "Setting the Use and Style properties - WCF samples"
+title: "Setting the Use and Style properties samples"
 ms.date: "03/30/2017"
 ms.assetid: c09a0600-116f-41cf-900a-1b7e4ea4e300
 ---

--- a/docs/fsharp/language-reference/fsharp-collection-types.md
+++ b/docs/fsharp/language-reference/fsharp-collection-types.md
@@ -1,5 +1,5 @@
 ---
-title: F# Collection Types
+title: Collection Types
 description: Learn about F# collection types and how they differ from collection types in the .NET Framework.
 ms.date: 05/16/2016
 ---

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -1,5 +1,5 @@
 ---
-title: F# Interactive Options
+title: Interactive Options
 description: Learn about the command-line options supported by F# Interactive, fsi.exe.
 ms.date: 05/16/2016
 ---

--- a/docs/fsharp/language-reference/fsharp-types.md
+++ b/docs/fsharp/language-reference/fsharp-types.md
@@ -1,5 +1,5 @@
 ---
-title: F# Types
+title: Types
 description: Learn about the types that are used in F# and how F# types are named and described.
 ms.date: 05/16/2016
 ---

--- a/docs/fsharp/language-reference/index.md
+++ b/docs/fsharp/language-reference/index.md
@@ -1,5 +1,5 @@
 ---
-title: F# Language Reference
+title: Language Reference
 description: Find F# language feature information from this reference to language tokens, concepts, types, expressions, and compiler-supported construct topics.
 ms.date: 05/16/2016
 ---

--- a/docs/fsharp/language-reference/slices.md
+++ b/docs/fsharp/language-reference/slices.md
@@ -1,5 +1,5 @@
 ---
-title: Slices (F#)
+title: Slices
 description: Learn about how to use slices for existing F# data types and how to define your own slices for other data types.
 ms.date: 01/22/2019
 ---

--- a/docs/fsharp/language-reference/xml-documentation.md
+++ b/docs/fsharp/language-reference/xml-documentation.md
@@ -1,5 +1,5 @@
 ---
-title: XML Documentation (F#)
+title: XML Documentation
 description: Learn about support in F# for generating documentation from comments.
 ms.date: 05/16/2016
 ---

--- a/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
+++ b/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
@@ -1,5 +1,5 @@
 ---
-title: Async Programming in F#
+title: Async Programming
 description: Learn how F# provides clean support for asynchrony based on a language-level programming model derived from core functional programming concepts.
 ms.date: 12/17/2018
 ---

--- a/docs/visual-basic/language-reference/operators/nameof.md
+++ b/docs/visual-basic/language-reference/operators/nameof.md
@@ -1,11 +1,11 @@
 ---
-title: "NameOf operator - Visual Basic"
+title: "NameOf operator"
 description: "Learn how to use the NameOf operator in Visual Basic"
 ms.date: 10/27/2019
 helpviewer_keywords:
   - "NameOf operator [Visual Basic]"
 ---
-# NameOf operator - Visual Basic
+# NameOf operator
 
 The `NameOf` operator obtains the name of a variable, type, or member as the string constant:
 

--- a/docs/visual-basic/language-reference/operators/nameof.md
+++ b/docs/visual-basic/language-reference/operators/nameof.md
@@ -5,7 +5,7 @@ ms.date: 10/27/2019
 helpviewer_keywords:
   - "NameOf operator [Visual Basic]"
 ---
-# NameOf operator
+# NameOf operator - Visual Basic
 
 The `NameOf` operator obtains the name of a variable, type, or member as the string constant:
 

--- a/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md
+++ b/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Try...Catch...Finally statement - Visual Basic"
+title: "Try...Catch...Finally statement"
 description: Learn to use exception handling with Visual Basic Try/Catch/Finally statements.
 ms.date: 12/07/2018
 f1_keywords: 

--- a/docs/visual-basic/programming-guide/concepts/index.md
+++ b/docs/visual-basic/programming-guide/concepts/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Programming concepts - Visual Basic"
+title: "Programming concepts"
 ms.date: 02/27/2017
 ms.assetid: cc9cac84-61f6-476e-b8c7-9bae7749bd90
 ---

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-build-linq-to-xml-examples.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-build-linq-to-xml-examples.md
@@ -1,5 +1,5 @@
 ---
-title: "How to: build LINQ to XML examples - Visual Basic"
+title: "How to: build LINQ to XML examples"
 ms.date: 07/20/2015
 ms.assetid: 565bca7a-ac8b-497f-8d8d-3323b3d7799e
 ---

--- a/docs/visual-basic/programming-guide/language-features/data-types/nullable-value-types.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/nullable-value-types.md
@@ -1,5 +1,5 @@
 ---
-title: "Nullable Value Types - Visual Basic"
+title: "Nullable Value Types"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Nullable"

--- a/docs/visual-basic/programming-guide/language-features/strings/how-to-search-within-a-string.md
+++ b/docs/visual-basic/programming-guide/language-features/strings/how-to-search-within-a-string.md
@@ -1,5 +1,5 @@
 ---
-title: "How to: search within a string - Visual Basic"
+title: "How to: search within a string"
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "strings [Visual Basic], finding"


### PR DESCRIPTION
The title suffix already exists in the docfx settings.