### PR TITLE
Typo "`-reference` is `/r`"→"`-reference` is `-r`"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/reference.md
+++ b/docs/visual-basic/reference/command-line-compiler/reference.md
@@ -46,7 +46,7 @@ or
   
  The Vbc.rsp response file, which references commonly used .NET Framework assemblies, is used by default. Use `-noconfig` if you do not want the compiler to use Vbc.rsp.  
   
- The short form of `-reference` is `/r`.  
+ The short form of `-reference` is `-r`.  
   
 ## Example  
  The following command compiles source file `Input.vb` and reference assemblies from `Metad1.dll` and `Metad2.dll` to produce `Out.exe`.  


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/reference

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
