### PR TITLE
Add image for ASP.Net Core

### DIFF
--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -173,12 +173,12 @@ The *Dockerfile* file is used by the `docker build` command to create a containe
 
 In your terminal, navigate up a directory to the working folder you created at the start. Create a file named *Dockerfile* in your working folder and open it in a text editor. Add the following command as the first line of the file:
 
-# .NET Core Runtime
+### .NET Core Runtime
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/runtime:2.2
 ```
 
-# ASP.NET Core Runtime
+### ASP.NET Core Runtime
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 ```

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -173,15 +173,16 @@ The *Dockerfile* file is used by the `docker build` command to create a containe
 
 In your terminal, navigate up a directory to the working folder you created at the start. Create a file named *Dockerfile* in your working folder and open it in a text editor. Add the following command as the first line of the file:
 
-#.NET Core Runtime
+# .NET Core Runtime
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/runtime:2.2
 ```
 
-#ASP.NET Core Runtime
+# ASP.NET Core Runtime
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 ```
+
 The `FROM` command tells Docker to pull down the image tagged **2.2** from the **mcr.microsoft.com/dotnet/core/runtime** repository. Make sure that you pull the .NET Core runtime that matches the runtime targeted by your SDK. For example, the app created in the previous section used the .NET Core 2.2 SDK and created an app that targeted .NET Core 2.2. So the base image referred to in the *Dockerfile* is tagged with **2.2**.
 
 Save the *Dockerfile* file. The directory structure of the working folder should look like the following. Some of the deeper-level files and folders have been cut to save space in the article:

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -173,10 +173,15 @@ The *Dockerfile* file is used by the `docker build` command to create a containe
 
 In your terminal, navigate up a directory to the working folder you created at the start. Create a file named *Dockerfile* in your working folder and open it in a text editor. Add the following command as the first line of the file:
 
+#.NET Core Runtime
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/runtime:2.2
 ```
 
+#ASP.NET Core Runtime
+```dockerfile
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
+```
 The `FROM` command tells Docker to pull down the image tagged **2.2** from the **mcr.microsoft.com/dotnet/core/runtime** repository. Make sure that you pull the .NET Core runtime that matches the runtime targeted by your SDK. For example, the app created in the previous section used the .NET Core 2.2 SDK and created an app that targeted .NET Core 2.2. So the base image referred to in the *Dockerfile* is tagged with **2.2**.
 
 Save the *Dockerfile* file. The directory structure of the working folder should look like the following. Some of the deeper-level files and folders have been cut to save space in the article:

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -174,11 +174,13 @@ The *Dockerfile* file is used by the `docker build` command to create a containe
 In your terminal, navigate up a directory to the working folder you created at the start. Create a file named *Dockerfile* in your working folder and open it in a text editor. Add the following command as the first line of the file:
 
 ### .NET Core Runtime
+
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/runtime:2.2
 ```
 
 ### ASP.NET Core Runtime
+
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 ```


### PR DESCRIPTION
Having only the image for console applications can be misleading, to help making the right decision on which image to use i propose adding the aspnet image to the documentation.

## Summary

Describe your changes here.

Fixes #16520 
