### PR TITLE
14). Add descriptions, fix links

### DIFF
--- a/docs/standard/linq/build-linq-xml-examples.md
+++ b/docs/standard/linq/build-linq-xml-examples.md
@@ -1,12 +1,13 @@
 ---
 title: "How to build LINQ to XML examples"
+description: The C# and Visual Basic code in this documentation uses classes and types from various namespaces. To compile and run the code you must provide appropriate directives and statements to access the namespaces. 
 ms.date: 07/20/2015
 ms.assetid: e5d18fa1-2704-48fe-a44b-1564f97c9e9c
 ---
 
 # How to build LINQ to XML examples
 
-The various snippets and examples in this documentation use classes and types from different kinds of namespaces. When compiling C# code you need to supply appropriate `using` directives, and when compiling Visual Basic code you need to supply appropriate `Imports` statements.
+The snippets and examples in this documentation use classes and types from various namespaces. When compiling C# code you need to supply appropriate `using` directives, and when compiling Visual Basic code you need to supply appropriate `Imports` statements.
 
 ## Example
 

--- a/docs/standard/linq/catch-parsing-errors.md
+++ b/docs/standard/linq/catch-parsing-errors.md
@@ -1,6 +1,6 @@
 ---
 title: "How to catch parsing errors - LINQ to XML"
-description: Learn how to detect badly formed or invalid XML.
+description: An exception can occur in your C# or Visual Basic program if it tries to parse invalid XML with a method such as XElement.Parse. You can write the program to catch and respond to such exceptions.
 ms.date: 7/20/2015
 dev_langs:
   - "csharp"
@@ -59,4 +59,4 @@ For information about the exceptions that the <xref:System.Xml.Linq.XElement.Par
 
 ## See also
 
-- [How to parse a string (LINQ to XML)](parse-string.md)
+- [How to parse a string](parse-string.md)

--- a/docs/standard/linq/control-namespace-prefixes.md
+++ b/docs/standard/linq/control-namespace-prefixes.md
@@ -1,6 +1,6 @@
 ---
 title: "How to control namespace prefixes - LINQ to XML"
-description: Learn how to control namespace prefixes when serializing an XML tree.
+description: You can control namespace prefixes when serializing an XML tree in C# and Visual Basic. To do this, insert attributes that declare namespaces.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -71,4 +71,4 @@ The example produces this output:
 
 ## See also
 
-- [Namespaces overview (LINQ to XML)](namespaces-overview.md)
+- [Namespaces overview](namespaces-overview.md)

--- a/docs/standard/linq/create-document-namespaces-csharp.md
+++ b/docs/standard/linq/create-document-namespaces-csharp.md
@@ -1,6 +1,6 @@
 ---
 title: "How to create a document with namespaces in C# - LINQ to XML"
-description: Learn how to create documents in C# that have namespaces.
+description: Use the XNamespace object in C# to create documents that have default namespaces or namespaces with a prefix.
 ms.date: 07/20/2015
 ms.assetid: 37e63c57-f86d-47ac-88a7-2c2d107def30
 ---
@@ -125,7 +125,7 @@ Another way to accomplish the same result is to use expanded names instead of de
 
 This approach has performance implications. Each time you pass a string that contains an expanded name to LINQ to XML, LINQ to XML must parse the name, find the atomized namespace, and find the atomized name. This process takes CPU time. If performance is important, you might want to declare and use an <xref:System.Xml.Linq.XNamespace> object explicitly.
 
-If performance is an important issue, see [Pre-Atomization of XName Objects (LINQ to XML)](pre-atomization-xname-objects.md) for more information.
+If performance is an important issue, see [Pre-Atomization of XName Objects](pre-atomization-xname-objects.md) for more information.
 
 ```csharp
 // Create an XML tree in a namespace, with a specified prefix
@@ -146,4 +146,4 @@ The example produces this output:
 
 ## See also
 
-- [Namespaces overview (LINQ to XML)](namespaces-overview.md)
+- [Namespaces overview](namespaces-overview.md)

--- a/docs/standard/linq/create-document-namespaces-visual-basic.md
+++ b/docs/standard/linq/create-document-namespaces-visual-basic.md
@@ -1,6 +1,6 @@
 ---
 title: "How to create a document with namespaces in Visual Basic - LINQ to XML"
-description: Learn how to create a document with namespaces in Visual Basic.
+description: Use XML literals in Visual Basic to create documents that have default namespaces or namespaces with a prefix.
 ms.date: 07/20/2015
 ms.assetid: cc5b0d4d-360c-4ada-94fa-2d2916e989be
 ---
@@ -13,7 +13,7 @@ When using XML literals in Visual Basic, users can define one global default XML
 
 You can also define other namespaces, and specify the namespace prefixes for those namespaces. You use the `Imports` keyword to define both types of namespace.
 
-For more information, see [XML literals in Visual Basic (LINQ to XML)](xml-literals.md).
+For more information, see [XML literals in Visual Basic](xml-literals.md).
 
 Note that the default XML namespace only applies to elements and not to attributes. Attributes are by default in the default namespace. However, you can use a namespace prefix to put an attribute in a namespace.
 
@@ -114,4 +114,4 @@ The example produces this output:
 
 ## See also
 
-- [Namespaces overview (LINQ to XML)](namespaces-overview.md)
+- [Namespaces overview](namespaces-overview.md)

--- a/docs/standard/linq/create-tree-xmlreader.md
+++ b/docs/standard/linq/create-tree-xmlreader.md
@@ -1,6 +1,6 @@
 ---
 title: "How to create a tree from an XmlReader - LINQ to XML"
-description: Learn how to create an XML tree directly from an XmlReader.
+description: You can use an XmlReader in C# or Visual Basic to read XML and create an XML tree. You must properly position the XmlReader on an element node.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -14,7 +14,7 @@ This article shows how to create an XML tree directly from an <xref:System.Xml.X
 
 ## Example: Load XElement object from an XmlReader object
 
-This example uses the XML document [Sample XML file: Books (LINQ to XML)](sample-xml-file-books.md).
+This example uses the XML document [Sample XML file: Books](sample-xml-file-books.md).
 
 The following code creates a <xref:System.Xml.XmlReader> object, reads nodes until it finds the first element node, and loads the <xref:System.Xml.Linq.XElement> object.
 

--- a/docs/standard/linq/create-xml-trees.md
+++ b/docs/standard/linq/create-xml-trees.md
@@ -1,5 +1,6 @@
 ---
 title: "Create XML Trees in C# - LINQ to XML"
+description: You can create an XML tree in C# using the LINQ to XML XElement and XAttribute constructors, and you can make the code resemble the structure of the underlying XML.
 ms.date: 08/31/2018
 ms.assetid: cc74234a-0bac-4327-9c8c-5a2ead15b595
 ---

--- a/docs/standard/linq/functional-construction.md
+++ b/docs/standard/linq/functional-construction.md
@@ -1,5 +1,6 @@
 ---
 title: "Functional construction - LINQ to XML"
+description: LINQ to XML provides functional construction, which enables you to create an XML tree in a single statement. 
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -95,5 +96,5 @@ The example produces this output:
 
 ## See also
 
-- [Create XML Trees in C# (LINQ to XML)](create-xml-trees.md)
-- [XML literals in Visual Basic (LINQ to XML)](xml-literals.md)
+- [Create XML Trees in C#](create-xml-trees.md)
+- [XML literals in Visual Basic](xml-literals.md)

--- a/docs/standard/linq/functional-vs-procedural-programming.md
+++ b/docs/standard/linq/functional-vs-procedural-programming.md
@@ -1,5 +1,6 @@
 ---
 title: "Functional vs. procedural programming"
+description: LINQ to XML supports both functional construction and procedural techniques for creating XML applications. Functional construction is a declarative approach. The procedural techniques support in-memory modification of XML trees.
 ms.date: 07/20/2015
 ms.assetid: fc64e39c-a487-4882-9169-da4de97917d9
 ---
@@ -28,6 +29,6 @@ When modifying an XML tree in place, you write code that traverses and navigates
 
 You can use LINQ to XML with either approach. You use the same classes, and in some cases the same methods. However, the structure and goals of the two approaches are different. For example, in different situations, one or the other approach will often have better performance, and use more or less memory. In addition, one or the other approach will be easier to write and yield more maintainable code.
 
-To see the two approaches contrasted, see [In-memory XML tree modification vs. functional construction (LINQ to XML)](in-memory-xml-tree-modification-vs-functional-construction.md).
+To see the two approaches contrasted, see [In-memory XML tree modification vs. functional construction](in-memory-xml-tree-modification-vs-functional-construction.md).
 
 For a tutorial on writing functional transformations, see [Introduction to pure functional transformations](pure-functional-transformations.md).

--- a/docs/standard/linq/index.md
+++ b/docs/standard/linq/index.md
@@ -1,6 +1,6 @@
 ---
 title: LINQ overview - .NET
-description: LINQ provides language-level querying capabilities and an API to C# and Visual Basic as a way to write expressive, declarative code.
+description: Language-Integrated Query (LINQ) provides language-level querying capabilities, and a higher-order function API to C# and Visual Basic, that enable you to write expressive declarative code. 
 author: cartermp
 ms.author: wiwagn
 ms.date: 06/20/2016
@@ -12,7 +12,7 @@ dev_langs:
 
 # LINQ overview
 
-Language-Integrated Query (LINQ) provides language-level querying capabilities and a [higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) API to C# and Visual Basic as a way to write expressive, declarative code.
+Language-Integrated Query (LINQ) provides language-level querying capabilities, and a [higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) API to C# and Visual Basic, that enable you to write expressive declarative code.
 
 ## Example: Language-level query syntax
 
@@ -106,7 +106,7 @@ End Function
 
 Writing code to manually traverse the XML document to do this task would be far more challenging.
 
-Interacting with XML isn’t the only thing you can do with LINQ Providers. [Linq to SQL](../../framework/data/adonet/sql/linq/index.md) is a fairly bare-bones Object-Relational Mapper (ORM) for an MSSQL Server Database. The [JSON.NET](https://www.newtonsoft.com/json/help/html/LINQtoJSON.htm) library provides efficient JSON Document traversal via LINQ. Furthermore, if there isn’t a library that does what you need, you can also [write your own LINQ Provider](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2012/bb546158(v=vs.110))!
+Interacting with XML isn't the only thing you can do with LINQ Providers. [Linq to SQL](../../framework/data/adonet/sql/linq/index.md) is a fairly bare-bones Object-Relational Mapper (ORM) for an MSSQL Server Database. The [JSON.NET](https://www.newtonsoft.com/json/help/html/LINQtoJSON.htm) library provides efficient JSON Document traversal via LINQ. Furthermore, if there isn't a library that does what you need, you can also [write your own LINQ Provider](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2012/bb546158(v=vs.110))!
 
 ## Reasons to use the query syntax
 
@@ -134,7 +134,7 @@ Dim filteredItems = From item In myItems
                     Select item
 ```
 
-Isn’t the API syntax just a more concise way to do the query syntax?
+Isn't the API syntax just a more concise way to do the query syntax?
 
 No. The query syntax allows for the use of the **let** clause, which allows you to introduce and bind a variable within the scope of the expression, using it in subsequent pieces of the expression. Reproducing the same code with only the API syntax can be done, but will most likely lead to code that's hard to read.
 
@@ -144,13 +144,13 @@ The answer to this question is **yes** if:
 
 - Your existing codebase already uses the query syntax.
 - You need to scope variables within your queries because of complexity.
-- You prefer the query syntax and it won’t distract from your codebase.
+- You prefer the query syntax and it won't distract from your codebase.
 
 The answer to this question is **no** if...
 
 - Your existing codebase already uses the API syntax
 - You have no need to scope variables within your queries
-- You prefer the API syntax and it won’t distract from your codebase
+- You prefer the API syntax and it won't distract from your codebase
 
 ## Examples: Essential LINQ
 

--- a/docs/standard/linq/linq-xml-classes-overview.md
+++ b/docs/standard/linq/linq-xml-classes-overview.md
@@ -1,5 +1,6 @@
 ---
 title: "LINQ to XML classes overview"
+description: This article provides a list of the LINQ to XML classes, with descriptions of each.
 ms.date: 07/20/2015
 ms.assetid: bf666100-5392-4968-97f4-f6b9d3287d7b
 ---

--- a/docs/standard/linq/linq-xml-overview.md
+++ b/docs/standard/linq/linq-xml-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Overview - LINQ to XML"
-description: LINQ to XML provides an in-memory XML programming interface that leverages the .NET Language-Integrated Query (LINQ) Framework.
+description: LINQ to XML provides an in-memory XML programming interface that is based on .NET capabilities, and comparable to an updated DOM API.
 ms.date: 10/30/2018
 dev_langs:
   - "csharp"

--- a/docs/standard/linq/linq-xml-vs-dom.md
+++ b/docs/standard/linq/linq-xml-vs-dom.md
@@ -1,5 +1,6 @@
 ---
 title: "LINQ to XML vs. DOM"
+description: There are key differences between LINQ to XML and DOM. LINQ to XML supports functional construction and XML literals, which better show the structure of the XML trees that they build. 
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -156,13 +157,13 @@ When using LINQ to XML, you use the <xref:System.Xml.Linq.XDocument> class only 
 
 ## Simplified handling of names and namespaces
 
-Handling names, namespaces, and namespace prefixes is generally a complex part of XML programming. LINQ to XML simplifies names and namespaces by eliminating the requirement to deal with namespace prefixes. If you want to control namespace prefixes, you can. But if you decide to not explicitly control namespace prefixes, LINQ to XML will assign namespace prefixes during serialization if they're required, or will serialize using default namespaces if they aren't. If default namespaces are used, there will be no namespace prefixes in the resulting document. For more information, see [Namespaces overview (LINQ to XML)](namespaces-overview.md).
+Handling names, namespaces, and namespace prefixes is generally a complex part of XML programming. LINQ to XML simplifies names and namespaces by eliminating the requirement to deal with namespace prefixes. If you want to control namespace prefixes, you can. But if you decide to not explicitly control namespace prefixes, LINQ to XML will assign namespace prefixes during serialization if they're required, or will serialize using default namespaces if they aren't. If default namespaces are used, there will be no namespace prefixes in the resulting document. For more information, see [Namespaces overview](namespaces-overview.md).
 
 Another problem with the DOM is that it doesn't let you change the name of a node. Instead, you have to create a new node and copy all the child nodes to it, losing the original node identity. LINQ to XML avoids this problem by enabling you to set the <xref:System.Xml.Linq.XName> property on a node.
 
 ## Static method support for loading XML
 
-LINQ to XML lets you load XML by using static methods, instead of instance methods. This simplifies loading and parsing. For more information, see [How to load XML from a file (LINQ to XML)](load-xml-file.md).
+LINQ to XML lets you load XML by using static methods, instead of instance methods. This simplifies loading and parsing. For more information, see [How to load XML from a file](load-xml-file.md).
 
 ## Removal of support for DTD constructs
 

--- a/docs/standard/linq/linq-xml-vs-xml-technologies.md
+++ b/docs/standard/linq/linq-xml-vs-xml-technologies.md
@@ -1,12 +1,13 @@
 ---
 title: "LINQ to XML vs. other XML technologies"
+description: Learn how LINQ to XML compares to XSLT, MSXML, and XmlLite, to make better technology choices.
 ms.date: 07/20/2015
 ms.assetid: 01b8e746-12d3-471d-b811-7539e4547784
 ---
 
 # LINQ to XML vs. other XML technologies
 
-This article compares LINQ to XML to the following XML technologies: <xref:System.Xml.XmlReader>, XSLT, MSXML, and XmlLite. This information can help you decide which technology to use.
+This article compares LINQ to XML to the following XML technologies: <xref:System.Xml.XmlReader>, XSLT, MSXML, and XmlLite. This information can help you decide which technologies to use.
 
 For a comparison of LINQ to XML to the Document Object Model (DOM), see [LINQ to XML vs. DOM](linq-xml-vs-dom.md).
 

--- a/docs/standard/linq/load-xml-file.md
+++ b/docs/standard/linq/load-xml-file.md
@@ -1,6 +1,6 @@
 ---
 title: "How to load XML from a file - LINQ to XML"
-description: Learn how to load XML from a file.
+description: You can use the XElement.Load method in C# and Visual Basic to load an XML document from a file.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -16,7 +16,7 @@ This article shows how to load XML from a file in C# and Visual Basic using the 
 
 The following example shows how to load an XML document from a file by providing <xref:System.Xml.Linq.XElement.Load%2A?displayProperty=nameWithType> with the URI that references the file. The example loads books.xml and outputs the XML tree to the console.
 
-The contents of books.xml are shown in [Sample XML file: Books (LINQ to XML)](sample-xml-file-books.md).
+The contents of books.xml are shown in [Sample XML file: Books](sample-xml-file-books.md).
 
 ```csharp
 XElement booksFromFile = XElement.Load(@"books.xml");

--- a/docs/standard/linq/namespaces-overview.md
+++ b/docs/standard/linq/namespaces-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Namespaces overview - LINQ to XML"
-description: An introduction to namespaces in LINQ to XML.
+description: Learn about XML names, XML namespaces, and XML namespace prefixes, and about the XName and XNamespace classes. 
 ms.date: 07/20/2015
 ms.assetid: 16283322-8238-4918-ab11-802ac6748eb7
 ---

--- a/docs/standard/linq/parse-string.md
+++ b/docs/standard/linq/parse-string.md
@@ -1,5 +1,6 @@
 ---
 title: "How to parse a string - LINQ to XML"
+description: You can parse a string with XElement.Parse to create an XML tree in C# and Visual Basic, and you can create an XML tree with XML literals in Visual Basic.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"

--- a/docs/standard/linq/populate-xml-tree-xmlwriter.md
+++ b/docs/standard/linq/populate-xml-tree-xmlwriter.md
@@ -1,6 +1,6 @@
 ---
 title: "How to populate an XML tree with an XmlWriter - LINQ to XML"
-description: Learn how to populate an XML tree using the CreateWriter method.
+description: To populate an XML tree in C# and Visual Basic, create an XMLWriter using CreateWriter, then write to the XmlWriter.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"

--- a/docs/standard/linq/preserve-white-space-loading-parsing-xml.md
+++ b/docs/standard/linq/preserve-white-space-loading-parsing-xml.md
@@ -1,6 +1,6 @@
 ---
 title: "Preserve white space while loading or parsing XML - LINQ to XML"
-description: Learn how to control the white-space behavior of methods that populate XML trees.
+description: You can control the white-space behavior of LINQ to XML methods that populate XML trees. For instance, you can remove indentation for in-memory processing, or leave it as is.
 ms.date: 07/20/2015
 ms.assetid: f3ff58c4-55aa-4fcd-b933-e3a2ee6e706c
 ---
@@ -13,7 +13,7 @@ A common scenario is to read indented XML, create an in-memory XML tree without 
 
 Another common scenario is to read and modify XML that has already been intentionally indented. You might not want to change this indentation in any way. To do this in LINQ to XML, you preserve white space when you load or parse the XML and disable formatting when you serialize the XML.
 
-This article describes the white-space behavior of methods that populate XML trees. For information about controlling white space when you serialize XML trees, see [Preserve white space while serializing (LINQ to XML)](preserve-white-space-serializing.md).
+This article describes the white-space behavior of methods that populate XML trees. For information about controlling white space when you serialize XML trees, see [Preserve white space while serializing](preserve-white-space-serializing.md).
 
 ## Behavior of methods that populate XML trees
 

--- a/docs/standard/linq/preserve-white-space-serializing.md
+++ b/docs/standard/linq/preserve-white-space-serializing.md
@@ -1,6 +1,6 @@
 ---
 title: "Preserve white space while serializing - LINQ to XML"
-description: Learn how to control white space when serializing an XML tree.
+description: You can control white space in various ways when serializing an XML tree.
 ms.date: 07/20/2015
 ms.assetid: 0c4f8b98-483b-4cf8-86be-fa146eef90dc
 ---

--- a/docs/standard/linq/sample-xml-file-customers-orders.md
+++ b/docs/standard/linq/sample-xml-file-customers-orders.md
@@ -7,9 +7,9 @@ ms.assetid: d6d1c9ea-be74-4e6d-bfdd-d4bcc2d301cf
 
 The following XML file is used in various examples in the LINQ to XML documentation. This file contains customers and orders.
 
-The article [Sample XSD file: Customers and orders (LINQ to XML)](sample-xsd-file-customers-orders.md) contains an XSD that can be used to validate this document. It uses the `xs:key` and `xs:keyref` features of XSD to establish that the `CustomerID` attribute of the `Customer` element is a key, and to establish a relationship between the `CustomerID` element in each `Order` element and the `CustomerID` attribute in each `Customer` element.
+The article [Sample XSD file: Customers and orders](sample-xsd-file-customers-orders.md) contains an XSD that can be used to validate this document. It uses the `xs:key` and `xs:keyref` features of XSD to establish that the `CustomerID` attribute of the `Customer` element is a key, and to establish a relationship between the `CustomerID` element in each `Order` element and the `CustomerID` attribute in each `Customer` element.
 
-For an example of writing LINQ queries that take advantage of this relationship using the `Join` clause, see [How to join two collections (LINQ to XML)](join-two-collections.md).
+For an example of writing LINQ queries that take advantage of this relationship using the `Join` clause, see [How to join two collections](join-two-collections.md).
 
 ## CustomersOrders.xml
 

--- a/docs/standard/linq/sample-xsd-file-customers-orders.md
+++ b/docs/standard/linq/sample-xsd-file-customers-orders.md
@@ -7,7 +7,7 @@ ms.assetid: ef9911a3-7ac4-44fd-b36e-a0c0ad0a157d
 
 The following XSD file is used in various examples in the LINQ to XML documentation. This file contains a schema definition for the [Sample XML file: Customers and orders](sample-xml-file-customers-orders.md). The schema uses the `xs:key` and `xs:keyref` features of XSD to establish that the `CustomerID` attribute of the `Customer` element is a key, and to establish a relationship between the `CustomerID` element in each `Order` element and the `CustomerID` attribute in each `Customer` element.
 
-For an example of writing LINQ queries that take advantage of this relationship using the `Join` clause, see [How to join two collections (LINQ to XML)](join-two-collections.md).
+For an example of writing LINQ queries that take advantage of this relationship using the `Join` clause, see [How to join two collections](join-two-collections.md).
 
 ## CustomersOrders.xsd
 

--- a/docs/standard/linq/scope-default-namespaces.md
+++ b/docs/standard/linq/scope-default-namespaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Scope of default namespaces - LINQ to XML"
-description: Find out the proper and the improper way of querying an XML tree that has a default namespace.
+description: Default namespaces as represented in the XML tree aren't in scope for queries. Here are proper and improper ways of querying them.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -136,4 +136,4 @@ End of result set
 
 ## See also
 
-- [Namespaces overview (LINQ to XML)](namespaces-overview.md)
+- [Namespaces overview](namespaces-overview.md)

--- a/docs/standard/linq/stream-xml-fragments-xmlreader.md
+++ b/docs/standard/linq/stream-xml-fragments-xmlreader.md
@@ -1,6 +1,6 @@
 ---
 title: "How to stream XML fragments from an XmlReader - LINQ to XML"
-description: Learn how to stream XML fragments using an XmlReader when loading the whole XML tree into memory is not feasible.
+description: You can stream XML fragments from an XmlReader using a custom axis method in C# and Visual Basic. This is an approach that can work when loading the whole XML tree into memory is infeasible.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -18,9 +18,9 @@ When you create an XML tree from an <xref:System.Xml.XmlReader> object, the <xre
 
 If you want to create a partial tree, you can instantiate an <xref:System.Xml.XmlReader>, position the reader on the node that you want to convert to an <xref:System.Xml.Linq.XElement> tree, and then create the <xref:System.Xml.Linq.XElement> object.
 
-The article [How to stream XML fragments with access to header information (LINQ to XML)](stream-xml-fragments-access-header-information.md) contains information on streaming a more complex document.
+The article [How to stream XML fragments with access to header information](stream-xml-fragments-access-header-information.md) contains information on streaming a more complex document.
 
-The article [How to perform streaming transform of large XML documents (LINQ to XML)](perform-streaming-transform-large-xml-documents.md) contains an example of using LINQ to XML to transform extremely large XML documents while maintaining a small memory footprint.
+The article [How to perform streaming transform of large XML documents](perform-streaming-transform-large-xml-documents.md) contains an example of using LINQ to XML to transform extremely large XML documents while maintaining a small memory footprint.
 
 ## Example: Create a custom axis method
 

--- a/docs/standard/linq/toc.yml
+++ b/docs/standard/linq/toc.yml
@@ -36,8 +36,6 @@
           href: create-xml-trees.md
         - name: XML literals in Visual Basic
           href: xml-literals.md
-        - name: Cloning vs. attaching
-          href: cloning-vs-attaching.md
         - name: Parse XML
           items:
           - name: "How to parse a string"

--- a/docs/standard/linq/valid-content-xelement-xdocument-objects.md
+++ b/docs/standard/linq/valid-content-xelement-xdocument-objects.md
@@ -1,5 +1,6 @@
 ---
 title: "Valid content of XElement and XDocument objects - LINQ to XML"
+description: The XElement and XDocument constructors accept many argument types, including collections returned from queries. There are other constructors and functions for adding XML content.
 ms.date: 07/20/2015
 ms.assetid: 0d253586-2b97-459f-b1a7-f30f38f3ed9f
 ---

--- a/docs/standard/linq/validate-xsd.md
+++ b/docs/standard/linq/validate-xsd.md
@@ -1,6 +1,6 @@
 ---
 title: "How to validate using XSD - LINQ to XML"
-description: Learn how to use the extension methods in the System.Xml.Schema namespace to validate an XML tree against an XSD file.
+description: You can use extension methods from the System.Xml.Schema namespace to validate an XML tree against an XML Schema Definition Language (XSD) file.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -128,7 +128,7 @@ doc2 did not validate
 
 ## Example: Validate an XML document from a file against a schema from a file
 
-The following example validates that the XML document from [Sample XML file: Customers and orders (LINQ to XML)](sample-xml-file-customers-orders.md) is valid per the schema from [Sample XSD file: Customers and orders (LINQ to XML)](sample-xsd-file-customers-orders.md). It then modifies the source XML document. It changes the `CustomerID` attribute on the first customer. After the change, orders will then refer to a customer that doesn't exist, so the XML document will no longer validate.
+The following example validates that the XML document from [Sample XML file: Customers and orders](sample-xml-file-customers-orders.md) is valid per the schema from [Sample XSD file: Customers and orders](sample-xsd-file-customers-orders.md). It then modifies the source XML document. It changes the `CustomerID` attribute on the first customer. After the change, orders will then refer to a customer that doesn't exist, so the XML document will no longer validate.
 
 ```csharp
 XmlSchemaSet schemas = new XmlSchemaSet();

--- a/docs/standard/linq/work-global-namespaces.md
+++ b/docs/standard/linq/work-global-namespaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Work with global namespaces in Visual Basic - LINQ to XML"
-description: Learn how to use the Imports statement to declare XML namespaces using XML literals in Visual Basic.
+description: You declare a namespace in Visual Basic with the Imports statement, whether the namespace is a default namespace or has a prefix. This article discusses Import statements and other aspects of working with namespaces.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -208,4 +208,4 @@ http://www.adventure-works.com
 
 ## See also
 
-- [Namespaces overview (LINQ to XML)](namespaces-overview.md)
+- [Namespaces overview](namespaces-overview.md)

--- a/docs/standard/linq/write-queries-xml-namespaces.md
+++ b/docs/standard/linq/write-queries-xml-namespaces.md
@@ -1,5 +1,6 @@
 ---
 title: "How to write queries on XML in namespaces - LINQ to XML"
+description: To write a query on XML that's in a namespace, you use XName objects that have the correct namespace. Learn how to do this in C# and Visual Basic, and how to create queries. 
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"
@@ -129,4 +130,4 @@ The example produces this output:
 
 ## See also
 
-- [Namespaces overview (LINQ to XML)](namespaces-overview.md)
+- [Namespaces overview](namespaces-overview.md)

--- a/docs/standard/linq/xattribute-class-overview.md
+++ b/docs/standard/linq/xattribute-class-overview.md
@@ -1,5 +1,6 @@
 ---
 title: "XAttribute class overview"
+description: The XAttribute class represents XML attributes. Working with attributes in LINQ to XML is similar to working with elements.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"

--- a/docs/standard/linq/xdocument-class-overview.md
+++ b/docs/standard/linq/xdocument-class-overview.md
@@ -1,5 +1,6 @@
 ---
 title: XDocument class overview
+description: The LINQ to XML XDocument class contains the information necessary for a valid XML document. In many cases you do not require the functionality of an XDocument object and can use an XElement object instead.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"

--- a/docs/standard/linq/xelement-class-overview.md
+++ b/docs/standard/linq/xelement-class-overview.md
@@ -1,5 +1,6 @@
 ---
 title: "XElement class overview"
+description: The XElement class represents XML elements. You can use it to create and change elements, add attributes and children, and to serialize.
 ms.date: 07/20/2015
 dev_langs:
   - "csharp"

--- a/docs/standard/linq/xml-literals.md
+++ b/docs/standard/linq/xml-literals.md
@@ -1,5 +1,6 @@
 ---
 title: XML Literals in Visual Basic - LINQ to XML
+description: You can create an XML tree in Visual Basic using XML literals and embedded expressions. Embedded expressions enable you to evaluate an expression and insert the results of the expression into the XML tree.
 ms.date: 07/20/2015
 ms.assetid: cc74234a-0bac-4327-9c8c-5a2ead15b595
 ---
@@ -201,4 +202,4 @@ Child2 was attached
 
 ## See also
 
-- [Functional construction (LINQ to XML)](functional-construction.md)
+- [Functional construction](functional-construction.md)


### PR DESCRIPTION
@mairaw @BillWagner
This PR is for user story #1576037.

It removes " (LINQ to XML)" from link text and adds description metadata for existing articles. There is also a small TOC change.

cc: @tfosmark

Contributes to #4728