### PR TITLE
Correct one line calling powershell

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -183,7 +183,8 @@ You can install a specific version using the `--version` argument. The version m
   Windows:
 
   ```powershell
-  @powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) <additional install-script args>"
+  #Run an seperate powershell process because the script calls exit and so will end the current powershell session.
+  &powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) <additional install-script args>"
   ```
 
   macOS/Linux:

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -183,7 +183,7 @@ You can install a specific version using the `--version` argument. The version m
   Windows:
 
   ```powershell
-  #Run an seperate powershell process because the script calls exit and so will end the current powershell session.
+  # Run a separate PowerShell process because the script calls exit, so it will end the current PowerShell session.
   &powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) <additional install-script args>"
   ```
 


### PR DESCRIPTION
Corrected the one line for installing with powershell from using @ to using &

## Summary

The one liner for installing in powershell uses the @ rather than the &. Also explained why you need to use a separate powershell process because the script calls exit