### PR TITLE
Update lts-current redirection

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -399,7 +399,7 @@
     },
     {
       "source_path": "docs/core/versions/lts-current.md",
-      "redirect_url": "https://dotnet.microsoft.com/platform/support/policy"
+      "redirect_url": "https://dotnet.microsoft.com/platform/support/policy/dotnet-core"
     },
     {
       "source_path": "docs/core/versions/servicing.md",


### PR DESCRIPTION
The old link didn't contain info about which version is the current LTS. 