### PR TITLE
remove old SEO hackathons metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -518,10 +518,6 @@
         "docs/standard/data/sqlite/**/**.md": "Microsoft.Data.Sqlite",
         "docs/visual-basic/**/**.md": "Visual Basic"
       },
-      "ms.custom": {
-        "docs/fsharp/tutorials/**/**.md": "seodec18",
-        "docs/fsharp/language-reference/**/**.md": "seodec18"
-      },
       "open_to_public_contributors": {
 	      "docs/standard/design-guidelines/**.md": false
       }

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -3,7 +3,6 @@ title: WCF svcutil tool overview
 description: An overview of the Microsoft WCF dotnet-svcutil tool that adds functionality for .NET Core and ASP.NET Core projects, similar to the WCF svcutil tool for .NET Framework projects.
 author: mlacouture
 ms.date: 02/22/2019
-ms.custom: "seodec18"
 ---
 # WCF dotnet-svcutil tool for .NET Core
 

--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -3,7 +3,7 @@ title: Additional CLI tools
 description: An overview of the additional tools you can install that support and extend .NET Core functionality.
 author: mlacouture
 ms.date: 12/02/2019
-ms.custom: "mvc, seodec18"
+ms.custom: "mvc"
 ---
 # .NET Core additional tools overview
 

--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -3,7 +3,7 @@ title: Add WCF Web Service Reference
 description: An overview of the Microsoft WCF Web Service Reference Provider Tool that adds functionality for .NET Core and ASP.NET Core projects, similar to Add Service Reference for .NET Framework projects.
 author: dasetser
 ms.date: 10/29/2019
-ms.custom: "mvc, seodec18"
+ms.custom: "mvc"
 ---
 
 # Use the WCF Web Service Reference Provider Tool

--- a/docs/core/additional-tools/xml-serializer-generator.md
+++ b/docs/core/additional-tools/xml-serializer-generator.md
@@ -4,7 +4,7 @@ description: An overview of the Microsoft XML Serializer Generator. Use the XML 
 author: mlacouture
 ms.date: 01/19/2017
 ms.topic: tutorial
-ms.custom: "mvc, seodec18"
+ms.custom: "mvc"
 ---
 # Using Microsoft XML Serializer Generator on .NET Core
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -3,7 +3,6 @@ title: .NET Core distribution packaging
 description: Learn how to package, name, and version .NET Core for distribution.
 author: tmds
 ms.date: 10/09/2019
-ms.custom: "seodec18"
 ---
 # .NET Core distribution packaging
 

--- a/docs/core/build/index.md
+++ b/docs/core/build/index.md
@@ -3,7 +3,6 @@ title: Build .NET Core from source
 description: Learn how to build .NET Core and the .NET Core CLI from the source code.
 author: bleroy
 ms.date: 06/28/2017
-ms.custom: "seodec18"
 ---
 
 # Build .NET Core from source

--- a/docs/core/deploying/creating-nuget-packages.md
+++ b/docs/core/deploying/creating-nuget-packages.md
@@ -4,7 +4,6 @@ description: Learn how to create a NuGet package with the 'dotnet pack' command.
 author: cartermp
 ms.date: 06/20/2016
 ms.technology: dotnet-cli
-ms.custom: seodec18
 ---
 # How to create a NuGet package with .NET Core command-line interface (CLI) tools
 

--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -7,7 +7,6 @@ ms.date: 12/12/2019
 dev_langs:
   - "csharp"
   - "vb"
-ms.custom: seodec18
 ---
 
 # Publish .NET Core apps with the CLI

--- a/docs/core/deploying/deploy-with-vs.md
+++ b/docs/core/deploying/deploy-with-vs.md
@@ -5,7 +5,7 @@ ms.date: 09/03/2018
 dev_langs: 
   - "csharp"
   - "vb"
-ms.custom: vs-dotnet, seodec18
+ms.custom: vs-dotnet
 ---
 # Deploy .NET Core apps with Visual Studio
 

--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -2,7 +2,6 @@
 title: .NET Core Application Deployment
 description: Learn about the ways to deploy a .NET Core application.
 ms.date: 12/03/2018
-ms.custom: seodec18
 ---
 # .NET Core application deployment
 

--- a/docs/core/deploying/reducing-dependencies.md
+++ b/docs/core/deploying/reducing-dependencies.md
@@ -3,7 +3,6 @@ title: Reducing Package Dependencies with project.json
 description: Reduce package dependencies when authoring project.json-based libraries.
 author: cartermp
 ms.date: 06/20/2016
-ms.custom: "seodec18"
 ---
 
 # Reducing Package Dependencies with project.json

--- a/docs/core/deploying/runtime-patch-selection.md
+++ b/docs/core/deploying/runtime-patch-selection.md
@@ -3,7 +3,6 @@ title: Runtime roll forward for .NET Core self-contained app deployments.
 description: Learn about dotnet publish changes for self-contained deployments.
 author: KathleenDollard
 ms.date: 05/31/2018
-ms.custom: seodec18
 ---
 # Self-contained deployment runtime roll forward
 

--- a/docs/core/deploying/runtime-store.md
+++ b/docs/core/deploying/runtime-store.md
@@ -3,7 +3,6 @@ title: Runtime package store
 description: Learn how to use the runtime package store to target manifests used by .NET Core.
 author: bleroy
 ms.date: 08/12/2017
-ms.custom: seodec18
 ---
 # Runtime package store
 

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -3,7 +3,7 @@ title: Containerize an app with Docker tutorial
 description: In this tutorial, you will learn how to containerize a .NET Core application with Docker.
 ms.date: 06/26/2019
 ms.topic: tutorial
-ms.custom: "mvc, seodec18"
+ms.custom: "mvc"
 #Customer intent: As a developer, I want to containerize my .NET Core app so that I can deploy it to the cloud.
 ---
 

--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -2,7 +2,7 @@
 title: Introduction to Docker
 description: This article provides an introduction and overview to Docker in the context of a .NET Core application.
 ms.date: 03/20/2019
-ms.custom: "mvc, seodec18"
+ms.custom: "mvc"
 ---
 
 # Introduction to .NET and Docker

--- a/docs/core/migration/20-21.md
+++ b/docs/core/migration/20-21.md
@@ -2,7 +2,6 @@
 title: Migrate from .NET Core 2.0 to 2.1
 description: Learn how to upgrade your .NET Core 2.0 app to 2.1.
 ms.date: 08/06/2018
-ms.custom: "seodec18"
 ---
 # Migrate from .NET Core 2.0 to 2.1
 

--- a/docs/core/migration/from-dnx.md
+++ b/docs/core/migration/from-dnx.md
@@ -2,7 +2,6 @@
 title: Migrating from DNX to .NET Core CLI
 description: Migrate from using DNX tooling to .NET Core CLI tooling.
 ms.date: 06/20/2016
-ms.custom: "seodec18"
 ---
 # Migrating from DNX to .NET Core CLI (project.json)
 

--- a/docs/core/migration/index.md
+++ b/docs/core/migration/index.md
@@ -2,7 +2,6 @@
 title: .NET Core migration from project.json
 description: Learn how to migrate an older .NET Core project using project.json
 ms.date: 07/19/2017
-ms.custom: "seodec18"
 ---
 # Migrating .NET Core projects from project.json
 

--- a/docs/core/packages.md
+++ b/docs/core/packages.md
@@ -3,7 +3,6 @@ title: Packages, metapackages and frameworks - .NET Core
 description: Learn terminology for packages, metapackages, and frameworks.
 author: richlander
 ms.date: 06/20/2016
-ms.custom: "seodec18"
 ---
 # Packages, metapackages and frameworks
 

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -3,7 +3,6 @@ title: Port from .NET Framework to .NET Core
 description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET Core.
 author: cartermp
 ms.date: 10/22/2019
-ms.custom: seodec18
 ---
 # Overview of the porting process from .NET Framework to .NET Core
 

--- a/docs/core/porting/libraries.md
+++ b/docs/core/porting/libraries.md
@@ -3,7 +3,6 @@ title: Port libraries to .NET Core
 description: Learn how to port library projects from the .NET Framework to .NET Core.
 author: cartermp
 ms.date: 12/07/2018
-ms.custom: seodec18
 ---
 # Port .NET Framework libraries to .NET Core
 

--- a/docs/core/porting/project-structure.md
+++ b/docs/core/porting/project-structure.md
@@ -3,7 +3,6 @@ title: Organize projects for .NET Framework and .NET Core
 description: Help for project owners who want to compile their solution against .NET Framework and .NET Core side-by-side.
 author: conniey
 ms.date: 12/07/2018
-ms.custom: seodec18
 ---
 # Organize your project to support both .NET Framework and .NET Core
 

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -3,7 +3,6 @@ title: Analyze dependencies to port code to .NET Core
 description: Learn how to analyze external dependencies in order to port your project from .NET Framework to .NET Core.
 author: cartermp
 ms.date: 10/22/2019
-ms.custom: seodec18
 ---
 # Analyze your dependencies to port code to .NET Core
 

--- a/docs/core/porting/windows-compat-pack.md
+++ b/docs/core/porting/windows-compat-pack.md
@@ -3,7 +3,6 @@ title: Use the Windows Compatibility Pack to port code to .NET Core
 description: Learn about the Windows Compatibility Pack and how can you use it to port existing .NET Framework code to .NET Core
 author: terrajobst
 ms.date: 12/07/2018
-ms.custom: seodec18
 ---
 # Use the Windows Compatibility Pack to port code to .NET Core
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -4,7 +4,6 @@ description: This article gives a brief overview of unit testing for .NET Core a
 author: ardalis
 ms.author: wiwagn
 ms.date: 08/30/2017
-ms.custom: "seodec18"
 ---
 
 # Unit testing in .NET Core and .NET Standard

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -3,7 +3,6 @@ title: Running selective unit tests
 description: How to use a filter expression to run selective unit tests with the dotnet test command in .NET Core.
 author: smadala
 ms.date: 03/22/2017
-ms.custom: seodec18
 ---
 
 # Running selective unit tests

--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -4,7 +4,6 @@ description: Learn best practices for writing unit tests that drive code quality
 author: jpreese
 ms.author: wiwagn
 ms.date: 07/28/2018
-ms.custom: "seodec18"
 ---
 
 # Unit testing best practices with .NET Core and .NET Standard

--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -4,7 +4,6 @@ description: Learn unit test concepts for F# in .NET Core through an interactive
 author: billwagner
 ms.author: wiwagn
 ms.date: 08/30/2017
-ms.custom: "seodec18"
 ---
 # Unit testing F# libraries in .NET Core using dotnet test and xUnit
 

--- a/docs/core/testing/unit-testing-fsharp-with-mstest.md
+++ b/docs/core/testing/unit-testing-fsharp-with-mstest.md
@@ -4,7 +4,6 @@ description: Learn unit test concepts for F# in .NET Core through an interactive
 author: billwagner
 ms.author: wiwagn
 ms.date: 08/30/2017
-ms.custom: "seodec18"
 ---
 # Unit testing F# libraries in .NET Core using dotnet test and MSTest
 

--- a/docs/core/testing/unit-testing-fsharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-fsharp-with-nunit.md
@@ -5,7 +5,6 @@ author: rprouse
 ms.date: 10/04/2018
 dev_langs: 
   - "fsharp"
-ms.custom: "seodec18"
 ---
 # Unit testing F# libraries in .NET Core using dotnet test and NUnit
 

--- a/docs/core/testing/unit-testing-published-output.md
+++ b/docs/core/testing/unit-testing-published-output.md
@@ -4,7 +4,6 @@ description: Learn how to run tests on published libraries, instead of on source
 author: kendrahavens
 ms.author: kehavens
 ms.date: 10/18/2017
-ms.custom: "seodec18"
 ---
 # Test published output with dotnet vstest
 

--- a/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
@@ -4,7 +4,6 @@ description: Learn unit test concepts in .NET Core through an interactive experi
 author: billwagner
 ms.author: wiwagn
 ms.date: 09/01/2017
-ms.custom: "seodec18"
 ---
 # Unit testing Visual Basic .NET Core libraries using dotnet test and xUnit
 

--- a/docs/core/testing/unit-testing-visual-basic-with-mstest.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-mstest.md
@@ -4,7 +4,6 @@ description: Learn unit test concepts in .NET Core through an interactive experi
 author: billwagner
 ms.author: wiwagn
 ms.date: 09/01/2017
-ms.custom: "seodec18"
 ---
 # Unit testing Visual Basic .NET Core libraries using dotnet test and MSTest
 

--- a/docs/core/testing/unit-testing-visual-basic-with-nunit.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-nunit.md
@@ -3,7 +3,6 @@ title: Unit testing Visual Basic in .NET Core with dotnet test and NUnit
 description: Learn unit test concepts in .NET Core through an interactive experience building a sample Visual Basic solution step-by-step using NUnit.
 author: rprouse
 ms.date: 10/04/2018
-ms.custom: "seodec18"
 ---
 # Unit testing Visual Basic .NET Core libraries using dotnet test and NUnit
 

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -4,7 +4,6 @@ description: Learn unit test concepts in C# and .NET Core through an interactive
 author: ardalis
 ms.author: wiwagn
 ms.date: 12/04/2019
-ms.custom: "seodec18"
 ---
 # Unit testing C# in .NET Core using dotnet test and xUnit
 

--- a/docs/core/testing/unit-testing-with-mstest.md
+++ b/docs/core/testing/unit-testing-with-mstest.md
@@ -4,7 +4,6 @@ description: Learn unit test concepts in C# and .NET Core through an interactive
 author: ncarandini
 ms.author: wiwagn
 ms.date: 09/08/2017
-ms.custom: "seodec18"
 ---
 # Unit testing C# with MSTest and .NET Core
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -3,7 +3,6 @@ title: Unit testing C# with NUnit and .NET Core
 description: Learn unit test concepts in C# and .NET Core through an interactive experience building a sample solution step-by-step using dotnet test and NUnit.
 author: rprouse
 ms.date: 08/31/2018
-ms.custom: "seodec18"
 ---
 # Unit testing C# with NUnit and .NET Core
 

--- a/docs/core/tools/dependencies.md
+++ b/docs/core/tools/dependencies.md
@@ -2,7 +2,6 @@
 title: Managing dependencies in .NET Core tooling
 description: Explains how to manage your dependencies with the .NET Core tools.
 ms.date: 03/06/2017
-ms.custom: "seodec18"
 ---
 # Managing dependencies with .NET Core SDK 1.0
 

--- a/docs/core/tools/dotnet-store.md
+++ b/docs/core/tools/dotnet-store.md
@@ -3,7 +3,6 @@ title: dotnet store command
 description: The 'dotnet store' command stores the specified assemblies in the runtime package store.
 author: bleroy
 ms.date: 05/29/2018
-ms.custom: "seodec18"
 ---
 # dotnet store
 

--- a/docs/core/tools/extensibility.md
+++ b/docs/core/tools/extensibility.md
@@ -2,7 +2,6 @@
 title: .NET Core CLI extensibility model
 description: Learn how you can extend the Command-line Interface (CLI) tools.
 ms.date: 04/12/2017
-ms.custom: "seodec18"
 ---
 
 # .NET Core CLI tools extensibility model

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -2,7 +2,7 @@
 title: global.json overview
 description: Learn how to use the global.json file to set the .NET Core SDK version when running .NET Core CLI commands.
 ms.date: 12/03/2018
-ms.custom: "updateeachrelease, seodec18"
+ms.custom: "updateeachrelease"
 ---
 # global.json overview
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -3,7 +3,6 @@ title: .NET Core Global Tools
 description: An overview of what .NET Core Global Tools are and the .NET Core CLI commands available for them. 
 author: KathleenDollard
 ms.date: 05/29/2018
-ms.custom: "seodec18"
 ---
 # .NET Core Global Tools overview
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -2,7 +2,6 @@
 title: .NET Core Command-Line Interface (CLI) Tools
 description: An overview of the .NET Core Command-Line Interface (CLI) tools and features.
 ms.date: 08/14/2017
-ms.custom: "seodec18"
 ---
 # .NET Core command-line interface (CLI) tools
 

--- a/docs/core/tools/project-json-to-csproj.md
+++ b/docs/core/tools/project-json-to-csproj.md
@@ -3,7 +3,6 @@ title: project.json and csproj comparison
 description: See a mapping between project.json and csproj elements.
 author: natemcmaster
 ms.date: 03/13/2017
-ms.custom: "seodec18"
 ---
 # A mapping between project.json and csproj properties
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -3,7 +3,6 @@ title: .NET Core SDK telemetry
 description: Discover the .NET Core SDK telemetry features that collect usage information for analysis, which data is collected, and how to disable it.
 author: KathleenDollard
 ms.date: 08/27/2019
-ms.custom: "seodec18"
 ---
 # .NET Core SDK telemetry
 

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -3,7 +3,6 @@ title: Continuous Integration (CI) with .NET Core SDK and tools
 description: Learn how to use the .NET Core SDK and its tools on the build server with continuous integration.
 author: mairaw
 ms.date: 05/18/2017
-ms.custom: seodec18
 ---
 # Using .NET Core SDK and tools in Continuous Integration (CI)
 

--- a/docs/core/tutorials/aspnet-core.md
+++ b/docs/core/tutorials/aspnet-core.md
@@ -2,7 +2,6 @@
 title: Get started with ASP.NET Core
 description: Learn more about ASP.NET Core with tutorials in the ASP.NET Core documentation.
 ms.date: 06/20/2016
-ms.custom: "seodec18"
 ---
 # Get started with ASP.NET Core
 

--- a/docs/core/tutorials/cli-create-console-app.md
+++ b/docs/core/tutorials/cli-create-console-app.md
@@ -5,7 +5,7 @@ author: thraka
 ms.author: adegeo
 ms.date: 12/05/2019
 ms.technology: dotnet-cli
-ms.custom: "seodec18,updateeachrelease"
+ms.custom: "updateeachrelease"
 ---
 # Get started with .NET Core on Windows/Linux/macOS using the command line
 

--- a/docs/core/tutorials/consuming-library-with-visual-studio.md
+++ b/docs/core/tutorials/consuming-library-with-visual-studio.md
@@ -5,7 +5,7 @@ ms.date: 12/20/2019
 dev_langs:
   - "csharp"
   - "vb"
-ms.custom: "vs-dotnet, seodec18"
+ms.custom: "vs-dotnet"
 ---
 # Consume a .NET Standard library in Visual Studio
 

--- a/docs/core/tutorials/debugging-with-visual-studio.md
+++ b/docs/core/tutorials/debugging-with-visual-studio.md
@@ -2,7 +2,7 @@
 title: Debug your Hello World .NET Core application with Visual Studio
 description: Learn how to debug a Hello World app written in C# or Visual Basic with Visual Studio.
 ms.date: 12/05/2019
-ms.custom: "vs-dotnet, seodec18"
+ms.custom: "vs-dotnet"
 ---
 # Debug your C# or Visual Basic .NET Core Hello World application using Visual Studio
 

--- a/docs/core/tutorials/index.md
+++ b/docs/core/tutorials/index.md
@@ -4,7 +4,6 @@ description: Follow tutorials for learning .NET Core to build apps and libraries
 author: richlander
 ms.date: 03/16/2017
 titleSuffix: ""
-ms.custom: seodec18
 ---
 # Learn .NET Core and the .NET Core SDK tools by exploring these tutorials
 

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -3,7 +3,6 @@ title: Developing Libraries with Cross Platform Tools
 description: Learn how to create .NET Core libraries using the .NET Core CLI tools. You'll create a library that supports multiple frameworks.
 author: cartermp
 ms.date: 05/01/2017
-ms.custom: seodec18
 ---
 # Develop libraries with cross-platform tools
 

--- a/docs/core/tutorials/library-with-visual-studio.md
+++ b/docs/core/tutorials/library-with-visual-studio.md
@@ -2,7 +2,7 @@
 title: Build a .NET Standard class library in Visual Studio
 description: Learn how to build a .NET Standard class library written in C# or Visual Basic using Visual Studio
 ms.date: 12/09/2019
-ms.custom: "vs-dotnet, seodec18"
+ms.custom: "vs-dotnet"
 ---
 # Build a .NET Standard library in Visual Studio
 

--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -3,7 +3,6 @@ title: Write a custom .NET Core runtime host
 description: Learn to host the .NET Core runtime from native code to support advanced scenarios that require controlling how the .NET Core runtime works.
 author: mjrousos
 ms.date: 12/21/2018
-ms.custom: seodec18
 ---
 # Write a custom .NET Core host to control the .NET runtime from your native code
 

--- a/docs/core/tutorials/publishing-with-visual-studio.md
+++ b/docs/core/tutorials/publishing-with-visual-studio.md
@@ -4,7 +4,7 @@ description: Publishing creates the set of files that are needed to run your .NE
 author: BillWagner
 ms.author: wiwagn
 ms.date: 12/10/2019
-ms.custom: "vs-dotnet, seodec18"
+ms.custom: "vs-dotnet"
 ---
 # Publish your .NET Core Hello World application with Visual Studio
 

--- a/docs/core/tutorials/testing-with-cli.md
+++ b/docs/core/tutorials/testing-with-cli.md
@@ -3,7 +3,6 @@ title: Organizing and testing projects with the .NET Core command line
 description: This tutorial explains how to organize and test .NET Core projects from the command line.
 author: cartermp
 ms.date: 09/10/2018
-ms.custom: "seodec18"
 ---
 
 # Organizing and testing projects with the .NET Core command line

--- a/docs/core/tutorials/using-on-mac-vs-full-solution.md
+++ b/docs/core/tutorials/using-on-mac-vs-full-solution.md
@@ -3,7 +3,6 @@ title: Build a complete .NET Core solution using Visual Studio for Mac
 description: This article walks you through building a .NET Core solution that includes a reusable library and unit testing.
 author: mairaw
 ms.date: 12/19/2019
-ms.custom: seodec18
 ---
 # Build a complete .NET Core solution on macOS using Visual Studio for Mac
 

--- a/docs/core/tutorials/using-on-mac-vs.md
+++ b/docs/core/tutorials/using-on-mac-vs.md
@@ -3,7 +3,6 @@ title: Get started with .NET Core using Visual Studio for Mac
 description: This topic walks you through building a simple console application using Visual Studio for Mac and .NET Core.
 author: mairaw
 ms.date: 12/19/2019
-ms.custom: "seodec18"
 ---
 # Get started with .NET Core on macOS using Visual Studio for Mac
 

--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -2,7 +2,6 @@
 title: "Tutorial: Create a .NET Core solution in macOS using Visual Studio Code"
 description: This document provides the steps and workflow to create a .NET Core Solution using Visual Studio Code.
 ms.date: 12/19/2019
-ms.custom: seodec18
 ---
 # Tutorial: Create a .NET Core solution in macOS using Visual Studio Code
 

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -3,7 +3,6 @@ title: Get started with C# and Visual Studio Code
 description: Learn how to create and debug your first .NET Core application in C# using Visual Studio Code.
 author: kendrahavens
 ms.date: 12/05/2018
-ms.custom: "seodec18"
 ---
 # Get started with C# and Visual Studio Code
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -4,7 +4,7 @@ description: Learn how to create your first .NET Core console application with C
 author: BillWagner
 ms.author: wiwagn
 ms.date: 12/09/2019
-ms.custom: "vs-dotnet, seodec18"
+ms.custom: "vs-dotnet"
 ---
 # Tutorial: Create your first .NET Core console application in Visual Studio 2019
 

--- a/docs/core/versions/index.md
+++ b/docs/core/versions/index.md
@@ -3,7 +3,6 @@ title: How the .NET Core Runtime and SDK are versioned
 description: This article teaches you how the .NET Core SDK and Runtime are versioned (similar to semantic versioning).
 author: bleroy
 ms.date: 07/26/2018
-ms.custom: "seodec18"
 ---
 
 # Overview of how .NET Core is versioned

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -4,7 +4,7 @@ description: This article describes how to determine which versions of the .NET 
 ms.date: 12/17/2019
 author: billwagner
 ms.author: wiwagn
-ms.custom: "seodec18,updateeachrelease"
+ms.custom: "updateeachrelease"
 ---
 
 # How to remove the .NET Core Runtime and SDK

--- a/docs/core/versions/selection.md
+++ b/docs/core/versions/selection.md
@@ -4,7 +4,6 @@ description: Learn how .NET Core automatically finds and chooses runtime version
 author: thraka
 ms.author: adegeo
 ms.date: 06/26/2019
-ms.custom: "seodec18"
 ---
 
 # Select the .NET Core version to use

--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -5,7 +5,6 @@ author: cartermp
 ms.date: 06/20/2016
 ms.technology: csharp-async
 ms.assetid: b878c34c-a78f-419e-a594-a2b44fa521a4
-ms.custom: seodec18
 ---
 # Asynchronous programming
 

--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -5,7 +5,6 @@ helpviewer_keywords:
   - "Visual C#, getting started"
   - "getting started, Visual C#"
 ms.date: 04/05/2019
-ms.custom: seoapril2019
 ---
 # Get started with C\#
 

--- a/docs/csharp/language-reference/keywords/abstract.md
+++ b/docs/csharp/language-reference/keywords/abstract.md
@@ -1,7 +1,5 @@
 ---
 title: "abstract - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "abstract"

--- a/docs/csharp/language-reference/keywords/access-modifiers.md
+++ b/docs/csharp/language-reference/keywords/access-modifiers.md
@@ -1,7 +1,5 @@
 ---
 title: "Access Modifiers - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "access modifiers [C#]"

--- a/docs/csharp/language-reference/keywords/accessibility-domain.md
+++ b/docs/csharp/language-reference/keywords/accessibility-domain.md
@@ -1,7 +1,5 @@
 ---
 title: "Accessibility Domain - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "accessibility domain [C#]"

--- a/docs/csharp/language-reference/keywords/accessibility-levels.md
+++ b/docs/csharp/language-reference/keywords/accessibility-levels.md
@@ -1,7 +1,5 @@
 ---
 title: "Accessibility Levels - C# Reference"
-ms.custom: seodec18
-
 ms.date: 12/06/2017
 helpviewer_keywords: 
   - "access modifiers [C#], accessibility levels"

--- a/docs/csharp/language-reference/keywords/add.md
+++ b/docs/csharp/language-reference/keywords/add.md
@@ -1,7 +1,5 @@
 ---
 title: "add - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "add_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/ascending.md
+++ b/docs/csharp/language-reference/keywords/ascending.md
@@ -1,7 +1,5 @@
 ---
 title: "ascending - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "ascending"

--- a/docs/csharp/language-reference/keywords/async.md
+++ b/docs/csharp/language-reference/keywords/async.md
@@ -1,6 +1,5 @@
 ---
 title: "async - C# Reference"
-ms.custom: seodec18
 ms.date: 05/22/2017
 f1_keywords: 
   - "async_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/base.md
+++ b/docs/csharp/language-reference/keywords/base.md
@@ -1,6 +1,5 @@
 ---
 title: "base keyword - C# Reference"
-ms.custom: seodec18
 description: Learn about the base keyword, which is used to access members of the base class from within a derived class in C#.
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/csharp/language-reference/keywords/break.md
+++ b/docs/csharp/language-reference/keywords/break.md
@@ -1,7 +1,5 @@
 ---
 title: "break statement - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "break"

--- a/docs/csharp/language-reference/keywords/built-in-types-table.md
+++ b/docs/csharp/language-reference/keywords/built-in-types-table.md
@@ -1,7 +1,5 @@
 ---
 title: "Built-in types table - C# Reference"
-ms.custom: seodec18
-
 description: "Keywords for built-in C# types"
 ms.date: 08/17/2018
 helpviewer_keywords: 

--- a/docs/csharp/language-reference/keywords/by.md
+++ b/docs/csharp/language-reference/keywords/by.md
@@ -1,7 +1,5 @@
 ---
 title: "by contextual keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "by"

--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -1,6 +1,5 @@
 ---
 title: "Checked and Unchecked - C# Reference"
-ms.custom: seodec18
 ms.date: 05/15/2018
 helpviewer_keywords: 
   - "operators [C#], checked and unchecked"

--- a/docs/csharp/language-reference/keywords/checked.md
+++ b/docs/csharp/language-reference/keywords/checked.md
@@ -1,7 +1,5 @@
 ---
 title: "checked keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "checked_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/class.md
+++ b/docs/csharp/language-reference/keywords/class.md
@@ -1,7 +1,5 @@
 ---
 title: "class keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/18/2017
 f1_keywords: 
   - "class_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/const.md
+++ b/docs/csharp/language-reference/keywords/const.md
@@ -1,7 +1,5 @@
 ---
 title: "const keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "const_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/contextual-keywords.md
+++ b/docs/csharp/language-reference/keywords/contextual-keywords.md
@@ -1,6 +1,5 @@
 ---
 title: "Contextual Keywords - C# Reference"
-ms.custom: seodec18
 ms.date: 03/07/2017
 helpviewer_keywords: 
   - "contextual keywords [C#]"

--- a/docs/csharp/language-reference/keywords/continue.md
+++ b/docs/csharp/language-reference/keywords/continue.md
@@ -1,7 +1,5 @@
 ---
 title: "continue statement - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "continue_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/default-values-table.md
+++ b/docs/csharp/language-reference/keywords/default-values-table.md
@@ -1,6 +1,5 @@
 ---
 title: "Default values table - C# reference"
-ms.custom: seodec18
 description: Learn what are the default values of C# types.
 ms.date: 12/18/2019
 helpviewer_keywords: 

--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -1,6 +1,5 @@
 ---
 title: "default - C# Reference"
-ms.custom: seodec18
 ms.date: 08/04/2017
 f1_keywords: 
   - "default"

--- a/docs/csharp/language-reference/keywords/descending.md
+++ b/docs/csharp/language-reference/keywords/descending.md
@@ -1,7 +1,5 @@
 ---
 title: "descending contextual keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "descending"

--- a/docs/csharp/language-reference/keywords/do.md
+++ b/docs/csharp/language-reference/keywords/do.md
@@ -1,6 +1,5 @@
 ---
 title: "do - C# Reference"
-ms.custom: seodec18
 ms.date: 05/28/2018
 f1_keywords: 
   - "do_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/equals.md
+++ b/docs/csharp/language-reference/keywords/equals.md
@@ -1,7 +1,5 @@
 ---
 title: "equals contextual keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "equals_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/event.md
+++ b/docs/csharp/language-reference/keywords/event.md
@@ -1,6 +1,5 @@
 ---
 title: "event - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords:
   - "event"

--- a/docs/csharp/language-reference/keywords/extern-alias.md
+++ b/docs/csharp/language-reference/keywords/extern-alias.md
@@ -1,6 +1,5 @@
 ---
 title: "extern alias - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "alias_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/extern.md
+++ b/docs/csharp/language-reference/keywords/extern.md
@@ -1,7 +1,5 @@
 ---
 title: "extern modifier - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords:
   - "extern_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/fixed-statement.md
+++ b/docs/csharp/language-reference/keywords/fixed-statement.md
@@ -1,6 +1,5 @@
 ---
 title: "fixed Statement - C# Reference"
-ms.custom: seodec18
 ms.date: 05/10/2018
 f1_keywords: 
   - "fixed_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/formatting-numeric-results-table.md
+++ b/docs/csharp/language-reference/keywords/formatting-numeric-results-table.md
@@ -1,7 +1,5 @@
 ---
 title: "Formatting numeric results table - C# Reference"
-ms.custom: seodec18
-
 description: "Learn about C# standard numeric format strings"
 ms.date: 09/20/2018
 helpviewer_keywords: 

--- a/docs/csharp/language-reference/keywords/from-clause.md
+++ b/docs/csharp/language-reference/keywords/from-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "from clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "from_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/get.md
+++ b/docs/csharp/language-reference/keywords/get.md
@@ -1,7 +1,5 @@
 ---
 title: "get - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/10/2017
 f1_keywords: 
   - "get_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/goto.md
+++ b/docs/csharp/language-reference/keywords/goto.md
@@ -1,7 +1,5 @@
 ---
 title: "goto statement - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "goto_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/group-clause.md
+++ b/docs/csharp/language-reference/keywords/group-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "group clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "group"

--- a/docs/csharp/language-reference/keywords/if-else.md
+++ b/docs/csharp/language-reference/keywords/if-else.md
@@ -1,6 +1,5 @@
 ---
 title: "if-else - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "if_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/in-generic-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-generic-modifier.md
@@ -1,7 +1,5 @@
 ---
 title: "in (Generic Modifier) - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "contravariance, in keyword [C#]"

--- a/docs/csharp/language-reference/keywords/in-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-parameter-modifier.md
@@ -1,6 +1,5 @@
 ---
 title: "in parameter modifier - C# Reference"
-ms.custom: seodec18
 ms.date: 03/26/2019
 helpviewer_keywords: 
   - "parameters [C#], in"

--- a/docs/csharp/language-reference/keywords/in.md
+++ b/docs/csharp/language-reference/keywords/in.md
@@ -1,7 +1,5 @@
 ---
 title: "in - C# Reference"
-ms.custom: seodec18
-
 ms.date: 02/06/2018
 f1_keywords: 
   - "in"

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -1,7 +1,5 @@
 ---
 title: "interface - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "interface_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/internal.md
+++ b/docs/csharp/language-reference/keywords/internal.md
@@ -1,7 +1,5 @@
 ---
 title: "internal - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "internal_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/into.md
+++ b/docs/csharp/language-reference/keywords/into.md
@@ -1,7 +1,5 @@
 ---
 title: "into - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "into_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/is.md
+++ b/docs/csharp/language-reference/keywords/is.md
@@ -1,6 +1,5 @@
 ---
 title: "is - C# Reference"
-ms.custom: seodec18
 ms.date: 06/21/2019
 f1_keywords: 
   - "is_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/join-clause.md
+++ b/docs/csharp/language-reference/keywords/join-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "join clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "join"

--- a/docs/csharp/language-reference/keywords/let-clause.md
+++ b/docs/csharp/language-reference/keywords/let-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "let clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "let_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/lock-statement.md
+++ b/docs/csharp/language-reference/keywords/lock-statement.md
@@ -1,6 +1,5 @@
 ---
 title: "lock statement - C# reference"
-ms.custom: seodec18
 description: "Use the C# lock statement to synchronize thread access to a shared resource"
 ms.date: 10/01/2018
 f1_keywords: 

--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -1,7 +1,5 @@
 ---
 title: "Method Parameters - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "methods [C#], parameters"

--- a/docs/csharp/language-reference/keywords/namespace.md
+++ b/docs/csharp/language-reference/keywords/namespace.md
@@ -1,6 +1,5 @@
 ---
 title: "namespace keyword - C# Reference"
-ms.custom: seoapril2019
 ms.date: 07/20/2015
 f1_keywords: 
   - "namespace_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/new-constraint.md
+++ b/docs/csharp/language-reference/keywords/new-constraint.md
@@ -1,6 +1,5 @@
 ---
 title: "new constraint - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "new constraint keyword [C#]"

--- a/docs/csharp/language-reference/keywords/new-modifier.md
+++ b/docs/csharp/language-reference/keywords/new-modifier.md
@@ -1,6 +1,5 @@
 ---
 title: "new modifier - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "new modifier keyword [C#]"

--- a/docs/csharp/language-reference/keywords/null.md
+++ b/docs/csharp/language-reference/keywords/null.md
@@ -1,6 +1,5 @@
 ---
 title: "null keyword - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords:
   - "null"

--- a/docs/csharp/language-reference/keywords/on.md
+++ b/docs/csharp/language-reference/keywords/on.md
@@ -1,7 +1,5 @@
 ---
 title: "on keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "on_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/orderby-clause.md
+++ b/docs/csharp/language-reference/keywords/orderby-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "orderby clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "orderby"

--- a/docs/csharp/language-reference/keywords/out-generic-modifier.md
+++ b/docs/csharp/language-reference/keywords/out-generic-modifier.md
@@ -1,7 +1,5 @@
 ---
 title: "out keyword (generic modifier) - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "covariance, out keyword [C#]"

--- a/docs/csharp/language-reference/keywords/out-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/out-parameter-modifier.md
@@ -1,7 +1,5 @@
 ---
 title: "out parameter modifier - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/26/2019
 helpviewer_keywords: 
   - "parameters [C#], out"

--- a/docs/csharp/language-reference/keywords/out.md
+++ b/docs/csharp/language-reference/keywords/out.md
@@ -1,7 +1,5 @@
 ---
 title: "out keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/01/2017
 f1_keywords: 
   - "out_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/override.md
+++ b/docs/csharp/language-reference/keywords/override.md
@@ -1,6 +1,5 @@
 ---
 title: "override modifier - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "override"

--- a/docs/csharp/language-reference/keywords/params.md
+++ b/docs/csharp/language-reference/keywords/params.md
@@ -1,7 +1,5 @@
 ---
 title: "params keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "params_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/partial-method.md
+++ b/docs/csharp/language-reference/keywords/partial-method.md
@@ -1,7 +1,5 @@
 ---
 title: "partial method - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "partialmethod_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/partial-type.md
+++ b/docs/csharp/language-reference/keywords/partial-type.md
@@ -1,7 +1,5 @@
 ---
 title: "partial type - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "partialtype"

--- a/docs/csharp/language-reference/keywords/private-protected.md
+++ b/docs/csharp/language-reference/keywords/private-protected.md
@@ -1,7 +1,5 @@
 ---
 title: "private protected - C# Reference"
-ms.custom: seodec18
-
 ms.date: 11/15/2017
 author: "sputier"
 ---

--- a/docs/csharp/language-reference/keywords/private.md
+++ b/docs/csharp/language-reference/keywords/private.md
@@ -1,7 +1,5 @@
 ---
 title: "private keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "private_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -1,7 +1,5 @@
 ---
 title: "protected internal - C# Reference"
-ms.custom: seodec18
-
 ms.date: 11/15/2017
 author: "sputier"
 ---

--- a/docs/csharp/language-reference/keywords/protected.md
+++ b/docs/csharp/language-reference/keywords/protected.md
@@ -1,7 +1,5 @@
 ---
 title: "protected keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords:
   - "protected"

--- a/docs/csharp/language-reference/keywords/public.md
+++ b/docs/csharp/language-reference/keywords/public.md
@@ -1,7 +1,5 @@
 ---
 title: "public keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords:
   - "public"

--- a/docs/csharp/language-reference/keywords/query-keywords.md
+++ b/docs/csharp/language-reference/keywords/query-keywords.md
@@ -1,7 +1,5 @@
 ---
 title: "Query keywords - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "query keywords [C#]"

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -1,6 +1,5 @@
 ---
 title: "readonly keyword - C# Reference"
-ms.custom: seodec18
 ms.date: 06/21/2018
 f1_keywords: 
   - "readonly_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -1,7 +1,5 @@
 ---
 title: "ref keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/26/2019
 f1_keywords: 
   - "ref_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/reference-types.md
+++ b/docs/csharp/language-reference/keywords/reference-types.md
@@ -1,7 +1,5 @@
 ---
 title: "Reference types - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "cs.referencetypes"

--- a/docs/csharp/language-reference/keywords/remove.md
+++ b/docs/csharp/language-reference/keywords/remove.md
@@ -1,7 +1,5 @@
 ---
 title: "remove contextual keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "remove_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/restrictions-on-using-accessibility-levels.md
+++ b/docs/csharp/language-reference/keywords/restrictions-on-using-accessibility-levels.md
@@ -1,7 +1,5 @@
 ---
 title: "Restrictions on using accessibility levels - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "access modifiers [C#], accessibility level restrictions"

--- a/docs/csharp/language-reference/keywords/return.md
+++ b/docs/csharp/language-reference/keywords/return.md
@@ -1,7 +1,5 @@
 ---
 title: "return statement - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "return_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/sealed.md
+++ b/docs/csharp/language-reference/keywords/sealed.md
@@ -1,7 +1,5 @@
 ---
 title: "sealed modifier - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "sealed"

--- a/docs/csharp/language-reference/keywords/select-clause.md
+++ b/docs/csharp/language-reference/keywords/select-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "select clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "select_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/set.md
+++ b/docs/csharp/language-reference/keywords/set.md
@@ -1,7 +1,5 @@
 ---
 title: "set keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/10/2017
 f1_keywords: 
   - "set"

--- a/docs/csharp/language-reference/keywords/statement-keywords.md
+++ b/docs/csharp/language-reference/keywords/statement-keywords.md
@@ -1,7 +1,5 @@
 ---
 title: "Statement keywords - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "keywords [C#], statements"

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -1,7 +1,5 @@
 ---
 title: "static modifier - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "static"

--- a/docs/csharp/language-reference/keywords/struct.md
+++ b/docs/csharp/language-reference/keywords/struct.md
@@ -1,6 +1,5 @@
 ---
 title: "struct - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "struct_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/this.md
+++ b/docs/csharp/language-reference/keywords/this.md
@@ -1,7 +1,5 @@
 ---
 title: "this keyword - C# Reference"
-ms.custom: seodec18
-
 description: this keyword (C# Reference)
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/csharp/language-reference/keywords/throw.md
+++ b/docs/csharp/language-reference/keywords/throw.md
@@ -1,7 +1,5 @@
 ---
 title: "throw - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/02/2015
 f1_keywords: 
   - "throw"

--- a/docs/csharp/language-reference/keywords/try-catch-finally.md
+++ b/docs/csharp/language-reference/keywords/try-catch-finally.md
@@ -1,6 +1,5 @@
 ---
 title: "try-catch-finally - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "catch-finally_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/try-catch.md
+++ b/docs/csharp/language-reference/keywords/try-catch.md
@@ -1,6 +1,5 @@
 ---
 title: "try-catch - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "try"

--- a/docs/csharp/language-reference/keywords/try-finally.md
+++ b/docs/csharp/language-reference/keywords/try-finally.md
@@ -1,7 +1,5 @@
 ---
 title: "try-finally - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "finally"

--- a/docs/csharp/language-reference/keywords/unchecked.md
+++ b/docs/csharp/language-reference/keywords/unchecked.md
@@ -1,7 +1,5 @@
 ---
 title: "unchecked keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords:
   - "unchecked_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/unsafe.md
+++ b/docs/csharp/language-reference/keywords/unsafe.md
@@ -1,6 +1,5 @@
 ---
 title: "unsafe keyword - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords:
   - "unsafe_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -1,6 +1,5 @@
 ---
 title: "using directive - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "using directive [C#]"

--- a/docs/csharp/language-reference/keywords/using-statement.md
+++ b/docs/csharp/language-reference/keywords/using-statement.md
@@ -1,6 +1,5 @@
 ---
 title: "using statement - C# Reference"
-ms.custom: seodec18
 ms.date: 10/15/2019
 helpviewer_keywords:
   - "using statement [C#]"

--- a/docs/csharp/language-reference/keywords/using-static.md
+++ b/docs/csharp/language-reference/keywords/using-static.md
@@ -1,6 +1,5 @@
 ---
 title: "using static directive - C# Reference"
-ms.custom: seodec18
 ms.date: 03/10/2017
 helpviewer_keywords: 
   - "using static directive [C#]"

--- a/docs/csharp/language-reference/keywords/using.md
+++ b/docs/csharp/language-reference/keywords/using.md
@@ -1,6 +1,5 @@
 ---
 title: "using keyword - C# Reference"
-ms.custom: seoapril2019
 ms.date: 04/05/2019
 f1_keywords: 
   - "using_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/value-types-table.md
+++ b/docs/csharp/language-reference/keywords/value-types-table.md
@@ -1,6 +1,5 @@
 ---
 title: "Value types table - C# reference"
-ms.custom: seodec18
 ms.date: 11/06/2019
 helpviewer_keywords: 
   - "value types [C#], table"

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -1,6 +1,5 @@
 ---
 title: "Value types - C# Reference"
-ms.custom: seodec18
 ms.date: 11/26/2018
 f1_keywords: 
   - "cs.valuetypes"

--- a/docs/csharp/language-reference/keywords/value.md
+++ b/docs/csharp/language-reference/keywords/value.md
@@ -1,6 +1,5 @@
 ---
 title: "value contextual keyword - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "value_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/var.md
+++ b/docs/csharp/language-reference/keywords/var.md
@@ -1,7 +1,5 @@
 ---
 title: "var - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "var"

--- a/docs/csharp/language-reference/keywords/virtual.md
+++ b/docs/csharp/language-reference/keywords/virtual.md
@@ -1,6 +1,5 @@
 ---
 title: "virtual - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "virtual_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/void.md
+++ b/docs/csharp/language-reference/keywords/void.md
@@ -1,7 +1,5 @@
 ---
 title: "void - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "void_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/volatile.md
+++ b/docs/csharp/language-reference/keywords/volatile.md
@@ -1,7 +1,5 @@
 ---
 title: "volatile - C# Reference"
-ms.custom: seodec18
-
 ms.date: 10/24/2018
 f1_keywords: 
   - "volatile_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/when.md
+++ b/docs/csharp/language-reference/keywords/when.md
@@ -1,7 +1,5 @@
 ---
 title: "when contextual keyword - C# Reference"
-ms.custom: seodec18
-
 ms.date: 03/07/2017
 f1_keywords: 
   - "when_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/where-clause.md
+++ b/docs/csharp/language-reference/keywords/where-clause.md
@@ -1,7 +1,5 @@
 ---
 title: "where clause - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "whereclause_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
+++ b/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
@@ -1,6 +1,5 @@
 ---
 title: "where (generic type constraint) - C# Reference"
-ms.custom: seodec18
 
 ms.date: 04/12/2018
 f1_keywords:

--- a/docs/csharp/language-reference/keywords/while.md
+++ b/docs/csharp/language-reference/keywords/while.md
@@ -1,6 +1,5 @@
 ---
 title: "while - C# Reference"
-ms.custom: seodec18
 ms.date: 05/28/2018
 f1_keywords: 
   - "while_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -1,6 +1,5 @@
 ---
 title: "yield contextual keyword - C# Reference"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "yield"

--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "+ and += operators - C# reference"
-ms.custom: seodec18
 ms.date: 05/24/2019
 f1_keywords: 
   - "+_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "Assignment operators - C# reference"
-ms.custom: seodec18
 ms.date: 09/10/2019
 f1_keywords: 
   - "=_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/await.md
+++ b/docs/csharp/language-reference/operators/await.md
@@ -1,6 +1,5 @@
 ---
 title: "await operator - C# reference"
-ms.custom: seodec18
 ms.date: 11/08/2019
 f1_keywords: 
   - "await_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "?: operator - C# reference"
-ms.custom: seodec18
 ms.date: "11/20/2018"
 f1_keywords:
   - "?:_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -1,6 +1,5 @@
 ---
 title: "default operator - C# reference"
-ms.custom: seodec18
 description: "Use the default operator to produce the default value of a type"
 ms.date: 08/01/2019
 helpviewer_keywords: 

--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "=> operator - C# reference"
-ms.custom: seodec18
 ms.date: 01/22/2019
 f1_keywords: 
   - "=>_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -1,6 +1,5 @@
 ---
 title: "nameof operator - C# reference"
-ms.custom: seodec18
 ms.date: 07/12/2019
 f1_keywords:
   - "nameof_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/namespace-alias-qualifier.md
+++ b/docs/csharp/language-reference/operators/namespace-alias-qualifier.md
@@ -1,6 +1,5 @@
 ---
 title: ":: operator - C# reference"
-ms.custom: seodec18
 ms.date: 08/09/2019
 f1_keywords: 
   - "::_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/new-operator.md
+++ b/docs/csharp/language-reference/operators/new-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "new operator - C# reference"
-ms.custom: seodec18
 ms.date: 06/25/2019
 helpviewer_keywords: 
   - "new operator keyword [C#]"

--- a/docs/csharp/language-reference/operators/null-coalescing-operator.md
+++ b/docs/csharp/language-reference/operators/null-coalescing-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "?? and ??= operators - C# reference"
-ms.custom: seodec18
 ms.date: 09/10/2019
 f1_keywords: 
   - "??_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -1,6 +1,5 @@
 ---
 title: "sizeof operator - C# reference"
-ms.custom: seodec18
 ms.date: 07/25/2019
 f1_keywords: 
   - "sizeof_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -1,6 +1,5 @@
 ---
 title: "stackalloc operator - C# reference"
-ms.custom: seodec18
 ms.date: 09/20/2019
 f1_keywords: 
   - "stackalloc_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/subtraction-operator.md
+++ b/docs/csharp/language-reference/operators/subtraction-operator.md
@@ -1,6 +1,5 @@
 ---
 title: "- and -= operators - C# reference"
-ms.custom: seodec18
 ms.date: 05/27/2019
 f1_keywords: 
   - "-_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/true-false-operators.md
+++ b/docs/csharp/language-reference/operators/true-false-operators.md
@@ -1,6 +1,5 @@
 ---
 title: "true and false operators - C# reference"
-ms.custom: seodec18
 ms.date: 12/10/2018
 helpviewer_keywords: 
   - "false operator [C#]"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-define.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-define.md
@@ -1,7 +1,5 @@
 ---
 title: "#define - C# Reference"
-ms.custom: seodec18
-
 ms.date: 06/30/2018
 f1_keywords: 
   - "#define"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-elif.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-elif.md
@@ -1,7 +1,5 @@
 ---
 title: "#elif - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#elif"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-else.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-else.md
@@ -1,7 +1,5 @@
 ---
 title: "#else - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#else"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-endif.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-endif.md
@@ -1,7 +1,5 @@
 ---
 title: "#endif - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#endif"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-endregion.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-endregion.md
@@ -1,7 +1,5 @@
 ---
 title: "#endregion - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#endregion"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-error.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-error.md
@@ -1,7 +1,5 @@
 ---
 title: "#error - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#error"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
@@ -1,6 +1,5 @@
 ---
 title: "#if preprocessor directive - C# Reference"
-ms.custom: seodec18
 ms.date: 10/27/2019
 f1_keywords: 
   - "#if"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
@@ -1,7 +1,5 @@
 ---
 title: "#line - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords:
   - "#line"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md
@@ -1,7 +1,5 @@
 ---
 title: "#pragma checksum - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#pragma checksum"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md
@@ -1,7 +1,5 @@
 ---
 title: "#pragma warning - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#pragma warning"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma.md
@@ -1,7 +1,5 @@
 ---
 title: "#pragma - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#pragma"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
@@ -1,7 +1,5 @@
 ---
 title: "#region - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#region"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-undef.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-undef.md
@@ -1,7 +1,5 @@
 ---
 title: "#undef - C# Reference"
-ms.custom: seodec18
-
 ms.date: 06/30/2018
 f1_keywords: 
   - "#undef"

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-warning.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-warning.md
@@ -1,7 +1,5 @@
 ---
 title: "#warning - C# Reference"
-ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "#warning"

--- a/docs/csharp/language-reference/tokens/index.md
+++ b/docs/csharp/language-reference/tokens/index.md
@@ -1,7 +1,5 @@
 ---
 title: "Special Characters - C# Reference"
-ms.custom: seodec18
-
 ms.date: 02/14/2017
 f1_keywords: 
   - "cs.special characters"

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -1,6 +1,5 @@
 ---
 title: "$ - string interpolation - C# reference"
-ms.custom: seodec18
 description: String interpolation provides a more readable and convenient syntax to format string output than traditional string composite formatting.
 ms.date: 09/02/2019
 f1_keywords: 

--- a/docs/csharp/language-reference/tokens/verbatim.md
+++ b/docs/csharp/language-reference/tokens/verbatim.md
@@ -1,7 +1,5 @@
 ---
 title: "@ - C# Reference"
-ms.custom: seodec18
-
 ms.date: 02/09/2017
 f1_keywords: 
   - "@_CSharpKeyword"

--- a/docs/csharp/programming-guide/arrays/arrays-as-objects.md
+++ b/docs/csharp/programming-guide/arrays/arrays-as-objects.md
@@ -1,6 +1,5 @@
 ---
 title: "Arrays as Objects - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "arrays [C#], as objects"

--- a/docs/csharp/programming-guide/arrays/implicitly-typed-arrays.md
+++ b/docs/csharp/programming-guide/arrays/implicitly-typed-arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Implicitly Typed Arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "arrays [C#], implicitly-typed"

--- a/docs/csharp/programming-guide/arrays/index.md
+++ b/docs/csharp/programming-guide/arrays/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "arrays [C#]"

--- a/docs/csharp/programming-guide/arrays/jagged-arrays.md
+++ b/docs/csharp/programming-guide/arrays/jagged-arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Jagged Arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "jagged arrays [C#]"

--- a/docs/csharp/programming-guide/arrays/multidimensional-arrays.md
+++ b/docs/csharp/programming-guide/arrays/multidimensional-arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Multidimensional Arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "arrays [C#], multidimensional"

--- a/docs/csharp/programming-guide/arrays/passing-arrays-as-arguments.md
+++ b/docs/csharp/programming-guide/arrays/passing-arrays-as-arguments.md
@@ -1,6 +1,5 @@
 ---
 title: "Passing arrays as arguments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/05/2018
 helpviewer_keywords: 
   - "arrays [C#], passing as arguments"

--- a/docs/csharp/programming-guide/arrays/single-dimensional-arrays.md
+++ b/docs/csharp/programming-guide/arrays/single-dimensional-arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Single-Dimensional Arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "single-dimensional arrays [C#]"

--- a/docs/csharp/programming-guide/arrays/using-foreach-with-arrays.md
+++ b/docs/csharp/programming-guide/arrays/using-foreach-with-arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Using foreach with arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 05/23/2018
 helpviewer_keywords: 
   - "arrays [C#], foreach"

--- a/docs/csharp/programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md
@@ -1,6 +1,5 @@
 ---
 title: "Abstract and Sealed Classes and Class Members - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "abstract classes [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -1,6 +1,5 @@
 ---
 title: "Access Modifiers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# Language, access modifiers"

--- a/docs/csharp/programming-guide/classes-and-structs/anonymous-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/anonymous-types.md
@@ -1,6 +1,5 @@
 ---
 title: "Anonymous Types - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "anonymous types [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/auto-implemented-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/auto-implemented-properties.md
@@ -1,6 +1,5 @@
 ---
 title: "Auto-Implemented Properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "auto-implemented properties [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/classes.md
+++ b/docs/csharp/programming-guide/classes-and-structs/classes.md
@@ -1,6 +1,5 @@
 ---
 title: "Classes - C# Programming Guide"
-ms.custom: seodec18
 description: Learn about the class types and how to create them
 ms.date: 08/21/2018
 helpviewer_keywords: 

--- a/docs/csharp/programming-guide/classes-and-structs/constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constants.md
@@ -1,6 +1,5 @@
 ---
 title: "Constants - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, constants"

--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Constructors - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 05/05/2017
 helpviewer_keywords: 
   - "constructors [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/destructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/destructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Finalizers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 10/08/2018
 helpviewer_keywords: 
   - "~ [C#], in finalizers"

--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -1,6 +1,5 @@
 ---
 title: "Extension Methods - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "methods [C#], adding to existing types"

--- a/docs/csharp/programming-guide/classes-and-structs/fields.md
+++ b/docs/csharp/programming-guide/classes-and-structs/fields.md
@@ -1,6 +1,5 @@
 ---
 title: Fields - C# Programming Guide
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "fields [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
@@ -1,6 +1,5 @@
 ---
 title: "How to create a new method for an enumeration - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "enumerations [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-declare-and-use-read-write-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-declare-and-use-read-write-properties.md
@@ -1,6 +1,5 @@
 ---
 title: "How to declare and use read write properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "get accessor [C#], declaring properties"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-define-abstract-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-define-abstract-properties.md
@@ -1,6 +1,5 @@
 ---
 title: "How to define abstract properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "properties [C#], abstract"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-implement-a-lightweight-class-with-auto-implemented-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-implement-a-lightweight-class-with-auto-implemented-properties.md
@@ -1,6 +1,5 @@
 ---
 title: "How to implement a lightweight class with auto-implemented properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "auto-implemented properties [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-implement-and-call-a-custom-extension-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-implement-and-call-a-custom-extension-method.md
@@ -1,6 +1,5 @@
 ---
 title: "How to implement and call a custom extension method - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "extension methods [C#], implementing and calling"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -1,6 +1,5 @@
 ---
 title: "How to initialize a dictionary with a collection initializer - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 12/20/2018
 helpviewer_keywords: 
   - "collection initializers [C#], with Dictionary"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
@@ -1,6 +1,5 @@
 ---
 title: "How to initialize objects by using an object initializer - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 12/20/2018
 helpviewer_keywords: 
   - "object initializers [C#], how to use"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-know-the-difference-passing-a-struct-and-passing-a-class-to-a-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-know-the-difference-passing-a-struct-and-passing-a-class-to-a-method.md
@@ -1,6 +1,5 @@
 ---
 title: "How to know the difference between passing a struct and passing a class reference to a method - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "structs [C#], passing as method parameter"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-override-the-tostring-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-override-the-tostring-method.md
@@ -1,6 +1,5 @@
 ---
 title: "How to override the ToString method - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "ToString method, overriding in C#"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-return-subsets-of-element-properties-in-a-query.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-return-subsets-of-element-properties-in-a-query.md
@@ -1,6 +1,5 @@
 ---
 title: "How to return subsets of element properties in a query - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "anonymous types [C#], for subsets of element properties"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-use-implicitly-typed-local-variables-and-arrays-in-a-query-expression.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-use-implicitly-typed-local-variables-and-arrays-in-a-query-expression.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use implicitly typed local variables and arrays in a query expression - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "implicitly-typed local variables [C#], how to use"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-use-named-and-optional-arguments-in-office-programming.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-use-named-and-optional-arguments-in-office-programming.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use named and optional arguments in Office programming - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "named and optional arguments [C#], Office programming"

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md
@@ -1,6 +1,5 @@
 ---
 title: "How to write a copy constructor - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# Language, copy constructor"

--- a/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
+++ b/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
@@ -1,6 +1,5 @@
 ---
 title: "Implicitly typed local variables - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "implicitly-typed local variables [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/index.md
+++ b/docs/csharp/programming-guide/classes-and-structs/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Classes and Structs - C# Programming Guide"
-ms.custom: seodec18
 description: Describes the use of classes and structures (structs) in C#.
 ms.date: 01/17/2016
 helpviewer_keywords: 

--- a/docs/csharp/programming-guide/classes-and-structs/inheritance.md
+++ b/docs/csharp/programming-guide/classes-and-structs/inheritance.md
@@ -1,6 +1,5 @@
 ---
 title: "Inheritance - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "abstract methods [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Instance Constructors - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "constructors [C#], instance constructors"

--- a/docs/csharp/programming-guide/classes-and-structs/interface-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/interface-properties.md
@@ -1,6 +1,5 @@
 ---
 title: "Interface Properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "properties [C#], on interfaces"

--- a/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md
@@ -1,6 +1,5 @@
 ---
 title: "Knowing When to Use Override and New Keywords - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "override keyword [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -1,6 +1,5 @@
 ---
 title: "Local functions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 06/14/2017
 helpviewer_keywords: 
   - "local functions [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/members.md
@@ -1,6 +1,5 @@
 ---
 title: "Members - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "types [C#], nested types"

--- a/docs/csharp/programming-guide/classes-and-structs/methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/methods.md
@@ -1,6 +1,5 @@
 ---
 title: "Methods - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "methods [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -1,6 +1,5 @@
 ---
 title: "Named and Optional Arguments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "namedParameter_CSharpKeyword"

--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -1,6 +1,5 @@
 ---
 title: "Nested Types - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/10/2017
 helpviewer_keywords: 
   - "nested types [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -1,6 +1,5 @@
 ---
 title: "Object and Collection Initializers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 12/19/2018
 helpviewer_keywords: 
   - "object initializers [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/objects.md
+++ b/docs/csharp/programming-guide/classes-and-structs/objects.md
@@ -1,6 +1,5 @@
 ---
 title: "Objects - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "objects [C#], about objects"

--- a/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
@@ -1,6 +1,5 @@
 ---
 title: "Partial Classes and Methods - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "partial methods [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/passing-parameters.md
+++ b/docs/csharp/programming-guide/classes-and-structs/passing-parameters.md
@@ -1,6 +1,5 @@
 ---
 title: "Passing Parameters - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "parameters [C#], passing"

--- a/docs/csharp/programming-guide/classes-and-structs/passing-reference-type-parameters.md
+++ b/docs/csharp/programming-guide/classes-and-structs/passing-reference-type-parameters.md
@@ -1,6 +1,5 @@
 ---
 title: "Passing Reference-Type Parameters - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "method parameters [C#], reference types"

--- a/docs/csharp/programming-guide/classes-and-structs/passing-value-type-parameters.md
+++ b/docs/csharp/programming-guide/classes-and-structs/passing-value-type-parameters.md
@@ -1,6 +1,5 @@
 ---
 title: "Passing Value-Type Parameters - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "method parameters [C#], value types"

--- a/docs/csharp/programming-guide/classes-and-structs/polymorphism.md
+++ b/docs/csharp/programming-guide/classes-and-structs/polymorphism.md
@@ -1,6 +1,5 @@
 ---
 title: "Polymorphism - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, polymorphism"

--- a/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Private Constructors - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, private constructors"

--- a/docs/csharp/programming-guide/classes-and-structs/properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/properties.md
@@ -1,6 +1,5 @@
 ---
 title: "Properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 03/10/2017
 f1_keywords: 
   - "cs.properties"

--- a/docs/csharp/programming-guide/classes-and-structs/restricting-accessor-accessibility.md
+++ b/docs/csharp/programming-guide/classes-and-structs/restricting-accessor-accessibility.md
@@ -1,6 +1,5 @@
 ---
 title: "Restricting Accessor Accessibility - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "read-only properties [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
@@ -1,6 +1,5 @@
 ---
 title: "Static Classes and Static Class Members - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, static members"

--- a/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Static Constructors - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "static constructors [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/structs.md
+++ b/docs/csharp/programming-guide/classes-and-structs/structs.md
@@ -1,6 +1,5 @@
 ---
 title: "Structs - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 08/21/2018
 helpviewer_keywords: 
   - "C# language, structs"

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Constructors - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "constructors [C#], about constructors"

--- a/docs/csharp/programming-guide/classes-and-structs/using-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-properties.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Properties - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "set accessor [C#]"

--- a/docs/csharp/programming-guide/classes-and-structs/using-structs.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-structs.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Structs - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "structs [C#], using"

--- a/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
@@ -1,6 +1,5 @@
 ---
 title: "Versioning with the Override and New Keywords - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, versioning"

--- a/docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods.md
+++ b/docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods.md
@@ -1,6 +1,5 @@
 ---
 title: "Delegates with Named vs. Anonymous Methods - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "delegates [C#], with named vs. anonymous methods"

--- a/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md
+++ b/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md
@@ -1,6 +1,5 @@
 ---
 title: "How to combine delegates (Multicast Delegates) - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "delegates [C#], combining"

--- a/docs/csharp/programming-guide/delegates/how-to-declare-instantiate-and-use-a-delegate.md
+++ b/docs/csharp/programming-guide/delegates/how-to-declare-instantiate-and-use-a-delegate.md
@@ -1,6 +1,5 @@
 ---
 title: "How to declare, instantiate, and use a delegate - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "delegates [C#], declaring and instantiating"

--- a/docs/csharp/programming-guide/delegates/index.md
+++ b/docs/csharp/programming-guide/delegates/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Delegates - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, delegates"

--- a/docs/csharp/programming-guide/delegates/using-delegates.md
+++ b/docs/csharp/programming-guide/delegates/using-delegates.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Delegates - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "delegates [C#], how to use"

--- a/docs/csharp/programming-guide/events/how-to-implement-custom-event-accessors.md
+++ b/docs/csharp/programming-guide/events/how-to-implement-custom-event-accessors.md
@@ -1,6 +1,5 @@
 ---
 title: "How to implement custom event accessors - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "accessors [C#], event accessors"

--- a/docs/csharp/programming-guide/events/how-to-implement-interface-events.md
+++ b/docs/csharp/programming-guide/events/how-to-implement-interface-events.md
@@ -1,6 +1,5 @@
 ---
 title: "How to implement interface events - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "interfaces [C#], event implementation in classes"

--- a/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
+++ b/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
@@ -1,6 +1,5 @@
 ---
 title: "How to publish events that conform to .NET Framework Guidelines - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "events [C#], implementation guidelines"

--- a/docs/csharp/programming-guide/events/how-to-raise-base-class-events-in-derived-classes.md
+++ b/docs/csharp/programming-guide/events/how-to-raise-base-class-events-in-derived-classes.md
@@ -1,6 +1,5 @@
 ---
 title: "How to raise base class events in derived classes - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "events [C#], in derived classes"

--- a/docs/csharp/programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md
+++ b/docs/csharp/programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md
@@ -1,6 +1,5 @@
 ---
 title: "How to subscribe to and unsubscribe from events - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "event handlers [C#], creating"

--- a/docs/csharp/programming-guide/events/index.md
+++ b/docs/csharp/programming-guide/events/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Events - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "classes [C#], events"

--- a/docs/csharp/programming-guide/exceptions/compiler-generated-exceptions.md
+++ b/docs/csharp/programming-guide/exceptions/compiler-generated-exceptions.md
@@ -1,6 +1,5 @@
 ---
 title: "Compiler-Generated Exceptions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "exceptions [C#], compiler-generated"

--- a/docs/csharp/programming-guide/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/programming-guide/exceptions/creating-and-throwing-exceptions.md
@@ -1,6 +1,5 @@
 ---
 title: "Creating and Throwing Exceptions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "catching exceptions [C#]"

--- a/docs/csharp/programming-guide/exceptions/exception-handling.md
+++ b/docs/csharp/programming-guide/exceptions/exception-handling.md
@@ -1,6 +1,5 @@
 ---
 title: "Exception Handling - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "exception handling [C#], about exception handling"

--- a/docs/csharp/programming-guide/exceptions/how-to-execute-cleanup-code-using-finally.md
+++ b/docs/csharp/programming-guide/exceptions/how-to-execute-cleanup-code-using-finally.md
@@ -1,6 +1,5 @@
 ---
 title: "How to execute cleanup code using finally - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "try/finally blocks [C#]"

--- a/docs/csharp/programming-guide/exceptions/how-to-handle-an-exception-using-try-catch.md
+++ b/docs/csharp/programming-guide/exceptions/how-to-handle-an-exception-using-try-catch.md
@@ -1,6 +1,5 @@
 ---
 title: "How to handle an exception using try-catch - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "exception handling [C#], try/catch blocks"

--- a/docs/csharp/programming-guide/exceptions/index.md
+++ b/docs/csharp/programming-guide/exceptions/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Exceptions and Exception Handling - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "exception handling [C#]"

--- a/docs/csharp/programming-guide/exceptions/using-exceptions.md
+++ b/docs/csharp/programming-guide/exceptions/using-exceptions.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Exceptions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "exception handling [C#], about exception handling"

--- a/docs/csharp/programming-guide/file-system/how-to-copy-delete-and-move-files-and-folders.md
+++ b/docs/csharp/programming-guide/file-system/how-to-copy-delete-and-move-files-and-folders.md
@@ -1,6 +1,5 @@
 ---
 title: "How to copy, delete, and move files and folders - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "I/O [C#]"

--- a/docs/csharp/programming-guide/file-system/how-to-create-a-file-or-folder.md
+++ b/docs/csharp/programming-guide/file-system/how-to-create-a-file-or-folder.md
@@ -1,6 +1,5 @@
 ---
 title: "How to create a file or folder - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "folders [C#]"

--- a/docs/csharp/programming-guide/file-system/how-to-get-information-about-files-folders-and-drives.md
+++ b/docs/csharp/programming-guide/file-system/how-to-get-information-about-files-folders-and-drives.md
@@ -1,6 +1,5 @@
 ---
 title: "How to get information about files, folders, and drives  - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "files [C#], getting information about"

--- a/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
+++ b/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
@@ -1,6 +1,5 @@
 ---
 title: "How to iterate through a directory tree - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "iterating through folders [C#]"

--- a/docs/csharp/programming-guide/file-system/how-to-provide-a-progress-dialog-box-for-file-operations.md
+++ b/docs/csharp/programming-guide/file-system/how-to-provide-a-progress-dialog-box-for-file-operations.md
@@ -1,6 +1,5 @@
 ---
 title: "How to provide a progress dialog box for file operations - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "progress dialog [C#]"

--- a/docs/csharp/programming-guide/file-system/how-to-read-from-a-text-file.md
+++ b/docs/csharp/programming-guide/file-system/how-to-read-from-a-text-file.md
@@ -1,6 +1,5 @@
 ---
 title: "How to read from a text file - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "StreamReader.ReadToEnd"

--- a/docs/csharp/programming-guide/file-system/how-to-write-to-a-text-file.md
+++ b/docs/csharp/programming-guide/file-system/how-to-write-to-a-text-file.md
@@ -1,6 +1,5 @@
 ---
 title: "How to write to a text file - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "TextWriter.WriteLine"

--- a/docs/csharp/programming-guide/file-system/index.md
+++ b/docs/csharp/programming-guide/file-system/index.md
@@ -1,6 +1,5 @@
 ---
 title: "File System and the Registry - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "file system [C#]"

--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -1,6 +1,5 @@
 ---
 title: "Constraints on type parameters - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 04/12/2018
 helpviewer_keywords: 
   - "generics [C#], type constraints"

--- a/docs/csharp/programming-guide/generics/differences-between-cpp-templates-and-csharp-generics.md
+++ b/docs/csharp/programming-guide/generics/differences-between-cpp-templates-and-csharp-generics.md
@@ -1,6 +1,5 @@
 ---
 title: "Differences Between C++ Templates and C# Generics - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], vs. C++ templates"

--- a/docs/csharp/programming-guide/generics/generic-classes.md
+++ b/docs/csharp/programming-guide/generics/generic-classes.md
@@ -1,6 +1,5 @@
 ---
 title: "Generic Classes - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, generic classes"

--- a/docs/csharp/programming-guide/generics/generic-delegates.md
+++ b/docs/csharp/programming-guide/generics/generic-delegates.md
@@ -1,6 +1,5 @@
 ---
 title: "Generic Delegates - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], delegates"

--- a/docs/csharp/programming-guide/generics/generic-interfaces.md
+++ b/docs/csharp/programming-guide/generics/generic-interfaces.md
@@ -1,6 +1,5 @@
 ---
 title: "Generic Interfaces - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, generic interfaces"

--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -1,6 +1,5 @@
 ---
 title: "Generic Methods - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], methods"

--- a/docs/csharp/programming-guide/generics/generic-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/generic-type-parameters.md
@@ -1,6 +1,5 @@
 ---
 title: "Generic Type Parameters - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], type parameters"

--- a/docs/csharp/programming-guide/generics/generics-and-arrays.md
+++ b/docs/csharp/programming-guide/generics/generics-and-arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Generics and Arrays - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], arrays"

--- a/docs/csharp/programming-guide/generics/generics-and-attributes.md
+++ b/docs/csharp/programming-guide/generics/generics-and-attributes.md
@@ -1,6 +1,5 @@
 ---
 title: "Generics and Attributes - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], attributes"

--- a/docs/csharp/programming-guide/generics/generics-and-reflection.md
+++ b/docs/csharp/programming-guide/generics/generics-and-reflection.md
@@ -1,6 +1,5 @@
 ---
 title: "Generics and Reflection - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], reflection"

--- a/docs/csharp/programming-guide/generics/generics-in-the-run-time.md
+++ b/docs/csharp/programming-guide/generics/generics-in-the-run-time.md
@@ -1,6 +1,5 @@
 ---
 title: "Generics in the Run Time - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "generics [C#], at run time"

--- a/docs/csharp/programming-guide/generics/index.md
+++ b/docs/csharp/programming-guide/generics/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Generics - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, generics"

--- a/docs/csharp/programming-guide/indexers/comparison-between-properties-and-indexers.md
+++ b/docs/csharp/programming-guide/indexers/comparison-between-properties-and-indexers.md
@@ -1,6 +1,5 @@
 ---
 title: "Comparison Between Properties and Indexers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "properties [C#], vs. indexers"

--- a/docs/csharp/programming-guide/indexers/index.md
+++ b/docs/csharp/programming-guide/indexers/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Indexers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 03/10/2017
 f1_keywords: 
   - "cs.indexers"

--- a/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
+++ b/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
@@ -1,6 +1,5 @@
 ---
 title: "Indexers in Interfaces - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "indexers [C#], in interfaces"

--- a/docs/csharp/programming-guide/indexers/using-indexers.md
+++ b/docs/csharp/programming-guide/indexers/using-indexers.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Indexers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 10/03/2018
 helpviewer_keywords: 
   - "indexers [C#], about indexers"

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -1,6 +1,5 @@
 ---
 title: "C# Coding Conventions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "coding conventions, C#"

--- a/docs/csharp/programming-guide/inside-a-program/general-structure-of-a-csharp-program.md
+++ b/docs/csharp/programming-guide/inside-a-program/general-structure-of-a-csharp-program.md
@@ -1,6 +1,5 @@
 ---
 title: "General Structure of a C# Program - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, program structure"

--- a/docs/csharp/programming-guide/inside-a-program/hello-world-your-first-program.md
+++ b/docs/csharp/programming-guide/inside-a-program/hello-world-your-first-program.md
@@ -1,6 +1,5 @@
 ---
 title: "Hello World -- Your first program using Visual Studio on Windows or Mac - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 09/12/2019
 f1_keywords:
   - "cs.program"

--- a/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
+++ b/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
@@ -1,6 +1,5 @@
 ---
 title: "Explicit Interface Implementation - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "explicit interfaces [C#]"

--- a/docs/csharp/programming-guide/interfaces/how-to-explicitly-implement-interface-members.md
+++ b/docs/csharp/programming-guide/interfaces/how-to-explicitly-implement-interface-members.md
@@ -1,6 +1,5 @@
 ---
 title: "How to explicitly implement interface members - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "interfaces [C#], explicitly implementing"

--- a/docs/csharp/programming-guide/interfaces/how-to-explicitly-implement-members-of-two-interfaces.md
+++ b/docs/csharp/programming-guide/interfaces/how-to-explicitly-implement-members-of-two-interfaces.md
@@ -1,6 +1,5 @@
 ---
 title: "How to explicitly implement members of two interfaces - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "inheritance [C#], explicitly implementing interface members"

--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Interfaces - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 08/21/2018
 helpviewer_keywords: 
   - "interfaces [C#]"

--- a/docs/csharp/programming-guide/interop/example-com-class.md
+++ b/docs/csharp/programming-guide/interop/example-com-class.md
@@ -1,6 +1,5 @@
 ---
 title: "Example COM Class - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "examples [C#], COM classes"

--- a/docs/csharp/programming-guide/interop/how-to-access-office-onterop-objects.md
+++ b/docs/csharp/programming-guide/interop/how-to-access-office-onterop-objects.md
@@ -1,6 +1,5 @@
 ---
 title: "How to access Office interop objects - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "optional parameters [C#], Office programming"

--- a/docs/csharp/programming-guide/interop/how-to-use-indexed-properties-in-com-interop-rogramming.md
+++ b/docs/csharp/programming-guide/interop/how-to-use-indexed-properties-in-com-interop-rogramming.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use indexed properties in COM interop programming - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "indexed properties [C#]"

--- a/docs/csharp/programming-guide/interop/how-to-use-platform-invoke-to-play-a-wave-file.md
+++ b/docs/csharp/programming-guide/interop/how-to-use-platform-invoke-to-play-a-wave-file.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use platform invoke to play a WAV file - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "platform invoke, sound files"

--- a/docs/csharp/programming-guide/interop/index.md
+++ b/docs/csharp/programming-guide/interop/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Interoperability - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "COM interop"

--- a/docs/csharp/programming-guide/interop/interoperability-overview.md
+++ b/docs/csharp/programming-guide/interop/interoperability-overview.md
@@ -1,6 +1,5 @@
 ---
 title: "Interoperability Overview - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "COM interop"

--- a/docs/csharp/programming-guide/main-and-command-args/command-line-arguments.md
+++ b/docs/csharp/programming-guide/main-and-command-args/command-line-arguments.md
@@ -1,6 +1,5 @@
 ---
 title: "Command-Line Arguments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "command-line arguments [C#]"

--- a/docs/csharp/programming-guide/main-and-command-args/how-to-display-command-line-arguments.md
+++ b/docs/csharp/programming-guide/main-and-command-args/how-to-display-command-line-arguments.md
@@ -1,6 +1,5 @@
 ---
 title: "How to display command line arguments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "command-line arguments [C#], displaying"

--- a/docs/csharp/programming-guide/main-and-command-args/index.md
+++ b/docs/csharp/programming-guide/main-and-command-args/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Main() and command-line arguments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 08/02/2017
 f1_keywords: 
   - "CS5001"

--- a/docs/csharp/programming-guide/main-and-command-args/main-return-values.md
+++ b/docs/csharp/programming-guide/main-and-command-args/main-return-values.md
@@ -1,6 +1,5 @@
 ---
 title: "Main() Return Values - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 08/02/2017
 helpviewer_keywords: 
   - "Main method [C#], return values"

--- a/docs/csharp/programming-guide/namespaces/how-to-use-the-my-namespace.md
+++ b/docs/csharp/programming-guide/namespaces/how-to-use-the-my-namespace.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use the My namespace - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, My namespace access"

--- a/docs/csharp/programming-guide/namespaces/index.md
+++ b/docs/csharp/programming-guide/namespaces/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Namespaces - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 08/21/2018
 helpviewer_keywords: 
   - "C# language, namespaces"

--- a/docs/csharp/programming-guide/namespaces/using-namespaces.md
+++ b/docs/csharp/programming-guide/namespaces/using-namespaces.md
@@ -1,6 +1,5 @@
 ---
 title: "Using Namespaces - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "cs.names"

--- a/docs/csharp/programming-guide/statements-expressions-operators/anonymous-functions.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/anonymous-functions.md
@@ -1,6 +1,5 @@
 ---
 title: "Anonymous functions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "lambda expressions [C#], as anonymous functions"

--- a/docs/csharp/programming-guide/statements-expressions-operators/equality-comparisons.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/equality-comparisons.md
@@ -1,6 +1,5 @@
 ---
 title: "Equality Comparisons - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "object equality [C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -1,6 +1,5 @@
 ---
 title: "Expression-bodied members - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 02/06/2019
 helpviewer_keywords: 
   - "expression-bodied members[C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/expressions.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expressions.md
@@ -1,6 +1,5 @@
 ---
 title: "Expressions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 05/11/2017
 helpviewer_keywords: 
   - "expressions [C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
@@ -1,6 +1,5 @@
 ---
 title: "How to define value equality for a type - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "overriding Equals method [C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
@@ -1,6 +1,5 @@
 ---
 title: "How to test for reference equality (Identity) - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "object identity [C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-use-lambda-expressions-in-a-query.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-use-lambda-expressions-in-a-query.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use lambda expressions in a query - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "lambda expressions [C#], in LINQ"

--- a/docs/csharp/programming-guide/statements-expressions-operators/index.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Statements, Expressions, and Operators - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "expressions [C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/lambda-expressions.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/lambda-expressions.md
@@ -1,6 +1,5 @@
 ---
 title: "Lambda expressions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/29/2019
 helpviewer_keywords: 
   - "lambda expressions [C#]"

--- a/docs/csharp/programming-guide/statements-expressions-operators/statements.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/statements.md
@@ -1,6 +1,5 @@
 ---
 title: "Statements - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "statements [C#], about statements"

--- a/docs/csharp/programming-guide/strings/how-to-determine-whether-a-string-represents-a-numeric-value.md
+++ b/docs/csharp/programming-guide/strings/how-to-determine-whether-a-string-represents-a-numeric-value.md
@@ -1,6 +1,5 @@
 ---
 title: "How to determine whether a string represents a numeric value - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "numeric strings [C#]"

--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Strings - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 06/27/2019
 helpviewer_keywords: 
   - "C# language, strings"

--- a/docs/csharp/programming-guide/types/boxing-and-unboxing.md
+++ b/docs/csharp/programming-guide/types/boxing-and-unboxing.md
@@ -1,6 +1,5 @@
 ---
 title: "Boxing and Unboxing - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "cs.boxing"

--- a/docs/csharp/programming-guide/types/casting-and-type-conversions.md
+++ b/docs/csharp/programming-guide/types/casting-and-type-conversions.md
@@ -1,6 +1,5 @@
 ---
 title: "Casting and type conversions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "type conversion [C#]"

--- a/docs/csharp/programming-guide/types/how-to-convert-a-byte-array-to-an-int.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-a-byte-array-to-an-int.md
@@ -1,6 +1,5 @@
 ---
 title: "How to convert a byte array to an int - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "conversions [C#], byte array to int"

--- a/docs/csharp/programming-guide/types/how-to-convert-a-string-to-a-number.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-a-string-to-a-number.md
@@ -1,6 +1,5 @@
 ---
 title: "How to convert a string to a number - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 02/11/2019
 helpviewer_keywords: 
   - "conversions [C#]"

--- a/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
@@ -1,6 +1,5 @@
 ---
 title: "How to convert between hexadecimal strings and numeric types - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "hexadecimal strings [C#], converting to numeric type"

--- a/docs/csharp/programming-guide/types/index.md
+++ b/docs/csharp/programming-guide/types/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Types - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "value types [C#]"

--- a/docs/csharp/programming-guide/types/using-type-dynamic.md
+++ b/docs/csharp/programming-guide/types/using-type-dynamic.md
@@ -1,6 +1,5 @@
 ---
 title: "Using type dynamic - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "dynamic [C#], about dynamic type"

--- a/docs/csharp/programming-guide/unsafe-code-pointers/fixed-size-buffers.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/fixed-size-buffers.md
@@ -1,6 +1,5 @@
 ---
 title: "Fixed Size Buffers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 04/20/2018
 helpviewer_keywords: 
   - "fixed size buffers [C#]"

--- a/docs/csharp/programming-guide/unsafe-code-pointers/how-to-use-pointers-to-copy-an-array-of-bytes.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/how-to-use-pointers-to-copy-an-array-of-bytes.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use pointers to copy an array of bytes - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 04/20/2018
 helpviewer_keywords: 
   - "byte arrays [C#]"

--- a/docs/csharp/programming-guide/unsafe-code-pointers/index.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Unsafe code and pointers - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "security [C#], type safety"

--- a/docs/csharp/programming-guide/unsafe-code-pointers/pointer-conversions.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/pointer-conversions.md
@@ -1,6 +1,5 @@
 ---
 title: "Pointer Conversions - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "pointers [C#], conversions"

--- a/docs/csharp/programming-guide/unsafe-code-pointers/pointer-types.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/pointer-types.md
@@ -1,6 +1,5 @@
 ---
 title: "Pointer types - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 04/20/2018
 helpviewer_keywords: 
   - "unsafe code [C#], pointers"

--- a/docs/csharp/programming-guide/xmldoc/code-inline.md
+++ b/docs/csharp/programming-guide/xmldoc/code-inline.md
@@ -1,6 +1,5 @@
 ---
 title: "<c> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "c"

--- a/docs/csharp/programming-guide/xmldoc/code.md
+++ b/docs/csharp/programming-guide/xmldoc/code.md
@@ -1,6 +1,5 @@
 ---
 title: "<code> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "code"

--- a/docs/csharp/programming-guide/xmldoc/cref-attribute.md
+++ b/docs/csharp/programming-guide/xmldoc/cref-attribute.md
@@ -1,6 +1,5 @@
 ---
 title: "cref Attribute - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "cref [C#]"

--- a/docs/csharp/programming-guide/xmldoc/delimiters-for-documentation-tags.md
+++ b/docs/csharp/programming-guide/xmldoc/delimiters-for-documentation-tags.md
@@ -1,6 +1,5 @@
 ---
 title: "Delimiters for Documentation Tags - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "XML [C#], delimiters"

--- a/docs/csharp/programming-guide/xmldoc/example.md
+++ b/docs/csharp/programming-guide/xmldoc/example.md
@@ -1,6 +1,5 @@
 ---
 title: "<example> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "<example>"

--- a/docs/csharp/programming-guide/xmldoc/exception.md
+++ b/docs/csharp/programming-guide/xmldoc/exception.md
@@ -1,6 +1,5 @@
 ---
 title: "<exception> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "exception"

--- a/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
+++ b/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
@@ -1,6 +1,5 @@
 ---
 title: "How to use the XML documentation features - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 06/01/2018
 helpviewer_keywords: 
   - "XML documentation [C#]"

--- a/docs/csharp/programming-guide/xmldoc/include.md
+++ b/docs/csharp/programming-guide/xmldoc/include.md
@@ -1,6 +1,5 @@
 ---
 title: "<include> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "include"

--- a/docs/csharp/programming-guide/xmldoc/index.md
+++ b/docs/csharp/programming-guide/xmldoc/index.md
@@ -1,6 +1,5 @@
 ---
 title: "XML Documentation Comments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "cs.xml"

--- a/docs/csharp/programming-guide/xmldoc/list.md
+++ b/docs/csharp/programming-guide/xmldoc/list.md
@@ -1,6 +1,5 @@
 ---
 title: "<list> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "list"

--- a/docs/csharp/programming-guide/xmldoc/para.md
+++ b/docs/csharp/programming-guide/xmldoc/para.md
@@ -1,6 +1,5 @@
 ---
 title: "<para> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "<para>"

--- a/docs/csharp/programming-guide/xmldoc/param.md
+++ b/docs/csharp/programming-guide/xmldoc/param.md
@@ -1,6 +1,5 @@
 ---
 title: "<param> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "param"

--- a/docs/csharp/programming-guide/xmldoc/paramref.md
+++ b/docs/csharp/programming-guide/xmldoc/paramref.md
@@ -1,6 +1,5 @@
 ---
 title: "<paramref> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "paramref"

--- a/docs/csharp/programming-guide/xmldoc/permission.md
+++ b/docs/csharp/programming-guide/xmldoc/permission.md
@@ -1,6 +1,5 @@
 ---
 title: "<permission> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "permission"

--- a/docs/csharp/programming-guide/xmldoc/processing-the-xml-file.md
+++ b/docs/csharp/programming-guide/xmldoc/processing-the-xml-file.md
@@ -1,6 +1,5 @@
 ---
 title: "Processing the XML File - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "XML processing [C#]"

--- a/docs/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
+++ b/docs/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
@@ -1,6 +1,5 @@
 ---
 title: "Recommended Tags for Documentation Comments - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "XML [C#], tags"

--- a/docs/csharp/programming-guide/xmldoc/remarks.md
+++ b/docs/csharp/programming-guide/xmldoc/remarks.md
@@ -1,6 +1,5 @@
 ---
 title: "<remarks> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "remarks"

--- a/docs/csharp/programming-guide/xmldoc/returns.md
+++ b/docs/csharp/programming-guide/xmldoc/returns.md
@@ -1,6 +1,5 @@
 ---
 title: "<returns> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "returns"

--- a/docs/csharp/programming-guide/xmldoc/see.md
+++ b/docs/csharp/programming-guide/xmldoc/see.md
@@ -1,6 +1,5 @@
 ---
 title: "<see> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "<see>"

--- a/docs/csharp/programming-guide/xmldoc/seealso.md
+++ b/docs/csharp/programming-guide/xmldoc/seealso.md
@@ -1,6 +1,5 @@
 ---
 title: "<seealso> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "cref"

--- a/docs/csharp/programming-guide/xmldoc/summary.md
+++ b/docs/csharp/programming-guide/xmldoc/summary.md
@@ -1,6 +1,5 @@
 ---
 title: "<summary> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "<summary>"

--- a/docs/csharp/programming-guide/xmldoc/typeparam.md
+++ b/docs/csharp/programming-guide/xmldoc/typeparam.md
@@ -1,6 +1,5 @@
 ---
 title: "<typeparam> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "typeparam"

--- a/docs/csharp/programming-guide/xmldoc/typeparamref.md
+++ b/docs/csharp/programming-guide/xmldoc/typeparamref.md
@@ -1,6 +1,5 @@
 ---
 title: "<typeparamref> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "typeparamref"

--- a/docs/csharp/programming-guide/xmldoc/value.md
+++ b/docs/csharp/programming-guide/xmldoc/value.md
@@ -1,6 +1,5 @@
 ---
 title: "<value> - C# Programming Guide"
-ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
   - "<value>"

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -2,7 +2,6 @@
 title: A Tour of C# - C# Guide
 description: New to C#? Learn the basics of the language.
 ms.date: 04/05/2019
-ms.custom: seoapril2019
 ---
 
 # A tour of the C# language

--- a/docs/machine-learning/how-to-guides/index.md
+++ b/docs/machine-learning/how-to-guides/index.md
@@ -1,7 +1,6 @@
 ---
 title: ML.NET how-to guides
 description: Learn how to do specific tasks to assist with custom AI solutions creation and Machine Learning integration into your .NET applications.
-ms.custom: seodec18
 ms.date: 03/01/2019
 ---
 # .NET Machine learning how-to guides

--- a/docs/machine-learning/resources/glossary.md
+++ b/docs/machine-learning/resources/glossary.md
@@ -1,7 +1,6 @@
 ---
 title: Machine learning glossary
 description: A glossary of important machine learning terms that are useful as you build your custom models in ML.NET.
-ms.custom: seodec18
 ms.topic: reference
 ms.date: 07/31/2019
 ---

--- a/docs/machine-learning/resources/tasks.md
+++ b/docs/machine-learning/resources/tasks.md
@@ -1,7 +1,6 @@
 ---
 title: Machine learning tasks
 description: Explore the different machine learning tasks and associated tasks that are supported in ML.NET.
-ms.custom: seodec18
 ms.date: 12/23/2019
 author: natke
 ---

--- a/docs/machine-learning/tutorials/index.md
+++ b/docs/machine-learning/tutorials/index.md
@@ -1,7 +1,6 @@
 ---
 title:  ML.NET tutorials
 description: Explore the ML.NET tutorials to learn how to build custom AI solutions and integrate them into your .NET applications.
-ms.custom: seodec18
 ms.date: 07/08/2019
 ---
 # ML.NET tutorials

--- a/docs/machine-learning/tutorials/iris-clustering.md
+++ b/docs/machine-learning/tutorials/iris-clustering.md
@@ -4,7 +4,7 @@ description: Learn how to use ML.NET in a clustering scenario
 author: pkulikov
 ms.date: 11/15/2019
 ms.topic: tutorial
-ms.custom: mvc, seodec18, title-hack-0516
+ms.custom: mvc, title-hack-0516
 #Customer intent: As a developer, I want to use ML.NET so that I can build a k-means clustering model to categorize iris flowers based on its parameters.
 ---
 # Tutorial: Categorize iris flowers using k-means clustering with ML.NET

--- a/docs/machine-learning/tutorials/predict-prices.md
+++ b/docs/machine-learning/tutorials/predict-prices.md
@@ -3,7 +3,7 @@ title: 'Tutorial: Predict prices using regression'
 description: This tutorial illustrates how to build a regression model using ML.NET to predict prices, specifically, New York City taxi fares.
 ms.date: 09/30/2019
 ms.topic: tutorial
-ms.custom: mvc, seodec18, title-hack-0516
+ms.custom: mvc, title-hack-0516
 #Customer intent: As a developer, I want to use ML.NET so that I can train and build a model in a regression scenario to predict prices.
 ---
 # Tutorial: Predict prices using regression with ML.NET

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -3,7 +3,7 @@ title: 'Tutorial: Analyze website comments - binary classification'
 description: This tutorial shows you how to create a .NET Core console application that classifies sentiment from website comments and takes the appropriate action. The binary sentiment classifier uses C# in Visual Studio.
 ms.date: 09/30/2019
 ms.topic: tutorial
-ms.custom: mvc, seodec18
+ms.custom: mvc
 #Customer intent: As a developer, I want to use ML.NET to apply a binary classification task so that I can understand how to use sentiment prediction to take appropriate action.
 ---
 # Tutorial: Analyze sentiment of website comments with binary classification in ML.NET

--- a/docs/standard/base-types/alternation-constructs-in-regular-expressions.md
+++ b/docs/standard/base-types/alternation-constructs-in-regular-expressions.md
@@ -15,7 +15,6 @@ helpviewer_keywords:
   - "constructs, alternation"
   - ".NET Framework regular expressions, alternation constructs"
 ms.assetid: 071e22e9-fbb0-4ecf-add1-8d2424f9f2d1
-ms.custom: seodec18
 ---
 # Alternation Constructs in Regular Expressions
 

--- a/docs/standard/base-types/anchors-in-regular-expressions.md
+++ b/docs/standard/base-types/anchors-in-regular-expressions.md
@@ -16,7 +16,6 @@ helpviewer_keywords:
   - ".NET Framework regular expressions, anchors"
   - ".NET Framework regular expressions, atomic zero-width assertions"
 ms.assetid: 336391f6-2614-499b-8b1b-07a6837108a7
-ms.custom: seodec18
 ---
 # Anchors in Regular Expressions
 Anchors, or atomic zero-width assertions, specify a position in the string where a match must occur. When you use an anchor in your search expression, the regular expression engine does not advance through the string or consume characters; it looks for a match in the specified position only. For example, `^` specifies that the match must start at the beginning of a line or string. Therefore, the regular expression `^http:` matches "http:" only when it occurs at the beginning of a line. The following table lists the anchors supported by the regular expressions in .NET.  

--- a/docs/standard/base-types/backreference-constructs-in-regular-expressions.md
+++ b/docs/standard/base-types/backreference-constructs-in-regular-expressions.md
@@ -12,7 +12,6 @@ helpviewer_keywords:
   - ".NET Framework regular expressions, backreference constructs"
   - "regular expressions, backreference constructs"
 ms.assetid: 567a4b8d-0e79-49dc-8df9-f4b1aa376a2a
-ms.custom: seodec18
 ---
 
 # Backreference Constructs in Regular Expressions

--- a/docs/standard/base-types/backtracking-in-regular-expressions.md
+++ b/docs/standard/base-types/backtracking-in-regular-expressions.md
@@ -17,7 +17,6 @@ helpviewer_keywords:
   - "strings [.NET Framework], regular expressions"
   - "parsing text with regular expressions, backtracking"
 ms.assetid: 34df1152-0b22-4a1c-a76c-3c28c47b70d8
-ms.custom: seodec18
 ---
 # Backtracking in Regular Expressions
 Backtracking occurs when a regular expression pattern contains optional [quantifiers](../../../docs/standard/base-types/quantifiers-in-regular-expressions.md) or [alternation constructs](../../../docs/standard/base-types/alternation-constructs-in-regular-expressions.md), and the regular expression engine returns to a previous saved state to continue its search for a match. Backtracking is central to the power of regular expressions; it makes it possible for expressions to be powerful and flexible, and to match very complex patterns. At the same time, this power comes at a cost. Backtracking is often the single most important factor that affects the performance of the regular expression engine. Fortunately, the developer has control over the behavior of the regular expression engine and how it uses backtracking. This topic explains how backtracking works and how it can be controlled.  

--- a/docs/standard/base-types/basic-manipulations.md
+++ b/docs/standard/base-types/basic-manipulations.md
@@ -9,7 +9,6 @@ dev_langs:
 helpviewer_keywords: 
   - "strings [.NET Framework], examples"
 ms.assetid: 121d1eae-251b-44c0-8818-57da04b8215e
-ms.custom: seodec18
 ---
 # How to: Perform Basic String Manipulations in .NET
 The following example uses some of the methods discussed in the [Basic String Operations](../../../docs/standard/base-types/basic-string-operations.md) topics to construct a class that performs string manipulations in a manner that might be found in a real-world application. The `MailToData` class stores the name and address of an individual in separate properties and provides a way to combine the `City`, `State`, and `Zip` fields into a single string for display to the user. Furthermore, the class allows the user to enter the city, state, and ZIP Code information as a single string; the application automatically parses the single string and enters the proper information into the corresponding property.  

--- a/docs/standard/base-types/best-practices-strings.md
+++ b/docs/standard/base-types/best-practices-strings.md
@@ -18,7 +18,6 @@ helpviewer_keywords:
   - "comparing strings"
   - "strings [.NET Framework],comparing"
 ms.assetid: b9f0bf53-e2de-4116-8ce9-d4f91a1df4f7
-ms.custom: seodec18
 ---
 # Best Practices for Using Strings in .NET
 

--- a/docs/standard/base-types/best-practices.md
+++ b/docs/standard/base-types/best-practices.md
@@ -10,7 +10,6 @@ helpviewer_keywords:
   - ".NET Framework regular expressions, best practices"
   - "regular expressions, best practices"
 ms.assetid: 618e5afb-3a97-440d-831a-70e4c526a51c
-ms.custom: seodec18
 ---
 # Best practices for regular expressions in .NET
 

--- a/docs/standard/base-types/changing-case.md
+++ b/docs/standard/base-types/changing-case.md
@@ -14,7 +14,6 @@ helpviewer_keywords:
   - "uppercase"
   - "lowercase"
 ms.assetid: 6805f81b-e9ad-4387-9f4c-b9bdb21b87c0
-ms.custom: seodec18
 ---
 # Changing Case in .NET
 If you write an application that accepts input from a user, you can never be sure what case he or she will use to enter the data. Often, you want strings to be cased consistently, particularly if you are displaying them in the user interface. The following table describes three case-changing methods. The first two methods provide an overload that accepts a culture.  

--- a/docs/standard/base-types/character-classes-in-regular-expressions.md
+++ b/docs/standard/base-types/character-classes-in-regular-expressions.md
@@ -12,7 +12,6 @@ helpviewer_keywords:
   - "characters, matching syntax"
   - ".NET Framework regular expressions, character classes"
 ms.assetid: 0f8bffab-ee0d-4e0e-9a96-2b4a252bb7e4
-ms.custom: seodec18
 ---
 # Character classes in regular expressions
 

--- a/docs/standard/base-types/character-encoding.md
+++ b/docs/standard/base-types/character-encoding.md
@@ -11,7 +11,6 @@ helpviewer_keywords:
   - "encoding, choosing"
   - "encoding, fallback strategy"
 ms.assetid: bf6d9823-4c2d-48af-b280-919c5af66ae9
-ms.custom: seodec18
 ---
 # Character Encoding in .NET
 

--- a/docs/standard/base-types/character-escapes-in-regular-expressions.md
+++ b/docs/standard/base-types/character-escapes-in-regular-expressions.md
@@ -15,7 +15,6 @@ helpviewer_keywords:
   - ".NET Framework regular expressions, character escapes"
   - "constructs, character escapes"
 ms.assetid: f49cc9cc-db7d-4058-8b8a-422bc08b29b0
-ms.custom: seodec18
 ---
 # Character Escapes in Regular Expressions
 The backslash (\\) in a regular expression indicates one of the following:  

--- a/docs/standard/base-types/common-type-system.md
+++ b/docs/standard/base-types/common-type-system.md
@@ -16,7 +16,6 @@ helpviewer_keywords:
   - "namespaces [.NET Framework], types"
   - "types, about types"
 ms.assetid: 53c57c96-83e1-4ee3-9543-9ac832671a89
-ms.custom: seodec18
 ---
 # Common Type System
 The common type system defines how types are declared, used, and managed in the common language runtime, and is also an important part of the runtime's support for cross-language integration. The common type system performs the following functions:  

--- a/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md
+++ b/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md
@@ -20,7 +20,6 @@ helpviewer_keywords:
   - "Visual Basic code, handling errors while running"
   - "structured exception handling, Try...Catch...Finally statements"
 ms.assetid: d6488026-ccb3-42b8-a810-0d97b9d6472b
-ms.custom: seodec18
 ---
 # Try...Catch...Finally Statement (Visual Basic)
 


### PR DESCRIPTION
removed ms.custom seodec18 and seoapril2019 from articles

From Carolyn:

![image](https://user-images.githubusercontent.com/12971179/71855619-63741100-3096-11ea-8218-faa21f9f139a.png)
