### PR TITLE
Update Tour of C# for dotnet CLI, and general accuracy and tone

### DIFF
--- a/docs/csharp/tour-of-csharp/arrays.md
+++ b/docs/csharp/tour-of-csharp/arrays.md
@@ -1,7 +1,7 @@
 ---
 title: C# Arrays - A tour of the C# language
 description: Arrays are the most basic collection type in the C# language
-ms.date: 08/10/2016
+ms.date: 02/27/2020
 ms.assetid: a440704c-9e88-4c75-97dd-bfe30ca0fb97
 ---
 
@@ -20,7 +20,7 @@ This example creates and operates on a ***single-dimensional array***. C# also s
 [!code-csharp[ArrayRank](../../../samples/snippets/csharp/tour/arrays/Program.cs#L24-L26)]
 
 The `a1` array contains 10 elements, the `a2` array contains 50 (10 × 5) elements, and the `a3` array contains 100 (10 × 5 × 2) elements.
-The element type of an array can be any type, including an array type. An array with elements of an array type is sometimes called a ***jagged array*** because the lengths of the element arrays do not all have to be the same. The following example allocates an array of arrays of `int`:
+The element type of an array can be any type, including an array type. An array with elements of an array type is sometimes called a ***jagged array*** because the lengths of the element arrays don't all have to be the same. The following example allocates an array of arrays of `int`:
 
 [!code-csharp[ArrayAllocation](../../../samples/snippets/csharp/tour/arrays/Program.cs#L31-L34)]
 
@@ -30,11 +30,11 @@ The new operator permits the initial values of the array elements to be specifie
 
 [!code-csharp[ArrayInitialization](../../../samples/snippets/csharp/tour/arrays/Program.cs#L39-L39)]
 
-Note that the length of the array is inferred from the number of expressions between { and }. Local variable and field declarations can be shortened further such that the array type does not have to be restated.
+The length of the array is inferred from the number of expressions between { and }. Local variable and field declarations can be shortened further such that the array type does not have to be restated.
 
 [!code-csharp[ArrayInitialization](../../../samples/snippets/csharp/tour/arrays/Program.cs#L44-L44)]
 
-Both of the previous examples are equivalent to the following:
+Both of the previous examples are equivalent to the following code:
 
 [!code-csharp[ArrayAssignment](../../../samples/snippets/csharp/tour/arrays/Program.cs#L49-L53)]
 

--- a/docs/csharp/tour-of-csharp/attributes.md
+++ b/docs/csharp/tour-of-csharp/attributes.md
@@ -1,7 +1,7 @@
 ---
 title: C# Attributes - A tour of the C# language
 description: Learn about declarative programming using attributes in C#
-ms.date: 08/10/2016
+ms.date: 02/27/2020
 ms.assetid: 753bcfe2-7ddd-4487-9513-ba70937fc8e9
 ---
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -1,7 +1,7 @@
 ---
 title: Classes and Objects in C# - A tour of the C# Language
-description: New to C#? Read this overview of classes, objects and inheritance
-ms.date: 08/10/2016
+description: New to C#? Read this overview of classes, objects, and inheritance
+ms.date: 02/27/2020
 ms.assetid: 63a89bde-0f05-4bc4-b0cd-4f693854f0cd
 ---
 
@@ -11,7 +11,7 @@ ms.assetid: 63a89bde-0f05-4bc4-b0cd-4f693854f0cd
 
 New classes are created using class declarations. A class declaration starts with a header that specifies the attributes and modifiers of the class, the name of the class, the base class (if given), and the interfaces implemented by the class. The header is followed by the class body, which consists of a list of member declarations written between the delimiters `{` and `}`.
 
-The following is a declaration of a simple class named `Point`:
+The following code shows a declaration of a simple class named `Point`:
 
 [!code-csharp[PointClass](~/samples/snippets/csharp/tour/classes-and-objects/Point.cs#L3-L11)]
 
@@ -19,13 +19,13 @@ Instances of classes are created using the `new` operator, which allocates memor
 
 [!code-csharp[PointExample](~/samples/snippets/csharp/tour/classes-and-objects/Program.cs#L9-L10)]
 
-The memory occupied by an object is automatically reclaimed when the object is no longer reachable. It is neither necessary nor possible to explicitly deallocate objects in C#.
+The memory occupied by an object is automatically reclaimed when the object is no longer reachable. It's neither necessary nor possible to explicitly deallocate objects in C#.
 
 ## Members
 
 The members of a class are either static members or instance members. Static members belong to classes, and instance members belong to objects (instances of classes).
 
-The following provides an overview of the kinds of members a class can contain.
+The following list provides an overview of the kinds of members a class can contain.
 
 - Constants
   - Constant values associated with the class
@@ -50,20 +50,20 @@ The following provides an overview of the kinds of members a class can contain.
 
 ## Accessibility
 
-Each member of a class has an associated accessibility, which controls the regions of program text that are able to access the member. There are six possible forms of accessibility. These are summarized below.
+Each member of a class has an associated accessibility, which controls the regions of program text that can access the member. There are six possible forms of accessibility. These accessors are summarized below.
 
 - `public`
-  - Access not limited
+  - Access isn't limited
 - `protected`
-  - Access limited to this class or classes derived from this class
+  - Access is limited to this class or classes derived from this class
 - `internal`
-  - Access limited to the current assembly (.exe, .dll, etc.)
+  - Access is limited to the current assembly (.exe, .dll, and so on.)
 - `protected internal`
-  - Access limited to the containing class, classes derived from the containing class, or classes within the same assembly
+  - Access is limited to the containing class, classes derived from the containing class, or classes within the same assembly
 - `private`
-  - Access limited to this class
+  - Access is limited to this class
 - `private protected`
-  - Access limited to the containing class or classes derived from the containing type within the same assembly
+  - Access is limited to the containing class or classes derived from the containing type within the same assembly
 
 ## Type parameters
 
@@ -71,7 +71,7 @@ A class definition may specify a set of type parameters by following the class n
 
 [!code-csharp[Pair](~/samples/snippets/csharp/tour/classes-and-objects/Pair.cs#L3-L7)]
 
-A class type that is declared to take type parameters is called a *generic class type*. Struct, interface and delegate types can also be generic.
+A class type that is declared to take type parameters is called a *generic class type*. Struct, interface, and delegate types can also be generic.
 When the generic class is used, type arguments must be provided for each of the type parameters:
 
 [!code-csharp[PairExample](~/samples/snippets/csharp/tour/classes-and-objects/Program.cs#L15-L17)]
@@ -84,9 +84,9 @@ A class declaration may specify a base class by following the class name and typ
 
 [!code-csharp[Point3DClass](~/samples/snippets/csharp/tour/classes-and-objects/Point.cs#L3-L20)]
 
-A class inherits the members of its base class. Inheritance means that a class implicitly contains all members of its base class, except for the instance and static constructors, and the finalizers of the base class. A derived class can add new members to those it inherits, but it cannot remove the definition of an inherited member. In the previous example, `Point3D` inherits the `x` and `y` fields from `Point`, and every `Point3D` instance contains three fields, `x`, `y`, and `z`.
+A class inherits the members of its base class. Inheritance means that a class implicitly contains all members of its base class, except for the instance and static constructors, and the finalizers of the base class. A derived class can add new members to those members it inherits, but it can't remove the definition of an inherited member. In the previous example, `Point3D` inherits the `x` and `y` fields from `Point`, and every `Point3D` instance contains three fields, `x`, `y`, and `z`.
 
-An implicit conversion exists from a class type to any of its base class types. Therefore, a variable of a class type can reference an instance of that class or an instance of any derived class. For example, given the previous class declarations, a variable of type `Point` can reference either a `Point` or a `Point3D`:
+An implicit conversion exists from a class type to any of its base class types. A variable of a class type can reference an instance of that class or an instance of any derived class. For example, given the previous class declarations, a variable of type `Point` can reference either a `Point` or a `Point3D`:
 
 [!code-csharp[Point3DExample](~/samples/snippets/csharp/tour/classes-and-objects/Program.cs#L22-L23)]
 
@@ -94,11 +94,11 @@ An implicit conversion exists from a class type to any of its base class types. 
 
 A *field* is a variable that is associated with a class or with an instance of a class.
 
-A field declared with the static modifier defines a static field. A static field identifies exactly one storage location. No matter how many instances of a class are created, there is only ever one copy of a static field.
+A field declared with the static modifier defines a static field. A static field identifies exactly one storage location. No matter how many instances of a class are created, there's only ever one copy of a static field.
 
 A field declared without the static modifier defines an instance field. Every instance of a class contains a separate copy of all the instance fields of that class.
 
-In the following example, each instance of the `Color` class has a separate copy of the `r`, `g`, and `b` instance fields, but there is only one copy of the `Black`, `White`, `Red`, `Green`, and `Blue` static fields:
+In the following example, each instance of the `Color` class has a separate copy of the `r`, `g`, and `b` instance fields, but there's only one copy of the `Black`, `White`, `Red`, `Green`, and `Blue` static fields:
 
 [!code-csharp[ColorClass](~/samples/snippets/csharp/tour/classes-and-objects/Color.cs#L3-L17)]
 
@@ -108,17 +108,17 @@ As shown in the previous example, *read-only fields* may be declared with a `rea
 
 A *method* is a member that implements a computation or action that can be performed by an object or class. *Static methods* are accessed through the class. *Instance methods* are accessed through instances of the class.
 
-Methods may have a list of *parameters*, which represent values or variable references passed to the method, and a *return type*, which specifies the type of the value computed and returned by the method. A method’s return type is `void` if it does not return a value.
+Methods may have a list of *parameters*, which represent values or variable references passed to the method, and a *return type*, which specifies the type of the value computed and returned by the method. A method’s return type is `void` if it doesn't return a value.
 
 Like types, methods may also have a set of type parameters, for which type arguments must be specified when the method is called. Unlike types, the type arguments can often be inferred from the arguments of a method call and need not be explicitly given.
 
-The *signature* of a method must be unique in the class in which the method is declared. The signature of a method consists of the name of the method, the number of type parameters and the number, modifiers, and types of its parameters. The signature of a method does not include the return type.
+The *signature* of a method must be unique in the class in which the method is declared. The signature of a method consists of the name of the method, the number of type parameters and the number, modifiers, and types of its parameters. The signature of a method doesn't include the return type.
 
 ### Parameters
 
 Parameters are used to pass values or variable references to methods. The parameters of a method get their actual values from the *arguments* that are specified when the method is invoked. There are four kinds of parameters: value parameters, reference parameters, output parameters, and parameter arrays.
 
-A *value parameter* is used for passing input arguments. A value parameter corresponds to a local variable that gets its initial value from the argument that was passed for the parameter. Modifications to a value parameter do not affect the argument that was passed for the parameter.
+A *value parameter* is used for passing input arguments. A value parameter corresponds to a local variable that gets its initial value from the argument that was passed for the parameter. Modifications to a value parameter don't affect the argument that was passed for the parameter.
 
 Value parameters can be optional, by specifying a default value so that corresponding arguments can be omitted.
 
@@ -130,11 +130,11 @@ An *output parameter* is used for passing arguments by reference. It's similar t
 
 [!code-csharp[OutExample](~/samples/snippets/csharp/tour/classes-and-objects/OutExample.cs#L3-L17)]
 
-A *parameter array* permits a variable number of arguments to be passed to a method. A parameter array is declared with the `params` modifier. Only the last parameter of a method can be a parameter array, and the type of a parameter array must be a single-dimensional array type. The Write and WriteLine methods of the <xref:System.Console?displayProperty=nameWithType> class are good examples of parameter array usage. They are declared as follows.
+A *parameter array* permits a variable number of arguments to be passed to a method. A parameter array is declared with the `params` modifier. Only the last parameter of a method can be a parameter array, and the type of a parameter array must be a single-dimensional array type. The Write and WriteLine methods of the <xref:System.Console?displayProperty=nameWithType> class are good examples of parameter array usage. They're declared as follows.
 
 [!code-csharp[ConsoleExample](~/samples/snippets/csharp/tour/classes-and-objects/Program.cs#L78-L83)]
 
-Within a method that uses a parameter array, the parameter array behaves exactly like a regular parameter of an array type. However, in an invocation of a method with a parameter array, it is possible to pass either a single argument of the parameter array type or any number of arguments of the element type of the parameter array. In the latter case, an array instance is automatically created and initialized with the given arguments. This example
+Within a method that uses a parameter array, the parameter array behaves exactly like a regular parameter of an array type. However, in an invocation of a method with a parameter array, it's possible to pass either a single argument of the parameter array type or any number of arguments of the element type of the parameter array. In the latter case, an array instance is automatically created and initialized with the given arguments. This example
 
 [!code-csharp[StringFormat](~/samples/snippets/csharp/tour/classes-and-objects/Program.cs#L55-L55)]
 
@@ -150,21 +150,21 @@ A method body can declare variables that are specific to the invocation of the m
 
 [!code-csharp[Squares](~/samples/snippets/csharp/tour/classes-and-objects/Squares.cs#L3-L17)]
 
-C# requires a local variable to be *definitely assigned* before its value can be obtained. For example, if the declaration of the previous `i` did not include an initial value, the compiler would report an error for the subsequent usages of `i` because `i` would not be definitely assigned at those points in the program.
+C# requires a local variable to be *definitely assigned* before its value can be obtained. For example, if the declaration of the previous `i` didn't include an initial value, the compiler would report an error for the subsequent usages of `i` because `i` wouldn't be definitely assigned at those points in the program.
 
-A method can use `return` statements to return control to its caller. In a method returning `void`, `return` statements cannot specify an expression. In a method returning non-void, `return` statements must include an expression that computes the return value.
+A method can use `return` statements to return control to its caller. In a method returning `void`, `return` statements can't specify an expression. In a method returning non-void, `return` statements must include an expression that computes the return value.
 
 ### Static and instance methods
 
-A method declared with a static modifier is a *static method*. A static method does not operate on a specific instance and can only directly access static members.
+A method declared with a static modifier is a *static method*. A static method doesn't operate on a specific instance and can only directly access static members.
 
-A method declared without a static modifier is an *instance method*. An instance method operates on a specific instance and can access both static and instance members. The instance on which an instance method was invoked can be explicitly accessed as `this`. It is an error to refer to `this` in a static method.
+A method declared without a static modifier is an *instance method*. An instance method operates on a specific instance and can access both static and instance members. The instance on which an instance method was invoked can be explicitly accessed as `this`. It's an error to refer to `this` in a static method.
 
 The following `Entity` class has both static and instance members.
 
 [!code-csharp[Entity](~/samples/snippets/csharp/tour/classes-and-objects/Entity.cs#L16-L36)]
 
-Each `Entity` instance contains a serial number (and presumably some other information that is not shown here). The `Entity` constructor (which is like an instance method) initializes the new instance with the next available serial number. Because the constructor is an instance member, it is permitted to access both the `serialNo` instance field and the `nextSerialNo` static field.
+Each `Entity` instance contains a serial number (and presumably some other information that isn't shown here). The `Entity` constructor (which is like an instance method) initializes the new instance with the next available serial number. Because the constructor is an instance member, it's permitted to access both the `serialNo` instance field and the `nextSerialNo` static field.
 
 The `GetNextSerialNo` and `SetNextSerialNo` static methods can access the `nextSerialNo` static field, but it would be an error for them to directly access the `serialNo` instance field.
 
@@ -172,7 +172,7 @@ The following example shows the use of the Entity class.
 
 [!code-csharp[EntityExample](~/samples/snippets/csharp/tour/classes-and-objects/Entity.cs#L3-L15)]
 
-Note that the `SetNextSerialNo` and `GetNextSerialNo` static methods are invoked on the class whereas the `GetSerialNo` instance method is invoked on instances of the class.
+The `SetNextSerialNo` and `GetNextSerialNo` static methods are invoked on the class whereas the `GetSerialNo` instance method is invoked on instances of the class.
 
 ### Virtual, override, and abstract methods
 
@@ -184,7 +184,7 @@ A virtual method can be *overridden* in a derived class. When an instance method
 
 An *abstract method* is a virtual method with no implementation. An abstract method is declared with the abstract modifier and is permitted only in a class that is also declared abstract. An abstract method must be overridden in every non-abstract derived class.
 
-The following example declares an abstract class, `Expression`, which represents an expression tree node, and three derived classes, `Constant`, `VariableReference`, and `Operation`, which implement expression tree nodes for constants, variable references, and arithmetic operations. (This is similar to, but not to be confused with the expression tree types).
+The following example declares an abstract class, `Expression`, which represents an expression tree node, and three derived classes, `Constant`, `VariableReference`, and `Operation`, which implement expression tree nodes for constants, variable references, and arithmetic operations. (This example is similar to, but not to be confused with the expression tree types).
 
 [!code-csharp[ExpressionClass](~/samples/snippets/csharp/tour/classes-and-objects/Expressions.cs#L3-L61)]
 
@@ -202,7 +202,7 @@ The following program uses the `Expression` classes to evaluate the expression `
 
 ### Method overloading
 
-Method *overloading* permits multiple methods in the same class to have the same name as long as they have unique signatures. When compiling an invocation of an overloaded method, the compiler uses *overload resolution* to determine the specific method to invoke. Overload resolution finds the one method that best matches the arguments or reports an error if no single best match can be found. The following example shows overload resolution in effect. The comment for each invocation in the `UsageExample` method shows which method is actually invoked.
+Method *overloading* permits multiple methods in the same class to have the same name as long as they have unique signatures. When compiling an invocation of an overloaded method, the compiler uses *overload resolution* to determine the specific method to invoke. Overload resolution finds the one method that best matches the arguments or reports an error if no single best match can be found. The following example shows overload resolution in effect. The comment for each invocation in the `UsageExample` method shows which method is invoked.
 
 [!code-csharp[OverloadUsage](~/samples/snippets/csharp/tour/classes-and-objects/Overloading.cs#L3-L41)]
 
@@ -210,9 +210,9 @@ As shown by the example, a particular method can always be selected by explicitl
 
 ## Other function members
 
-Members that contain executable code are collectively known as the *function members* of a class. The preceding section describes methods, which are the primary kind of function members. This section describes the other kinds of function members supported by C#: constructors, properties, indexers, events, operators, and finalizers.
+Members that contain executable code are collectively known as the *function members* of a class. The preceding section describes methods, which are the primary types of function members. This section describes the other kinds of function members supported by C#: constructors, properties, indexers, events, operators, and finalizers.
 
-The following shows a generic class called `MyList<T>`, which implements a growable list of objects. The class contains several examples of the most common kinds of function members.
+The following example shows a generic class called `MyList<T>`, which implements a growable list of objects. The class contains several examples of the most common kinds of function members.
 
 > [!NOTE]
 > This example creates a `MyList` class, which is not the same as the .NET standard <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. It does illustrate the concepts needed for this tour, but is not a replacement for that class.
@@ -221,7 +221,7 @@ The following shows a generic class called `MyList<T>`, which implements a growa
 
 ### Constructors
 
-C# supports both instance and static constructors. An *instance constructor* is a member that implements the actions required to initialize an instance of a class. A *static constructor* is a member that implements the actions required to initialize a class itself when it is first loaded.
+C# supports both instance and static constructors. An *instance constructor* is a member that implements the actions required to initialize an instance of a class. A *static constructor* is a member that implements the actions required to initialize a class itself when it's first loaded.
 
 A constructor is declared like a method with no return type and the same name as the containing class. If a constructor declaration includes a static modifier, it declares a static constructor. Otherwise, it declares an instance constructor.
 
@@ -229,11 +229,11 @@ Instance constructors can be overloaded and can have optional parameters. For ex
 
 [!code-csharp[ListExample1](~/samples/snippets/csharp/tour/classes-and-objects/ListBasedExamples.cs#L95-L96)]
 
-Unlike other members, instance constructors are not inherited, and a class has no instance constructors other than those actually declared in the class. If no instance constructor is supplied for a class, then an empty one with no parameters is automatically provided.
+Unlike other members, instance constructors aren't inherited, and a class has no instance constructors other than those constructors actually declared in the class. If no instance constructor is supplied for a class, then an empty one with no parameters is automatically provided.
 
 ### Properties
 
-*Properties* are a natural extension of fields. Both are named members with associated types, and the syntax for accessing fields and properties is the same. However, unlike fields, properties do not denote storage locations. Instead, properties have *accessors* that specify the statements to be executed when their values are read or written.
+*Properties* are a natural extension of fields. Both are named members with associated types, and the syntax for accessing fields and properties is the same. However, unlike fields, properties don't denote storage locations. Instead, properties have *accessors* that specify the statements to be executed when their values are read or written.
 
 A property is declared like a field, except that the declaration ends with a get accessor and/or a set accessor written between the delimiters `{` and `}` instead of ending in a semicolon. A property that has both a get accessor and a set accessor is a *read-write property*, a property that has only a get accessor is a *read-only property*, and a property that has only a set accessor is a *write-only property*.
 
@@ -241,7 +241,7 @@ A get accessor corresponds to a parameterless method with a return value of the 
 
 A set accessor corresponds to a method with a single parameter named value and no return type. When a property is referenced as the target of an assignment or as the operand of ++ or --, the set accessor is invoked with an argument that provides the new value.
 
-The `MyList<T>` class declares two properties, `Count` and `Capacity`, which are read-only and read-write, respectively. The following is an example of use of these properties:
+The `MyList<T>` class declares two properties, `Count` and `Capacity`, which are read-only and read-write, respectively. The following code is an example of use of these properties:
 
 [!code-csharp[ListExample2](~/samples/snippets/csharp/tour/classes-and-objects/ListBasedExamples.cs#L101-L104)]
 
@@ -263,7 +263,7 @@ Indexers can be overloaded, meaning that a class can declare multiple indexers a
 
 An *event* is a member that enables a class or object to provide notifications. An event is declared like a field except that the declaration includes an event keyword and the type must be a delegate type.
 
-Within a class that declares an event member, the event behaves just like a field of a delegate type (provided the event is not abstract and does not declare accessors). The field stores a reference to a delegate that represents the event handlers that have been added to the event. If no event handlers are present, the field is `null`.
+Within a class that declares an event member, the event behaves just like a field of a delegate type (provided the event isn't abstract and doesn't declare accessors). The field stores a reference to a delegate that represents the event handlers that have been added to the event. If no event handlers are present, the field is `null`.
 
 The `MyList<T>` class declares a single event member called `Changed`, which indicates that a new item has been added to the list. The Changed event is raised by the `OnChanged` virtual method, which first checks whether the event is `null` (meaning that no handlers are present). The notion of raising an event is precisely equivalent to invoking the delegate represented by the event—thus, there are no special language constructs for raising events.
 
@@ -271,7 +271,7 @@ Clients react to events through *event handlers*. Event handlers are attached us
 
 [!code-csharp[EventExample](~/samples/snippets/csharp/tour/classes-and-objects/ListBasedExamples.cs#L132-L148)]
 
-For advanced scenarios where control of the underlying storage of an event is desired, an event declaration can explicitly provide `add` and `remove` accessors, which are somewhat similar to the `set` accessor of a property.
+For advanced scenarios where control of the underlying storage of an event is desired, an event declaration can explicitly provide `add` and `remove` accessors, which are similar to the `set` accessor of a property.
 
 ### Operators
 
@@ -285,9 +285,9 @@ The first `Console.WriteLine` outputs `True` because the two lists contain the s
 
 ### Finalizers
 
-A *finalizer* is a member that implements the actions required to finalize an instance of a class. Finalizers cannot have parameters, they cannot have accessibility modifiers, and they cannot be invoked explicitly. The finalizer for an instance is invoked automatically during garbage collection.
+A *finalizer* is a member that implements the actions required to finalize an instance of a class. Finalizers can't have parameters, they can't have accessibility modifiers, and they can't be invoked explicitly. The finalizer for an instance is invoked automatically during garbage collection.
 
-The garbage collector is allowed wide latitude in deciding when to collect objects and run finalizers. Specifically, the timing of finalizer invocations is not deterministic, and finalizers may be executed on any thread. For these and other reasons, classes should implement finalizers only when no other solutions are feasible.
+The garbage collector is allowed wide latitude in deciding when to collect objects and run finalizers. Specifically, the timing of finalizer invocations isn't deterministic, and finalizers may be executed on any thread. For these and other reasons, classes should implement finalizers only when no other solutions are feasible.
 
 The `using` statement provides a better approach to object destruction.
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -50,7 +50,7 @@ The following list provides an overview of the kinds of members a class can cont
 
 ## Accessibility
 
-Each member of a class has an associated accessibility, which controls the regions of program text that can access the member. There are six possible forms of accessibility. These accessors are summarized below.
+Each member of a class has an associated accessibility, which controls the regions of program text that can access the member. There are six possible forms of accessibility. The access modifiers are summarized below.
 
 - `public`
   - Access isn't limited

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -53,17 +53,17 @@ The following list provides an overview of the kinds of members a class can cont
 Each member of a class has an associated accessibility, which controls the regions of program text that can access the member. There are six possible forms of accessibility. The access modifiers are summarized below.
 
 - `public`
-  - Access isn't limited
+  - Access isn't limited.
 - `protected`
-  - Access is limited to this class or classes derived from this class
+  - Access is limited to this class or classes derived from this class.
 - `internal`
-  - Access is limited to the current assembly (.exe, .dll, and so on.)
+  - Access is limited to the current assembly (.exe, .dll, and so on.).
 - `protected internal`
-  - Access is limited to the containing class, classes derived from the containing class, or classes within the same assembly
+  - Access is limited to the containing class, classes derived from the containing class, or classes within the same assembly.
 - `private`
-  - Access is limited to this class
+  - Access is limited to this class.
 - `private protected`
-  - Access is limited to the containing class or classes derived from the containing type within the same assembly
+  - Access is limited to the containing class or classes derived from the containing type within the same assembly.
 
 ## Type parameters
 

--- a/docs/csharp/tour-of-csharp/delegates.md
+++ b/docs/csharp/tour-of-csharp/delegates.md
@@ -1,13 +1,13 @@
 ---
 title: C# Delegates - A tour of the C# language
 description: Learn late binding with C# delegates
-ms.date: 08/10/2016
+ms.date: 02/27/2020
 ms.assetid: 3cc27357-3ac2-43a1-aad0-86a77b88f884
 ---
 
 # Delegates
 
-A ***delegate type*** represents references to methods with a particular parameter list and return type. Delegates make it possible to treat methods as entities that can be assigned to variables and passed as parameters. Delegates are similar to the concept of function pointers found in some other languages, but unlike function pointers, delegates are object-oriented and type-safe.
+A ***delegate type*** represents references to methods with a particular parameter list and return type. Delegates make it possible to treat methods as entities that can be assigned to variables and passed as parameters. Delegates are similar to the concept of function pointers found in some other languages. Unlike function pointers, delegates are object-oriented and type-safe.
 
 The following example declares and uses a delegate type named `Function`.
 
@@ -17,11 +17,11 @@ An instance of the `Function` delegate type can reference any method that takes 
 
 A delegate can reference either a static method (such as `Square` or `Math.Sin` in the previous example) or an instance method (such as `m.Multiply` in the previous example). A delegate that references an instance method also references a particular object, and when the instance method is invoked through the delegate, that object becomes `this` in the invocation.
 
-Delegates can also be created using anonymous functions, which are "inline methods" that are created on the fly. Anonymous functions can see the local variables of the surrounding methods. Thus, the multiplier example above can be written more easily without using a Multiplier class:
+Delegates can also be created using anonymous functions, which are "inline methods" that are created when declared. Anonymous functions can see the local variables of the surrounding methods. The following example doesn't create a class:
 
 [!code-csharp[LambdaExample](../../../samples/snippets/csharp/tour/delegates/Program.cs#L44-L44)]
 
-An interesting and useful property of a delegate is that it does not know or care about the class of the method it references; all that matters is that the referenced method has the same parameters and return type as the delegate.
+A delegate doesn't know or care about the class of the method it references; all that matters is that the referenced method has the same parameters and return type as the delegate.
 
 >[!div class="step-by-step"]
 >[Previous](interfaces.md)

--- a/docs/csharp/tour-of-csharp/expressions.md
+++ b/docs/csharp/tour-of-csharp/expressions.md
@@ -1,7 +1,7 @@
 ---
 title: C# Expressions - A tour of the C# language
 description: Expressions, operands, and operators are building blocks of the C# language
-ms.date: 04/25/2019
+ms.date: 02/27/2020
 ms.assetid: 20d5eb10-7381-47b9-ad90-f1cc895aa27e
 ---
 # Expressions

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -1,22 +1,24 @@
 ---
 title: A Tour of C# - C# Guide
 description: New to C#? Learn the basics of the language.
-ms.date: 04/05/2019
+ms.date: 02/26/2020
 ---
 
 # A tour of the C# language
 
-C# (pronounced "See Sharp") is a simple, modern, object-oriented, and type-safe programming language. C# has its roots in the C family of languages and will be immediately familiar to C, C++, Java, and JavaScript programmers.
+C# (pronounced "See Sharp") is a modern, object-oriented, and type-safe programming language. C# has its roots in the C family of languages and will be immediately familiar to C, C++, Java, and JavaScript programmers.
 
-This tour provides an overview of the major components of the language in C# 7 and later. If you want to explore the language through interactive examples, try the [introduction to C#](../tutorials/intro-to-csharp/index.md) tutorials.
+This tour provides an overview of the major components of the language in C# 8 and earlier. If you want to explore the language through interactive examples, try the [introduction to C#](../tutorials/intro-to-csharp/index.md) tutorials.
 
-C# is an object-oriented language, but C# further includes support for ***component-oriented*** programming. Contemporary software design increasingly relies on software components in the form of self-contained and self-describing packages of functionality. Key to such components is that they present a programming model with properties, methods, and events; they have attributes that provide declarative information about the component; and they incorporate their own documentation. C# provides language constructs to support directly these concepts, making C# a very natural language in which to create and use software components.
+C# is an object-oriented language, but C# further includes support for ***component-oriented*** programming. Contemporary software design increasingly relies on software components in the form of self-contained and self-describing packages of functionality. Key to such components is that they present a programming model with properties, methods, and events. They have attributes that provide declarative information about the component. They incorporate their own documentation. C# provides language constructs to support directly these concepts, making C# a natural language in which to create and use software components.
 
-Several C# features aid in the construction of robust and durable applications: ***Garbage collection*** automatically reclaims memory occupied by unreachable unused objects; ***exception handling*** provides a structured and extensible approach to error detection and recovery; and the ***type-safe*** design of the language makes it impossible to read from uninitialized variables, to index arrays beyond their bounds, or to perform unchecked type casts.
+Several C# features aid in the construction of robust and durable applications. ***Garbage collection*** automatically reclaims memory occupied by unreachable unused objects. ***Exception handling*** provides a structured and extensible approach to error detection and recovery. The ***type-safe*** design of the language makes it impossible to read from uninitialized variables, to index arrays beyond their bounds, or to perform unchecked type casts.
 
 C# has a ***unified type system***. All C# types, including primitive types such as `int` and `double`, inherit from a single root `object` type. Thus, all types share a set of common operations, and values of any type can be stored, transported, and operated upon in a consistent manner. Furthermore, C# supports both user-defined reference types and value types, allowing dynamic allocation of objects as well as in-line storage of lightweight structures.
 
-To ensure that C# programs and libraries can evolve over time in a compatible manner, much emphasis has been placed on ***versioning*** in C#'s design. Many programming languages pay little attention to this issue, and, as a result, programs written in those languages break more often than necessary when newer versions of dependent libraries are introduced. Aspects of C#'s design that were directly influenced by versioning considerations include the separate `virtual` and `override` modifiers, the rules for method overload resolution, and support for explicit interface member declarations.
+To ensure that C# programs and libraries can evolve over time in a compatible manner, much emphasis has been placed on ***versioning*** in C#'s design. Many programming languages pay little attention to this issue. As a result, programs written in those other languages break more often than necessary when newer versions of dependent libraries are introduced. Aspects of C#'s design that were directly influenced by versioning considerations include the separate `virtual` and `override` modifiers, the rules for method overload resolution, and support for explicit interface member declarations.
+
+In more recent versions, C# has embraced other programming paradigms. C# has included features that support functional programming techniques like lambda expressions. Other new features support separating data and algorithms, like pattern matching.
 
 ## Hello world
 
@@ -24,20 +26,18 @@ The "Hello, World" program is traditionally used to introduce a programming lang
 
 [!code-csharp[Hello World](~/samples/snippets/csharp/tour/hello/Program.cs)]
 
-C# source files typically have the file extension `.cs`. Assuming that the "Hello, World" program is stored in the file *hello.cs*, the program might be compiled using the command line:
+C# source files typically have the file extension `.cs`. To create this program, first download and install the [.NET Core SDK](https://dotnet.microsoft.com/download). Then, execute the command `dotnet new console -o hello` to create a new program, and a build script. The program and build script are in the files `Program.cs` and `hello.csproj`, respectively. You build and run the application with the `run` commands:
 
 ```console
-csc hello.cs
+cd hello
+dotnet run
 ```
 
-which produces an executable assembly named *hello.exe*. The output produced by this application when it is run is:
+That produces the following output: 
 
 ```console
-Hello, World
+Hello, World!
 ```
-
-> [!IMPORTANT]
-> The `csc` command compiles for the full framework, and may not be available on all platforms.
 
 The "Hello, World" program starts with a `using` directive that references the `System` namespace. Namespaces provide a hierarchical means of organizing C# programs and libraries. Namespaces contain types and other namespaces—for example, the `System` namespace contains a number of types, such as the `Console` class referenced in the program, and a number of other namespaces, such as `IO` and `Collections`. A `using` directive that references a given namespace enables unqualified use of the types that are members of that namespace. Because of the `using` directive, the program can use `Console.WriteLine` as shorthand for `System.Console.WriteLine`.
 
@@ -62,7 +62,7 @@ There's a lot more to learn about C#. The following topics provide an overview o
 - [Arrays](arrays.md)
   - An ***array*** is a data structure that contains a number of variables that are accessed through computed indices.
 - [Interfaces](interfaces.md)
-  - An ***interface*** defines a contract that can be implemented by classes and structs. An interface can contain methods, properties, events, and indexers. An interface does not provide implementations of the members it defines—it merely specifies the members that must be supplied by classes or structs that implement the interface.
+  - An ***interface*** defines a contract that can be implemented by classes and structs. An interface can contain methods, properties, events, and indexers. An interface doesn't provide implementations of the members it defines—it merely specifies the members that must be supplied by classes or structs that implement the interface.
 - [Delegates](delegates.md)
   - A ***delegate type*** represents references to methods with a particular parameter list and return type. Delegates make it possible to treat methods as entities that can be assigned to variables and passed as parameters. Delegates are similar to the concept of function pointers found in some other languages, but unlike function pointers, delegates are object-oriented and type-safe.
 - [Attributes](attributes.md)

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -26,14 +26,14 @@ The "Hello, World" program is traditionally used to introduce a programming lang
 
 [!code-csharp[Hello World](~/samples/snippets/csharp/tour/hello/Program.cs)]
 
-C# source files typically have the file extension `.cs`. To create this program, first download and install the [.NET Core SDK](https://dotnet.microsoft.com/download). Then, execute the command `dotnet new console -o hello` to create a new program, and a build script. The program and build script are in the files `Program.cs` and `hello.csproj`, respectively. You build and run the application with the `run` commands:
+C# source files typically have the file extension `.cs`. To create this program, first download and install the [.NET Core SDK](https://dotnet.microsoft.com/download). Then, execute the command `dotnet new console -o hello` to create a new program and a build script. The program and build script are in the files `Program.cs` and `hello.csproj`, respectively. You build and run the application with the `run` commands:
 
 ```console
 cd hello
 dotnet run
 ```
 
-That produces the following output: 
+The program produces the following output: 
 
 ```console
 Hello, World!

--- a/docs/csharp/tour-of-csharp/interfaces.md
+++ b/docs/csharp/tour-of-csharp/interfaces.md
@@ -1,13 +1,13 @@
 ---
 title: C# Interfaces - A tour of the C# language
 description: Interfaces define contracts implemented by types in C#
-ms.date: 08/10/2016
+ms.date: 02/27/2020
 ms.assetid: a9bf82f4-efd1-4216-bd34-4ef0fa48c968
 ---
 
 # Interfaces
 
-An ***interface*** defines a contract that can be implemented by classes and structs. An interface can contain methods, properties, events, and indexers. An interface does not provide implementations of the members it defines—it merely specifies the members that must be supplied by classes or structs that implement the interface.
+An ***interface*** defines a contract that can be implemented by classes and structs. An interface can contain methods, properties, events, and indexers. An interface doesn't provide implementations of the members it defines—it merely specifies the members that must be supplied by classes or structs that implement the interface.
 
 Interfaces may employ ***multiple inheritance***. In the following example, the interface `IComboBox` inherits from both `ITextBox` and `IListBox`.
 
@@ -21,7 +21,7 @@ When a class or struct implements a particular interface, instances of that clas
 
 [!code-csharp[InterfacesThree](../../../samples/snippets/csharp/tour/interfaces/Program.cs#L33-L35)]
 
-In cases where an instance is not statically known to implement a particular interface, dynamic type casts can be used. For example, the following statements use dynamic type casts to obtain an object’s `IControl` and `IDataBound` interface implementations. Because the run-time actual type of the object is `EditBox`, the casts succeed.
+In cases where an instance isn't statically known to implement a particular interface, dynamic type casts can be used. For example, the following statements use dynamic type casts to obtain an object’s `IControl` and `IDataBound` interface implementations. Because the run-time actual type of the object is `EditBox`, the casts succeed.
 
 [!code-csharp[InterfacesFour](../../../samples/snippets/csharp/tour/interfaces/Program.cs#L40-L42)]
 

--- a/docs/csharp/tour-of-csharp/program-structure.md
+++ b/docs/csharp/tour-of-csharp/program-structure.md
@@ -1,42 +1,47 @@
 ---
 title: C# Program Structure - A Tour of the C# Language
 description: Learn the basic building blocks of a C# program
-ms.date: 08/10/2016
+ms.date: 02/25/2020
 ms.assetid: 984f0314-507f-47a0-af56-9011243f5e65
 ---
 
 # Program Structure
 
-The key organizational concepts in C# are ***programs***, ***namespaces***, ***types***, ***members***, and ***assemblies***. C# programs consist of one or more source files. Programs declare types, which contain members and can be organized into namespaces. Classes and interfaces are examples of types. Fields, methods, properties, and events are examples of members. When C# programs are compiled, they are physically packaged into assemblies. Assemblies typically have the file extension `.exe` or `.dll`, depending on whether they implement ***applications*** or ***libraries***, respectively.
+The key organizational concepts in C# are ***programs***, ***namespaces***, ***types***, ***members***, and ***assemblies***. C# programs consist of one or more source files. Programs declare types, which contain members and can be organized into namespaces. Classes and interfaces are examples of types. Fields, methods, properties, and events are examples of members. When C# programs are compiled, they're physically packaged into assemblies. Assemblies typically have the file extension `.exe` or `.dll`, depending on whether they implement ***applications*** or ***libraries***, respectively.
 
-The example declares a class named `Stack` in a namespace called `Acme.Collections`:
+You can create a library project named *acme* using the `dotnet new` command:
+
+```console
+dotnet new classlib -o acme
+```
+
+In that project, declare a class named `Stack` in a namespace called `Acme.Collections`:
 
 [!code-csharp[Stack](../../../samples/snippets/csharp/tour/program-structure/program.cs#L1-L34)]
 
-The fully qualified name of this class is `Acme.Collections.Stack`. The class contains several members: a field named `top`, two methods named `Push` and `Pop`, and a nested class named `Entry`. The `Entry` class further contains three members: a field named `next`, a field named `data`, and a constructor. Assuming that the source code of the example is stored in the file `acme.cs`, the command line
+The fully qualified name of this class is `Acme.Collections.Stack`. The class contains several members: a field named `top`, two methods named `Push` and `Pop`, and a nested class named `Entry`. The `Entry` class further contains three members: a field named `next`, a field named `data`, and a constructor. The command:
 
 ```console
-csc /t:library acme.cs
+dotnet build 
 ```
 
 compiles the example as a library (code without a `Main` entry point) and produces an assembly named `acme.dll`.
 
-> [!IMPORTANT]
-> The examples above use `csc` as the command line C# compiler. This compiler is a Windows executable. To use C# across other platforms, you should use the tools for .NET Core. The .NET Core ecosystem uses the `dotnet` CLI to manage command line builds. This includes managing dependencies, and invoking the C# compiler. See [this tutorial](../../core/tutorials/cli-create-console-app.md) for a full description of those tools on the platforms supported by .NET Core.
+Assemblies contain executable code in the form of Intermediate Language (IL) instructions, and symbolic information in the form of metadata. Before it's executed, the Just-In-Time (JIT) compiler of .NET Common Language Runtime converts the IL code in an assembly to processor-specific code.
 
-Assemblies contain executable code in the form of Intermediate Language (IL) instructions, and symbolic information in the form of metadata. Before it is executed, the IL code in an assembly is automatically converted to processor-specific code by the Just-In-Time (JIT) compiler of .NET Common Language Runtime.
-
-Because an assembly is a self-describing unit of functionality containing both code and metadata, there is no need for `#include` directives and header files in C#. The public types and members contained in a particular assembly are made available in a C# program simply by referencing that assembly when compiling the program. For example, this program uses the `Acme.Collections.Stack` class from the `acme.dll` assembly:
+Because an assembly is a self-describing unit of functionality containing both code and metadata, there's no need for `#include` directives and header files in C#. The public types and members contained in a particular assembly are made available in a C# program simply by referencing that assembly when compiling the program. For example, this program uses the `Acme.Collections.Stack` class from the `acme.dll` assembly:
 
 [!code-csharp[UsingStack](../../../samples/snippets/csharp/tour/program-structure/Program.cs#L38-L52)]
 
-If the program is stored in the file `example.cs`, when `example.cs` is compiled, the acme.dll assembly can be referenced using the compiler’s /r option:
+The *csproj* file for the preceding program's project must include a reference node for the C# compiler to resolve references to the classes in the `acme.dll` assembly:
 
-```console
-csc /r:acme.dll example.cs
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\acme\acme.csproj" />
+  </ItemGroup>
 ```
 
-This creates an executable assembly named `example.exe`, which, when run, produces the output:
+After that addition, `dotnet build` creates an executable assembly named `example.exe`, which, when run, produces the output:
 
 ```console
 100
@@ -44,7 +49,7 @@ This creates an executable assembly named `example.exe`, which, when run, produc
 1
 ```
 
-C# permits the source text of a program to be stored in several source files. When a multi-file C# program is compiled, all of the source files are processed together, and the source files can freely reference each other—conceptually, it is as if all the source files were concatenated into one large file before being processed. Forward declarations are never needed in C# because, with very few exceptions, declaration order is insignificant. C# does not limit a source file to declaring only one public type nor does it require the name of the source file to match a type declared in the source file.
+C# permits the source text of a program to be stored in several source files. When a multi-file C# program is compiled, all of the source files are processed together, and the source files can freely reference each other—conceptually, it is as if all the source files were concatenated into one large file before being processed. Forward declarations are never needed in C# because, with few exceptions, declaration order is insignificant. C# does not limit a source file to declaring only one public type nor does it require the name of the source file to match a type declared in the source file.
 
 >[!div class="step-by-step"]
 >[Previous](index.md)

--- a/docs/csharp/tour-of-csharp/statements.md
+++ b/docs/csharp/tour-of-csharp/statements.md
@@ -1,7 +1,7 @@
 ---
 title: C# Statements - A tour of the C# language
 description: You create the actions of a C# program using statements
-ms.date: 11/06/2016
+ms.date: 02/27/202
 ms.assetid: 5409c379-5622-4fae-88b5-1654276ea8d4
 ---
 
@@ -15,11 +15,11 @@ A *block* permits multiple statements to be written in contexts where a single s
 
 *Expression statements* are used to evaluate expressions. Expressions that can be used as statements include method invocations, object allocations using the `new` operator, assignments using `=` and the compound assignment operators, increment and decrement operations using the `++` and `--` operators and `await` expressions.
 
-*Selection statements* are used to select one of a number of possible statements for execution based on the value of some expression. In this group are the `if` and `switch` statements.
+*Selection statements* are used to select one of a number of possible statements for execution based on the value of some expression. This group contains the `if` and `switch` statements.
 
-*Iteration statements* are used to execute repeatedly an embedded statement. In this group are the `while`, `do`, `for`, and `foreach` statements.
+*Iteration statements* are used to execute repeatedly an embedded statement. This group contains the `while`, `do`, `for`, and `foreach` statements.
 
-*Jump statements* are used to transfer control. In this group are the `break`, `continue`, `goto`, `throw`, `return`, and `yield` statements.
+*Jump statements* are used to transfer control. This group contains the `break`, `continue`, `goto`, `throw`, `return`, and `yield` statements.
 
 The `try`...`catch` statement is used to catch exceptions that occur during execution of a block, and the `try`...`finally` statement is used to specify finalization code that is always executed, whether an exception occurred or not.
 

--- a/docs/csharp/tour-of-csharp/types-and-variables.md
+++ b/docs/csharp/tour-of-csharp/types-and-variables.md
@@ -1,17 +1,17 @@
 ---
 title: C# Types and Variables - A tour of the C# language
 description: Learn about defining types and declaring variables in C#
-ms.date: 08/10/2016
+ms.date: 02/25/202
 ms.assetid: f8a8051e-0049-43f1-b594-9c84cc7b1224
 ---
 
 # Types and variables
 
-There are two kinds of types in C#: *value types* and *reference types*. Variables of value types directly contain their data whereas variables of reference types store references to their data, the latter being known as objects. With reference types, it is possible for two variables to reference the same object and thus possible for operations on one variable to affect the object referenced by the other variable. With value types, the variables each have their own copy of the data, and it is not possible for operations on one to affect the other (except in the case of `ref` and `out` parameter variables).
+There are two kinds of types in C#: *value types* and *reference types*. Variables of value types directly contain their data whereas variables of reference types store references to their data, the latter being known as objects. With reference types, it's possible for two variables to reference the same object and thus possible for operations on one variable to affect the object referenced by the other variable. With value types, the variables each have their own copy of the data, and it isn't possible for operations on one to affect the other (except for `ref` and `out` parameter variables).
 
 C#’s value types are further divided into *simple types*, *enum types*, *struct types*, and *nullable value types*. C#’s reference types are further divided into *class types*, *interface types*, *array types*, and *delegate types*.
 
-The following provides an overview of C#’s type system.
+The following outline provides an overview of C#’s type system.
 
 - [Value types][ValueTypes]
   - [Simple types][SimpleTypes]
@@ -60,19 +60,19 @@ C# programs use *type declarations* to create new types. A type declaration spec
 
 A `class` type defines a data structure that contains data members (fields) and function members (methods, properties, and others). Class types support single inheritance and polymorphism, mechanisms whereby derived classes can extend and specialize base classes.
 
-A `struct` type is similar to a class type in that it represents a structure with data members and function members. However, unlike classes, structs are value types and do not typically require heap allocation. Struct types do not support user-specified inheritance, and all struct types implicitly inherit from type `object`.
+A `struct` type is similar to a class type in that it represents a structure with data members and function members. However, unlike classes, structs are value types and don't typically require heap allocation. Struct types don't support user-specified inheritance, and all struct types implicitly inherit from type `object`.
 
 An `interface` type defines a contract as a named set of public function members. A `class` or `struct` that implements an `interface` must provide implementations of the interface’s function members. An `interface` may inherit from multiple base interfaces, and a `class` or `struct` may implement multiple interfaces.
 
-A `delegate` type represents references to methods with a particular parameter list and return type. Delegates make it possible to treat methods as entities that can be assigned to variables and passed as parameters. Delegates are analogous to function types provided by functional languages. They are also similar to the concept of function pointers found in some other languages, but unlike function pointers, delegates are object-oriented and type-safe.
+A `delegate` type represents references to methods with a particular parameter list and return type. Delegates make it possible to treat methods as entities that can be assigned to variables and passed as parameters. Delegates are analogous to function types provided by functional languages. They're also similar to the concept of function pointers found in some other languages. Unlike function pointers, delegates are object-oriented and type-safe.
 
-The `class`, `struct`, `interface` and `delegate` types all support generics, whereby they can be parameterized with other types.
+The `class`, `struct`, `interface`, and `delegate` types all support generics, whereby they can be parameterized with other types.
 
 An `enum` type is a distinct type with named constants. Every `enum` type has an underlying type, which must be one of the eight integral types. The set of values of an `enum` type is the same as the set of values of the underlying type.
 
-C# supports single- and multi-dimensional arrays of any type. Unlike the types listed above, array types do not have to be declared before they can be used. Instead, array types are constructed by following a type name with square brackets. For example, `int[]` is a single-dimensional array of `int`, `int[,]` is a two-dimensional array of `int`, and `int[][]` is a single-dimensional array of single-dimensional array of `int`.
+C# supports single- and multi-dimensional arrays of any type. Unlike the types listed above, array types don't have to be declared before they can be used. Instead, array types are constructed by following a type name with square brackets. For example, `int[]` is a single-dimensional array of `int`, `int[,]` is a two-dimensional array of `int`, and `int[][]` is a single-dimensional array of single-dimensional array of `int`.
 
-Nullable value types also do not have to be declared before they can be used. For each non-nullable value type `T` there is a corresponding nullable value type `T?`, which can hold an additional value, `null`. For instance, `int?` is a type that can hold any 32-bit integer or the value `null`.
+Nullable value types also don't have to be declared before they can be used. For each non-nullable value type `T`, there is a corresponding nullable value type `T?`, which can hold an additional value, `null`. For instance, `int?` is a type that can hold any 32-bit integer or the value `null`.
 
 C#’s type system is unified such that a value of any type can be treated as an `object`. Every type in C# directly or indirectly derives from the `object` class type, and `object` is the ultimate base class of all types. Values of reference types are treated as objects simply by viewing the values as type `object`. Values of value types are treated as objects by performing *boxing* and *unboxing operations*. In the following example, an `int` value is converted to `object` and back again to `int`.
 


### PR DESCRIPTION
Fixes #6196 

The introductory demos in the "Tour of C#" used `csc`, instead of `dotnet build` and other `dotnet` commands.

This PR updates those examples to use the `dotnet new`, `dotnet build` and `dotnet `run` commands. 

In addition, while reviewing the tour, I ran Acrolinx on all files in this section. 