### PR TITLE
Fix wrong statement

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -290,7 +290,7 @@ private static async Task<List<Repository>> ProcessRepositories()
 Then, just return the repositories after processing the JSON response:
 
 ```csharp
-var repositories = serializer.ReadObject(await streamTask) as List<Repository>;
+var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
 return repositories;
 ```
 


### PR DESCRIPTION
## Summary
Fixes a statement that is in the document which resolves  the " inconsistency in the snippet of "Controlling Serialization". The code line that reads:
```csharp
var repositories = serializer.ReadObject(await streamTask) as List<Repository>;
```
should be replaced by:
```csharp
var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
```

Fixes #16753
