### PR TITLE
add example showing how to push to official NuGet

### DIFF
--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -92,7 +92,7 @@ The `dotnet nuget push` command pushes a package to the server and publishes it.
   dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
   ```
 
-* Push *foo.nupkg* to the offical NuGet server, specifying an API key:
+* Push *foo.nupkg* to the official NuGet server, specifying an API key:
 
   ```dotnetcli
   dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -s https://api.nuget.org/v3/index.json

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -92,7 +92,13 @@ The `dotnet nuget push` command pushes a package to the server and publishes it.
   dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
   ```
 
-* Push *foo.nupkg* to the custom push source `https://customsource`, specifying an API key:
+* Push *foo.nupkg* to the offical NuGet server, specifying an API key:
+
+  ```dotnetcli
+  dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -s https://api.nuget.org/v3/index.json
+  ```
+  
+  * Push *foo.nupkg* to the custom push source `https://customsource`, specifying an API key:
 
   ```dotnetcli
   dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -s https://customsource/


### PR DESCRIPTION
## Summary
On the donet nuget push command, there's currently only an example showing how to push to a custom push source. This adds an example showing how to push to the official NuGet server.