### PR TITLE
Update summary to mention default implementation

### DIFF
--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -48,7 +48,7 @@ An interface has the following properties:
 - An interface is like an abstract base class with only abstract members. Any class or struct that implements the interface must implement all its members.
 - An interface can't be instantiated directly. Its members are implemented by any class or struct that implements the interface.
 - Interfaces can contain events, indexers, methods, and properties.
-- Interfaces contain no implementation of methods.
+- Interfaces contain no implementation of methods (In C# 8.0, Interfaces can have [default implementation for methods](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#default-interface-methods) ).
 - A class or struct can implement multiple interfaces. A class can inherit a base class and also implement one or more interfaces.
 
 ## In this section

--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -48,7 +48,7 @@ An interface has the following properties:
 - An interface is like an abstract base class with only abstract members. Any class or struct that implements the interface must implement all its members.
 - An interface can't be instantiated directly. Its members are implemented by any class or struct that implements the interface.
 - Interfaces can contain events, indexers, methods, and properties.
-- Interfaces contain no implementation of methods (In C# 8.0, Interfaces can have [default implementation for methods](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#default-interface-methods) ).
+- Interfaces contain no implementation of methods (In C# 8.0, Interfaces can have [default implementation for methods](../../whats-new/csharp-8.md#default-interface-methods)).
 - A class or struct can implement multiple interfaces. A class can inherit a base class and also implement one or more interfaces.
 
 ## In this section


### PR DESCRIPTION
As of C# 8.0, the below statement in the summary is no longer correct:
"- Interfaces contain no implementation of methods".

In C# 8.0, you can add default implementation to interface methods.

Source: https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#default-interface-methods

## Summary

Added a statement with a link to "What's new in C# 8.0" to inform the reader that as of C# 8.0, interfaces can have default implementation of methods.