### PR TITLE
Consistent wording

### DIFF
--- a/docs/csharp/programming-guide/exceptions/compiler-generated-exceptions.md
+++ b/docs/csharp/programming-guide/exceptions/compiler-generated-exceptions.md
@@ -16,7 +16,7 @@ Some exceptions are thrown automatically by the .NET Framework's common language
 |<xref:System.DivideByZeroException>|Thrown when an attempt is made to divide an integral value by zero.|  
 |<xref:System.IndexOutOfRangeException>|Thrown when an attempt is made to index an array when the index is less than zero or outside the bounds of the array.|  
 |<xref:System.InvalidCastException>|Thrown when an explicit conversion from a base type to an interface or to a derived type fails at runtime.|  
-|<xref:System.NullReferenceException>|Thrown when you attempt to reference an object whose value is [null](../../language-reference/keywords/null.md).|  
+|<xref:System.NullReferenceException>|Thrown when an attempt is made to reference an object whose value is [null](../../language-reference/keywords/null.md).|  
 |<xref:System.OutOfMemoryException>|Thrown when an attempt to allocate memory using the [new](../../language-reference/operators/new-operator.md) operator fails. This indicates that the memory available to the common language runtime has been exhausted.|  
 |<xref:System.OverflowException>|Thrown when an arithmetic operation in a `checked` context overflows.|  
 |<xref:System.StackOverflowException>|Thrown when the execution stack is exhausted by having too many pending method calls; usually indicates a very deep or infinite recursion.|  


### PR DESCRIPTION
Reworded to keep the descriptions consistent across all exception descriptions.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
