### PR TITLE
Add the manual download and install for Windows section

### DIFF
--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -86,9 +86,9 @@ dotnet-install.ps1 -Channel 3.1 -Runtime aspnetcore
 
 ## Download and manually install
 
-First [download](#all-net-core-downloads) a .NET Core binary release. Then create a directory to install to, for example `%USERPROFILE%\dotnet`. And finally extract the downloaded zip file into that directory.
+To extract the runtime and make the .NET Core CLI commands available at the terminal, first [download](#all-net-core-downloads) a .NET Core binary release. Then, create a directory to install to, for example `%USERPROFILE%\dotnet`. Finally, extract the downloaded zip file into that directory.
 
-.NET Core installed in this way will not be picked up by default, you have to explicitly choose to use it. To do so, change the environment variables with which an application is started:
+By default, .NET Core CLI commands and apps will not use .NET Core installed in this way. You have to explicitly choose to use it. To do so, change the environment variables with which an application is started:
 
 ```
 set DOTNET_ROOT=%USERPROFILE%\dotnet

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -90,14 +90,14 @@ To extract the runtime and make the .NET Core CLI commands available at the term
 
 By default, .NET Core CLI commands and apps will not use .NET Core installed in this way. You have to explicitly choose to use it. To do so, change the environment variables with which an application is started:
 
-```
+```console
 set DOTNET_ROOT=%USERPROFILE%\dotnet
 set PATH=%USERPROFILE%\dotnet;%PATH%
 ```
 
-This approach lets you install multiple different versions into separate locations and explicitly choose which application should use which install location by running the application with its own set of environment variable values.
+This approach lets you install multiple versions into separate locations, then explicitly choose which install location an application should use by running the application with environment variables pointing at that location.
 
-Even with the application started under this environment .NET Core will still consider the default global install location (typically `C:\Program Files\dotnet`) which is used by the installers when selecting the best framework for running the application. You can instruct the runtime to only use the custom install location by setting this environment variable as well:
+Even when these environment variables are set, .NET Core still considers the default global install location when selecting the best framework for running the application. The default is typically `C:\Program Files\dotnet`, which the installers use. You can instruct the runtime to only use the custom install location by setting this environment variable as well:
 
 ```console
 set DOTNET_MULTILEVEL_LOOKUP=0

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -95,7 +95,9 @@ set DOTNET_ROOT=%USERPROFILE%\dotnet
 set PATH=%USERPROFILE%\dotnet;%PATH%
 ```
 
-This approach lets you install multiple different versions into separate locations and explicitly choose which application should use which install location by running the application with its own set of environment variable values. Even with the application started under this environment .NET Core will still consider the default global install location (typically `C:\Program Files\dotnet`) which is used by the installers when selecting the best framework for running the application. You can instruct the runtime to only use the custom install location by setting this environment variable as well:
+This approach lets you install multiple different versions into separate locations and explicitly choose which application should use which install location by running the application with its own set of environment variable values.
+
+Even with the application started under this environment .NET Core will still consider the default global install location (typically `C:\Program Files\dotnet`) which is used by the installers when selecting the best framework for running the application. You can instruct the runtime to only use the custom install location by setting this environment variable as well:
 
 ```console
 set DOTNET_MULTILEVEL_LOOKUP=0

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -64,6 +64,9 @@ export PATH=$PATH:$HOME/dotnet
 >
 > Also, add `export DOTNET_ROOT=$HOME/dotnet` to the end of the file.
 
+> [!TIP]
+> This approach lets you install multiple different versions into separate locations and choose explicitly which one to use by which application.
+
 ::: zone-end
 
 ::: zone pivot="os-windows"
@@ -80,6 +83,24 @@ dotnet-install.ps1 -Channel 3.1 -Runtime aspnetcore
 
 > [!NOTE]
 > The command above installs the ASP.NET Core runtime for maximum compatability. The ASP.NET Core runtime also includes the standard .NET Core runtime.
+
+## Download and manual install
+
+First [download](#all-net-core-downloads) a .NET Core binary release. Then create a directory to install to, for example `%USERPROFILE%\dotnet`. And finally extract the downloaded zip file into that directory.
+
+.NET Core installed in this way will not be picked up by default, you have to explicitly choose to use it. To do so, change the environment variables with which an application is started:
+
+```
+set DOTNET_ROOT=%USERPROFILE%\dotnet
+set PATH=%USERPROFILE%\dotnet;%PATH%
+```
+
+> [!TIP] 
+> This approach lets you install multiple different versions into separate locations and choose explicitly which one to use by which application. Even with the application started under this environment, .NET Core will still consider the default global install location (typically `C:\Program Files\dotnet`) which is used by the installers. To disable this and ask the runtime to only consider the custom install location also modify this environment variable:
+>
+> ```
+> set DOTNET_MULTILEVEL_LOOKUP=0
+> ```
 
 ::: zone-end
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -84,7 +84,7 @@ dotnet-install.ps1 -Channel 3.1 -Runtime aspnetcore
 > [!NOTE]
 > The command above installs the ASP.NET Core runtime for maximum compatability. The ASP.NET Core runtime also includes the standard .NET Core runtime.
 
-## Download and manual install
+## Download and manually install
 
 First [download](#all-net-core-downloads) a .NET Core binary release. Then create a directory to install to, for example `%USERPROFILE%\dotnet`. And finally extract the downloaded zip file into that directory.
 
@@ -95,12 +95,11 @@ set DOTNET_ROOT=%USERPROFILE%\dotnet
 set PATH=%USERPROFILE%\dotnet;%PATH%
 ```
 
-> [!TIP] 
-> This approach lets you install multiple different versions into separate locations and choose explicitly which one to use by which application. Even with the application started under this environment, .NET Core will still consider the default global install location (typically `C:\Program Files\dotnet`) which is used by the installers. To disable this and ask the runtime to only consider the custom install location also modify this environment variable:
->
-> ```
-> set DOTNET_MULTILEVEL_LOOKUP=0
-> ```
+This approach lets you install multiple different versions into separate locations and explicitly choose which application should use which install location by running the application with its own set of environment variable values. Even with the application started under this environment .NET Core will still consider the default global install location (typically `C:\Program Files\dotnet`) which is used by the installers when selecting the best framework for running the application. You can instruct the runtime to only use the custom install location by setting this environment variable as well:
+
+```console
+set DOTNET_MULTILEVEL_LOOKUP=0
+```
 
 ::: zone-end
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -64,8 +64,7 @@ export PATH=$PATH:$HOME/dotnet
 >
 > Also, add `export DOTNET_ROOT=$HOME/dotnet` to the end of the file.
 
-> [!TIP]
-> This approach lets you install multiple different versions into separate locations and choose explicitly which one to use by which application.
+This approach lets you install different versions into separate locations and choose explicitly which one to use by which application.
 
 ::: zone-end
 


### PR DESCRIPTION
Currently the install doc describes the manual way of downloading and installing .NET Core runtime only for Linux platforms. This change adds the same option to Windows as well.