### PR TITLE
add title suffix to design guidelines book

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -516,6 +516,7 @@
         "docs/desktop-wpf/**/**.md": "WPF",
         "docs/machine-learning/**/**.md": "ML.NET",
         "docs/standard/data/sqlite/**/**.md": "Microsoft.Data.Sqlite",
+        "docs/standard/design-guidelines/**/**.md": "Framework Design Guidelines",
         "docs/visual-basic/**/**.md": "Visual Basic"
       },
       "open_to_public_contributors": {

--- a/docs/standard/design-guidelines/index.md
+++ b/docs/standard/design-guidelines/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Framework Design Guidelines"
+titleSuffix: ""
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 


### PR DESCRIPTION
Otherwise, you have very weak titles such as https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/attributes