### PR TITLE
TOC fixes

### DIFF
--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -50,7 +50,7 @@
     href: install/localized-intellisense.md
 - name: Get started
   items:
-  - name: Get started with C# and the CLI
+  - name: Get started with C#
     href: get-started.md
   - name: Get started with C# and Visual Studio Code
     href: tutorials/with-visual-studio-code.md
@@ -85,7 +85,7 @@
   href: compatibility/
 - name: Tutorials
   items:
-  - name: Index of tutorials
+  - name: Overview
     href: tutorials/index.md
   - name: Get started with .NET Core using Visual Studio for Mac
     href: tutorials/using-on-mac-vs.md
@@ -392,5 +392,5 @@
       href: tutorials/creating-app-with-plugin-support.md
     - name: How to use and debug assembly unloadability in .NET Core
       href: ../standard/assembly/unloadability-howto.md
-  - name: .NET Core distribution packaging
-    href: distribution-packaging.md
+- name: .NET Core distribution packaging
+  href: distribution-packaging.md

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -50,7 +50,7 @@
     href: install/localized-intellisense.md
 - name: Get started
   items:
-  - name: Get started with C#
+  - name: Get started
     href: get-started.md
   - name: Get started with C# and Visual Studio Code
     href: tutorials/with-visual-studio-code.md

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -367,7 +367,7 @@
   - name: Port WPF projects
     href: porting/wpf.md
   - name: Port C++/CLI projects
-    href: porting/cpp-cli.md    
+    href: porting/cpp-cli.md
 - name: Dependency management and loading
   items:
   - name: Dependency management

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -357,7 +357,7 @@
   - name: Organize projects for .NET Core
     href: porting/project-structure.md
   - name: Unavailable technologies
-    href: porting/net-framework-tech-unavailable.md 
+    href: porting/net-framework-tech-unavailable.md
   - name: Tools
     href: porting/tools.md
   - name: Use the Windows Compatibility Pack

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -368,15 +368,15 @@
     href: porting/wpf.md
   - name: Port C++/CLI projects
     href: porting/cpp-cli.md    
-- name: Dependency management
-  href: tools/dependencies.md
-- name: Dependency loading
+- name: Dependency management and loading
   items:
-  - name: Overview
+  - name: Dependency management
+    href: tools/dependencies.md
+  - name: Dependency loading
     href: dependency-loading/overview.md
   - name: Understand AssemblyLoadContext
     href: dependency-loading/understanding-assemblyloadcontext.md
-  - name: Loading details
+  - name: Dependency loading details
     items:
     - name: Default dependency probing
       href: dependency-loading/default-probing.md

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -49,8 +49,9 @@
   - name: Install localized IntelliSense
     href: install/localized-intellisense.md
 - name: Get started
-  href: get-started.md
   items:
+  - name: Get started with C# and the CLI
+    href: get-started.md
   - name: Get started with C# and Visual Studio Code
     href: tutorials/with-visual-studio-code.md
   - name: Get started with .NET Core on macOS using Visual Studio Code
@@ -83,16 +84,9 @@
   displayName: app compatibility
   href: compatibility/
 - name: Tutorials
-  href: tutorials/index.md
   items:
-  - name: Templates for the CLI
-    items:
-    - name: 1 - Create an item template
-      href: tutorials/cli-templates-create-item-template.md
-    - name: 2 - Create a project template
-      href: tutorials/cli-templates-create-project-template.md
-    - name: 3 - Create a template pack
-      href: tutorials/cli-templates-create-template-pack.md
+  - name: Index of tutorials
+    href: tutorials/index.md
   - name: Get started with .NET Core using Visual Studio for Mac
     href: tutorials/using-on-mac-vs.md
   - name: Build a complete .NET Core solution on macOS
@@ -109,6 +103,14 @@
     href: tutorials/aspnet-core.md
   - name: Host .NET Core from native code
     href: tutorials/netcore-hosting.md
+  - name: Create templates for the CLI
+    items:
+    - name: 1 - Create an item template
+      href: tutorials/cli-templates-create-item-template.md
+    - name: 2 - Create a project template
+      href: tutorials/cli-templates-create-project-template.md
+    - name: 3 - Create a template pack
+      href: tutorials/cli-templates-create-template-pack.md
 - name: Run-time configuration
   items:
   - name: Settings
@@ -131,13 +133,6 @@
     href: native-interop/expose-components-to-com.md
 - name: Packages, metapackages, and frameworks
   href: packages.md
-- name: Changes in CLI overview
-  href: tools/cli-msbuild-architecture.md
-  items:
-  - name: Dependency management
-    href: tools/dependencies.md
-  - name: Additions to the csproj format
-    href: tools/csproj.md
 - name: Migration
   items:
   - name: .NET Core 2.0 to 2.1
@@ -146,11 +141,16 @@
     href: migration/index.md
   - name: Map between project.json and csproj
     href: tools/project-json-to-csproj.md
+  - name: Changes in CLI overview
+    href: tools/cli-msbuild-architecture.md
+  - name: Additions to the csproj format
+    href: tools/csproj.md
   - name: Migrate from DNX
     href: migration/from-dnx.md
 - name: Application deployment
-  href: deploying/index.md
   items:
+  - name: Overview
+    href: deploying/index.md
   - name: Publish apps with the CLI
     href: deploying/deploy-with-cli.md
   - name: Deploy apps with Visual Studio
@@ -192,6 +192,8 @@
 - name: Unit testing
   href: testing/index.md
   items:
+  - name: Overview
+    href: testing/index.md
   - name: Unit testing best practices
     href: testing/unit-testing-best-practices.md
   - name: C# unit testing with xUnit
@@ -221,8 +223,9 @@
 - name: Continuous integration
   href: tools/using-ci-with-cli.md
 - name: Versioning
-  href: versions/index.md
   items:
+  - name: Overview
+    href: versions/index.md
   - name: .NET Core version selection
     href: versions/selection.md
   - name: Remove outdated runtimes and SDKs
@@ -330,8 +333,9 @@
       - name: dotnet remove package
         href: tools/dotnet-remove-package.md
 - name: .NET Core additional tools
-  href: additional-tools/index.md
   items:
+  - name: Overview
+    href: additional-tools/index.md
   - name: .NET Core Uninstall Tool
     href: additional-tools/uninstall-tool.md
   - name: WCF Web Service Reference Provider
@@ -353,7 +357,7 @@
   - name: Organize projects for .NET Core
     href: porting/project-structure.md
   - name: Unavailable technologies
-    href: porting/net-framework-tech-unavailable.md
+    href: porting/net-framework-tech-unavailable.md 
   - name: Tools
     href: porting/tools.md
   - name: Use the Windows Compatibility Pack
@@ -363,7 +367,9 @@
   - name: Port WPF projects
     href: porting/wpf.md
   - name: Port C++/CLI projects
-    href: porting/cpp-cli.md
+    href: porting/cpp-cli.md    
+- name: Dependency management
+  href: tools/dependencies.md
 - name: Dependency loading
   items:
   - name: Overview
@@ -386,7 +392,5 @@
       href: tutorials/creating-app-with-plugin-support.md
     - name: How to use and debug assembly unloadability in .NET Core
       href: ../standard/assembly/unloadability-howto.md
-- name: .NET Core distribution packaging
-  items:
-  - name: Overview
+  - name: .NET Core distribution packaging
     href: distribution-packaging.md

--- a/docs/core/tutorials/index.md
+++ b/docs/core/tutorials/index.md
@@ -41,6 +41,8 @@ The following tutorials are available for learning about .NET Core.
 - [Unit testing with MSTest and .NET Core](../testing/unit-testing-with-mstest.md)
 - [Developing Libraries with Cross Platform Tools](libraries.md)
 - [Hosting .NET Core from native code](netcore-hosting.md)
-- [Create a custom template for dotnet new](cli-templates-create-item-template.md)
+- [Create a custom item template for the CLI](cli-templates-create-item-template.md)
+- [Create a custom project template for the CLI](cli-templates-create-project-template.md)
+- [Create a template pack for the CLI](cli-templates-create-template-pack.md)
 
 For tutorials about developing ASP.NET Core web applications, see the [ASP.NET Core documentation](/aspnet/core/).

--- a/docs/core/tutorials/index.md
+++ b/docs/core/tutorials/index.md
@@ -41,8 +41,6 @@ The following tutorials are available for learning about .NET Core.
 - [Unit testing with MSTest and .NET Core](../testing/unit-testing-with-mstest.md)
 - [Developing Libraries with Cross Platform Tools](libraries.md)
 - [Hosting .NET Core from native code](netcore-hosting.md)
-- [Create a custom item template for the CLI](cli-templates-create-item-template.md)
-- [Create a custom project template for the CLI](cli-templates-create-project-template.md)
-- [Create a template pack for the CLI](cli-templates-create-template-pack.md)
+- [Create templates for the CLI](cli-templates-create-item-template.md)
 
 For tutorials about developing ASP.NET Core web applications, see the [ASP.NET Core documentation](/aspnet/core/).


### PR DESCRIPTION
Fixes #16894 

* Fix remaining non-leaf nodes with links
* Move **Dependency management** to **Dependency loading**, renamed as "Dependency management and loading"
* Move **Changes in CLI** and **Additions to .csproj** to after **project.json to .csproj** entry in Migration section

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/core/tutorials/?branch=pr-en-us-16918)