### PR TITLE
Update using-directive.md

### DIFF
--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -62,7 +62,7 @@ Create a `using` alias directive to make it easier to qualify an identifier to a
 
 ```csharp
 using s = System.Text;
-using s.RegularExpressions;
+using s.RegularExpressions; // Generates a compiler error.
 ```
 
 Create a `using` directive to use the types in a namespace without having to specify the namespace. A `using` directive does not give you access to any namespaces that are nested in the namespace you specify.


### PR DESCRIPTION
In this type of examples where errors are generated, I think it would be better to clearly indicate that this is not an example you just should copy and use in your program.

I have seen many of these and if you just browse the page and see this snippet, with a handy copy button, you very well could think: "_Aha.. that is also a way to do it._"

I know that the text points out that this is wrong, but who reads manuals 😎

Often the code snippet includes comments of errors but not always, and as I said this is just one example.

And of course, this is only my personal point of view.

## Summary

Added a clarifying comment about the compiler error.