### PR TITLE
Create get-started-macos-instructions.md

### DIFF
--- a/docs/spark/toc.yml
+++ b/docs/spark/toc.yml
@@ -11,6 +11,8 @@
   items:
   - name: Get started
     href: tutorials/get-started.md
+  - name: Get started with .NET for Apache Spark on macOS
+    href: tutorials/get-started-macos-instructions.md
   - name: Deploy to Azure HDInsight
     href: tutorials/hdinsight-deployment.md
   - name: Deploy to AWS EMR Spark

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with .NET for Apache Spark on macOS
-description: Discover how to run a .NET for Apache Spark app using .NET Core on MacOSX.
+description: Discover how to run a .NET for Apache Spark app using .NET Core on macOS.
 ms.date: 01/22/2019
 ms.topic: tutorial
 ms.custom: mvc

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -1,0 +1,127 @@
+---
+title: Get Started with .NET for Apache Spark on MacOSX
+description: Discover how to run a .NET for Apache Spark app using .NET Core on MacOSX.
+ms.date: 12/30/2019
+ms.topic: tutorial
+ms.custom: mvc
+# Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark on MacOSX.
+---
+
+# Tutorial: Get Started with .NET for Apache Spark on MacOS
+
+This tutorial will show you how to run a .NET for Apache Spark app using .NET Core on MacOSX.
+
+> [!div class="checklist"]
+>
+> * Pre-requisites to run your .NET for Apache Spark application
+> * Write a simple .NET for Apache Spark application
+> * Build and run your .NET for Apache Spark application
+
+## Pre-requisites
+
+- Download and install **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** 
+- Install **[Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** 
+  - Select the appropriate version for your operating system e.g., `jdk-8u231-macosx-x64.dmg`.
+  - Install using the installer and verify you are able to run `java` from your command-line
+- Download and install **[Apache Spark 2.4.4](https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz)**:
+  - Add the necessary environment variables SPARK_HOME e.g., `~/bin/spark-2.4.4-bin-hadoop2.7/`
+  
+    ```bash
+    export SPARK_HOME=~/bin/spark-2.4.4-bin-hadoop2.7/
+    export PATH="$SPARK_HOME/bin:$PATH"
+    source ~/.bashrc
+    ```
+    
+- Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
+  - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (e.g., `/bin/Microsoft.Spark.Worker/`).
+    - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `/bin/Microsoft.Spark.Worker/`).
+
+
+## Authoring a .NET for Apache Spark App
+
+- Use the `dotnet` CLI to create a console application.
+
+    ```
+    dotnet new console -o HelloSpark
+    ```
+    
+- Install `Microsoft.Spark` Nuget package into the project from the [spark nuget.org feed](https://www.nuget.org/profiles/spark) - see [Ways to install Nuget Package](https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package)
+    
+    ```
+    cd HelloSpark
+    dotnet add package Microsoft.Spark
+    ```
+    
+- Replace the contents of the `Program.cs` file with the following code:
+    
+    ```csharp
+    using Microsoft.Spark.Sql;
+
+    namespace HelloSpark
+    {
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                var spark = SparkSession.Builder().GetOrCreate();
+                var df = spark.Read().Json("people.json");
+                df.Show();
+            }
+        }
+    }
+    ```
+    
+- Use the `dotnet` CLI to build the application:
+    
+    ```bash
+    dotnet build
+    ```
+
+## Running your .NET for Apache Spark App
+
+- Open your terminal and navigate into your app folder:
+    
+    ```bash
+    cd <your-app-output-directory>
+    ```
+    
+- Create `people.json` with the following content:
+    
+    ```json
+    { "name" : "Michael" }
+    { "name" : "Andy", "age" : 30 }
+    { "name" : "Justin", "age" : 19 }
+    ```
+    
+- Run your app
+    
+    ```bash
+    spark-submit \
+    --class org.apache.spark.deploy.dotnet.DotnetRunner \
+    --master local \
+    microsoft-spark-2.4.x-<version>.jar \
+    dotnet HelloSpark.dll 
+    ```
+    
+    **Note**: This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `~/spark/bin/spark-submit`).
+    
+- The output of the application should look similar to the output below:
+    
+    ```text
+    +----+-------+
+    | age|   name|
+    +----+-------+
+    |null|Michael|
+    |  30|   Andy|
+    |  19| Justin|
+    +----+-------+
+    ```
+   
+## Next steps
+
+In this tutorial, you learn how to run your .NET for Apache Spark on MacOSX. Continue to learn more about how to run your .NET for Apache Spark on Windows and Ubuntu.
+> [!div class="nextstepaction"]
+
+> [Tutorial: Get Started with .NET for Apache Spark on Ubuntu](get-started-windows-instructions.md)
+
+> [Tutorial: Get Started with .NET for Apache Spark on MacOSX](get-started-ubuntu-instructions.md)

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -33,7 +33,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     ```
     
 - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
-  - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (e.g., `/bin/Microsoft.Spark.Worker/`).
+  - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (for example, `/bin/Microsoft.Spark.Worker/`).
   - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `/bin/Microsoft.Spark.Worker/`).
 
 ## Authoring a .NET for Apache Spark App

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -4,7 +4,7 @@ description: Discover how to run a .NET for Apache Spark app using .NET Core on 
 ms.date: 01/22/2020
 ms.topic: tutorial
 ms.custom: mvc
-# Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark on MacOSX.
+# Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark on macOS.
 ---
 
 # Tutorial: Get started with .NET for Apache Spark on macOS

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -125,4 +125,4 @@ In this tutorial, you learned how to run your .NET for Apache Spark on macOS. Co
 > [!div class="nextstepaction"]
 > [Tutorial: Get Started with .NET for Apache Spark on Windows](get-started-windows-instructions.md)
 
-> [Tutorial: Get Started with .NET for Apache Spark on MacOSX](get-started-ubuntu-instructions.md)
+> [Tutorial: Get Started with .NET for Apache Spark on Ubuntu](get-started-ubuntu-instructions.md)

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -9,7 +9,7 @@ ms.custom: mvc
 
 # Tutorial: Get started with .NET for Apache Spark on macOS
 
-This tutorial will show you how to run a .NET for Apache Spark app using .NET Core on macOS.
+This tutorial shows you how to run a .NET for Apache Spark app using .NET Core on macOS.
 
 > [!div class="checklist"]
 >

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -78,7 +78,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
 
 ## Running your .NET for Apache Spark App
 
-- Open your terminal and navigate into your app folder:
+1. Open your terminal and navigate into your app folder:
     
     ```bash
     cd <your-app-output-directory>

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -40,7 +40,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
 
 - Use the `dotnet` CLI to create a console application.
 
-    ```
+    ```dotnetcli
     dotnet new console -o HelloSpark
     ```
     

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -34,7 +34,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     
 - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
   - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (for example, `/bin/Microsoft.Spark.Worker/`).
-  - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, `/bin/Microsoft.Spark.Worker/`).
+  - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, *~/bin/Microsoft.Spark.Worker/*).
 
 ## Author a .NET for Apache Spark app
 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -51,7 +51,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     dotnet add package Microsoft.Spark
     ```
     
-- Replace the contents of the `Program.cs` file with the following code:
+1. Replace the contents of the *Program.cs* file with the following code:
     
     ```csharp
     using Microsoft.Spark.Sql;

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -24,7 +24,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
   - Select the appropriate version for your operating system, for example, `jdk-8u231-macosx-x64.dmg`.
   - Install using the installer and verify you are able to run `java` from the command line
 - Download and install **[Apache Spark 2.4.4](https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz)**:
-  - Add the necessary environment variable SPARK_HOME with a value of, for example, `~/bin/spark-2.4.4-bin-hadoop2.7/`
+  - Add the necessary environment variable SPARK_HOME with a value of, for example, *~/bin/spark-2.4.4-bin-hadoop2.7/*
   
     ```bash
     export SPARK_HOME=~/bin/spark-2.4.4-bin-hadoop2.7/

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -38,7 +38,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
 
 ## Authoring a .NET for Apache Spark App
 
-- Use the `dotnet` CLI to create a console application.
+1. Use the .NET Core CLI to create a console application.
 
     ```dotnetcli
     dotnet new console -o HelloSpark

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -15,7 +15,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
 >
 > * Prerequisites to run a .NET for Apache Spark application
 > * Write a simple .NET for Apache Spark application
-> * Build and run your .NET for Apache Spark application
+> * Build and run a .NET for Apache Spark application
 
 ## Pre-requisites
 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -9,7 +9,7 @@ ms.custom: mvc
 
 # Tutorial: Get started with .NET for Apache Spark on macOS
 
-This tutorial will show you how to run a .NET for Apache Spark app using .NET Core on MacOSX.
+This tutorial will show you how to run a .NET for Apache Spark app using .NET Core on macOS.
 
 > [!div class="checklist"]
 >

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -24,7 +24,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
   - Select the appropriate version for your operating system, for example, `jdk-8u231-macosx-x64.dmg`.
   - Install using the installer and verify you are able to run `java` from the command line
 - Download and install **[Apache Spark 2.4.4](https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz)**:
-  - Add the necessary environment variables SPARK_HOME e.g., `~/bin/spark-2.4.4-bin-hadoop2.7/`
+  - Add the necessary environment variable SPARK_HOME with a value of, for example, `~/bin/spark-2.4.4-bin-hadoop2.7/`
   
     ```bash
     export SPARK_HOME=~/bin/spark-2.4.4-bin-hadoop2.7/

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -102,7 +102,8 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     dotnet HelloSpark.dll 
     ```
     
-    **Note**: This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `~/spark/bin/spark-submit`).
+    > [!NOTE]
+    > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `~/spark/bin/spark-submit`).
     
 - The output of the application should look similar to the output below:
     

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -46,7 +46,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     
 1. Install the `Microsoft.Spark` NuGet package into the project from the [spark nuget.org feed](https://www.nuget.org/profiles/spark). For more information, see [Ways to install Nuget Package](https://docs.microsoft.com/nuget/consume-packages/ways-to-install-a-package).
     
-    ```
+    ```dotnetcli
     cd HelloSpark
     dotnet add package Microsoft.Spark
     ```

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -119,7 +119,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
    
 ## Next steps
 
-In this tutorial, you learn how to run your .NET for Apache Spark on MacOSX. Continue to learn more about how to run your .NET for Apache Spark on Windows and Ubuntu.
+In this tutorial, you learned how to run your .NET for Apache Spark on macOS. Continue to learn more about how to run your .NET for Apache Spark on Windows and Ubuntu.
 > [!div class="nextstepaction"]
 
 > [!div class="nextstepaction"]

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -105,7 +105,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     > [!NOTE]
     > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`. Otherwise, you would have to use the full path (for example, `~/spark/bin/spark-submit`).
     
-1. The output of the application should look similar to the output below:
+1. The output of the application should look similar to the following output:
     
     ```text
     +----+-------+

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -17,7 +17,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
 > * Write a simple .NET for Apache Spark application
 > * Build and run a .NET for Apache Spark application
 
-## Pre-requisites
+## Prerequisites
 
 - Download and install **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** 
 - Install **[Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -63,7 +63,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
             static void Main(string[] args)
             {
                 var spark = SparkSession.Builder().GetOrCreate();
-                var df = spark.Read().Json("people.json");
+                DataFrame df = spark.Read().Json("people.json");
                 df.Show();
             }
         }

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -1,7 +1,7 @@
 ---
 title: Get started with .NET for Apache Spark on macOS
 description: Discover how to run a .NET for Apache Spark app using .NET Core on macOS.
-ms.date: 01/22/2019
+ms.date: 01/22/2020
 ms.topic: tutorial
 ms.custom: mvc
 # Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark on MacOSX.

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -1,5 +1,5 @@
 ---
-title: Get Started with .NET for Apache Spark on MacOSX
+title: Get started with .NET for Apache Spark on macOS
 description: Discover how to run a .NET for Apache Spark app using .NET Core on MacOSX.
 ms.date: 12/30/2019
 ms.topic: tutorial

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -84,7 +84,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     cd <your-app-output-directory>
     ```
     
-- Create `people.json` with the following content:
+1. Create *people.json* with the following content:
     
     ```json
     { "name" : "Michael" }

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -22,7 +22,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
 - Download and install **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** 
 - Install **[Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** 
   - Select the appropriate version for your operating system, for example, `jdk-8u231-macosx-x64.dmg`.
-  - Install using the installer and verify you are able to run `java` from your command-line
+  - Install using the installer and verify you are able to run `java` from the command line
 - Download and install **[Apache Spark 2.4.4](https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz)**:
   - Add the necessary environment variables SPARK_HOME e.g., `~/bin/spark-2.4.4-bin-hadoop2.7/`
   

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -70,7 +70,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     }
     ```
     
-- Use the `dotnet` CLI to build the application:
+1. Use the .NET Core CLI to build the application:
     
     ```dotnetcli
     dotnet build

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -103,7 +103,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     ```
     
     > [!NOTE]
-    > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `~/spark/bin/spark-submit`).
+    > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`. Otherwise, you would have to use the full path (for example, `~/spark/bin/spark-submit`).
     
 1. The output of the application should look similar to the output below:
     

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -76,7 +76,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     dotnet build
     ```
 
-## Running your .NET for Apache Spark App
+## Run your .NET for Apache Spark app
 
 1. Open your terminal and navigate into your app folder:
     

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -105,7 +105,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     > [!NOTE]
     > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`, otherwise, you would have to use the full path (e.g., `~/spark/bin/spark-submit`).
     
-- The output of the application should look similar to the output below:
+1. The output of the application should look similar to the output below:
     
     ```text
     +----+-------+

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -92,7 +92,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     { "name" : "Justin", "age" : 19 }
     ```
     
-1. Run your app
+1. Run the app.
     
     ```bash
     spark-submit \

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -34,8 +34,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     
 - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
   - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (e.g., `/bin/Microsoft.Spark.Worker/`).
-    - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `/bin/Microsoft.Spark.Worker/`).
-
+  - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `/bin/Microsoft.Spark.Worker/`).
 
 ## Authoring a .NET for Apache Spark App
 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -122,6 +122,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
 In this tutorial, you learn how to run your .NET for Apache Spark on MacOSX. Continue to learn more about how to run your .NET for Apache Spark on Windows and Ubuntu.
 > [!div class="nextstepaction"]
 
-> [Tutorial: Get Started with .NET for Apache Spark on Ubuntu](get-started-windows-instructions.md)
+> [!div class="nextstepaction"]
+> [Tutorial: Get Started with .NET for Apache Spark on Windows](get-started-windows-instructions.md)
 
 > [Tutorial: Get Started with .NET for Apache Spark on MacOSX](get-started-ubuntu-instructions.md)

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -33,7 +33,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     ```
     
 - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
-  - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (for example, `/bin/Microsoft.Spark.Worker/`).
+  - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (for example, *~/bin/Microsoft.Spark.Worker/*).
   - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, *~/bin/Microsoft.Spark.Worker/*).
 
 ## Author a .NET for Apache Spark app

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -21,7 +21,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
 
 - Download and install **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** 
 - Install **[Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** 
-  - Select the appropriate version for your operating system e.g., `jdk-8u231-macosx-x64.dmg`.
+  - Select the appropriate version for your operating system, for example, `jdk-8u231-macosx-x64.dmg`.
   - Install using the installer and verify you are able to run `java` from your command-line
 - Download and install **[Apache Spark 2.4.4](https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz)**:
   - Add the necessary environment variables SPARK_HOME e.g., `~/bin/spark-2.4.4-bin-hadoop2.7/`

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -44,7 +44,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     dotnet new console -o HelloSpark
     ```
     
-- Install `Microsoft.Spark` Nuget package into the project from the [spark nuget.org feed](https://www.nuget.org/profiles/spark) - see [Ways to install Nuget Package](https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package)
+1. Install the `Microsoft.Spark` NuGet package into the project from the [spark nuget.org feed](https://www.nuget.org/profiles/spark) - see [Ways to install Nuget Package](https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package)
     
     ```
     cd HelloSpark

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -72,7 +72,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     
 - Use the `dotnet` CLI to build the application:
     
-    ```bash
+    ```dotnetcli
     dotnet build
     ```
 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -92,7 +92,7 @@ This tutorial will show you how to run a .NET for Apache Spark app using .NET Co
     { "name" : "Justin", "age" : 19 }
     ```
     
-- Run your app
+1. Run your app
     
     ```bash
     spark-submit \

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -13,7 +13,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
 
 > [!div class="checklist"]
 >
-> * Pre-requisites to run your .NET for Apache Spark application
+> * Prerequisites to run a .NET for Apache Spark application
 > * Write a simple .NET for Apache Spark application
 > * Build and run your .NET for Apache Spark application
 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -1,7 +1,7 @@
 ---
 title: Get started with .NET for Apache Spark on macOS
 description: Discover how to run a .NET for Apache Spark app using .NET Core on MacOSX.
-ms.date: 12/30/2019
+ms.date: 01/22/2019
 ms.topic: tutorial
 ms.custom: mvc
 # Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark on MacOSX.
@@ -19,7 +19,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
 
 ## Prerequisites
 
-- Download and install **[.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)** 
+- Download and install **[.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)** 
 - Install **[Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)** 
   - Select the appropriate version for your operating system, for example, `jdk-8u231-macosx-x64.dmg`.
   - Install using the installer and verify you are able to run `java` from the command line

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -7,7 +7,7 @@ ms.custom: mvc
 # Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark on MacOSX.
 ---
 
-# Tutorial: Get Started with .NET for Apache Spark on MacOS
+# Tutorial: Get started with .NET for Apache Spark on macOS
 
 This tutorial will show you how to run a .NET for Apache Spark app using .NET Core on MacOSX.
 

--- a/docs/spark/tutorials/get-started-macos-instructions.md
+++ b/docs/spark/tutorials/get-started-macos-instructions.md
@@ -34,9 +34,9 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     
 - Download and install **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release:
   - Select a **[Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases)** release from .NET for Apache Spark GitHub Releases page and download into your local machine (for example, `/bin/Microsoft.Spark.Worker/`).
-  - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (e.g., `/bin/Microsoft.Spark.Worker/`).
+  - **IMPORTANT** Create a new environment variable using ```export DOTNET_WORKER_DIR <your_path>``` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, `/bin/Microsoft.Spark.Worker/`).
 
-## Authoring a .NET for Apache Spark App
+## Author a .NET for Apache Spark app
 
 1. Use the .NET Core CLI to create a console application.
 
@@ -44,7 +44,7 @@ This tutorial shows you how to run a .NET for Apache Spark app using .NET Core o
     dotnet new console -o HelloSpark
     ```
     
-1. Install the `Microsoft.Spark` NuGet package into the project from the [spark nuget.org feed](https://www.nuget.org/profiles/spark) - see [Ways to install Nuget Package](https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package)
+1. Install the `Microsoft.Spark` NuGet package into the project from the [spark nuget.org feed](https://www.nuget.org/profiles/spark). For more information, see [Ways to install Nuget Package](https://docs.microsoft.com/nuget/consume-packages/ways-to-install-a-package).
     
     ```
     cd HelloSpark


### PR DESCRIPTION
## Summary

This PR create the tutorial of getting started with .NET for Apache Spark on macos.

Move contents from [Spark Dotnet](https://github.com/dotnet/spark/tree/master/docs) to docs.
