### PR TITLE
Adding `new DefaultHttpContext()`

### DIFF
--- a/includes/core-changes/aspnetcore/3.0/http-defaulthttpcontext-extensibility-removed.md
+++ b/includes/core-changes/aspnetcore/3.0/http-defaulthttpcontext-extensibility-removed.md
@@ -2,7 +2,7 @@
 
 As part of ASP.NET Core 3.0 performance improvements, the extensibility of `DefaultHttpContext` was removed. The class is now `sealed`. For more information, see [dotnet/aspnetcore#6504](https://github.com/dotnet/aspnetcore/pull/6504).
 
-If your unit tests use `Mock<DefaultHttpContext>`, use `Mock<HttpContext>` instead.
+If your unit tests use `Mock<DefaultHttpContext>`, use `Mock<HttpContext>` or `new DefaultHttpContext()` instead.
 
 For discussion, see [dotnet/aspnetcore#6534](https://github.com/dotnet/aspnetcore/issues/6534).
 


### PR DESCRIPTION
## Summary

Adding `new DefaultHttpContext()` to `Mock<DefaultHttpContext>` alternatives

Fixes #17321 