### PR TITLE
Fix incorrect argument for global tool docs

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -24,7 +24,7 @@ dotnet tool install <-h|--help>
 
 The `dotnet tool install` command provides a way for you to install .NET Core tools on your machine. To use the command, you specify one of the following installation options:
 
-* To install a global tool in the default location, use the `--tool-path` option.
+* To install a global tool in the default location, use the `--global` option.
 * To install a global tool in a custom location,  use the `--tool-path` option.
 * To install a local tool, omit the `--global` and `--tool-path` options.
 


### PR DESCRIPTION
## Summary

This sentence is referring to installing a global tool in the default location, but incorrectly says you should use `--tool-path` instead of `--global`. 
