### PR TITLE
Remove method from unsupported APIs

### DIFF
--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -240,7 +240,6 @@ This article organizes the affected API members by namespace.
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.Removable?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.UniqueKeyContainerName?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.HashAlgorithm.Create?displayProperty=nameWithType> | All |
-| <xref:System.Security.Cryptography.HashAlgorithm.Create(System.String)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.HMAC.Create?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.HMAC.Create(System.String)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.HMAC.HashCore%2A?displayProperty=nameWithType> | All |


### PR DESCRIPTION
Remove HashAlgorithm.Create(String) from list.

Fixes #16978