### PR TITLE
Updated information about mixing integral and floating-point types

### DIFF
--- a/docs/csharp/language-reference/builtin-types/floating-point-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/floating-point-numeric-types.md
@@ -1,7 +1,7 @@
 ---
 title: "Floating-point numeric types - C# reference"
-description: "Overview of the built-in C# floating-point types"
-ms.date: 10/22/2019
+description: "Learn about the built-in C# floating-point types: float, double, and decimal"
+ms.date: 02/10/2020
 f1_keywords:
   - "float"
   - "float_CSharpKeyword"
@@ -44,19 +44,21 @@ The default value of each floating-point type is zero, `0`. Each of the floating
 
 Because the `decimal` type has more precision and a smaller range than both `float` and `double`, it's appropriate for financial and monetary calculations.
 
-You can mix [integral](integral-numeric-types.md) types and floating-point types in an expression. In this case, the integral types are converted to floating-point types. The evaluation of the expression is performed according to the following rules:
+You can mix [integral](integral-numeric-types.md) types and the `float` and `double` types in an expression. In this case, integral types are implicitly converted to one of the floating-point types and, if necessary, the `float` type is implicitly converted to `double`. The expression is evaluated as follows:
 
-- If one of the floating-point types is `double`, the expression evaluates to `double`, or to [bool](bool.md) in relational and equality comparisons.
-- If there is no `double` type in the expression, the expression evaluates to `float`, or to [bool](bool.md) in relational and equality comparisons.
+- If there is `double` type in the expression, the expression evaluates to `double`, or to [`bool`](bool.md) in relational and equality comparisons.
+- If there is no `double` type in the expression, the expression evaluates to `float`, or to `bool` in relational and equality comparisons.
 
-A floating-point expression can contain the following sets of values:
+You can also mix integral types and the `decimal` type in an expression. In this case, integral types are implicitly converted to the `decimal` type and the expression evaluates to `decimal`, or to `bool` in relational and equality comparisons.
 
-- Positive and negative zero
-- Positive and negative infinity
-- Not-a-Number value (NaN)
-- The finite set of nonzero values
+You cannot mix the `decimal` type with the `float` and `double` types in an expression. In this case, if you want to perform arithmetic, comparison, or equality operations, you must explicitly convert the operands either from or to the `decimal` type, as the following example shows:
 
-For more information about these values, see IEEE Standard for Binary Floating-Point Arithmetic, available on the [IEEE](https://www.ieee.org) website.
+```csharp-interactive
+double a = 1.0;
+decimal b = 2.1m;
+Console.WriteLine(a + (double)b);
+Console.WriteLine((decimal)a + b);
+```
 
 You can use either [standard numeric format strings](../../../standard/base-types/standard-numeric-format-strings.md) or [custom numeric format strings](../../../standard/base-types/custom-numeric-format-strings.md) to format a floating-point value.
 


### PR DESCRIPTION
- Be more elaborate about how integral and floating-point types can be mixed in an expression and how not.
- Remove the paragraph about the special values because those are mentioned earlier in the article.
