### PR TITLE
Miscellaneous refresh to old .NET Fx docs

### DIFF
--- a/docs/framework/develop-client-apps.md
+++ b/docs/framework/develop-client-apps.md
@@ -18,7 +18,7 @@ ms.assetid: 2dfb50b7-5af2-4e12-9bbb-c5ade0e39a68
 
 There are several ways to develop Windows-based applications with .NET Framework. You can use any of these tools and frameworks:
 
-- [Universal Windows Platform (UWP)](https://developer.microsoft.com/windows/apps)
+- [Universal Windows Platform (UWP)](/windows/uwp/)
 - [Windows Presentation Foundation (WPF)](./wpf/index.md)
 - [Windows Forms](./winforms/index.md)
 
@@ -26,20 +26,20 @@ This section contains articles that describe how to create Windows-based applica
 
 ## Related sections
 
-[Universal Windows Platform](https://developer.microsoft.com/windows/apps)\
-Describes how to create applications for Windows 10 that you can make available to users through Microsoft Store.
+[Universal Windows Platform](/windows/uwp/)\
+Describes how to create UWP applications that you can make available to users through Microsoft Store.
 
-[.NET for UWP apps](https://msdn.microsoft.com/library/windows/apps/mt185501.aspx)\
-Describes .NET Framework support for UWP apps, which can be deployed to Windows computers and devices.
+[.NET API for UWP apps](/dotnet/api/index?view=dotnet-uwp-10.0)\
+Reference for .NET types that support UWP apps.
+  
+[Develop for Multiple Platforms](../standard/cross-platform/index.md)\
+Describes the different methods you can use .NET Framework to target multiple client app types.
+
+[Get Started with ASP.NET Web Sites](https://dotnet.microsoft.com/apps/aspnet/web-apps)\
+Describes the ways you can develop web apps using ASP.NET.
 
 [.NET API for Windows Phone Silverlight](https://docs.microsoft.com/previous-versions/windows/apps/jj207211\(v=vs.105\))\
 Lists .NET Framework APIs you can use for building apps with Windows Phone Silverlight.
-  
-[Developing for Multiple Platforms](../standard/cross-platform/index.md)\
-Describes the different methods you can use .NET Framework to target multiple client app types.
-
-[Get Started with ASP.NET Web Sites](https://www.asp.net/get-started/websites)\
-Describes the ways you can develop web apps using ASP.NET.
 
 ## See also
 

--- a/docs/framework/develop-client-apps.md
+++ b/docs/framework/develop-client-apps.md
@@ -14,39 +14,31 @@ helpviewer_keywords:
   - "client/server applications, Windows applications"
 ms.assetid: 2dfb50b7-5af2-4e12-9bbb-c5ade0e39a68
 ---
-# Develop client applications with the .NET Framework
+# Develop client applications with .NET Framework
 
-There are several ways to develop Windows-based applications with the .NET Framework. You can use any of these tools and frameworks:
+There are several ways to develop Windows-based applications with .NET Framework. You can use any of these tools and frameworks:
 
 - [Universal Windows Platform (UWP)](https://developer.microsoft.com/windows/apps)
 - [Windows Presentation Foundation (WPF)](./wpf/index.md)
 - [Windows Forms](./winforms/index.md)
 
-This section contains topics that describe how to create Windows-based applications by using Windows Presentation Foundation or by using Windows Forms. However, you can also create web applications using the .NET Framework, and client applications for computers or devices that you make available through the Microsoft Store.
-
-## In this section
-
-[Windows Presentation Foundation](./wpf/index.md)  
-Provides information about developing applications by using WPF.
-
-[Windows Forms](./winforms/index.md)  
-Provides information about developing applications by using Windows Forms.
+This section contains articles that describe how to create Windows-based applications by using Windows Presentation Foundation or Windows Forms. However, you can also create web applications using .NET Framework and client applications for computers or devices that you make available through Microsoft Store (UWP apps).
 
 ## Related sections
 
-[Universal Windows Platform](https://developer.microsoft.com/windows/apps)  
-Describes how to create applications for Windows 10 that you can make available to users through the Windows Store.
+[Universal Windows Platform](https://developer.microsoft.com/windows/apps)\
+Describes how to create applications for Windows 10 that you can make available to users through Microsoft Store.
 
-[.NET for UWP apps](https://msdn.microsoft.com/library/windows/apps/mt185501.aspx)  
-Describes the .NET Framework support for Store apps, which can be deployed to Windows computers and devices.
+[.NET for UWP apps](https://msdn.microsoft.com/library/windows/apps/mt185501.aspx)\
+Describes .NET Framework support for UWP apps, which can be deployed to Windows computers and devices.
 
-[.NET API for Windows Phone Silverlight](https://docs.microsoft.com/previous-versions/windows/apps/jj207211\(v=vs.105\))  
-Lists the .NET Framework APIs you can use for building apps with Windows Phone Silverlight.
+[.NET API for Windows Phone Silverlight](https://docs.microsoft.com/previous-versions/windows/apps/jj207211\(v=vs.105\))\
+Lists .NET Framework APIs you can use for building apps with Windows Phone Silverlight.
   
-[Developing for Multiple Platforms](../standard/cross-platform/index.md)  
-Describes the different methods you can use the .NET Framework to target multiple client app types.
+[Developing for Multiple Platforms](../standard/cross-platform/index.md)\
+Describes the different methods you can use .NET Framework to target multiple client app types.
 
-[Get Started with ASP.NET Web Sites](https://www.asp.net/get-started/websites)  
+[Get Started with ASP.NET Web Sites](https://www.asp.net/get-started/websites)\
 Describes the ways you can develop web apps using ASP.NET.
 
 ## See also

--- a/docs/framework/get-started/index.md
+++ b/docs/framework/get-started/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Get started with the .NET Framework"
+title: Get started with the .NET Framework
 ms.custom: "updateeachrelease"
 ms.date: "04/02/2019"
 helpviewer_keywords: 
@@ -7,76 +7,75 @@ helpviewer_keywords:
   - "getting started [.NET Framework]"
 ms.assetid: c693fd34-88fe-4d90-b332-19eeadf3b7e7
 ---
+# Get started with .NET Framework
 
-# Get started with the .NET Framework
-
-The .NET Framework is a runtime execution environment that manages apps that target the .NET Framework. It consists of the common language runtime, which provides memory management and other system services, and an extensive class library, which enables programmers to take advantage of robust, reliable code for all major areas of app development.
+.NET Framework is a run-time execution environment that manages apps that target .NET Framework. It consists of the common language runtime, which provides memory management and other system services, and an extensive class library, which enables programmers to take advantage of robust, reliable code for all major areas of app development.
 
 > [!NOTE] 
-> The .NET Framework is available on Windows systems only. You can use [.NET Core](../../core/index.md) to run apps on Windows, MacOS, and Linux. 
+> .NET Framework is available on Windows systems only. You can use [.NET Core](../../core/index.md) to run apps on Windows, MacOS, and Linux. 
 
-## <a name="Introducing"></a> What is the .NET Framework?
+## What is .NET Framework?
 
-The .NET Framework is a managed execution environment for Windows that provides a variety of services to its running apps. It consists of two major components: the common language runtime (CLR), which is the execution engine that handles running apps, and the .NET Framework Class Library, which provides a library of tested, reusable code that developers can call from their own apps. The services that the .NET Framework provides to running apps include the following:
+.NET Framework is a managed execution environment for Windows that provides a variety of services to its running apps. It consists of two major components: the common language runtime (CLR), which is the execution engine that handles running apps, and the .NET Framework Class Library, which provides a library of tested, reusable code that developers can call from their own apps. The services that .NET Framework provides to running apps include the following:
 
 - Memory management. In many programming languages, programmers are responsible for allocating and releasing memory and for handling object lifetimes. In .NET Framework apps, the CLR provides these services on behalf of the app.
 
-- A common type system. In traditional programming languages, basic types are defined by the compiler, which complicates cross-language interoperability. In the .NET Framework, basic types are defined by the .NET Framework type system and are common to all languages that target the .NET Framework.
+- A common type system. In traditional programming languages, basic types are defined by the compiler, which complicates cross-language interoperability. In .NET Framework, basic types are defined by the .NET Framework type system and are common to all languages that target .NET Framework.
 
 - An extensive class library. Instead of having to write vast amounts of code to handle common low-level programming operations, programmers use a readily accessible library of types and their members from the .NET Framework Class Library.
 
-- Development frameworks and technologies. The .NET Framework includes libraries for specific areas of app development, such as ASP.NET for web apps, ADO.NET for data access, Windows Communication Foundation for service-oriented apps, and Windows Presentation Foundation for Windows desktop apps.
+- Development frameworks and technologies. .NET Framework includes libraries for specific areas of app development, such as ASP.NET for web apps, ADO.NET for data access, Windows Communication Foundation for service-oriented apps, and Windows Presentation Foundation for Windows desktop apps.
 
-- Language interoperability. Language compilers that target the .NET Framework emit an intermediate code named Common Intermediate Language (CIL), which, in turn, is compiled at runtime by the common language runtime. With this feature, routines written in one language are accessible to other languages, and programmers focus on creating apps in their preferred languages.
+- Language interoperability. Language compilers that target .NET Framework emit an intermediate code named Common Intermediate Language (CIL), which, in turn, is compiled at runtime by the common language runtime. With this feature, routines written in one language are accessible to other languages, and programmers focus on creating apps in their preferred languages.
 
-- Version compatibility. With rare exceptions, apps that are developed by using a particular version of the .NET Framework run without modification on a later version.
+- Version compatibility. With rare exceptions, apps that are developed by using a particular version of .NET Framework run without modification on a later version.
 
-- Side-by-side execution. The .NET Framework helps resolve version conflicts by allowing multiple versions of the common language runtime to exist on the same computer. This means that multiple versions of apps can coexist and that an app can run on the version of the .NET Framework with which it was built. Side-by-side execution applies to the .NET Framework version groups 1.0/1.1, 2.0/3.0/3.5, and 4/4.5.x/4.6.x/4.7.x/4.8.
+- Side-by-side execution. .NET Framework helps resolve version conflicts by allowing multiple versions of the common language runtime to exist on the same computer. This means that multiple versions of apps can coexist and that an app can run on the version of .NET Framework with which it was built. Side-by-side execution applies to the .NET Framework version groups 1.0/1.1, 2.0/3.0/3.5, and 4/4.5.x/4.6.x/4.7.x/4.8.
 
-- Multitargeting. By targeting [.NET Standard](../../standard/net-standard.md), developers create class libraries that work on multiple .NET Framework platforms supported by that version of the standard. For example, libraries that target the .NET Standard 2.0 can be used by apps that target the .NET Framework 4.6.1, .NET Core 2.0, and UWP 10.0.16299. 
+- Multitargeting. By targeting [.NET Standard](../../standard/net-standard.md), developers create class libraries that work on multiple .NET Framework platforms supported by that version of the standard. For example, libraries that target .NET Standard 2.0 can be used by apps that target .NET Framework 4.6.1, .NET Core 2.0, and UWP 10.0.16299. 
 
 <a name="ForUsers"></a>
 ## The .NET Framework for users
 
-If you don't develop .NET Framework apps, but you use them, you aren't required to have specific knowledge about the .NET Framework or its operation. For the most part, the .NET Framework is completely transparent to users.
+If you don't develop .NET Framework apps, but you use them, you aren't required to have specific knowledge about .NET Framework or its operation. For the most part, the framework is completely transparent to users.
 
-If you're using the Windows operating system, the .NET Framework may already be installed on your computer. In addition, if you install an app that requires the .NET Framework, the app's setup program might install a specific version of the .NET Framework on your computer. In some cases, you may see a dialog box that asks you to install the .NET Framework. If you've just tried to run an app when this dialog box appears and if your computer has Internet access, you can go to a webpage that lets you install the missing version of the .NET Framework. For more information, see the [Installation guide](../install/index.md).
+If you're using the Windows operating system, .NET Framework may already be installed on your computer. In addition, if you install an app that requires .NET Framework, the app's setup program might install a specific version of the framework on your computer. In some cases, you may see a dialog box that asks you to install .NET Framework. If you've just tried to run an app when this dialog box appears and if your computer has internet access, you can go to a webpage that lets you install the missing version of .NET Framework. For more information, see the [Installation guide](../install/index.md).
 
-In general, you shouldn't uninstall versions of the .NET Framework that are installed on your computer. There are two reasons for this:
+In general, you shouldn't uninstall versions of .NET Framework that are installed on your computer. There are two reasons for this:
 
-- If an app that you use depends on a specific version of the .NET Framework, that app may break if that version is removed.
+- If an app that you use depends on a specific version of .NET Framework, that app may break if that version is removed.
 
-- Some versions of the .NET Framework are in-place updates to earlier versions. For example, the .NET Framework 3.5 is an in-place update to version 2.0, and the .NET Framework 4.8 is an in-place update to versions 4 through 4.7.2. For more information, see [.NET Framework Versions and Dependencies](../migration-guide/versions-and-dependencies.md).
+- Some versions of .NET Framework are in-place updates to earlier versions. For example, .NET Framework 3.5 is an in-place update to version 2.0, and .NET Framework 4.8 is an in-place update to versions 4 through 4.7.2. For more information, see [.NET Framework Versions and Dependencies](../migration-guide/versions-and-dependencies.md).
 
-On Windows versions before Windows 8, if you do choose to remove the .NET Framework, always use **Programs and Features** from Control Panel to uninstall it. Never remove a version of the .NET Framework manually. On Windows 8 and above, the .NET Framework is an operating system component and cannot be independently uninstalled.
+On Windows versions before Windows 8, if you do choose to remove .NET Framework, always use **Programs and Features** from Control Panel to uninstall it. Never remove a version of .NET Framework manually. On Windows 8 and above, .NET Framework is an operating system component and cannot be independently uninstalled.
 
-Note that multiple versions of the .NET Framework can coexist on a single computer at the same time. This means that you don't have to uninstall previous versions in order to install a later version.
+Multiple versions of .NET Framework can coexist on a single computer at the same time. This means that you don't have to uninstall previous versions in order to install a later version.
 
-## <a name="ForDevelopers"></a> The .NET Framework for developers
+## .NET Framework for developers
 
-If you're a developer, choose any programming language that supports the .NET Framework to create your apps. Because the .NET Framework provides language independence and interoperability, you interact with other .NET Framework apps and components regardless of the language with which they were developed.
+If you're a developer, choose any programming language that supports .NET Framework to create your apps. Because .NET Framework provides language independence and interoperability, you interact with other .NET Framework apps and components regardless of the language with which they were developed.
 
 To develop .NET Framework apps or components, do the following:
 
-1. If it's not preinstalled on your operating system, install the version of the .NET Framework that your app will target. The most recent production version is the .NET Framework 4.8. It is preinstalled on Windows 10 May 2019 Update, and it is available for download on earlier versions of the Windows operating system. For .NET Framework system requirements, see [System Requirements](system-requirements.md). For information on installing other versions of the .NET Framework, see [Installation Guide](../install/guide-for-developers.md). Additional .NET Framework packages are released out of band, which means that they're released on a rolling basis outside of any regular or scheduled release cycle. For information about these packages, see [The .NET Framework and Out-of-Band Releases](the-net-framework-and-out-of-band-releases.md).
+1. If it's not preinstalled on your operating system, install the version of .NET Framework that your app will target. The most recent production version is .NET Framework 4.8. It is preinstalled on Windows 10 May 2019 Update, and it's available for download on earlier versions of the Windows operating system. For .NET Framework system requirements, see [System Requirements](system-requirements.md). For information on installing other versions of .NET Framework, see [Installation Guide](../install/guide-for-developers.md). Additional .NET Framework packages are released out of band, which means that they're released on a rolling basis outside of any regular or scheduled release cycle. For information about these packages, see [.NET Framework and Out-of-Band Releases](the-net-framework-and-out-of-band-releases.md).
 
-2. Select the language or languages supported by the .NET Framework that you intend to use to develop your apps. A number of languages are available, including [Visual Basic](../../visual-basic/index.yml), [C#](../../csharp/index.yml), [F#](../../fsharp/index.yml), and [C++/CLI](/cpp/dotnet/dotnet-programming-with-cpp-cli-visual-cpp) from Microsoft. (A programming language that allows you to develop apps for the .NET Framework adheres to the [Common Language Infrastructure (CLI) specification](https://visualstudio.microsoft.com/license-terms/ecma-c-common-language-infrastructure-standards/).)
+2. Select the language or languages supported by the .NET Framework version that you intend to use to develop your apps. A number of languages are available, including [Visual Basic](../../visual-basic/index.yml), [C#](../../csharp/index.yml), [F#](../../fsharp/index.yml), and [C++/CLI](/cpp/dotnet/dotnet-programming-with-cpp-cli-visual-cpp) from Microsoft. (A programming language that allows you to develop apps for .NET Framework adheres to the [Common Language Infrastructure (CLI) specification](https://visualstudio.microsoft.com/license-terms/ecma-c-common-language-infrastructure-standards/).)
 
 3. Select and install the development environment to use to create your apps and that supports your selected programming language or languages. The Microsoft integrated development environment (IDE) for .NET Framework apps is [Visual Studio](https://visualstudio.microsoft.com/vs/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link). It's available in a number of editions.
 
-For more information on developing apps that target the .NET Framework, see the [Development Guide](../development-guide.md).
+For more information on developing apps that target .NET Framework, see the [Development Guide](../development-guide.md).
 
 ## Related articles
 
 | Title | Description |
 | ----- |------------ |
-| [Overview](overview.md) | Provides detailed information for developers who build apps that target the .NET Framework. |
-| [Installation guide](../install/index.md) | Provides information about installing the .NET Framework. |  
-| [The .NET Framework and Out-of-Band Releases](the-net-framework-and-out-of-band-releases.md) | Describes the .NET Framework out of band releases and how to use them in your app. |
-| [System Requirements](system-requirements.md) | Lists the hardware and software requirements for running the .NET Framework. |
-| [.NET Core and Open-Source](net-core-and-open-source.md) | Describes .NET Core in relation to the .NET Framework and how to access the open-source .NET Core projects. |
+| [Overview](overview.md) | Provides detailed information for developers who build apps that target .NET Framework. |
+| [Installation guide](../install/index.md) | Provides information about installing .NET Framework. |  
+| [.NET Framework and Out-of-Band Releases](the-net-framework-and-out-of-band-releases.md) | Describes the .NET Framework out-of-band releases and how to use them in your app. |
+| [System Requirements](system-requirements.md) | Lists the hardware and software requirements for running .NET Framework. |
+| [.NET Core and Open-Source](net-core-and-open-source.md) | Describes .NET Core in relation to .NET Framework and how to access the open-source .NET Core projects. |
 | [.NET Core documentation](../../core/index.md) | Provides the conceptual and API reference documentation for .NET Core. |
-| [.NET Standard](../../standard/net-standard.md) | Discusses .NET Standard, a versioned specification that individual .NET implementations support to guarantee that a consistent set of APIs are available on multiple platforms.
+| [.NET Standard](../../standard/net-standard.md) | Discusses .NET Standard, a versioned specification that individual .NET implementations support to guarantee that a consistent set of APIs is available on multiple platforms.
 
 ## See also
 

--- a/docs/framework/get-started/net-core-and-open-source.md
+++ b/docs/framework/get-started/net-core-and-open-source.md
@@ -6,12 +6,12 @@ ms.assetid: e6bd4655-ce37-4003-8462-468a6fe2c40f
 # .NET Core and open source
 
 This article provides a brief overview of what .NET Core is and shows how you can find more information. To find the complete list of documentation for .NET Core, visit the [.NET Core guide](../../core/index.md).
-  
-<a name="BKMK_WhatisNETCore"></a>   
+    
 ## What is .NET Core?  
- .NET Core is a general purpose, modular, cross-platform and open source implementation of the .NET Standard. It contains many of the same APIs as the .NET Framework (but .NET Core is a smaller set) and includes runtime, framework, compiler and tools components that support a variety of operating systems and chip targets. The .NET Core implementation was primarily driven by the ASP.NET Core workloads but also by the need and desire to have a more modern implementation. It can be used in device, cloud and embedded/IoT scenarios.  
+
+.NET Core is a general purpose, modular, cross-platform and open source implementation of the .NET Standard. It contains many of the same APIs as the .NET Framework (but .NET Core is a smaller set) and includes runtime, framework, compiler and tools components that support a variety of operating systems and chip targets. The .NET Core implementation was primarily driven by the ASP.NET Core workloads but also by the need and desire to have a more modern implementation. It can be used in device, cloud and embedded/IoT scenarios.  
   
- To get started with .NET Core, visit the .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro).  
+To get started with .NET Core, visit the .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro).  
   
 The main characteristics of .NET Core are:
   

--- a/docs/framework/get-started/overview.md
+++ b/docs/framework/get-started/overview.md
@@ -8,12 +8,11 @@ helpviewer_keywords:
   - "common language runtime, overview"
 ms.assetid: 29848c96-fc36-462d-8072-ba223a40b697
 ---
+# Overview of .NET Framework
 
-# Overview of the .NET Framework
+.NET Framework is a technology that supports building and running Windows apps and web services. .NET Framework is designed to fulfill the following objectives:
 
-The .NET Framework is a technology that supports building and running the next generation of apps and XML Web services. The .NET Framework is designed to fulfill the following objectives:
-
-- To provide a consistent object-oriented programming environment whether object code is stored and executed locally, executed locally but Internet-distributed, or executed remotely.
+- To provide a consistent object-oriented programming environment whether object code is stored and executed locally, executed locally but web-distributed, or executed remotely.
 
 - To provide a code-execution environment that minimizes software deployment and versioning conflicts.
 
@@ -23,16 +22,16 @@ The .NET Framework is a technology that supports building and running the next g
 
 - To make the developer experience consistent across widely varying types of apps, such as Windows-based apps and Web-based apps.
 
-- To build all communication on industry standards to ensure that code based on the .NET Framework integrates with any other code.
+- To build all communication on industry standards to ensure that code based on .NET Framework integrates with any other code.
 
 > [!NOTE]
-> For a general introduction to the .NET Framework for both users and developers, see [Getting Started](index.md).
+> For a general introduction to .NET Framework for both users and developers, see [Getting Started](index.md).
 
-The .NET Framework consists of the common language runtime (CLR) and the .NET Framework class library. The common language runtime is the foundation of the .NET Framework. Think of the runtime as an agent that manages code at execution time, providing core services such as memory management, thread management, and remoting, while also enforcing strict type safety and other forms of code accuracy that promote security and robustness. In fact, the concept of code management is a fundamental principle of the runtime. Code that targets the runtime is known as managed code, while code that doesn't target the runtime is known as unmanaged code. The class library is a comprehensive, object-oriented collection of reusable types that you use to develop apps ranging from traditional command-line or graphical user interface (GUI) apps to apps based on the latest innovations provided by ASP.NET, such as Web Forms and XML Web services.
+.NET Framework consists of the common language runtime (CLR) and the .NET Framework class library. The common language runtime is the foundation of .NET Framework. Think of the runtime as an agent that manages code at execution time, providing core services such as memory management, thread management, and remoting, while also enforcing strict type safety and other forms of code accuracy that promote security and robustness. In fact, the concept of code management is a fundamental principle of the runtime. Code that targets the runtime is known as managed code, while code that doesn't target the runtime is known as unmanaged code. The class library is a comprehensive, object-oriented collection of reusable types that you use to develop apps ranging from traditional command-line or graphical user interface (GUI) apps to apps based on the latest innovations provided by ASP.NET, such as Web Forms and XML web services.
 
-The .NET Framework can be hosted by unmanaged components that load the common language runtime into their processes and initiate the execution of managed code, thereby creating a software environment that exploits both managed and unmanaged features. The .NET Framework not only provides several runtime hosts but also supports the development of third-party runtime hosts.
+.NET Framework can be hosted by unmanaged components that load the common language runtime into their processes and initiate the execution of managed code, thereby creating a software environment that exploits both managed and unmanaged features. .NET Framework not only provides several runtime hosts but also supports the development of third-party runtime hosts.
 
-For example, ASP.NET hosts the runtime to provide a scalable, server-side environment for managed code. ASP.NET works directly with the runtime to enable ASP.NET apps and XML Web services, both of which are discussed later in this topic.
+For example, ASP.NET hosts the runtime to provide a scalable, server-side environment for managed code. ASP.NET works directly with the runtime to enable ASP.NET apps and XML web services, both of which are discussed later in this article.
 
 Internet Explorer is an example of an unmanaged app that hosts the runtime (in the form of a MIME type extension). Using Internet Explorer to host the runtime enables you to embed managed components or Windows Forms controls in HTML documents. Hosting the runtime in this way makes managed mobile code possible, but with significant improvements that only managed code offers, such as semi-trusted execution and isolated file storage.
 
@@ -40,7 +39,7 @@ The following illustration shows the relationship of the common language runtime
 
 ![Screenshot that shows how managed code operates within a larger architecture.](./media/overview/language-runtime-class-library-relationship.gif)
 
-The following sections describe the main features of the .NET Framework in greater detail.
+The following sections describe the main features of .NET Framework in greater detail.
 
 ## Features of the common language runtime
 

--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -13,7 +13,7 @@ ms.assetid: 298275e2-da1d-4618-9f74-6a3567832350
 ---
 # .NET Framework system requirements
 
-The tables in this topic provide the hardware, operating system, and software requirements for the following .NET Framework versions:
+The tables in this article provide the hardware, operating system, and software requirements for the following .NET Framework versions:
 
 - .NET Framework 4.5 and its point releases (4.5.1 and 4.5.2).
 - .NET Framework 4.6 and its point releases (4.6.1 and 4.6.2).
@@ -22,7 +22,7 @@ The tables in this topic provide the hardware, operating system, and software re
 
 For information on .NET Framework versions earlier than .NET Framework 4.5, see [.NET Framework versions and dependencies](../migration-guide/versions-and-dependencies.md).
 
-Development environments that enable you to develop apps for the .NET Framework have a separate set of requirements.
+Development environments that enable you to develop apps for .NET Framework have a separate set of requirements.
 
 [!INCLUDE[net-framework-4-versions](../../../includes/net-framework-4x-versions.md)]
 
@@ -42,7 +42,7 @@ For information on the support lifecycle of .NET Framework versions, see [Micros
 
 ## Installation requirements
 
-The .NET Framework requires administrator privileges for installation. If you don't have administrator rights to the computer where you'd like to install the .NET Framework, contact your network administrator.
+.NET Framework requires administrator privileges for installation. If you don't have administrator rights to the computer where you'd like to install .NET Framework, contact your network administrator.
 
 ## Supported client operating systems
 
@@ -64,7 +64,7 @@ The .NET Framework requires administrator privileges for installation. If you do
 
  **Notes:**
 
-- On Windows 7 systems, the .NET Framework requires Windows 7 SP1. If you're on Windows 7 and haven't yet installed Service Pack 1, you need to do so before installing the .NET Framework.
+- On Windows 7 systems, .NET Framework requires Windows 7 SP1. If you're on Windows 7 and haven't yet installed Service Pack 1, you need to do so before installing the .NET Framework.
 
 - .NET Framework 4.5 is supported on the Windows Preinstallation Environment (Windows PE). Not all features are supported on Windows PE.
 
@@ -72,7 +72,7 @@ The .NET Framework requires administrator privileges for installation. If you do
 
 - For all platforms, we recommend that you upgrade to the latest Windows Service Pack and install critical updates available from [Windows Update](https://support.microsoft.com/help/12373/windows-update-faq) to ensure the best compatibility and security.
 
-- On 64-bit operating systems, the .NET Framework supports both WOW64 (32-bit processing on a 64-bit machine) and native 64-bit processing.
+- On 64-bit operating systems, .NET Framework supports both WOW64 (32-bit processing on a 64-bit machine) and native 64-bit processing.
 
 ## Supported server operating systems
 
@@ -88,19 +88,19 @@ The .NET Framework requires administrator privileges for installation. If you do
 | Windows Server 2008 R2 SP1|64-bit | -- | .NET Framework 4<br /><br /> .NET Framework 4.5<br /><br /> .NET Framework 4.5.1<br /><br /> .NET Framework 4.5.2<br /><br /> .NET Framework 4.6<br /><br /> .NET Framework 4.6.1<br /><br /> .NET Framework 4.6.2<br /><br />.NET Framework 4.7<br/><br/>.NET Framework 4.7.1<br/><br/>.NET Framework 4.7.2<br/><br/>.NET Framework 4.8 |
 | Windows Server 2008 SP2|32-bit and 64-bit | -- | .NET Framework 4<br /><br /> .NET Framework 4.5<br /><br /> .NET Framework 4.5.1<br /><br /> .NET Framework 4.5.2<br /><br /> .NET Framework 4.6 |
 
- **Notes:**
+**Notes:**
 
 - Windows Server 2012 includes .NET Framework 4.5, so you don't have to install it separately. Similarly, Windows Server 2012 R2 includes .NET Framework 4.5.1.
 
-- The .NET Framework has limited support for the Server Core Role with Windows Server 2008 R2 SP1 or later. See [Server Core .NET Functionality](https://docs.microsoft.com/previous-versions//dd745015(v=vs.85)) for a list of unsupported APIs.
+- .NET Framework has limited support for the Server Core Role with Windows Server 2008 R2 SP1 or later. See [Server Core .NET Functionality](https://docs.microsoft.com/previous-versions//dd745015(v=vs.85)) for a list of unsupported APIs.
 
-- The .NET Framework isn't supported on Windows Server 2008 R2 for Itanium-Based Systems.
+- .NET Framework isn't supported on Windows Server 2008 R2 for Itanium-Based Systems.
 
-- On Windows Server 2008 SP2, the .NET Framework is not supported in the Server Core Role.
+- On Windows Server 2008 SP2, .NET Framework is not supported in the Server Core Role.
 
 - For all platforms, we recommend that you upgrade to the latest Windows Service Pack and critical updates available from [Windows Update](https://support.microsoft.com/help/12373/windows-update-faq) to ensure the best compatibility and security. Installation of the latest Windows Service Pack may be required on some operating systems.
 
-- On 64-bit operating systems, the .NET Framework supports both WOW64 (32-bit processing on a 64-bit machine) and native 64-bit processing.
+- On 64-bit operating systems, .NET Framework supports both WOW64 (32-bit processing on a 64-bit machine) and native 64-bit processing.
 
 ## See also
 

--- a/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
+++ b/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
@@ -1,32 +1,25 @@
 ---
-title: "The .NET Framework and Out-of-Band Releases"
+title: .NET Framework and Out-of-Band Releases
 ms.date: 10/10/2018
 ms.assetid: 721f10fa-3189-4124-a00d-56ddabd889b3
 ---
-# The .NET Framework and Out-of-Band Releases
+# .NET Framework and out-of-band releases
 
-The .NET Framework is evolving to accommodate different platforms such as Windows Phone and Windows Store apps as well as traditional desktop and web apps, and to maximize code reuse. In addition to our regular .NET Framework releases, we release new features out of band (OOB) to improve cross-platform development or to introduce new functionality. This topic discusses the future direction of the .NET Framework and its OOB releases.
+.NET Framework has evolved to accommodate different platforms, such as UWP apps and traditional desktop and web apps, and to maximize code reuse. In addition to regular .NET Framework releases, new features are released out of band (OOB) to improve cross-platform development or to introduce new functionality.
 
 ## Advantages of OOB releases
- Shipping new components or updates to components out of band enables Microsoft to provide more frequent updates to the .NET Framework. In addition, we can gather and respond to customer feedback more quickly.
 
- When you use an OOB feature in your app, your users do not have to install the latest version of the .NET Framework to run your app, because the OOB assemblies deploy with your app package.
+Shipping new components or updates to components out of band enables Microsoft to provide more frequent updates to .NET Framework. In addition, we can gather and respond to customer feedback more quickly.
+
+When you use an OOB feature in your app, your users do not have to install the latest version of .NET Framework to run your app, because the OOB assemblies deploy with your app package.
 
 ## How OOB packages are distributed
-OOB releases for core common language runtime (CLR) components are delivered through the [NuGet](https://www.nuget.org/), which is a package manager for .NET. NuGet enables you to browse and add libraries to your .NET Framework projects easily from the Solution Explorer in Visual Studio. NuGet is included with all editions of Visual Studio starting with Visual Studio 2012. To see if NuGet is installed, look for **NuGet Package Manager** on the Visual Studio **Tools** menu. If it’s not installed:
 
-1. On the Visual Studio menu bar, choose **Tools**, **Extensions and Updates** (in Visual Studio 2010, choose **Extension Manager**).
+OOB releases for core common language runtime (CLR) components are delivered through [NuGet](https://www.nuget.org/), which is the package manager for .NET. NuGet enables you to browse and add libraries to your .NET Framework projects easily from within Visual Studio. NuGet Package Manager is included with all editions of Visual Studio starting with Visual Studio 2012. Look for **NuGet Package Manager** on the **Tools** menu in Visual Studio. If it's not installed, follow the instructions on [Installing NuGet](/nuget/install-nuget-client-tools). For more information about NuGet, see the [NuGet docs](/nuget).
 
-     The **Extensions and Updates** dialog box opens.
+## Use a NuGet OOB package
 
-2. Choose **Online**, **NuGet Package Manager**, and then choose **Download**.
-
-3. After the download completes, restart Visual Studio.
-
- For detailed installation instructions, see [Installing NuGet](/nuget/install-nuget-client-tools) on the NuGet Docs website. For more information about NuGet, see the [NuGet documentation](/nuget).
-
-## Using a NuGet OOB package
- After you install NuGet, you can browse and add references to NuGet packages by using Solution Explorer in Visual Studio:
+If NuGet Package Manager is installed, you can browse and add references to NuGet packages by using Solution Explorer in Visual Studio:
 
 1. Open the shortcut menu for your project in Visual Studio, and then choose **Manage NuGet Packages**. (This option is also available from the **Project** menu.)
 
@@ -36,15 +29,16 @@ OOB releases for core common language runtime (CLR) components are delivered thr
 
 4. In the right pane, use the **Search** box to locate the package you would like to use. Some Microsoft packages are identified by the Microsoft .NET Framework logo, and all identify Microsoft as the publisher.
 
- ![Screenshot that shows the NuGet Package Manager.](./media/the-net-framework-and-out-of-band-releases/nuget-package-manager-dialog.png)
+![The NuGet Package Manager.](./media/the-net-framework-and-out-of-band-releases/nuget-package-manager-dialog.png)
 
- As mentioned previously, when you deploy an app that uses an OOB package, the OOB assemblies will ship with your app package.
+As mentioned previously, when you deploy an app that uses an OOB package, the OOB assemblies will ship with your app package.
 
 ## Types of OOB releases
- Typically, an OOB package has one or more prerelease versions and a stable version. The license that accompanies a prerelease doesn't typically allow redistribution, but enables you to try out a package and provide feedback. Feedback is incorporated in any updates made to the package. A final release is distributed as a stable package with NuGet and includes a license that lets you redistribute the NuGet package with your app. Stable packages are supported by Microsoft. Microsoft provides IntelliSense support as well as other types of documentation such as blog posts and forum answers for all packages. In addition, source code may be available with some, but not all, packages. For announcements regarding new and updated packages, you can subscribe to [the .NET Framework Blog](https://devblogs.microsoft.com/dotnet/).
 
- To find both prerelease and stable packages, choose **Include Prerelease** in the NuGet Package Manager.
+Typically, an OOB package has one or more prerelease versions and a stable version. The license that accompanies a prerelease doesn't typically allow redistribution, but enables you to try out a package and provide feedback. Feedback is incorporated in any updates made to the package. A final release is distributed as a stable package with NuGet and includes a license that lets you redistribute the NuGet package with your app. Stable packages are supported by Microsoft. Microsoft provides IntelliSense support as well as other types of documentation such as blog posts and forum answers for all packages. In addition, source code may be available with some, but not all, packages. For announcements regarding new and updated packages, you can subscribe to [the .NET Framework Blog](https://devblogs.microsoft.com/dotnet/).
+
+To find both prerelease and stable packages, choose **Include Prerelease** in NuGet Package Manager.
 
 ## See also
 
-- [Getting Started](index.md)
+- [Getting started](index.md)

--- a/docs/framework/get-started/toc.yml
+++ b/docs/framework/get-started/toc.yml
@@ -1,11 +1,11 @@
-- name: Getting Started
+- name: Getting started
   href: index.md
   items:
   - name: Overview
     href: overview.md
-  - name: The .NET Framework and Out-of-Band Releases
+  - name: .NET Framework and out-of-band releases
     href: the-net-framework-and-out-of-band-releases.md
-  - name: .NET Core and Open-Source
+  - name: .NET Core and open-source
     href: net-core-and-open-source.md
-  - name: System Requirements
+  - name: System requirements
     href: system-requirements.md

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -9,27 +9,26 @@ helpviewer_keywords:
   - "documentation, .NET Framework"
 ms.assetid: f61f02f2-2f20-483d-8f56-a9c8f3a54986
 ---
-
-# .NET Framework Guide
+# .NET Framework guide
 
 > [!NOTE]
-> This .NET Framework content set includes information for .NET Framework versions 4.5 through 4.8. To download the .NET Framework, see [Installing the .NET Framework](./install/guide-for-developers.md). For a list of new features and changes in the NET Framework, see [What's New in the .NET Framework](./whats-new/index.md). For a list of supported platforms, see [.NET Framework System Requirements](./get-started/system-requirements.md). For documentation about older versions of the .NET Framework, see [.NET previous versions documentation](https://docs.microsoft.com/previous-versions/dotnet/).
+> This .NET Framework content set includes information for .NET Framework versions 4.5 through 4.8. To download .NET Framework, see [Install .NET Framework](./install/guide-for-developers.md). For a list of new features and changes in .NET Framework, see [What's New in .NET Framework](./whats-new/index.md). For a list of supported platforms, see [.NET Framework System Requirements](./get-started/system-requirements.md). For documentation about older versions of .NET Framework, see [.NET previous versions documentation](https://docs.microsoft.com/previous-versions/dotnet/).
 
-The .NET Framework is a development platform for building apps for web, Windows, Windows Phone, Windows Server, and Microsoft Azure. It consists of the common language runtime (CLR) and the .NET Framework class library, which includes a broad range of functionality and support for many industry standards.
+.NET Framework is a development platform for building apps for web, Windows, Windows Server, and Microsoft Azure. It consists of the common language runtime (CLR) and the .NET Framework class library, which includes a broad range of functionality and support for many industry standards.
 
-The .NET Framework provides many services, including memory management, type and memory safety, security, networking, and application deployment. It provides easy-to-use data structures and APIs that abstract the lower-level Windows operating system. You can use different programming languages with the .NET Framework, including C#, F#, and Visual Basic.
+.NET Framework provides many services, including memory management, type and memory safety, security, networking, and application deployment. It provides easy-to-use data structures and APIs that abstract the lower-level Windows operating system. You can use different programming languages with .NET Framework, including C#, F#, and Visual Basic.
 
-For a general introduction to the .NET Framework for both users and developers, see [Getting Started](./get-started/index.md). For an introduction to the architecture and key features of the .NET Framework, see the [overview](./get-started/overview.md).
+For a general introduction to .NET Framework for both users and developers, see [Getting Started](./get-started/index.md). For an introduction to the architecture and key features of .NET Framework, see the [overview](./get-started/overview.md).
 
-The .NET Framework can be used with Docker and with [Windows Containers](/virtualization/windowscontainers/about/).
+.NET Framework can be used with Docker and with [Windows Containers](/virtualization/windowscontainers/about/).
 
 ## Installation
 
-The .NET Framework comes with Windows, enabling you to run .NET Framework applications. You may need a later version of the .NET Framework than the one that comes with your Windows version. For more information, see [Install the .NET Framework on Windows](./install/index.md).
+.NET Framework comes with Windows, which enables you to run .NET Framework applications. You may need a later version of .NET Framework than the one that comes with your Windows version. For more information, see [Install .NET Framework on Windows](./install/index.md).
 
-See [Repair the .NET Framework](./install/repair.md) to learn how to repair your .NET Framework installation if you're experiencing errors when installing the .NET Framework.
+To learn how to repair your .NET Framework installation if you're experiencing errors during installation, see [Repair .NET Framework](./install/repair.md).
 
-For more detailed information on downloading the .NET Framework, see [Install the .NET Framework for developers](./install/guide-for-developers.md).
+For more detailed information on downloading .NET Framework, see [Install the .NET Framework for developers](./install/guide-for-developers.md).
 
 ## In this section
 

--- a/docs/framework/toc.yml
+++ b/docs/framework/toc.yml
@@ -1,46 +1,47 @@
-- name: .NET Framework Guide
+- name: .NET Framework guide
   href: index.md
-- name: What's New
+- name: What's new
   href: whats-new/
-- name: Get Started
+- name: Get started
   href: get-started/
 - name: Installation guide
   href: install/
-- name: Migration Guide
+- name: Migration guide
   href: migration-guide/
-- name: Development Guide
+- name: Development guide
   href: development-guide.md
   items:
-  - name: Application Domains and Assemblies
+  - name: Application domains and assemblies
     href: app-domains/
-  - name: Resources in Desktop Apps
+  - name: Resources in desktop apps
     href: resources/
   - name: Accessibility
     href: ui-automation/
-  - name: Data and Modeling
+  - name: Data and modeling
     href: data/
-  - name: Client Applications
-    href: develop-client-apps.md
+  - name: Client apps
     items:
+    - name: Overview
+      href: develop-client-apps.md
     - name: Windows Presentation Foundation
       href: wpf/
     - name: Windows Forms
       href: winforms/
-  - name: Service-Oriented Applications with WCF
+  - name: Service-oriented apps with WCF
     href: wcf/
   - name: Windows Workflow Foundation
     href: windows-workflow-foundation/
-  - name: Windows Service Applications
+  - name: Windows Service apps
     href: windows-services/
-  - name: 64-bit Applications
+  - name: 64-bit apps
     href: 64-bit-apps.md
-  - name: Web Applications with ASP.NET
+  - name: Web apps with ASP.NET
     href: develop-web-apps-with-aspnet.md
-  - name: Network Programming in the .NET Framework
+  - name: Network programming
     href: network-programming/
-  - name: Configuring Apps
+  - name: Configure apps
     href: configure-apps/
-  - name: Compiling Apps with .NET Native
+  - name: Compile apps with .NET Native
     href: net-native/
   - name: Debugging, Tracing, and Profiling
     href: debug-trace-profile/
@@ -48,17 +49,17 @@
     href: deployment/
   - name: Performance
     href: performance/
-  - name: Dynamic Programming
+  - name: Dynamic programming
     href: reflection-and-codedom/
   - name: Managed Extensibility Framework (MEF)
     href: mef/
-  - name: Interoperating with Unmanaged Code
+  - name: Interoperate with unmanaged code
     href: interop/
-  - name: Unmanaged API Reference
+  - name: Unmanaged API reference
     href: unmanaged-api/
   - name: XAML Services
     href: ../desktop-wpf/xaml-services/
 - name: Tools
   href: tools/
-- name: Additional Class Libraries and APIs
+- name: Additional class libraries and APIs
   href: additional-apis/


### PR DESCRIPTION
- Remove 'the' from 'the .NET Framework'
- TOC capitalization
- Store apps -> UWP apps
- Updates to reflect that .NET Framework is no longer the latest and greatest

(Ignore whitespace on diff.)