### PR TITLE
Add info about API docs

### DIFF
--- a/docs/whats-new/2019-12.md
+++ b/docs/whats-new/2019-12.md
@@ -59,7 +59,7 @@ Welcome to what's new in .NET docs for December 2019. This article lists some of
 
 ## .NET APIs
 
-.NET API documentation was updated to reflect .NET Core 3.1 release.
+.NET API documentation was updated to reflect [.NET Core 3.1](https://docs.microsoft.com/dotnet/api/?view=netcore-3.1) release.
 
 ## Visual Basic language
 

--- a/docs/whats-new/2019-12.md
+++ b/docs/whats-new/2019-12.md
@@ -57,6 +57,10 @@ Welcome to what's new in .NET docs for December 2019. This article lists some of
 
 - [Version tolerant serialization](../standard/serialization/version-tolerant-serialization.md) - Fix duplicate link in see also, and cleanup article
 
+## .NET APIs
+
+.NET API documentation was updated to reflect .NET Core 3.1 release.
+
 ## Visual Basic language
 
 ### New articles


### PR DESCRIPTION
We probably don't have a good way to add API docs changes for now so I think we should manually add significant changes for the what's new. @BillWagner what do you think?
