### PR TITLE
[dotnet/api] replace outdated Xamarin links with Xamarin.Forms

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -3,8 +3,8 @@ layout: ApiBrowserPage
 hide_bc: true
 title: .NET API browser
 quickFilterColumn1: netcore-3.1,netframework-4.8,netstandard-2.1,aspnetcore-3.1
-quickFilterColumn2: xamarinios-10.8,xamarinandroid-7.1,xamarinmac-3.0,efcore-3.1
-quickFilterColumn3: azure-dotnet,roslyn-dotnet,ml-dotnet,spark-dotnet
+quickFilterColumn2: xamarin-forms,efcore-3.1,roslyn-dotnet
+quickFilterColumn3: azure-dotnet,ml-dotnet,spark-dotnet
 ms.topic: landing-page
 ms.custom: "updateeachrelease"
 ms.date: "01/24/2020"


### PR DESCRIPTION
The Xamarin.iOS, Xamarin.Android, and Xamarin.Mac BCL links are confusing customers expecting to find the native platform SDK APIs. Replacing with Xamarin.Forms which is currently missing, and what most customers would be looking for anyway.

Attempted to keep the columns balanced - not sure if there should be any specific ordering?