### PR TITLE
Fixed the F# active patterns sample

### DIFF
--- a/samples/snippets/fsharp/lang-ref-2/snippet5005.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5005.fs
@@ -13,8 +13,6 @@ let (|Cube|_|) (x : int) =
 let examineNumber x =
    match x with
       | Cube x -> printfn "%d is a cube" x
-      | _ -> ()
-   match x with
       | Square x -> printfn "%d is a square" x
       | _ -> ()
 


### PR DESCRIPTION
## Summary

Fixed F# active patterns sample — I guess, this is what was meant, otherwise the result of the first match is ignored.