### PR TITLE
The default NuGet version rule for PackageReference is equal or greater

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -184,7 +184,7 @@ Note that `DotNetCliToolReference` is [now deprecated](https://github.com/dotnet
 
 #### Version
 
-`Version` specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/create-packages/dependency-versions#version-ranges) scheme. The default behavior is an exact version match. For example, specifying `Version="1.2.3"` is equivalent to NuGet notation `[1.2.3]` for the exact 1.2.3 version of the package.
+`Version` specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/create-packages/dependency-versions#version-ranges) scheme. The default behavior is a minimum version, inclusive match. For example, specifying `Version="1.2.3"` means the resolved package will have the version 1.2.3 if available or greater otherwise.
 
 ### RuntimeIdentifiers
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -140,7 +140,7 @@ A `<PackageReference>` item element specifies a [NuGet dependency in the project
 
 #### Version
 
-The required `Version` attribute specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/reference/package-versioning#version-ranges-and-wildcards) scheme. The default behavior is a minimum version, inclusive match. For example, specifying `Version="1.2.3"` means the resolved package will have the version 1.2.3 if available or greater otherwise.
+The required `Version` attribute specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/reference/package-versioning#version-ranges-and-wildcards) scheme. The default behavior is a minimum version, inclusive match. For example, specifying `Version="1.2.3"` is equivalent to NuGet notation `[1.2.3, )` and means the resolved package will have the version 1.2.3 if available or greater otherwise.
 
 #### IncludeAssets, ExcludeAssets, and PrivateAssets
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -184,7 +184,7 @@ Note that `DotNetCliToolReference` is [now deprecated](https://github.com/dotnet
 
 #### Version
 
-`Version` specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/create-packages/dependency-versions#version-ranges) scheme. The default behavior is a minimum version, inclusive match. For example, specifying `Version="1.2.3"` means the resolved package will have the version 1.2.3 if available or greater otherwise.
+`Version` specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/create-packages/dependency-versions#version-ranges) scheme. The default behavior is a minimum version, inclusive match. For example, specifying `Version="1.2.3"` is equivalent to NuGet notation `[1.2.3, )` and means the resolved package will have the version 1.2.3 if available or greater otherwise.
 
 ### RuntimeIdentifiers
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -140,7 +140,7 @@ A `<PackageReference>` item element specifies a [NuGet dependency in the project
 
 #### Version
 
-The required `Version` attribute specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/reference/package-versioning#version-ranges-and-wildcards) scheme. The default behavior is an exact version match. For example, specifying `Version="1.2.3"` is equivalent to NuGet notation `[1.2.3]` for the exact 1.2.3 version of the package.
+The required `Version` attribute specifies the version of the package to restore. The attribute respects the rules of the [NuGet versioning](/nuget/reference/package-versioning#version-ranges-and-wildcards) scheme. The default behavior is a minimum version, inclusive match. For example, specifying `Version="1.2.3"` means the resolved package will have the version 1.2.3 if available or greater otherwise.
 
 #### IncludeAssets, ExcludeAssets, and PrivateAssets
 


### PR DESCRIPTION
Fixes #14978.
I'm guessing the same thing applies to DotNetCliToolReference below.