### PR TITLE
Fix a formatting mistake

### DIFF
--- a/docs/csharp/programming-guide/statements-expressions-operators/equality-comparisons.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/equality-comparisons.md
@@ -28,7 +28,7 @@ int a = GetOriginalValue();
 int b = GetCurrentValue();  
   
 // Test for value equality.   
-if( b == a)   
+if(b == a)   
 {  
     // The two integers are equal.  
 }  

--- a/docs/csharp/programming-guide/statements-expressions-operators/equality-comparisons.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/equality-comparisons.md
@@ -28,7 +28,7 @@ int a = GetOriginalValue();
 int b = GetCurrentValue();  
   
 // Test for value equality.   
-if(b == a)   
+if (b == a)
 {  
     // The two integers are equal.  
 }  


### PR DESCRIPTION
Fixes an accidental space in the equality-comparisons documentation page.

## Summary

This is a tiny change, just something that slightly bothered me. 😅

Just doing my tiny part in making the docs a better place.
