### PR TITLE
Remove dependency note

### DIFF
--- a/docs/core/install/linux-package-manager-opensuse15.md
+++ b/docs/core/install/linux-package-manager-opensuse15.md
@@ -32,14 +32,6 @@ sudo mv prod.repo /etc/zypp/repos.d/microsoft-prod.repo
 sudo chown root:root /etc/zypp/repos.d/microsoft-prod.repo
 ```
 
-## Dependency error with .NET Core 3.1
-
-The .NET Core 3.1 package feed for openSUSE has a problem with the **krb5** dependency. Use the following command to install the correct dependencies prior to installing .NET Core 3.1 or ASP.NET Core 3.1.
-
-```bash
-sudo zypper install https://packages.microsoft.com/opensuse/15/prod/dotnet-runtime-deps-3.1.0-opensuse.42-x64.rpm
-```
-
 ## Install the .NET Core SDK
 
 Update the products available for installation, then install the .NET Core SDK. In your terminal, run the following command.
@@ -47,13 +39,6 @@ Update the products available for installation, then install the .NET Core SDK. 
 ```bash
 sudo zypper install dotnet-sdk-3.1
 ```
-
-> [!IMPORTANT]
-> The .NET Core 3.1 package feed for openSUSE has a problem with the **krb5** dependency. Use the following command to install the correct dependencies, then install the .NET Core 3.1 SDK.
->
-> ```bash
-> sudo zypper install https://packages.microsoft.com/opensuse/15/prod/dotnet-runtime-deps-3.1.0-opensuse.42-x64.rpm
-> ```
 
 ## Install the ASP.NET Core runtime
 
@@ -63,13 +48,6 @@ Update the products available for installation, then install the ASP.NET runtime
 sudo zypper install aspnetcore-runtime-3.1
 ```
 
-> [!IMPORTANT]
-> The .NET Core 3.1 package feed for openSUSE has a problem with the **krb5** dependency. Use the following command to install the correct dependencies, then install the ASP.NET Core 3.1 runtime.
->
-> ```bash
-> sudo zypper install https://packages.microsoft.com/opensuse/15/prod/dotnet-runtime-deps-3.1.0-opensuse.42-x64.rpm
-> ```
-
 ## Install the .NET Core runtime
 
 Update the products available for installation, then install the .NET Core runtime. In your terminal, run the following command.
@@ -77,13 +55,6 @@ Update the products available for installation, then install the .NET Core runti
 ```bash
 sudo zypper install dotnet-runtime-3.1
 ```
-
-> [!IMPORTANT]
-> The .NET Core 3.1 package feed for openSUSE has a problem with the **krb5** dependency. Use the following command to install the correct dependencies, then install the .NET Core 3.1 runtime.
->
-> ```bash
-> sudo zypper install https://packages.microsoft.com/opensuse/15/prod/dotnet-runtime-deps-3.1.0-opensuse.42-x64.rpm
-> ```
 
 ## How to install other versions
 


### PR DESCRIPTION
## Summary

Remove the dependency note for 3.1 as it's no longer valid.

Fixes #16691
