### PR TITLE
Update links to other xaml sections

### DIFF
--- a/docs/desktop-wpf/fundamentals/xaml.md
+++ b/docs/desktop-wpf/fundamentals/xaml.md
@@ -41,7 +41,7 @@ The following example shows how you might create a button as part of a UI. This 
 
 ## XAML syntax in brief
 
-The following sections explain the basic forms of XAML syntax, and give a short markup example. These sections are not intended to provide complete information about each syntax form, such as how these are represented in the backing type system. <!--TODO For more information about the specifics of XAML syntax for each of the syntax forms introduced in this article, see [XAML Syntax In Detail](xaml-syntax-in-detail.md).-->
+The following sections explain the basic forms of XAML syntax, and give a short markup example. These sections are not intended to provide complete information about each syntax form, such as how these are represented in the backing type system. For more information about the specifics of XAML syntax, see [XAML Syntax In Detail](../../framework/wpf/advanced/xaml-syntax-in-detail.md).
 
 Much of the material in the next few sections will be elementary to you if you have previous familiarity with the XML language. This is a consequence of one of the basic design principles of XAML. The XAML language defines concepts of its own, but these concepts work within the XML language and markup form.
 
@@ -115,7 +115,7 @@ As a rule of the XAML language, the value of a XAML content property must be giv
   blue button</Button>
 ```
 
-<!-- TODO For more information about this restriction on XAML content properties, see the "XAML Content Properties" section of [XAML Syntax In Detail](xaml-syntax-in-detail.md).-->
+For more information about the specifics of XAML syntax, see [XAML Syntax In Detail](../../framework/wpf/advanced/xaml-syntax-in-detail.md).
 
 ### Text content
 
@@ -167,14 +167,11 @@ There is more to events and XAML in WPF than just this example of the attribute 
 
 In general, XAML is case-sensitive. For purposes of resolving backing types, WPF XAML is case-sensitive by the same rules that the CLR is case-sensitive. Object elements, property elements, and attribute names must all be specified by using the sensitive casing when compared by name to the underlying type in the assembly, or to a member of a type. XAML language keywords and primitives are also case-sensitive. Values are not always case-sensitive. Case sensitivity for values will depend on the type converter behavior associated with the property that takes the value, or the property value type. For example, properties that take the <xref:System.Boolean> type can take either `true` or `True` as equivalent values, but only because the native WPF XAML parser type conversion for string to <xref:System.Boolean> already permits these as equivalents.
 
-WPF XAML processors and serializers will ignore or drop all nonsignificant white space, and will normalize any significant white space. This is consistent with the default white-space behavior recommendations of the XAML specification. This behavior is only of consequence when you specify strings within XAML content properties. In simplest terms, XAML converts space, linefeed, and tab characters into spaces, and then preserves one space if found at either end of a contiguous string. The full explanation of XAML white-space handling is not covered in this article.
-<!--TODO For details, see [White space processing in XAML](../xaml-services/white-space-processing.md).-->
+WPF XAML processors and serializers will ignore or drop all nonsignificant white space, and will normalize any significant white space. This is consistent with the default white-space behavior recommendations of the XAML specification. This behavior is only of consequence when you specify strings within XAML content properties. In simplest terms, XAML converts space, linefeed, and tab characters into spaces, and then preserves one space if found at either end of a contiguous string. The full explanation of XAML white-space handling is not covered in this article. For more information, see [White space processing in XAML](../xaml-services/white-space-processing.md).
 
 ## Markup extensions
 
 Markup extensions are a XAML language concept. When used to provide the value of an attribute syntax, curly braces (`{` and `}`) indicate a markup extension usage. This usage directs the XAML processing to escape from the general treatment of attribute values as either a literal string or a string-convertible value.
-
-<!-- TODO LINK CLEAN UP -->
 
 The most common markup extensions used in WPF app programming are [`Binding`](../../framework/wpf/advanced/binding-markup-extension.md), used for data binding expressions, and the resource references [`StaticResource`](../../framework/wpf/advanced/staticresource-markup-extension.md) and [`DynamicResource`](../../framework/wpf/advanced/dynamicresource-markup-extension.md). By using markup extensions, you can use attribute syntax to provide values for properties even if that property does not support an attribute syntax in general. Markup extensions often use intermediate expression types to enable features such as deferring values or referencing other objects that are only present at run-time.
 
@@ -184,8 +181,7 @@ For example, the following markup sets the value of the <xref:System.Windows.Fra
 [!code-xaml[FEResourceSH_snip#XAMLOvwShortResources2](~/samples/snippets/csharp/VS_Snippets_Wpf/FEResourceSH_snip/CS/page1.xaml#xamlovwshortresources2)]
 [!code-xaml[FEResourceSH_snip#XAMLOvwShortResources3](~/samples/snippets/csharp/VS_Snippets_Wpf/FEResourceSH_snip/CS/page1.xaml#xamlovwshortresources3)]
 
-<!-- TODO 
-For a reference listing of all markup extensions for XAML implemented specifically in WPF, see [WPF XAML Extensions](wpf-xaml-extensions.md). For a reference listing of the markup extensions that are defined by System.Xaml and are more widely available for .NET Core XAML implementations, see [XAML Namespace (x:) Language Features](../xaml-services/namespace-language-features.md). For more information about markup extension concepts, see [Markup Extensions and WPF XAML](markup-extensions-and-wpf-xaml.md). -->
+For a reference listing of all markup extensions for XAML implemented specifically in WPF, see [WPF XAML Extensions](../../framework/wpf/advanced/wpf-xaml-extensions.md). For a reference listing of the markup extensions that are defined by System.Xaml and are more widely available for .NET Core XAML implementations, see [XAML Namespace (x:) Language Features](../xaml-services/namespace-language-features.md). For more information about markup extension concepts, see [Markup Extensions and WPF XAML](../../framework/wpf/advanced/markup-extensions-and-wpf-xaml.md).
 
 ## Type converters
 
@@ -202,7 +198,7 @@ The previous attribute syntax example is equivalent to the following more verbos
 > [!NOTE]
 > There are also a limited number of objects where the type conversion is the only public way to set a property to that type without involving a subclass, because the type itself does not have a parameterless constructor. An example is <xref:System.Windows.Input.Cursor>.
 
-<!-- TODO For more information on how type conversion and its use for attribute syntax is supported, see [TypeConverters and XAML](typeconverters-and-xaml.md). -->
+For more information on type conversion, see [TypeConverters and XAML](../../framework/wpf/advanced/typeconverters-and-xaml.md).
 
 ## XAML root elements and XAML namespaces
 
@@ -254,9 +250,9 @@ The following is a basic example of how custom prefixes work in XAML markup. The
 </Page>
 ```
 
-<!-- TODO For more information about custom types in XAML, see [XAML and Custom Classes for WPF](xaml-and-custom-classes-for-wpf.md).
+For more information about custom types in XAML, see [XAML and Custom Classes for WPF](../../framework/wpf/advanced/xaml-and-custom-classes-for-wpf.md).
 
-For more information about how XML namespaces and the namespaces of the backing code in assemblies are related, see [XAML Namespaces and Namespace Mapping for WPF XAML](xaml-namespaces-and-namespace-mapping-for-wpf-xaml.md).-->
+For more information about how XML namespaces and code namespaces in assemblies are related, see [XAML Namespaces and Namespace Mapping for WPF XAML](../../framework/wpf/advanced/xaml-namespaces-and-namespace-mapping-for-wpf-xaml.md).
 
 ## Events and XAML code-behind
 
@@ -271,13 +267,13 @@ In the examples so far, you have seen several buttons, but none of these buttons
 
 Notice that the code-behind file uses the CLR namespace `ExampleNamespace` and declares `ExamplePage` as a partial class within that namespace. This parallels the `x:Class` attribute value of `ExampleNamespace`.`ExamplePage` that was provided in the markup root. The WPF markup compiler will create a partial class for any compiled XAML file, by deriving a class from the root element type. When you provide code-behind that also defines the same partial class, the resulting code is combined within the same namespace and class of the compiled app.
 
-<!-- TODO For more information about requirements for code-behind programming in WPF, see the "Code-behind, Event Handler, and Partial Class Requirements" section of [Code-Behind and XAML in WPF](code-behind-and-xaml-in-wpf.md). -->
+For more information about requirements for code-behind programming in WPF, see [Code-behind, Event Handler, and Partial Class Requirements in WPF](../../framework/wpf/advanced/code-behind-and-xaml-in-wpf.md#code-behind-event-handler-and-partial-class-requirements-in-wpf).
 
-If you do not want to create a separate code-behind file, you can also inline your code in a XAML file. However, inline code is a less versatile technique that has substantial limitations. <!-- TODO For details, see [Code-Behind and XAML in WPF](code-behind-and-xaml-in-wpf.md).-->
+If you do not want to create a separate code-behind file, you can also inline your code in a XAML file. However, inline code is a less versatile technique that has substantial limitations. For more informaiton, see [Code-Behind and XAML in WPF](../../framework/wpf/advanced/code-behind-and-xaml-in-wpf.md).
 
 ### Routed events
 
-A particular event feature that is fundamental to WPF is a routed event. Routed events enable an element to handle an event that was raised by a different element, as long as the elements are connected through a tree relationship. When specifying event handling with a XAML attribute, the routed event can be listened for and handled on any element, including elements that do not list that particular event in the class members table. This is accomplished by qualifying the event name attribute with the owning class name. For instance, the parent `StackPanel` in the ongoing `StackPanel` / `Button` example could register a handler for the child element button's <xref:System.Windows.Controls.Primitives.ButtonBase.Click> event by specifying the attribute `Button.Click` on the `StackPanel` object element, with your handler name as the attribute value. <!-- TODO For more information about how routed events work, see [Routed Events Overview](routed-events-overview.md).-->
+A particular event feature that is fundamental to WPF is a routed event. Routed events enable an element to handle an event that was raised by a different element, as long as the elements are connected through a tree relationship. When specifying event handling with a XAML attribute, the routed event can be listened for and handled on any element, including elements that do not list that particular event in the class members table. This is accomplished by qualifying the event name attribute with the owning class name. For instance, the parent `StackPanel` in the ongoing `StackPanel` / `Button` example could register a handler for the child element button's <xref:System.Windows.Controls.Primitives.ButtonBase.Click> event by specifying the attribute `Button.Click` on the `StackPanel` object element, with your handler name as the attribute value. For more information, see [Routed Events Overview](../../framework/wpf/advanced/routed-events-overview.md).
 
 ## XAML named elements
 
@@ -293,7 +289,7 @@ The following example sets <xref:System.Windows.FrameworkElement.Name%2A> on a <
 [!code-csharp[XAMLOvwSupport#NameCode](~/samples/snippets/csharp/VS_Snippets_Wpf/XAMLOvwSupport/CSharp/page7.xaml.cs#namecode)]
 [!code-vb[XAMLOvwSupport#NameCode](~/samples/snippets/visualbasic/VS_Snippets_Wpf/XAMLOvwSupport/VisualBasic/Page1.xaml.vb#namecode)]
 
-Just like a variable, the XAML name for an instance is governed by a concept of scope, so that names can be enforced to be unique within a certain scope that is predictable. The primary markup that defines a page denotes one unique XAML namescope, with the XAML namescope boundary being the root element of that page. However, other markup sources can interact with a page at run-time, such as styles or templates within styles, and such markup sources often have their own XAML namescopes that do not necessarily connect with the XAML namescope of the page. For more information on `x:Name` and XAML namescopes, see <xref:System.Windows.FrameworkElement.Name%2A>, [x:Name Directive](../xaml-services/xname-directive.md). <!-- TODO , or [WPF XAML Namescopes](wpf-xaml-namescopes.md).-->
+Just like a variable, the XAML name for an instance is governed by a concept of scope, so that names can be enforced to be unique within a certain scope that is predictable. The primary markup that defines a page denotes one unique XAML namescope, with the XAML namescope boundary being the root element of that page. However, other markup sources can interact with a page at run-time, such as styles or templates within styles, and such markup sources often have their own XAML namescopes that do not necessarily connect with the XAML namescope of the page. For more information on `x:Name` and XAML namescopes, see <xref:System.Windows.FrameworkElement.Name%2A>, [x:Name Directive](../xaml-services/xname-directive.md), or [WPF XAML Namescopes](../../framework/wpf/advanced/wpf-xaml-namescopes.md).
 
 ## Attached properties and attached events
 
@@ -309,9 +305,9 @@ The following example illustrates the <xref:System.Windows.Controls.DockPanel.Do
 
 [!code-xaml[XAMLOvwSupport#DockAP](~/samples/snippets/csharp/VS_Snippets_Wpf/XAMLOvwSupport/CSharp/page8.xaml#dockap)]
 
-In WPF, most or all the attached properties are also implemented as dependency properties. <!-- TODO For details, see [Attached Properties Overview](attached-properties-overview.md).-->
+In WPF, most or all the attached properties are also implemented as dependency properties. For more information, see [Attached Properties Overview](../../framework/wpf/advanced/attached-properties-overview.md).
 
-Attached events use a similar `ownerType.eventName` form of attribute syntax. Just like the non-attached events, the attribute value for an attached event in XAML specifies the name of the handler method that is invoked when the event is handled on the element. Attached event usages in WPF XAML are less common. <!-- TODO For more information, see [Attached Events Overview](attached-events-overview.md).-->
+Attached events use a similar `ownerType.eventName` form of attribute syntax. Just like the non-attached events, the attribute value for an attached event in XAML specifies the name of the handler method that is invoked when the event is handled on the element. Attached event usages in WPF XAML are less common. For more information, see [Attached Events Overview](../../framework/wpf/advanced/attached-events-overview.md).
 
 ## Base types and XAML
 
@@ -320,33 +316,22 @@ Underlying WPF XAML and its XAML namespace is a collection of types that corresp
 ## XAML security
 
 XAML is a markup language that directly represents object instantiation and execution. Therefore, elements created in XAML have the same ability to interact with system resources (network access, file system IO, for example) as the equivalent generated code does. XAML loaded in to a fully trusted app has the same access to the system resources as the hosting app does.
-<!-- TODO
-WPF supports the .NET Framework 4 security framework Code Access Security (CAS). This means that WPF content running in the internet zone has reduced execution permissions. "Loose XAML" (pages of noncompiled XAML interpreted at load time by a XAML viewer) and XBAP are usually run in this internet zone and use the same permission set. However, XAML loaded in to a fully trusted application has the same access to the system resources as the hosting application does. For more information, see [WPF Partial Trust Security](../wpf-partial-trust-security.md). -->
+
+### Code Access Security (CAS) in WPF
+
+**This section only applies to .NET Framework. WPF for .NET Core doesn't support CAS. For more information, see [Code Access Security differences](../migration/differences-from-net-framework.md#code-access-security).**
+
+WPF for .NET Framework supports Code Access Security (CAS). This means that WPF content running in the internet zone has reduced execution permissions. "Loose XAML" (pages of noncompiled XAML interpreted at load time by a XAML viewer) and XBAP are usually run in this internet zone and use the same permission set. However, XAML loaded in to a fully trusted application has the same access to the system resources as the hosting application does. For more information, see [WPF Partial Trust Security](../../framework/wpf/wpf-partial-trust-security.md).
 
 ## Loading XAML from code
 
-XAML can be used to define all of the UI, but it is sometimes also appropriate to define just a piece of the UI in XAML. This capability could be used to enable partial customization, local storage of information, using XAML to provide a business object, or a variety of possible scenarios. The key to these scenarios is the <xref:System.Windows.Markup.XamlReader> class and its <xref:System.Windows.Markup.XamlReader.Load%2A> method. The input is a XAML file, and the output is an object that represents all of the run-time tree of objects that was created from that markup. You then can insert the object to be a property of another object that already exists in the app. So long as the property is an appropriate property in the content model that has eventual display capabilities and that will notify the execution engine that new content has been added into the app, you can modify a running app's contents easily by loading in XAML. <!-- TODO This capability is generally only available in full-trust applications, because of the obvious security implications of loading files into applications as they run. -->
-
-<!-- TODO
-## Next steps
-
-This article provides a basic introduction to XAML syntax concepts and terminology as it applies to WPF. For more information about the terms used here, see [XAML Syntax in detail](xaml-syntax-in-detail.md).
-
-If you have not already done this, try the exercises in the tutorial article [Walkthrough: My first WPF desktop application](../getting-started/walkthrough-my-first-wpf-desktop-application.md). When you create the markup-centric app described by the tutorial, the exercise will help reinforce many of the concepts described in this article.
-
-WPF uses a particular application model that is based on the <xref:System.Windows.Application> class. For details, see [Application Management Overview](../app-development/application-management-overview.md).
-
-[Building a WPF Application](../app-development/building-a-wpf-application-wpf.md) gives you more details about how to build XAML inclusive app from the command line and with Visual Studio.
-
-[Dependency Properties Overview](dependency-properties-overview.md) gives more information about the versatility of properties in WPF, and introduces the concept of dependency properties.
+XAML can be used to define all of the UI, but it is sometimes also appropriate to define just a piece of the UI in XAML. This capability could be used to enable partial customization, local storage of information, using XAML to provide a business object, or a variety of possible scenarios. The key to these scenarios is the <xref:System.Windows.Markup.XamlReader> class and its <xref:System.Windows.Markup.XamlReader.Load%2A> method. The input is a XAML file, and the output is an object that represents all of the run-time tree of objects that was created from that markup. You then can insert the object to be a property of another object that already exists in the app. So long as the property is an appropriate property in the content model that has eventual display capabilities and that will notify the execution engine that new content has been added into the app, you can modify a running app's contents easily by loading in XAML. For .NET Framework, this capability is generally only available in full-trust applications, because of the obvious security implications of loading files into applications as they run.
 
 ## See also
 
-- [XAML Syntax In Detail](xaml-syntax-in-detail.md)
-- [XAML and Custom Classes for WPF](xaml-and-custom-classes-for-wpf.md)
+- [XAML Syntax In Detail](../../framework/wpf/advanced/xaml-syntax-in-detail.md)
+- [XAML and Custom Classes for WPF](../../framework/wpf/advanced/xaml-and-custom-classes-for-wpf.md)
 - [XAML Namespace (x:) Language Features](../xaml-services/namespace-language-features.md)
-- [WPF XAML Extensions](wpf-xaml-extensions.md)
-- [Base Elements Overview](base-elements-overview.md)
-- [Trees in WPF](trees-in-wpf.md)
-
--->
+- [WPF XAML Extensions](../../framework/wpf/advanced/wpf-xaml-extensions.md)
+- [Base Elements Overview](../../framework/wpf/advanced/base-elements-overview.md)
+- [Trees in WPF](../../framework/wpf/advanced/trees-in-wpf.md)

--- a/docs/desktop-wpf/overview/index.md
+++ b/docs/desktop-wpf/overview/index.md
@@ -48,7 +48,7 @@ For example, the previous XAML code defined a button with the visible content se
 
 WPF provides different markup extensions for XAML such as `{Binding}` for data binding.
 
-<!--For more information, see [Markup Extensions and WPF XAML](../../../framework/wpf/advanced/markup-extensions-and-wpf-xaml.md).-->
+For more information, see [Markup Extensions and WPF XAML](../../framework/wpf/advanced/markup-extensions-and-wpf-xaml.md).
 
 ## Property system
 


### PR DESCRIPTION
## Summary

Updated commented out links. Linked to the correct spots and set the link titles. Removed the "Next Steps" section and added the "See Also" section.

Fixes #14334
