### PR TITLE
Add information on default interface members - added in C# 8.0

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0106.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0106.md
@@ -13,8 +13,6 @@ The modifier 'modifier' is not valid for this item
 
  A class or interface member was marked with an invalid access modifier. The following examples describe some of these invalid modifiers:
 
-- The [static](../keywords/static.md) and [public](../keywords/public.md) modifiers are not permitted on interface methods.
-
 - The [static](../keywords/static.md) modifier is not permitted on a [local function](../../programming-guide/classes-and-structs/local-functions.md).
 
 - The `public` keyword is not allowed on an explicit interface declaration. In this case, remove the `public` keyword from the explicit interface declaration.
@@ -38,7 +36,6 @@ namespace MyNamespace
    interface I
    {
       void m();
-      static public void f();   // CS0106
    }
 
    public class MyClass

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -34,7 +34,14 @@ These preceding member declarations typically do not contain a body. Beginning w
 - Member declarations using the explicit interface implementation syntax.
 - Explicit access modifiers (the default access is [`public`](access-modifiers.md)).
 
-Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field.
+Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field. This rule has a subtle effect on property declarations. In an interface declaration, the following does not declare an auto-implemented property as it does in a `class` or `struct`. Instead, it declares a property that doesn't have a default implementation, but must be implemented in any type that implements the interface:
+
+```csharp
+public interface INamed
+{
+  public string Name {get; set;}
+}
+```
 
 An interface can inherit from one or more base interfaces. When an interface [overrides a method](override.md) implemented in a base interface, it must use the explicit interface implementation syntax.
 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -29,7 +29,7 @@ These preceding member declarations typically do not contain a body. Beginning w
 - [Constants](const.md)
 - [Operators](../operators/operator-overloading.md)
 - [Static constructor](../../programming-guide/classes-and-structs/constructors.md#static-constructors).
-- [Nested types](../../programming-guide/classes-and-structs/nested-types)
+- [Nested types](../../programming-guide/classes-and-structs/nested-types.md)
 - [Static fields, methods, properties, indexers, and events](static.md)
 - Member declarations using the explicit interface implementation syntax.
 - Explicit access modifiers (the default access is [`public`](access-modifiers.md)).

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -7,7 +7,7 @@ helpviewer_keywords:
   - "interface keyword [C#]"
 ms.assetid: 7da38e81-4f99-4bc5-b07d-c986b687eeba
 ---
-# interface (C# Reference)
+# :::no-loc text="interface"::: (C# Reference)
 
 An interface defines a contract. Any [`class`](class.md) or [`struct`](struct.md) that implements that contract must provide an implementation of the members defined in the interface. Beginning with C# 8.0, an interface may define a default implementation for members. It may also define [`static`](static.md) members in order to provide a single implementation for common functionality. In the following example, class `ImplementationClass` must implement a method named `SampleMethod` that has no parameters and returns `void`.
 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -1,6 +1,6 @@
 ---
 title: "interface - C# Reference"
-ms.date: 01/17/2019
+ms.date: 01/17/2020
 f1_keywords: 
   - "interface_CSharpKeyword"
 helpviewer_keywords: 
@@ -9,7 +9,9 @@ ms.assetid: 7da38e81-4f99-4bc5-b07d-c986b687eeba
 ---
 # :::no-loc text="interface"::: (C# Reference)
 
-An interface defines a contract. Any [`class`](class.md) or [`struct`](struct.md) that implements that contract must provide an implementation of the members defined in the interface. Beginning with C# 8.0, an interface may define a default implementation for members. It may also define [`static`](static.md) members in order to provide a single implementation for common functionality. In the following example, class `ImplementationClass` must implement a method named `SampleMethod` that has no parameters and returns `void`.
+An interface defines a contract. Any [`class`](class.md) or [`struct`](struct.md) that implements that contract must provide an implementation of the members defined in the interface. Beginning with C# 8.0, an interface may define a default implementation for members. It may also define [`static`](static.md) members in order to provide a single implementation for common functionality.
+
+In the following example, class `ImplementationClass` must implement a method named `SampleMethod` that has no parameters and returns `void`.
 
 For more information and examples, see [Interfaces](../../programming-guide/interfaces/index.md).
 
@@ -24,7 +26,7 @@ An interface can be a member of a namespace or a class. An interface declaration
 - [Indexers](../../programming-guide/indexers/using-indexers.md)
 - [Events](event.md)
 
-These preceding member declarations typically do not contain a body. Beginning with C# 8.0, an interface may declare a body, called a *default implementation*. Members with bodies permit the interface to provide a "default" implementation for the method in classes and structs that do not provide an overriding implementation. In addition, beginning with C# 8.0, an interface may include:
+These preceding member declarations typically do not contain a body. Beginning with C# 8.0, an interface member may declare a body. This is called a *default implementation*. Members with bodies permit the interface to provide a "default" implementation for classes and structs that don't provide an overriding implementation. In addition, beginning with C# 8.0, an interface may include:
 
 - [Constants](const.md)
 - [Operators](../operators/operator-overloading.md)
@@ -34,7 +36,7 @@ These preceding member declarations typically do not contain a body. Beginning w
 - Member declarations using the explicit interface implementation syntax.
 - Explicit access modifiers (the default access is [`public`](access-modifiers.md)).
 
-Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field. This rule has a subtle effect on property declarations. In an interface declaration, the following does not declare an auto-implemented property as it does in a `class` or `struct`. Instead, it declares a property that doesn't have a default implementation, but must be implemented in any type that implements the interface:
+Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field. This rule has a subtle effect on property declarations. In an interface declaration, the following code does not declare an auto-implemented property as it does in a `class` or `struct`. Instead, it declares a property that doesn't have a default implementation but must be implemented in any type that implements the interface:
 
 ```csharp
 public interface INamed
@@ -43,11 +45,11 @@ public interface INamed
 }
 ```
 
-An interface can inherit from one or more base interfaces. When an interface [overrides a method](override.md) implemented in a base interface, it must use the explicit interface implementation syntax.
+An interface can inherit from one or more base interfaces. When an interface [overrides a method](override.md) implemented in a base interface, it must use the [explicit interface implementation](../../programming-guide/interfaces/explicit-interface-implementation.md) syntax.
 
 When a base type list contains a base class and interfaces, the base class must come first in the list.
 
-A class that implements an interface can explicitly implement members of that interface. An explicitly implemented member cannot be accessed through a class instance, but only through an instance of the interface. Default interface members can only be accessed through an instance of the interface.
+A class that implements an interface can explicitly implement members of that interface. An explicitly implemented member cannot be accessed through a class instance, but only through an instance of the interface. In addtion, default interface members can only be accessed through an instance of the interface.
 
 For more information about explicit interface implementation, see [Explicit Interface Implementation](../../programming-guide/interfaces/explicit-interface-implementation.md).
 
@@ -59,7 +61,7 @@ The following example demonstrates interface implementation. In this example, th
 
 ## C# language specification
 
-For more information, see the [Interfaces](~/_csharplang/spec/interfaces.md) section of the [C# language specification](~/_csharplang/spec/introduction.md), and the feature specification for [Default interface members - C# 8.0](~/_csharplang/proposals/csharp-8.0/default-interface-methods.md)
+For more information, see the [Interfaces](~/_csharplang/spec/interfaces.md) section of the [C# language specification](~/_csharplang/spec/introduction.md) and the feature specification for [Default interface members - C# 8.0](~/_csharplang/proposals/csharp-8.0/default-interface-methods.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -1,6 +1,6 @@
 ---
 title: "interface - C# Reference"
-ms.date: 07/20/2015
+ms.date: 01/17/2019
 f1_keywords: 
   - "interface_CSharpKeyword"
 helpviewer_keywords: 
@@ -9,7 +9,7 @@ ms.assetid: 7da38e81-4f99-4bc5-b07d-c986b687eeba
 ---
 # interface (C# Reference)
 
-An interface contains only the signatures of [methods](../../programming-guide/classes-and-structs/methods.md), [properties](../../programming-guide/classes-and-structs/properties.md), [events](../../programming-guide/events/index.md) or [indexers](../../programming-guide/indexers/index.md). A class or struct that implements the interface must implement the members of the interface that are specified in the interface definition. In the following example, class `ImplementationClass` must implement a method named `SampleMethod` that has no parameters and returns `void`.
+An interface defines a contract. Any [`class`](class.md) or [`struct`](struct.md) that implements that contract must provide an implementation of the members defined in the interface. Beginning with C# 8.0, an interface may define a default implementation for members. It may also define [`static`](static.md) members in order to provide a single implementation for common functionality. In the following example, class `ImplementationClass` must implement a method named `SampleMethod` that has no parameters and returns `void`.
 
 For more information and examples, see [Interfaces](../../programming-guide/interfaces/index.md).
 
@@ -17,23 +17,32 @@ For more information and examples, see [Interfaces](../../programming-guide/inte
 
 [!code-csharp[csrefKeywordsTypes#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsTypes/CS/keywordsTypes.cs#14)]
 
-An interface can be a member of a namespace or a class and can contain signatures of the following members:
+An interface can be a member of a namespace or a class. An interface declaration can contain declarations (signatures without any implementation) of the following members:
 
 - [Methods](../../programming-guide/classes-and-structs/methods.md)
-
 - [Properties](../../programming-guide/classes-and-structs/using-properties.md)
-
 - [Indexers](../../programming-guide/indexers/using-indexers.md)
-
 - [Events](event.md)
 
-An interface can inherit from one or more base interfaces.
+These preceding member declarations typically do not contain a body. Beginning with C# 8.0, an interface may declare a body, called a *default implementation*. Members with bodies permit the interface to provide a "default" implementation for the method in classes and structs that do not provide an overriding implementation. In addition, beginning with C# 8.0, an interface may include:
+
+- [Constants](const.md)
+- [Operators](../operators/operator-overloading.md)
+- [Static constructor](../../programming-guide/classes-and-structs/constructors.md#static-constructors).
+- [Nested types](../../programming-guide/classes-and-structs/nested-types)
+- [Static fields, methods, properties, indexers, and events](static.md)
+- Member declarations using the explicit interface implementation syntax.
+- Explicit access modifiers (the default access is [`public`](access-modifiers.md)).
+
+Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field.
+
+An interface can inherit from one or more base interfaces. When an interface [overrides a method](override.md) implemented in a base interface, it must use the explicit interface implementation syntax.
 
 When a base type list contains a base class and interfaces, the base class must come first in the list.
 
-A class that implements an interface can explicitly implement members of that interface. An explicitly implemented member cannot be accessed through a class instance, but only through an instance of the interface.
+A class that implements an interface can explicitly implement members of that interface. An explicitly implemented member cannot be accessed through a class instance, but only through an instance of the interface. Default interface members can only be accessed through an instance of the interface.
 
-For more details and code examples on explicit interface implementation, see [Explicit Interface Implementation](../../programming-guide/interfaces/explicit-interface-implementation.md).
+For more information about explicit interface implementation, see [Explicit Interface Implementation](../../programming-guide/interfaces/explicit-interface-implementation.md).
 
 ## Example
 
@@ -43,7 +52,7 @@ The following example demonstrates interface implementation. In this example, th
 
 ## C# language specification
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see the [Interfaces](~/_csharplang/spec/interfaces.md) section of the [C# language specification](~/_csharplang/spec/introduction.md), and the feature specification for [Default interface members - C# 8.0](~/_csharplang/proposals/csharp-8.0/default-interface-methods.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -1,6 +1,6 @@
 ---
 title: "static modifier - C# Reference"
-ms.date: 001/22/2020
+ms.date: 01/22/2020
 f1_keywords: 
   - "static"
   - "static_CSharpKeyword"
@@ -10,7 +10,7 @@ ms.assetid: 5509e215-2183-4da3-bab4-6b7e607a4fdf
 ---
 # static (C# Reference)
 
-Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare static classes. In classes, interfaces and structs, you may add the static modifier to fields, methods, properties, operators, events, and constructors. The static modifier can't be used with indexers, finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
+Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare static classes. In classes, interfaces, and structs, you may add the `static` modifier to fields, methods, properties, operators, events, and constructors. The `static` modifier can't be used with indexers or finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
 
 ## Example
 
@@ -34,12 +34,12 @@ It isn't possible to use [`this`](this.md) to reference static methods or proper
 
 If the `static` keyword is applied to a class, all the members of the class must be `static`.
 
-Classes, interfaces, and static classes may have static constructors. Static constructors are called at some point between when the program starts and the class is instantiated.
+Classes, interfaces, and static classes may have static constructors. A static constructor is called at some point between when the program starts and the class is instantiated.
 
 > [!NOTE]
 > The `static` keyword has more limited uses than in C++. To compare with the C++ keyword, see [Storage classes (C++)](/cpp/cpp/storage-classes-cpp#static).
 
-To demonstrate static members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field don't belong to any instance employee. Instead they belong to the company class. They should be declared as `static` members of the class.
+To demonstrate static members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field don't belong to any one employee instance. Instead, they belong to the class of employees as a whole. They should be declared as `static` members of the class.
 
 ## Example
 

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -1,6 +1,6 @@
 ---
 title: "static modifier - C# Reference"
-ms.date: 07/20/2015
+ms.date: 001/22/2020
 f1_keywords: 
   - "static"
   - "static_CSharpKeyword"
@@ -10,7 +10,7 @@ ms.assetid: 5509e215-2183-4da3-bab4-6b7e607a4fdf
 ---
 # static (C# Reference)
 
-Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used with classes, fields, methods, properties, operators, events, and constructors, but it cannot be used with indexers, finalizers, or types other than classes. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
+Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare static classes. In classes and structs, the static modifier may be used on fields, methods, properties, operators, events, and constructors, but it cannot be used with indexers, finalizers. Interfaces may declare static methods, properties, operators, events, and constructors. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
 
 ## Example
 
@@ -36,7 +36,7 @@ It is not possible to use [this](this.md) to reference static methods or propert
 
 If the `static` keyword is applied to a class, all the members of the class must be static.
 
-Classes and static classes may have static constructors. Static constructors are called at some point between when the program starts and the class is instantiated.
+Classes, interfaces, and static classes may have static constructors. Static constructors are called at some point between when the program starts and the class is instantiated.
 
 > [!NOTE]
 > The `static` keyword has more limited uses than in C++. To compare with the C++ keyword, see [Storage classes (C++)](/cpp/cpp/storage-classes-cpp#static).

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -10,7 +10,7 @@ ms.assetid: 5509e215-2183-4da3-bab4-6b7e607a4fdf
 ---
 # static (C# Reference)
 
-Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare static classes. In classes and structs, the static modifier may be used on fields, methods, properties, operators, events, and constructors, but it cannot be used with indexers, finalizers. Interfaces may declare static methods, properties, operators, events, and constructors. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
+Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare static classes. In classes, interfaces and structs, you may add the static modifier to fields, methods, properties, operators, events, and constructors. The static modifier can't be used with indexers, finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
 
 ## Example
 
@@ -18,40 +18,38 @@ The following class is declared as `static` and contains only `static` methods:
 
 [!code-csharp[csrefKeywordsModifiers#18](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#18)]
 
-A constant or type declaration is implicitly a static member.
-
-A static member cannot be referenced through an instance. Instead, it is referenced through the type name. For example, consider the following class:
+A constant or type declaration is implicitly a `static` member. A `static` member can't be referenced through an instance. Instead, it's referenced through the type name. For example, consider the following class:
 
 [!code-csharp[csrefKeywordsModifiers#19](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#19)]
 
-To refer to the static member `x`, use the fully qualified name, `MyBaseC.MyStruct.x`, unless the member is accessible from the same scope:
+To refer to the `static` member `x`, use the fully qualified name, `MyBaseC.MyStruct.x`, unless the member is accessible from the same scope:
 
 ```csharp
 Console.WriteLine(MyBaseC.MyStruct.x);
 ```
 
-While an instance of a class contains a separate copy of all instance fields of the class, there is only one copy of each static field.
+While an instance of a class contains a separate copy of all instance fields of the class, there's only one copy of each static field.
 
-It is not possible to use [this](this.md) to reference static methods or property accessors.
+It isn't possible to use [`this`](this.md) to reference static methods or property accessors.
 
-If the `static` keyword is applied to a class, all the members of the class must be static.
+If the `static` keyword is applied to a class, all the members of the class must be `static`.
 
 Classes, interfaces, and static classes may have static constructors. Static constructors are called at some point between when the program starts and the class is instantiated.
 
 > [!NOTE]
 > The `static` keyword has more limited uses than in C++. To compare with the C++ keyword, see [Storage classes (C++)](/cpp/cpp/storage-classes-cpp#static).
 
-To demonstrate static members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field do not belong to any instance employee. Instead they belong to the company class. Therefore, they should be declared as static members of the class.
+To demonstrate static members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field don't belong to any instance employee. Instead they belong to the company class. They should be declared as `static` members of the class.
 
 ## Example
 
-This example reads the name and ID of a new employee, increments the employee counter by one, and displays the information for the new employee and the new number of employees. For simplicity, this program reads the current number of employees from the keyboard. In a real application, this information should be read from a file.
+This example reads the name and ID of a new employee, increments the employee counter by one, and displays the information for the new employee and the new number of employees. This program reads the current number of employees from the keyboard.
 
 [!code-csharp[csrefKeywordsModifiers#20](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#20)]  
 
 ## Example
 
-This example shows that although you can initialize a static field by using another static field not yet declared, the results will be undefined until you explicitly assign a value to the static field.
+This example shows that you can initialize a static field by using another static field that is not yet declared. The results will be undefined until you explicitly assign a value to the static field.
 
 [!code-csharp[csrefKeywordsModifiers#21](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#21)]  
 

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -10,7 +10,7 @@ ms.assetid: 5509e215-2183-4da3-bab4-6b7e607a4fdf
 ---
 # static (C# Reference)
 
-Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare static classes. In classes, interfaces, and structs, you may add the `static` modifier to fields, methods, properties, operators, events, and constructors. The `static` modifier can't be used with indexers or finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
+Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare `static` classes. In classes, interfaces, and structs, you may add the `static` modifier to fields, methods, properties, operators, events, and constructors. The `static` modifier can't be used with indexers or finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
 
 ## Example
 
@@ -28,18 +28,18 @@ To refer to the `static` member `x`, use the fully qualified name, `MyBaseC.MySt
 Console.WriteLine(MyBaseC.MyStruct.x);
 ```
 
-While an instance of a class contains a separate copy of all instance fields of the class, there's only one copy of each static field.
+While an instance of a class contains a separate copy of all instance fields of the class, there's only one copy of each `static` field.
 
-It isn't possible to use [`this`](this.md) to reference static methods or property accessors.
+It isn't possible to use [`this`](this.md) to reference `static` methods or property accessors.
 
 If the `static` keyword is applied to a class, all the members of the class must be `static`.
 
-Classes, interfaces, and static classes may have static constructors. A static constructor is called at some point between when the program starts and the class is instantiated.
+Classes, interfaces, and `static` classes may have `static` constructors. A `static` constructor is called at some point between when the program starts and the class is instantiated.
 
 > [!NOTE]
 > The `static` keyword has more limited uses than in C++. To compare with the C++ keyword, see [Storage classes (C++)](/cpp/cpp/storage-classes-cpp#static).
 
-To demonstrate static members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field don't belong to any one employee instance. Instead, they belong to the class of employees as a whole. They should be declared as `static` members of the class.
+To demonstrate `static` members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field don't belong to any one employee instance. Instead, they belong to the class of employees as a whole. They should be declared as `static` members of the class.
 
 ## Example
 
@@ -49,7 +49,7 @@ This example reads the name and ID of a new employee, increments the employee co
 
 ## Example
 
-This example shows that you can initialize a static field by using another static field that is not yet declared. The results will be undefined until you explicitly assign a value to the static field.
+This example shows that you can initialize a `static` field by using another `static` field that is not yet declared. The results will be undefined until you explicitly assign a value to the `static` field.
 
 [!code-csharp[csrefKeywordsModifiers#21](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#21)]  
 


### PR DESCRIPTION
Fixes #12490 
Fixes #16061 

Interfaces can now contain implementations of some member types.

- Include information on default interface members and what new member types are allowed in interfaces.
- Rewrite the opening to match the new uses of interfaces.
- Refer to the correct section of the language standard.
- Add a reference to the C# 8.0 default interface members specification.
