### PR TITLE
Change "member" to "method or properties"

### DIFF
--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -97,7 +97,7 @@ You gain two advantages by applying the `readonly` modifier to applicable `struc
 
 The `readonly` modifier is valid on most members of a `struct`, including methods that override methods declared in <xref:System.Object?displayProperty=nameWithType>. There are some restrictions:
 
-- You can't declare `readonly` static members.
+- You can't declare `readonly` static methods or properties.
 - You can't declare `readonly` constructors.
 
 You can add the `readonly` modifier to a property or indexer declaration:


### PR DESCRIPTION
readonly static fields are allowed. 

Fixes #16501
