### PR TITLE
Remove author from articles - core/diagnostics

### DIFF
--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -1,8 +1,6 @@
 ---
 title: Debug a memory leak tutorial
 description: Learn how to debug a memory leak in .NET Core.
-author: sdmaclea
-ms.author: stmaclea
 ms.topic: tutorial
 ms.date: 12/17/2019
 ---

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -1,8 +1,6 @@
 ---
 title: dotnet-counters - .NET Core
 description: Learn how to install and use the dotnet-counter command-line tool.
-author: sdmaclea
-ms.author: stmaclea
 ms.date: 10/14/2019
 ---
 # dotnet-counters

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -1,8 +1,6 @@
 ---
 title: dotnet-dump - .NET Core
 description: Installing and using the dotnet-dump command-line tool.
-author: sdmaclea
-ms.author: stmaclea
 ms.date: 10/14/2019
 ---
 # Dump collection and analysis utility (`dotnet-dump`)

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -1,8 +1,6 @@
 ---
 title: dotnet-trace tool - .NET Core
 description: Installing and using the dotnet-trace command-line tool.
-author: sdmaclea
-ms.author: stmaclea
 ms.date: 11/21/2019
 ---
 # dotnet-trace performance analysis utility

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -1,8 +1,6 @@
 ---
 title: Diagnostics tools overview - .NET Core
 description: An overview of the tools and techniques available to diagnose .NET Core applications.
-author: sdmaclea
-ms.author: stmaclea
 ms.date: 12/17/2019
 ms.topic: overview
 #Customer intent: As a .NET Core developer I want to find the best tools to help me diagnose problems so that I can be productive.

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -1,8 +1,6 @@
 ---
 title: Logging and tracing - .NET Core
 description: An introduction to .NET Core logging and tracing.
-author: sdmaclea
-ms.author: stmaclea
 ms.date: 08/05/2019
 ---
 # .NET Core logging and tracing

--- a/docs/core/diagnostics/managed-debuggers.md
+++ b/docs/core/diagnostics/managed-debuggers.md
@@ -1,8 +1,6 @@
 ---
 title: Managed debuggers - .NET Core
 description: An overview of the Visual Studio and Visual Studio Code managed debuggers.
-author: sdmaclea
-ms.author: stmaclea
 ms.date: 08/05/2019
 ---
 # .NET Core managed debuggers


### PR DESCRIPTION
The author and ms.author are already set for `"docs/core/diagnostics/**/**.md"` globally in docfx.json