### PR TITLE
Add that interfaces may declare methods

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/methods.md
@@ -15,7 +15,7 @@ A method is a code block that contains a series of statements. A program causes 
 
 ## Method signatures
 
-Methods are declared in a [class](../../language-reference/keywords/class.md), [struct](../../language-reference/keywords/struct.md), or [interface](../interfaces/index/md) by specifying the access level such as `public` or `private`, optional modifiers such as `abstract` or `sealed`, the return value, the name of the method, and any method parameters. These parts together are the signature of the method.
+Methods are declared in a [class](../../language-reference/keywords/class.md), [struct](../../language-reference/keywords/struct.md), or [interface](../interfaces/index.md) by specifying the access level such as `public` or `private`, optional modifiers such as `abstract` or `sealed`, the return value, the name of the method, and any method parameters. These parts together are the signature of the method.
 
 > [!NOTE]
 > A return type of a method is not part of the signature of the method for the purposes of method overloading. However, it is part of the signature of the method when determining the compatibility between a delegate and the method that it points to.

--- a/docs/csharp/programming-guide/classes-and-structs/methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/methods.md
@@ -15,7 +15,7 @@ A method is a code block that contains a series of statements. A program causes 
 
 ## Method signatures
 
-Methods are declared in a [class](../../language-reference/keywords/class.md) or [struct](../../language-reference/keywords/struct.md) by specifying the access level such as `public` or `private`, optional modifiers such as `abstract` or `sealed`, the return value, the name of the method, and any method parameters. These parts together are the signature of the method.
+Methods are declared in a [class](../../language-reference/keywords/class.md), [struct](../../language-reference/keywords/struct.md), or [interface](../interfaces/index/md) by specifying the access level such as `public` or `private`, optional modifiers such as `abstract` or `sealed`, the return value, the name of the method, and any method parameters. These parts together are the signature of the method.
 
 > [!NOTE]
 > A return type of a method is not part of the signature of the method for the purposes of method overloading. However, it is part of the signature of the method when determining the compatibility between a delegate and the method that it points to.


### PR DESCRIPTION
As of C# 8.0, methods may be declared in interfaces.

See https://github.com/dotnet/docs/pull/17093#issuecomment-586577102

/cc @pkulikov 