### PR TITLE
Fix terminated I/O thread "raised when" field

### DIFF
--- a/docs/framework/performance/thread-pool-etw-events.md
+++ b/docs/framework/performance/thread-pool-etw-events.md
@@ -193,7 +193,7 @@ These events collect information about worker and I/O threads.
   
 |Event|Event ID|Raised when|  
 |-----------|--------------|-----------------|  
-|`IOThreadTerminate`|45|An I/O thread is created in the thread pool.|  
+|`IOThreadTerminate`|45|An I/O thread is terminated in the thread pool.|  
   
  The following table shows the event data.  
   


### PR DESCRIPTION
Perhaps a copy/paste mistake

## Summary

A minimum mistake
