### PR TITLE
Remove todo comment that's already done

### DIFF
--- a/docs/core/install/linux-package-manager-rhel7.md
+++ b/docs/core/install/linux-package-manager-rhel7.md
@@ -30,7 +30,6 @@ scl enable rh-dotnet30 bash
 
 After registering with the Subscription Manager, you're ready to install and enable the ASP.NET Core Runtime. In your terminal, run the following commands.
 
-<!-- TODO: is this the correct value? Taken from the webpage but it doesn't have aspnet in the name -->
 ```bash
 subscription-manager repos --enable=rhel-7-server-dotnet-rpms
 yum install rh-dotnet30-aspnetcore-runtime-3.0 -y

--- a/docs/core/install/linux-package-manager-rhel81.md
+++ b/docs/core/install/linux-package-manager-rhel81.md
@@ -32,7 +32,6 @@ scl enable dotnet-sdk-3.0 bash
 
 After registering with the Subscription Manager, you're ready to install and enable the ASP.NET Core Runtime. In your terminal, run the following commands.
 
-<!-- TODO: is this the correct value? Taken from the webpage but it doesn't have aspnet in the name -->
 ```bash
 dnf install aspnetcore-runtime-3.0
 scl enable aspnetcore-runtime-3.0 bash


### PR DESCRIPTION
For RHEL7, the package name was corrected in https://github.com/dotnet/docs/pull/16050
For RHEL81, it seems that it's correct from the beginning (https://github.com/dotnet/docs/pull/15569)