### PR TITLE
Conditional ref expression: update phrasing

### DIFF
--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -1,6 +1,6 @@
 ---
 title: "?: operator - C# reference"
-ms.date: "11/20/2018"
+ms.date: "03/06/2020"
 f1_keywords:
   - "?:_CSharpKeyword"
   - "?_CSharpKeyword"
@@ -12,7 +12,7 @@ ms.assetid: e83a17f1-7500-48ba-8bee-2fbc4c847af4
 ---
 # ?: operator (C# reference)
 
-The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`. Beginning with C# 7.2, the [conditional ref expression](#conditional-ref-expression) returns the reference to the result of one of the two expressions.
+The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`.
 
 The syntax for the conditional operator is as follows:
 
@@ -49,7 +49,7 @@ The following example demonstrates the usage of the conditional operator:
 
 ## Conditional ref expression
 
-Beginning with C# 7.2, you can use the conditional ref expression to return the reference to the result of one of the two expressions. You can assign that reference to a [ref local](../keywords/ref.md#ref-locals) or [ref readonly local](../keywords/ref.md#ref-readonly-locals) variable, or use it as a [reference return value](../keywords/ref.md#reference-return-values) or as a [`ref` method parameter](../keywords/ref.md#passing-an-argument-by-reference).
+Beginning with C# 7.2, a [ref local](../keywords/ref.md#ref-locals) or [ref readonly local](../keywords/ref.md#ref-readonly-locals) variable can be assigned conditionally with the conditional ref expression. You can also use the conditional ref expression as a [reference return value](../keywords/ref.md#reference-return-values) or as a [`ref` method argument](../keywords/ref.md#passing-an-argument-by-reference).
 
 The syntax for the conditional ref expression is as follows:
 


### PR DESCRIPTION
Motivation to this update is to remove "the reference to the result" wording, which might be confusing because of reference types.
