### PR TITLE
programmatically create string content

### DIFF
--- a/docs/csharp/how-to/modify-string-contents.md
+++ b/docs/csharp/how-to/modify-string-contents.md
@@ -56,12 +56,13 @@ The following example shows how to replace a set of characters in a string. Firs
 
 [!code-csharp-interactive[replace creates a new string](../../../samples/snippets/csharp/how-to/strings/ModifyStrings.cs#6)]
 
-## Unsafe modifications to string
+## Programmatically build up string content
 
-Using **unsafe** code, you can modify a string "in place" after it has been created. Unsafe code bypasses many of the features of .NET designed to minimize certain types of bugs in code. You need to use unsafe code to modify a string in place because the string class is designed as an **immutable** type. Once it has been created, its value does not change. Unsafe code circumvents this property by accessing and modifying the memory used by a `string` without using normal `string` methods.
-The following example is provided for those rare situations where you want to modify a string in-place using unsafe code. The example shows how to use the `fixed` keyword. The `fixed` keyword prevents the garbage collector (GC) from moving the string object in memory while code accesses the memory using the unsafe pointer. It also demonstrates one possible side effect of unsafe operations on strings that results from the way that the C# compiler stores (interns) strings internally. In general, you shouldn't use this technique unless it is absolutely necessary. You can learn more in the articles on [unsafe](../language-reference/keywords/unsafe.md) and [fixed](../language-reference/keywords/fixed-statement.md). The API reference for <xref:System.String.Intern%2A> includes information on string interning.
+Since strings are immutable, the previous examples all create temporary strings or character arrays. In high performance scenarios, it may be desirable to avoid these heap allocations. .NET Core provides a <xref:System.String.Create%2A?displayProperty=nameWithType> method that allows you to programmatically fill in the character content of a string via a callback while avoiding the intermediate temporary string allocations.
 
-[!code-csharp[unsafe ways to create a new string](../../../samples/snippets/csharp/how-to/strings/ModifyStrings.cs#7)]
+[!code-csharp[using string.Create to programmatically build the string content for a new string](../../../samples/snippets/csharp/how-to/strings/ModifyStrings.cs#7)]
+
+You could modify a string in a fixed block with unsafe code but it is **strongly** discouraged to modify the string content after a string is created. Doing so will break things in unpredictable ways. For example, if someone interns a string that has the same content as yours, they will get your copy and will not expect that you are modifying their string at all.
 
 You can try these samples by looking at the code in our [GitHub repository](https://github.com/dotnet/samples/tree/master/snippets/csharp/how-to/strings). Or you can download the samples [as a zip file](https://github.com/dotnet/samples/raw/master/snippets/csharp/how-to/strings.zip).
 


### PR DESCRIPTION
## Summary

We should be discouraging folks to use fixed to change the string content and recommend to use string.Create if they want to programmatically build a string.

@gewarren, do we have a code sample somewhere that uses string.Create? The doc for it seems quite brief. 

cc @jkotas, per our conversation.
