### PR TITLE
Fix integer overflow in backoff calculation.

### DIFF
--- a/docs/architecture/microservices/implement-resilient-applications/explore-custom-http-call-retries-exponential-backoff.md
+++ b/docs/architecture/microservices/implement-resilient-applications/explore-custom-http-call-retries-exponential-backoff.md
@@ -75,7 +75,7 @@ public struct ExponentialBackoff
         {
             m_pow = m_pow << 1; // m_pow = Pow(2, m_retries - 1)
         }
-        int delay = Math.Min(m_delayMilliseconds * (m_pow - 1) / 2,
+        int delay = (int)Math.Min((long)m_delayMilliseconds * (m_pow - 1) / 2,
             m_maxDelayMilliseconds);
         return Task.Delay(delay);
     }


### PR DESCRIPTION
Fixes an integer overflow that causes delay values to be negative on the 24th retry with the default values which causes `Task.Delay()` to throw.

Fixes #16754
