### PR TITLE
Update F# type attribute example

### DIFF
--- a/docs/fsharp/language-reference/attributes.md
+++ b/docs/fsharp/language-reference/attributes.md
@@ -86,12 +86,12 @@ Although you do not usually need to specify the attribute target explicitly, val
     <td>type</td>
     <td>
         <pre lang="fsharp"><code>
-[&lt;type: StructLayout(Sequential)&gt;]
+[&lt;type: StructLayout(LayoutKind.Sequential)&gt;]
 type MyStruct =
-struct
-x : byte
-y : int
-end</code></pre>
+  struct
+    val x : byte
+    val y : int
+  end</code></pre>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
Make the struct definition valid, and qualify the reference to `Sequential`
