### PR TITLE
Missing double quotation mark in line 117

### DIFF
--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -114,7 +114,7 @@ The advantage of verbatim strings is that escape sequences are *not* processed, 
 To include a double quotation mark in an @-quoted string, double it:
 
 ```csharp
-@"""Ahoy!"" cried the captain." // "Ahoy!" cried the captain.
+@"""Ahoy!""" cried the captain." // "Ahoy!" cried the captain.
 ```
 
 ## The delegate type


### PR DESCRIPTION
When describing a double quotation mark inclusion in an @-quoted string, ending marks are just two quotation marks where it should be three.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
