### PR TITLE
fix markdown lint warning

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/self-hosted.md
+++ b/docs/architecture/grpc-for-wcf-developers/self-hosted.md
@@ -85,6 +85,7 @@ Now publish your application. The application can be either framework dependent 
   ```dotnetcli
   dotnet publish -c Release -r linux-x64 -o ./publish
   ```
+  
 Copy the complete contents of the `publish` directory to an installation folder on the Linux host. Registering the service requires a special file, called a *unit file*, to be added to the `/etc/systemd/system` directory. You'll need root permission to create a file in this folder. Name the file with the identifier that you want `systemd` to use and the `.service` extension. For example, use `/etc/systemd/system/myapp.service`.
 
 The service file uses INI format, as shown in this example:


### PR DESCRIPTION
add a blank line after the code block.
