### PR TITLE
Fix typo/syntax error in event tutorial

### DIFF
--- a/docs/framework/winforms/controls/defining-an-event-in-windows-forms-controls.md
+++ b/docs/framework/winforms/controls/defining-an-event-in-windows-forms-controls.md
@@ -65,7 +65,7 @@ public class FlashTrackBar : Control {
    // changed. Derived controls can override this method.    
    protected virtual void OnValueChanged(EventArgs e) 
    {  
-       ValueChanged?.Invoke(this, e);  
+       onValueChanged?.Invoke(this, e);  
    }  
 }  
 ```  


### PR DESCRIPTION
ValueChanged?.Invoke(this, e) should be onValueChanged?.Invoke(this, e)
## Summary

Fixing a typo as the given tutorial code does not compile.
