### PR TITLE
Make var usage consistent with other docs

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
+++ b/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
@@ -82,7 +82,7 @@ The `var` keyword can also be useful when the specific type of the variable is t
 
 [!code-csharp[cscsrefQueryKeywords#13](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Group.cs#13)]
 
-However, the use of `var` does have at least the potential to make your code more difficult to understand for other developers. For that reason, the C# documentation generally uses `var` only when it is required.
+The use of `var` helps simplify your code, but its use should be restricted to cases where it is required, or when it makes your code easier to read. See the C# Coding Guidelines' section on [Implicitly typed local variables](../inside-a-program/coding-conventions.md#user-content-implicitly-typed-local-variables) for more details on when to use `var` properly.
 
 ## See also
 


### PR DESCRIPTION
Edited paragraph on use of var to correspond with Coding Guidelines.

## Summary

The coding guidelines suggest the use of `var` in certain circumstances -- e.g. when the type is obvious on the right side, in for loops, and other cases. However, this document says it should only be used when its use is strictly required. This is a contradiction, so I'm clarifying the use cases here.
