### PR TITLE
Fix .NET Core CLI command

### DIFF
--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -25,7 +25,7 @@ Inside the solution directory, create a *MathService* directory. The directory a
     /MathService
 ```
 
-Make *MathService* the current directory and run [`dotnet new classlib -lang "F#"`](../tools/dotnet-new.md) to create the source project.  You'll create a failing implementation of the math service:
+Make *MathService* the current directory, and run `dotnet new classlib -lang "F#"` to create the source project. You'll create a failing implementation of the math service:
 
 ```fsharp
 module MyMath =

--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -25,7 +25,7 @@ Inside the solution directory, create a *MathService* directory. The directory a
     /MathService
 ```
 
-Make *MathService* the current directory and run [`dotnet new classlib -lang F#`](../tools/dotnet-new.md) to create the source project.  You'll create a failing implementation of the math service:
+Make *MathService* the current directory and run [`dotnet new classlib -lang "F#"`](../tools/dotnet-new.md) to create the source project.  You'll create a failing implementation of the math service:
 
 ```fsharp
 module MyMath =
@@ -48,7 +48,7 @@ Next, create the *MathService.Tests* directory. The following outline shows the 
     /MathService.Tests
 ```
 
-Make the *MathService.Tests* directory the current directory and create a new project using [`dotnet new xunit -lang F#`](../tools/dotnet-new.md). This creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *MathServiceTests.fsproj*:
+Make the *MathService.Tests* directory the current directory and create a new project using [`dotnet new xunit -lang "F#"`](../tools/dotnet-new.md). This creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *MathServiceTests.fsproj*:
 
 ```xml
 <ItemGroup>

--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -15,7 +15,7 @@ This tutorial takes you through an interactive experience building a sample solu
 ## Creating the source project
 
 Open a shell window. Create a directory called *unit-testing-with-fsharp* to hold the solution.
-Inside this new directory, run [`dotnet new sln`](../tools/dotnet-new.md) to create a new solution. This
+Inside this new directory, run `dotnet new sln` to create a new solution. This
 makes it easier to manage both the class library and the unit test project.
 Inside the solution directory, create a *MathService* directory. The directory and file structure thus far is shown below:
 
@@ -32,8 +32,7 @@ module MyMath =
     let squaresOfOdds xs = raise (System.NotImplementedException("You haven't written a test yet!"))
 ```
 
-Change the directory back to the *unit-testing-with-fsharp* directory. Run [`dotnet sln add .\MathService\MathService.fsproj`](../tools/dotnet-sln.md)
-to add the class library project to the solution.
+Change the directory back to the *unit-testing-with-fsharp* directory. Run `dotnet sln add .\MathService\MathService.fsproj` to add the class library project to the solution.
 
 ## Creating the test project
 
@@ -48,7 +47,7 @@ Next, create the *MathService.Tests* directory. The following outline shows the 
     /MathService.Tests
 ```
 
-Make the *MathService.Tests* directory the current directory and create a new project using [`dotnet new xunit -lang "F#"`](../tools/dotnet-new.md). This creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *MathServiceTests.fsproj*:
+Make the *MathService.Tests* directory the current directory and create a new project using `dotnet new xunit -lang "F#"`. This creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *MathServiceTests.fsproj*:
 
 ```xml
 <ItemGroup>
@@ -58,7 +57,7 @@ Make the *MathService.Tests* directory the current directory and create a new pr
 </ItemGroup>
 ```
 
-The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added xUnit and the xUnit runner. Now, add the `MathService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
+The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added xUnit and the xUnit runner. Now, add the `MathService` class library as another dependency to the project. Use the `dotnet add reference` command:
 
 ```dotnetcli
 dotnet add reference ../MathService/MathService.fsproj
@@ -79,7 +78,7 @@ You have the following final solution layout:
         MathServiceTests.fsproj
 ```
 
-Execute [`dotnet sln add .\MathService.Tests\MathService.Tests.fsproj`](../tools/dotnet-sln.md) in the *unit-testing-with-fsharp* directory. 
+Execute `dotnet sln add .\MathService.Tests\MathService.Tests.fsproj` in the *unit-testing-with-fsharp* directory. 
 
 ## Creating the first test
 
@@ -94,7 +93,7 @@ let ``My test`` () =
 let ``Fail every time`` () = Assert.True(false)
 ```
 
-The `[<Fact>]` attribute denotes a test method that is run by the test runner. From the *unit-testing-with-fsharp*, execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The xUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
+The `[<Fact>]` attribute denotes a test method that is run by the test runner. From the *unit-testing-with-fsharp*, execute `dotnet test` to build the tests and the class library and then run the tests. The xUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
 
 These two tests show the most basic passing and failing tests. `My test` passes, and `Fail every time` fails. Now, create a test for the `squaresOfOdds` method. The `squaresOfOdds` method returns a sequence of the squares of all odd integer values that are part of the input sequence. Rather than trying to write all of those functions at once, you can iteratively create tests that validate the functionality. Making each test pass means creating the necessary functionality for the method.
 
@@ -162,3 +161,11 @@ let squaresOfOdds xs =
 ```
 
 You've built a small library and a set of unit tests for that library. You've structured the solution so that adding new packages and tests is part of the normal workflow. You've concentrated most of your time and effort on solving the goals of the application.
+
+## See also
+
+- [dotnet new](../tools/dotnet-new.md)
+- [dotnet sln](../tools/dotnet-new.md)
+- [dotnet add reference](../tools/dotnet-add-reference.md)
+- [dotnet test](../tools/dotnet-test.md)
+

--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -168,4 +168,3 @@ You've built a small library and a set of unit tests for that library. You've st
 - [dotnet sln](../tools/dotnet-new.md)
 - [dotnet add reference](../tools/dotnet-add-reference.md)
 - [dotnet test](../tools/dotnet-test.md)
-

--- a/docs/core/testing/unit-testing-fsharp-with-mstest.md
+++ b/docs/core/testing/unit-testing-fsharp-with-mstest.md
@@ -25,7 +25,7 @@ Inside the solution directory, create a *MathService* directory. The directory a
     /MathService
 ```
 
-Make *MathService* the current directory and run [`dotnet new classlib -lang F#`](../tools/dotnet-new.md) to create the source project.  You'll create a failing implementation of the math service:
+Make *MathService* the current directory and run [`dotnet new classlib -lang "F#"`](../tools/dotnet-new.md) to create the source project.  You'll create a failing implementation of the math service:
 
 ```fsharp
 module MyMath =
@@ -48,7 +48,7 @@ Next, create the *MathService.Tests* directory. The following outline shows the 
     /MathService.Tests
 ```
 
-Make the *MathService.Tests* directory the current directory and create a new project using [`dotnet new mstest -lang F#`](../tools/dotnet-new.md). This creates a test project that uses MSTest as the test framework. The generated template configures the test runner in the *MathServiceTests.fsproj*:
+Make the *MathService.Tests* directory the current directory and create a new project using [`dotnet new mstest -lang "F#"`](../tools/dotnet-new.md). This creates a test project that uses MSTest as the test framework. The generated template configures the test runner in the *MathServiceTests.fsproj*:
 
 ```xml
 <ItemGroup>

--- a/docs/core/testing/unit-testing-fsharp-with-mstest.md
+++ b/docs/core/testing/unit-testing-fsharp-with-mstest.md
@@ -15,7 +15,7 @@ This tutorial takes you through an interactive experience building a sample solu
 ## Creating the source project
 
 Open a shell window. Create a directory called *unit-testing-with-fsharp* to hold the solution.
-Inside this new directory, run [`dotnet new sln`](../tools/dotnet-new.md) to create a new solution. This
+Inside this new directory, run `dotnet new sln` to create a new solution. This
 makes it easier to manage both the class library and the unit test project.
 Inside the solution directory, create a *MathService* directory. The directory and file structure thus far is shown below:
 
@@ -25,15 +25,14 @@ Inside the solution directory, create a *MathService* directory. The directory a
     /MathService
 ```
 
-Make *MathService* the current directory and run [`dotnet new classlib -lang "F#"`](../tools/dotnet-new.md) to create the source project.  You'll create a failing implementation of the math service:
+Make *MathService* the current directory and run `dotnet new classlib -lang "F#"` to create the source project.  You'll create a failing implementation of the math service:
 
 ```fsharp
 module MyMath =
     let squaresOfOdds xs = raise (System.NotImplementedException("You haven't written a test yet!"))
 ```
 
-Change the directory back to the *unit-testing-with-fsharp* directory. Run [`dotnet sln add .\MathService\MathService.fsproj`](../tools/dotnet-sln.md)
-to add the class library project to the solution.
+Change the directory back to the *unit-testing-with-fsharp* directory. Run `dotnet sln add .\MathService\MathService.fsproj` to add the class library project to the solution.
 
 ## Creating the test project
 
@@ -48,7 +47,7 @@ Next, create the *MathService.Tests* directory. The following outline shows the 
     /MathService.Tests
 ```
 
-Make the *MathService.Tests* directory the current directory and create a new project using [`dotnet new mstest -lang "F#"`](../tools/dotnet-new.md). This creates a test project that uses MSTest as the test framework. The generated template configures the test runner in the *MathServiceTests.fsproj*:
+Make the *MathService.Tests* directory the current directory and create a new project using `dotnet new mstest -lang "F#"`. This creates a test project that uses MSTest as the test framework. The generated template configures the test runner in the *MathServiceTests.fsproj*:
 
 ```xml
 <ItemGroup>
@@ -58,7 +57,7 @@ Make the *MathService.Tests* directory the current directory and create a new pr
 </ItemGroup>
 ```
 
-The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added MSTest and the MSTest runner. Now, add the `MathService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
+The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added MSTest and the MSTest runner. Now, add the `MathService` class library as another dependency to the project. Use the `dotnet add reference` command:
 
 ```dotnetcli
 dotnet add reference ../MathService/MathService.fsproj
@@ -79,7 +78,7 @@ You have the following final solution layout:
         MathServiceTests.fsproj
 ```
 
-Execute [`dotnet sln add .\MathService.Tests\MathService.Tests.fsproj`](../tools/dotnet-sln.md) in the *unit-testing-with-fsharp* directory.
+Execute `dotnet sln add .\MathService.Tests\MathService.Tests.fsproj` in the *unit-testing-with-fsharp* directory.
 
 ## Creating the first test
 
@@ -103,7 +102,7 @@ type TestClass () =
      member this.FailEveryTime() = Assert.IsTrue(false)
 ```
 
-The `[<TestClass>]` attribute denotes a class that contains tests. The `[<TestMethod>]` attribute denotes a test method that is run by the test runner. From the *unit-testing-with-fsharp* directory, execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The MSTest test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
+The `[<TestClass>]` attribute denotes a class that contains tests. The `[<TestMethod>]` attribute denotes a test method that is run by the test runner. From the *unit-testing-with-fsharp* directory, execute `dotnet test` to build the tests and the class library and then run the tests. The MSTest test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
 
 These two tests show the most basic passing and failing tests. `My test` passes, and `Fail every time` fails. Now, create a test for the `squaresOfOdds` method. The `squaresOfOdds` method returns a list of the squares of all odd integer values that are part of the input sequence. Rather than trying to write all of those functions at once, you can iteratively create tests that validate the functionality. Making each test pass means creating the necessary functionality for the method.
 
@@ -176,3 +175,10 @@ let squaresOfOdds xs =
 ```
 
 You've built a small library and a set of unit tests for that library. You've structured the solution so that adding new packages and tests is part of the normal workflow. You've concentrated most of your time and effort on solving the goals of the application.
+
+## See also
+
+- [dotnet new](../tools/dotnet-new.md)
+- [dotnet sln](../tools/dotnet-sln.md)
+- [dotnet add reference](../tools/dotnet-add-reference.md)
+- [dotnet test](../tools/dotnet-test.md)

--- a/docs/core/testing/unit-testing-fsharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-fsharp-with-nunit.md
@@ -83,7 +83,7 @@ This creates a test project that uses NUnit as the test framework. The generated
 </ItemGroup>
 ```
 
-The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added NUnit and the NUnit test adapter. Now, add the `MathService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
+The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added NUnit and the NUnit test adapter. Now, add the `MathService` class library as another dependency to the project. Use the `dotnet add reference` command:
 
 ```dotnetcli
 dotnet add reference ../MathService/MathService.fsproj
@@ -132,7 +132,7 @@ type TestClass () =
      member this.FailEveryTime() = Assert.True(false)
 ```
 
-The `[<TestFixture>]` attribute denotes a class that contains tests. The `[<Test>]` attribute denotes a test method that is run by the test runner. From the *unit-testing-with-fsharp* directory, execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The NUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
+The `[<TestFixture>]` attribute denotes a class that contains tests. The `[<Test>]` attribute denotes a test method that is run by the test runner. From the *unit-testing-with-fsharp* directory, execute `dotnet test` to build the tests and the class library and then run the tests. The NUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
 
 These two tests show the most basic passing and failing tests. `My test` passes, and `Fail every time` fails. Now, create a test for the `squaresOfOdds` method. The `squaresOfOdds` method returns a sequence of the squares of all odd integer values that are part of the input sequence. Rather than trying to write all of those functions at once, you can iteratively create tests that validate the functionality. Making each test pass means creating the necessary functionality for the method.
 
@@ -204,3 +204,8 @@ let squaresOfOdds xs =
 ```
 
 You've built a small library and a set of unit tests for that library. You've structured the solution so that adding new packages and tests is part of the normal workflow. You've concentrated most of your time and effort on solving the goals of the application.
+
+## See also
+
+- [dotnet add reference](../tools/dotnet-add-reference.md)
+- [dotnet test](../tools/dotnet-test.md)

--- a/docs/core/testing/unit-testing-fsharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-fsharp-with-nunit.md
@@ -38,7 +38,7 @@ Next, create a *MathService* directory. The following outline shows the director
 Make *MathService* the current directory and run the following command to create the source project:
 
 ```dotnetcli
-dotnet new classlib -lang F#
+dotnet new classlib -lang "F#"
 ```
 
 You create a failing implementation of the math service:
@@ -70,7 +70,7 @@ Next, create the *MathService.Tests* directory. The following outline shows the 
 Make the *MathService.Tests* directory the current directory and create a new project using the following command:
 
 ```dotnetcli
-dotnet new nunit -lang F#
+dotnet new nunit -lang "F#"
 ```
 
 This creates a test project that uses NUnit as the test framework. The generated template configures the test runner in the *MathServiceTests.fsproj*:

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -302,7 +302,7 @@ mkdir AwesomeLibrary.Core && cd AwesomeLibrary.Core && dotnet new classlib
 cd ..
 mkdir AwesomeLibrary.CSharp && cd AwesomeLibrary.CSharp && dotnet new classlib
 cd ..
-mkdir AwesomeLibrary.FSharp && cd AwesomeLibrary.FSharp && dotnet new classlib -lang F#
+mkdir AwesomeLibrary.FSharp && cd AwesomeLibrary.FSharp && dotnet new classlib -lang "F#"
 cd ..
 dotnet sln add AwesomeLibrary.Core/AwesomeLibrary.Core.csproj
 dotnet sln add AwesomeLibrary.CSharp/AwesomeLibrary.CSharp.csproj

--- a/docs/fsharp/get-started/get-started-command-line.md
+++ b/docs/fsharp/get-started/get-started-command-line.md
@@ -35,7 +35,7 @@ Change directories to *FSNetCore*.
 Use the `dotnet new` command, create a class library project in the **src** folder named Library.
 
 ```dotnetcli
-dotnet new classlib -lang F# -o src/Library
+dotnet new classlib -lang "F#" -o src/Library
 ```
 
 The following directory structure is produced after running the previous command:
@@ -79,7 +79,7 @@ Run `dotnet build` to build the project. Unresolved dependencies will be restore
 Use the `dotnet new` command, create a console application in the **src** folder named App.
 
 ```dotnetcli
-dotnet new console -lang F# -o src/App
+dotnet new console -lang "F#" -o src/App
 ```
 
 The following directory structure is produced after running the previous command:

--- a/docs/fsharp/get-started/get-started-vscode.md
+++ b/docs/fsharp/get-started/get-started-vscode.md
@@ -14,7 +14,7 @@ To begin, ensure that you have [F# and the Ionide plugin correctly installed](in
 To create a new F# project, open a command line and create a new project with the .NET Core CLI:
 
 ```dotnetcli
-dotnet new console -lang F# -o FirstIonideProject
+dotnet new console -lang "F#" -o FirstIonideProject
 ```
 
 Once it completes, change directory to the project and open Visual Studio Code:

--- a/docs/fsharp/get-started/get-started-vscode.md
+++ b/docs/fsharp/get-started/get-started-vscode.md
@@ -145,7 +145,7 @@ let main argv =
 
 Now you can run your console app from the command line:
 
-```console
+```dotnetcli
 dotnet run apple banana
 ```
 


### PR DESCRIPTION
From the [dotnet new documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new). It says:

> Some shells interpret # as a special character. In those cases, you need to enclose the language parameter value, such as `dotnet new console -lang "F#"`.

Also, may you check in the staging site if the highlighting is fixed by this ?

Currently, the rest of the line is highlighted as a comment.

![image](https://user-images.githubusercontent.com/31348972/71554985-bd3d6100-2a2e-11ea-9c60-f887e50ddd8f.png)

~~**Adding WIP until I check if there are other occurrences.**~~
(Fixed all occurrences. Except for one example in the `dotnet new` article to not cause conflicts for @mairaw draft PR. @mairaw, If you'd like, I can make a PR for that in the branch you're working on in your fork)
