### PR TITLE
Update outdated info about .NET Core WinForms designer

### DIFF
--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -3,7 +3,7 @@ title: Port a Windows Forms app to .NET Core
 description: Teaches you how to port a .NET Framework Windows Forms application to .NET Core for Windows.
 author: Thraka
 ms.author: adegeo
-ms.date: 03/01/2019
+ms.date: 01/24/2020
 ---
 # How to port a Windows Forms desktop app to .NET Core
 
@@ -54,10 +54,6 @@ When porting a .NET Framework Windows Forms application, there are a few things 
 01. Update the NuGet packages used by your project.
 
     It's always a good practice to use the latest versions of NuGet packages before any migration. If your application is referencing any NuGet packages, update them to the latest version. Ensure your application builds successfully. After upgrading, if there are any package errors, downgrade the package to the latest version that doesn't break your code.
-
-01. Visual Studio 2019 doesn't yet support the Forms Designer for .NET Core 3.0
-
-    Currently, you need to keep your existing .NET Framework Windows Forms project file if you want to use the Forms Designer from Visual Studio.
 
 ## Create a new SDK project
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -31,7 +31,7 @@ In this article, various names are used to identify types of files used for migr
 - [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) 3.0 or later.
 
 > [!NOTE]
-> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects. Starting with **Visual Studio 2019 16.5 Preview 1**, the .NET Core Windows Forms designer is supported.
+> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects. Starting with **Visual Studio 2019 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
 >
 > To enable the designer, Go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -31,7 +31,9 @@ In this article, various names are used to identify types of files used for migr
 - [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) 3.0 or later.
 
 > [!NOTE]
-> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects but doesn't yet support the visual designer for .NET Core 3.0 Windows Forms projects. To use the visual designer, you must have a .NET Windows Forms project in a solution that shares the forms files with the .NET Core project.
+> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects. Starting with **Visual Studio 2019 16.5 Preview 1**, the .NET Core Windows Forms designer is supported.
+>
+> To enable the designer, Go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
 
 ### Consider
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -31,7 +31,7 @@ In this article, various names are used to identify types of files used for migr
 - [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) 3.0 or later.
 
 > [!NOTE]
-> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects. Starting with **Visual Studio 2019 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
+> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects. Starting with **Visual Studio 2019 version 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
 >
 > To enable the designer, Go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -31,9 +31,9 @@ In this article, various names are used to identify types of files used for migr
 - [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) 3.0 or later.
 
 > [!NOTE]
-> **Visual Studio 2017** doesn't support .NET Core 3.0 projects. **Visual Studio 2019** supports .NET Core 3.0 projects. Starting with **Visual Studio 2019 version 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
+> .NET Core 3.0 projects are only supported in **Visual Studio 2019** or a later version. Starting with **Visual Studio 2019 version 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
 >
-> To enable the designer, Go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
+> To enable the designer, go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
 
 ### Consider
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -20,7 +20,7 @@ In this article, various names are used to identify types of files used for migr
 
 ## Prerequisites
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) for any designer work you want to do.
+- [Visual Studio 2019 16.5 Preview 1](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) for any designer work you want to do.
 
   Install the following Visual Studio workloads:
   - .NET desktop development
@@ -28,7 +28,6 @@ In this article, various names are used to identify types of files used for migr
 
 - A working Windows Forms project in a solution that builds and runs without issue.
 - A project coded in C#.
-- [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) 3.0 or later.
 
 > [!NOTE]
 > .NET Core 3.0 projects are only supported in **Visual Studio 2019** or a later version. Starting with **Visual Studio 2019 version 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -20,7 +20,7 @@ In this article, various names are used to identify types of files used for migr
 
 ## Prerequisites
 
-- [Visual Studio 2019 16.5 Preview 1](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) for any designer work you want to do.
+- [Visual Studio 2019 16.5 Preview 1](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) or later for any designer work you want to do. We recommend to update to the latest [Preview version of Visual Studio](https://visualstudio.microsoft.com/vs/preview/)
 
   Install the following Visual Studio workloads:
   - .NET desktop development


### PR DESCRIPTION
As announced [here](https://devblogs.microsoft.com/dotnet/updates-to-net-core-windows-forms-designer-in-visual-studio-16-5-preview-1/). The designer is now available in VS 16.5 Preview 1.

/cc @OliaG 