### PR TITLE
Adding documentation of cli DOTNET_NOLOGO env variable

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -251,7 +251,7 @@ dotnet myapp.dll
 
 - `DOTNET_NOLOGO`
 
-  Specified whether .NET Core welcome and telemetry messages are displayed on first run. Set to `true` to mute these messages (values `true`, `1`, or `yes` accepted) or set to `false` to allow (values `false`, `0`, or `no` accepted). If not set, the default is `false` and the messages will be displayed on first run. Note that this flag has no effect on telemetry (see `DOTNET_CLI_TELEMETRY_OPTOUT` for opting out of sending telemetry).
+  Specifies whether .NET Core welcome and telemetry messages are displayed on first run. Set to `true` to mute these messages (values `true`, `1`, or `yes` accepted) or set to `false` to allow (values `false`, `0`, or `no` accepted). If not set, the default is `false` and the messages will be displayed on first run. Note that this flag has no effect on telemetry (see `DOTNET_CLI_TELEMETRY_OPTOUT` for opting out of sending telemetry).
 
 - `DOTNET_CLI_TELEMETRY_OPTOUT`
 

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -249,6 +249,10 @@ dotnet myapp.dll
 
   Specifies the location of the servicing index to use by the shared host when loading the runtime.
 
+- `DOTNET_NOLOGO`
+
+  Specified whether .NET Core welcome and telemetry messages are displayed on first run. Set to `true` to mute these messages (values `true`, `1`, or `yes` accepted) or set to `false` to allow (values `false`, `0`, or `no` accepted). If not set, the default is `false` and the messages will be displayed on first run. Note that this flag has no effect on telemetry (see `DOTNET_CLI_TELEMETRY_OPTOUT` for opting out of sending telemetry).
+
 - `DOTNET_CLI_TELEMETRY_OPTOUT`
 
   Specifies whether data about the .NET Core tools usage is collected and sent to Microsoft. Set to `true` to opt-out of the telemetry feature (values `true`, `1`, or `yes` accepted). Otherwise, set to `false` to opt into the telemetry features (values `false`, `0`, or `no` accepted). If not set, the default is `false` and the telemetry feature is active.

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -40,7 +40,7 @@ The .NET Core tools collect usage data in order to help us improve your experien
 Read more about .NET Core CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
 ```
 
-To disable this message and the .NET Core welcome message, set the `DOTNET_NOLOGO` environment variable to true. Note that this variable has no effect on telemetry opt out.
+To disable this message and the .NET Core welcome message, set the `DOTNET_NOLOGO` environment variable to `true`. Note that this variable has no effect on telemetry opt out.
 
 ## Data points
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -40,6 +40,8 @@ The .NET Core tools collect usage data in order to help us improve your experien
 Read more about .NET Core CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
 ```
 
+To disable this message and the .NET Core welcome message, set the `DOTNET_NOLOGO` environment variable to true. Note that this variable has no effect on telemetry opt out.
+
 ## Data points
 
 The telemetry feature doesn't collect personal data, such as usernames or email addresses. It doesn't scan your code and doesn't extract project-level data, such as name, repository, or author. The data is sent securely to Microsoft servers using [Azure Monitor](https://azure.microsoft.com/services/monitor/) technology, held under restricted access, and published under strict security controls from secure [Azure Storage](https://azure.microsoft.com/services/storage/) systems.


### PR DESCRIPTION
## Summary

Updating docs to reflect addition of new CLI environment variable: see dotnet/cli#13275
Set as WIP until change is checked in.

cc @KathleenDollard, @wli3 