### PR TITLE
Add ASP.NET Core API ref to the hub page

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -257,6 +257,10 @@ additionalContent:
         summary: API reference documentation for .NET Framework
         url: https://docs.microsoft.com/dotnet/api/?view=netframework-4.8
       # Card
+      - title: "ASP.NET Core API reference"
+        summary: API reference documentation for ASP.NET Core
+        url: https://docs.microsoft.com/dotnet/api/?view=aspnetcore-3.1
+      # Card
       - title: "ML.NET API reference"
         summary: API reference documentation for ML.NET
         url: https://docs.microsoft.com/dotnet/api/?view=ml-dotnet


### PR DESCRIPTION
Add an ASP.NET Core API ref card to the hub page, per our discussion today.