### PR TITLE
Fix typo in code example

### DIFF
--- a/docs/architecture/blazor-for-web-forms-developers/components.md
+++ b/docs/architecture/blazor-for-web-forms-developers/components.md
@@ -263,7 +263,7 @@ Event handlers can execute synchronously or asynchronously. For example, the fol
 After an event is handled, the component is rendered to account for any component state changes. With asynchronous event handlers, the component is rendered immediately after the handler execution completes. The component is rendered *again* after the asynchronous `Task` completes. This asynchronous execution mode provides an opportunity to render some appropriate UI while the asynchronous `Task` is still in progress.
 
 ```razor
-<button @onclick="Get message">Get message</button>
+<button @onclick="ShowMessage">Get message</button>
 
 @if (showMessage)
 {


### PR DESCRIPTION
Fixes #16550

Fix typo in code example:
Changing from `Get Message` to `ShowMessage` in button click