### PR TITLE
Revert "fix casing of curl ssl option"

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -207,7 +207,7 @@ You can install a specific version using the `-Version|--version` argument. The 
   macOS/Linux:
 
   ```bash
-  curl -ssl https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
   ```
 
 ## See also


### PR DESCRIPTION
Reverts dotnet/docs#16576

`-sSL` option (with single hyphen) is the short form of `-s, --silent`, `-S, --show-error`, `-L, --location`, so cURL can follow redirects. Not to be confused with `--ssl`, which only tells the lib to "try SSL"; we do not need to specify it with HTTPS URLs.

Reference manual: <kbd>**[cURL(1)](https://linux.die.net/man/1/curl)**</kbd>