### PR TITLE
Create deploy-worker-udf-binaries.md

### DIFF
--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -19,8 +19,8 @@ When deploying workers and writing UDFs, there are a few commonly used environme
 
 <table>
   <tr>
-    <td width="25%"><b>Environment Variable</b></td>
-    <td width="75%"><b>Description</b></td>
+  <td width="25%"><b>Environment Variable</b></td>
+  <td width="75%"><b>Description</b></td>
   </tr>
   <tr>
     <td><b>DOTNET_WORKER_DIR</b></td>

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -110,7 +110,7 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
 #### 4. Question: How to run my spark application with UDFs on YARN? Which environment variables and parameters should I use?
 
 **Answer:** To launch the spark application on YARN, the environment variables should be specified as `spark.yarn.appMasterEnv.[EnvironmentVariableName]`. Please see below as an example using `spark-submit`:
-```console
+```shell
 spark-submit \
 --class org.apache.spark.deploy.dotnet.DotnetRunner \
 --master yarn \

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -16,81 +16,25 @@ Configurations show the general environment variables and parameters settings in
 ### Environment variables
 When deploying workers and writing UDFs, there are a few commonly used environment variables that you may need to set: 
 
-<table>
-  <tr>
-    <td width="25%">
-      <b>Environment Variable</b>
-    </td>
-    <td width="75%">
-      <b>Description</b>
-    </td>
-  </tr>
-  <tr>
-    <td><b>DOTNET_WORKER_DIR</b></td>
-    <td>Path where the <code>Microsoft.Spark.Worker</code> binary has been generated.</br>It's used by the Spark driver and will be passed to Spark executors. If this variable is not set up, the Spark executors will search the path specified in the <code>PATH</code> environment variable.</br><i>e.g. "C:\bin\Microsoft.Spark.Worker"</i></td>
-  </tr>
-  <tr>
-    <td><b>DOTNET_ASSEMBLY_SEARCH_PATHS</b></td>
-    <td>Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in <b>yarn mode</b>, "." would represent the container's working directory.</br><i>e.g. "C:\Users\&lt;user name&gt;\&lt;mysparkapp&gt;\bin\Debug\&lt;dotnet version&gt;"</i></td>
-  </tr>
-  <tr>
-    <td><b>DOTNET_WORKER_DEBUG</b></td>
-    <td>If you want to <a href="https://github.com/dotnet/spark/blob/master/docs/developer-guide.md#debugging-user-defined-function-udf">debug a UDF</a>, then set this environment variable to <code>1</code> before running <code>spark-submit</code>.</td>
-  </tr>
-</table>
+| Environment Variable         | Description
+| :--------------------------- | :---------- 
+| DOTNET_WORKER_DIR            | Path where the <code>Microsoft.Spark.Worker</code> binary has been generated.</br>It's used by the Spark driver and will be passed to Spark executors. If this variable is not set up, the Spark executors will search the path specified in the <code>PATH</code> environment variable.</br><i>e.g. "C:\bin\Microsoft.Spark.Worker"</i>
+| DOTNET_ASSEMBLY_SEARCH_PATHS | Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in <b>yarn mode</b>, "." would represent the container's working directory.</br><i>e.g. "C:\Users\&lt;user name&gt;\&lt;mysparkapp&gt;\bin\Debug\&lt;dotnet version&gt;"</i>
+| DOTNET_WORKER_DEBUG          | If you want to <a href="https://github.com/dotnet/spark/blob/master/docs/developer-guide.md#debugging-user-defined-function-udf">debug a UDF</a>, then set this environment variable to <code>1</code> before running <code>spark-submit</code>.
 
 ### Parameter options
 Once the Spark application is [bundled](https://spark.apache.org/docs/latest/submitting-applications.html#bundling-your-applications-dependencies), you can launch it using `spark-submit`. The following table shows some of the commonly used options: 
 
-<table>
-  <tr>
-    <td width="25%"><b>Parameter Name</b></td>
-    <td width="75%"><b>Description</b></td>
-  </tr>
-  <tr>
-    <td><b>--class</b></td>
-      <td>The entry point for your application.</br><i>e.g. org.apache.spark.deploy.dotnet.DotnetRunner</i></td>
-  </tr>
-  <tr>
-    <td><b>--master</b></td>
-    <td>The <a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">master URL</a> for the cluster.</br><i>e.g. yarn</i></td>
-  </tr>
-  <tr>
-    <td><b>--deploy-mode</b></td>
-    <td>Whether to deploy your driver on the worker nodes (<code>cluster</code>) or locally as an external client (<code>client</code>).</br>Default: <code>client</code></td>
-  </tr>
-  <tr>
-    <td><b>--conf</b></td>
-      <td>Arbitrary Spark configuration property in <code>key=value</code> format.</br><i>e.g. spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=.\worker\Microsoft.Spark.Worker</i></td>
-  </tr>
-  <tr>
-    <td><b>--files</b></td>
-    <td>Comma-separated list of files to be placed in the working directory of each executor.</br>
-      <ul>
-        <li>Please note that this option is only applicable for yarn mode.</li>
-        <li>It supports specifying file names with # similar to Hadoop.</br>
-      </ul>
-      <i>e.g. <code>myLocalSparkApp.dll#appSeen.dll</code>. Your application should use the name as <code>appSeen.dll</code> to reference <code>myLocalSparkApp.dll</code> when running on YARN.</i></li></td>
-  </tr>
-  <tr>
-    <td><b>--archives</b></td>
-    <td>Comma-separated list of archives to be extracted into the working directory of each executor.</br>
-      <ul>
-        <li>Please note that this option is only applicable for yarn mode.</li>
-        <li>It supports specifying file names with # similar to Hadoop.</br>
-      </ul>
-      <i>e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder.</i></li></td>
-  </tr>
-  <tr>
-    <td><b>application-jar</b></td>
-    <td>Path to a bundled jar including your application and all dependencies.</br>
-    <i>e.g. hdfs://&lt;path to your jar&gt;/microsoft-spark-&lt;version&gt;.jar</i></td>
-  </tr>
-  <tr>
-    <td><b>application-arguments</b></td>
-    <td>Arguments passed to the main method of your main class, if any.</br><i>e.g. hdfs://&lt;path to your app&gt;/&lt;your app&gt;.zip &lt;your app name&gt; &lt;app args&gt;</i></td>
-  </tr>
-</table>
+| Parameter Name        | Description
+| :---------------------| :---------- 
+| --class               | The entry point for your application.</br><i>e.g. org.apache.spark.deploy.dotnet.DotnetRunner</i>
+| --master              | The <a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">master URL</a> for the cluster.</br><i>e.g. yarn</i>
+| --deploy-mode         | Whether to deploy your driver on the worker nodes (<code>cluster</code>) or locally as an external client (<code>client</code>).</br>Default: <code>client</code>
+| --conf                | Arbitrary Spark configuration property in <code>key=value</code> format.</br><i>e.g. spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=.\worker\Microsoft.Spark.Worker</i>
+| --files               | Comma-separated list of files to be placed in the working directory of each executor.<br/><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul><i>e.g. <code>myLocalSparkApp.dll#appSeen.dll</code>. Your application should use the name as <code>appSeen.dll</code> to reference <code>myLocalSparkApp.dll</code> when running on YARN.</i></li>
+| ----archives          | Comma-separated list of archives to be extracted into the working directory of each executor.</br><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul><i>e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder.</i></li>
+| application-jar       | Path to a bundled jar including your application and all dependencies.</br><i>e.g. hdfs://&lt;path to your jar&gt;/microsoft-spark-&lt;version&gt;.jar</i>
+| application-arguments | Arguments passed to the main method of your main class, if any.</br><i>e.g. hdfs://&lt;path to your app&gt;/&lt;your app&gt;.zip &lt;your app name&gt; &lt;app args&gt;</i>
 
 > [!NOTE]
 > Specify all the `--options` before `application-jar` when launching applications with `spark-submit`, otherwise they will be ignored. For more information, see [`spark-submit` options](https://spark.apache.org/docs/latest/submitting-applications.html) and [running spark on YARN details](https://spark.apache.org/docs/latest/running-on-yarn.html).

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -1,20 +1,19 @@
 ---
-title: Deploy Worker and UDF Binaries
-description: Learn how to deploy Worker and UDF (User-Defined Function) binaries.
+title: Deploy .NET for Apache Spark worker and user-defined function binaries
+description: Learn how to deploy .NET for Apache Spark worker and user-defined function binaries.
 ms.date: 12/30/2019
 ms.topic: conceptual
 ms.custom: mvc,how-to
 ---
 
-# Deploy Worker and UDF Binaries
+# Deploy .NET for Apache Spark worker and user-defined function binaries
 
-This how-to provides general instructions on how to deploy Worker and UDF (User-Defined Function) binaries, 
-including which Environment Variables to set up and some commonly used parameters 
-when launching applications with `spark-submit`.
+This how-to provides general instructions on how to deploy .NET for Apache Spark worker and user-defined function binaries, including which Environment Variables to set up and some commonly used parameters when launching applications with `spark-submit`.
 
 ## Configurations
+Configurations show the general environment variables and parameters settings in order to deploy .NET for Apache Spark worker and user-defined function binaries.
 
-### 1. Environment Variables
+### Environment variables
 When deploying workers and writing UDFs, there are a few commonly used environment variables that you may need to set: 
 
 <table>
@@ -40,7 +39,7 @@ When deploying workers and writing UDFs, there are a few commonly used environme
   </tr>
 </table>
 
-### 2. Parameter Options
+### Parameter options
 Once the Spark application is [bundled](https://spark.apache.org/docs/latest/submitting-applications.html#bundling-your-applications-dependencies), you can launch it using `spark-submit`. The following table shows some of the commonly used options: 
 
 <table>
@@ -93,29 +92,30 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
   </tr>
 </table>
 
-> Note: Please specify all the `--options` before `application-jar` when launching applications with `spark-submit`, otherwise they will be ignored. Please see more `spark-submit` options [here](https://spark.apache.org/docs/latest/submitting-applications.html) and running spark on YARN details [here](https://spark.apache.org/docs/latest/running-on-yarn.html).
+> [!NOTE]
+> Specify all the `--options` before `application-jar` when launching applications with `spark-submit`, otherwise they will be ignored. For more information, see [`spark-submit` options](https://spark.apache.org/docs/latest/submitting-applications.html) and [running spark on YARN details](https://spark.apache.org/docs/latest/running-on-yarn.html).
 
-## FAQ
-#### 1. Question: When I run a spark app with UDFs, I get the following error. What should I do?
+## Frequently asked questions
+### When I run a spark app with UDFs, I get a `FileNotFoundException' error. What should I do?
 > **Error:** [ ] [ ] [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.IO.FileNotFoundException: Assembly 'mySparkApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' file not found: 'mySparkApp.dll'
 
-**Answer:** Please check if the `DOTNET_ASSEMBLY_SEARCH_PATHS` environment variable is set correctly. It should be the path that contains your `mySparkApp.dll`.
+**Answer:** Check that the `DOTNET_ASSEMBLY_SEARCH_PATHS` environment variable is set correctly. It should be the path that contains your `mySparkApp.dll`.
 
-#### 2. Question: After I upgraded my Spark Dotnet version and reset the `DOTNET_WORKER_DIR` environment variable, why do I still get the following error?
+### After I upgraded my .NET for Apache Spark version and reset the `DOTNET_WORKER_DIR` environment variable, why do I still get the following `IOException` error?
 > **Error:** Lost task 0.0 in stage 11.0 (TID 24, localhost, executor driver): java.io.IOException: Cannot run program "Microsoft.Spark.Worker.exe": CreateProcess error=2, The system cannot find the file specified.
 
-**Answer:** Please try restarting your PowerShell window (or other command windows) first so that it can take the latest environment variable values. Then start your program.
+**Answer:** Try restarting your PowerShell window (or other command windows) first so that it can take the latest environment variable values. Then start your program.
 
-#### 3. Question: After submitting my Spark application, I get the error `System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context'`.
+### After submitting my Spark application, I get the error `System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context'`.
 > **Error:** [ ] [ ] [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=...'.
 
-**Answer:** Please check the `Microsoft.Spark.Worker` version you are using. We currently provide two versions: **.NET Framework 4.6.1** and **.NET Core 2.1.x**. In this case, `Microsoft.Spark.Worker.net461.win-x64-<version>` (which you can download [here](https://github.com/dotnet/spark/releases)) should be used since `System.Runtime.Remoting.Contexts.Context` is only for .NET Framework.
+**Answer:** Check the `Microsoft.Spark.Worker` version you are using. There are two versions: **.NET Framework 4.6.1** and **.NET Core 2.1.x**. In this case, `Microsoft.Spark.Worker.net461.win-x64-<version>` (which you can [download](https://github.com/dotnet/spark/releases)) should be used since `System.Runtime.Remoting.Contexts.Context` is only for .NET Framework.
 
-#### 4. Question: How to run my spark application with UDFs on YARN? Which environment variables and parameters should I use?
+### How do I run my spark application with UDFs on YARN? Which environment variables and parameters should I use?
 
 **Answer:** To launch the spark application on YARN, the environment variables should be specified as `spark.yarn.appMasterEnv.[EnvironmentVariableName]`. Please see below as an example using `spark-submit`:
 
-```shell
+```powershell
 spark-submit \
 --class org.apache.spark.deploy.dotnet.DotnetRunner \
 --master yarn \

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -1,14 +1,14 @@
 ---
 title: Deploy .NET for Apache Spark worker and user-defined function binaries
 description: Learn how to deploy .NET for Apache Spark worker and user-defined function binaries.
-ms.date: 12/30/2019
+ms.date: 01/21/2019
 ms.topic: conceptual
 ms.custom: mvc,how-to
 ---
 
 # Deploy .NET for Apache Spark worker and user-defined function binaries
 
-This how-to provides general instructions on how to deploy .NET for Apache Spark worker and user-defined function binaries, including which Environment Variables to set up and some commonly used parameters when launching applications with `spark-submit`.
+This how-to provides general instructions on how to deploy .NET for Apache Spark worker and user-defined function binaries. You learn which Environment Variables to set up, as well as some commonly used parameters for launching applications with `spark-submit`.
 
 ## Configurations
 Configurations show the general environment variables and parameters settings in order to deploy .NET for Apache Spark worker and user-defined function binaries.
@@ -19,7 +19,7 @@ When deploying workers and writing UDFs, there are a few commonly used environme
 | Environment Variable         | Description
 | :--------------------------- | :---------- 
 | DOTNET_WORKER_DIR            | Path where the <code>Microsoft.Spark.Worker</code> binary has been generated.</br>It's used by the Spark driver and will be passed to Spark executors. If this variable is not set up, the Spark executors will search the path specified in the <code>PATH</code> environment variable.</br>_e.g. "C:\bin\Microsoft.Spark.Worker"_
-| DOTNET_ASSEMBLY_SEARCH_PATHS | Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in **yarn mode**, "." would represent the container's working directory.</br>_e.g. "C:\Users\&lt;user name&gt;\&lt;mysparkapp&gt;\bin\Debug\&lt;dotnet version&gt;"_
+| DOTNET_ASSEMBLY_SEARCH_PATHS | Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in **yarn mode**, "." would represent the container's working directory.</br>_e.g. "C:\Users\\&lt;user name&gt;\\&lt;mysparkapp&gt;\bin\Debug\\&lt;dotnet version&gt;"_
 | DOTNET_WORKER_DEBUG          | If you want to <a href="https://github.com/dotnet/spark/blob/master/docs/developer-guide.md#debugging-user-defined-function-udf">debug a UDF</a>, then set this environment variable to <code>1</code> before running <code>spark-submit</code>.
 
 ### Parameter options
@@ -27,12 +27,12 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
 
 | Parameter Name        | Description
 | :---------------------| :---------- 
-| --class               | The entry point for your application.</br>_>e.g. org.apache.spark.deploy.dotnet.DotnetRunner_
+| --class               | The entry point for your application.</br>_e.g. org.apache.spark.deploy.dotnet.DotnetRunner_
 | --master              | The <a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">master URL</a> for the cluster.</br>_e.g. yarn_
 | --deploy-mode         | Whether to deploy your driver on the worker nodes (<code>cluster</code>) or locally as an external client (<code>client</code>).</br>Default: <code>client</code>
 | --conf                | Arbitrary Spark configuration property in <code>key=value</code> format.</br>_e.g. spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=.\worker\Microsoft.Spark.Worker_
 | --files               | Comma-separated list of files to be placed in the working directory of each executor.<br/><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul>_e.g. <code>myLocalSparkApp.dll#appSeen.dll</code>. Your application should use the name as <code>appSeen.dll</code> to reference <code>myLocalSparkApp.dll</code> when running on YARN._</li>
-| ----archives          | Comma-separated list of archives to be extracted into the working directory of each executor.</br><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul>_e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder._</li>
+| --archives          | Comma-separated list of archives to be extracted into the working directory of each executor.</br><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul>_e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder._</li>
 | application-jar       | Path to a bundled jar including your application and all dependencies.</br>_e.g. hdfs://&lt;path to your jar&gt;/microsoft-spark-&lt;version&gt;.jar_
 | application-arguments | Arguments passed to the main method of your main class, if any.</br>_e.g. hdfs://&lt;path to your app&gt;/&lt;your app&gt;.zip &lt;your app name&gt; &lt;app args&gt;_
 
@@ -41,7 +41,7 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
 
 ## Frequently asked questions
 ### When I run a spark app with UDFs, I get a `FileNotFoundException' error. What should I do?
-> **Error:** [ ] [ ] [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.IO.FileNotFoundException: Assembly 'mySparkApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' file not found: 'mySparkApp.dll'
+> **Error:** [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.IO.FileNotFoundException: Assembly 'mySparkApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' file not found: 'mySparkApp.dll'
 
 **Answer:** Check that the `DOTNET_ASSEMBLY_SEARCH_PATHS` environment variable is set correctly. It should be the path that contains your `mySparkApp.dll`.
 
@@ -51,7 +51,7 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
 **Answer:** Try restarting your PowerShell window (or other command windows) first so that it can take the latest environment variable values. Then start your program.
 
 ### After submitting my Spark application, I get the error `System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context'`.
-> **Error:** [ ] [ ] [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=...'.
+> **Error:** [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=...'.
 
 **Answer:** Check the `Microsoft.Spark.Worker` version you are using. There are two versions: **.NET Framework 4.6.1** and **.NET Core 2.1.x**. In this case, `Microsoft.Spark.Worker.net461.win-x64-<version>` (which you can [download](https://github.com/dotnet/spark/releases)) should be used since `System.Runtime.Remoting.Contexts.Context` is only for .NET Framework.
 

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -18,8 +18,8 @@ When deploying workers and writing UDFs, there are a few commonly used environme
 
 | Environment Variable         | Description
 | :--------------------------- | :---------- 
-| DOTNET_WORKER_DIR            | Path where the <code>Microsoft.Spark.Worker</code> binary has been generated.</br>It's used by the Spark driver and will be passed to Spark executors. If this variable is not set up, the Spark executors will search the path specified in the <code>PATH</code> environment variable.</br><i>e.g. "C:\bin\Microsoft.Spark.Worker"</i>
-| DOTNET_ASSEMBLY_SEARCH_PATHS | Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in <b>yarn mode</b>, "." would represent the container's working directory.</br><i>e.g. "C:\Users\&lt;user name&gt;\&lt;mysparkapp&gt;\bin\Debug\&lt;dotnet version&gt;"</i>
+| DOTNET_WORKER_DIR            | Path where the <code>Microsoft.Spark.Worker</code> binary has been generated.</br>It's used by the Spark driver and will be passed to Spark executors. If this variable is not set up, the Spark executors will search the path specified in the <code>PATH</code> environment variable.</br>_e.g. "C:\bin\Microsoft.Spark.Worker"_
+| DOTNET_ASSEMBLY_SEARCH_PATHS | Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in **yarn mode**, "." would represent the container's working directory.</br>_e.g. "C:\Users\&lt;user name&gt;\&lt;mysparkapp&gt;\bin\Debug\&lt;dotnet version&gt;"_
 | DOTNET_WORKER_DEBUG          | If you want to <a href="https://github.com/dotnet/spark/blob/master/docs/developer-guide.md#debugging-user-defined-function-udf">debug a UDF</a>, then set this environment variable to <code>1</code> before running <code>spark-submit</code>.
 
 ### Parameter options
@@ -27,14 +27,14 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
 
 | Parameter Name        | Description
 | :---------------------| :---------- 
-| --class               | The entry point for your application.</br><i>e.g. org.apache.spark.deploy.dotnet.DotnetRunner</i>
-| --master              | The <a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">master URL</a> for the cluster.</br><i>e.g. yarn</i>
+| --class               | The entry point for your application.</br>_>e.g. org.apache.spark.deploy.dotnet.DotnetRunner_
+| --master              | The <a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">master URL</a> for the cluster.</br>_e.g. yarn_
 | --deploy-mode         | Whether to deploy your driver on the worker nodes (<code>cluster</code>) or locally as an external client (<code>client</code>).</br>Default: <code>client</code>
-| --conf                | Arbitrary Spark configuration property in <code>key=value</code> format.</br><i>e.g. spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=.\worker\Microsoft.Spark.Worker</i>
-| --files               | Comma-separated list of files to be placed in the working directory of each executor.<br/><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul><i>e.g. <code>myLocalSparkApp.dll#appSeen.dll</code>. Your application should use the name as <code>appSeen.dll</code> to reference <code>myLocalSparkApp.dll</code> when running on YARN.</i></li>
-| ----archives          | Comma-separated list of archives to be extracted into the working directory of each executor.</br><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul><i>e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder.</i></li>
-| application-jar       | Path to a bundled jar including your application and all dependencies.</br><i>e.g. hdfs://&lt;path to your jar&gt;/microsoft-spark-&lt;version&gt;.jar</i>
-| application-arguments | Arguments passed to the main method of your main class, if any.</br><i>e.g. hdfs://&lt;path to your app&gt;/&lt;your app&gt;.zip &lt;your app name&gt; &lt;app args&gt;</i>
+| --conf                | Arbitrary Spark configuration property in <code>key=value</code> format.</br>_e.g. spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=.\worker\Microsoft.Spark.Worker_
+| --files               | Comma-separated list of files to be placed in the working directory of each executor.<br/><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul>_e.g. <code>myLocalSparkApp.dll#appSeen.dll</code>. Your application should use the name as <code>appSeen.dll</code> to reference <code>myLocalSparkApp.dll</code> when running on YARN._</li>
+| ----archives          | Comma-separated list of archives to be extracted into the working directory of each executor.</br><ul><li>Please note that this option is only applicable for yarn mode.</li><li>It supports specifying file names with # similar to Hadoop.</br></ul>_e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder._</li>
+| application-jar       | Path to a bundled jar including your application and all dependencies.</br>_e.g. hdfs://&lt;path to your jar&gt;/microsoft-spark-&lt;version&gt;.jar_
+| application-arguments | Arguments passed to the main method of your main class, if any.</br>_e.g. hdfs://&lt;path to your app&gt;/&lt;your app&gt;.zip &lt;your app name&gt; &lt;app args&gt;_
 
 > [!NOTE]
 > Specify all the `--options` before `application-jar` when launching applications with `spark-submit`, otherwise they will be ignored. For more information, see [`spark-submit` options](https://spark.apache.org/docs/latest/submitting-applications.html) and [running spark on YARN details](https://spark.apache.org/docs/latest/running-on-yarn.html).

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -1,0 +1,128 @@
+---
+title: Deploy Worker and UDF Binaries
+description: Learn how to deploy Worker and UDF (User-Defined Function) binaries.
+ms.date: 12/30/2019
+ms.topic: conceptual
+ms.custom: mvc,how-to
+---
+
+# Deploy Worker and UDF Binaries
+
+This how-to provides general instructions on how to deploy Worker and UDF (User-Defined Function) binaries, 
+including which Environment Variables to set up and some commonly used parameters 
+when launching applications with `spark-submit`.
+
+## Configurations
+
+### 1. Environment Variables
+When deploying workers and writing UDFs, there are a few commonly used environment variables that you may need to set: 
+
+<table>
+  <tr>
+    <td width="25%"><b>Environment Variable</b></td>
+    <td width="75%"><b>Description</b></td>
+  </tr>
+  <tr>
+    <td><b>DOTNET_WORKER_DIR</b></td>
+    <td>Path where the <code>Microsoft.Spark.Worker</code> binary has been generated.</br>It's used by the Spark driver and will be passed to Spark executors. If this variable is not set up, the Spark executors will search the path specified in the <code>PATH</code> environment variable.</br><i>e.g. "C:\bin\Microsoft.Spark.Worker"</i></td>
+  </tr>
+  <tr>
+    <td><b>DOTNET_ASSEMBLY_SEARCH_PATHS</b></td>
+    <td>Comma-separated paths where <code>Microsoft.Spark.Worker</code> will load assemblies.</br>Note that if a path starts with ".", the working directory will be prepended. If in <b>yarn mode</b>, "." would represent the container's working directory.</br><i>e.g. "C:\Users\&lt;user name&gt;\&lt;mysparkapp&gt;\bin\Debug\&lt;dotnet version&gt;"</i></td>
+  </tr>
+  <tr>
+    <td><b>DOTNET_WORKER_DEBUG</b></td>
+    <td>If you want to <a href="https://github.com/dotnet/spark/blob/master/docs/developer-guide.md#debugging-user-defined-function-udf">debug a UDF</a>, then set this environment variable to <code>1</code> before running <code>spark-submit</code>.</td>
+  </tr>
+</table>
+
+### 2. Parameter Options
+Once the Spark application is [bundled](https://spark.apache.org/docs/latest/submitting-applications.html#bundling-your-applications-dependencies), you can launch it using `spark-submit`. The following table shows some of the commonly used options: 
+
+<table>
+  <tr>
+    <td width="25%"><b>Parameter Name</b></td>
+    <td width="75%"><b>Description</b></td>
+  </tr>
+  <tr>
+    <td><b>--class</b></td>
+      <td>The entry point for your application.</br><i>e.g. org.apache.spark.deploy.dotnet.DotnetRunner</i></td>
+  </tr>
+  <tr>
+    <td><b>--master</b></td>
+    <td>The <a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">master URL</a> for the cluster.</br><i>e.g. yarn</i></td>
+  </tr>
+  <tr>
+    <td><b>--deploy-mode</b></td>
+    <td>Whether to deploy your driver on the worker nodes (<code>cluster</code>) or locally as an external client (<code>client</code>).</br>Default: <code>client</code></td>
+  </tr>
+  <tr>
+    <td><b>--conf</b></td>
+      <td>Arbitrary Spark configuration property in <code>key=value</code> format.</br><i>e.g. spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=.\worker\Microsoft.Spark.Worker</i></td>
+  </tr>
+  <tr>
+    <td><b>--files</b></td>
+    <td>Comma-separated list of files to be placed in the working directory of each executor.</br>
+      <ul>
+        <li>Please note that this option is only applicable for yarn mode.</li>
+        <li>It supports specifying file names with # similar to Hadoop.</br>
+      </ul>
+      <i>e.g. <code>myLocalSparkApp.dll#appSeen.dll</code>. Your application should use the name as <code>appSeen.dll</code> to reference <code>myLocalSparkApp.dll</code> when running on YARN.</i></li></td>
+  </tr>
+  <tr>
+    <td><b>--archives</b></td>
+    <td>Comma-separated list of archives to be extracted into the working directory of each executor.</br>
+      <ul>
+        <li>Please note that this option is only applicable for yarn mode.</li>
+        <li>It supports specifying file names with # similar to Hadoop.</br>
+      </ul>
+      <i>e.g. <code>hdfs://&lt;path to your worker file&gt;/Microsoft.Spark.Worker.zip#worker</code>. This will copy and extract the zip file to <code>worker</code> folder.</i></li></td>
+  </tr>
+  <tr>
+    <td><b>application-jar</b></td>
+    <td>Path to a bundled jar including your application and all dependencies.</br>
+    <i>e.g. hdfs://&lt;path to your jar&gt;/microsoft-spark-&lt;version&gt;.jar</i></td>
+  </tr>
+  <tr>
+    <td><b>application-arguments</b></td>
+    <td>Arguments passed to the main method of your main class, if any.</br><i>e.g. hdfs://&lt;path to your app&gt;/&lt;your app&gt;.zip &lt;your app name&gt; &lt;app args&gt;</i></td>
+  </tr>
+</table>
+
+> Note: Please specify all the `--options` before `application-jar` when launching applications with `spark-submit`, otherwise they will be ignored. Please see more `spark-submit` options [here](https://spark.apache.org/docs/latest/submitting-applications.html) and running spark on YARN details [here](https://spark.apache.org/docs/latest/running-on-yarn.html).
+
+## FAQ
+#### 1. Question: When I run a spark app with UDFs, I get the following error. What should I do?
+> **Error:** [ ] [ ] [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.IO.FileNotFoundException: Assembly 'mySparkApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' file not found: 'mySparkApp.dll'
+
+**Answer:** Please check if the `DOTNET_ASSEMBLY_SEARCH_PATHS` environment variable is set correctly. It should be the path that contains your `mySparkApp.dll`.
+
+#### 2. Question: After I upgraded my Spark Dotnet version and reset the `DOTNET_WORKER_DIR` environment variable, why do I still get the following error?
+> **Error:** Lost task 0.0 in stage 11.0 (TID 24, localhost, executor driver): java.io.IOException: Cannot run program "Microsoft.Spark.Worker.exe": CreateProcess error=2, The system cannot find the file specified.
+
+**Answer:** Please try restarting your PowerShell window (or other command windows) first so that it can take the latest environment variable values. Then start your program.
+
+#### 3. Question: After submitting my Spark application, I get the error `System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context'`.
+> **Error:** [ ] [ ] [Error] [TaskRunner] [0] ProcessStream() failed with exception: System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Contexts.Context' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=...'.
+
+**Answer:** Please check the `Microsoft.Spark.Worker` version you are using. We currently provide two versions: **.NET Framework 4.6.1** and **.NET Core 2.1.x**. In this case, `Microsoft.Spark.Worker.net461.win-x64-<version>` (which you can download [here](https://github.com/dotnet/spark/releases)) should be used since `System.Runtime.Remoting.Contexts.Context` is only for .NET Framework.
+
+#### 4. Question: How to run my spark application with UDFs on YARN? Which environment variables and parameters should I use?
+
+**Answer:** To launch the spark application on YARN, the environment variables should be specified as `spark.yarn.appMasterEnv.[EnvironmentVariableName]`. Please see below as an example using `spark-submit`:
+```console
+spark-submit \
+--class org.apache.spark.deploy.dotnet.DotnetRunner \
+--master yarn \
+--deploy-mode cluster \
+--conf spark.yarn.appMasterEnv.DOTNET_WORKER_DIR=./worker/Microsoft.Spark.Worker-<version> \
+--conf spark.yarn.appMasterEnv.DOTNET_ASSEMBLY_SEARCH_PATHS=./udfs \
+--archives hdfs://<path to your files>/Microsoft.Spark.Worker.net461.win-x64-<version>.zip#worker,hdfs://<path to your files>/mySparkApp.zip#udfs \
+hdfs://<path to jar file>/microsoft-spark-2.4.x-<version>.jar \
+hdfs://<path to your files>/mySparkApp.zip mySparkApp
+```
+
+## Next steps
+
+* [Get started with .NET for Apache Spark](../tutorials/get-started.md)
+* [Debug a .NET for Apache Spark application on Windows](../how-to-guides/debug.md)

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -110,6 +110,7 @@ Once the Spark application is [bundled](https://spark.apache.org/docs/latest/sub
 #### 4. Question: How to run my spark application with UDFs on YARN? Which environment variables and parameters should I use?
 
 **Answer:** To launch the spark application on YARN, the environment variables should be specified as `spark.yarn.appMasterEnv.[EnvironmentVariableName]`. Please see below as an example using `spark-submit`:
+
 ```shell
 spark-submit \
 --class org.apache.spark.deploy.dotnet.DotnetRunner \

--- a/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
+++ b/docs/spark/how-to-guides/deploy-worker-udf-binaries.md
@@ -19,8 +19,12 @@ When deploying workers and writing UDFs, there are a few commonly used environme
 
 <table>
   <tr>
-  <td width="25%"><b>Environment Variable</b></td>
-  <td width="75%"><b>Description</b></td>
+    <td width="25%">
+      <b>Environment Variable</b>
+    </td>
+    <td width="75%">
+      <b>Description</b>
+    </td>
   </tr>
   <tr>
     <td><b>DOTNET_WORKER_DIR</b></td>

--- a/docs/spark/toc.yml
+++ b/docs/spark/toc.yml
@@ -29,6 +29,8 @@
     href: how-to-guides/hdinsight-deploy-methods.md
   - name: Submit jobs to Databricks
     href: how-to-guides/databricks-deploy-methods.md
+  - name: Deploy worker and UDF binaries
+    href: how-to-guides/deploy-worker-udf-binaries.md
 - name: Reference
   items:
   - name: API Reference


### PR DESCRIPTION
## Summary

This PR provides general instructions on how to deploy Worker and UDF (User-Defined Function) binaries.

Move contents from [Spark Dotnet](https://github.com/dotnet/spark/tree/master/docs) to docs.