### PR TITLE
Updating Health check documentation to use built in .NET core classes…

### DIFF
--- a/docs/architecture/microservices/implement-resilient-applications/monitor-app-health.md
+++ b/docs/architecture/microservices/implement-resilient-applications/monitor-app-health.md
@@ -34,10 +34,11 @@ public void ConfigureServices(IServiceCollection services)
     // Registers required services for health checks
     services.AddHealthChecks()
         // Add a health check for a SQL Server database
-        .AddSqlServer(
-            configuration["ConnectionString"],
-            name: "OrderingDB-check",
-            tags: new string[] { "orderingdb" });
+        .AddCheck(
+            "OrderingDB-check", 
+            new SqlConnectionHealthCheck(Configuration["ConnectionString"]), 
+            HealthStatus.Unhealthy, 
+            new string[] { "orderingdb" });
 }
 ```
 
@@ -108,11 +109,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     app.UseEndpoints(endpoints =>
     {
         //...
-        endpoints.MapHealthChecks("/hc", new HealthCheckOptions()
-        {
-            Predicate = _ => true,
-            ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-        });
+        endpoints.MapHealthChecks("/hc");
         //...
     });
     //…


### PR DESCRIPTION
… instead of 3rd party tool

## Summary

The document at 

https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health

has samples that do not match the text.  They appear to be leftovers from the previous edition with .NET core 2.2 where a non-Microsoft library was needed.  In 3.1 the HealthCheck class can be implemented using only Microsoft classes.

I changed the 1st and 3rd code sample to work correctly with these new classes.


