### PR TITLE
Fix snippet ID for new snippet syntax 

### DIFF
--- a/docs/csharp/language-reference/builtin-types/value-types.md
+++ b/docs/csharp/language-reference/builtin-types/value-types.md
@@ -13,13 +13,13 @@ ms.assetid: 471eb994-2958-49d5-a6be-19b4313f80a3
 
 *Value types* and [reference types](../keywords/reference-types.md) are the two main categories of C# types. A variable of a value type contains an instance of the type. This differs from a variable of a reference type, which contains a reference to an instance of the type. By default, on [assignment](../operators/assignment-operator.md), passing an argument to a method, or returning a method result, variable values are copied. In the case of value-type variables, the corresponding type instances are copied. The following example demonstrates that behavior:
 
-:::code language="csharp" source="~/samples/csharp/language-reference/builtin-types/ValueTypes.cs" id="ValueTypeCopied":::
+[!code-csharp[copy of values](~/samples/csharp/language-reference/builtin-types/ValueTypes.cs#ValueTypeCopied)]
 
 As the preceding example shows, operations on a value-type variable affect only that instance of the value type, stored in the variable.
 
 If a value type contains a data member of a reference type, only the reference to the instance of the reference type is copied when a value-type instance is copied. Both the copy and original value-type instance have access to the same reference-type instance. The following example demonstrates that behavior:
 
-:::code language="csharp" source="~/samples/csharp/language-reference/builtin-types/ValueTypes.cs" id="ShallowCopy":::
+[!code-csharp[shallow copy](~/samples/csharp/language-reference/builtin-types/ValueTypes.cs#ShallowCopy)]
 
 > [!NOTE]
 > To make your code less error-prone and more robust, define and use immutable value types. This article uses mutable value types only for demonstration purposes.

--- a/docs/csharp/language-reference/builtin-types/value-types.md
+++ b/docs/csharp/language-reference/builtin-types/value-types.md
@@ -13,13 +13,13 @@ ms.assetid: 471eb994-2958-49d5-a6be-19b4313f80a3
 
 *Value types* and [reference types](../keywords/reference-types.md) are the two main categories of C# types. A variable of a value type contains an instance of the type. This differs from a variable of a reference type, which contains a reference to an instance of the type. By default, on [assignment](../operators/assignment-operator.md), passing an argument to a method, or returning a method result, variable values are copied. In the case of value-type variables, the corresponding type instances are copied. The following example demonstrates that behavior:
 
-:::code language="csharp" source="~/samples/csharp/language-reference/builtin-types/ValueTypes.cs" id="SnippetValueTypeCopied":::
+[!code-csharp[copy of values](~/samples/csharp/language-reference/builtin-types/ValueTypes.cs#ValueTypeCopied)]
 
 As the preceding example shows, operations on a value-type variable affect only that instance of the value type, stored in the variable.
 
 If a value type contains a data member of a reference type, only the reference to the instance of the reference type is copied when a value-type instance is copied. Both the copy and original value-type instance have access to the same reference-type instance. The following example demonstrates that behavior:
 
-:::code language="csharp" source="~/samples/csharp/language-reference/builtin-types/ValueTypes.cs" id="SnippetShallowCopy":::
+[!code-csharp[shallow copy](~/samples/csharp/language-reference/builtin-types/ValueTypes.cs#ShallowCopy)]
 
 > [!NOTE]
 > To make your code less error-prone and more robust, define and use immutable value types. This article uses mutable value types only for demonstration purposes.

--- a/docs/csharp/language-reference/builtin-types/value-types.md
+++ b/docs/csharp/language-reference/builtin-types/value-types.md
@@ -13,7 +13,7 @@ ms.assetid: 471eb994-2958-49d5-a6be-19b4313f80a3
 
 *Value types* and [reference types](../keywords/reference-types.md) are the two main categories of C# types. A variable of a value type contains an instance of the type. This differs from a variable of a reference type, which contains a reference to an instance of the type. By default, on [assignment](../operators/assignment-operator.md), passing an argument to a method, or returning a method result, variable values are copied. In the case of value-type variables, the corresponding type instances are copied. The following example demonstrates that behavior:
 
-[!code-csharp[copy of values](~/samples/csharp/language-reference/builtin-types/ValueTypes.cs#ValueTypeCopied)]
+:::code language="csharp" source="~/samples/csharp/language-reference/builtin-types/ValueTypes.cs" id="SnippetValueTypeCopied":::
 
 As the preceding example shows, operations on a value-type variable affect only that instance of the value type, stored in the variable.
 

--- a/docs/csharp/language-reference/builtin-types/value-types.md
+++ b/docs/csharp/language-reference/builtin-types/value-types.md
@@ -19,7 +19,7 @@ As the preceding example shows, operations on a value-type variable affect only 
 
 If a value type contains a data member of a reference type, only the reference to the instance of the reference type is copied when a value-type instance is copied. Both the copy and original value-type instance have access to the same reference-type instance. The following example demonstrates that behavior:
 
-[!code-csharp[shallow copy](~/samples/csharp/language-reference/builtin-types/ValueTypes.cs#ShallowCopy)]
+:::code language="csharp" source="~/samples/csharp/language-reference/builtin-types/ValueTypes.cs" id="SnippetShallowCopy":::
 
 > [!NOTE]
 > To make your code less error-prone and more robust, define and use immutable value types. This article uses mutable value types only for demonstration purposes.


### PR DESCRIPTION
Maybe I've used the new syntax not correctly but currently it renders the *whole* file with the snippets:
![image](https://user-images.githubusercontent.com/15279990/72874035-6f481000-3cf1-11ea-9840-9d99e3749510.png)

So, switching to the original syntax, or please correct me if the usage of the new syntax is wrong.
/cc @Youssef1313 

Article in consideration:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types