### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -20,7 +20,7 @@ ms.date: 09/17/2019
 C#, Visual Basic, and F# languages can be used to write applications and libraries for .NET Core. These languages can be used in your favorite text editor or Integrated Development Environment (IDE), including:
 
 - [Visual Studio](https://visualstudio.microsoft.com/vs/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link)
-- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 - Sublime Text
 - Vim
 

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -20,7 +20,7 @@ ms.date: 09/17/2019
 C#, Visual Basic, and F# languages can be used to write applications and libraries for .NET Core. These languages can be used in your favorite text editor or Integrated Development Environment (IDE), including:
 
 - [Visual Studio](https://visualstudio.microsoft.com/vs/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link)
-- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
+- [Visual Studio Code](https://code.visualstudio.com/download)
 - Sublime Text
 - Vim
 

--- a/docs/core/install/sdk.md
+++ b/docs/core/install/sdk.md
@@ -152,7 +152,7 @@ While Visual Studio Code doesn't come with an automated .NET Core installer like
 
 01. [Download and install Visual Studio Code](https://code.visualstudio.com/Download).
 01. [Download and install the .NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core).
-01. [Install the C# extension from the Visual Studio Code marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+01. [Install the C# extension from the Visual Studio Code marketplace](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 ::: zone pivot="os-windows"
 

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -12,7 +12,7 @@ ms.date: 12/05/2018
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/).
 2. Install the [.NET Core SDK](https://dotnet.microsoft.com/download).
-3. Install the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) for Visual Studio Code. For more information about how to install extensions on Visual Studio Code, see [VS Code Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
+3. Install the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) for Visual Studio Code. For more information about how to install extensions on Visual Studio Code, see [VS Code Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
 
 ## Hello World
 


### PR DESCRIPTION
[C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) has been renamed from `ms-vscode.csharp` to `ms-dotnettools.csharp`, this PR corrects to new correct uris.