### PR TITLE
Fix title and description metadata for page "Upgrade an app to nullable reference types"

### DIFF
--- a/docs/csharp/tutorials/upgrade-to-nullable-references.md
+++ b/docs/csharp/tutorials/upgrade-to-nullable-references.md
@@ -1,6 +1,6 @@
 ---
-title: Design with nullable reference types
-description: This advanced tutorial provides an introduction to nullable reference types. You'll learn to express your design intent on when reference values may be null, and have the compiler enforce when they cannot be null.
+title: Upgrade to nullable reference types
+description: This advanced tutorial demonstrates how to migrate existing code with nullable reference types.
 ms.date: 02/19/2019
 ms.technology: csharp-null-safety
 ms.custom: mvc


### PR DESCRIPTION
## Summary

Fix title and description metadata for page "Upgrade an app to nullable reference types"

Fixes #16428
