### PR TITLE
remove some resources from enums article

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -76,12 +76,6 @@ public class CardType : Enumeration
 
 ## Additional resources
 
-- **Enum’s are evil—update** \
-  <https://www.planetgeek.ch/2009/07/01/enums-are-evil/>
-
-- **Daniel Hardman. How Enums Spread Disease — And How To Cure It** \
-  <https://codecraft.co/2012/10/29/how-enums-spread-disease-and-how-to-cure-it/>
-
 - **Jimmy Bogard. Enumeration classes** \
   <https://lostechies.com/jimmybogard/2008/08/12/enumeration-classes/>
 


### PR DESCRIPTION
Fixes #16126

The first resource is not well defended, and primarily lists a series of possible coding mistakes.
The second is a deliberately bad design case for enums and doesn't reinforce the guidance in this article.
