### PR TITLE
Change proj name in tutorial to microsoft-botsay

### DIFF
--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -26,24 +26,18 @@ This is the first in a series of three tutorials. In this tutorial, you create a
 
 1. Open a command prompt and create a folder named *repository*.
 
-1. Navigate to the *repository* folder and enter the following command, replacing `<name>` with a unique value to make the project name unique.
+1. Navigate to the *repository* folder and enter the following command:
 
    ```dotnetcli
-   dotnet new console -n botsay-<name>
+   dotnet new console -n microsoft-botsay
    ```
 
-   For example, you could run the following command:
+   The command creates a new folder named *microsoft-botsay* under the *repository* folder.
 
-   ```dotnetcli
-   dotnet new console -n botsay-nancydavolio
-   ```
-
-   The command creates a new folder named *botsay-\<name>* under the *repository* folder.
-
-1. Navigate to the *botsay-\<name>* folder.
+1. Navigate to the *microsoft-botsay* folder.
 
    ```console
-   cd botsay-<name>
+   cd microsoft-botsay
    ```
 
 ## Add the code
@@ -148,7 +142,7 @@ All arguments after the `--` delimiter are passed to your application.
 
 Before you can pack and distribute the application as a tool, you need to modify the project file.
 
-1. Open the *botsay-\<name>.csproj* file and add three new XML nodes to the end of the `<PropertyGroup>` node:
+1. Open the *microsoft-botsay.csproj* file and add three new XML nodes to the end of the `<PropertyGroup>` node:
 
    ```xml
    <PackAsTool>true</PackAsTool>
@@ -185,7 +179,7 @@ Before you can pack and distribute the application as a tool, you need to modify
    dotnet pack
    ```
 
-   The *botsay-\<name>.1.0.0.nupkg* file is created in the folder identified by the `<PackageOutputPath>` value from the *botsay-\<name>.csproj* file, which in this example is the *./nupkg* folder.
+   The *microsoft-botsay.1.0.0.nupkg* file is created in the folder identified by the `<PackageOutputPath>` value from the *microsoft-botsay.csproj* file, which in this example is the *./nupkg* folder.
   
    When you want to release a tool publicly, you can upload it to `https://www.nuget.org`. Once the tool is available on NuGet, developers can install the tool by using the [dotnet tool install](dotnet-tool-install.md) command. For this tutorial you install the package directly from the local *nupkg* folder, so there's no need to upload the package to NuGet.
 

--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -29,15 +29,15 @@ This is the first in a series of three tutorials. In this tutorial, you create a
 1. Navigate to the *repository* folder and enter the following command:
 
    ```dotnetcli
-   dotnet new console -n microsoft-botsay
+   dotnet new console -n microsoft.botsay
    ```
 
-   The command creates a new folder named *microsoft-botsay* under the *repository* folder.
+   The command creates a new folder named *microsoft.botsay* under the *repository* folder.
 
-1. Navigate to the *microsoft-botsay* folder.
+1. Navigate to the *microsoft.botsay* folder.
 
    ```console
-   cd microsoft-botsay
+   cd microsoft.botsay
    ```
 
 ## Add the code
@@ -142,7 +142,7 @@ All arguments after the `--` delimiter are passed to your application.
 
 Before you can pack and distribute the application as a tool, you need to modify the project file.
 
-1. Open the *microsoft-botsay.csproj* file and add three new XML nodes to the end of the `<PropertyGroup>` node:
+1. Open the *microsoft.botsay.csproj* file and add three new XML nodes to the end of the `<PropertyGroup>` node:
 
    ```xml
    <PackAsTool>true</PackAsTool>
@@ -179,7 +179,7 @@ Before you can pack and distribute the application as a tool, you need to modify
    dotnet pack
    ```
 
-   The *microsoft-botsay.1.0.0.nupkg* file is created in the folder identified by the `<PackageOutputPath>` value from the *microsoft-botsay.csproj* file, which in this example is the *./nupkg* folder.
+   The *microsoft.botsay.1.0.0.nupkg* file is created in the folder identified by the `<PackageOutputPath>` value from the *microsoft.botsay.csproj* file, which in this example is the *./nupkg* folder.
   
    When you want to release a tool publicly, you can upload it to `https://www.nuget.org`. Once the tool is available on NuGet, developers can install the tool by using the [dotnet tool install](dotnet-tool-install.md) command. For this tutorial you install the package directly from the local *nupkg* folder, so there's no need to upload the package to NuGet.
 

--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -92,7 +92,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    On Windows:
 
    ```dotnetcli
-   dotnet tool uninstall --tool-path c:\dotnet-tools botsay --add-source ./nupkg microsoft-botsay
+   dotnet tool uninstall --tool-path c:\dotnet-tools microsoft-botsay
    ```
 
    On Linux or macOS:

--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -16,10 +16,10 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
 ## Use the tool as a global tool
 
-1. Install the tool from the package by running the [dotnet tool install](dotnet-tool-install.md) command in the *botsay-\<name>* project folder:
+1. Install the tool from the package by running the [dotnet tool install](dotnet-tool-install.md) command in the *microsoft-botsay* project folder:
 
    ```dotnetcli
-   dotnet tool install --global --add-source ./nupkg botsay-<name>
+   dotnet tool install --global --add-source ./nupkg microsoft-botsay
    ```
 
    The `--global` parameter tells the .NET Core CLI to install the tool binaries in a default location that is automatically added to the PATH environment variable.
@@ -30,7 +30,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
    ```console
    You can invoke the tool using the following command: botsay
-   Tool 'botsay-<name>' (version '1.0.0') was successfully installed.
+   Tool 'microsoft-botsay' (version '1.0.0') was successfully installed.
    ```
 
 1. Invoke the tool:
@@ -45,7 +45,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 1. Remove the tool by running the [dotnet tool uninstall](dotnet-tool-uninstall.md) command:
 
    ```dotnetcli
-   dotnet tool uninstall -g botsay-<name>
+   dotnet tool uninstall -g microsoft-botsay
    ```
 
 ## Use the tool as a global tool installed in a custom location
@@ -55,13 +55,13 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    On Windows:
 
    ```dotnetcli
-   dotnet tool install --tool-path c:\dotnet-tools --add-source ./nupkg botsay-<name>
+   dotnet tool install --tool-path c:\dotnet-tools --add-source ./nupkg microsoft-botsay
    ```
 
    On Linux or macOS:
 
    ```dotnetcli
-   dotnet tool install --tool-path ~/bin --add-source ./nupkg botsay-<name>
+   dotnet tool install --tool-path ~/bin --add-source ./nupkg microsoft-botsay
    ```
 
    The `--tool-path` parameter tells the .NET Core CLI to install the tool binaries in the specified location. If the directory doesn't exist, it is created. This directory is not automatically added to the PATH environment variable.
@@ -70,7 +70,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
    ```console
    You can invoke the tool using the following command: botsay
-   Tool 'botsay-<name>' (version '1.0.0') was successfully installed.
+   Tool 'microsoft-botsay' (version '1.0.0') was successfully installed.
    ```
 
 1. Invoke the tool:
@@ -92,13 +92,13 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    On Windows:
 
    ```dotnetcli
-   dotnet tool uninstall --tool-path c:\dotnet-tools botsay --add-source ./nupkg botsay-<name>
+   dotnet tool uninstall --tool-path c:\dotnet-tools botsay --add-source ./nupkg microsoft-botsay
    ```
 
    On Linux or macOS:
 
    ```dotnetcli
-   dotnet tool uninstall --tool-path ~/bin botsay-<name>
+   dotnet tool uninstall --tool-path ~/bin microsoft-botsay
    ```
 
 ## Troubleshoot

--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -16,10 +16,10 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
 ## Use the tool as a global tool
 
-1. Install the tool from the package by running the [dotnet tool install](dotnet-tool-install.md) command in the *microsoft-botsay* project folder:
+1. Install the tool from the package by running the [dotnet tool install](dotnet-tool-install.md) command in the *microsoft.botsay* project folder:
 
    ```dotnetcli
-   dotnet tool install --global --add-source ./nupkg microsoft-botsay
+   dotnet tool install --global --add-source ./nupkg microsoft.botsay
    ```
 
    The `--global` parameter tells the .NET Core CLI to install the tool binaries in a default location that is automatically added to the PATH environment variable.
@@ -30,7 +30,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
    ```console
    You can invoke the tool using the following command: botsay
-   Tool 'microsoft-botsay' (version '1.0.0') was successfully installed.
+   Tool 'microsoft.botsay' (version '1.0.0') was successfully installed.
    ```
 
 1. Invoke the tool:
@@ -45,7 +45,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 1. Remove the tool by running the [dotnet tool uninstall](dotnet-tool-uninstall.md) command:
 
    ```dotnetcli
-   dotnet tool uninstall -g microsoft-botsay
+   dotnet tool uninstall -g microsoft.botsay
    ```
 
 ## Use the tool as a global tool installed in a custom location
@@ -55,13 +55,13 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    On Windows:
 
    ```dotnetcli
-   dotnet tool install --tool-path c:\dotnet-tools --add-source ./nupkg microsoft-botsay
+   dotnet tool install --tool-path c:\dotnet-tools --add-source ./nupkg microsoft.botsay
    ```
 
    On Linux or macOS:
 
    ```dotnetcli
-   dotnet tool install --tool-path ~/bin --add-source ./nupkg microsoft-botsay
+   dotnet tool install --tool-path ~/bin --add-source ./nupkg microsoft.botsay
    ```
 
    The `--tool-path` parameter tells the .NET Core CLI to install the tool binaries in the specified location. If the directory doesn't exist, it is created. This directory is not automatically added to the PATH environment variable.
@@ -70,7 +70,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
    ```console
    You can invoke the tool using the following command: botsay
-   Tool 'microsoft-botsay' (version '1.0.0') was successfully installed.
+   Tool 'microsoft.botsay' (version '1.0.0') was successfully installed.
    ```
 
 1. Invoke the tool:
@@ -92,13 +92,13 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    On Windows:
 
    ```dotnetcli
-   dotnet tool uninstall --tool-path c:\dotnet-tools microsoft-botsay
+   dotnet tool uninstall --tool-path c:\dotnet-tools microsoft.botsay
    ```
 
    On Linux or macOS:
 
    ```dotnetcli
-   dotnet tool uninstall --tool-path ~/bin microsoft-botsay
+   dotnet tool uninstall --tool-path ~/bin microsoft.botsay
    ```
 
 ## Troubleshoot

--- a/docs/core/tools/local-tools-how-to-use.md
+++ b/docs/core/tools/local-tools-how-to-use.md
@@ -152,9 +152,9 @@ You typically install a local tool in the root directory of the repository. Afte
 
    ```console
    Package Id      Version      Commands       Manifest
-   -------------------------------------------------------------------------------------------
-   microsoft-botsay   1.0.0        botsay         /home/name/repository/.config/dotnet-tools.json
-   dotnetsay       2.1.3        dotnetsay      /home/name/repository/.config/dotnet-tools.json
+   --------------------------------------------------------------------------------------------
+   microsoft-botsay 1.0.0        botsay         /home/name/repository/.config/dotnet-tools.json
+   dotnetsay        2.1.3        dotnetsay      /home/name/repository/.config/dotnet-tools.json
    ```
 
 1. Test the tools:

--- a/docs/core/tools/local-tools-how-to-use.md
+++ b/docs/core/tools/local-tools-how-to-use.md
@@ -21,7 +21,7 @@ This tutorial teaches you how to install and use a local tool. You use a tool th
 
 To install a tool for local access only (for the current directory and subdirectories), it has to be added to a manifest file.
 
-From the *microsoft-botsay* folder, navigate up one level to the *repository* folder:
+From the *microsoft.botsay* folder, navigate up one level to the *repository* folder:
 
 ```console
 cd ..
@@ -58,7 +58,7 @@ When you use a CLI command that refers to a local tool, the SDK searches for a m
 Install the tool from the package that you created in the first tutorial:
 
 ```dotnetcli
-dotnet tool install --add-source ./microsoft-botsay/nupkg microsoft-botsay
+dotnet tool install --add-source ./microsoft.botsay/nupkg microsoft.botsay
 ```
 
 This command adds the tool to the manifest file that you created in the preceding step. The command output shows which manifest file the newly installed tool is in:
@@ -66,7 +66,7 @@ This command adds the tool to the manifest file that you created in the precedin
  ```console
  You can invoke the tool from this directory using the following command:
  'dotnet tool run botsay' or 'dotnet botsay'
- Tool 'microsoft-botsay' (version '1.0.0') was successfully installed.
+ Tool 'microsoft.botsay' (version '1.0.0') was successfully installed.
  Entry is added to the manifest file /home/name/repository/.config/dotnet-tools.json
  ```
 
@@ -77,7 +77,7 @@ The *.config/dotnet-tools.json* file now has one tool:
   "version": 1,
   "isRoot": true,
   "tools": {
-    "microsoft-botsay": {
+    "microsoft.botsay": {
       "version": "1.0.0",
       "commands": [
         "botsay"
@@ -106,7 +106,7 @@ You typically install a local tool in the root directory of the repository. Afte
      "version": 1,
      "isRoot": true,
      "tools": {
-       "microsoft-botsay": {
+       "microsoft.botsay": {
          "version": "1.0.0",
          "commands": [
            "botsay"
@@ -137,7 +137,7 @@ You typically install a local tool in the root directory of the repository. Afte
    The command produces output like the following example:
 
    ```console
-   Tool 'microsoft-botsay' (version '1.0.0') was restored. Available commands: botsay
+   Tool 'microsoft.botsay' (version '1.0.0') was restored. Available commands: botsay
    Tool 'dotnetsay' (version '2.1.3') was restored. Available commands: dotnetsay
    Restore was successful.
    ```
@@ -153,7 +153,7 @@ You typically install a local tool in the root directory of the repository. Afte
    ```console
    Package Id      Version      Commands       Manifest
    --------------------------------------------------------------------------------------------
-   microsoft-botsay 1.0.0        botsay         /home/name/repository/.config/dotnet-tools.json
+   microsoft.botsay 1.0.0        botsay         /home/name/repository/.config/dotnet-tools.json
    dotnetsay        2.1.3        dotnetsay      /home/name/repository/.config/dotnet-tools.json
    ```
 
@@ -186,7 +186,7 @@ The update command finds the first manifest file that contains the package ID an
 Remove the installed tools by running the [dotnet tool uninstall](dotnet-tool-uninstall.md) command:
 
 ```dotnetcli
-dotnet tool uninstall microsoft-botsay
+dotnet tool uninstall microsoft.botsay
 ```
 
 ```dotnetcli

--- a/docs/core/tools/local-tools-how-to-use.md
+++ b/docs/core/tools/local-tools-how-to-use.md
@@ -21,7 +21,7 @@ This tutorial teaches you how to install and use a local tool. You use a tool th
 
 To install a tool for local access only (for the current directory and subdirectories), it has to be added to a manifest file.
 
-From the *botsay-\<name>* folder, navigate up one level to the *repository* folder:
+From the *microsoft-botsay* folder, navigate up one level to the *repository* folder:
 
 ```console
 cd ..
@@ -58,7 +58,7 @@ When you use a CLI command that refers to a local tool, the SDK searches for a m
 Install the tool from the package that you created in the first tutorial:
 
 ```dotnetcli
-dotnet tool install --add-source ./botsay-<name>/nupkg botsay-<name>
+dotnet tool install --add-source ./microsoft-botsay/nupkg microsoft-botsay
 ```
 
 This command adds the tool to the manifest file that you created in the preceding step. The command output shows which manifest file the newly installed tool is in:
@@ -66,7 +66,7 @@ This command adds the tool to the manifest file that you created in the precedin
  ```console
  You can invoke the tool from this directory using the following command:
  'dotnet tool run botsay' or 'dotnet botsay'
- Tool 'botsay-<name>' (version '1.0.0') was successfully installed.
+ Tool 'microsoft-botsay' (version '1.0.0') was successfully installed.
  Entry is added to the manifest file /home/name/repository/.config/dotnet-tools.json
  ```
 
@@ -77,7 +77,7 @@ The *.config/dotnet-tools.json* file now has one tool:
   "version": 1,
   "isRoot": true,
   "tools": {
-    "botsay-<name>": {
+    "microsoft-botsay": {
       "version": "1.0.0",
       "commands": [
         "botsay"
@@ -106,7 +106,7 @@ You typically install a local tool in the root directory of the repository. Afte
      "version": 1,
      "isRoot": true,
      "tools": {
-       "botsay-<name>": {
+       "microsoft-botsay": {
          "version": "1.0.0",
          "commands": [
            "botsay"
@@ -137,7 +137,7 @@ You typically install a local tool in the root directory of the repository. Afte
    The command produces output like the following example:
 
    ```console
-   Tool 'botsay-<name>' (version '1.0.0') was restored. Available commands: botsay
+   Tool 'microsoft-botsay' (version '1.0.0') was restored. Available commands: botsay
    Tool 'dotnetsay' (version '2.1.3') was restored. Available commands: dotnetsay
    Restore was successful.
    ```
@@ -153,7 +153,7 @@ You typically install a local tool in the root directory of the repository. Afte
    ```console
    Package Id      Version      Commands       Manifest
    -------------------------------------------------------------------------------------------
-   botsay-<name>   1.0.0        botsay         /home/name/repository/.config/dotnet-tools.json
+   microsoft-botsay   1.0.0        botsay         /home/name/repository/.config/dotnet-tools.json
    dotnetsay       2.1.3        dotnetsay      /home/name/repository/.config/dotnet-tools.json
    ```
 
@@ -186,7 +186,7 @@ The update command finds the first manifest file that contains the package ID an
 Remove the installed tools by running the [dotnet tool uninstall](dotnet-tool-uninstall.md) command:
 
 ```dotnetcli
-dotnet tool uninstall botsay-<name>
+dotnet tool uninstall microsoft-botsay
 ```
 
 ```dotnetcli


### PR DESCRIPTION
Per suggestion from @Thraka , prevents uploading to NuGet without requiring user to come up with a unique name.

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create?branch=pr-en-us-17252)