### PR TITLE
Typo "[`prefix:]name`"→"`[prefix:]name`"

### DIFF
--- a/docs/visual-basic/language-reference/xml-axis/xml-child-axis-property.md
+++ b/docs/visual-basic/language-reference/xml-axis/xml-child-axis-property.md
@@ -26,7 +26,7 @@ object.<child>
 |---|---|  
 |`object`|Required. An <xref:System.Xml.Linq.XElement> object, an <xref:System.Xml.Linq.XDocument> object, a collection of <xref:System.Xml.Linq.XElement> objects, or a collection of <xref:System.Xml.Linq.XDocument> objects.|  
 |.<|Required. Denotes the start of a child axis property.|  
-|`child`|Required. Name of the child nodes to access, of the form [`prefix:]name`.<br /><br /> -   `Prefix` - Optional. XML namespace prefix for the child node. Must be a global XML namespace defined with an `Imports` statement.<br />-   `Name` - Required. Local child node name. See [Names of Declared XML Elements and Attributes](../../../visual-basic/programming-guide/language-features/xml/names-of-declared-xml-elements-and-attributes.md).|  
+|`child`|Required. Name of the child nodes to access, of the form `[prefix:]name`.<br /><br /> -   `Prefix` - Optional. XML namespace prefix for the child node. Must be a global XML namespace defined with an `Imports` statement.<br />-   `Name` - Required. Local child node name. See [Names of Declared XML Elements and Attributes](../../../visual-basic/programming-guide/language-features/xml/names-of-declared-xml-elements-and-attributes.md).|  
 |>|Required. Denotes the end of a child axis property.|  
   
 ## Return Value  


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/xml-axis/xml-child-axis-property

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
