### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/bcnotify.yaml
+++ b/.github/workflows/bcnotify.yaml
@@ -1,5 +1,5 @@
 name: "bc-notification"
-on: 
+on:
   issues:
     types: [edited, labeled]
 
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: timheuer/issue-notifier@v1.0.2
       env:
         SENDGRID_API_KEY: ${{ secrets.SENDGRID_API }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,6 +1,12 @@
 name: Markdownlint
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "**/*.md"
+  pull_request:
+    paths:
+      - "**/*.md"
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
Few small things I've figured out playing with the Actions on other repos.
- v2 of the checkout is supposed to be using a quicker API
- The "paths" filter allows only triggering actions when certain files are changed. Since Markdownlint only runs on MD files, no need to trigger if YAML or JSON only changes are pushed
