### PR TITLE
Typo "/out:OfficeApp.exe"→"-out:OfficeApp.exe"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/link.md
+++ b/docs/visual-basic/reference/command-line-compiler/link.md
@@ -80,7 +80,7 @@ or
  The following command line compiles source file `OfficeApp.vb` and reference assemblies from `COMData1.dll` and `COMData2.dll` to produce `OfficeApp.exe`.  
   
 ```console  
-vbc -link:COMData1.dll,COMData2.dll /out:OfficeApp.exe OfficeApp.vb  
+vbc -link:COMData1.dll,COMData2.dll -out:OfficeApp.exe OfficeApp.vb  
 ```  
   
 ## See also


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/link

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
