### PR TITLE
Changed _integrationEventLogService to _catalogIntegrationEventService

### DIFF
--- a/docs/architecture/microservices/implement-resilient-applications/implement-resilient-entity-framework-core-sql-connections.md
+++ b/docs/architecture/microservices/implement-resilient-applications/implement-resilient-entity-framework-core-sql-connections.md
@@ -82,7 +82,7 @@ public async Task<IActionResult> UpdateProduct(
 }
 ```
 
-The first <xref:Microsoft.EntityFrameworkCore.DbContext> is `_catalogContext` and the second `DbContext` is within the `_integrationEventLogService` object. The Commit action is performed across all `DbContext` objects using an EF execution strategy.
+The first <xref:Microsoft.EntityFrameworkCore.DbContext> is `_catalogContext` and the second `DbContext` is within the `_catalogIntegrationEventService` object. The Commit action is performed across all `DbContext` objects using an EF execution strategy.
 
 To achieve this multiple `DbContext` commit, the `SaveEventAndCatalogContextChangesAsync` uses a `ResilientTransaction` class, as shown in the following code:
 


### PR DESCRIPTION
Changed texted to reference _catalogIntegrationEventService

## Summary

Document referenced _integrationEventLogService which does not exist in the sample code.  Changed texted to reference _catalogIntegrationEventService
