### PR TITLE
Add documentation for DevelopmentDependency

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -292,7 +292,7 @@ A Boolean value that specifies whether the client must prompt the consumer to ac
 
 ### DevelopmentDependency
 
-A Boolean value specifying whether the package is be marked as a development-only-dependency, which prevents the package from being included as a dependency in other packages. With PackageReference (NuGet 4.8+), this flag also means that it will exclude compile-time assets from compilation. See [DevelopmentDependency support for PackageReference](https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference)
+A Boolean value that specifies whether the package is marked as a development-only dependency, which prevents the package from being included as a dependency in other packages. With PackageReference (NuGet 4.8+), this flag also means that compile-time assets are excluded from compilation. For more information, see [DevelopmentDependency support for PackageReference](https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference).
 
 ### PackageLicenseExpression
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -290,6 +290,10 @@ Copyright details for the package.
 
 A Boolean value that specifies whether the client must prompt the consumer to accept the package license before installing the package. The default is `false`.
 
+### DevelopmentDependency
+
+A Boolean value specifying whether the package is be marked as a development-only-dependency, which prevents the package from being included as a dependency in other packages. With PackageReference (NuGet 4.8+), this flag also means that it will exclude compile-time assets from compilation. See [DevelopmentDependency support for PackageReference](https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference)
+
 ### PackageLicenseExpression
 
 An [SPDX license identifier](https://spdx.org/licenses/) or expression. For example, `Apache-2.0`.


### PR DESCRIPTION
It was missing. Copied the docs from here: https://github.com/NuGet/docs.microsoft.com-nuget/blob/master/docs/reference/nuspec.md

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
