### PR TITLE
Remove the note about the struct breaking change from the conceptual docs

### DIFF
--- a/docs/csharp/structs.md
+++ b/docs/csharp/structs.md
@@ -41,9 +41,6 @@ Structs share most of the same syntax as classes, although structs are more limi
 
 - Unlike classes, structs can be instantiated without using a `new` operator.
 
-   > [!NOTE]
-   > Beginning with .NET Core 2.1, certain .NET struct types, which can be instantiated without the `new` operator in earlier .NET Core versions, can only be instantiated with the [new operator](language-reference/operators/new-operator.md) or [default literal](language-reference/operators/default.md#default-literal). For more information, see [Breaking changes for migration from version 2.0 to 2.1](../core/compatibility/2.0-2.1.md#corefx).
-
 - Structs can declare constructors that have parameters.
 
 - A struct cannot inherit from another struct or class, and it cannot be the base of a class. All structs inherit directly from <xref:System.ValueType>, which inherits from <xref:System.Object>.

--- a/docs/csharp/structs.md
+++ b/docs/csharp/structs.md
@@ -42,7 +42,7 @@ Structs share most of the same syntax as classes, although structs are more limi
 - Unlike classes, structs can be instantiated without using a `new` operator.
 
    > [!NOTE]
-   > In .NET Core 2.1 and later, a struct type must be instantiated by using the [new operator](language-reference/operators/new-operator.md) or [default literal](language-reference/operators/default.md#default-literal), or by initializing each of its private fields. For more information, see [Breaking changes for migration from version 2.0 to 2.1](../core/compatibility/2.0-2.1.md#corefx).
+   > Beginning with .NET Core 2.1, certain .NET struct types, which can be instantiated without the `new` operator in earlier .NET Core versions, can only be instantiated with the [new operator](language-reference/operators/new-operator.md) or [default literal](language-reference/operators/default.md#default-literal). For more information, see [Breaking changes for migration from version 2.0 to 2.1](../core/compatibility/2.0-2.1.md#corefx).
 
 - Structs can declare constructors that have parameters.
 


### PR DESCRIPTION
The original note has sounded as if it's applicable to ANY structure type, which is not true, as far as I understand. This PR introduces two fixes:

- As the original issue #9148 states, the change affects only certain .NET structs. Not any struct type.
- If one doesn't use the `new` operator, one cannot initialize private fields after declaration of a struct instance. One can avoid using the `new` operator only if all instance fields are public. Because affected .NET structs have private fields added, there are only two ways to initialize them: the `new` operator or `default`. So, I've removed the third alternative.

However, now, after the fixes applied, the note is very specific and, I believe, about a rare use case. I don't think that note should be in [this article](https://docs.microsoft.com/en-us/dotnet/csharp/structs), which is the general overview of structs, at all. I believe that having it at the [breaking changes](https://docs.microsoft.com/en-us/dotnet/core/compatibility/2.0-2.1) part of the docs is enough. 

So, I suggest to remove this note at all.
@BillWagner @gewarren @jaredpar what do you think?

Related to #9148 and #16312
