### PR TITLE
dotnet msbuild

### DIFF
--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -19,9 +19,9 @@ ms.date: 12/03/2018
 
 The `dotnet msbuild` command allows access to a fully functional MSBuild.
 
-The command has the exact same capabilities as the existing MSBuild command-line client for SDK-style project only. The options are all the same. For more information about the available options, see the [MSBuild Command-Line Reference](/visualstudio/msbuild/msbuild-command-line-reference).
+The command has the exact same capabilities as the existing MSBuild command-line client for SDK-style projects only. The options are all the same. For more information about the available options, see the [MSBuild command-line reference](/visualstudio/msbuild/msbuild-command-line-reference).
 
-The [dotnet build](dotnet-build.md) command is equivalent to `dotnet msbuild -restore -target:Build`. `dotnet build` is more commonly used for building projects, but `dotnet msbuild` gives you more control. For example, if you have a specific target you want to run (without running the build target), you probably want to use `dotnet msbuild`.
+The [dotnet build](dotnet-build.md) command is equivalent to `dotnet msbuild -restore -target:Build`. [dotnet build](dotnet-build.md) is more commonly used for building projects, but because it always runs the build target, you can use `dotnet msbuild` when you don't want to build the project. For example, if you have a specific target you want to run without building the project, use `dotnet msbuild` and specify the target.
 
 ## Examples
 
@@ -34,17 +34,17 @@ The [dotnet build](dotnet-build.md) command is equivalent to `dotnet msbuild -re
 * Build a project and its dependencies using Release configuration:
 
   ```dotnetcli
-  dotnet msbuild -p:Configuration=Release
+  dotnet msbuild -property:Configuration=Release
   ```
 
 * Run the publish target and publish for the `osx.10.11-x64` RID:
 
   ```dotnetcli
-  dotnet msbuild -t:Publish -p:RuntimeIdentifiers=osx.10.11-x64
+  dotnet msbuild -target:Publish -property:RuntimeIdentifiers=osx.10.11-x64
   ```
 
 * See the whole project with all targets included by the SDK:
 
   ```dotnetcli
-  dotnet msbuild -pp
+  dotnet msbuild -preprocess
   ```


### PR DESCRIPTION
- Grammar and clarifications
- Use long form for options for readability

Fixes #6295, which was already mostly fixed by https://github.com/dotnet/docs/commit/1bfcc6595014c966d158b88123abb52ac5ed4af6#diff-d891c5697126b5d84b901017d97a7b7e.