### PR TITLE
Explain C# version defaults more clearly.

### DIFF
--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -8,7 +8,7 @@ ms.date: 02/21/2020
 
 The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio doesn't provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensures you don't use a language that requires types or runtime behavior not available in your target framework. Choosing a language version newer than the default can cause hard to diagnose compile-time and runtime errors.
 
-These new defaults mean C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
+These new defaults mean C# 8.0 (and higher) is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
 
 - Default interface member implementation requires new features in the .NET Core 3.0 CLR.
 - Async streams require the new types <xref:System.IAsyncDisposable?displayPropert=nameWithType>, <xref:System.IAsyncEnumerable%601?displayPropert=nameWithType>, and <xref:System.IAsyncEnumerator%601?displayPropert=nameWithType>.

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -1,14 +1,19 @@
 ---
 title: C# language versioning - C# Guide
 description: Learn about how the C# language version is determined based on your project, and the different values you can manually adjust it to.
-ms.date: 07/10/2019
+ms.date: 02/21/2020
 ---
 
 # C# language versioning
 
-The latest C# compiler determines a default language version based on your project's target framework or frameworks. This is because the C# language may have features that rely on types or runtime components that are not available in every .NET implementation. This also ensures that for whatever target your project is built against, you get the highest compatible language version by default.
+The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio does not provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensure you don't use a language that requires types or runtime behavior not available in your target framework. That would cause hard to diagnose compile-time and runtime errors.
 
-The rules in this article apply to the compiler delivered with Visual Studio 2019 or the .NET Core 3.0 SDK. The C# compilers that are part of the Visual Studio 2017 installation or earlier .NET Core SDK versions target C# 7.0 by default. 
+These new defaults mean that C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest features make use of library and runtime features introduced in .NET Core 3.x:
+
+- Default interface member implementation requires new features in the .NET Core 3.0 CLR.
+- Async streams require the new types <xref:System.IAsyncDisposable?displayPropert=nameWithType>, <xref:System.IAsyncEnumerable%601?displayPropert=nameWithType>, and <xref:System.IAsyncEnumerator%601?displayPropert=nameWithType>.
+- Indexes and Ranges require the new types <xref:System.Index?displayProperty=nameWithType> and <xref:System.Range?displayProperty=nameWithType>.
+- Nullable reference types make use of several [attributes](../nullable-attributes.md) to provide better warnings. Those attributes were added in .NET 3.0, and .NET Framework libraries have not been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
 
 ## Defaults
 
@@ -22,8 +27,6 @@ The compiler determines a default based on these rules:
 |.NET Standard|2.0|C# 7.3|
 |.NET Standard|1.x|C# 7.3|
 |.NET Framework|all|C# 7.3|
-
-## Default for previews
 
 When your project targets a preview framework that has a corresponding preview language version, the language version used is the preview language version. This ensures that you can use the latest features that are guaranteed to work with that preview in any environment without affecting your projects that target a released .NET Core version.
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -8,7 +8,7 @@ ms.date: 02/21/2020
 
 The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio doesn't provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensures you don't use a language that requires types or runtime behavior not available in your target framework. Choosing a language version newer than the default can cause hard to diagnose compile-time and runtime errors.
 
-These new defaults mean C# 8.0 (and higher) is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
+C# 8.0 (and higher) is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
 
 - Default interface member implementation requires new features in the .NET Core 3.0 CLR.
 - Async streams require the new types <xref:System.IAsyncDisposable?displayProperty=nameWithType>, <xref:System.Collections.Generic.IAsyncEnumerable%601?displayProperty=nameWithType>, and <xref:System.Collections.Generic.IAsyncEnumerator%601?displayProperty=nameWithType>.

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -11,7 +11,7 @@ The latest C# compiler determines a default language version based on your proje
 These new defaults mean C# 8.0 (and higher) is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
 
 - Default interface member implementation requires new features in the .NET Core 3.0 CLR.
-- Async streams require the new types <xref:System.IAsyncDisposable?displayPropert=nameWithType>, <xref:System.IAsyncEnumerable%601?displayPropert=nameWithType>, and <xref:System.IAsyncEnumerator%601?displayPropert=nameWithType>.
+- Async streams require the new types <xref:System.IAsyncDisposable?displayProperty=nameWithType>, <xref:System.Collections.Generic.IAsyncEnumerable%601?displayProperty=nameWithType>, and <xref:System.Collections.Generic.IAsyncEnumerator%601?displayProperty=nameWithType>.
 - Indexes and Ranges require the new types <xref:System.Index?displayProperty=nameWithType> and <xref:System.Range?displayProperty=nameWithType>.
 - Nullable reference types make use of several [attributes](../nullable-attributes.md) to provide better warnings. Those attributes were added in .NET Core 3.0. Other target frameworks haven't been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -1,19 +1,19 @@
 ---
 title: C# language versioning - C# Guide
-description: Learn about how the C# language version is determined based on your project, and the different values you can manually adjust it to.
+description: Learn about how the C# language version is determined based on your project and the reasons behind that choice. Learn how to override the default manually.
 ms.date: 02/21/2020
 ---
 
 # C# language versioning
 
-The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio does not provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensure you don't use a language that requires types or runtime behavior not available in your target framework. That would cause hard to diagnose compile-time and runtime errors.
+The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio doesn't provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensures you don't use a language that requires types or runtime behavior not available in your target framework. Choosing a language version newer than the default can cause hard to diagnose compile-time and runtime errors.
 
-These new defaults mean that C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest features make use of library and runtime features introduced in .NET Core 3.x:
+These new defaults mean C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
 
 - Default interface member implementation requires new features in the .NET Core 3.0 CLR.
 - Async streams require the new types <xref:System.IAsyncDisposable?displayPropert=nameWithType>, <xref:System.IAsyncEnumerable%601?displayPropert=nameWithType>, and <xref:System.IAsyncEnumerator%601?displayPropert=nameWithType>.
 - Indexes and Ranges require the new types <xref:System.Index?displayProperty=nameWithType> and <xref:System.Range?displayProperty=nameWithType>.
-- Nullable reference types make use of several [attributes](../nullable-attributes.md) to provide better warnings. Those attributes were added in .NET 3.0, and .NET Framework libraries have not been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
+- Nullable reference types make use of several [attributes](../nullable-attributes.md) to provide better warnings. Those attributes were added in .NET 3.0, and .NET Framework libraries haven't been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
 
 ## Defaults
 
@@ -28,7 +28,7 @@ The compiler determines a default based on these rules:
 |.NET Standard|1.x|C# 7.3|
 |.NET Framework|all|C# 7.3|
 
-When your project targets a preview framework that has a corresponding preview language version, the language version used is the preview language version. This ensures that you can use the latest features that are guaranteed to work with that preview in any environment without affecting your projects that target a released .NET Core version.
+When your project targets a preview framework that has a corresponding preview language version, the language version used is the preview language version. You use the latest features with that preview in any environment, without affecting projects that target a released .NET Core version.
 
 ## Override a default
 
@@ -62,11 +62,11 @@ To configure multiple projects, you can create a **Directory.Build.props** file 
 </Project>
 ```
 
-Now, builds in every subdirectory of the directory containing that file will use the preview C# version. For more information, see the article on [Customize your build](/visualstudio/msbuild/customize-your-build).
+Builds in all subdirectories of the directory containing that file will use the preview C# version. For more information, see the article on [Customize your build](/visualstudio/msbuild/customize-your-build).
 
 ## C# language version reference
 
-The following table shows all current C# language versions. Your compiler may not necessarily understand every value if it is older. If you install .NET Core 3.0, then you will have access to everything listed.
+The following table shows all current C# language versions. Your compiler may not necessarily understand every value if it's older. If you install .NET Core 3.0 or later, then you have access to everything listed.
 
 |Value|Meaning|
 |------------|-------------|

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -13,7 +13,7 @@ These new defaults mean C# 8.0 is supported only on .NET Core 3.x and newer vers
 - Default interface member implementation requires new features in the .NET Core 3.0 CLR.
 - Async streams require the new types <xref:System.IAsyncDisposable?displayPropert=nameWithType>, <xref:System.IAsyncEnumerable%601?displayPropert=nameWithType>, and <xref:System.IAsyncEnumerator%601?displayPropert=nameWithType>.
 - Indexes and Ranges require the new types <xref:System.Index?displayProperty=nameWithType> and <xref:System.Range?displayProperty=nameWithType>.
-- Nullable reference types make use of several [attributes](../nullable-attributes.md) to provide better warnings. Those attributes were added in .NET 3.0, and .NET Framework libraries haven't been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
+- Nullable reference types make use of several [attributes](../nullable-attributes.md) to provide better warnings. Those attributes were added in .NET Core 3.0. Other target frameworks haven't been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
 
 ## Defaults
 


### PR DESCRIPTION
Fixes [AB#1664867](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1664867)

Fixes #16335 
Fixes #15860

This article has several negative comments.

In this PR, I explain in more detail why these decisions were made. I also clarify why the UI was removed to select a different version, and point to how readers can edit the value to select an unsupported configuration

