### PR TITLE
Fix 19.04 listed for 2.2; update hack url desc

### DIFF
--- a/docs/core/install/dependencies.md
+++ b/docs/core/install/dependencies.md
@@ -184,7 +184,7 @@ For more information about how to install .NET Core 3.0 on ARM64, see [Installin
 | Oracle Linux                   |  7                      | x64 |
 | Fedora                         |  29, 30                 | x64 |
 | Debian                         |  9                      | x64, ARM32 |
-| Ubuntu                         |  16.04, 18.04, 18.10, 19.04    | x64, ARM32 |
+| Ubuntu                         |  16.04, 18.04, 18.10    | x64, ARM32 |
 | Linux Mint                     |  17, 18                 | x64 |
 | openSUSE                       |  15+                    | x64 |
 | SUSE Enterprise Linux (SLES)   |  12 SP2+                | x64 |

--- a/docs/core/install/includes/package-manager-heading-hack-pkgname.md
+++ b/docs/core/install/includes/package-manager-heading-hack-pkgname.md
@@ -16,16 +16,18 @@ Chooses the SDK or the runtime. Valid options are:
 - **version**\
 The version of the SDK or runtime to install. This article will always give the instructions for the latest supported version. Valid options are any released version, such as:
 
+  - 3.1
   - 3.0
-  - 2.2
   - 2.1
+
+  It is possible that the SDK/runtime that you're trying to download is not available for your Linux distribution. For a list of supported distributions, see [.NET Core dependencies and requirements](../dependencies.md?pivots=os-linux).
 
 ### Examples
 
-- Install the .NET Core 2.2 SDK: `dotnet-sdk-2.2`
 - Install the ASP.NET Core 3.1 runtime: `aspnetcore-runtime-3.1`
 - Install the .NET Core 2.1 runtime: `dotnet-runtime-2.1`
+- Install the .NET Core 3.0 SDK: `dotnet-sdk-3.0`
 
 ### Package missing
 
-If the package-version combination doesn't work, it's not available. For example, there isn't an ASP.NET Core SDK, the SDK components are included with the .NET Core SDK. The value `aspnetcore-sdk-2.2` is incorrect and should be `dotnet-sdk-2.2`.
+If the package-version combination doesn't work, it's not available. For example, there isn't an ASP.NET Core SDK, the SDK components are included with the .NET Core SDK. The value `aspnetcore-sdk-2.2` is incorrect and should be `dotnet-sdk-2.2`. For a list of Linux distributions supported by .NET Core, see [.NET Core dependencies and requirements](../dependencies.md?pivots=os-linux).

--- a/docs/core/install/includes/package-manager-heading-hack-pkgname.md
+++ b/docs/core/install/includes/package-manager-heading-hack-pkgname.md
@@ -20,7 +20,7 @@ The version of the SDK or runtime to install. This article will always give the 
   - 3.0
   - 2.1
 
-  It is possible that the SDK/runtime that you're trying to download is not available for your Linux distribution. For a list of supported distributions, see [.NET Core dependencies and requirements](../dependencies.md?pivots=os-linux).
+  It's possible the SDK/runtime you're trying to download is not available for your Linux distribution. For a list of supported distributions, see [.NET Core dependencies and requirements](../dependencies.md?pivots=os-linux).
 
 ### Examples
 


### PR DESCRIPTION
## Summary

- Removed Ubuntu 19.04 listed as supported by Core 2.2.
- Enhance hack url include to link to supported os article.

Fixes #17034


