### PR TITLE
Update coding-conventions.md

### DIFF
--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -88,15 +88,12 @@ ms.assetid: f4f60de9-d49b-4fb6-bab1-20e19ea24710
   
 - Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md).  
   
-- Use implicit typing to determine the type of the loop variable in [for](../../language-reference/keywords/for.md) and [foreach](../../language-reference/keywords/foreach-in.md) loops.  
+- Use implicit typing to determine the type of the loop variable in [for](../../language-reference/keywords/for.md) loops.  
   
      The following example uses implicit typing in a `for` statement.  
   
      [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#7)]  
-  
-     The following example uses implicit typing in a `foreach` statement.  
-  
-     [!code-csharp[csProgGuideCodingConventions#12](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#12)]  
+
   
 ### Unsigned Data Type  
   

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -94,7 +94,6 @@ ms.assetid: f4f60de9-d49b-4fb6-bab1-20e19ea24710
   
      [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#7)]  
 
-  
 ### Unsigned Data Type  
   
 - In general, use `int` rather than unsigned types. The use of `int` is common throughout C#, and it is easier to interact with other libraries when you use `int`.  

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -94,6 +94,16 @@ ms.assetid: f4f60de9-d49b-4fb6-bab1-20e19ea24710
   
      [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#7)]  
 
+- Do not use implicit typing to determine the type of the loop variable in [foreach](../../language-reference/keywords/foreach-in.md) loops.
+
+     The following example uses explicit typing in a `foreach` statement.
+
+     [!code-csharp[csProgGuideCodingConventions#12](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#12)]
+
+     > [!NOTE]
+     > Be careful not to accidentally change a type of an element of the iterable collection.
+     For example,  it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.Generic.IEnumerable?displayProperty=nameWithType> in `foreach` statement, which changes the execution of a query.
+
 ### Unsigned Data Type  
   
 - In general, use `int` rather than unsigned types. The use of `int` is common throughout C#, and it is easier to interact with other libraries when you use `int`.  


### PR DESCRIPTION
## Summary

My proposal is to recommend to use an explicit type in foreach loops as, currently, it clashes with the rule: Do not use var when the type is not apparent from the right side of the assignment.
Using var in foreach loops makes it harder to read as often it's not clear what the type of an element is. Especially, when it concerns code reviews, for quick understanding and checking what is going on a loop it's utterly nice to know the type. Tools, such as VS Code, Microsoft VS, can help with that, but even in that case, you will have to spend more time using IntelliSense (move your cursor and so on), it's faster to read code without any popping up hints.
