### PR TITLE
fix casing of curl ssl option

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -189,7 +189,7 @@ You can install a specific version using the `--version` argument. The version m
   macOS/Linux:
 
   ```bash
-  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
+  curl -ssl https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
   ```
 
 ## See also


### PR DESCRIPTION
Use the same casing as displayed in the curl manpage.

![image](https://user-images.githubusercontent.com/10702007/71922730-21f46c00-3151-11ea-89ce-0238b2dd026e.png)

