### PR TITLE
Fix code snippets in console-webapiclient

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -196,7 +196,7 @@ namespace WebAPIClient
 {
     public class Repository
     {
-        public string name { get; set; };
+        public string name { get; set; }
     }
 }
 ```
@@ -218,7 +218,6 @@ Next, you'll use the serializer to convert JSON into C# objects. Replace the cal
 ```csharp
 var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
 var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
-return repositories;
 ```
 
 You're using a new namespace, so you'll need to add it at the top of the file as well:
@@ -291,6 +290,7 @@ Then, just return the repositories after processing the JSON response:
 
 ```csharp
 var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
+var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
 return repositories;
 ```
 


### PR DESCRIPTION
- Remove semicolon from Repository class name property
- Remove return statement from ProcessRepository method
- Add repositories assignment prior to return statement in ProcessRepository method