### PR TITLE
Fix code fencing

### DIFF
--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -27,7 +27,7 @@ C# has a number of built-in reference types. They have keywords or operators tha
 
 ## The object type
 
-The `object` type is an alias for <xref:System.Object?displayProperty=nameWithType> in .NET. In the unified type system of C#, all types, predefined and user-defined, reference types and value types, inherit directly or indirectly from <xref:System.Object?displayProperty=nameWithType>. You can assign values of any type to variables of type `object`. Any `object` variable can be assigned to its default value using the literal `null`. When a variable of a value type is converted to object, it is said to be *boxed*. When a variable of type object is converted to a value type, it is said to be *unboxed*. For more information, see [Boxing and Unboxing](../../programming-guide/types/boxing-and-unboxing.md). 
+The `object` type is an alias for <xref:System.Object?displayProperty=nameWithType> in .NET. In the unified type system of C#, all types, predefined and user-defined, reference types and value types, inherit directly or indirectly from <xref:System.Object?displayProperty=nameWithType>. You can assign values of any type to variables of type `object`. Any `object` variable can be assigned to its default value using the literal `null`. When a variable of a value type is converted to object, it is said to be *boxed*. When a variable of type `object` is converted to a value type, it is said to be *unboxed*. For more information, see [Boxing and Unboxing](../../programming-guide/types/boxing-and-unboxing.md). 
 
 ## The string type
 
@@ -61,14 +61,14 @@ string b = "h";
 b += "ello";
 ```
 
-The `[]` [operator](../operators/member-access-operators.md#indexer-operator-) can be used for readonly access to individual characters of a `string`. Valid values start at `0` and must be less than the length of the `string`:
+The `[]` [operator](../operators/member-access-operators.md#indexer-operator-) can be used for readonly access to individual characters of a string. Valid index values start at `0` and must be less than the length of the string:
 
 ```csharp
 string str = "test";
 char x = str[2];  // x = 's';
 ```
 
-In similar fashion, the `[]` operator can also be used for iterating over each character in a `string`:
+In similar fashion, the `[]` operator can also be used for iterating over each character in a string:
 
 ```csharp-interactive
 string str = "test";


### PR DESCRIPTION
- Code-fenced one occurrence of "object" where it refers to the type
- Removed code fencing where the "string" word refers to an instance
