### PR TITLE
Minor update to exe path in getting started

### DIFF
--- a/docs/core/tutorials/cli-create-console-app.md
+++ b/docs/core/tutorials/cli-create-console-app.md
@@ -177,7 +177,7 @@ Hello World!
 As mentioned at the start of this article, an operating system-specific executable was created along with the `Hello.dll`. On Windows, this would be `Hello.exe`; on Linux or macOS, this would be `hello`. With the example above, the file is named with `Hello.exe` or `Hello`. You can run this published executable directly.
 
 ```console
-bin\Debug\netcoreapp3.1\publish\Hello.exe
+.\bin\Debug\netcoreapp3.1\publish\Hello.exe
 
 Hello World!
 ```

--- a/docs/core/tutorials/cli-create-console-app.md
+++ b/docs/core/tutorials/cli-create-console-app.md
@@ -177,7 +177,7 @@ Hello World!
 As mentioned at the start of this article, an operating system-specific executable was created along with the `Hello.dll`. On Windows, this would be `Hello.exe`; on Linux or macOS, this would be `hello`. With the example above, the file is named with `Hello.exe` or `Hello`. You can run this published executable directly.
 
 ```console
-.\bin\Debug\netcoreapp3.1\Hello.exe
+bin\Debug\netcoreapp3.1\publish\Hello.exe
 
 Hello World!
 ```


### PR DESCRIPTION
## Summary

- Changed the path to the exe version to the publish folder.
- Even thought there will be an exe in the non publish folder, the previous command the user runs is in the publish folder. This should reduce any confusion.

Fixes #16770
