### PR TITLE
Add breaking change in FieldInfo.SetValue

### DIFF
--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -275,6 +275,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 - [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [JsonElement API changes](#jsonelement-api-changes)
+- [FieldInfo.SetValue throws exception for init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 
@@ -325,6 +326,10 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 ***
 
 [!INCLUDE[JsonElement API changes](~/includes/core-changes/corefx/3.0/jsonelement-api-changes.md)]
+
+***
+
+[!INCLUDE [FieldInfo.SetValue throws exception for init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -275,7 +275,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 - [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [JsonElement API changes](#jsonelement-api-changes)
-- [FieldInfo.SetValue throws exception for init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
+- [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 
@@ -329,7 +329,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 
 ***
 
-[!INCLUDE [FieldInfo.SetValue throws exception for init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
+[!INCLUDE [FieldInfo.SetValue throws exception for static, init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -275,7 +275,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 - [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [JsonElement API changes](#jsonelement-api-changes)
-- [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
+- [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-init-only-fields)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -278,7 +278,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 - [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [JsonElement API changes](#jsonelement-api-changes)
-- [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
+- [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-init-only-fields)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -278,6 +278,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 - [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [JsonElement API changes](#jsonelement-api-changes)
+- [FieldInfo.SetValue throws exception for init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 
@@ -328,6 +329,10 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 ***
 
 [!INCLUDE[JsonElement API changes](~/includes/core-changes/corefx/3.0/jsonelement-api-changes.md)]
+
+***
+
+[!INCLUDE [FieldInfo.SetValue throws exception for init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -278,7 +278,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 - [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [JsonElement API changes](#jsonelement-api-changes)
-- [FieldInfo.SetValue throws exception for init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
+- [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 
@@ -332,7 +332,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 
 ***
 
-[!INCLUDE [FieldInfo.SetValue throws exception for init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
+[!INCLUDE [FieldInfo.SetValue throws exception for static, init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
 
 ***
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -24,7 +24,7 @@ The following breaking changes are documented on this page:
 | [JsonEncodedText.Encode methods have an additional JavaScriptEncoder argument](#jsonencodedtextencode-methods-have-an-additional-javascriptencoder-argument) | 3.0 |
 | [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed) | 3.0 |
 | [JsonElement API changes](#jsonelement-api-changes) | 3.0 |
-| [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields) | 3.0 |
+| [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-init-only-fields) | 3.0 |
 | [Private fields added to built-in struct types](#private-fields-added-to-built-in-struct-types) | 2.1 |
 | [Change in default value of UseShellExecute](#change-in-default-value-of-useshellexecute) | 2.1 |
 | [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes) | 1.0 |

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -24,7 +24,7 @@ The following breaking changes are documented on this page:
 | [JsonEncodedText.Encode methods have an additional JavaScriptEncoder argument](#jsonencodedtextencode-methods-have-an-additional-javascriptencoder-argument) | 3.0 |
 | [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed) | 3.0 |
 | [JsonElement API changes](#jsonelement-api-changes) | 3.0 |
-| [FieldInfo.SetValue throws exception for init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields) | 3.0 |
+| [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields) | 3.0 |
 | [Private fields added to built-in struct types](#private-fields-added-to-built-in-struct-types) | 2.1 |
 | [Change in default value of UseShellExecute](#change-in-default-value-of-useshellexecute) | 2.1 |
 | [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes) | 1.0 |
@@ -83,7 +83,7 @@ The following breaking changes are documented on this page:
 
 ***
 
-[!INCLUDE [FieldInfo.SetValue throws exception for init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
+[!INCLUDE [FieldInfo.SetValue throws exception for static, init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
 
 ***
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -24,6 +24,7 @@ The following breaking changes are documented on this page:
 | [JsonEncodedText.Encode methods have an additional JavaScriptEncoder argument](#jsonencodedtextencode-methods-have-an-additional-javascriptencoder-argument) | 3.0 |
 | [JsonFactoryConverter.CreateConverter signature changed](#jsonfactoryconvertercreateconverter-signature-changed) | 3.0 |
 | [JsonElement API changes](#jsonelement-api-changes) | 3.0 |
+| [FieldInfo.SetValue throws exception for init-only fields](#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields) | 3.0 |
 | [Private fields added to built-in struct types](#private-fields-added-to-built-in-struct-types) | 2.1 |
 | [Change in default value of UseShellExecute](#change-in-default-value-of-useshellexecute) | 2.1 |
 | [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes) | 1.0 |
@@ -79,6 +80,10 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE[JsonElement API changes](~/includes/core-changes/corefx/3.0/jsonelement-api-changes.md)]
+
+***
+
+[!INCLUDE [FieldInfo.SetValue throws exception for init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
 
 ***
 

--- a/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md
+++ b/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md
@@ -1,0 +1,38 @@
+### FieldInfo.SetValue throws exception for static, initialization-only fields
+
+Starting in .NET Core 3.0, an exception is thrown when you attempt to set a value on a static, initialization-only field by calling <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=fullName>.
+
+#### Change description
+
+In .NET Framework and versions of .NET Core prior to 3.0, you could set the value of a static, initialization-only ([readonly in C#](~/docs/csharp/language-reference/keywords/readonly.md)) field by calling <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=fullName>. However, setting a static, initialization-only field in this way resulted in unpredictable behavior based on the target framework and optimization settings.
+
+In .NET Core 3.0 and later versions, when you call <xref:System.Reflection.FieldInfo.SetValue%2A> on a static, initialization-only field, a <xref:System.FieldAccessException?displayProperty=nameWithType> exception is thrown.
+
+> [!TIP]
+> An initialization-only field is one that can only be set at the time it's declared or in the constructor for the containing class.
+
+#### Version introduced
+
+3.0
+
+#### Recommended action
+
+The best way to initialize static, initialization-only fields is in a static constructor. This applies to both dynamic and non-dynamic types. Or, remove the <xref:System.Reflection.FieldAttributes.InitOnly?displayProperty=nameWithType> attribute from the field, and then call <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=nameWithType>.
+
+#### Category
+
+CoreFx
+
+#### Affected APIs
+
+- <xref:System.Reflection.FieldInfo.SetValue(System.Object,System.Object)?displayProperty=nameWithType>
+- <xref:System.Reflection.FieldInfo.SetValue(System.Object,System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Globalization.CultureInfo)?displayProperty=nameWithType>
+
+<!--
+
+### Affected APIs
+
+- `M:System.Reflection.FieldInfo.SetValue(System.Object,System.Object)`
+- `M:System.Reflection.FieldInfo.SetValue(System.Object,System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Globalization.CultureInfo)`
+
+-->

--- a/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md
+++ b/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md
@@ -1,15 +1,15 @@
-### FieldInfo.SetValue throws exception for static, initialization-only fields
+### FieldInfo.SetValue throws exception for static, init-only fields
 
-Starting in .NET Core 3.0, an exception is thrown when you attempt to set a value on a static, initialization-only field by calling <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=fullName>.
+Starting in .NET Core 3.0, an exception is thrown when you attempt to set a value on a static, <xref:System.Reflection.FieldAttributes.InitOnly> field by calling <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=fullName>.
 
 #### Change description
 
-In .NET Framework and versions of .NET Core prior to 3.0, you could set the value of a static, initialization-only ([readonly in C#](~/docs/csharp/language-reference/keywords/readonly.md)) field by calling <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=fullName>. However, setting a static, initialization-only field in this way resulted in unpredictable behavior based on the target framework and optimization settings.
+In .NET Framework and versions of .NET Core prior to 3.0, you could set the value of a static field that's constant after it is initialized ([readonly in C#](~/docs/csharp/language-reference/keywords/readonly.md)) by calling <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=fullName>. However, setting such a field in this way resulted in unpredictable behavior based on the target framework and optimization settings.
 
-In .NET Core 3.0 and later versions, when you call <xref:System.Reflection.FieldInfo.SetValue%2A> on a static, initialization-only field, a <xref:System.FieldAccessException?displayProperty=nameWithType> exception is thrown.
+In .NET Core 3.0 and later versions, when you call <xref:System.Reflection.FieldInfo.SetValue%2A> on a static, <xref:System.Reflection.FieldAttributes.InitOnly> field, a <xref:System.FieldAccessException?displayProperty=nameWithType> exception is thrown.
 
 > [!TIP]
-> An initialization-only field is one that can only be set at the time it's declared or in the constructor for the containing class.
+> An <xref:System.Reflection.FieldAttributes.InitOnly> field is one that can only be set at the time it's declared or in the constructor for the containing class. In other words, it's constant after it is initialized.
 
 #### Version introduced
 
@@ -17,7 +17,7 @@ In .NET Core 3.0 and later versions, when you call <xref:System.Reflection.Field
 
 #### Recommended action
 
-Initialize static, initialization-only fields in a static constructor. This applies to both dynamic and non-dynamic types.
+Initialize static, <xref:System.Reflection.FieldAttributes.InitOnly> fields in a static constructor. This applies to both dynamic and non-dynamic types.
 
 Alternatively, you can remove the <xref:System.Reflection.FieldAttributes.InitOnly?displayProperty=nameWithType> attribute from the field, and then call <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=nameWithType>.
 

--- a/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md
+++ b/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md
@@ -17,7 +17,9 @@ In .NET Core 3.0 and later versions, when you call <xref:System.Reflection.Field
 
 #### Recommended action
 
-The best way to initialize static, initialization-only fields is in a static constructor. This applies to both dynamic and non-dynamic types. Or, remove the <xref:System.Reflection.FieldAttributes.InitOnly?displayProperty=nameWithType> attribute from the field, and then call <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=nameWithType>.
+Initialize static, initialization-only fields in a static constructor. This applies to both dynamic and non-dynamic types.
+
+Alternatively, you can remove the <xref:System.Reflection.FieldAttributes.InitOnly?displayProperty=nameWithType> attribute from the field, and then call <xref:System.Reflection.FieldInfo.SetValue%2A?displayProperty=nameWithType>.
 
 #### Category
 


### PR DESCRIPTION
Fixes #17060

[Internal preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-17062#fieldinfosetvalue-throws-exception-for-static-initialization-only-fields)

Related to https://github.com/dotnet/dotnet-api-docs/issues/3851 and https://github.com/dotnet/runtime/issues/11571.