### PR TITLE
fix comment in interactive code block

### DIFF
--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -91,9 +91,9 @@ String literals can contain any character literal. Escape sequences are included
 ```csharp-interactive
 string a = "\\\u0066\n F";
 Console.WriteLine(a);
-\\ Output:
-\\ \f
-\\  F
+// Output:
+// \f
+//  F
 ```
 
 > [!NOTE]


### PR DESCRIPTION
this small fix prevents the system error `CS1056: Unexpected character "\" at run time.`

## Summary

fix comment as forward slashes in code block so it does not error out in csharp interactive 

Fixes #Issue_Number (if available)
