### PR TITLE
Add custom metadata for ML.NET tooling articles.

### DIFF
--- a/docs/machine-learning/automate-training-with-cli.md
+++ b/docs/machine-learning/automate-training-with-cli.md
@@ -2,7 +2,7 @@
 title: Automate model training with the ML.NET CLI
 description: Discover how to use the ML.NET CLI tool to automatically train the best model from the command-line.
 ms.date: 12/17/2019
-ms.custom: how-to
+ms.custom: how-to, mlnet-tooling
 #Customer intent: As a developer, I want to use ML.NET CLI to automatically train the "best model" from the command-prompt. I also want to understand the output provided by the tool (metrics and output assets)
 ---
 # Automate model training with the ML.NET CLI

--- a/docs/machine-learning/automate-training-with-model-builder.md
+++ b/docs/machine-learning/automate-training-with-model-builder.md
@@ -2,7 +2,7 @@
 title: What is Model Builder and how does it work?
 description: How to use the ML.NET Model Builder to automatically train a machine learning model
 ms.date: 01/07/2020
-ms.custom: overview
+ms.custom: overview, mlnet-tooling
 #Customer intent: As a developer, I want to use Model Builder to automatically train a model using a visual interface.
 ---
 # What is Model Builder and how does it work?

--- a/docs/machine-learning/automl-overview.md
+++ b/docs/machine-learning/automl-overview.md
@@ -3,7 +3,7 @@ title: Automated machine learning with ML.NET
 description: Overview of automatic model selection and training
 ms.date: 05/01/2019
 ms.topic: overview
-ms.custom: mvc
+ms.custom: mvc, mlnet-tooling
 #Customer intent: As a developer, I want to use ML.NET CLI to automatically select and train a model.
 ---
 # Automated machine learning with ML.NET

--- a/docs/machine-learning/how-to-guides/install-ml-net-cli.md
+++ b/docs/machine-learning/how-to-guides/install-ml-net-cli.md
@@ -2,6 +2,7 @@
 title: How to install the ML.NET Command-Line Interface (CLI) tool
 description: Learn how to install, upgrade, downgrade, and uninstall the ML.NET Command-Line Interface (CLI) tool.
 ms.date: 12/18/2019
+ms.custom: mlnet-tooling
 ---
 
 # How to install the ML.NET Command-Line Interface (CLI) tool

--- a/docs/machine-learning/how-to-guides/install-model-builder.md
+++ b/docs/machine-learning/how-to-guides/install-model-builder.md
@@ -4,7 +4,7 @@ description: Learn how to install the ML.NET Model Builder tool
 author: luisquintanilla
 ms.author: luquinta
 ms.date: 11/21/2019
-ms.custom: mvc, how-to
+ms.custom: mvc, how-to, mlnet-tooling
 #Customer intent: As a non-developer I want know how to install Model Builder to add machine learning to my .NET application.
 ---
 

--- a/docs/machine-learning/how-to-guides/load-data-model-builder.md
+++ b/docs/machine-learning/how-to-guides/load-data-model-builder.md
@@ -4,7 +4,7 @@ description: Learn how to load training data from a SQL Server database or a fil
 ms.date: 10/29/2019
 author: luisquintanilla
 ms.author: luquinta
-ms.custom: mvc, how-to
+ms.custom: mvc, how-to, mlnet-tooling
 #Customer intent: As a developer, I want to load data in Model Builder
 ---
 

--- a/docs/machine-learning/reference/ml-net-cli-reference.md
+++ b/docs/machine-learning/reference/ml-net-cli-reference.md
@@ -2,6 +2,7 @@
 title: ML.NET CLI Command Reference
 description: Overview, samples, and reference for the auto-train command in the ML.NET CLI tool.
 ms.date: 12/18/2019
+ms.custom: mlnet-tooling
 ---
 
 # The ML.NET CLI command reference

--- a/docs/machine-learning/resources/ml-net-cli-telemetry.md
+++ b/docs/machine-learning/resources/ml-net-cli-telemetry.md
@@ -3,7 +3,7 @@ title: Telemetry collection by ML.NET CLI
 description: Learn about ML.NET CLI telemetry features that collect usage information for analysis, which data is collected, and how to disable it. Also, find links to the .NET license agreement and information about Microsoft GDPR compliance.
 ms.topic: conceptual
 ms.date: 09/03/2019
-ms.custom: ""
+ms.custom: mlnet-tooling
 ---
 
 # Telemetry collection by the ML.NET CLI


### PR DESCRIPTION
Add metadata to distinguish between API and tooling docs for docs performance reporting