### PR TITLE
Update rhel8 documentation

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -167,6 +167,10 @@
       "ms.custom": "updateeachrelease"
     },
     {
+      "source_path": "docs/core/install/linux-package-manager-rhel81.md",
+      "redirect_url": "/dotnet/core/install/linux-package-manager-rhel8"
+    },
+    {
       "source_path": "docs/core/migrating-from-dnx.md",
       "redirect_url": "/dotnet/core/migration/from-dnx",
       "redirect_document_id": true

--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -12,7 +12,7 @@
 > - [Fedora 30 - x64](../linux-package-manager-fedora30.md)
 > - [Fedora 29 - x64](../linux-package-manager-fedora29.md)
 > - [OpenSUSE 15 - x64](../linux-package-manager-opensuse15.md)
-> - [RHEL 8.1 - x64](../linux-package-manager-rhel81.md)
+> - [RHEL 8 - x64](../linux-package-manager-rhel8.md)
 > - [RHEL 7 - x64](../linux-package-manager-rhel7.md)
 > - [SLES 15 - x64](../linux-package-manager-sles15.md)
 > - [SLES 12 - x64](../linux-package-manager-sles12.md)

--- a/docs/core/install/linux-package-manager-rhel8.md
+++ b/docs/core/install/linux-package-manager-rhel8.md
@@ -1,19 +1,16 @@
 ---
-title: Install .NET Core on Linux RHEL 8.1 package manager - .NET Core
-description: Use a package manager to install .NET Core SDK and runtime on RHEL 8.1.
+title: Install .NET Core on Linux RHEL 8 package manager - .NET Core
+description: Use a package manager to install .NET Core SDK and runtime on RHEL 8.
 author: thraka
 ms.author: adegeo
 ms.date: 12/03/2019
 ---
 
-# RHEL 8.1 Package Manager - Install .NET Core
+# RHEL 8 Package Manager - Install .NET Core
 
 [!INCLUDE [package-manager-switcher](includes/package-manager-switcher.md)]
 
-This article describes how to use a package manager to install .NET Core on RHEL 8.1. .NET Core 3.1 is not yet available for RHEL 8.1.
-
-> [!NOTE]
-> RHEL 8.0 does not include .NET Core 3.0. Use the command `yum upgrade` to update to RHEL 8.1.
+This article describes how to use a package manager to install .NET Core on RHEL 8.
 
 ## Register your Red Hat subscription
 
@@ -24,8 +21,8 @@ To install .NET Core from Red Hat on RHEL, you first need to register using the 
 After registering with the Subscription Manager, you're ready to install and enable the .NET Core SDK. In your terminal, run the following commands.
 
 ```bash
-dnf install dotnet-sdk-3.0
-scl enable dotnet-sdk-3.0 bash
+sudo dnf update
+sudo dnf install dotnet-sdk-3.1
 ```
 
 ## Install the ASP.NET Core Runtime
@@ -33,8 +30,8 @@ scl enable dotnet-sdk-3.0 bash
 After registering with the Subscription Manager, you're ready to install and enable the ASP.NET Core Runtime. In your terminal, run the following commands.
 
 ```bash
-dnf install aspnetcore-runtime-3.0
-scl enable aspnetcore-runtime-3.0 bash
+sudo dnf update
+sudo dnf install aspnetcore-runtime-3.1
 ```
 
 ## Install the .NET Core Runtime
@@ -42,10 +39,10 @@ scl enable aspnetcore-runtime-3.0 bash
 After registering with the Subscription Manager, you're ready to install and enable the .NET Core Runtime. In your terminal, run the following commands.
 
 ```bash
-sudo dnf install dotnet-runtime-3.0
-scl enable dotnet-runtime-3.0 bash
+sudo dnf update
+sudo dnf install dotnet-runtime-3.1
 ```
 
 ## See also
 
-- [Using .NET Core 3.0 on Red Hat Enterprise Linux 8](https://access.redhat.com/documentation/en-us/net_core/3.0/html/getting_started_guide_for_rhel_8/gs_install_dotnet)
+- [Using .NET Core 3.1 on Red Hat Enterprise Linux 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/developing_.net_applications_in_rhel_8/index)

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -40,8 +40,8 @@
       href: install/linux-package-manager-fedora29.md
     - name: OpenSUSE 15
       href: install/linux-package-manager-opensuse15.md
-    - name: RHEL 8.1
-      href: install/linux-package-manager-rhel81.md
+    - name: RHEL 8
+      href: install/linux-package-manager-rhel8.md
     - name: RHEL 7
       href: install/linux-package-manager-rhel7.md
     - name: SLES 15

--- a/docs/whats-new/2019-11.md
+++ b/docs/whats-new/2019-11.md
@@ -24,7 +24,7 @@ Welcome to what's new in .NET docs for November 2019. This article lists some of
 - [Fedora 30 Package Manager - Install .NET Core](../core/install/linux-package-manager-fedora30.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
 - [openSUSE 15 Package Manager - Install .NET Core](../core/install/linux-package-manager-opensuse15.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
 - [RHEL 7 Package Manager - Install .NET Core](../core/install/linux-package-manager-rhel7.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
-- [RHEL 8.1 Package Manager - Install .NET Core](../core/install/linux-package-manager-rhel81.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
+- [RHEL 8 Package Manager - Install .NET Core](../core/install/linux-package-manager-rhel8.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
 - [SLES 12 Package Manager - Install .NET Core](../core/install/linux-package-manager-sles12.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
 - [SLES 15 Package Manager - Install .NET Core](../core/install/linux-package-manager-sles15.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers
 - [Ubuntu 16.04 Package Manager - Install .NET Core](../core/install/linux-package-manager-ubuntu-1604.md) - Design new .NET Core Setup/Install area; Rewrite prereqs articles; Add package managers


### PR DESCRIPTION
## Summary

RHEL8 documentation shouldn't include a minor.
Remove .NET Core 3.0 (EOL March 3), update to 3.1 which is available on RHEL8.

@omajid ptal