### PR TITLE
Remove "updateeachrelease" when appropriate

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md
@@ -1,6 +1,5 @@
 ---
 title: "AppContextSwitchOverrides Element"
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 helpviewer_keywords:
   - "AppContextSwitchOverrides"

--- a/docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md
+++ b/docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md
@@ -1,7 +1,6 @@
 ---
 title: "<supportedRuntime> configuration element - .NET"
 ms.date: "04/02/2019"
-ms.custom: "updateeachrelease"
 f1_keywords: 
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#supportedRuntime"
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#configuration/startup/supportedRuntime"

--- a/docs/framework/deployment/deployment-guide-for-developers.md
+++ b/docs/framework/deployment/deployment-guide-for-developers.md
@@ -1,6 +1,5 @@
 ---
 title: ".NET Framework deployment guide for developers"
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 helpviewer_keywords:
   - "developer's guide, deploying .NET Framework"

--- a/docs/framework/get-started/index.md
+++ b/docs/framework/get-started/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Get started with the .NET Framework"
-ms.custom: "updateeachrelease"
 ms.date: "04/02/2019"
 helpviewer_keywords: 
   - ".NET Framework, getting started"

--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -1,7 +1,6 @@
 ---
 title: ".NET Framework system requirements"
 description: "Find out what are the hardware, operating system and software requirements to install .NET Framework 4.5 and later versions."
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 helpviewer_keywords: 
   - "software requirements"

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -1,7 +1,6 @@
 ---
 title: ".NET Framework documentation"
 ms.date: "04/02/2019"
-ms.custom: "updateeachrelease"
 f1_keywords: 
   - "f61f02f2-2f20-483d-8f56-a9c8f3a54986"
 helpviewer_keywords: 

--- a/docs/framework/install/guide-for-developers.md
+++ b/docs/framework/install/guide-for-developers.md
@@ -1,6 +1,5 @@
 ---
 title: "Install the .NET Framework developer pack or redistributable"
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 helpviewer_keywords:
   - ".NET Framework redistributable package, downloading"

--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -2,7 +2,6 @@
 title: Install the .NET Framework on Windows 10
 description: Learn how to install the .NET Framework on Windows 10 or Windows Server 2016.
 ms.date: 04/18/2019
-ms.custom: "updateeachrelease"
 ---
 # Install the .NET Framework on Windows 10 and Windows Server 2016 and later
 

--- a/docs/framework/install/on-windows-7.md
+++ b/docs/framework/install/on-windows-7.md
@@ -1,6 +1,5 @@
 ---
 title: Install the .NET Framework on Windows 7 SP1
-ms.custom: "updateeachrelease"
 description: Learn how to install the .NET Framework on Windows 7 SP1.
 ms.date: 04/18/2019
 ---

--- a/docs/framework/install/on-windows-8-1.md
+++ b/docs/framework/install/on-windows-8-1.md
@@ -1,6 +1,5 @@
 ---
 title: Install the .NET Framework on Windows 8.1
-ms.custom: "updateeachrelease"
 description: Learn how to install .NET Framework on Windows 8.1
 ms.date: 04/18/2019
 ---

--- a/docs/framework/install/on-windows-8.md
+++ b/docs/framework/install/on-windows-8.md
@@ -1,6 +1,5 @@
 ---
 title: Install the .NET Framework on Windows 8
-ms.custom: "updateeachrelease"
 description: Learn how to install .NET Framework on Windows 8
 ms.date: 04/18/2019
 ---

--- a/docs/framework/install/on-windows-vista.md
+++ b/docs/framework/install/on-windows-vista.md
@@ -1,7 +1,6 @@
 ---
 title: Install the .NET Framework on Windows Vista
 description: Learn how to install the .NET Framework on Windows Vista.
-ms.custom: "updateeachrelease"
 ms.date: 04/18/2019
 ---
 

--- a/docs/framework/install/on-windows-xp.md
+++ b/docs/framework/install/on-windows-xp.md
@@ -1,7 +1,6 @@
 ---
 title: Install the .NET Framework on Windows XP
 description: Learn how to install the .NET Framework on Windows XP.
-ms.custom: "updateeachrelease"
 ms.date: 04/18/2019
 ---
 

--- a/docs/framework/install/troubleshoot-blocked-installations-and-uninstallations.md
+++ b/docs/framework/install/troubleshoot-blocked-installations-and-uninstallations.md
@@ -1,7 +1,6 @@
 ---
 title: "Troubleshoot blocked .NET Framework installations and uninstallations"
 ms.date: "04/18/2019"
-ms.custom: "updateeachrelease"
 helpviewer_keywords: 
   - ".NET Framework, troubleshooting blocked installations"
   - "blocked .NET Framework installations, troubleshooting"

--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -4,7 +4,6 @@ ms.date: "04/18/2019"
 dev_langs:
   - "csharp"
   - "vb"
-ms.custom: "updateeachrelease"
 helpviewer_keywords:
   - "versions, determining for .NET Framework"
   - ".NET Framework, determining version"

--- a/docs/framework/migration-guide/index.md
+++ b/docs/framework/migration-guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Migration Guide to the .NET Framework 4.8, 4.7, 4.6, and 4.5 "
+title: "Migration Guide to the .NET Framework 4.8, 4.7, 4.6, and 4.5"
 description: A guide for migrating to newer .NET Framework versions that includes resources for new features and application compatibility.
 ms.date: "04/18/2019"
 helpviewer_keywords: 

--- a/docs/framework/migration-guide/index.md
+++ b/docs/framework/migration-guide/index.md
@@ -1,6 +1,5 @@
 ---
-title: "Migration Guide to the .NET Framework 4.8, 4.7, 4.6, and 4.5 "
-ms.custom: "updateeachrelease"
+title: "Migration Guide to the .NET Framework 4.8, 4.7, 4.6, and 4.5"
 ms.date: "04/18/2019"
 helpviewer_keywords: 
   - ".NET Framework, migrating applications to"

--- a/docs/framework/migration-guide/version-compatibility.md
+++ b/docs/framework/migration-guide/version-compatibility.md
@@ -1,6 +1,5 @@
 ---
 title: "Version compatibility in the .NET Framework"
-ms.custom: "updateeachrelease"
 ms.date: "04/02/2019"
 helpviewer_keywords: 
   - ".NET Framework, version compatibility"

--- a/docs/framework/migration-guide/versions-and-dependencies.md
+++ b/docs/framework/migration-guide/versions-and-dependencies.md
@@ -1,6 +1,5 @@
 ---
 title: ".NET Framework Versions and Dependencies"
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 helpviewer_keywords: 
   - "versions, .NET Framework"

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -1,6 +1,5 @@
 ---
 title: "What's new in the .NET Framework"
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 dev_langs:
   - "csharp"

--- a/docs/framework/whats-new/obsolete-members.md
+++ b/docs/framework/whats-new/obsolete-members.md
@@ -1,6 +1,5 @@
 ---
 title: "Obsolete members - .NET Framework"
-ms.custom: "updateeachrelease"
 ms.date: "10/17/2017"
 helpviewer_keywords:
   - ".NET Framework, obsolete members"

--- a/docs/framework/whats-new/whats-new-in-accessibility.md
+++ b/docs/framework/whats-new/whats-new-in-accessibility.md
@@ -1,6 +1,5 @@
 ---
 title: "What's new in accessibility in the .NET Framework"
-ms.custom: "updateeachrelease"
 ms.date: "04/18/2019"
 dev_langs:
   - "csharp"

--- a/docs/framework/whats-new/whats-obsolete.md
+++ b/docs/framework/whats-new/whats-obsolete.md
@@ -1,6 +1,5 @@
 ---
 title: What's obsolete in .NET Framework
-ms.custom: "updateeachrelease"
 ms.date: "04/02/2019"
 helpviewer_keywords: 
   - "obsolete [.NET Framework]"


### PR DESCRIPTION
Since [.NET Framework 4.8 is the latest major release of .NET Framework](https://devblogs.microsoft.com/dotnet/net-core-is-the-future-of-net/), I think it's not necessary now to have this metadata.

> .NET Framework 4.8 will be the last major version of .NET Framework. If you have existing .NET Framework applications that you are maintaining, there is no need to move these applications to .NET Core. We will continue to both service and support .NET Framework, which includes bug–, reliability– and security fixes. It will continue to ship with Windows (much of Windows depends on .NET Framework) and we will continue to improve the tooling support for .NET in Visual Studio (Visual Studio is written on .NET Framework). 