### PR TITLE
Typo  "`/bugreport`"→"`-bugreport`"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/bugreport.md
+++ b/docs/visual-basic/reference/command-line-compiler/bugreport.md
@@ -45,7 +45,7 @@ Creates a file that you can use when you file a bug report.
  If this option is used with `-errorreport:prompt`, `-errorreport:queue`, or `-errorreport:send`, and your application encounters an internal compiler error, the information in `file` is sent to Microsoft Corporation. That information will help Microsoft engineers identify the cause of the error and may help improve the next release of Visual Basic. By default, no information is sent to Microsoft. However, when you compile an application by using `-errorreport:queue`, which is enabled by default, the application collects its error reports. Then, when the computer's administrator logs in, the error reporting system displays a pop-up window that enables the administrator to forward to Microsoft any error reports that occurred since the logon.  
   
 > [!NOTE]
-> The `/bugreport` option is not available from within the Visual Studio development environment; it is available only when you compile from the command line.  
+> The `-bugreport` option is not available from within the Visual Studio development environment; it is available only when you compile from the command line.  
   
 ## Example  
  The following example compiles `T2.vb` and puts all bug-reporting information in the file `Problem.txt`.  


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/bugreport

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
