### PR TITLE
Add note about microsoft archive repo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ To contribute, see the [Projects for .NET Community Contributors](https://github
 
 If you're interested in helping migrate existing code that targets the .NET Framework from the [retired Code Gallery](https://docs.microsoft.com/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
 
-
 This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community.
 For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ We welcome contributions to help us improve and complete the .NET docs. This is 
 
 To contribute, see the [Projects for .NET Community Contributors](https://github.com/dotnet/docs/projects/35) for ideas. The [Contributing Guide](CONTRIBUTING.md) has instructions on procedures we use. 
 
-If you're interested in helping migrate existing code that targets the .NET Framework from [Code Gallery](https://code.msdn.microsoft.com) to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. 
+If you're interested in helping migrate existing code that targets the .NET Framework from the retired code gallery to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?utf8=%E2%9C%93&q=msdn-code-gallery&type=&language=) organization.
 
-We anticipate that [Xamarin](https://docs.microsoft.com/xamarin), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib) and [Unity](https://docs.unity3d.com/Manual/index.html) will also use this documentation.
+We anticipate that [Xamarin](https://docs.microsoft.com/xamarin), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib), and [Unity](https://docs.unity3d.com/Manual/index.html) will also use this documentation.
 
 This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ We welcome contributions to help us improve and complete the .NET docs. This is 
 
 To contribute, see the [Projects for .NET Community Contributors](https://github.com/dotnet/docs/projects/35) for ideas. The [Contributing Guide](CONTRIBUTING.md) has instructions on procedures we use. 
 
-If you're interested in helping migrate existing code that targets the .NET Framework from the retired code gallery to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
+If you're interested in helping migrate existing code that targets the .NET Framework from the [retired Code Gallery](https://docs.microsoft.com/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
 
-We anticipate that [Xamarin](https://docs.microsoft.com/xamarin), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib), and [Unity](https://docs.unity3d.com/Manual/index.html) will also use this documentation.
 
 This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We welcome contributions to help us improve and complete the .NET docs. This is 
 
 To contribute, see the [Projects for .NET Community Contributors](https://github.com/dotnet/docs/projects/35) for ideas. The [Contributing Guide](CONTRIBUTING.md) has instructions on procedures we use. 
 
-If you're interested in helping migrate existing code that targets the .NET Framework from the retired code gallery to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?utf8=%E2%9C%93&q=msdn-code-gallery&type=&language=) organization.
+If you're interested in helping migrate existing code that targets the .NET Framework from the retired code gallery to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
 
 We anticipate that [Xamarin](https://docs.microsoft.com/xamarin), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib), and [Unity](https://docs.unity3d.com/Manual/index.html) will also use this documentation.
 


### PR DESCRIPTION
The link that was specified to the code gallery (<https://code.msdn.microsoft.com>) redirects to the samples browser and is no longer useful. I removed that link, specified that the code gallery is retired, and pointed to where the samples were moved.