### PR TITLE
Update tracing-and-instrumenting-applications.md

### DIFF
--- a/docs/framework/debug-trace-profile/tracing-and-instrumenting-applications.md
+++ b/docs/framework/debug-trace-profile/tracing-and-instrumenting-applications.md
@@ -91,7 +91,7 @@ System.Diagnostics.Debug.WriteLine("Hello World!");
   
 7. If a problem occurs during run time, turn on the appropriate trace switch. For more information, see [Configuring Trace Switches](how-to-create-initialize-and-configure-trace-switches.md).  
   
-     The tracing code writes tracing messages to a specified target, for example, a screen, a text file, or an event log. The type of listener you included in the **Trace.Listeners** collection determines the target.  
+     The tracing code writes tracing messages to a specified target, for example, a screen, a text file, or an event log. The type of listener you included in the <xref:System.Diagnostics.Trace.Listeners%2A?displayProperty=nameWithType> collection determines the target.  
   
 8. Analyze the tracing messages to identify and understand the problem in the application.  
   
@@ -114,18 +114,18 @@ System.Diagnostics.Debug.WriteLine("Hello World!");
   
 |Method|Output|  
 |------------|------------|  
-|**Assert**|The specified text; or, if none is specified, the Call Stack. The output is written only if the condition specified as an argument in the **Assert** statement is **false**.|  
-|**Fail**|The specified text; or, if none is specified, the Call Stack.|  
-|**Write**|The specified text.|  
-|**WriteIf**|The specified text, if the condition specified as an argument in the **WriteIf** statement is satisfied.|  
-|**WriteLine**|The specified text and a carriage return.|  
-|**WriteLineIf**|The specified text and a carriage return, if the condition specified as an argument in the **WriteLineIf** statement is satisfied.|  
+|`Assert`|The specified text; or, if none is specified, the Call Stack. The output is written only if the condition specified as an argument in the `Assert` statement is **false**.|  
+|`Fail`|The specified text; or, if none is specified, the Call Stack.|  
+|`Write`|The specified text.|  
+|`WriteIf`|The specified text, if the condition specified as an argument in the `WriteIf` statement is satisfied.|  
+|`WriteLine`|The specified text and a carriage return.|  
+|`WriteLineIf`|The specified text and a carriage return, if the condition specified as an argument in the `WriteLineIf` statement is satisfied.|  
   
- All listeners in the <xref:System.Diagnostics.Trace.Listeners%2A> collection receive the messages described in the above table, but the actions taken may vary depending on what kind of listener receives the message. For example, the <xref:System.Diagnostics.DefaultTraceListener> displays an assertion dialog box when it receives a **Fail** or failed **Assert** notification, but a <xref:System.Diagnostics.TextWriterTraceListener> simply writes the output to its stream.  
+ All listeners in the <xref:System.Diagnostics.Trace.Listeners%2A> collection receive the messages described in the above table, but the actions taken may vary depending on what kind of listener receives the message. For example, the <xref:System.Diagnostics.DefaultTraceListener> displays an assertion dialog box when it receives a `Fail` or failed `Assert` notification, but a <xref:System.Diagnostics.TextWriterTraceListener> simply writes the output to its stream.  
   
  You can produce custom results by implementing your own listener. A custom trace listener might, for example, display the messages to a message box, or connect to a database to add messages to a table. All custom listeners should support the six methods mentioned above. For more information on creating developer-defined listeners, see <xref:System.Diagnostics.TraceListener> in the .NET Framework reference.  
   
- The **Write** and **WriteLine** methods always write the text that you specify. **Assert**, **WriteIf**, and **WriteLineIf** require a Boolean argument that controls whether or not they write the specified text; they write the specified text only if the expression is **true** (for **WriteIf** and **WriteLineIf**), or **false** (for **Assert**). The **Fail** method always writes the specified text. For more information, see [How to: Add Trace Statements to Application Code](how-to-add-trace-statements-to-application-code.md) and the .NET Framework reference.  
+ The `Write` and `WriteLine` methods always write the text that you specify. `Assert`, `WriteIf`, and `WriteLineIf` require a Boolean argument that controls whether or not they write the specified text; they write the specified text only if the expression is **true** (for `WriteIf` and `WriteLineIf`), or **false** (for `Assert`). The `Fail` method always writes the specified text. For more information, see [How to: Add Trace Statements to Application Code](how-to-add-trace-statements-to-application-code.md) and the .NET Framework reference.  
   
 ## Security Concerns  
  If you do not disable tracing and debugging before deploying an ASP.NET application, your application may reveal information about itself that could be exploited by a malicious program. For more information, see [How to: Compile Conditionally with Trace and Debug](how-to-compile-conditionally-with-trace-and-debug.md), [Compiling and Building](/visualstudio/ide/compiling-and-building-in-visual-studio), and [How to: Create, Initialize and Configure Trace Switches](how-to-create-initialize-and-configure-trace-switches.md). Debugging is also configurable through Internet Information Services (IIS).  


### PR DESCRIPTION
Format methods as inline code to prevent localization

