### PR TITLE
explain relationship between ECMA and netstandard

### DIFF
--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -1,14 +1,14 @@
 ---
 title: .NET Standard
 description: Learn about .NET Standard, its versions and the .NET implementations that support it.
-ms.date: 09/23/2019
+ms.date: 02/13/2020f
 ms.technology: dotnet-standard
 ms.custom: "updateeachrelease"
 ms.assetid: c044882c-af15-45f2-96d1-534557a5ee9b
 ---
 # .NET Standard
 
-[.NET Standard](https://github.com/dotnet/standard) is a formal specification of .NET APIs that are intended to be available on all .NET implementations. The motivation behind .NET Standard is establishing greater uniformity in the .NET ecosystem. [ECMA 335](https://github.com/dotnet/runtime/blob/master/docs/project/dotnet-standards.md) continues to establish uniformity for .NET implementation behavior, but there's no similar spec for the .NET Base Class Libraries (BCL) for .NET library implementations.
+[.NET Standard](https://github.com/dotnet/standard) is a formal specification of .NET APIs that are intended to be available on all .NET implementations. The motivation behind .NET Standard is establishing greater uniformity in the .NET ecosystem. [ECMA 335](https://github.com/dotnet/runtime/blob/master/docs/project/dotnet-standards.md) continues to establish uniformity for .NET implementation behavior, and while ECMA 335 specifies a small set of standard libraries, .NET Standard encompasses a broader range of .NET APIs.
 
 .NET Standard enables the following key scenarios:
 

--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Standard
 description: Learn about .NET Standard, its versions and the .NET implementations that support it.
-ms.date: 02/13/2020f
+ms.date: 02/13/2020
 ms.technology: dotnet-standard
 ms.custom: "updateeachrelease"
 ms.assetid: c044882c-af15-45f2-96d1-534557a5ee9b

--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -8,7 +8,7 @@ ms.assetid: c044882c-af15-45f2-96d1-534557a5ee9b
 ---
 # .NET Standard
 
-[.NET Standard](https://github.com/dotnet/standard) is a formal specification of .NET APIs that are intended to be available on all .NET implementations. The motivation behind .NET Standard is establishing greater uniformity in the .NET ecosystem. [ECMA 335](https://github.com/dotnet/runtime/blob/master/docs/project/dotnet-standards.md) continues to establish uniformity for .NET implementation behavior, and while ECMA 335 specifies a small set of standard libraries, .NET Standard encompasses a broader range of .NET APIs.
+[.NET Standard](https://github.com/dotnet/standard) is a formal specification of .NET APIs that are intended to be available on all .NET implementations. The motivation behind .NET Standard is to establish greater uniformity in the .NET ecosystem. [ECMA 335](https://github.com/dotnet/runtime/blob/master/docs/project/dotnet-standards.md) continues to establish uniformity for .NET implementation behavior, and while ECMA 335 specifies a small set of standard libraries, the .NET Standard specification encompasses a broader range of .NET APIs.
 
 .NET Standard enables the following key scenarios:
 


### PR DESCRIPTION
The ECMA 335 standard specifies a small set of standard APIs, while netstandard is more agile and specifies a more broard set of APIs available on implemented platforms.

/cc @CarolEidt 

Fixes #17032 