### PR TITLE
Document ASP.NET Core 3.0 breaking change for HTTPS redirection

### DIFF
--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 2.2 to 3.0 - .NET Core
 description: Lists the breaking changes from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, and EF Core.
-ms.date: 12/20/2019
+ms.date: 01/10/2020
 ---
 # Breaking changes for migration from Version 2.2 to 3.0
 
@@ -62,6 +62,10 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 ***
 
 [!INCLUDE[Hosting: Generic host restriction on Startup constructor injection](~/includes/core-changes/aspnetcore/3.0/hosting-generic-host-startup-ctor-restriction.md)]
+
+***
+
+[!INCLUDE[Hosting: HTTPS redirection enabled for IIS OutOfProcess](~/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 2.2 to 3.1 - .NET Core
 description: Lists the breaking changes from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, and EF Core.
-ms.date: 12/20/2019
+ms.date: 01/10/2020
 ---
 # Breaking changes for migration from Version 2.2 to 3.1
 
@@ -66,6 +66,10 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 ***
 
 [!INCLUDE[Hosting: Generic host restriction on Startup constructor injection](~/includes/core-changes/aspnetcore/3.0/hosting-generic-host-startup-ctor-restriction.md)]
+
+***
+
+[!INCLUDE[Hosting: HTTPS redirection enabled for IIS OutOfProcess](~/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -1,7 +1,7 @@
 ---
 title: ASP.NET Core breaking changes - .NET Core
 description: Lists the breaking changes in ASP.NET Core.
-ms.date: "12/20/2019"
+ms.date: "01/10/2020"
 author: "scottaddie"
 ms.author: "scaddie"
 ---
@@ -68,6 +68,10 @@ The following is a list of ASP.NET Core breaking changes by ASP.NET Core version
 ***
 
 [!INCLUDE[Hosting: Generic host restriction on Startup constructor injection](~/includes/core-changes/aspnetcore/3.0/hosting-generic-host-startup-ctor-restriction.md)]
+
+***
+
+[!INCLUDE[Hosting: HTTPS redirection enabled for IIS OutOfProcess](~/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
+++ b/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
@@ -14,7 +14,7 @@ The ASP.NET Core 2.1 project template first introduced support for HTTPS tools l
 
 #### New behavior
 
-In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/aspnet/AspNetCore/pull/4685). With the enhancement, an app could discover the server's HTTPS ports and make `UseHttpsRedirection` work by default. InProcess accomplished port discovery with the `IServerAddresses` feature, which only affects ASP.NET Core 3.0 apps because the InProcess library is versioned with the framework. OutOfProcess changed to automatically add the `ASPNETCORE_HTTPS_PORT` environment variable. This change affected both ASP.NET Core 2.2 and 3.0 apps because the OutOfProcess component is shared globally. ASP.NET Core 2.1 apps aren't affected because they use a prior version of ANCM by default.
+In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/dotnet/AspNetCore/pull/4685). With the enhancement, an app could discover the server's HTTPS ports and make `UseHttpsRedirection` work by default. InProcess accomplished port discovery with the `IServerAddresses` feature, which only affects ASP.NET Core 3.0 apps because the InProcess library is versioned with the framework. OutOfProcess changed to automatically add the `ASPNETCORE_HTTPS_PORT` environment variable. This change affected both ASP.NET Core 2.2 and 3.0 apps because the OutOfProcess component is shared globally. ASP.NET Core 2.1 apps aren't affected because they use a prior version of ANCM by default.
 
 #### Reason for change
 

--- a/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
+++ b/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
@@ -1,0 +1,53 @@
+### Hosting: HTTPS redirection enabled for IIS OutOfProcess
+
+Version 13.0.19218.0 of the [ASP.NET Core Module (ANCM)](/aspnet/core/host-and-deploy/aspnet-core-module) for hosting via IIS OutOfProcess enables an existing HTTPS redirection feature for ASP.NET Core 3.0 and 2.2 apps.
+
+For discussion, see [dotnet/AspNetCore#15243](https://github.com/dotnet/AspNetCore/issues/15243).
+
+#### Version introduced
+
+3.0
+
+#### Old behavior
+
+The ASP.NET Core 2.1 project template first introduced support for HTTPS tools like <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A> and <xref:Microsoft.AspNetCore.Builder.HstsBuilderExtensions.UseHsts%2A>. Enabling HTTPS redirection required the addition of configuration since apps in development don't use the default port of 443. [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) is active only if the request is already using HTTPS. Localhost is skipped by default.
+
+#### New behavior
+
+In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/aspnet/AspNetCore/pull/4685). With the enhancement, an app could discover the server's HTTPS ports and make `UseHttpsRedirection` work by default. InProcess accomplished port discovery with the `IServerAddresses` feature, which only affects ASP.NET Core 3.0 apps because the InProcess library is versioned with the framework. OutOfProcess changed to automatically add the `ASPNETCORE_HTTPS_PORT` environment variable. This change affected both ASP.NET Core 2.2 and 3.0 apps because the OutOfProcess component is shared globally. ASP.NET Core 2.1 apps aren't affected because they use a prior version of ANCM by default.
+
+#### Reason for change
+
+Improved ASP.NET Core 3.0 functionality.
+
+#### Recommended action
+
+No action is required if you want all clients to use HTTPS. To allow some clients to use HTTP, take one of the following steps:
+
+* Remove the calls to `UseHttpsRedirection` and `UseHsts` from your project's `Startup.Configure` method and redeploy the app.
+
+* In your *web.config* file, set the `ASPNETCORE_HTTPS_PORT` environment variable to an empty string. This change can occur directly on the server without redeploying the app. For example:
+
+    ```xml
+    <aspNetCore processPath="dotnet" arguments=".\WebApplication3.dll" stdoutLogEnabled="false" stdoutLogFile="\\?\%home%\LogFiles\stdout" >
+        <environmentVariables>
+        <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="" />
+        </environmentVariables>
+    </aspNetCore>
+    ```
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+<xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection(Microsoft.AspNetCore.Builder.IApplicationBuilder)?displayProperty=nameWithType>
+
+<!-- 
+
+#### Affected APIs
+
+`M:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection(Microsoft.AspNetCore.Builder.IApplicationBuilder)`
+
+-->

--- a/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
+++ b/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
@@ -10,7 +10,7 @@ For discussion, see [dotnet/AspNetCore#15243](https://github.com/dotnet/AspNetCo
 
 #### Old behavior
 
-The ASP.NET Core 2.1 project template first introduced support for HTTPS middleware methods like <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A> and <xref:Microsoft.AspNetCore.Builder.HstsBuilderExtensions.UseHsts%2A>. Enabling HTTPS redirection required the addition of configuration since apps in development don't use the default port of 443. [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) is active only if the request is already using HTTPS. Localhost is skipped by default.
+The ASP.NET Core 2.1 project template first introduced support for HTTPS middleware methods like <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A> and <xref:Microsoft.AspNetCore.Builder.HstsBuilderExtensions.UseHsts%2A>. Enabling HTTPS redirection required the addition of configuration, since apps in development don't use the default port of 443. [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) is active only if the request is already using HTTPS. Localhost is skipped by default.
 
 #### New behavior
 
@@ -18,7 +18,7 @@ In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/do
 
 The preceding behavior was modified in ASP.NET Core 3.0.1 and 3.1.0 Preview 3 to reverse the behavior changes in ASP.NET Core 2.x. These changes only affect IIS out-of-process apps.
 
-As detailed above, installing ASP.NET Core 3.0.0 had the side effect of also activating the `UseHttpsRedirection` middleware in ASP.NET Core 2.x apps. A change was made to ANCM in ASP.NET Core 3.0.1 and 3.1.0 Preview 3 such that installing them no longer has this effect on ASP.NET Core 2.x apps. The `ASPNETCORE_HTTPS_PORT` environment variable that ANCM populated in ASP.NET Core 3.0.0 was changed to `ASPNETCORE_ANCM_HTTPS_PORT` in ASP.NET Core 3.0.1 and 3.1.0 Preview 3. `UseHttpsRedirection` was also updated in these releases to understand both the new and old variables. ASP.NET Core 2.x won't be updated. As a result, its reverts to the previous behavior of disabled by default.
+As detailed above, installing ASP.NET Core 3.0.0 had the side effect of also activating the `UseHttpsRedirection` middleware in ASP.NET Core 2.x apps. A change was made to ANCM in ASP.NET Core 3.0.1 and 3.1.0 Preview 3 such that installing them no longer has this effect on ASP.NET Core 2.x apps. The `ASPNETCORE_HTTPS_PORT` environment variable that ANCM populated in ASP.NET Core 3.0.0 was changed to `ASPNETCORE_ANCM_HTTPS_PORT` in ASP.NET Core 3.0.1 and 3.1.0 Preview 3. `UseHttpsRedirection` was also updated in these releases to understand both the new and old variables. ASP.NET Core 2.x won't be updated. As a result, it reverts to the previous behavior of being disabled by default.
 
 #### Reason for change
 
@@ -28,7 +28,7 @@ Improved ASP.NET Core 3.0 functionality.
 
 No action is required if you want all clients to use HTTPS. To allow some clients to use HTTP, take one of the following steps:
 
-* Remove the calls to `UseHttpsRedirection` and `UseHsts` from your project's `Startup.Configure` method and redeploy the app.
+* Remove the calls to `UseHttpsRedirection` and `UseHsts` from your project's `Startup.Configure` method, and redeploy the app.
 * In your *web.config* file, set the `ASPNETCORE_HTTPS_PORT` environment variable to an empty string. This change can occur directly on the server without redeploying the app. For example:
 
     ```xml

--- a/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
+++ b/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
@@ -1,6 +1,6 @@
-### Hosting: HTTPS redirection enabled for IIS OutOfProcess
+### Hosting: HTTPS redirection enabled for IIS out-of-process apps
 
-Version 13.0.19218.0 of the [ASP.NET Core Module (ANCM)](/aspnet/core/host-and-deploy/aspnet-core-module) for hosting via IIS OutOfProcess enables an existing HTTPS redirection feature for ASP.NET Core 3.0 and 2.2 apps.
+Version 13.0.19218.0 of the [ASP.NET Core Module (ANCM)](/aspnet/core/host-and-deploy/aspnet-core-module) for hosting via IIS out-of-process enables an existing HTTPS redirection feature for ASP.NET Core 3.0 and 2.2 apps.
 
 For discussion, see [dotnet/AspNetCore#15243](https://github.com/dotnet/AspNetCore/issues/15243).
 
@@ -14,7 +14,7 @@ The ASP.NET Core 2.1 project template first introduced support for HTTPS tools l
 
 #### New behavior
 
-In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/dotnet/AspNetCore/pull/4685). With the enhancement, an app could discover the server's HTTPS ports and make `UseHttpsRedirection` work by default. InProcess accomplished port discovery with the `IServerAddresses` feature, which only affects ASP.NET Core 3.0 apps because the InProcess library is versioned with the framework. OutOfProcess changed to automatically add the `ASPNETCORE_HTTPS_PORT` environment variable. This change affected both ASP.NET Core 2.2 and 3.0 apps because the OutOfProcess component is shared globally. ASP.NET Core 2.1 apps aren't affected because they use a prior version of ANCM by default.
+In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/dotnet/AspNetCore/pull/4685). With the enhancement, an app could discover the server's HTTPS ports and make `UseHttpsRedirection` work by default. The in-process component accomplished port discovery with the `IServerAddresses` feature, which only affects ASP.NET Core 3.0 apps because the in-process library is versioned with the framework. The out-of-process component changed to automatically add the `ASPNETCORE_HTTPS_PORT` environment variable. This change affected both ASP.NET Core 2.2 and 3.0 apps because the out-of-process component is shared globally. ASP.NET Core 2.1 apps aren't affected because they use a prior version of ANCM by default.
 
 #### Reason for change
 

--- a/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
+++ b/includes/core-changes/aspnetcore/3.0/hosting-https-redirection-iis-outofprocess.md
@@ -10,11 +10,15 @@ For discussion, see [dotnet/AspNetCore#15243](https://github.com/dotnet/AspNetCo
 
 #### Old behavior
 
-The ASP.NET Core 2.1 project template first introduced support for HTTPS tools like <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A> and <xref:Microsoft.AspNetCore.Builder.HstsBuilderExtensions.UseHsts%2A>. Enabling HTTPS redirection required the addition of configuration since apps in development don't use the default port of 443. [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) is active only if the request is already using HTTPS. Localhost is skipped by default.
+The ASP.NET Core 2.1 project template first introduced support for HTTPS middleware methods like <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A> and <xref:Microsoft.AspNetCore.Builder.HstsBuilderExtensions.UseHsts%2A>. Enabling HTTPS redirection required the addition of configuration since apps in development don't use the default port of 443. [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) is active only if the request is already using HTTPS. Localhost is skipped by default.
 
 #### New behavior
 
 In ASP.NET Core 3.0, the IIS HTTPS scenario was [enhanced](https://github.com/dotnet/AspNetCore/pull/4685). With the enhancement, an app could discover the server's HTTPS ports and make `UseHttpsRedirection` work by default. The in-process component accomplished port discovery with the `IServerAddresses` feature, which only affects ASP.NET Core 3.0 apps because the in-process library is versioned with the framework. The out-of-process component changed to automatically add the `ASPNETCORE_HTTPS_PORT` environment variable. This change affected both ASP.NET Core 2.2 and 3.0 apps because the out-of-process component is shared globally. ASP.NET Core 2.1 apps aren't affected because they use a prior version of ANCM by default.
+
+The preceding behavior was modified in ASP.NET Core 3.0.1 and 3.1.0 Preview 3 to reverse the behavior changes in ASP.NET Core 2.x. These changes only affect IIS out-of-process apps.
+
+As detailed above, installing ASP.NET Core 3.0.0 had the side effect of also activating the `UseHttpsRedirection` middleware in ASP.NET Core 2.x apps. A change was made to ANCM in ASP.NET Core 3.0.1 and 3.1.0 Preview 3 such that installing them no longer has this effect on ASP.NET Core 2.x apps. The `ASPNETCORE_HTTPS_PORT` environment variable that ANCM populated in ASP.NET Core 3.0.0 was changed to `ASPNETCORE_ANCM_HTTPS_PORT` in ASP.NET Core 3.0.1 and 3.1.0 Preview 3. `UseHttpsRedirection` was also updated in these releases to understand both the new and old variables. ASP.NET Core 2.x won't be updated. As a result, its reverts to the previous behavior of disabled by default.
 
 #### Reason for change
 
@@ -25,7 +29,6 @@ Improved ASP.NET Core 3.0 functionality.
 No action is required if you want all clients to use HTTPS. To allow some clients to use HTTP, take one of the following steps:
 
 * Remove the calls to `UseHttpsRedirection` and `UseHsts` from your project's `Startup.Configure` method and redeploy the app.
-
 * In your *web.config* file, set the `ASPNETCORE_HTTPS_PORT` environment variable to an empty string. This change can occur directly on the server without redeploying the app. For example:
 
     ```xml
@@ -35,6 +38,15 @@ No action is required if you want all clients to use HTTPS. To allow some client
         </environmentVariables>
     </aspNetCore>
     ```
+
+`UseHttpsRedirection` can still be:
+
+* Activated manually in ASP.NET Core 2.x by setting the `ASPNETCORE_HTTPS_PORT` environment variable to the appropriate port number (443 in most production scenarios).
+* Deactivated in ASP.NET Core 3.x by defining `ASPNETCORE_ANCM_HTTPS_PORT` with an empty string value. This value is set in the same fashion as the preceding `ASPNETCORE_HTTPS_PORT` example.
+
+Machines running ASP.NET Core 3.0.0 apps should install the ASP.NET Core 3.0.1 runtime before installing the ASP.NET Core 3.1.0 Preview 3 ANCM. Doing so ensures that `UseHttpsRedirection` continues to operate as expected for the ASP.NET Core 3.0 apps.
+
+In Azure App Service, ANCM deploys on a separate schedule from the runtime because of its global nature. ANCM was deployed to Azure with these changes after ASP.NET Core 3.0.1 and 3.1.0 were deployed.
 
 #### Category
 


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/392
