### PR TITLE
Inform developers that DotNetCliToolReference is outdated

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -180,6 +180,8 @@ A `<DotNetCliToolReference>` item element specifies the CLI tool that the user w
 <DotNetCliToolReference Include="<package-id>" Version="" />
 ```
 
+Note that `DotNetCliToolReference` is [now deprecated](https://github.com/dotnet/announcements/issues/107) in favor of [.NET Core Local Tools](https://aka.ms/local-tools).
+
 #### Version
 
 `Version` specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/create-packages/dependency-versions#version-ranges) scheme. The default behavior is an exact version match. For example, specifying `Version="1.2.3"` is equivalent to NuGet notation `[1.2.3]` for the exact 1.2.3 version of the package.


### PR DESCRIPTION
## Summary

Added information that developers should use .NET Core local tools now instead of `DotNetCliToolReference`.