### PR TITLE
Configure valid docset dev langs for docs-markdown extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+    "markdown.docsetLanguages": [
+        ".NET Core CLI",
+        "ASPX",
+        "ASP.NET (C#)",
+        "Azure CLI",
+        "Bash",
+        "C++",
+        "C#",
+        "Dockerfile",
+        "F#",
+        "HTML",
+        "Ini",
+        "JavaScript",
+        "JSON",
+        "Kusto",
+        "Markdown",
+        "PowerShell",
+        "Protocol Buffers",
+        "Razor CSHTML",
+        "SQL",
+        "Terraform (HCL)",
+        "VB.NET",
+        "XAML",
+        "XML",
+        "YAML"
+    ]
+}


### PR DESCRIPTION
See https://github.com/aspnet/AspNetCore.Docs/pull/16986 for an explanation of what this configuration change does. Feel free to tweak the list. The goal is to help contributors (those with the Docs Authoring Pack extension installed) select valid dev langs for code snippets.