### PR TITLE
Update byrefs.md

### DIFF
--- a/docs/fsharp/language-reference/byrefs.md
+++ b/docs/fsharp/language-reference/byrefs.md
@@ -98,7 +98,7 @@ All of these rules together mean that the holder of an `inref` pointer may not m
 
 ### Outref semantics
 
-The purpose of `outref<'T>` is to indicate that the pointer should only be read from. Unexpectedly, `outref<'T>` permits reading the underlying value despite its name. This is for compatibility purposes. Semantically, `outref<'T>` is no different than `byref<'T>`.
+The purpose of `outref<'T>` is to indicate that the pointer should only be written to. Unexpectedly, `outref<'T>` permits reading the underlying value despite its name. This is for compatibility purposes. Semantically, `outref<'T>` is no different than `byref<'T>`.
 
 ### Interop with C\#
 


### PR DESCRIPTION
outref<'T> should be written to, not read from. In the Outref semantics section.

