### PR TITLE
Typo "`/target:module`"→"`-target:module`"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/doc.md
+++ b/docs/visual-basic/reference/command-line-compiler/doc.md
@@ -40,7 +40,7 @@ or
   
  To use the generated XML file with the Visual Studio [IntelliSense](/visualstudio/ide/using-intellisense) feature, let the file name of the XML file be the same as the assembly you want to support. Make sure the XML file is in the same directory as the assembly so that when the assembly is referenced in the Visual Studio project, the .xml file is found as well. XML documentation files are not required for IntelliSense to work for code within a project or within projects referenced by a project.  
   
- Unless you compile with `/target:module`, the XML file contains the tags `<assembly></assembly>`. These tags specify the name of the file containing the assembly manifest for the output file of the compilation.  
+ Unless you compile with `-target:module`, the XML file contains the tags `<assembly></assembly>`. These tags specify the name of the file containing the assembly manifest for the output file of the compilation.  
   
  See [XML Comment Tags](../../../visual-basic/language-reference/xmldoc/index.md) for ways to generate documentation from comments in your code.  
   


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/doc

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
