### PR TITLE
Typo "`/optionstrict:custom`"→"`-optionstrict:custom`"

### DIFF
--- a/docs/visual-basic/misc/bc31141.md
+++ b/docs/visual-basic/misc/bc31141.md
@@ -11,7 +11,7 @@ ms.assetid: c32ae8ff-aacc-40b4-960a-6f2d5d246671
 # Option Strict Custom can only be used as an option to the command-line compiler (vbc.exe)
 The `Option Strict` statement takes only `On` and `Off` as arguments; `Option Strict Custom` is not allowed.  
   
- Use the `/optionstrict:custom` compiler option to warn when strict language semantics are not respected.  
+ Use the `-optionstrict:custom` compiler option to warn when strict language semantics are not respected.  
   
  **Error ID:** BC31141  
   


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/misc/bc31141

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
