### PR TITLE
Remove author from articles - machine-learning

### DIFF
--- a/docs/machine-learning/automate-training-with-cli.md
+++ b/docs/machine-learning/automate-training-with-cli.md
@@ -1,8 +1,6 @@
 ---
 title: Automate model training with the ML.NET CLI
 description: Discover how to use the ML.NET CLI tool to automatically train the best model from the command-line.
-author: natke
-ms.author: nakersha
 ms.date: 12/17/2019
 ms.custom: how-to
 #Customer intent: As a developer, I want to use ML.NET CLI to automatically train the "best model" from the command-prompt. I also want to understand the output provided by the tool (metrics and output assets)

--- a/docs/machine-learning/automate-training-with-model-builder.md
+++ b/docs/machine-learning/automate-training-with-model-builder.md
@@ -1,7 +1,6 @@
 ---
 title: What is Model Builder and how does it work?
 description: How to use the ML.NET Model Builder to automatically train a machine learning model
-author: natke
 ms.date: 08/07/2019
 ms.custom: overview
 #Customer intent: As a developer, I want to use Model Builder to automatically train a model using a visual interface.

--- a/docs/machine-learning/automl-overview.md
+++ b/docs/machine-learning/automl-overview.md
@@ -1,11 +1,9 @@
 ---
 title: Automated machine learning with ML.NET
 description: Overview of automatic model selection and training
-author: natke
 ms.date: 05/01/2019
 ms.topic: overview
 ms.custom: mvc
-ms.author: nakersha
 #Customer intent: As a developer, I want to use ML.NET CLI to automatically select and train a model.
 ---
 # Automated machine learning with ML.NET

--- a/docs/machine-learning/how-does-mldotnet-work.md
+++ b/docs/machine-learning/how-does-mldotnet-work.md
@@ -4,8 +4,6 @@ description: ML.NET gives you the ability to add machine learning to .NET applic
 ms.date: 11/5/2019
 ms.topic: overview
 ms.custom: mvc
-ms.author: nakersha
-author: natke
 #Customer intent: As a developer, I want to learn how ML.NET works so that I can leverage machine learning in my applications.
 ---
 

--- a/docs/machine-learning/how-to-choose-an-ml-net-algorithm.md
+++ b/docs/machine-learning/how-to-choose-an-ml-net-algorithm.md
@@ -1,7 +1,6 @@
 ---
 title: How to choose an ML.NET algorithm
 description: Learn how to choose an ML.NET algorithm for your machine learning model
-author: natke
 ms.topic: overview
 ms.date: 06/05/2019
 ---

--- a/docs/machine-learning/how-to-guides/install-ml-net-cli.md
+++ b/docs/machine-learning/how-to-guides/install-ml-net-cli.md
@@ -2,8 +2,6 @@
 title: How to install the ML.NET Command-Line Interface (CLI) tool
 description: Learn how to install, upgrade, downgrade, and uninstall the ML.NET Command-Line Interface (CLI) tool.
 ms.date: 12/18/2019
-ms.author: nakersha
-author: natke
 ---
 
 # How to install the ML.NET Command-Line Interface (CLI) tool

--- a/docs/machine-learning/resources/index.md
+++ b/docs/machine-learning/resources/index.md
@@ -1,9 +1,7 @@
 ---
 title:  ML.NET resources
 description: Learn more about machine learning and ML.NET
-author: natke
 ms.topic: reference
-ms.author: nakersha
 ms.date: 11/07/2019
 ---
 # ML.NET resources

--- a/docs/machine-learning/resources/metrics.md
+++ b/docs/machine-learning/resources/metrics.md
@@ -2,9 +2,6 @@
 title: ML.NET metrics
 description: Understand the metrics that are used to evaluate the performance of an ML.NET model
 ms.date: 12/17/2019
-author: natke
-ms.author: nakersha
-
 ---
 # Evaluate your ML.NET model with metrics
 

--- a/docs/machine-learning/resources/tasks.md
+++ b/docs/machine-learning/resources/tasks.md
@@ -3,7 +3,6 @@ title: Machine learning tasks
 description: Explore the different machine learning tasks and associated tasks that are supported in ML.NET.
 ms.custom: seodec18
 ms.date: 12/23/2019
-author: natke
 ---
 # Machine learning tasks in ML.NET
 

--- a/docs/machine-learning/resources/transforms.md
+++ b/docs/machine-learning/resources/transforms.md
@@ -1,8 +1,6 @@
 ---
 title: Data transformations
 description: Explore the feature engineering components supported in ML.NET.
-author: natke
-ms.author: nakersha
 ms.date: 04/02/2019
 ---
 

--- a/docs/machine-learning/tutorials/image-classification.md
+++ b/docs/machine-learning/tutorials/image-classification.md
@@ -4,8 +4,6 @@ description: Learn how to transfer the knowledge from an existing TensorFlow mod
 ms.date: 11/15/2019
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0612
-author: natke
-ms.author: nakersha
 #Customer intent: As a developer, I want to use a pre-trained TensorFlow model with ML.NET so that I can classify images with a small amount of training data.
 ---
 # Tutorial: Generate an ML.NET image classification model from a pre-trained TensorFlow model

--- a/docs/machine-learning/tutorials/text-classification-tf.md
+++ b/docs/machine-learning/tutorials/text-classification-tf.md
@@ -4,8 +4,6 @@ description: This tutorial shows you how to use a pre-trained TensorFlow model t
 ms.date: 11/15/2019
 ms.topic: tutorial
 ms.custom: mvc
-ms.author: nakersha
-author: natke
 #Customer intent: As a developer, I want to use ML.NET to make inferences with a pre-trained TensorFlow model.
 ---
 # Tutorial: Analyze sentiment of movie reviews using a pre-trained TensorFlow model in ML.NET


### PR DESCRIPTION
The author and ms.author are already set for `"docs/machine-learning/**/**.md"` globally in docfx.json