### PR TITLE
docs for `dotnet nuget add source` and related

### DIFF
--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -166,6 +166,18 @@
         href: tools/dotnet-nuget-locals.md
       - name: dotnet nuget push
         href: tools/dotnet-nuget-push.md
+      - name: dotnet nuget add source
+        href: tools/dotnet-nuget-add-source.md
+      - name: dotnet nuget disable source
+        href: tools/dotnet-nuget-disable-source.md
+      - name: dotnet nuget enable source
+        href: tools/dotnet-nuget-enable-source.md
+      - name: dotnet nuget list source
+        href: tools/dotnet-nuget-list-source.md
+      - name: dotnet nuget remove source
+        href: tools/dotnet-nuget-remove-source.md
+      - name: dotnet nuget update source
+        href: tools/dotnet-nuget-update-source.md
     - name: dotnet pack
       href: tools/dotnet-pack.md
     - name: dotnet publish

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,8 +1,7 @@
 ---
 title: dotnet nuget add source command
 description: The dotnet nuget add source command adds a new package source to your NuGet configuration files. 
-author: nugetClient
-ms.date: 03/09/2020
+ms.date: 03/20/2020
 ---
 # dotnet nuget add source
 
@@ -33,13 +32,13 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
 ## Options
 
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
+
 - **`-n|--name`**
 
   Name of the source.
-
-- **`-u|--username`**
-
-  Username to be used when connecting to an authenticated source.
 
 - **`-p|--password`**
 
@@ -49,13 +48,13 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
   Enables storing portable package source credentials by disabling password encryption.
 
+- **`-u|--username`**
+
+  Username to be used when connecting to an authenticated source.
+
 - **`--valid-authentication-types`**
 
-  Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: basic,negotiate
-
-- **`--configfile`**
-
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
+  Comma-separated list of valid authentication types for this source. Set this to basic if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include negotiate, kerberos, ntlm, and digest, but these values are unlikely to be useful.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,10 +1,10 @@
-﻿# dotnet nuget add source
----
+﻿---
 title: dotnet nuget add source command
 description: The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
+# dotnet nuget add source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: dotnet nuget add source command
 description: The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,10 +1,10 @@
-﻿---
+﻿# dotnet nuget add source
+---
 title: dotnet nuget add source command
 description: The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
-# dotnet nuget add source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: dotnet nuget add source command
 description: The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -22,7 +22,7 @@ dotnet nuget add source [-h|--help]
 
 ## Description
 
-The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
+The `dotnet nuget add source` command adds a new package source to your NuGet configuration files.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -6,6 +6,7 @@ ms.date: 03/09/2020
 ---
 # dotnet nuget add source
 
+**This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,0 +1,87 @@
+---
+title: dotnet nuget add source command
+description: The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
+author: nugetClient
+ms.date: 03/09/2020
+---
+# dotnet nuget add source
+
+
+## Name
+
+`dotnet nuget add source` - Add a NuGet source.
+
+## Synopsis
+
+```dotnetcli
+`dotnet nuget add source PACKAGESOURCEPATH [--name] [--username] [--password] [--store-password-in-clear-text] [--valid-authentication-types] [--configfile]`
+`dotnet nuget add source [-h|--help]`
+```
+
+## Description
+
+The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
+
+## Arguments
+
+- **`PACKAGESOURCEPATH`**
+
+  Path to the package(s) source.
+
+## Options
+
+- **`-n|--name`**
+
+  Name of the source.
+
+- **`-u|--username`**
+
+  Username to be used when connecting to an authenticated source.
+
+- **`-p|--password`**
+
+  Password to be used when connecting to an authenticated source.
+
+- **`--store-password-in-clear-text`**
+
+  Enables storing portable package source credentials by disabling password encryption.
+
+- **`--valid-authentication-types`**
+
+  Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: basic,negotiate
+
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+
+## Examples
+
+- Add `nuget.org` as a source:
+
+  ```dotnetcli
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
+  ```
+
+- Add `c:\packages` as a local source:
+
+  ```dotnetcli
+  dotnet nuget add source c:\packages
+  ```
+
+- Add a source that needs authentication:
+
+  ```dotnetcli
+  dotnet nuget add source https://someServer/myTeam -n myTeam -u myUsername -p myPassword --store-password-in-clear-text
+  ```
+
+- Add a source that needs authentication (then go install credential provider):
+
+  ```dotnetcli
+  dotnet nuget add source https://azureartifacts.microsoft.com/myTeam -n myTeam
+  ```
+
+## See also
+
+- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+
+- [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet nuget add source command
-description: The `dotnet nuget add source` command adds a new package source to your NuGet configuration files. 
+description: The dotnet nuget add source command adds a new package source to your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
@@ -15,8 +15,10 @@ ms.date: 03/09/2020
 ## Synopsis
 
 ```dotnetcli
-`dotnet nuget add source PACKAGESOURCEPATH [--name] [--username] [--password] [--store-password-in-clear-text] [--valid-authentication-types] [--configfile]`
-`dotnet nuget add source [-h|--help]`
+dotnet nuget add source <PACKAGE_SOURCE_PATH> [--name] [--username]
+    [--password] [--store-password-in-clear-text] [--valid-authentication-types]
+    [--configfile]
+dotnet nuget add source [-h|--help]
 ```
 
 ## Description
@@ -25,9 +27,9 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
 ## Arguments
 
-- **`PACKAGESOURCEPATH`**
+- **`PACKAGE_SOURCE_PATH`**
 
-  Path to the package(s) source.
+  Path to the package source.
 
 ## Options
 
@@ -53,7 +55,7 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
 - **`--configfile`**
 
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -54,7 +54,7 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
 - **`--valid-authentication-types`**
 
-  Comma-separated list of valid authentication types for this source. Set this to basic if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include negotiate, kerberos, ntlm, and digest, but these values are unlikely to be useful.
+  Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -6,6 +6,7 @@ ms.date: 03/09/2020
 ---
 # dotnet nuget disable source
 
+**This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,0 +1,50 @@
+---
+title: dotnet nuget disable source command
+description: The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
+author: nugetClient
+ms.date: 03/09/2020
+---
+# dotnet nuget disable source
+
+
+## Name
+
+`dotnet nuget disable source` - Disable a NuGet source.
+
+## Synopsis
+
+```dotnetcli
+`dotnet nuget disable source NAME [--configfile]`
+`dotnet nuget disable source [-h|--help]`
+```
+
+## Description
+
+The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
+
+## Arguments
+
+- **`NAME`**
+
+  Name of the source.
+
+
+## Options
+
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+
+## Examples
+
+- Disable a source with name of `mySource`:
+
+  ```dotnetcli
+  dotnet nuget disable source mySource
+  ```
+
+## See also
+
+- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+
+- [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,8 +1,7 @@
 ---
 title: dotnet nuget disable source command
 description: The dotnet nuget disable source command disables an existing source in your NuGet configuration files. 
-author: nugetClient
-ms.date: 03/09/2020
+ms.date: 03/20/2020
 ---
 # dotnet nuget disable source
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: dotnet nuget disable source command
 description: The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
 author: nugetClient
@@ -28,7 +28,6 @@ The `dotnet nuget disable source` command disables an existing source in your Nu
 - **`NAME`**
 
   Name of the source.
-
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,10 +1,10 @@
-﻿# dotnet nuget disable source
----
+﻿---
 title: dotnet nuget disable source command
 description: The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
+# dotnet nuget disable source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: dotnet nuget disable source command
 description: The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,10 +1,10 @@
-﻿---
+﻿# dotnet nuget disable source
+---
 title: dotnet nuget disable source command
 description: The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
-# dotnet nuget disable source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -20,7 +20,7 @@ dotnet nuget disable source [-h|--help]
 
 ## Description
 
-The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
+The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet nuget disable source command
-description: The `dotnet nuget disable source` command disables an existing source in your NuGet configuration files. 
+description: The dotnet nuget disable source command disables an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
@@ -15,8 +15,8 @@ ms.date: 03/09/2020
 ## Synopsis
 
 ```dotnetcli
-`dotnet nuget disable source NAME [--configfile]`
-`dotnet nuget disable source [-h|--help]`
+dotnet nuget disable source <NAME> [--configfile]
+dotnet nuget disable source [-h|--help]
 ```
 
 ## Description
@@ -33,7 +33,7 @@ The `dotnet nuget disable source` command disables an existing source in your Nu
 
 - **`--configfile`**
 
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,10 +1,10 @@
-﻿# dotnet nuget enable source
----
+﻿---
 title: dotnet nuget enable source command
 description: The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
+# dotnet nuget enable source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: dotnet nuget enable source command
 description: The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet nuget enable source command
-description: The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
+description: The dotnet nuget enable source command enables an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
@@ -15,8 +15,8 @@ ms.date: 03/09/2020
 ## Synopsis
 
 ```dotnetcli
-`dotnet nuget enable source NAME [--configfile]`
-`dotnet nuget enable source [-h|--help]`
+dotnet nuget enable source <NAME> [--configfile]
+dotnet nuget enable source [-h|--help]
 ```
 
 ## Description
@@ -33,7 +33,7 @@ The `dotnet nuget enable source` command enables an existing source in your NuGe
 
 - **`--configfile`**
 
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,10 +1,10 @@
-﻿---
+﻿# dotnet nuget enable source
+---
 title: dotnet nuget enable source command
 description: The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
-# dotnet nuget enable source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: dotnet nuget enable source command
 description: The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
 author: nugetClient
@@ -28,7 +28,6 @@ The `dotnet nuget enable source` command enables an existing source in your NuGe
 - **`NAME`**
 
   Name of the source.
-
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -20,7 +20,7 @@ dotnet nuget enable source [-h|--help]
 
 ## Description
 
-The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
+The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,8 +1,7 @@
 ---
 title: dotnet nuget enable source command
 description: The dotnet nuget enable source command enables an existing source in your NuGet configuration files. 
-author: nugetClient
-ms.date: 03/09/2020
+ms.date: 03/20/2020
 ---
 # dotnet nuget enable source
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -1,0 +1,50 @@
+---
+title: dotnet nuget enable source command
+description: The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
+author: nugetClient
+ms.date: 03/09/2020
+---
+# dotnet nuget enable source
+
+
+## Name
+
+`dotnet nuget enable source` - Enable a NuGet source.
+
+## Synopsis
+
+```dotnetcli
+`dotnet nuget enable source NAME [--configfile]`
+`dotnet nuget enable source [-h|--help]`
+```
+
+## Description
+
+The `dotnet nuget enable source` command enables an existing source in your NuGet configuration files. 
+
+## Arguments
+
+- **`NAME`**
+
+  Name of the source.
+
+
+## Options
+
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+
+## Examples
+
+- Enable a source with name of `mySource`:
+
+  ```dotnetcli
+  dotnet nuget enable source mySource
+  ```
+
+## See also
+
+- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+
+- [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -6,6 +6,7 @@ ms.date: 03/09/2020
 ---
 # dotnet nuget enable source
 
+**This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: dotnet nuget list source command
 description: The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -6,6 +6,7 @@ ms.date: 03/09/2020
 ---
 # dotnet nuget list source
 
+**This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,10 +1,10 @@
-﻿# dotnet nuget list source
----
+﻿---
 title: dotnet nuget list source command
 description: The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
+# dotnet nuget list source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,8 +1,7 @@
 ---
 title: dotnet nuget list source command
 description: The dotnet nuget list source command lists all existing sources from your NuGet configuration files. 
-author: nugetClient
-ms.date: 03/09/2020
+ms.date: 03/20/2020
 ---
 # dotnet nuget list source
 
@@ -25,13 +24,13 @@ The `dotnet nuget list source` command lists all existing sources from your NuGe
 
 ## Options
 
-- **`--format`**
-
-  The format of the list command output: `Detailed` (the default) and `Short`.
-
 - **`--configfile`**
 
   The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
+
+- **`--format`**
+
+  The format of the list command output: `Detailed` (the default) and `Short`.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,0 +1,47 @@
+---
+title: dotnet nuget list source command
+description: The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
+author: nugetClient
+ms.date: 03/09/2020
+---
+# dotnet nuget list source
+
+
+## Name
+
+`dotnet nuget list source` - Lists all configured NuGet sources.
+
+## Synopsis
+
+```dotnetcli
+`dotnet nuget list source [--format] [--configfile]`
+`dotnet nuget list source [-h|--help]`
+```
+
+## Description
+
+The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
+
+## Options
+
+- **`--format`**
+
+  The format of the list command output: `Detailed` (the default) and `Short`.
+
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+
+## Examples
+
+- List configured sources from the current directory:
+
+  ```dotnetcli
+  dotnet nuget list source
+  ```
+
+## See also
+
+- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+
+- [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet nuget list source command
-description: The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
+description: The dotnet nuget list source command lists all existing sources from your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
@@ -15,8 +15,8 @@ ms.date: 03/09/2020
 ## Synopsis
 
 ```dotnetcli
-`dotnet nuget list source [--format] [--configfile]`
-`dotnet nuget list source [-h|--help]`
+dotnet nuget list source [--format] [--configfile]
+dotnet nuget list source [-h|--help]
 ```
 
 ## Description
@@ -31,7 +31,7 @@ The `dotnet nuget list source` command lists all existing sources from your NuGe
 
 - **`--configfile`**
 
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -20,7 +20,7 @@ dotnet nuget list source [-h|--help]
 
 ## Description
 
-The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
+The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files.
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,10 +1,10 @@
-﻿---
+﻿# dotnet nuget list source
+---
 title: dotnet nuget list source command
 description: The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
-# dotnet nuget list source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: dotnet nuget list source command
 description: The `dotnet nuget list source` command lists all existing sources from your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -20,7 +20,7 @@ dotnet nuget remove source [-h|--help]
 
 ## Description
 
-The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
+The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet nuget remove source command
-description: The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
+description: The dotnet nuget remove source command removes an existing source from your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
@@ -15,8 +15,8 @@ ms.date: 03/09/2020
 ## Synopsis
 
 ```dotnetcli
-`dotnet nuget remove source NAME [--configfile]`
-`dotnet nuget remove source [-h|--help]`
+dotnet nuget remove source <NAME> [--configfile]
+dotnet nuget remove source [-h|--help]
 ```
 
 ## Description
@@ -33,7 +33,7 @@ The `dotnet nuget remove source` command removes an existing source from your Nu
 
 - **`--configfile`**
 
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,0 +1,50 @@
+---
+title: dotnet nuget remove source command
+description: The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
+author: nugetClient
+ms.date: 03/09/2020
+---
+# dotnet nuget remove source
+
+
+## Name
+
+`dotnet nuget remove source` - Remove a NuGet source.
+
+## Synopsis
+
+```dotnetcli
+`dotnet nuget remove source NAME [--configfile]`
+`dotnet nuget remove source [-h|--help]`
+```
+
+## Description
+
+The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
+
+## Arguments
+
+- **`NAME`**
+
+  Name of the source.
+
+
+## Options
+
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+
+## Examples
+
+- Remove a source with name of `mySource`:
+
+  ```dotnetcli
+  dotnet nuget remove source mySource
+  ```
+
+## See also
+
+- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+
+- [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: dotnet nuget remove source command
 description: The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: dotnet nuget remove source command
 description: The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
 author: nugetClient
@@ -28,7 +28,6 @@ The `dotnet nuget remove source` command removes an existing source from your Nu
 - **`NAME`**
 
   Name of the source.
-
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,10 +1,10 @@
-﻿# dotnet nuget remove source
----
+﻿---
 title: dotnet nuget remove source command
 description: The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
+# dotnet nuget remove source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,10 +1,10 @@
-﻿---
+﻿# dotnet nuget remove source
+---
 title: dotnet nuget remove source command
 description: The `dotnet nuget remove source` command removes an existing source from your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
-# dotnet nuget remove source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -1,8 +1,7 @@
 ---
 title: dotnet nuget remove source command
 description: The dotnet nuget remove source command removes an existing source from your NuGet configuration files. 
-author: nugetClient
-ms.date: 03/09/2020
+ms.date: 03/20/2020
 ---
 # dotnet nuget remove source
 

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -6,6 +6,7 @@ ms.date: 03/09/2020
 ---
 # dotnet nuget remove source
 
+**This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,10 +1,10 @@
-﻿# dotnet nuget update source
----
+﻿---
 title: dotnet nuget update source command
 description: The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
+# dotnet nuget update source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet nuget update source command
-description: The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
+description: The dotnet nuget update source command updates an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
@@ -15,8 +15,10 @@ ms.date: 03/09/2020
 ## Synopsis
 
 ```dotnetcli
-`dotnet nuget update source NAME [--source] [--username] [--password] [--store-password-in-clear-text] [--valid-authentication-types] [--configfile]`
-`dotnet nuget update source [-h|--help]`
+dotnet nuget update source <NAME> [--source] [--username]
+    [--password] [--store-password-in-clear-text] [--valid-authentication-types]
+    [--configfile]
+dotnet nuget update source [-h|--help]
 ```
 
 ## Description
@@ -33,7 +35,7 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
 - **`-s|--source`**
 
-  Path to the package(s) source.
+  Path to the package source.
 
 - **`-u|--username`**
 
@@ -53,7 +55,7 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
 - **`--configfile`**
 
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: dotnet nuget update source command
 description: The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
 author: nugetClient
@@ -28,7 +28,6 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 - **`NAME`**
 
   Name of the source.
-
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,0 +1,70 @@
+---
+title: dotnet nuget update source command
+description: The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
+author: nugetClient
+ms.date: 03/09/2020
+---
+# dotnet nuget update source
+
+
+## Name
+
+`dotnet nuget update source` - Update a NuGet source.
+
+## Synopsis
+
+```dotnetcli
+`dotnet nuget update source NAME [--source] [--username] [--password] [--store-password-in-clear-text] [--valid-authentication-types] [--configfile]`
+`dotnet nuget update source [-h|--help]`
+```
+
+## Description
+
+The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
+
+## Arguments
+
+- **`NAME`**
+
+  Name of the source.
+
+
+## Options
+
+- **`-s|--source`**
+
+  Path to the package(s) source.
+
+- **`-u|--username`**
+
+  Username to be used when connecting to an authenticated source.
+
+- **`-p|--password`**
+
+  Password to be used when connecting to an authenticated source.
+
+- **`--store-password-in-clear-text`**
+
+  Enables storing portable package source credentials by disabling password encryption.
+
+- **`--valid-authentication-types`**
+
+  Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: basic,negotiate
+
+- **`--configfile`**
+
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. To learn more about NuGet configuration go to https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior.
+
+## Examples
+
+- Update a source with name of `mySource`:
+
+  ```dotnetcli
+  dotnet nuget update source mySource --source c:\packages
+  ```
+
+## See also
+
+- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+
+- [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,8 +1,7 @@
 ---
 title: dotnet nuget update source command
 description: The dotnet nuget update source command updates an existing source in your NuGet configuration files. 
-author: nugetClient
-ms.date: 03/09/2020
+ms.date: 03/20/2020
 ---
 # dotnet nuget update source
 
@@ -33,29 +32,29 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
 ## Options
 
-- **`-s|--source`**
+- **`--configfile`**
 
-  Path to the package source.
-
-- **`-u|--username`**
-
-  Username to be used when connecting to an authenticated source.
+  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 - **`-p|--password`**
 
   Password to be used when connecting to an authenticated source.
 
+- **`-s|--source`**
+
+  Path to the package source.
+
 - **`--store-password-in-clear-text`**
 
   Enables storing portable package source credentials by disabling password encryption.
 
+- **`-u|--username`**
+
+  Username to be used when connecting to an authenticated source.
+
 - **`--valid-authentication-types`**
 
-  Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: basic,negotiate
-
-- **`--configfile`**
-
-  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
+  Comma-separated list of valid authentication types for this source. Set this to basic if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include negotiate, kerberos, ntlm, and digest, but these values are unlikely to be useful.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: dotnet nuget update source command
 description: The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
 author: nugetClient

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -1,10 +1,10 @@
-﻿---
+﻿# dotnet nuget update source
+---
 title: dotnet nuget update source command
 description: The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
 author: nugetClient
 ms.date: 03/09/2020
 ---
-# dotnet nuget update source
 
 **This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -6,6 +6,7 @@ ms.date: 03/09/2020
 ---
 # dotnet nuget update source
 
+**This article applies to:** ✔️ .NET Core 3.1.200 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -22,7 +22,7 @@ dotnet nuget update source [-h|--help]
 
 ## Description
 
-The `dotnet nuget update source` command updates an existing source in your NuGet configuration files. 
+The `dotnet nuget update source` command updates an existing source in your NuGet configuration files.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -54,7 +54,7 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
 - **`--valid-authentication-types`**
 
-  Comma-separated list of valid authentication types for this source. Set this to basic if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include negotiate, kerberos, ntlm, and digest, but these values are unlikely to be useful.
+  Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful.
 
 ## Examples
 

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -187,8 +187,14 @@ Command | Function
 Command | Function
 --- | ---
 [dotnet nuget delete](dotnet-nuget-delete.md) | Deletes or unlists a package from the server.
-[dotnet nuget locals](dotnet-nuget-locals.md) | Clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder.
 [dotnet nuget push](dotnet-nuget-push.md) | Pushes a package to the server and publishes it.
+[dotnet nuget locals](dotnet-nuget-locals.md) | Clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder.
+[dotnet nuget add source](dotnet-nuget-add-source.md) | Adds a NuGet source.
+[dotnet nuget disable source](dotnet-nuget-disable-source.md) | Disables a NuGet source.
+[dotnet nuget enable source](dotnet-nuget-enable-source.md) | Enables a NuGet source.
+[dotnet nuget list source](dotnet-nuget-list-source.md) | Lists all configured NuGet sources.
+[dotnet nuget remove source](dotnet-nuget-remove-source.md) | Removes a NuGet source.
+[dotnet nuget update source](dotnet-nuget-update-source.md) | Updates a NuGet source.
 
 ### Global, tool-path, and local tools commands
 


### PR DESCRIPTION
## Summary
dotnet 3.1.200 has added `dotnet nuget add source` and related commands

This is documentation that is autogenerated in https://github.com/nuget/nuget.client 
Template for docs is: src\NuGet.Core\NuGet.CommandLine.XPlat\external\docs.tt
Data for docs is from: src\NuGet.Core\NuGet.CommandLine.XPlat\Commands\Commands.xml

Happy to iterate to make these better based on feedback.

initially discussed offline with: @tdykstra 
