### PR TITLE
Add more items for quick filters in .NET API landing page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 # In each subsection folders are order first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
+######## API landing page ###########
+/api/index.md @mairaw
+
 ############ WHATS NEW ###############
 /docs/whats-new/** @mairaw @billwagner
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 ######## API landing page ###########
-/api/index.md @mairaw
+/api/** @mairaw
 
 ############ WHATS NEW ###############
 /docs/whats-new/** @mairaw @billwagner

--- a/api/index.md
+++ b/api/index.md
@@ -2,7 +2,7 @@
 layout: ApiBrowserPage
 hide_bc: true
 title: .NET API browser
-quickFilterColumn1: netframework-4.8,netcore-3.1,netstandard-2.1,aspnetcore-3.1
+quickFilterColumn1: netcore-3.1,netframework-4.8,netstandard-2.1,aspnetcore-3.1
 quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0,efcore-3.1
 quickFilterColumn3: azure-dotnet,roslyn-dotnet,ml-dotnet,spark-dotnet
 ms.topic: landing-page

--- a/api/index.md
+++ b/api/index.md
@@ -2,10 +2,9 @@
 layout: ApiBrowserPage
 hide_bc: true
 title: .NET API browser
-quickFilterColumn1: netframework-4.8,netcore-3.1,netstandard-2.1
-quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0
-quickFilterColumn3: azure-dotnet,aspnetcore-3.1,efcore-3.1
-quickFilterColumn4: roslyn-dotnet,ml-dotnet,spark-dotnet
+quickFilterColumn1: netframework-4.8,netcore-3.1,netstandard-2.1,aspnetcore-3.1
+quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0,efcore-3.1
+quickFilterColumn3: azure-dotnet,roslyn-dotnet,ml-dotnet,spark-dotnet
 ms.topic: landing-page
 ms.custom: "updateeachrelease"
 ms.date: "12/12/2019"

--- a/api/index.md
+++ b/api/index.md
@@ -7,8 +7,8 @@ quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0,efcore-3.1
 quickFilterColumn3: azure-dotnet,roslyn-dotnet,ml-dotnet,spark-dotnet
 ms.topic: landing-page
 ms.custom: "updateeachrelease"
-ms.date: "12/12/2019"
+ms.date: "01/24/2020"
 ---
 # .NET API browser
 
-Welcome to the .NET API browser – your one-stop shop for all .NET-based APIs from Microsoft. Start searching for any managed APIs by typing in the box below. You can learn more about the API Browser [in our blog post](https://aka.ms/apibrowser). If you have any feedback, create a new issue in the [MicrosoftDocs/feedback repository on GitHub](https://github.com/MicrosoftDocs/feedback/issues).
+Welcome to the .NET API browser – your one-stop shop for all .NET-based APIs from Microsoft. Start searching for any managed APIs by typing in the box below. You can learn more about the API browser [in our blog post](https://aka.ms/apibrowser). If you have any feedback, create a new issue in the [MicrosoftDocs/feedback repository on GitHub](https://github.com/MicrosoftDocs/feedback/issues).

--- a/api/index.md
+++ b/api/index.md
@@ -4,8 +4,8 @@ hide_bc: true
 title: .NET API browser
 quickFilterColumn1: netframework-4.8,netcore-3.1,netstandard-2.1
 quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0
-quickFilterColumn3: azure-dotnet,aspnetcore-3.1,ml-dotnet
-quickFilterColumn4: aspnetcore-3.1,efcore-3.1,spark-dotnet
+quickFilterColumn3: azure-dotnet,aspnetcore-3.1,efcore-3.1
+quickFilterColumn4: roslyn-dotnet,ml-dotnet,spark-dotnet
 ms.topic: landing-page
 ms.custom: "updateeachrelease"
 ms.date: "12/12/2019"

--- a/api/index.md
+++ b/api/index.md
@@ -1,14 +1,15 @@
 ---
 layout: ApiBrowserPage
 hide_bc: true
-title: .NET API Browser
+title: .NET API browser
 quickFilterColumn1: netframework-4.8,netcore-3.1,netstandard-2.1
 quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0
 quickFilterColumn3: azure-dotnet,aspnetcore-3.1,ml-dotnet
+quickFilterColumn4: aspnetcore-3.1,efcore-3.1,spark-dotnet
 ms.topic: landing-page
 ms.custom: "updateeachrelease"
 ms.date: "12/12/2019"
 ---
-# .NET API Browser
+# .NET API browser
 
-Welcome to the .NET API Browser – your one-stop shop for all .NET-based APIs from Microsoft. Start searching for any managed APIs by typing in the box below. You can learn more about the API Browser [in our blog post](https://aka.ms/apibrowser). If you have any feedback, create a new issue in the [MicrosoftDocs/feedback repo on GitHub](https://github.com/MicrosoftDocs/feedback/issues).
+Welcome to the .NET API browser – your one-stop shop for all .NET-based APIs from Microsoft. Start searching for any managed APIs by typing in the box below. You can learn more about the API Browser [in our blog post](https://aka.ms/apibrowser). If you have any feedback, create a new issue in the [MicrosoftDocs/feedback repository on GitHub](https://github.com/MicrosoftDocs/feedback/issues).


### PR DESCRIPTION
I think these are helpful to exist in the landing page.
I noticed that this PR didn't automatically request a review because the api landing page didn't exist in CODEOWNERS file. I've added @mairaw as a code owner based on the file history.

I also made some minor changes.