### PR TITLE
chore: Cleanup docs/core MD009

### DIFF
--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -7,7 +7,7 @@ ms.date: 01/31/2020
 
 Applications you create with .NET Core can be published in two different modes, and the mode affects how a user runs your app.
 
-Publishing your app as *self-contained* produces an application that includes the .NET Core runtime and libraries, and your application and its dependencies. Users of the application can run it on a machine that doesn't have the .NET Core runtime installed. 
+Publishing your app as *self-contained* produces an application that includes the .NET Core runtime and libraries, and your application and its dependencies. Users of the application can run it on a machine that doesn't have the .NET Core runtime installed.
 
 Publishing your app as *runtime-dependent* produces an application that includes only your application itself and its dependencies. Users of the application have to separately install the .NET Core runtime.
 
@@ -126,7 +126,7 @@ Because your app includes the .NET Core runtime and all of your app dependencies
   > You can reduce the size of your deployment on Linux systems by approximately 28 MB by using .NET Core [*globalization invariant mode*](https://github.com/dotnet/runtime/blob/master/docs/design/features/globalization-invariant-mode.md). This forces your app to treat all cultures like the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture?displayProperty=nameWithType).
 
 - **Harder to update the .NET Core version**\
-.NET Core Runtime (distributed with your app) can only be upgraded by releasing a new version of your app. You're responsible for supplying an updated version of your application for security patches to the .NET Core Runtime. 
+.NET Core Runtime (distributed with your app) can only be upgraded by releasing a new version of your app. You're responsible for supplying an updated version of your application for security patches to the .NET Core Runtime.
 
 ### Examples
 

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -137,7 +137,7 @@ dotnet publish -c Release
 
 This command compiles your app to the *publish* folder. The path to the *publish* folder from the working folder should be `.\app\bin\Release\netcoreapp3.1\publish\`
 
-From the *app* folder, get a directory listing of the publish folder to verify that the *myapp.dll* file was created. 
+From the *app* folder, get a directory listing of the publish folder to verify that the *myapp.dll* file was created.
 
 ```console
 > dir bin\Release\netcoreapp3.1\publish

--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -13,7 +13,7 @@ For more information about how to install Docker, see the download page for [Doc
 
 ## Docker basics
 
-There are a few concepts you should be familiar with. The Docker client has a CLI that you can use to manage images and containers. As previously stated, you should take the time to read through the [Docker overview](https://docs.docker.com/engine/docker-overview/) documentation. 
+There are a few concepts you should be familiar with. The Docker client has a CLI that you can use to manage images and containers. As previously stated, you should take the time to read through the [Docker overview](https://docs.docker.com/engine/docker-overview/) documentation.
 
 ### Images
 
@@ -29,7 +29,7 @@ A container is a runnable instance of an image. As you build your image, you dep
 
 Container registries are a collection of image repositories. You can base your images on a registry image. You can create containers directly from an image in a registry. The [relationship between Docker containers, images, and registries](../../architecture/microservices/container-docker-introduction/docker-containers-images-registries.md) is an important concept when [architecting and building containerized applications or microservices](../../architecture/microservices/architect-microservice-container-applications/index.md). This approach greatly shortens the time between development and deployment.
 
-Docker has a public registry hosted at the [Docker Hub](https://hub.docker.com/) that you can use. [.NET Core related images](https://hub.docker.com/_/microsoft-dotnet-core/) are listed at the Docker Hub. 
+Docker has a public registry hosted at the [Docker Hub](https://hub.docker.com/) that you can use. [.NET Core related images](https://hub.docker.com/_/microsoft-dotnet-core/) are listed at the Docker Hub.
 
 The Microsoft Container Registry (MCR) is the official source of Microsoft-provided container images. The MCR is built on Azure CDN to provide globally-replicated images. However, the MCR does not have a public-facing website and the primary way to learn about Microsoft-provided container images is through the [Microsoft Docker Hub pages](https://hub.docker.com/_/microsoft-dotnet-core/).
 
@@ -39,7 +39,7 @@ A **Dockerfile** is a file that defines a set of instructions that creates an im
 
 ## .NET Core images
 
-Official .NET Core Docker images are published to the Microsoft Container Registry (MCR) and are discoverable at the [Microsoft .NET Core Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet-core/). Each repository contains images for different combinations of the .NET (SDK or Runtime) and OS that you can use. 
+Official .NET Core Docker images are published to the Microsoft Container Registry (MCR) and are discoverable at the [Microsoft .NET Core Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet-core/). Each repository contains images for different combinations of the .NET (SDK or Runtime) and OS that you can use.
 
 Microsoft provides images that are tailored for specific scenarios. For example, the [ASP.NET Core repository](https://hub.docker.com/_/microsoft-dotnet-core-aspnet/) provides images that are built for running ASP.NET Core apps in production.
 

--- a/docs/core/install/localized-intellisense.md
+++ b/docs/core/install/localized-intellisense.md
@@ -36,7 +36,7 @@ ms.date: 01/23/2020
       | .NET Core       | *Microsoft.NETCore.App.Ref*        |
       | Windows Desktop | *Microsoft.WindowsDesktop.App.Ref* |
       | .NET Standard   | *NETStandard.Library.Ref*          |
-   
+
    1. Navigate to the version you want to install the localized IntelliSense for. For example, *3.1.0*.
    1. Open the *ref* folder.
    1. Open the moniker folder. For example, *netcoreapp3.1*.
@@ -110,7 +110,7 @@ Once you've installed the desired language packs, modify your Visual Studio sett
 
 1. Under the **Environment** node, choose **International Settings**.
 
-1. On the **Language** drop-down, select the desired language. Choose **OK**. 
+1. On the **Language** drop-down, select the desired language. Choose **OK**.
 
 1. A dialog informs you that you have to restart Visual Studio for the changes to take effect. Choose **OK**.
 

--- a/docs/core/install/runtime.md
+++ b/docs/core/install/runtime.md
@@ -59,7 +59,7 @@ export PATH=$PATH:$HOME/dotnet
 > - **Bash Shell**: *~/.bash_profile*, *~/.bashrc*
 > - **Korn Shell**: *~/.kshrc* or *.profile*
 > - **Z Shell**: *~/.zshrc* or *.zprofile*
-> 
+>
 > Edit the appropriate source file for your shell and add `:$HOME/dotnet` to the end of the existing `PATH` statement. If no `PATH` statement is included, add a new line with `export PATH=$PATH:$HOME/dotnet`.
 >
 > Also, add `export DOTNET_ROOT=$HOME/dotnet` to the end of the file.

--- a/docs/core/native-interop/expose-components-to-com.md
+++ b/docs/core/native-interop/expose-components-to-com.md
@@ -27,7 +27,7 @@ In .NET Core, the process for exposing your .NET objects to COM has been signifi
 The first step is to create the library.
 
 1. Create a new folder, and in that folder run the following command:
-    
+
     ```dotnetcli
     dotnet new classlib
     ```

--- a/docs/core/porting/libraries.md
+++ b/docs/core/porting/libraries.md
@@ -91,7 +91,7 @@ This approach might be best for larger and more complex projects, where restruct
 1. Is it reasonable to write your own implementation of an unavailable .NET Framework API?
    You could consider copying, modifying, and using code from the [.NET Framework reference source](https://github.com/Microsoft/referencesource). The reference source code is licensed under the [MIT License](https://github.com/Microsoft/referencesource/blob/master/LICENSE.txt), so you have significant freedom to use the source as a basis for your own code. Just be sure to properly attribute Microsoft in your code.
 1. Repeat this process as needed for different projects.
- 
+
 The analysis phase could take some time depending on the size of your codebase. Spending time in this phase to thoroughly understand the scope of changes needed and to develop a plan usually saves you time in the long run, particularly if you have a complex codebase.
 
 Your plan could involve making significant changes to your codebase while still targeting .NET Framework 4.7.2, making this a more structured version of the previous approach. How you go about executing your plan is dependent on your codebase.

--- a/docs/core/porting/tools.md
+++ b/docs/core/porting/tools.md
@@ -15,5 +15,5 @@ You may find the tools listed in this article helpful when porting:
 
 Additionally, you can attempt to port smaller solutions or individual projects to the .NET Core project file format with the [CsprojToVs2017](https://github.com/hvanbakel/CsprojToVs2017) tool.
 
-> [!WARNING] 
+> [!WARNING]
 > CsprojToVs2017 is a third-party tool. There is no guarantee that it will work for all of your projects, and it may cause subtle changes in behavior that you depend on. CsprojToVs2017 should be used as a _starting point_ that automates the basic things that can be automated. It is not a guaranteed solution to migrating project file formats.

--- a/docs/core/sdk.md
+++ b/docs/core/sdk.md
@@ -19,16 +19,16 @@ As with any tooling, the first thing is to get the tools to your machine. Depend
 - Use the native installers.
 - Use the installation shell script.
 
-The native installers are primarily meant for developer's machines. The SDK is distributed using each supported platform's 
-native install mechanism, such as DEB packages on Ubuntu or MSI bundles on Windows. These installers install 
-and set up the environment as needed for the user to use the SDK immediately after the install. However, they also 
+The native installers are primarily meant for developer's machines. The SDK is distributed using each supported platform's
+native install mechanism, such as DEB packages on Ubuntu or MSI bundles on Windows. These installers install
+and set up the environment as needed for the user to use the SDK immediately after the install. However, they also
 require administrative privileges on the machine. You can find the SDK to install on the
 [.NET downloads](https://dotnet.microsoft.com/download) page.
 
-Install scripts, on the other hand, don't require administrative privileges. However, they also don't install any 
-prerequisites on the machine; you need to install all of the prerequisites manually. The scripts are meant mostly for 
-setting up build servers or when you wish to install the tools without admin privileges (do note the prerequisites 
-caveat above). You can find more information in the [install script reference](tools/dotnet-install-script.md) article. If you're 
+Install scripts, on the other hand, don't require administrative privileges. However, they also don't install any
+prerequisites on the machine; you need to install all of the prerequisites manually. The scripts are meant mostly for
+setting up build servers or when you wish to install the tools without admin privileges (do note the prerequisites
+caveat above). You can find more information in the [install script reference](tools/dotnet-install-script.md) article. If you're
 interested in how to set up the SDK on your CI build server, see the [Using .NET Core SDK and tools in Continuous Integration (CI)](tools/using-ci-with-cli.md) article.
 
 By default, the SDK installs in a "side-by-side" (SxS) manner, which means multiple versions

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -18,9 +18,9 @@ You are able to use built-in .NET Core 2.0 and later unit test project templates
 
 ## What are unit tests?
 
-Having automated tests is a great way to ensure a software application does what its authors intend it to do. There are multiple types of tests for software applications. These include integration tests, web tests, load tests, and others. **Unit tests** test individual software components and methods. Unit tests should only test code within the developer’s control. They should not test infrastructure concerns. Infrastructure concerns include databases, file systems, and network resources. 
+Having automated tests is a great way to ensure a software application does what its authors intend it to do. There are multiple types of tests for software applications. These include integration tests, web tests, load tests, and others. **Unit tests** test individual software components and methods. Unit tests should only test code within the developer’s control. They should not test infrastructure concerns. Infrastructure concerns include databases, file systems, and network resources.
 
-Also, keep in mind there are best practices for writing tests. For example, [Test Driven Development (TDD)](https://deviq.com/test-driven-development/) is when a unit test is written before the code it is meant to check. TDD is like creating an outline for a book before we write it. It is meant to help developers write simpler, more readable, and efficient code. 
+Also, keep in mind there are best practices for writing tests. For example, [Test Driven Development (TDD)](https://deviq.com/test-driven-development/) is when a unit test is written before the code it is meant to check. TDD is like creating an outline for a book before we write it. It is meant to help developers write simpler, more readable, and efficient code.
 
 > [!NOTE]
 > The ASP.NET team follows [these conventions](https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines#unit-tests-and-functional-tests) to help developers come up with good names for test classes and methods.
@@ -35,11 +35,11 @@ More information on unit testing in .NET Core projects:
 
 - [C#](../../csharp/index.yml)
 - [F#](../../fsharp/index.yml)
-- [Visual Basic](../../visual-basic/index.yml) 
+- [Visual Basic](../../visual-basic/index.yml)
 
 You can also choose between:
 
-- [xUnit](https://xunit.github.io) 
+- [xUnit](https://xunit.github.io)
 - [NUnit](https://nunit.org)
 - [MSTest](https://github.com/Microsoft/testfx-docs)
 

--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -164,7 +164,7 @@ Naming variables in unit tests is as important, if not more important, than nami
 
 Magic strings can cause confusion to the reader of your tests. If a string looks out of the ordinary, they may wonder why a certain value was chosen for a parameter or return value. This may lead them to take a closer look at the implementation details, rather than focus on the test.
 
-> [!TIP] 
+> [!TIP]
 > When writing tests, you should aim to express as much intent as possible. In the case of magic strings, a good approach is to assign these values to constants.
 
 #### Bad:
@@ -203,7 +203,7 @@ If you require a similar object or state for your tests, prefer a helper method 
 
 In unit testing frameworks, `Setup` is called before each and every unit test within your test suite. While some may see this as a useful tool, it generally ends up leading to bloated and hard to read tests. Each test will generally have different requirements in order to get the test up and running. Unfortunately, `Setup` forces you to use the exact same requirements for each test.
 
-> [!NOTE] 
+> [!NOTE]
 > xUnit has removed both SetUp and TearDown as of version 2.x
 
 #### Bad:
@@ -234,7 +234,7 @@ When writing your tests, try to only include one Assert per test. Common approac
 
 - If one Assert fails, the subsequent Asserts will not be evaluated.
 - Ensures you are not asserting multiple cases in your tests.
-- Gives you the entire picture as to why your tests are failing. 
+- Gives you the entire picture as to why your tests are failing.
 
 When introducing multiple asserts into a test case, it is not guaranteed that all of the asserts will be executed. In most unit testing frameworks, once an assertion fails in a unit test, the proceeding tests are automatically considered to be failing. This can be confusing as functionality that is actually working, will be shown as failing.
 
@@ -248,7 +248,7 @@ When introducing multiple asserts into a test case, it is not guaranteed that al
 [!code-csharp[AfterMultipleAsserts](../../../samples/csharp/unit-testing-best-practices/after/StringCalculatorTests.cs#AfterMultipleAsserts)]
 
 ### Validate private methods by unit testing public methods
-In most cases, there should not be a need to test a private method. Private methods are an implementation detail. You can think of it this way: private methods never exist in isolation. At some point, there is going to be a public facing method that calls the private method as part of its implementation. What you should care about is the end result of the public method that calls into the private one. 
+In most cases, there should not be a need to test a private method. Private methods are an implementation detail. You can think of it this way: private methods never exist in isolation. At some point, there is going to be a public facing method that calls the private method as part of its implementation. What you should care about is the end result of the public method that calls into the private one.
 
 Consider the following case
 
@@ -265,9 +265,9 @@ private string TrimInput(string input)
 }
 ```
 
-Your first reaction may be to start writing a test for `TrimInput` because you want to make sure that the method is working as expected. However, it is entirely possible that `ParseLogLine` manipulates `sanitizedInput` in such a way that you do not expect, rendering a test against `TrimInput` useless. 
+Your first reaction may be to start writing a test for `TrimInput` because you want to make sure that the method is working as expected. However, it is entirely possible that `ParseLogLine` manipulates `sanitizedInput` in such a way that you do not expect, rendering a test against `TrimInput` useless.
 
-The real test should be done against the public facing method `ParseLogLine` because that is what you should ultimately care about. 
+The real test should be done against the public facing method `ParseLogLine` because that is what you should ultimately care about.
 
 ```csharp
 public void ParseLogLine_ByDefault_ReturnsTrimmedResult()
@@ -288,11 +288,11 @@ One of the principles of a unit test is that it must have full control of the sy
 ```csharp
 public int GetDiscountedPrice(int price)
 {
-    if(DateTime.Now.DayOfWeek == DayOfWeek.Tuesday) 
+    if(DateTime.Now.DayOfWeek == DayOfWeek.Tuesday)
     {
         return price / 2;
     }
-    else 
+    else
     {
         return price;
     }
@@ -321,7 +321,7 @@ public void GetDiscountedPrice_OnTuesday_ReturnsHalfPrice()
 }
 ```
 
-Unfortunately, you will quickly realize that there are a couple problems with your tests. 
+Unfortunately, you will quickly realize that there are a couple problems with your tests.
 
 - If the test suite is run on a Tuesday, the second test will pass, but the first test will fail.
 - If the test suite is run on any other day, the first test will pass, but the second test will fail.
@@ -336,11 +336,11 @@ public interface IDateTimeProvider
 
 public int GetDiscountedPrice(int price, IDateTimeProvider dateTimeProvider)
 {
-    if(dateTimeProvider.DayOfWeek() == DayOfWeek.Tuesday) 
+    if(dateTimeProvider.DayOfWeek() == DayOfWeek.Tuesday)
     {
         return price / 2;
     }
-    else 
+    else
     {
         return price;
     }

--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -77,7 +77,7 @@ You have the following final solution layout:
         MathServiceTests.fsproj
 ```
 
-Execute `dotnet sln add .\MathService.Tests\MathService.Tests.fsproj` in the *unit-testing-with-fsharp* directory. 
+Execute `dotnet sln add .\MathService.Tests\MathService.Tests.fsproj` in the *unit-testing-with-fsharp* directory.
 
 ## Creating the first test
 
@@ -153,9 +153,9 @@ You can fix the test by piping the filtered sequence through a map operation to 
 let private square x = x * x
 let private isOdd x = x % 2 <> 0
 
-let squaresOfOdds xs = 
-    xs 
-    |> Seq.filter isOdd 
+let squaresOfOdds xs =
+    xs
+    |> Seq.filter isOdd
     |> Seq.map square
 ```
 

--- a/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
@@ -82,7 +82,7 @@ You have the following final folder layout:
         PrimeServiceTests.vbproj
 ```
 
-Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.vbproj`](../tools/dotnet-sln.md) in the *unit-testing-vb-using-dotnet-test* directory. 
+Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.vbproj`](../tools/dotnet-sln.md) in the *unit-testing-vb-using-dotnet-test* directory.
 
 ## Creating the first test
 

--- a/docs/core/testing/unit-testing-with-mstest.md
+++ b/docs/core/testing/unit-testing-with-mstest.md
@@ -31,15 +31,15 @@ namespace Prime.Services
 {
     public class PrimeService
     {
-        public bool IsPrime(int candidate) 
+        public bool IsPrime(int candidate)
         {
             throw new NotImplementedException("Please create a test first.");
-        } 
+        }
     }
 }
 ```
 
-Change the directory back to the *unit-testing-using-mstest* directory. Run [`dotnet sln add PrimeService/PrimeService.csproj`](../tools/dotnet-sln.md) to add the class library project to the solution. 
+Change the directory back to the *unit-testing-using-mstest* directory. Run [`dotnet sln add PrimeService/PrimeService.csproj`](../tools/dotnet-sln.md) to add the class library project to the solution.
 
 ## Create the test project
 
@@ -85,7 +85,7 @@ The following outline shows the final solution layout:
         PrimeServiceTests.csproj
 ```
 
-Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj`](../tools/dotnet-sln.md) in the *unit-testing-using-mstest* directory. 
+Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj`](../tools/dotnet-sln.md) in the *unit-testing-using-mstest* directory.
 
 ## Create the first test
 
@@ -118,7 +118,7 @@ namespace Prime.UnitTests.Services
 }
 ```
 
-The [TestClass attribute](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute) denotes a class that contains unit tests. The [TestMethod attribute](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute) indicates a method is a test method. 
+The [TestClass attribute](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute) denotes a class that contains unit tests. The [TestMethod attribute](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute) indicates a method is a test method.
 
 Save this file and execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The MSTest test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -22,7 +22,7 @@ Open a shell window. Create a directory called *unit-testing-using-nunit* to hol
 ```dotnetcli
 dotnet new sln
 ```
- 
+
 Next, create a *PrimeService* directory. The following outline shows the directory and file structure so far:
 
 ```console
@@ -131,11 +131,11 @@ namespace Prime.UnitTests.Services
 
             Assert.IsFalse(result, "1 should not be prime");
         }
-        
+
         /*
         More tests
         */
-        
+
         private PrimeService CreatePrimeService()
         {
              return new PrimeService();

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -14,7 +14,7 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet list [<PROJECT>|<SOLUTION>] package [--config] [--framework] [--highest-minor] [--highest-patch] 
+dotnet list [<PROJECT>|<SOLUTION>] package [--config] [--framework] [--highest-minor] [--highest-patch]
    [--include-prerelease] [--include-transitive] [--interactive] [--outdated] [--source]
 dotnet list package [-h|--help]
 ```

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -14,7 +14,7 @@ ms.date: 02/13/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet new <TEMPLATE> [--dry-run] [--force] [-i|--install] [-lang|--language] [-n|--name] 
+dotnet new <TEMPLATE> [--dry-run] [--force] [-i|--install] [-lang|--language] [-n|--name]
     [--nuget-source] [-o|--output] [-u|--uninstall] [--update-apply] [--update-check] [Template options]
 dotnet new <TEMPLATE> [-l|--list] [--type]
 dotnet new [-h|--help]
@@ -168,7 +168,7 @@ Each project template may have additional options available. The core templates 
 
   For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
 
-- **`--no-restore`** 
+- **`--no-restore`**
 
   If specified, doesn't execute an implicit restore during project creation. Available since .NET Core 2.2 SDK.
 
@@ -196,7 +196,7 @@ Each project template may have additional options available. The core templates 
 
 - **`-f|--framework <FRAMEWORK>`**
 
-  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK. 
+  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK.
 
 - **`--langVersion <VERSION_NUMBER>`**
 
@@ -228,7 +228,7 @@ Each project template may have additional options available. The core templates 
 
 - **`-f|--framework <FRAMEWORK>`**
 
-  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK. 
+  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK.
 
 - **`--exclude-launch-settings`**
 
@@ -497,7 +497,7 @@ Each project template may have additional options available. The core templates 
 
 - **`-au|--auth <AUTHENTICATION_TYPE>`**
 
-  The type of authentication to use. Available since .NET Core 3.0 SDK. 
+  The type of authentication to use. Available since .NET Core 3.0 SDK.
   
   The possible values are:
 
@@ -506,7 +506,7 @@ Each project template may have additional options available. The core templates 
 
 - **`--exclude-launch-settings`**
 
-  Excludes *launchSettings.json* from the generated template. 
+  Excludes *launchSettings.json* from the generated template.
 
 - **`--no-restore`**
 
@@ -538,7 +538,7 @@ Each project template may have additional options available. The core templates 
 
 - **`--exclude-launch-settings`**
 
-  Excludes *launchSettings.json* from the generated template. 
+  Excludes *launchSettings.json* from the generated template.
 
 - **`-f|--framework <FRAMEWORK>`**
 

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -14,8 +14,8 @@ ms.date: 02/19/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet run [-c|--configuration] [-f|--framework] [--force] [--interactive] [--launch-profile] 
-    [--no-build] [--no-dependencies] [--no-launch-profile] [--no-restore] [-p|--project] 
+dotnet run [-c|--configuration] [-f|--framework] [--force] [--interactive] [--launch-profile]
+    [--no-build] [--no-dependencies] [--no-launch-profile] [--no-restore] [-p|--project]
     [-r|--runtime] [-v|--verbosity] [[--] [application arguments]]
 dotnet run [-h|--help]
 ```
@@ -96,7 +96,7 @@ To run the application, the `dotnet run` command resolves the dependencies of th
 
 - **`-v|--verbosity <LEVEL>`**
 
-  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default value is `m`. Available since .NET Core 2.1 SDK. 
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default value is `m`. Available since .NET Core 2.1 SDK.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -67,7 +67,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`-g|--global`**
 
-  Specifies that the installation is user wide. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` specifies a local tool installation. 
+  Specifies that the installation is user wide. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` specifies a local tool installation.
 
 - **`-h|--help`**
 
@@ -75,7 +75,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`tool-path <PATH>`**
 
-  Specifies the location where to install the Global Tool. PATH can be absolute or relative. If PATH doesn't exist, the command tries to create it. Omitting both `--global` and `--tool-path` specifies a local tool installation. 
+  Specifies the location where to install the Global Tool. PATH can be absolute or relative. If PATH doesn't exist, the command tries to create it. Omitting both `--global` and `--tool-path` specifies a local tool installation.
 
 - **`-v|--verbosity <LEVEL>`**
 

--- a/docs/core/tools/dotnet-tool-list.md
+++ b/docs/core/tools/dotnet-tool-list.md
@@ -34,7 +34,7 @@ The `dotnet tool list` command provides a way for you to list all .NET Core glob
 
 - **`-g|--global`**
 
-  Lists user-wide global tools. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` lists local tools. 
+  Lists user-wide global tools. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` lists local tools.
 
 - **`-h|--help`**
 
@@ -42,7 +42,7 @@ The `dotnet tool list` command provides a way for you to list all .NET Core glob
 
 - **`--tool-path <PATH>`**
 
-  Specifies a custom location where to find global tools. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` lists local tools. 
+  Specifies a custom location where to find global tools. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` lists local tools.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-tool-run.md
+++ b/docs/core/tools/dotnet-tool-run.md
@@ -14,7 +14,7 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet tool run <COMMAND NAME> 
+dotnet tool run <COMMAND NAME>
 dotnet tool run <-h|--help>
 ```
 

--- a/docs/core/tools/dotnet-tool-uninstall.md
+++ b/docs/core/tools/dotnet-tool-uninstall.md
@@ -40,7 +40,7 @@ The `dotnet tool uninstall` command provides a way for you to uninstall .NET Cor
 
 - **`-g|--global`**
 
-  Specifies that the tool to be removed is from a user-wide installation. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` specifies that the tool to be removed is a local tool. 
+  Specifies that the tool to be removed is from a user-wide installation. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` specifies that the tool to be removed is a local tool.
 
 - **`-h|--help`**
 
@@ -48,7 +48,7 @@ The `dotnet tool uninstall` command provides a way for you to uninstall .NET Cor
 
 - **`--tool-path <PATH>`**
 
-  Specifies the location where to uninstall the tool. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be removed is a local tool. 
+  Specifies the location where to uninstall the tool. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be removed is a local tool.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -52,7 +52,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 - **`-g|--global`**
 
-  Specifies that the update is for a user-wide tool. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` specifies that the tool to be updated is a local tool. 
+  Specifies that the update is for a user-wide tool. Can't be combined with the `--tool-path` option. Omitting both `--global` and `--tool-path` specifies that the tool to be updated is a local tool.
 
 - **`-h|--help`**
 
@@ -60,7 +60,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 - **`--tool-path <PATH>`**
 
-  Specifies the location where the global tool is installed. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be updated is a local tool. 
+  Specifies the location where the global tool is installed. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be updated is a local tool.
 
 - **`-v|--verbosity <LEVEL>`**
 

--- a/docs/core/tools/elevated-access.md
+++ b/docs/core/tools/elevated-access.md
@@ -6,7 +6,7 @@ ms.date: 06/26/2019
 ---
 # Elevated access for dotnet commands
 
-Software development best practices guide developers to writing software that requires the least amount of privilege. However, some software, like performance monitoring tools, requires admin permission because of operating system rules. The following guidance describes supported scenarios for writing such software with .NET Core. 
+Software development best practices guide developers to writing software that requires the least amount of privilege. However, some software, like performance monitoring tools, requires admin permission because of operating system rules. The following guidance describes supported scenarios for writing such software with .NET Core.
 
 The following commands can be run elevated:
 
@@ -29,8 +29,8 @@ The following instructions demonstrate the recommended way to install, run, and 
 
 If the folder `%ProgramFiles%\dotnet-tools` already exists, do the following to check whether the "Users" group has permission to write or modify that directory:
 
-- Right-click the `%ProgramFiles%\dotnet-tools` folder and select **Properties**. The **Common Properties** dialog box opens. 
-- Select the **Security** tab. Under **Group or user names**, check whether the “Users” group has permission to write or modify the directory. 
+- Right-click the `%ProgramFiles%\dotnet-tools` folder and select **Properties**. The **Common Properties** dialog box opens.
+- Select the **Security** tab. Under **Group or user names**, check whether the “Users” group has permission to write or modify the directory.
 - If the "Users" group can write or modify the directory, use a different directory name when installing the tools rather than *dotnet-tools*.
 
 To install tools, run the following command in elevated prompt. It will create the *dotnet-tools* folder during the installation.
@@ -91,7 +91,7 @@ During development, you may need elevated access to test your application. This 
    dotnet build
    sudo ./bin/Debug/netcoreapp3.0/APPLICATIONNAME
    ```
-    
+
 - Using the [dotnet run](dotnet-run.md) command with the `—no-build` flag to avoid generating new binaries:
 
    ```dotnetcli

--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -33,18 +33,18 @@ Input                                | becomes                                  
 :------------------------------------|:----------------------------------------------------------------------------|:--------------------------------
 `dotnet a⇥`                          | `dotnet add`                                                                 | `add` is the first subcommand, alphabetically.
 `dotnet add p⇥`                      | `dotnet add --help`                                                          | Tab completion matches substrings and `--help` comes first alphabetically.
-`dotnet add p⇥⇥`                    | `dotnet add package`                                                          | Pressing tab a second time brings up the next suggestion.      
+`dotnet add p⇥⇥`                    | `dotnet add package`                                                          | Pressing tab a second time brings up the next suggestion.
 `dotnet add package Microsoft⇥`      | `dotnet add package Microsoft.ApplicationInsights.Web`                      | Results are returned alphabetically.
 `dotnet remove reference ⇥`          | `dotnet remove reference ..\..\src\OmniSharp.DotNet\OmniSharp.DotNet.csproj` | Tab completion is project file aware.
 
 ## PowerShell
 
-To add tab completion to **PowerShell** for the .NET Core CLI, create or edit the profile stored in the variable `$PROFILE`. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy). 
+To add tab completion to **PowerShell** for the .NET Core CLI, create or edit the profile stored in the variable `$PROFILE`. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
 
 Add the following code to your profile:
 
 ```powershell
-# PowerShell parameter completion shim for the dotnet CLI 
+# PowerShell parameter completion shim for the dotnet CLI
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
      param($commandName, $wordToComplete, $cursorPosition)
          dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
@@ -83,7 +83,7 @@ To add tab completion to your **zsh** shell for the .NET Core CLI, add the follo
 ```zsh
 # zsh parameter completion for the dotnet CLI
 
-_dotnet_zsh_complete() 
+_dotnet_zsh_complete()
 {
   local completions=("$(dotnet complete "$words")")
 

--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -26,7 +26,7 @@ This is the first in a series of three tutorials. In this tutorial, you create a
 
 1. Open a command prompt and create a folder named *repository*.
 
-1. Navigate to the *repository* folder and enter the following command, replacing `<name>` with a unique value to make the project name unique. 
+1. Navigate to the *repository* folder and enter the following command, replacing `<name>` with a unique value to make the project name unique.
 
    ```dotnetcli
    dotnet new console -n botsay-<name>
@@ -146,7 +146,7 @@ All arguments after the `--` delimiter are passed to your application.
 
 ## Package the tool
 
-Before you can pack and distribute the application as a tool, you need to modify the project file. 
+Before you can pack and distribute the application as a tool, you need to modify the project file.
 
 1. Open the *botsay-\<name>.csproj* file and add three new XML nodes to the end of the `<PropertyGroup>` node:
 

--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -24,7 +24,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
    The `--global` parameter tells the .NET Core CLI to install the tool binaries in a default location that is automatically added to the PATH environment variable.
 
-   The `--add-source` parameter tells the .NET Core CLI to temporarily use the *./nupkg* directory as an additional source feed for NuGet packages. You gave your package a unique name to make sure that it will only be found in the *./nupkg* directory, not on the Nuget.org site. 
+   The `--add-source` parameter tells the .NET Core CLI to temporarily use the *./nupkg* directory as an additional source feed for NuGet packages. You gave your package a unique name to make sure that it will only be found in the *./nupkg* directory, not on the Nuget.org site.
 
    The output shows the command used to call the tool and the version installed:
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -71,7 +71,7 @@ dotnet /build_output/my_app.dll
 
 ### Driver
 
-The driver is named [dotnet](dotnet.md) and has two responsibilities, either running a [framework-dependent app](../deploying/index.md) or executing a command. 
+The driver is named [dotnet](dotnet.md) and has two responsibilities, either running a [framework-dependent app](../deploying/index.md) or executing a command.
 
 To run a framework-dependent app, specify the app after the driver, for example, `dotnet /path/to/my_app.dll`. When executing the command from the folder where the app's DLL resides, simply execute `dotnet my_app.dll`. If you want to use a specific version of the .NET Core Runtime, use the `--fx-version <VERSION>` option (see the [dotnet command](dotnet.md) reference).
 

--- a/docs/core/tools/local-tools-how-to-use.md
+++ b/docs/core/tools/local-tools-how-to-use.md
@@ -19,7 +19,7 @@ This tutorial teaches you how to install and use a local tool. You use a tool th
 
 ## Create a manifest file
 
-To install a tool for local access only (for the current directory and subdirectories), it has to be added to a manifest file. 
+To install a tool for local access only (for the current directory and subdirectories), it has to be added to a manifest file.
 
 From the *botsay-\<name>* folder, navigate up one level to the *repository* folder:
 
@@ -126,7 +126,7 @@ You typically install a local tool in the root directory of the repository. Afte
 
 1. Save your changes.
 
-   Making this change is the same as getting the latest version from the repository after someone else installed the package `dotnetsay` for the project directory. 
+   Making this change is the same as getting the latest version from the repository after someone else installed the package `dotnetsay` for the project directory.
 
 1. Run the `dotnet tool restore` command.
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -8,7 +8,7 @@ ms.date: 08/27/2019
 
 The [.NET Core SDK](index.md) includes a telemetry feature that collects usage data and exception information when the .NET Core CLI crashes. The .NET Core CLI comes with the .NET Core SDK and is the set of verbs that enable you to build, test, and publish your .NET Core apps. It's important that the .NET team understands how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
 
-The collected data is anonymous and published in aggregate under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/). 
+The collected data is anonymous and published in aggregate under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
 ## Scope
 
@@ -24,7 +24,7 @@ Telemetry *is collected* when using any of the [.NET Core CLI commands](index.md
 
 ## How to opt out
 
-The .NET Core SDK telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`. 
+The .NET Core SDK telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
 
 A single telemetry entry is also sent by the .NET Core SDK installer when a successful installation happens. To opt out, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable before you install the .NET Core SDK.
 
@@ -126,7 +126,7 @@ at Microsoft.DotNet.Cli.Program.Main(String[] args)
 
 .NET Core contributors and anyone else running a version of the .NET Core SDK that they built themselves should consider the path to their SDK source code. If a crash occurs while using a .NET Core SDK that is a custom debug build or configured with custom build symbol files, the SDK source file path from the build machine is collected as part of the stack trace and isn't hashed.
 
-Because of this, custom builds of the .NET Core SDK shouldn't be located in directories whose path names expose personal or sensitive information. 
+Because of this, custom builds of the .NET Core SDK shouldn't be located in directories whose path names expose personal or sensitive information.
 
 ## See also
 

--- a/docs/core/tutorials/cli-create-console-app.md
+++ b/docs/core/tutorials/cli-create-console-app.md
@@ -34,30 +34,30 @@ Let's do a quick walkthrough:
 01. `dotnet new console`
 
     [dotnet new](../tools/dotnet-new.md) creates an up-to-date *Hello.csproj* project file with the dependencies necessary to build a console app. It also creates a *Program.cs*, a basic file containing the entry point for the application.
-    
+
     *Hello.csproj*:
-    
+
     [!code-xml[Hello.csproj](~/samples/core/console-apps/HelloMsBuild/Hello.csproj)]
-    
+
     The project file specifies everything that's needed to restore dependencies and build the program.
-    
+
     - The `<OutputType>` element specifies that we're building an executable, in other words a console application.
     - The `<TargetFramework>` element specifies what .NET implementation we're targeting. In an advanced scenario, you can specify multiple target frameworks and build to all those in a single operation. In this tutorial, we'll stick to building only for .NET Core 3.1.
-    
+
     *Program.cs*:
-    
+
     [!code-csharp[Program.cs](~/samples/core/console-apps/HelloMsBuild/Program.cs)]
-    
+
     The program starts by `using System`, which means "bring everything in the `System` namespace into scope for this file". The `System` namespace includes the `Console` class.
-    
+
     We then define a namespace called `Hello`. You can change this to anything you want. A class named `Program` is defined within that namespace, with a `Main` method that takes an array of strings named `args`. This array contains the list of arguments passed in when the program is run. As it is, this array is not used and the program simply writes the text "Hello World!" to the console. Later, we'll make changes to the code that will make use of this argument.
-    
+
     `dotnet new` calls [dotnet restore](../tools/dotnet-restore.md) implicitly. `dotnet restore` calls into [NuGet](https://www.nuget.org/) (.NET package manager) to restore the tree of dependencies. NuGet analyzes the *Hello.csproj* file, downloads the dependencies defined in the file (or grabs them from a cache on your machine), and writes the *obj/project.assets.json* file, which is necessary to compile and run the sample.
 
 02. `dotnet run`
 
     [dotnet run](../tools/dotnet-run.md) calls [dotnet build](../tools/dotnet-build.md) to ensure that the build targets have been built, and then calls `dotnet <assembly.dll>` to run the target application.
-    
+
     ```dotnetcli
     dotnet run
     ```
@@ -67,9 +67,9 @@ Let's do a quick walkthrough:
     ```console
     Hello World!
     ```
-    
+
     Alternatively, you can also run `dotnet build` to compile the code without running the build console applications. This results in a compiled application, as a DLL file, based on the name of the project. In this case, the file created is named *Hello.dll*. This app can be run with `dotnet bin\Debug\netcoreapp3.1\Hello.dll` on Windows (use `/` for non-Windows systems).
-    
+
     ```dotnetcli
     dotnet bin\Debug\netcoreapp3.1\Hello.dll
     ```
@@ -79,7 +79,7 @@ Let's do a quick walkthrough:
     ```console
     Hello World!
     ```
-    
+
     When the app is compiled, an operating system-specific executable was created along with the `Hello.dll`. On Windows, this would be `Hello.exe`; on Linux or macOS, this would be `hello`. With the example above, the file is named with `Hello.exe` or `Hello`. You can run that executable directly.
 
     ```console

--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -213,7 +213,7 @@ By using a different `PluginLoadContext` instance for each plugin, the plugins c
 Back in the root folder, do the following:
 
 1. Run the following command to create a new class library project named `HelloPlugin`:
-    
+
     ```dotnetcli
     dotnet new classlib -o HelloPlugin
     ```

--- a/docs/core/tutorials/debugging-with-visual-studio.md
+++ b/docs/core/tutorials/debugging-with-visual-studio.md
@@ -63,7 +63,7 @@ Run your program and try a few debugging features:
 1. Set a *breakpoint* on the line that reads `Console.WriteLine($"{vbCrLf}Hello, {name}, on {currentDate:d} at {currentDate:t}!")` by clicking in the left margin of the code window on that line. You can also set a breakpoint by placing the caret on the desired line and then choosing **Debug** > **Toggle Breakpoint** from the menu bar.
 
    A breakpoint temporarily interrupts the execution of the application *before* the line with the breakpoint is executed.
-   
+
    As the following figure shows, Visual Studio indicates the line on which the breakpoint is set by highlighting it and displaying a red circle in its left margin.
 
    ![Visual Studio Program window with breakpoint set](./media/debugging-with-visual-studio/vb/set-breakpoint-in-editor.png)

--- a/docs/core/tutorials/publishing-with-visual-studio.md
+++ b/docs/core/tutorials/publishing-with-visual-studio.md
@@ -19,15 +19,15 @@ In [Create a Hello World application with .NET Core in Visual Studio](with-visua
 1. Right-click on the **HelloWorld** project (not the HelloWorld solution) and select **Publish** from the menu. (You can also select **Publish HelloWorld** from the main **Build** menu.)
 
    ![Visual Studio Publish context menu](media/publishing-with-visual-studio/publish-context-menu.png)
-   
+
 1. On the **Pick a publish target** page, select **Folder**, and then select **Create Profile**.
 
    ![Pick a publish target in Visual Studio](media/publishing-with-visual-studio/pick-publish-target.png)
-   
+
 1. On the **Publish** page, select **Publish**.
 
    ![Visual Studio Publish window](media/publishing-with-visual-studio/publish-page.png)
-   
+
 ## Inspect the files
 
 The publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on any platform supported by .NET Core with .NET Core installed on the system. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
@@ -53,7 +53,7 @@ In the following steps, you'll look at the files created by the publish process.
          This is the [framework-dependent deployment](../deploying/deploy-with-cli.md#framework-dependent-deployment) version of the application. To execute this dynamic link library, enter `dotnet HelloWorld.dll` at a command prompt.
 
       * *HelloWorld.exe*
-      
+
          This is the [framework-dependent executable](../deploying/deploy-with-cli.md#framework-dependent-executable) version of the application. To run it, enter `HelloWorld.exe` at a command prompt.
 
       * *HelloWorld.pdb* (optional for deployment)

--- a/docs/core/tutorials/testing-library-with-visual-studio.md
+++ b/docs/core/tutorials/testing-library-with-visual-studio.md
@@ -48,13 +48,13 @@ To create the unit test project, do the following:
 
     ```vb
     Imports Microsoft.VisualStudio.TestTools.UnitTesting
-    
+
     Namespace StringLibraryTest
         <TestClass>
         Public Class UnitTest1
             <TestMethod>
             Sub TestSub()
-    
+
             End Sub
         End Class
     End Namespace

--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -149,7 +149,7 @@ Note that you assert the value 42 is not equal to 19+23 (or 42) when you first c
 From the *golden* folder, execute the following commands:
 
 ```dotnetcli
-dotnet restore 
+dotnet restore
 dotnet test test-library/test-library.csproj
 ```
 

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -107,7 +107,7 @@ You can also watch a short video tutorial for further setup help on [Windows](ht
 
     ```csharp
     using System;
-    
+
     namespace HelloWorld
     {
         class Program

--- a/docs/core/whats-new/dotnet-core-2-2.md
+++ b/docs/core/whats-new/dotnet-core-2-2.md
@@ -21,7 +21,7 @@ This new deployment mode has the distinct advantage of building an executable in
 
 **Handling events in runtime services**
 
-You may often want to monitor your application's use of runtime services, such as the GC, JIT, and ThreadPool, to understand how they impact your application. On Windows systems, this is commonly done by monitoring the ETW events of the current process. While this continues to work well, it's not always possible to use ETW if you're running in a low-privilege environment or on Linux or macOS. 
+You may often want to monitor your application's use of runtime services, such as the GC, JIT, and ThreadPool, to understand how they impact your application. On Windows systems, this is commonly done by monitoring the ETW events of the current process. While this continues to work well, it's not always possible to use ETW if you're running in a low-privilege environment or on Linux or macOS.
 
 Starting with .NET Core 2.2, CoreCLR events can now be consumed using the <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType> class. These events describe the behavior of such runtime services as GC, JIT, ThreadPool, and interop. These are the same events that are exposed as part of the CoreCLR ETW provider.  This allows for applications to consume these events or use a transport mechanism to send them to a telemetry aggregation service. You can see how to subscribe to events in the following code sample:
 


### PR DESCRIPTION
## Summary

Enabled the MD009 rule in Markdownlint and ran `markdownlint --fix "**/*.md"`. Since there were ~1900 touched files, I just staged docs/core as a start. If this makes sense, I'll just do small PRs by folder and enable the rule at the end.