### PR TITLE
Moved the default values table

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -585,6 +585,10 @@
       "redirect_url": "/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types"
     },
     {
+      "source_path": "docs/csharp/language-reference/keywords/default-values-table.md",
+      "redirect_url": "/dotnet/csharp/language-reference/builtin-types/default-values"
+    },
+    {
       "source_path": "docs/csharp/language-reference/keywords/delegate.md",
       "redirect_url": "/dotnet/csharp/language-reference/builtin-types/reference-types"
     },

--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -1,25 +1,24 @@
 ---
-title: "Default values table - C# reference"
-description: Learn what are the default values of C# types.
+title: "Default values of C# types - C# reference"
 ms.date: 12/18/2019
 helpviewer_keywords: 
   - "default [C#]"
   - "parameterless constructor [C#]"
 ---
-# Default values table (C# reference)
+# Default values of C# types (C# reference)
 
 The following table shows the default values of C# types:
 
 |Type|Default value|
 |---------|------------------|
 |Any reference type|`null`|
-|Any [built-in integral numeric type](../builtin-types/integral-numeric-types.md)|0 (zero)|
-|Any [built-in floating-point numeric type](../builtin-types/floating-point-numeric-types.md)|0 (zero)|
-|[bool](../builtin-types/bool.md)|`false`|
-|[char](../builtin-types/char.md)|`'\0'` (U+0000)|
-|[enum](../builtin-types/enum.md)|The value produced by the expression `(E)0`, where `E` is the enum identifier.|
-|[struct](struct.md)|The value produced by setting all value-type fields to their default values and all reference-type fields to `null`.|
-|Any [nullable value type](../builtin-types/nullable-value-types.md)|An instance for which the <xref:System.Nullable%601.HasValue%2A> property is `false` and the <xref:System.Nullable%601.Value%2A> property is undefined. That default value is also known as the *null* value of a nullable value type.|
+|Any [built-in integral numeric type](integral-numeric-types.md)|0 (zero)|
+|Any [built-in floating-point numeric type](floating-point-numeric-types.md)|0 (zero)|
+|[bool](bool.md)|`false`|
+|[char](char.md)|`'\0'` (U+0000)|
+|[enum](enum.md)|The value produced by the expression `(E)0`, where `E` is the enum identifier.|
+|[struct](../keywords/struct.md)|The value produced by setting all value-type fields to their default values and all reference-type fields to `null`.|
+|Any [nullable value type](nullable-value-types.md)|An instance for which the <xref:System.Nullable%601.HasValue%2A> property is `false` and the <xref:System.Nullable%601.Value%2A> property is undefined. That default value is also known as the *null* value of a nullable value type.|
 
 Use the [default operator](../operators/default.md) to produce the default value of a type, as the following example shows:
 
@@ -52,6 +51,4 @@ For more information, see the following sections of the [C# language specificati
 ## See also
 
 - [C# reference](../index.md)
-- [C# keywords](index.md)
-- [Built-in types table](built-in-types-table.md)
 - [Constructors](../../programming-guide/classes-and-structs/constructors.md)

--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -1,5 +1,6 @@
 ---
 title: "Default values of C# types - C# reference"
+description: "Learn the default values of C# types such as bool, char, int, float, double and more."
 ms.date: 12/18/2019
 helpviewer_keywords: 
   - "default [C#]"

--- a/docs/csharp/language-reference/builtin-types/nullable-value-types.md
+++ b/docs/csharp/language-reference/builtin-types/nullable-value-types.md
@@ -50,7 +50,7 @@ If you want to assign a value of a nullable value type to a non-nullable value t
 
 [!code-csharp-interactive[?? operator](~/samples/csharp/language-reference/builtin-types/NullableValueTypes.cs#NullCoalescing)]
 
-If you want to use the [default](../keywords/default-values-table.md) value of the underlying value type in place of `null`, use the <xref:System.Nullable%601.GetValueOrDefault?displayProperty=nameWithType> method.
+If you want to use the [default](default-values.md) value of the underlying value type in place of `null`, use the <xref:System.Nullable%601.GetValueOrDefault?displayProperty=nameWithType> method.
 
 You also can explicitly cast a nullable value type to a non-nullable type, as the following example shows:
 

--- a/docs/csharp/language-reference/keywords/built-in-types-table.md
+++ b/docs/csharp/language-reference/keywords/built-in-types-table.md
@@ -61,5 +61,5 @@ Console.WriteLine(doubleType.FullName);
 - [C# Keywords](index.md)
 - [Value types](value-types.md)
 - [Reference types](reference-types.md)
-- [Default values table](default-values-table.md)
-- [dynamic](../builtin-types/reference-types.md)
+- [Default values of C# types](../builtin-types/default-values.md)
+- [dynamic](../builtin-types/reference-types.md#the-dynamic-type)

--- a/docs/csharp/language-reference/keywords/null.md
+++ b/docs/csharp/language-reference/keywords/null.md
@@ -24,5 +24,5 @@ The following example demonstrates some behaviors of the null keyword:
 
 - [C# reference](../index.md)
 - [C# keywords](index.md)
-- [Default values table](default-values-table.md)
+- [Default values of C# types](../builtin-types/default-values.md)
 - [Nothing (Visual Basic)](../../../visual-basic/language-reference/nothing.md)

--- a/docs/csharp/language-reference/keywords/struct.md
+++ b/docs/csharp/language-reference/keywords/struct.md
@@ -44,7 +44,6 @@ For examples, see [Using Structs](../../programming-guide/classes-and-structs/us
 - [C# Reference](../index.md)
 - [C# Programming Guide](../../programming-guide/index.md)
 - [C# Keywords](index.md)
-- [Default Values Table](default-values-table.md)
 - [Built-In Types Table](built-in-types-table.md)
 - [Types](/dotnet/csharp/language-reference/keywords)
 - [Value Types](value-types.md)

--- a/docs/csharp/language-reference/keywords/value-types-table.md
+++ b/docs/csharp/language-reference/keywords/value-types-table.md
@@ -31,6 +31,6 @@ The following table shows the C# value types:
 ## See also
 
 - [C# reference](../index.md)
-- [Default values table](default-values-table.md)
+- [Default values of C# types](../builtin-types/default-values.md)
 - [Value types](value-types.md)
 - [Formatting numeric results table](formatting-numeric-results-table.md)

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -27,7 +27,7 @@ Unlike with reference types, you cannot derive a new type from a value type. How
 
 Value type variables cannot be `null` by default. However, variables of the corresponding [nullable value types](../builtin-types/nullable-value-types.md) can be `null`.
 
-Each value type has an implicit parameterless constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](default-values-table.md).
+Each value type has an implicit parameterless constructor that initializes the default value of that type. For information about default values of value types, see [Default values of C# types](../builtin-types/default-values.md).
 
 ## Simple types
 
@@ -81,7 +81,7 @@ int myInt = new int();
 int myInt = 0;
 ```
 
-Using the [new](../operators/new-operator.md) operator calls the parameterless constructor of the specific type and assigns the default value to the variable. In the preceding example, the parameterless constructor assigned the value `0` to `myInt`. For more information about values assigned by calling parameterless constructors, see [Default values table](default-values-table.md).
+Using the [new](../operators/new-operator.md) operator calls the parameterless constructor of the specific type and assigns the default value to the variable. In the preceding example, the parameterless constructor assigned the value `0` to `myInt`. For more information about values assigned by calling parameterless constructors, see [Default values of C# types](../builtin-types/default-values.md).
 
 With user-defined types, use [new](../operators/new-operator.md) to invoke the parameterless constructor. For example, the following statement invokes the parameterless constructor of the `Point` struct:
 

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -7,7 +7,7 @@ helpviewer_keywords:
 ---
 # default operator (C# reference)
 
-The `default` operator produces the [default value](../keywords/default-values-table.md) of a type. The argument to the `default` operator must be the name of a type or a type parameter.
+The `default` operator produces the [default value](../builtin-types/default-values.md) of a type. The argument to the `default` operator must be the name of a type or a type parameter.
 
 The following example shows the usage of the `default` operator:
 
@@ -38,5 +38,5 @@ For more information about the `default` literal, see the [feature proposal note
 
 - [C# reference](../index.md)
 - [C# operators](index.md)
-- [Default values table](../keywords/default-values-table.md)
+- [Default values of C# types](../builtin-types/default-values.md)
 - [Generics in .NET](../../../standard/generics/index.md)

--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -13,7 +13,7 @@ Whenever a [class](../../language-reference/keywords/class.md) or [struct](../..
 
 ## Parameterless constructors
   
-If you don't provide a constructor for your class, C# creates one by default that instantiates the object and sets member variables to the default values as listed in the [Default Values Table](../../language-reference/keywords/default-values-table.md). If you don't provide a constructor for your struct, C# relies on an *implicit parameterless constructor* to automatically initialize each field of a value type to its default value as listed in the [Default Values Table](../../language-reference/keywords/default-values-table.md). For more information and examples, see [Instance Constructors](./instance-constructors.md).  
+If you don't provide a constructor for your class, C# creates one by default that instantiates the object and sets member variables to the default values as listed in the [Default values of C# types](../../language-reference/builtin-types/default-values.md) article. If you don't provide a constructor for your struct, C# relies on an *implicit parameterless constructor* to automatically initialize each field to its default value. For more information and examples, see [Instance constructors](instance-constructors.md).  
 
 ## Constructor syntax
 
@@ -27,13 +27,13 @@ If a constructor can be implemented as a single statement, you can use an [expre
 
 ## Static constructors
 
-The previous examples have all shown instance constructors, which create a new object. A class or struct can also have a static constructor, which initializes static members of the type.  Static constructors are parameterless. If you don't provide a static constructor to initialize static fields, the C# compiler initializes static fields to their default value as listed in the [Default Values Table](../../language-reference/keywords/default-values-table.md).
+The previous examples have all shown instance constructors, which create a new object. A class or struct can also have a static constructor, which initializes static members of the type.  Static constructors are parameterless. If you don't provide a static constructor to initialize static fields, the C# compiler initializes static fields to their default value as listed in the [Default values of C# types](../../language-reference/builtin-types/default-values.md) article.
 
 The following example uses a static constructor to initialize a static field.
 
 [!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#2)]  
 
-You can also define a static constructor with an expression body definition, as the following example shows. 
+You can also define a static constructor with an expression body definition, as the following example shows.
 
 [!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#3)]  
 

--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -25,7 +25,7 @@ Instance constructors are used to create and initialize any instance member vari
   
  [!code-csharp[csProgGuideObjects#77](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs#77)]  
   
- If a class does not have a constructor, a parameterless constructor is automatically generated and default values are used to initialize the object fields. For example, an [int](../../language-reference/builtin-types/integral-numeric-types.md) is initialized to 0. For more information on default values, see [Default Values Table](../../language-reference/keywords/default-values-table.md). Therefore, because the `Coords` class parameterless constructor initializes all data members to zero, it can be removed altogether without changing how the class works. A complete example using multiple constructors is provided in Example 1 later in this topic, and an example of an automatically generated constructor is provided in Example 2.  
+ If a class does not have a constructor, a parameterless constructor is automatically generated and default values are used to initialize the object fields. For example, an [int](../../language-reference/builtin-types/integral-numeric-types.md) is initialized to 0. For information about the type default values, see [Default values of C# types](../../language-reference/builtin-types/default-values.md). Therefore, because the `Coords` class parameterless constructor initializes all data members to zero, it can be removed altogether without changing how the class works. A complete example using multiple constructors is provided in Example 1 later in this topic, and an example of an automatically generated constructor is provided in Example 2.  
   
  Instance constructors can also be used to call the instance constructors of base classes. The class constructor can invoke the constructor of the base class through the initializer, as follows:  
   
@@ -43,7 +43,7 @@ Instance constructors are used to create and initialize any instance member vari
   
  [!code-csharp[csProgGuideObjects#8](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs#8)]  
   
- Notice that the default value of `age` is `0` and the default value of `name` is `null`. For more information on default values, see [Default Values Table](../../language-reference/keywords/default-values-table.md).  
+ Notice that the default value of `age` is `0` and the default value of `name` is `null`.
   
 ## Example 3  
  The following example demonstrates using the base class initializer. The `Circle` class is derived from the general class `Shape`, and the `Cylinder` class is derived from the `Circle` class. The constructor on each derived class is using its base class initializer.  

--- a/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
@@ -26,7 +26,7 @@ Static constructors have the following properties:
   
 - A static constructor is called automatically to initialize the [class](../../language-reference/keywords/class.md) before the first instance is created or any static members are referenced. A static constructor will run before an instance constructor. Note that a type's static constructor is called when a static method assigned to an event or a delegate is invoked and not when it is assigned. If static field variable initializers are present in the class of the static constructor, they will be executed in the textual order in which they appear in the class declaration immediately prior to the execution of the static constructor.
 
-- If you don't provide a static constructor to initialize static fields, all static fields are initialized to their default value as listed in the [Default Values Table](../../language-reference/keywords/default-values-table.md). 
+- If you don't provide a static constructor to initialize static fields, all static fields are initialized to their default value as listed in [Default values of C# types](../../language-reference/builtin-types/default-values.md).
   
 - If a static constructor throws an exception, the runtime will not invoke it a second time, and the type will remain uninitialized for the lifetime of the application domain in which your program is running. Most commonly, a <xref:System.TypeInitializationException> exception is thrown when a static constructor is unable to instantiate a type or for an unhandled exception occurring within a static constructor. For implicit static constructors that are not explicitly defined in source code, troubleshooting may require inspection of the intermediate language (IL) code.
 

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -23,7 +23,7 @@ When a [class](../../language-reference/keywords/class.md) or [struct](../../lan
   
  For more information, see [Private Constructors](./private-constructors.md).  
   
- Constructors for [struct](../../language-reference/keywords/struct.md) types resemble class constructors, but `structs` cannot contain an explicit parameterless constructor because one is provided automatically by the compiler. This constructor initializes each field in the `struct` to the default values. For more information, see [Default Values Table](../../language-reference/keywords/default-values-table.md). However, this parameterless constructor is only invoked if the `struct` is instantiated with `new`. For example, this code uses the parameterless constructor for <xref:System.Int32>, so that you are assured that the integer is initialized:  
+ Constructors for [struct](../../language-reference/keywords/struct.md) types resemble class constructors, but `structs` cannot contain an explicit parameterless constructor because one is provided automatically by the compiler. This constructor initializes each field in the `struct` to the [default value](../../language-reference/builtin-types/default-values.md). However, this parameterless constructor is only invoked if the `struct` is instantiated with `new`. For example, this code uses the parameterless constructor for <xref:System.Int32>, so that you are assured that the integer is initialized:  
   
 ```csharp  
 int i = new int();  

--- a/docs/csharp/programming-guide/classes-and-structs/using-structs.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-structs.md
@@ -15,7 +15,7 @@ It is an error to define a parameterless constructor for a struct. It is also an
 
 When you create a struct object using the [new](../../language-reference/operators/new-operator.md) operator, it gets created and the appropriate constructor is called according to the [constructor's signature](constructors.md#constructor-syntax). Unlike classes, structs can be instantiated without using the `new` operator. In such a case, there is no constructor call, which makes the allocation more efficient. However, the fields will remain unassigned and the object cannot be used until all of the fields are initialized. This includes the inability to get or set values through properties.
 
-If you instantiate a struct object using the parameterless constructor, all members are assigned according to their [default values](../../language-reference/keywords/default-values-table.md).
+If you instantiate a struct object using the parameterless constructor, all members are assigned according to their [default values](../../language-reference/builtin-types/default-values.md).
 
 When writing a constructor with parameters for a struct, you must explicitly initialize all members; otherwise one or more members remain unassigned and the struct cannot be used, producing compiler error [CS0171](../../misc/cs0171.md).
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1377,14 +1377,14 @@
         href: language-reference/keywords/var.md
       - name: Unmanaged types
         href: language-reference/builtin-types/unmanaged-types.md
+      - name: Default values
+        href: language-reference/builtin-types/default-values.md
       - name: Reference tables for types
         items:
         - name: Built-in types table
           href: language-reference/keywords/built-in-types-table.md
         - name: Value types table
           href: language-reference/keywords/value-types-table.md
-        - name: Default values table
-          href: language-reference/keywords/default-values-table.md
         - name: Formatting numeric results table
           href: language-reference/keywords/formatting-numeric-results-table.md
     - name: Modifiers


### PR DESCRIPTION
Moved the article from the *keywords* folder to the *builtin-types* folder where it looks to fit better. As for TOC, it's updated according to the trend of getting rid of the "Reference tables for types" node.
