### PR TITLE
Fix typo in the gRPC compatibilities points

### DIFF
--- a/docs/architecture/cloud-native/rest-grpc.md
+++ b/docs/architecture/cloud-native/rest-grpc.md
@@ -19,7 +19,7 @@ gRPC is a modern RPC framework that is lightweight and highly performant. It use
 
 - While HTTP 1.1 sends data as clear text, HTTP/2 is a binary protocol. It parses data faster using less memory, reduces network latency with the related improvements to speed, and manages network resources more efficiently.
 - While HTTP 1.1 is limited to processing one round-trip request/response at a time, HTTP/2 supports multiplexing, or multiple parallel requests over the same connection.
-- HTTP/2 supports full-duplex, or bidirectional communication, where both client and server and can communicate at the same time. The client can be uploading request data at the same time the server is sending back response data.
+- HTTP/2 supports full-duplex, or bidirectional communication, where both client and server can communicate at the same time. The client can be uploading request data at the same time the server is sending back response data.
 - Streaming is built into HTTP/2 meaning that both requests and responses can asynchronously stream large data sets.
 - Combining gRPC and HTTP/2, performance dramatically increases. In [Windows Communication Foundation (WCF)](https://docs.microsoft.com/dotnet/framework/wcf/whats-wcf) parlance, gRPC performance meets and exceeds the speed and efficiency of [NetTCP bindings](https://docs.microsoft.com/dotnet/api/system.servicemodel.nettcpbinding?view=netframework-4.8). However, unlike NetTCP, gRPC isn't constrained to Microsoft languages such as C# or Visual Basic.
 


### PR DESCRIPTION
## Summary

I noticed a small grammar typo in the REST and gRPC doc while I was reading it today. English is not my native tongue but I'm pretty sure that it's a typo, and I wanted to get that corrected. Thanks!

Happy new year!

Fixes #Issue_Number (if available)
