### PR TITLE
Update XML documentation comments

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/code-inline.md
+++ b/docs/csharp/programming-guide/xmldoc/code-inline.md
@@ -1,36 +1,41 @@
 ---
-title: "<c> - C# Programming Guide"
+title: "<c> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "c"
   - "<c>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "text, marking as code [C#]"
   - "code, marking text as [C#]"
   - "c C# XML tag"
   - "<c> C# XML tag"
 ms.assetid: aad5b16e-a29e-445e-bd0d-eea0b138d7b2
 ---
-# \<c> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<c>text</c>  
-```  
-  
-## Parameters  
- `text`  
- The text you would like to indicate as code.  
-  
-## Remarks  
- The \<c> tag gives you a way to indicate that text within a description should be marked as code. Use [\<code>](./code.md) to indicate multiple lines as code.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#2)]  
+# \<c> (C# programming guide)
+
+## Syntax
+
+```xml
+<c>text</c>
+```
+
+## Parameters
+
+- `text`
+
+  The text you would like to indicate as code.
+
+## Remarks
+
+The \<c> tag gives you a way to indicate that text within a description should be marked as code. Use [\<code>](./code.md) to indicate multiple lines as code.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#2)]
   
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/code.md
+++ b/docs/csharp/programming-guide/xmldoc/code.md
@@ -1,34 +1,39 @@
 ---
-title: "<code> - C# Programming Guide"
+title: "<code> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "code"
   - "<code>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "code XML tag"
   - "<code> C# XML tag"
 ms.assetid: f235e3bc-a709-43cf-8a9f-bd57cabdf6da
 ---
-# \<code> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<code>content</code>  
-```  
-  
-## Parameters  
- `content`  
- The text you want marked as code.  
-  
-## Remarks  
- The \<code> tag gives you a way to indicate multiple lines as code. Use [\<c>](./code-inline.md) to indicate that text within a description should be marked as code.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- See the [\<example>](./example.md) topic for an example of how to use the \<code> tag.  
-  
+# \<code> (C# programming guide)
+
+## Syntax
+
+```xml
+<code>content</code>
+```
+
+## Parameters
+
+- `content`
+
+  The text you want marked as code.
+
+## Remarks
+
+The \<code> tag gives you a way to indicate multiple lines as code. Use [\<c>](./code-inline.md) to indicate that text within a description should be marked as code.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+See the [\<example>](./example.md) topic for an example of how to use the \<code> tag.
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/cref-attribute.md
+++ b/docs/csharp/programming-guide/xmldoc/cref-attribute.md
@@ -1,118 +1,82 @@
 ---
-title: "cref Attribute - C# Programming Guide"
+title: "cref attribute - C# programming guide"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "cref [C#]"
 ms.assetid: 66a6b0e5-b961-4504-a461-3a4cf481fc8b
 ---
-# cref Attribute (C# Programming Guide)
-The `cref` attribute in an XML documentation tag means "code reference." It specifies that the inner text of the tag is a code element, such as a type, method, or property. Documentation tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) use the `cref` attributes to automatically generate hyperlinks to the page where the type or member is documented.  
-  
-## Example  
- The following example shows `cref` attributes used in [\<see>](./see.md) tags.  
-  
- [!code-csharp[csProgGuideDocComments#3](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#3)]  
-  
- When compiled, the program produces the following XML file. Notice that the `cref` attribute for the `GetZero` method, for example, has been transformed by the compiler to `"M:TestNamespace.TestClass.GetZero"`. The "M:" prefix means "method" and is a convention that is recognized by documentation tools such as DocFX and Sandcastle. For a complete list of prefixes, see [Processing the XML File](./processing-the-xml-file.md).  
-  
+# cref attribute (C# programming guide)
+
+The `cref` attribute in an XML documentation tag means "code reference." It specifies that the inner text of the tag is a code element, such as a type, method, or property. Documentation tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) use the `cref` attributes to automatically generate hyperlinks to the page where the type or member is documented.
+
+## Example
+
+The following example shows `cref` attributes used in [\<see>](./see.md) tags.
+
+[!code-csharp[csProgGuideDocComments#3](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#3)]
+
+When compiled, the program produces the following XML file. Notice that the `cref` attribute for the `GetZero` method, for example, has been transformed by the compiler to `"M:TestNamespace.TestClass.GetZero"`. The "M:" prefix means "method" and is a convention that is recognized by documentation tools such as DocFX and Sandcastle. For a complete list of prefixes, see [Processing the XML File](./processing-the-xml-file.md).
+
 ```xml  
-<?xml version="1.0"?>  
-<doc>  
-    <assembly>  
-        <name>CRefTest</name>  
-    </assembly>  
-    <members>  
-        <member name="T:TestNamespace.TestClass">  
-            <summary>  
-            TestClass contains cref examples.  
-            </summary>  
-        </member>  
-        <member name="M:TestNamespace.TestClass.#ctor">  
-            <summary>  
-            This sample shows how to specify the <see cref="T:TestNamespace.TestClass"/> constructor as a cref attribute.   
-            </summary>  
-        </member>  
-        <member name="M:TestNamespace.TestClass.#ctor(System.Int32)">  
-            <summary>  
-            This sample shows how to specify the <see cref="M:TestNamespace.TestClass.#ctor(System.Int32)"/> constructor as a cref attribute.   
-            </summary>  
-        </member>  
-        <member name="M:TestNamespace.TestClass.GetZero">  
-            <summary>  
-            The GetZero method.  
-            </summary>  
-            <example>   
-            This sample shows how to call the <see cref="M:TestNamespace.TestClass.GetZero"/> method.  
-            <code>  
-            class TestClass   
-            {  
-                static int Main()   
-                {  
-                    return GetZero();  
-                }  
-            }  
-            </code>  
-            </example>  
-        </member>  
-        <member name="M:TestNamespace.TestClass.GetGenericValue``1(``0)">  
-            <summary>  
-            The GetGenericValue method.  
-            </summary>  
-            <remarks>   
-            This sample shows how to specify the <see cref="M:TestNamespace.TestClass.GetGenericValue``1(``0)"/> method as a cref attribute.  
-            </remarks>  
-        </member>  
-        <member name="T:TestNamespace.GenericClass`1">  
-            <summary>  
-            GenericClass.  
-            </summary>  
-            <remarks>   
-            This example shows how to specify the <see cref="T:TestNamespace.GenericClass`1"/> type as a cref attribute.  
-            </remarks>  
-        </member>  
-    </members>    <members>  
-        <member name="T:TestNamespace.TestClass">  
-            <summary>  
-            TestClass contains two cref examples.  
-            </summary>  
-        </member>  
-        <member name="M:TestNamespace.TestClass.GetZero">  
-            <summary>  
-            The GetZero method.  
-            </summary>  
-            <example> This sample shows how to call the <see cref="M:TestNamespace.TestClass.GetZero"/> method.  
-            <code>  
-            class TestClass   
-            {  
-                static int Main()   
-                {  
-                    return GetZero();  
-                }  
-            }  
-            </code>  
-            </example>  
-        </member>  
-        <member name="M:TestNamespace.TestClass.GetGenericValue``1(``0)">  
-            <summary>  
-            The GetGenericValue method.  
-            </summary>  
-            <remarks>   
-            This sample shows how to specify the <see cref="M:TestNamespace.TestClass.GetGenericValue``1(``0)"/> method as a cref attribute.  
-            </remarks>  
-        </member>  
-        <member name="T:TestNamespace.GenericClass`1">  
-            <summary>  
-            GenericClass.  
-            </summary>  
-            <remarks>   
-            This example shows how to specify the <see cref="T:TestNamespace.GenericClass`1"/> type as a cref attribute.  
-            </remarks>  
-        </member>  
-    </members>  
-</doc>  
-```  
-  
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>CRefTest</name>
+    </assembly>
+    <members>
+        <member name="T:TestNamespace.TestClass">
+            <summary>
+            TestClass contains several cref examples.
+            </summary>
+        </member>
+        <member name="M:TestNamespace.TestClass.#ctor">
+            <summary>
+            This sample shows how to specify the <see cref="T:TestNamespace.TestClass"/> constructor as a cref attribute.
+            </summary>
+        </member>
+        <member name="M:TestNamespace.TestClass.#ctor(System.Int32)">
+            <summary>
+            This sample shows how to specify the <see cref="M:TestNamespace.TestClass.#ctor(System.Int32)"/> constructor as a cref attribute.
+            </summary>
+        </member>
+        <member name="M:TestNamespace.TestClass.GetZero">
+            <summary>
+            The GetZero method.
+            </summary>
+            <example> 
+            This sample shows how to call the <see cref="M:TestNamespace.TestClass.GetZero"/> method.
+            <code>
+            class TestClass 
+            {
+                static int Main() 
+                {
+                    return GetZero();
+                }
+            }
+            </code>
+            </example>
+        </member>
+        <member name="M:TestNamespace.TestClass.GetGenericValue``1(``0)">
+            <summary>
+            The GetGenericValue method.
+            </summary>
+            <remarks> 
+            This sample shows how to specify the <see cref="M:TestNamespace.TestClass.GetGenericValue``1(``0)"/> method as a cref attribute.
+            </remarks>
+        </member>
+        <member name="T:TestNamespace.GenericClass`1">
+            <summary>
+            GenericClass.
+            </summary>
+            <remarks> 
+            This example shows how to specify the <see cref="T:TestNamespace.GenericClass`1"/> type as a cref attribute.
+            </remarks>
+        </member>
+    </members>
+</doc>
+```
+
 ## See also
 
-- [XML Documentation Comments](./index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [XML documentation comments](./index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/delimiters-for-documentation-tags.md
+++ b/docs/csharp/programming-guide/xmldoc/delimiters-for-documentation-tags.md
@@ -65,14 +65,16 @@ The use of XML doc comments requires delimiters, which indicate to the compiler 
 
   - The compiler finds no pattern in the following comment for two reasons. First, the number of spaces before the asterisk is not consistent. Second, the fifth line begins with a tab, which does not match spaces. Therefore, all text from lines two through five is processed as part of the comment.
 
+    <!-- markdownlint-disable MD010 -->
     ```csharp
     /**
       * <summary>
       * text
      *  text2
-		*  </summary>
+    	*  </summary>
     */
     ```
+    <!-- markdownlint-enable MD010 -->
 
 ## See also
 

--- a/docs/csharp/programming-guide/xmldoc/delimiters-for-documentation-tags.md
+++ b/docs/csharp/programming-guide/xmldoc/delimiters-for-documentation-tags.md
@@ -1,79 +1,81 @@
 ---
-title: "Delimiters for Documentation Tags - C# Programming Guide"
+title: "Delimiters for documentation tags - C# programming guide"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "XML [C#], delimiters"
   - "/** */ delimiters for C# documentation tags"
   - "/// delimiter for C# documentation"
 ms.assetid: 9b2bdd18-4f5c-4c0b-988e-fb992e0d233e
 ---
-# Delimiters for Documentation Tags (C# Programming Guide)
-The use of XML doc comments requires delimiters, which indicate to the compiler where a documentation comment begins and ends. You can use the following kinds of delimiters with the XML documentation tags:  
+# Delimiters for documentation tags (C# programming guide)
+
+The use of XML doc comments requires delimiters, which indicate to the compiler where a documentation comment begins and ends. You can use the following kinds of delimiters with the XML documentation tags:
+
+- `///`
+
+  Single-line delimiter. This is the form that is shown in documentation examples and used by the Visual C# project templates. If there is a white space character following the delimiter, that character is not included in the XML output.
+
+  > [!NOTE]
+  > The Visual Studio IDE has a feature called Smart Comment Editing that automatically inserts the \<summary> and \</summary> tags and moves your cursor within these tags after you type the `///` delimiter in the Code Editor. You can turn this feature on or off in the [Options dialog box](/visualstudio/ide/reference/options-text-editor-csharp-advanced).
   
- `///`  
- Single-line delimiter. This is the form that is shown in documentation examples and used by the Visual C# project templates. If there is a white space character following the delimiter, that character is not included in the XML output.  
+- `/** */`
+
+  Multiline delimiters.
+
+  There are some formatting rules to follow when you use the `/** */` delimiters:
   
-> [!NOTE]
-> The Visual Studio IDE has a feature called Smart Comment Editing that automatically inserts the \<summary> and \</summary> tags and moves your cursor within these tags after you type the `///` delimiter in the Code Editor. You can turn this feature on or off in the [Options dialog box](/visualstudio/ide/reference/options-text-editor-csharp-advanced).  
+  - On the line that contains the `/**` delimiter, if the remainder of the line is white space, the line is not processed for comments. If the first character after the `/**` delimiter is white space, that white space character is ignored and the rest of the line is processed. Otherwise, the entire text of the line after the `/**` delimiter is processed as part of the comment.
+
+  - On the line that contains the `*/` delimiter, if there is only white space up to the `*/` delimiter, that line is ignored. Otherwise, the text on the line up to the `*/` delimiter is processed as part of the comment, subject to the pattern-matching rules described in the following bullet.
   
- `/** */`  
- Multiline delimiters.  
-  
- There are some formatting rules to follow when you use the `/** */` delimiters.  
-  
-- On the line that contains the `/**` delimiter, if the remainder of the line is white space, the line is not processed for comments. If the first character after the `/**` delimiter is white space, that white space character is ignored and the rest of the line is processed. Otherwise, the entire text of the line after the `/**` delimiter is processed as part of the comment.  
-  
-- On the line that contains the `*/` delimiter, if there is only white space up to the `*/` delimiter, that line is ignored. Otherwise, the text on the line up to the `*/` delimiter is processed as part of the comment, subject to the pattern-matching rules described in the following bullet.  
-  
-- For the lines after the one that begins with the `/**` delimiter, the compiler looks for a common pattern at the beginning of each line. The pattern can consist of optional white space and an asterisk (`*`), followed by more optional white space. If the compiler finds a common pattern at the beginning of each line that does not begin with the `/**` delimiter or the `*/` delimiter, it ignores that pattern for each line.  
-  
- The following examples illustrate these rules.  
-  
-- The only part of the following comment that will be processed is the line that begins with `<summary>`. The three tag formats produce the same comments.  
-  
-    ```csharp  
-    /** <summary>text</summary> */   
-  
-    /**   
-    <summary>text</summary>   
-    */   
-  
-    /**   
-     * <summary>text</summary>   
-    */  
-    ```  
-  
-- The compiler identifies a common pattern of " * " at the beginning of the second and third lines. The pattern is not included in the output.  
-  
-    ```csharp  
-    /**   
-     * <summary>   
-     * text </summary>*/   
-    ```  
-  
-- The compiler finds no common pattern in the following comment because the second character on the third line is not an asterisk. Therefore, all text on the second and third lines is processed as part of the comment.  
-  
-    ```csharp  
-    /**   
-     * <summary>   
-       text </summary>  
-    */   
-    ```  
-  
-- The compiler finds no pattern in the following comment for two reasons. First, the number of spaces before the asterisk is not consistent. Second, the fifth line begins with a tab, which does not match spaces. Therefore, all text from lines two through five is processed as part of the comment.  
-  
-    ```csharp  
-    /**   
-      * <summary>   
-      * text   
-     *  text2   
-        *  </summary>   
-    */   
-    ```  
-  
+  - For the lines after the one that begins with the `/**` delimiter, the compiler looks for a common pattern at the beginning of each line. The pattern can consist of optional white space and an asterisk (`*`), followed by more optional white space. If the compiler finds a common pattern at the beginning of each line that does not begin with the `/**` delimiter or the `*/` delimiter, it ignores that pattern for each line.
+
+  The following examples illustrate these rules.
+
+  - The only part of the following comment that will be processed is the line that begins with `<summary>`. The three tag formats produce the same comments.
+
+    ```csharp
+    /** <summary>text</summary> */
+
+    /**
+    <summary>text</summary>
+    */
+
+    /**
+     * <summary>text</summary>
+    */
+    ```
+
+  - The compiler identifies a common pattern of " \* " at the beginning of the second and third lines. The pattern is not included in the output.
+
+    ```csharp
+    /**
+     * <summary>
+     * text </summary>*/
+    ```
+
+  - The compiler finds no common pattern in the following comment because the second character on the third line is not an asterisk. Therefore, all text on the second and third lines is processed as part of the comment.
+
+    ```csharp
+    /**
+     * <summary>
+       text </summary>
+    */
+    ```
+
+  - The compiler finds no pattern in the following comment for two reasons. First, the number of spaces before the asterisk is not consistent. Second, the fifth line begins with a tab, which does not match spaces. Therefore, all text from lines two through five is processed as part of the comment.
+
+    ```csharp
+    /**
+      * <summary>
+      * text
+     *  text2
+		*  </summary>
+    */
+    ```
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [XML Documentation Comments](./index.md)
-- [-doc (C# Compiler Options)](../../language-reference/compiler-options/doc-compiler-option.md)
-- [XML Documentation Comments](./index.md)
+- [C# programming guide](../index.md)
+- [XML documentation comments](./index.md)
+- [-doc (C# compiler options)](../../language-reference/compiler-options/doc-compiler-option.md)

--- a/docs/csharp/programming-guide/xmldoc/example.md
+++ b/docs/csharp/programming-guide/xmldoc/example.md
@@ -1,34 +1,39 @@
 ---
-title: "<example> - C# Programming Guide"
+title: "<example> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "<example>"
   - "example"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<example> C# XML tag"
   - "example C# XML tag"
 ms.assetid: 32d6e73b-2554-4abb-83ee-a1e321334fd2
 ---
-# \<example> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<example>description</example>  
-```  
-  
-## Parameters  
- `description`  
- A description of the code sample.  
-  
-## Remarks  
- The \<example> tag lets you specify an example of how to use a method or other library member. This commonly involves using the [\<code>](./code.md) tag.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#3](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#3)]  
-  
+# \<example> (C# programming guide)
+
+## Syntax
+
+```xml
+<example>description</example>
+```
+
+## Parameters
+
+- `description`
+
+  A description of the code sample.
+
+## Remarks
+
+The \<example> tag lets you specify an example of how to use a method or other library member. This commonly involves using the [\<code>](./code.md) tag.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#3](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#3)]
+
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/exception.md
+++ b/docs/csharp/programming-guide/xmldoc/exception.md
@@ -1,41 +1,47 @@
 ---
-title: "<exception> - C# Programming Guide"
+title: "<exception> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "exception"
   - "<exception>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<exception> C# XML tag"
   - "exception C# XML tag"
 ms.assetid: dd73aac5-3c74-4fcf-9498-f11bff3a2f3c
 ---
-# \<exception> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<exception cref="member">description</exception>  
-```  
-  
-## Parameters  
- cref = " `member`"  
- A reference to an exception that is available from the current compilation environment. The compiler checks that the given exception exists and translates `member` to the canonical element name in the output XML. `member` must appear within double quotation marks (" ").  
-  
- For more information on how to format `member` to reference a generic type, see [Processing the XML File](processing-the-xml-file.md).
-  
- `description`  
- A description of the exception.  
-  
-## Remarks  
- The \<exception> tag lets you specify which exceptions can be thrown. This tag can be applied to definitions for methods, properties, events, and indexers.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
- For more information about exception handling, see [Exceptions and Exception Handling](../exceptions/index.md).  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#4](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#4)]  
-  
+# \<exception> (C# programming guide)
+
+## Syntax
+
+```xml
+<exception cref="member">description</exception>
+```
+
+## Parameters
+
+- cref = " `member`"
+
+  A reference to an exception that is available from the current compilation environment. The compiler checks that the given exception exists and translates `member` to the canonical element name in the output XML. `member` must appear within double quotation marks (" ").
+
+  For more information on how to format `member` to reference a generic type, see [Processing the XML File](processing-the-xml-file.md).
+
+- `description`
+
+  A description of the exception.
+
+## Remarks
+
+The \<exception> tag lets you specify which exceptions can be thrown. This tag can be applied to definitions for methods, properties, events, and indexers.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+For more information about exception handling, see [Exceptions and Exception Handling](../exceptions/index.md).
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#4](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#4)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
+++ b/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
@@ -1,7 +1,7 @@
 ---
-title: "How to use the XML documentation features - C# Programming Guide"
+title: "How to use the XML documentation features - C# programming guide"
 ms.date: 06/01/2018
-helpviewer_keywords: 
+helpviewer_keywords:
   - "XML documentation [C#]"
   - "C# language, XML documentation features"
 ms.assetid: 8f33917b-9577-4c9a-818a-640dbbb0b399
@@ -14,7 +14,7 @@ The following sample provides a basic overview of a type that has been documente
 
 [!code-csharp[csProgGuideDocComments#15](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#15)]
 
-The example generates an .xml file with the following contents:
+The example generates an *.xml* file with the following contents.
 
 ```xml
 <?xml version="1.0"?>
@@ -114,7 +114,7 @@ XML documentation starts with ///. When you create a new project, the wizards pu
 
 - The documentation must be well-formed XML. If the XML is not well-formed, a warning is generated and the documentation file will contain a comment that says that an error was encountered.
 
-- Developers are free to create their own set of tags. There is a recommended set of tags (see [Recommended tags for documentation comments](recommended-tags-for-documentation-comments.md)). Some of the recommended tags have special meanings:
+- Developers are free to create their own set of tags. There is a [recommended set of tags](recommended-tags-for-documentation-comments.md). Some of the recommended tags have special meanings:
 
   - The \<param> tag is used to describe parameters. If used, the compiler verifies that the parameter exists and that all parameters are described in the documentation. If the verification failed, the compiler issues a warning.
 
@@ -127,8 +127,8 @@ XML documentation starts with ///. When you create a new project, the wizards pu
 
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [-doc (C# Compiler Options)](../../language-reference/compiler-options/doc-compiler-option.md)
-- [XML Documentation Comments](./index.md)
+- [C# programming guide](../index.md)
+- [-doc (C# compiler options)](../../language-reference/compiler-options/doc-compiler-option.md)
+- [XML documentation comments](./index.md)
 - [DocFX documentation processor](https://dotnet.github.io/docfx/)
 - [Sandcastle documentation processor](https://github.com/EWSoftware/SHFB)

--- a/docs/csharp/programming-guide/xmldoc/include.md
+++ b/docs/csharp/programming-guide/xmldoc/include.md
@@ -1,76 +1,85 @@
 ---
-title: "<include> - C# Programming Guide"
+title: "<include> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "include"
   - "<include>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<include> C# XML tag"
   - "include C# XML tag"
 ms.assetid: a8a70302-6196-4643-bd09-ef33f411f18f
 ---
-# \<include> (C# Programming Guide)
-## Syntax  
+# \<include> (C# programming guide)
+
+## Syntax
+
+```xml
+<include file='filename' path='tagpath[@name="id"]' />
+```
+
+## Parameters
+
+- `filename`
+
+  The name of the XML file containing the documentation. The file name can be qualified with a path relative to the source code file. Enclose `filename` in single quotation marks (' ').
+
+- `tagpath`
+
+  The path of the tags in `filename` that leads to the tag `name`. Enclose the path in single quotation marks (' ').
+
+- `name`
+
+  The name specifier in the tag that precedes the comments; `name` will have an `id`.
+
+- `id`
+
+The ID for the tag that precedes the comments. Enclose the ID in double quotation marks (" ").
+
+## Remarks
+
+The \<include> tag lets you refer to comments in another file that describe the types and members in your source code. This is an alternative to placing documentation comments directly in your source code file. By putting the documentation in a separate file, you can apply source control to the documentation separately from the source code. One person can have the source code file checked out and someone else can have the documentation file checked out.
+
+The \<include> tag uses the XML XPath syntax. Refer to XPath documentation for ways to customize your \<include> use.
+
+## Example
+
+This is a multifile example. The following is the first file, which uses \<include>.
+
+[!code-csharp[csProgGuideDocComments#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#5)]
+
+The second file, *xml_include_tag.doc*, contains the following documentation comments.
+
+```xml
+<MyDocs>
+
+<MyMembers name="test">
+<summary>
+The summary for this type.
+</summary>
+</MyMembers>
+
+<MyMembers name="test2">
+<summary>
+The summary for this other type.
+</summary>
+</MyMembers>
+
+</MyDocs>
+```
+
+## Program output
+
+The following output is generated when you compile the Test and Test2 classes with the following command line: `-doc:DocFileName.xml.` In Visual Studio, you specify the XML doc comments option in the Build pane of the Project Designer. When the C# compiler sees the \<include> tag, it will search for documentation comments in xml_include_tag.doc instead of the current source file. The compiler then generates DocFileName.xml, and this is the file that is consumed by documentation tools such as [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to produce the final documentation.  
   
-```xml  
-<include file='filename' path='tagpath[@name="id"]' />  
-```  
-  
-## Parameters  
- `filename`  
- The name of the XML file containing the documentation. The file name can be qualified with a path relative to the source code file. Enclose `filename` in single quotation marks (' ').  
-  
- `tagpath`  
- The path of the tags in `filename` that leads to the tag `name`. Enclose the path in single quotation marks (' ').  
-  
- `name`  
- The name specifier in the tag that precedes the comments; `name` will have an `id`.  
-  
- `id`  
- The ID for the tag that precedes the comments. Enclose the ID in double quotation marks (" ").  
-  
-## Remarks  
- The \<include> tag lets you refer to comments in another file that describe the types and members in your source code. This is an alternative to placing documentation comments directly in your source code file. By putting the documentation in a separate file, you can apply source control to the documentation separately from the source code. One person can have the source code file checked out and someone else can have the documentation file checked out.  
-  
- The \<include> tag uses the XML XPath syntax. Refer to XPath documentation for ways to customize your \<include> use.  
-  
-## Example  
- This is a multifile example. The first file, which uses \<include>, is listed below:  
-  
- [!code-csharp[csProgGuideDocComments#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#5)]  
-  
- The second file, xml_include_tag.doc, contains the following documentation comments:  
-  
-```xml  
-<MyDocs>  
-  
-<MyMembers name="test">  
-<summary>  
-The summary for this type.  
-</summary>  
-</MyMembers>  
-  
-<MyMembers name="test2">  
-<summary>  
-The summary for this other type.  
-</summary>  
-</MyMembers>  
-  
-</MyDocs>  
-```  
-  
-## Program Output  
- The following output is generated when you compile the Test and Test2 classes with the following command line: `/doc:DocFileName.xml.` In Visual Studio, you specify the XML doc comments option in the Build pane of the Project Designer. When the C# compiler sees the \<include> tag, it will search for documentation comments in xml_include_tag.doc instead of the current source file. The compiler then generates DocFileName.xml, and this is the file that is consumed by documentation tools such as [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to produce the final documentation.  
-  
-```xml  
-<?xml version="1.0"?>   
-<doc>   
-    <assembly>   
-        <name>xml_include_tag</name>   
-    </assembly>   
-    <members>   
-        <member name="T:Test">   
-            <summary>   
+```xml
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>xml_include_tag</name>
+    </assembly>
+    <members>
+        <member name="T:Test">
+            <summary>
 The summary for this type.   
 </summary>   
         </member>   

--- a/docs/csharp/programming-guide/xmldoc/index.md
+++ b/docs/csharp/programming-guide/xmldoc/index.md
@@ -1,9 +1,9 @@
 ---
-title: "XML Documentation Comments - C# Programming Guide"
+title: "XML documentation comments - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "cs.xml"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "XML [C#], code comments"
   - "comments [C#], XML"
   - "documentation comments [C#]"
@@ -12,41 +12,44 @@ helpviewer_keywords:
   - "XML documentation comments [C#]"
 ms.assetid: 803b7f7b-7428-4725-b5db-9a6cff273199
 ---
-# XML Documentation Comments (C# Programming Guide)
-In Visual C# you can create documentation for your code by including XML elements in special comment fields (indicated by triple slashes) in the source code directly before the code block to which the comments refer, for example:  
-  
-```csharp  
-/// <summary>  
-///  This class performs an important function.  
-/// </summary>  
-public class MyClass {}  
-```  
-  
- When you compile with the [-doc](../../language-reference/compiler-options/doc-compiler-option.md) option, the compiler will search for all XML tags in the source code and create an XML documentation file. To create the final documentation based on the compiler-generated file, you can create a custom tool or use a tool such as [DocFX](https://dotnet.github.io/docfx/) or [Sandcastle](https://github.com/EWSoftware/SHFB).  
-  
- To refer to XML elements (for example, your function processes specific XML elements that you want to describe in an XML documentation comment), you can use the standard quoting mechanism (`<` and `>`).  To refer to generic identifiers in code reference (`cref`) elements, you can use either the escape characters (for example, `cref="List&lt;T&gt;"`) or braces (`cref="List{T}"`).  As a special case, the compiler parses the braces as angle brackets to make the documentation comment less cumbersome to author when referring to generic identifiers.  
-  
+# XML documentation comments (C# programming guide)
+
+In C#, you can create documentation for your code by including XML elements in special comment fields (indicated by triple slashes) in the source code directly before the code block to which the comments refer, for example.
+
+```csharp
+/// <summary>
+///  This class performs an important function.
+/// </summary>
+public class MyClass {}
+```
+
+When you compile with the [-doc](../../language-reference/compiler-options/doc-compiler-option.md) option, the compiler will search for all XML tags in the source code and create an XML documentation file. To create the final documentation based on the compiler-generated file, you can create a custom tool or use a tool such as [DocFX](https://dotnet.github.io/docfx/) or [Sandcastle](https://github.com/EWSoftware/SHFB).
+
+To refer to XML elements (for example, your function processes specific XML elements that you want to describe in an XML documentation comment), you can use the standard quoting mechanism (`<` and `>`).  To refer to generic identifiers in code reference (`cref`) elements, you can use either the escape characters (for example, `cref="List&lt;T&gt;"`) or braces (`cref="List{T}"`).  As a special case, the compiler parses the braces as angle brackets to make the documentation comment less cumbersome to author when referring to generic identifiers.
+
 > [!NOTE]
-> The XML documentation comments are not metadata; they are not included in the compiled assembly and therefore they are not accessible through reflection.  
-  
-## In This Section  
-  
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)  
-  
-- [Processing the XML File](./processing-the-xml-file.md)  
-  
-- [Delimiters for Documentation Tags](./delimiters-for-documentation-tags.md)  
-  
+> The XML documentation comments are not metadata; they are not included in the compiled assembly and therefore they are not accessible through reflection.
+
+## In this section
+
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)
+
+- [Processing the XML file](./processing-the-xml-file.md)
+
+- [Delimiters for documentation tags](./delimiters-for-documentation-tags.md)
+
 - [How to use the XML documentation features](./how-to-use-the-xml-documentation-features.md)
-  
-## Related Sections  
- For more information, see:  
-  
-- [-doc (Process Documentation Comments)](../../language-reference/compiler-options/doc-compiler-option.md)  
-  
-## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
+
+## Related sections
+
+For more information, see:
+
+- [-doc (Process Documentation Comments)](../../language-reference/compiler-options/doc-compiler-option.md)
+
+## C# language specification
+
+[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+
 ## See also
 
 - [C# Programming Guide](../index.md)

--- a/docs/csharp/programming-guide/xmldoc/list.md
+++ b/docs/csharp/programming-guide/xmldoc/list.md
@@ -1,10 +1,10 @@
 ---
-title: "<list> - C# Programming Guide"
+title: "<list> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "list"
   - "<list>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "list C# XML tag"
   - "listheader C# XML tag"
   - "<listheader> C# XML tag"
@@ -13,42 +13,48 @@ helpviewer_keywords:
   - "<list> C# XML tag"
 ms.assetid: c9620b1b-c2e6-43f1-ab88-8ab47308ffec
 ---
-# \<list> (C# Programming Guide)
-## Syntax  
+# \<list> (C# programming guide)
+
+## Syntax
+
+```xml
+<list type="bullet|number|table">
+    <listheader>
+        <term>term</term>
+        <description>description</description>
+    </listheader>
+    <item>
+        <term>term</term>
+        <description>description</description>
+    </item>
+</list>
+```
+
+## Parameters
+
+- `term`
+
+  A term to define, which will be defined in `description`.
+
+- `description`
+
+  Either an item in a bullet or numbered list or the definition of a `term`.
   
-```xml  
-<list type="bullet" | "number" | "table">  
-    <listheader>  
-        <term>term</term>  
-        <description>description</description>  
-    </listheader>  
-    <item>  
-        <term>term</term>  
-        <description>description</description>  
-    </item>  
-</list>  
-```  
-  
-## Parameters  
- `term`  
- A term to define, which will be defined in `description`.  
-  
- `description`  
- Either an item in a bullet or numbered list or the definition of a `term`.  
-  
-## Remarks  
- The \<listheader> block is used to define the heading row of either a table or definition list. When defining a table, you only need to supply an entry for term in the heading.  
-  
- Each item in the list is specified with an \<item> block. When creating a definition list, you will need to specify both `term` and `description`. However, for a table, bulleted list, or numbered list, you only need to supply an entry for `description`.  
-  
- A list or table can have as many \<item> blocks as needed.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#6](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#6)]  
-  
+## Remarks
+
+The \<listheader> block is used to define the heading row of either a table or definition list. When defining a table, you only need to supply an entry for term in the heading.
+
+Each item in the list is specified with an \<item> block. When creating a definition list, you will need to specify both `term` and `description`. However, for a table, bulleted list, or numbered list, you only need to supply an entry for `description`.
+
+A list or table can have as many \<item> blocks as needed.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#6](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#6)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/para.md
+++ b/docs/csharp/programming-guide/xmldoc/para.md
@@ -1,34 +1,39 @@
 ---
-title: "<para> - C# Programming Guide"
+title: "<para> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "<para>"
   - "para"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<para> C# XML tag"
   - "para C# XML tag"
 ms.assetid: c74b8705-29df-40b1-bff5-237492b0e978
 ---
-# \<para> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<para>content</para>  
-```  
-  
-## Parameters  
- `content`  
- The text of the paragraph.  
-  
-## Remarks  
- The \<para> tag is for use inside a tag, such as [\<summary>](./summary.md), [\<remarks>](./remarks.md), or [\<returns>](./returns.md), and lets you add structure to the text.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- See [\<summary>](./summary.md) for an example of using \<para>.  
-  
+# \<para> (C# programming guide)
+
+## Syntax
+
+```xml
+<para>content</para>
+```
+
+## Parameters
+
+- `content`
+
+  The text of the paragraph.
+
+## Remarks
+
+The \<para> tag is for use inside a tag, such as [\<summary>](./summary.md), [\<remarks>](./remarks.md), or [\<returns>](./returns.md), and lets you add structure to the text.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+See [\<summary>](./summary.md) for an example of using \<para>.
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/param.md
+++ b/docs/csharp/programming-guide/xmldoc/param.md
@@ -1,39 +1,45 @@
 ---
-title: "<param> - C# Programming Guide"
+title: "<param> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "param"
   - "<param>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<param> C# XML tag"
   - "param C# XML tag"
 ms.assetid: 46d329b1-5b84-4537-9e17-73ca97313e4e
 ---
-# \<param> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<param name="name">description</param>  
-```  
-  
-## Parameters  
- `name`  
- The name of a method parameter. Enclose the name in double quotation marks (" ").  
-  
- `description`  
- A description for the parameter.  
-  
-## Remarks  
- The \<param> tag should be used in the comment for a method declaration to describe one of the parameters for the method. To document multiple parameters, use multiple \<param> tags.  
-  
- The text for the \<param> tag will be displayed in IntelliSense, the Object Browser, and in the Code Comment Web Report.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#1)]  
-  
+# \<param> (C# programming guide)
+
+## Syntax
+
+```xml
+<param name="name">description</param>
+```
+
+## Parameters
+
+- `name`
+
+  The name of a method parameter. Enclose the name in double quotation marks (" ").
+
+- `description`
+
+  A description for the parameter.
+
+## Remarks
+
+The \<param> tag should be used in the comment for a method declaration to describe one of the parameters for the method. To document multiple parameters, use multiple \<param> tags.
+
+The text for the \<param> tag will be displayed in IntelliSense, the Object Browser, and in the Code Comment Web Report.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#1)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/paramref.md
+++ b/docs/csharp/programming-guide/xmldoc/paramref.md
@@ -1,34 +1,39 @@
 ---
-title: "<paramref> - C# Programming Guide"
+title: "<paramref> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "paramref"
   - "<paramref>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<paramref> C# XML tag"
   - "paramref C# XML tag"
 ms.assetid: 756c24c1-f591-40e8-a838-559761539b0b
 ---
-# \<paramref> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<paramref name="name"/>  
-```  
-  
-## Parameters  
- `name`  
- The name of the parameter to refer to. Enclose the name in double quotation marks (" ").  
-  
-## Remarks  
- The \<paramref> tag gives you a way to indicate that a word in the code comments, for example in a \<summary> or \<remarks> block refers to a parameter. The XML file can be processed to format this word in some distinct way, such as with a bold or italic font.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#7](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#7)]  
-  
+# \<paramref> (C# programming guide)
+
+## Syntax
+
+```xml
+<paramref name="name"/>
+```
+
+## Parameters
+
+- `name`
+
+  The name of the parameter to refer to. Enclose the name in double quotation marks (" ").
+
+## Remarks
+
+The \<paramref> tag gives you a way to indicate that a word in the code comments, for example in a \<summary> or \<remarks> block refers to a parameter. The XML file can be processed to format this word in some distinct way, such as with a bold or italic font.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#7](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#7)]
+
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/permission.md
+++ b/docs/csharp/programming-guide/xmldoc/permission.md
@@ -1,39 +1,45 @@
 ---
-title: "<permission> - C# Programming Guide"
+title: "<permission> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "permission"
   - "<permission>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<permission> C# XML tag"
   - "permission C# XML tag"
 ms.assetid: 769e93fe-8404-443f-bf99-577aa42b6a49
 ---
-# \<permission> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<permission cref="member">description</permission>  
-```  
-  
-## Parameters  
- cref = " `member`"  
- A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and translates `member` to the canonical element name in the output XML. *member* must appear within double quotation marks (" ").  
-  
- For information on how to create a cref reference to a generic type, see [\<see>](./see.md).  
-  
- `description`  
- A description of the access to the member.  
-  
-## Remarks  
- The \<permission> tag lets you document the access of a member. The <xref:System.Security.PermissionSet> class lets you specify access to a member.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#8](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#8)]  
-  
+# \<permission> (C# programming guide)
+
+## Syntax
+
+```xml
+<permission cref="member">description</permission>
+```
+
+## Parameters
+
+- cref = " `member`"
+
+  A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and translates `member` to the canonical element name in the output XML. *member* must appear within double quotation marks (" ").
+
+  For information on how to create a cref reference to a generic type, see [\<see>](./see.md).
+
+- `description`
+
+  A description of the access to the member.
+
+## Remarks
+
+The \<permission> tag lets you document the access of a member. The <xref:System.Security.PermissionSet> class lets you specify access to a member.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#8](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#8)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/processing-the-xml-file.md
+++ b/docs/csharp/programming-guide/xmldoc/processing-the-xml-file.md
@@ -1,12 +1,12 @@
 ---
-title: "Processing the XML File - C# Programming Guide"
+title: "Processing the XML file - C# programming guide"
 ms.date: 07/20/2015
 helpviewer_keywords:
   - "XML processing [C#]"
   - "XML [C#], processing"
 ms.assetid: 60c71193-9dac-4cd3-98c5-100bd0edcc42
 ---
-# Processing the XML File (C# Programming Guide)
+# Processing the XML file (C# programming guide)
 
 The compiler generates an ID string for each construct in your code that is tagged to generate documentation. (For information about how to tag your code, see [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md).) The ID string uniquely identifies the construct. Programs that process the XML file can use the ID string to identify the corresponding .NET Framework metadata/reflection item that the documentation applies to.
 
@@ -21,7 +21,7 @@ The compiler observes the following rules when it generates the ID strings:
     |Character|Description|
     |---------------|-----------------|
     |N|namespace<br /><br /> You cannot add documentation comments to a namespace, but you can make cref references to them, where supported.|
-    |T|type: class, interface, struct, enum, delegate|
+    |T|type: class, interface, struct, enum, or delegate|
     |F|field|
     |P|property (including indexers or other indexed properties)|
     |M|method (including such special methods as constructors, operators, and so forth)|
@@ -78,6 +78,6 @@ The following examples show how the ID strings for a class and its members would
 
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [-doc (C# Compiler Options)](../../language-reference/compiler-options/doc-compiler-option.md)
-- [XML Documentation Comments](./index.md)
+- [C# programming guide](../index.md)
+- [-doc (C# compiler options)](../../language-reference/compiler-options/doc-compiler-option.md)
+- [XML documentation comments](./index.md)

--- a/docs/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
+++ b/docs/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
@@ -1,44 +1,45 @@
 ---
-title: "Recommended Tags for Documentation Comments - C# Programming Guide"
+title: "Recommended tags for documentation comments - C# programming guide"
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "XML [C#], tags"
   - "XML documentation [C#], tags"
 ms.assetid: 6e98f7a9-38f4-4d74-b644-1ff1b23320fd
 ---
-# Recommended Tags for Documentation Comments (C# Programming Guide)
-The C# compiler processes documentation comments in your code and formats them as XML in a file whose name you specify in the **/doc** command-line option. To create the final documentation based on the compiler-generated file, you can create a custom tool, or use a tool such as [DocFX](https://dotnet.github.io/docfx/) or [Sandcastle](https://github.com/EWSoftware/SHFB).  
-  
- Tags are processed on code constructs such as types and type members.  
-  
+# Recommended tags for documentation comments (C# programming guide)
+
+The C# compiler processes documentation comments in your code and formats them as XML in a file whose name you specify in the **/doc** command-line option. To create the final documentation based on the compiler-generated file, you can create a custom tool, or use a tool such as [DocFX](https://dotnet.github.io/docfx/) or [Sandcastle](https://github.com/EWSoftware/SHFB).
+
+Tags are processed on code constructs such as types and type members.
+
 > [!NOTE]
-> Documentation comments cannot be applied to a namespace.  
-  
- The compiler will process any tag that is valid XML. The following tags provide generally used functionality in user documentation.  
-  
-## Tags  
-  
+> Documentation comments cannot be applied to a namespace.
+
+The compiler will process any tag that is valid XML. The following tags provide generally used functionality in user documentation.
+
+## Tags
+
 ||||  
-|---|---|---|  
-|[\<c>](./code-inline.md)|[\<para>](./para.md)|[\<see>](./see.md)*|  
-|[\<code>](./code.md)|[\<param>](./param.md)*|[\<seealso>](./seealso.md)*|  
+|---|---|---|
+|[\<c>](./code-inline.md)|[\<para>](./para.md)|[\<see>](./see.md)\*|
+|[\<code>](./code.md)|[\<param>](./param.md)\*|[\<seealso>](./seealso.md)\*|  
 |[\<example>](./example.md)|[\<paramref>](./paramref.md)|[\<summary>](./summary.md)|  
-|[\<exception>](./exception.md)*|[\<permission>](./permission.md)*|[\<typeparam>](./typeparam.md)*|  
-|[\<include>](./include.md)*|[\<remarks>](./remarks.md)|[\<typeparamref>](./typeparamref.md)|  
+|[\<exception>](./exception.md)\*|[\<permission>](./permission.md)\*|[\<typeparam>](./typeparam.md)\*|  
+|[\<include>](./include.md)\*|[\<remarks>](./remarks.md)|[\<typeparamref>](./typeparamref.md)|  
 |[\<list>](./list.md)|[\<returns>](./returns.md)|[\<value>](./value.md)|  
   
- (* denotes that the compiler verifies syntax.)  
-  
- If you want angle brackets to appear in the text of a documentation comment, use the HTML encoding of `<` and `>` which is `&lt;` and `&gt;` respectively. This encoding is shown in the following example:
-  
-```csharp  
+(\* denotes that the compiler verifies syntax.)
+
+If you want angle brackets to appear in the text of a documentation comment, use the HTML encoding of `<` and `>` which is `&lt;` and `&gt;` respectively. This encoding is shown in the following example.
+
+```csharp
 /// <summary>
 /// This property always returns a value &lt; 1.
 /// </summary>
 ```
-  
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [-doc (C# Compiler Options)](../../language-reference/compiler-options/doc-compiler-option.md)
-- [XML Documentation Comments](./index.md)
+- [C# programming guide](../index.md)
+- [-doc (C# compiler options)](../../language-reference/compiler-options/doc-compiler-option.md)
+- [XML documentation comments](./index.md)

--- a/docs/csharp/programming-guide/xmldoc/remarks.md
+++ b/docs/csharp/programming-guide/xmldoc/remarks.md
@@ -1,34 +1,39 @@
 ---
-title: "<remarks> - C# Programming Guide"
+title: "<remarks> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "remarks"
   - "<remarks>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "remarks C# XML tag"
   - "<remarks> C# XML tag"
 ms.assetid: f8641391-31f3-4735-af7a-c502a5b6a251
 ---
-# \<remarks> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<remarks>description</remarks>  
-```  
-  
-## Parameters  
- `Description`  
- A description of the member.  
-  
-## Remarks  
- The \<remarks> tag is used to add information about a type, supplementing the information specified with [\<summary>](./summary.md). This information is displayed in the Object Browser window.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#9](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#9)]  
-  
+# \<remarks> (C# programming guide)
+
+## Syntax
+
+```xml
+<remarks>description</remarks>
+```
+
+## Parameters
+
+- `Description`
+
+  A description of the member.
+
+## Remarks
+
+The \<remarks> tag is used to add information about a type, supplementing the information specified with [\<summary>](./summary.md). This information is displayed in the Object Browser window.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#9](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#9)]
+
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/returns.md
+++ b/docs/csharp/programming-guide/xmldoc/returns.md
@@ -1,34 +1,39 @@
 ---
-title: "<returns> - C# Programming Guide"
+title: "<returns> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "returns"
   - "<returns>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<returns> C# XML tag"
   - "returns C# XML tag"
 ms.assetid: bb2d9958-62fc-47c7-9511-6311171f119f
 ---
-# \<returns> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<returns>description</returns>  
-```  
-  
-## Parameters  
- `description`  
- A description of the return value.  
-  
-## Remarks  
- The \<returns> tag should be used in the comment for a method declaration to describe the return value.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#10](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#10)]  
-  
+# \<returns> (C# programming guide)
+
+## Syntax
+
+```xml
+<returns>description</returns>
+```
+
+## Parameters
+
+- `description`
+
+  A description of the return value.
+
+## Remarks
+
+The \<returns> tag should be used in the comment for a method declaration to describe the return value.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#10](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#10)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/see.md
+++ b/docs/csharp/programming-guide/xmldoc/see.md
@@ -1,37 +1,41 @@
 ---
-title: "<see> - C# Programming Guide"
+title: "<see> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "<see>"
   - "see"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "cref [C#], <see> tag"
   - "<see> C# XML tag"
   - "cross-references [C#]"
   - "see C# XML tag"
 ms.assetid: 0200de01-7e2f-45c4-9094-829d61236383
 ---
-# \<see> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<see cref="member"/>  
-```  
-  
-## Parameters  
- cref = " `member`"  
- A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML. Place *member* within double quotation marks (" ").  
-  
-## Remarks  
- The \<see> tag lets you specify a link from within text. Use [\<seealso>](./seealso.md) to indicate that text should be placed in a See Also section. Use the [cref Attribute](./cref-attribute.md) to create internal hyperlinks to documentation pages for code elements.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
- The following example shows a \<see> tag within a summary section.  
-  
- [!code-csharp[csProgGuideDocComments#12](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#12)]  
-  
+# \<see> (C# programming guide)
+
+## Syntax
+
+```xml
+<see cref="member"/>
+```
+
+## Parameters
+
+- cref = " `member`"
+
+  A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML. Place *member* within double quotation marks (" ").
+
+## Remarks
+
+The \<see> tag lets you specify a link from within text. Use [\<seealso>](./seealso.md) to indicate that text should be placed in a See Also section. Use the [cref Attribute](./cref-attribute.md) to create internal hyperlinks to documentation pages for code elements.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+The following example shows a \<see> tag within a summary section.
+
+[!code-csharp[csProgGuideDocComments#12](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#12)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/seealso.md
+++ b/docs/csharp/programming-guide/xmldoc/seealso.md
@@ -1,11 +1,11 @@
 ---
-title: "<seealso> - C# Programming Guide"
+title: "<seealso> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "cref"
   - "<seealso>"
   - "seealso"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "cref [C#], see also"
   - "seealso C# XML tag"
   - "cref [C#]"
@@ -13,28 +13,33 @@ helpviewer_keywords:
   - "<seealso> C# XML tag"
 ms.assetid: 8e157f3f-f220-4fcf-9010-88905b080b18
 ---
-# \<seealso> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<seealso cref="member"/>  
-```  
-  
-## Parameters  
- cref = " `member`"  
- A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML.`member` must appear within double quotation marks (" ").  
-  
- For information on how to create a cref reference to a generic type, see [\<see>](./see.md).  
-  
-## Remarks  
- The \<seealso> tag lets you specify the text that you might want to appear in a See Also section. Use [\<see>](./see.md) to specify a link from within text.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- See [\<summary>](./summary.md) for an example of using \<seealso>.  
-  
+# \<seealso> (C# programming guide)
+
+## Syntax
+
+```xml
+<seealso cref="member"/>
+```
+
+## Parameters
+
+- cref = " `member`"
+
+  A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML.`member` must appear within double quotation marks (" ").
+
+  For information on how to create a cref reference to a generic type, see [\<see>](./see.md).
+
+## Remarks
+
+The \<seealso> tag lets you specify the text that you might want to appear in a See Also section. Use [\<see>](./see.md) to specify a link from within text.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+See [\<summary>](./summary.md) for an example of using \<seealso>.
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/summary.md
+++ b/docs/csharp/programming-guide/xmldoc/summary.md
@@ -1,92 +1,98 @@
 ---
-title: "<summary> - C# Programming Guide"
+title: "<summary> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "<summary>"
   - "summary"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<summary> C# XML tag"
   - "summary C# XML tag"
 ms.assetid: b4c43d92-2067-4eac-a59a-d32f5248c08b
 ---
-# \<summary> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<summary>description</summary>  
-```  
-  
-## Parameters  
- `description`  
- A summary of the object.  
-  
-## Remarks  
- The \<summary> tag should be used to describe a type or a type member. Use [\<remarks>](./remarks.md) to add supplemental information to a type description. Use the [cref Attribute](./cref-attribute.md) to enable documentation tools such as [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to create internal hyperlinks to documentation pages for code elements.  
-  
- The text for the \<summary> tag is the only source of information about the type in IntelliSense, and is also displayed in the Object Browser Window.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file. To create the final documentation based on the compiler-generated file, you can create a custom tool, or use a tool such as [DocFX](https://dotnet.github.io/docfx/) or [Sandcastle](https://github.com/EWSoftware/SHFB).  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#12](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#12)]  
-  
- The previous example produces the following XML file.  
-  
-```xml  
-<?xml version="1.0"?>  
-<doc>  
-    <assembly>  
-        <name>YourNamespace</name>  
-    </assembly>  
-    <members>  
-        <member name="T:DotNetEvents.TestClass">  
-            text for class TestClass  
-        </member>  
-        <member name="M:DotNetEvents.TestClass.DoWork(System.Int32)">  
-            <summary>DoWork is a method in the TestClass class.  
-            <para>Here's how you could make a second paragraph in a description. <see cref="M:System.Console.WriteLine(System.String)"/> for information about output statements.</para>  
-            <seealso cref="M:DotNetEvents.TestClass.Main"/>  
-            </summary>  
-        </member>  
-        <member name="M:DotNetEvents.TestClass.Main">  
-            text for Main  
-        </member>  
-    </members>  
-</doc>  
-```  
-  
-## Example  
- The following example shows how to make a `cref` reference to a generic type.  
-  
- [!code-csharp[csProgGuideDocComments#11](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#11)]  
-  
- The previous example produces the following XML file.  
-  
-```xml  
-<?xml version="1.0"?>  
-<doc>  
-    <assembly>  
-        <name>YourNamespace</name>  
-    </assembly>  
-    <members>  
-        <member name="T:ExtensionMethodsDemo1.A">  
-            <summary cref="T:ExtensionMethodsDemo1.C`1">  
-            </summary>  
-        </member>  
-        <member name="T:ExtensionMethodsDemo1.B">  
-            <summary cref="T:C`1">  
-            </summary>  
-        </member>  
-        <member name="T:ExtensionMethodsDemo1.C`1">  
-            <summary cref="T:ExtensionMethodsDemo1.A">  
-            </summary>  
-            <typeparam name="T"></typeparam>  
-        </member>  
-    </members>  
-</doc>  
-```  
-  
+# \<summary> (C# programming guide)
+
+## Syntax
+
+```xml
+<summary>description</summary>
+```
+
+## Parameters
+
+- `description`
+
+  A summary of the object.
+
+## Remarks
+
+The \<summary> tag should be used to describe a type or a type member. Use [\<remarks>](./remarks.md) to add supplemental information to a type description. Use the [cref Attribute](./cref-attribute.md) to enable documentation tools such as [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to create internal hyperlinks to documentation pages for code elements.
+
+The text for the \<summary> tag is the only source of information about the type in IntelliSense, and is also displayed in the Object Browser Window.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file. To create the final documentation based on the compiler-generated file, you can create a custom tool, or use a tool such as [DocFX](https://dotnet.github.io/docfx/) or [Sandcastle](https://github.com/EWSoftware/SHFB).
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#12](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#12)]
+
+The previous example produces the following XML file.
+
+```xml
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>YourNamespace</name>
+    </assembly>
+    <members>
+        <member name="T:TestClass">
+            text for class TestClass
+        </member>
+        <member name="M:TestClass.DoWork(System.Int32)">
+            <summary>DoWork is a method in the TestClass class.
+            <para>Here's how you could make a second paragraph in a description. <see cref="M:System.Console.WriteLine(System.String)"/> for information about output statements.</para>
+            <seealso cref="M:TestClass.Main"/>
+            </summary>
+        </member>
+        <member name="M:TestClass.Main">
+            text for Main
+        </member>
+    </members>
+</doc>
+```
+
+## Example
+
+The following example shows how to make a `cref` reference to a generic type.
+
+[!code-csharp[csProgGuideDocComments#11](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#11)]
+
+The previous example produces the following XML file.
+
+```xml
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>CRefTest</name>
+    </assembly>
+    <members>
+        <member name="T:A">
+            <summary cref="T:C`1">
+            </summary>
+        </member>
+        <member name="T:B">
+            <summary cref="T:C`1">
+            </summary>
+        </member>
+        <member name="T:C`1">
+            <summary cref="T:A">
+            </summary>
+            <typeparam name="T"></typeparam>
+        </member>
+    </members>
+</doc>
+```
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/typeparam.md
+++ b/docs/csharp/programming-guide/xmldoc/typeparam.md
@@ -1,41 +1,47 @@
 ---
-title: "<typeparam> - C# Programming Guide"
+title: "<typeparam> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "typeparam"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<typeparam> C# XML tag"
   - "typeparam C# XML tag"
 ms.assetid: 9b99d400-e911-4e55-99c6-64367c96aa4f
 ---
-# \<typeparam> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<typeparam name="name">description</typeparam>  
-```  
-  
-## Parameters  
- `name`  
- The name of the type parameter. Enclose the name in double quotation marks (" ").  
-  
- `description`  
- A description for the type parameter.  
-  
-## Remarks  
- The `<typeparam>` tag should be used in the comment for a generic type or method declaration to describe a type parameter. Add a tag for each type parameter of the generic type or method.  
-  
- For more information, see [Generics](../generics/index.md).  
-  
- The text for the `<typeparam>` tag will be displayed in IntelliSense, the [Object Browser Window](/visualstudio/ide/viewing-the-structure-of-code#BKMK_ObjectBrowser) code comment web report.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#13](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#13)]  
-  
+# \<typeparam> (C# programming guide)
+
+## Syntax
+
+```xml
+<typeparam name="name">description</typeparam>
+```
+
+## Parameters
+
+- `name`
+
+  The name of the type parameter. Enclose the name in double quotation marks (" ").
+
+- `description`
+
+  A description for the type parameter.
+
+## Remarks
+
+The `<typeparam>` tag should be used in the comment for a generic type or method declaration to describe a type parameter. Add a tag for each type parameter of the generic type or method.
+
+For more information, see [Generics](../generics/index.md).
+
+The text for the `<typeparam>` tag will be displayed in IntelliSense, the [Object Browser Window](/visualstudio/ide/viewing-the-structure-of-code#BKMK_ObjectBrowser) code comment web report.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#13](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#13)]
+
 ## See also
 
-- [C# Reference](../../language-reference/index.md)
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# reference](../../language-reference/index.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/typeparamref.md
+++ b/docs/csharp/programming-guide/xmldoc/typeparamref.md
@@ -1,35 +1,40 @@
 ---
-title: "<typeparamref> - C# Programming Guide"
+title: "<typeparamref> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "typeparamref"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "typeparamref C# XML tag"
   - "<typeparamref> C# XML tag"
 ms.assetid: 6d8ffc58-12c5-4688-8db6-833a7ded5886
 ---
-# \<typeparamref> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<typeparamref name="name"/>  
-```  
-  
-## Parameters  
- `name`  
- The name of the type parameter. Enclose the name in double quotation marks (" ").  
-  
-## Remarks  
- For more information on type parameters in generic types and methods, see [Generics](../generics/index.md).  
-  
- Use this tag to enable consumers of the documentation file to format the word in some distinct way, for example in italics.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#13](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#13)]  
-  
+# \<typeparamref> (C# programming guide)
+
+## Syntax
+
+```xml
+<typeparamref name="name"/>
+```
+
+## Parameters
+
+- `name`
+
+  The name of the type parameter. Enclose the name in double quotation marks (" ").
+
+## Remarks
+
+For more information on type parameters in generic types and methods, see [Generics](../generics/index.md).
+
+Use this tag to enable consumers of the documentation file to format the word in some distinct way, for example in italics.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#13](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#13)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/programming-guide/xmldoc/value.md
+++ b/docs/csharp/programming-guide/xmldoc/value.md
@@ -1,33 +1,38 @@
 ---
-title: "<value> - C# Programming Guide"
+title: "<value> - C# programming guide"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "<value>"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "<value> C# XML tag"
   - "value C# XML tag"
 ms.assetid: 08dbadaf-9ab6-43d9-9493-98e43bed199a
 ---
-# \<value> (C# Programming Guide)
-## Syntax  
-  
-```xml  
-<value>property-description</value>  
-```  
-  
-## Parameters  
- `property-description`  
- A description for the property.  
-  
-## Remarks  
- The \<value> tag lets you describe the value that a property represents. Note that when you add a property via code wizard in the Visual Studio .NET development environment, it will add a [\<summary>](./summary.md) tag for the new property. You should then manually add a \<value> tag to describe the value that the property represents.  
-  
- Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
-  
-## Example  
- [!code-csharp[csProgGuideDocComments#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#14)]  
-  
+# \<value> (C# programming guide)
+
+## Syntax
+
+```xml
+<value>property-description</value>
+```
+
+## Parameters
+
+- `property-description`
+
+  A description for the property.
+
+## Remarks
+
+The \<value> tag lets you describe the value that a property represents. Note that when you add a property via code wizard in the Visual Studio .NET development environment, it will add a [\<summary>](./summary.md) tag for the new property. You should then manually add a \<value> tag to describe the value that the property represents.
+
+Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
+
+## Example
+
+[!code-csharp[csProgGuideDocComments#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#14)]
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Recommended Tags for Documentation Comments](./recommended-tags-for-documentation-comments.md)
+- [C# programming guide](../index.md)
+- [Recommended tags for documentation comments](./recommended-tags-for-documentation-comments.md)

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1209,18 +1209,18 @@
         href: programming-guide/unsafe-code-pointers/pointer-conversions.md
       - name: "How to use pointers to copy an array of bytes"
         href: programming-guide/unsafe-code-pointers/how-to-use-pointers-to-copy-an-array-of-bytes.md
-  - name: XML Documentation Comments
+  - name: XML documentation comments
     items:
     - name: Overview
       displayName: xml documentation comments
       href: programming-guide/xmldoc/index.md
-    - name: Recommended Tags for Documentation Comments
+    - name: Recommended tags for documentation comments
       href: programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
-    - name: Processing the XML File
+    - name: Processing the XML file
       href: programming-guide/xmldoc/processing-the-xml-file.md
-    - name: Delimiters for Documentation Tags
+    - name: Delimiters for documentation tags
       href: programming-guide/xmldoc/delimiters-for-documentation-tags.md
-    - name: "How to use the XML documentation features"
+    - name: How to use the XML documentation features
       href: programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
     - name: Documentation tag reference
       items:
@@ -1228,7 +1228,7 @@
         href: programming-guide/xmldoc/code-inline.md
       - name: <code>
         href: programming-guide/xmldoc/code.md
-      - name: cref Attribute
+      - name: cref attribute
         href: programming-guide/xmldoc/cref-attribute.md
       - name: <example>
         href: programming-guide/xmldoc/example.md


### PR DESCRIPTION
When I tried running csc with -doc option, I got different outputs in some articles. This needs to be well-reviewed just in case the original output is correct and I'm going something wrong.

(Hide white-spaces for easier diff)