### PR TITLE
C# TOC and #if article improvements

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
@@ -17,7 +17,7 @@ When the C# compiler encounters an `#if` directive, followed eventually by an [#
 #endif
 ```
 
-You can use the operators [==](../operators/equality-operators.md#equality-operator-) (equality) and [!=](../operators/equality-operators.md#inequality-operator-) (inequality) only to test for the [bool](../builtin-types/bool.md) values `true` or `false`. `true` means the symbol is defined. The statement `#if DEBUG` has the same meaning as `#if (DEBUG == true)`. You can use the operators [&& (and)](../operators/boolean-logical-operators.md#conditional-logical-and-operator-), [&#124;&#124; (or)](../operators/boolean-logical-operators.md#conditional-logical-or-operator-), and [! (not)](../operators/boolean-logical-operators.md#logical-negation-operator-) to evaluate whether multiple symbols have been defined. You can also group symbols and operators with parentheses.
+You can use the operators [==](../operators/equality-operators.md#equality-operator-) (equality) and [!=](../operators/equality-operators.md#inequality-operator-) (inequality) only to test for the [bool](../builtin-types/bool.md) values `true` or `false`. `true` means the symbol is defined. The statement `#if DEBUG` has the same meaning as `#if (DEBUG == true)`. You can use the [&& (and)](../operators/boolean-logical-operators.md#conditional-logical-and-operator-), [&#124;&#124; (or)](../operators/boolean-logical-operators.md#conditional-logical-or-operator-), and [! (not)](../operators/boolean-logical-operators.md#logical-negation-operator-) operators to evaluate whether multiple symbols have been defined. You can also group symbols and operators with parentheses.
 
 ## Remarks
 

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
@@ -7,9 +7,9 @@ helpviewer_keywords:
   - "#if directive [C#]"
 ms.assetid: 48cabbff-ca82-491f-a56a-eeccd528c7c2
 ---
-# #if (C# Reference)
+# #if (C# reference)
 
-When the C# compiler encounters an `#if` directive, followed eventually by an [#endif](preprocessor-endif.md) directive, it compiles the code between the directives only if the specified symbol is defined. Unlike C and C++, you cannot assign a numeric value to a symbol. The #if statement in C# is Boolean and only tests whether the symbol has been defined or not. For example:
+When the C# compiler encounters an `#if` directive, followed eventually by an [#endif](preprocessor-endif.md) directive, it compiles the code between the directives only if the specified symbol is defined. Unlike C and C++, you cannot assign a numeric value to a symbol. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example:
 
 ```csharp
 #if DEBUG
@@ -17,7 +17,7 @@ When the C# compiler encounters an `#if` directive, followed eventually by an [#
 #endif
 ```
 
-You can use the operators [==](../operators/equality-operators.md#equality-operator-) (equality) and [!=](../operators/equality-operators.md#inequality-operator-) (inequality) only to test for the [bool](../builtin-types/bool.md) values `true` or `false`. True means the symbol is defined. The statement `#if DEBUG` has the same meaning as `#if (DEBUG == true)`. You can use the operators [&&](../operators/boolean-logical-operators.md#conditional-logical-and-operator-) (and), [&#124;&#124;](../operators/boolean-logical-operators.md#conditional-logical-or-operator-) (or), and [!](../operators/boolean-logical-operators.md#logical-negation-operator-) (not) to evaluate whether multiple symbols have been defined. You can also group symbols and operators with parentheses.
+You can use the operators [==](../operators/equality-operators.md#equality-operator-) (equality) and [!=](../operators/equality-operators.md#inequality-operator-) (inequality) only to test for the [bool](../builtin-types/bool.md) values `true` or `false`. `true` means the symbol is defined. The statement `#if DEBUG` has the same meaning as `#if (DEBUG == true)`. You can use the operators [&& (and)](../operators/boolean-logical-operators.md#conditional-logical-and-operator-), [&#124;&#124; (or)](../operators/boolean-logical-operators.md#conditional-logical-or-operator-), and [! (not)](../operators/boolean-logical-operators.md#logical-negation-operator-) to evaluate whether multiple symbols have been defined. You can also group symbols and operators with parentheses.
 
 ## Remarks
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -341,7 +341,7 @@
     - name: Asynchronous programming with async and await
       items:
       - name: Overview
-       displayName: asynchronous programming
+        displayName: asynchronous programming
         href: programming-guide/concepts/async/index.md
       - name: Task asynchronous programming model
         href: programming-guide/concepts/async/task-asynchronous-programming-model.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -915,7 +915,7 @@
   - name: Statements, expressions, and operators
     items:
     - name: Overview
-      displayName: statements expressions operators
+      displayName: statements, expressions, operators
       href: programming-guide/statements-expressions-operators/index.md
     - name: Statements
       href: programming-guide/statements-expressions-operators/statements.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -341,7 +341,7 @@
     - name: Asynchronous programming with async and await
       items:
       - name: Overview
-       displayName: asynchronous programming overview
+       displayName: asynchronous programming
         href: programming-guide/concepts/async/index.md
       - name: Task asynchronous programming model
         href: programming-guide/concepts/async/task-asynchronous-programming-model.md
@@ -374,7 +374,7 @@
     - name: Attributes
       items:
       - name: Overview
-        displayName: attributes overview
+        displayName: attributes
         href: programming-guide/concepts/attributes/index.md
       - name: Creating Custom Attributes
         href: programming-guide/concepts/attributes/creating-custom-attributes.md
@@ -393,7 +393,7 @@
     - name: Covariance and contravariance
       items:
       - name: Overview
-        displayName: covariance and contravariance overview
+        displayName: covariance and contravariance
         href: programming-guide/concepts/covariance-contravariance/index.md
       - name: Variance in Generic Interfaces
         href: programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
@@ -412,7 +412,7 @@
     - name: Expression trees
       items:
       - name: Overview
-        displayName: expression trees overview
+        displayName: expression trees
         href: programming-guide/concepts/expression-trees/index.md
       - name: "How to execute expression trees"
         href: programming-guide/concepts/expression-trees/how-to-execute-expression-trees.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1,14 +1,16 @@
 - name: C# documentation
   href: index.yml
-- name: Get Started
+- name: Get started
   items:
   - name: Overview
+    displayName: get started
     href: getting-started/index.md
   - name: Introduction to the C# language and the .NET framework
     href: getting-started/introduction-to-the-csharp-language-and-the-net-framework.md
 - name: Tutorials
   items:
   - name: Overview
+    displayName: tutorials
     href: tutorials/index.md
   - name: Introduction to programming with C#
     items:
@@ -93,6 +95,7 @@
 - name: What's new in C#
   items:
   - name: C# 8.0
+    displayName: what's new
     href: whats-new/csharp-8.md
   - name: C# 7.3
     href: whats-new/csharp-7-3.md
@@ -112,9 +115,9 @@
     href: whats-new/relationships-between-language-and-library.md
   - name: Version and update considerations
     href: whats-new/version-update-considerations.md
-- name: C# Concepts
+- name: C# concepts
   items:
-  - name: C# Type system
+  - name: C# type system
     href: programming-guide/types/index.md
   - name: Nullable reference types
     href: nullable-references.md
@@ -214,7 +217,7 @@
     href: pattern-matching.md
   - name: Write safe, efficient code
     href: write-safe-efficient-code.md
-  - name: Expression Trees
+  - name: Expression trees
     items:
     - name: Introduction to expression trees
       href: expression-trees.md
@@ -238,9 +241,10 @@
     href: codedoc.md
   - name: Versioning
     href: versioning.md
-- name: How To C# Topics
+- name: How-to C# articles
   items:
-  - name: Topic index
+  - name: Article index
+    displayName: how to's
     href: how-to/index.md
   - name: Parse strings using `String.Split`
     href: how-to/parse-strings-using-split.md
@@ -270,7 +274,7 @@
     href: roslyn-sdk/work-with-workspace.md
   - name: Explore code with the syntax visualizer
     href: roslyn-sdk/syntax-visualizer.md
-  - name: Quick Starts
+  - name: Quick starts
     items:
     - name: Syntax analysis
       href: roslyn-sdk/get-started/syntax-analysis.md
@@ -301,13 +305,14 @@
 #    - name: Make const
 #    - name: How to guides
 # Look at the samples, and determine which are "How To" vs. Samples.
-- name: C# Programming Guide
+- name: C# programming guide
   items:
   - name: Overview
+    displayName: programming guide
     href: programming-guide/index.md
-  - name: Inside a C# Program
+  - name: Inside a C# program
     items:
-    - name: What's inside a C# Program
+    - name: What's inside a C# program
       href: programming-guide/inside-a-program/index.md
     - name: Hello World -- Your First Program
       href: programming-guide/inside-a-program/hello-world-your-first-program.md
@@ -317,9 +322,10 @@
       href: programming-guide/inside-a-program/identifier-names.md
     - name: C# Coding Conventions
       href: programming-guide/inside-a-program/coding-conventions.md
-  - name: Main() and Command-Line Arguments
+  - name: Main() and command-line arguments
     items:
     - name: Overview
+      displayName: main method
       href: programming-guide/main-and-command-args/index.md
     - name: Command-Line Arguments
       href: programming-guide/main-and-command-args/command-line-arguments.md
@@ -327,13 +333,15 @@
       href: programming-guide/main-and-command-args/how-to-display-command-line-arguments.md
     - name: Main() Return Values
       href: programming-guide/main-and-command-args/main-return-values.md
-  - name: Programming Concepts
+  - name: Programming concepts
     items:
     - name: Overview
+      displayName: programming concepts
       href: programming-guide/concepts/index.md
-    - name: Asynchronous Programming with async and await
+    - name: Asynchronous programming with async and await
       items:
       - name: Overview
+       displayName: asynchronous programming overview
         href: programming-guide/concepts/async/index.md
       - name: Task asynchronous programming model
         href: programming-guide/concepts/async/task-asynchronous-programming-model.md
@@ -366,6 +374,7 @@
     - name: Attributes
       items:
       - name: Overview
+        displayName: attributes overview
         href: programming-guide/concepts/attributes/index.md
       - name: Creating Custom Attributes
         href: programming-guide/concepts/attributes/creating-custom-attributes.md
@@ -377,31 +386,33 @@
         href: programming-guide/concepts/attributes/how-to-create-a-c-cpp-union-by-using-attributes.md
       - name: Common Attributes
         href: programming-guide/concepts/attributes/common-attributes.md
-    - name: Caller Information
+    - name: Caller information
       href: programming-guide/concepts/caller-information.md
     - name: Collections
       href: programming-guide/concepts/collections.md
-    - name: Covariance and Contravariance
+    - name: Covariance and contravariance
       items:
       - name: Overview
+        displayName: covariance and contravariance overview
         href: programming-guide/concepts/covariance-contravariance/index.md
       - name: Variance in Generic Interfaces
         href: programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
         items:
-        - name: Creating Variant Generic Interfaces
+        - name: Create Variant Generic Interfaces
           href: programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md
-        - name: Using Variance in Interfaces for Generic Collections
+        - name: Use Variance in Interfaces for Generic Collections
           href: programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md
       - name: Variance in Delegates
         href: programming-guide/concepts/covariance-contravariance/variance-in-delegates.md
         items:
-        - name: Using Variance in Delegates
+        - name: Use Variance in Delegates
           href: programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md
-        - name: Using Variance for Func and Action Generic Delegates
+        - name: Use Variance for Func and Action Generic Delegates
           href: programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
-    - name: Expression Trees
+    - name: Expression trees
       items:
       - name: Overview
+        displayName: expression trees overview
         href: programming-guide/concepts/expression-trees/index.md
       - name: "How to execute expression trees"
         href: programming-guide/concepts/expression-trees/how-to-execute-expression-trees.md
@@ -418,6 +429,7 @@
     - name: Language-Integrated Query (LINQ)
       items:
       - name: Overview
+        displayName: LINQ overview
         href: programming-guide/concepts/linq/index.md
       - name: Getting Started with LINQ in C#
         items:
@@ -892,6 +904,7 @@
     - name: Serialization (C#)
       items:
       - name: Overview
+        displayName: serialization
         href: programming-guide/concepts/serialization/index.md
       - name: "How to write object data to an XML file"
         href: programming-guide/concepts/serialization/how-to-write-object-data-to-an-xml-file.md
@@ -899,9 +912,10 @@
         href: programming-guide/concepts/serialization/how-to-read-object-data-from-an-xml-file.md
       - name: "Walkthrough: Persisting an Object in Visual Studio"
         href: programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
-  - name: Statements, Expressions, and Operators
+  - name: Statements, expressions, and operators
     items:
     - name: Overview
+      displayName: statements expressions operators
       href: programming-guide/statements-expressions-operators/index.md
     - name: Statements
       href: programming-guide/statements-expressions-operators/statements.md
@@ -946,6 +960,7 @@
   - name: Classes and Structs
     items:
     - name: Overview
+      displayName: classes structs
       href: programming-guide/classes-and-structs/index.md
     - name: Classes
       href: programming-guide/classes-and-structs/classes.md
@@ -954,14 +969,16 @@
     - name: Structs
       items:
       - name: Overview
+        displayName: structs
         href: programming-guide/classes-and-structs/structs.md
-      - name: Using Structs
+      - name: Use structs
         href: programming-guide/classes-and-structs/using-structs.md
     - name: Inheritance
       href: programming-guide/classes-and-structs/inheritance.md
     - name: Polymorphism
       items:
       - name: Overview
+        displayName: polymorphism
         href: programming-guide/classes-and-structs/polymorphism.md
       - name: Versioning with the Override and New Keywords
         href: programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
@@ -1068,6 +1085,7 @@
   - name: Interfaces
     items:
     - name: Overview
+      displayName: interfaces
       href: programming-guide/interfaces/index.md
     - name: Explicit Interface Implementation
       href: programming-guide/interfaces/explicit-interface-implementation.md
@@ -1078,6 +1096,7 @@
   - name: Delegates
     items:
     - name: Overview
+      displayName: delegates
       href: programming-guide/delegates/index.md
     - name: Using Delegates
       href: programming-guide/delegates/using-delegates.md
@@ -1090,6 +1109,7 @@
   - name: Arrays
     items:
     - name: Overview
+      displayName: arrays
       href: programming-guide/arrays/index.md
     - name: Arrays as Objects
       href: programming-guide/arrays/arrays-as-objects.md
@@ -1114,6 +1134,7 @@
   - name: Indexers
     items:
     - name: Overview
+      displayName: indexers
       href: programming-guide/indexers/index.md
     - name: Using Indexers
       href: programming-guide/indexers/using-indexers.md
@@ -1124,6 +1145,7 @@
   - name: Events
     items:
     - name: Overview
+      displayName: events
       href: programming-guide/events/index.md
     - name: "How to subscribe to and unsubscribe from events"
       href: programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md
@@ -1138,6 +1160,7 @@
   - name: Generics
     items:
     - name: Overview
+      displayName: generics
       href: programming-guide/generics/index.md
     - name: Generic Type Parameters
       href: programming-guide/generics/generic-type-parameters.md
@@ -1164,6 +1187,7 @@
   - name: Namespaces
     items:
     - name: Overview
+      displayName: namespaces
       href: programming-guide/namespaces/index.md
     - name: Using namespaces
       href: programming-guide/namespaces/using-namespaces.md
@@ -1172,12 +1196,14 @@
   - name: Unsafe Code and Pointers
     items:
     - name: Overview and restrictions
+      displayName: unsafe code pointers
       href: programming-guide/unsafe-code-pointers/index.md
     - name: Fixed size buffers
       href: programming-guide/unsafe-code-pointers/fixed-size-buffers.md
     - name: Pointer types
       items:
       - name: Overview
+        displayName: pointer types
         href: programming-guide/unsafe-code-pointers/pointer-types.md
       - name: Pointer conversions
         href: programming-guide/unsafe-code-pointers/pointer-conversions.md
@@ -1186,6 +1212,7 @@
   - name: XML Documentation Comments
     items:
     - name: Overview
+      displayName: xml documentation comments
       href: programming-guide/xmldoc/index.md
     - name: Recommended Tags for Documentation Comments
       href: programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
@@ -1238,6 +1265,7 @@
   - name: Exceptions and Exception Handling
     items:
     - name: Overview
+      displayName: exceptions
       href: programming-guide/exceptions/index.md
     - name: Using Exceptions
       href: programming-guide/exceptions/using-exceptions.md
@@ -1256,6 +1284,7 @@
   - name: File System and the Registry
     items:
     - name: Overview
+      displayName: file system registry
       href: programming-guide/file-system/index.md
     - name: "How to iterate through a directory tree"
       href: programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
@@ -1294,12 +1323,14 @@
 - name: Language Reference
   items:
   - name: Overview
+    displayName: language reference
     href: language-reference/index.md
   - name: Configure language version
     href: language-reference/configure-language-version.md
   - name: C# keywords
     items:
     - name: Overview
+      displayName: keywords
       href: language-reference/keywords/index.md
     - name: Built-in types
       items:
@@ -1454,6 +1485,7 @@
       - name: Checked and Unchecked
         items:
         - name: Overview
+          displayName: checked unchecked
           href: language-reference/keywords/checked-and-unchecked.md
         - name: checked
           href: language-reference/keywords/checked.md
@@ -1518,6 +1550,7 @@
     - name: Contextual Keywords
       items:
       - name: Quick reference
+        displayName: contextual keywords
         href: language-reference/keywords/contextual-keywords.md
       - name: add
         href: language-reference/keywords/add.md
@@ -1540,6 +1573,7 @@
     - name: Query Keywords
       items:
       - name: Quick reference
+        displayName: query keywords
         href: language-reference/keywords/query-keywords.md
       - name: from clause
         href: language-reference/keywords/from-clause.md
@@ -1650,6 +1684,7 @@
   - name: C# special characters
     items:
     - name: Overview
+      displayName: special characters
       href: language-reference/tokens/index.md
     - name: $ -- string interpolation
       href: language-reference/tokens/interpolated.md
@@ -1658,6 +1693,7 @@
   - name: C# preprocessor directives
     items:
     - name: Overview
+      displayName: preprocessor directives
       href: language-reference/preprocessor-directives/index.md
     - name: "#if"
       href: language-reference/preprocessor-directives/preprocessor-if.md
@@ -1690,6 +1726,7 @@
   - name: C# compiler options
     items:
     - name: Overview
+      displayName: compiler options
       href: language-reference/compiler-options/index.md
     - name: Command-line Building With csc.exe
       href: language-reference/compiler-options/command-line-building-with-csc-exe.md


### PR DESCRIPTION
- add display names to TOC for filter use (e.g. I typed in "preprocessor" and nothing came up)
- improve formatting/readbility of one sentence in #if topic