### PR TITLE
Typo "/imports"→"-imports"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/imports.md
+++ b/docs/visual-basic/reference/command-line-compiler/imports.md
@@ -27,12 +27,12 @@ Imports namespaces from a specified assembly.
   
  The members in a namespace specified with `-imports` are available to all source-code files in the compilation. Use the [Imports Statement (.NET Namespace and Type)](../../../visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md) to use a namespace in a single source-code file.  
   
-|To set /imports in the Visual Studio integrated development environment|  
+|To set -imports in the Visual Studio integrated development environment|  
 |---|  
 |1.  Have a project selected in **Solution Explorer**. On the **Project** menu, click **Properties**. <br />2.  Click the **References** tab.<br />3.  Enter the namespace name in the box beside the **Add User Import** button.<br />4.  Click the **Add User Import** button.|  
   
 ## Example  
- The following code compiles when `/imports:system.globalization` is specified. Without it, successful compilation requires either that an `Imports System.Globalization` statement be included at the beginning of the source code file, or that the property be fully qualified as `System.Globalization.CultureInfo.CurrentCulture.Name`.
+ The following code compiles when `-imports:system.globalization` is specified. Without it, successful compilation requires either that an `Imports System.Globalization` statement be included at the beginning of the source code file, or that the property be fully qualified as `System.Globalization.CultureInfo.CurrentCulture.Name`.
 
 ```vb
 Module Example


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/imports

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
