### PR TITLE
add global rules, remove Maira

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,8 @@
 # More details are here: https://help.github.com/articles/about-codeowners/
 
 # The '*' pattern is global owners.
-# Not adding in this PR, but I'd like to try adding a global owner set with the entire team.
-# One interpretation of their docs is that global owners are added only if not removed
-# by a more local rule.
+
+*    @dotnet/docs
 
 # Order is important. The last matching pattern has the most precedence.
 # The folders are ordered as follows:
@@ -20,17 +19,17 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 ######## API landing page ###########
-/api/** @mairaw
+/api/** @dotnet/docs
 
 ############ WHATS NEW ###############
-/docs/whats-new/** @mairaw @billwagner
+/docs/whats-new/** @billwagner
 
 ############  GUIDES  ################
 # .NET Core
-/docs/core/** @mairaw
+/docs/core/** @dotnet/docs
 
 # .NET Framework
-/docs/framework/** @mairaw
+/docs/framework/** @dotnet/docs
 
 # .NET Standard
 /docs/standard/** @gewarren
@@ -119,7 +118,7 @@
 
 ################## .NET STANDARD ##################
 # Analyzers
-/docs/standard/analyzers/** @mairaw
+/docs/standard/analyzers/** @gewarren
 # Assembly
 /docs/standard/assembly/** @gewarren
 # Asynchronous Programming Patterns
@@ -137,7 +136,7 @@
 # Datetime
 /docs/standard/datetime/** @Thraka
 # Design guidelines
-/docs/standard/design-guidelines/** @mairaw
+/docs/standard/design-guidelines/** @BillWagner
 # Events
 /docs/standard/events/** @gewarren
 # Exceptions
@@ -147,13 +146,13 @@
 # Generics
 /docs/standard/generics/** @Thraka
 # Globalization
-/docs/standard/globalization-localization/** @mairaw
+/docs/standard/globalization-localization/** @dotnet/docs
 # I/O
 /docs/standard/io/** @Thraka
 # Library guidance
 /docs/standard/library-guidance/** @jamesnk
 # LINQ
-/docs/standard/linq/** @mairaw
+/docs/standard/linq/** @dotnet/docs
 # Memory and spans
 /docs/standard/memory-and-spans/** @tdykstra
 # Native Interop
@@ -167,7 +166,7 @@
 # Threading
 /docs/standard/threading/** @BillWagner
 # What's New
-/docs/standard/whats-new/** @mairaw
+/docs/standard/whats-new/** @dotnet/docs
 
 ################## E-BOOKS ##################
 # Blazor:


### PR DESCRIPTION
In this PR, I added a global rule to assign reviews to the dotnet/docs team if there isn't a better option.

In addition, I removed @mairaw from any areas. In almost all cases, I replaced her with the team alias.  Note for reviewers: If you want any of these sections, make a suggestion.

@mairaw Enjoy the new role. We already miss you. 👋 
