### PR TITLE
Typo "`/lib`"→"`-lib`"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/deterministic.md
+++ b/docs/visual-basic/reference/command-line-compiler/deterministic.md
@@ -38,7 +38,7 @@ The compiler considers the following inputs for the purpose of determinism:
   - Additional files that may be used by analyzers
 - The current culture (for the language in which diagnostics and exception messages are produced).
 - The default encoding (or the current code page) if the encoding is not specified.
-- The existence, non-existence, and contents of files on the compiler's search paths (specified, for example, by `/lib` or `/recurse`).
+- The existence, non-existence, and contents of files on the compiler's search paths (specified, for example, by `-lib` or `-recurse`).
 - The CLR platform on which the compiler is run.
 - The value of `%LIBPATH%`, which can affect analyzer dependency loading.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/deterministic

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
