### PR TITLE
Fixed "[+&#124;-]"→"[+\|-]"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
+++ b/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
@@ -51,7 +51,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |[-optioninfer](../../../visual-basic/reference/command-line-compiler/optioninfer.md)|Enables the use of local type inference in variable declarations.|  
 |[-optionstrict](../../../visual-basic/reference/command-line-compiler/optionstrict.md)|Enforces strict language semantics.|  
 |[-out](../../../visual-basic/reference/command-line-compiler/out.md)|Specifies an output file.|  
-|`-parallel[+&#124;-]`|Specifies whether to use concurrent build (+).|  
+|`-parallel[+|-]`|Specifies whether to use concurrent build (+).|  
 |[-platform](../../../visual-basic/reference/command-line-compiler/platform.md)|Specifies the processor platform the compiler targets for the output file.|  
 |`-preferreduilang`|Specify the preferred output language name.|  
 |[-quiet](../../../visual-basic/reference/command-line-compiler/quiet.md)|Prevents the compiler from displaying code for syntax-related errors and warnings.|  

--- a/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
+++ b/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
@@ -51,7 +51,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |[-optioninfer](../../../visual-basic/reference/command-line-compiler/optioninfer.md)|Enables the use of local type inference in variable declarations.|  
 |[-optionstrict](../../../visual-basic/reference/command-line-compiler/optionstrict.md)|Enforces strict language semantics.|  
 |[-out](../../../visual-basic/reference/command-line-compiler/out.md)|Specifies an output file.|  
-|`-parallel[+\|-]`|Specifies whether to use concurrent build (+).|  
+|<code>-parallel[+&#124;-]</code>|Specifies whether to use concurrent build (+).|  
 |[-platform](../../../visual-basic/reference/command-line-compiler/platform.md)|Specifies the processor platform the compiler targets for the output file.|  
 |`-preferreduilang`|Specify the preferred output language name.|  
 |[-quiet](../../../visual-basic/reference/command-line-compiler/quiet.md)|Prevents the compiler from displaying code for syntax-related errors and warnings.|  

--- a/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
+++ b/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
@@ -51,7 +51,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |[-optioninfer](../../../visual-basic/reference/command-line-compiler/optioninfer.md)|Enables the use of local type inference in variable declarations.|  
 |[-optionstrict](../../../visual-basic/reference/command-line-compiler/optionstrict.md)|Enforces strict language semantics.|  
 |[-out](../../../visual-basic/reference/command-line-compiler/out.md)|Specifies an output file.|  
-|'-parallel[+\|-]'|Specifies whether to use concurrent build (+).|  
+|`-parallel[+\|-]`|Specifies whether to use concurrent build (+).|  
 |[-platform](../../../visual-basic/reference/command-line-compiler/platform.md)|Specifies the processor platform the compiler targets for the output file.|  
 |`-preferreduilang`|Specify the preferred output language name.|  
 |[-quiet](../../../visual-basic/reference/command-line-compiler/quiet.md)|Prevents the compiler from displaying code for syntax-related errors and warnings.|  

--- a/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
+++ b/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
@@ -51,7 +51,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |[-optioninfer](../../../visual-basic/reference/command-line-compiler/optioninfer.md)|Enables the use of local type inference in variable declarations.|  
 |[-optionstrict](../../../visual-basic/reference/command-line-compiler/optionstrict.md)|Enforces strict language semantics.|  
 |[-out](../../../visual-basic/reference/command-line-compiler/out.md)|Specifies an output file.|  
-|`-parallel[+|-]`|Specifies whether to use concurrent build (+).|  
+|'-parallel[+\|-]'|Specifies whether to use concurrent build (+).|  
 |[-platform](../../../visual-basic/reference/command-line-compiler/platform.md)|Specifies the processor platform the compiler targets for the output file.|  
 |`-preferreduilang`|Specify the preferred output language name.|  
 |[-quiet](../../../visual-basic/reference/command-line-compiler/quiet.md)|Prevents the compiler from displaying code for syntax-related errors and warnings.|  


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
