### PR TITLE
Remove Repo - * issue labels and fix path

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -124,7 +124,7 @@
           "(?i).*master\/docs\/standard\/security.*": {
             "labels-add": ":card_file_box: Technology - Security"
           },
-          "(?i).*master\/docs\/standard\/standard\/design-guidelines\/.*": {
+          "(?i).*master\/docs\/standard\/design-guidelines\/.*": {
             "labels-add": ":book: guide - Framework Design Guidelines"
           },
           "(?i).*docs\/whats-new\/.*": {

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -37,10 +37,10 @@
             "labels-add": ":books: Area - .NET Guide"
           },
           "(?i)dotnet-ml-api$": {
-            "labels-add": ":books: Area - API Reference,:file_folder: Repo - ml-api-docs"
+            "labels-add": ":books: Area - API Reference"
           },
           "(?i)dotnet-roslyn-api$": {
-            "labels-add": ":books: Area - Roslyn API Reference,:file_folder: Repo - roslyn-api-docs"
+            "labels-add": ":books: Area - Roslyn API Reference"
           },
           "(?i)dotnet-whats-new$": {
             "labels-add": ":star2: What's New"

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -253,7 +253,7 @@
               "(?i).*docs\/standard\/security.*": {
                 "labels-add": ":card_file_box: Technology - Security"
               },
-              "(?i).*docs\/standard\/standard\/design-guidelines\/.*": {
+              "(?i).*docs\/standard\/design-guidelines\/.*": {
                 "labels-add": ":book: guide - Framework Design Guidelines"
               },
               "(?i).*docs\/visual-basic.*": {


### PR DESCRIPTION
Related to #15284

> - All the "repo" labels. We don't apply them consistently. 

The label can be removed from https://github.com/dotnet/docs/issues/16667