### PR TITLE
clarify that DIM is 8.0 only

### DIFF
--- a/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
+++ b/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
@@ -28,7 +28,7 @@ Explicit implementation is also used to resolve cases where two interfaces each 
 
 [!code-csharp[NameCollisions](~/samples/snippets/csharp/interfaces/ExplicitImplementation.cs#NameCollision)]
 
-If a class inherits a method implementation from an interface, that method is only accessible through a reference of the interface type. The inherited member doesn't appear as part of the public interface. The following sample defines a default implementation for an interface method:
+If a class inherits a method implementation from an interface, that method is only accessible through a reference of the interface type. The inherited member doesn't appear as part of the public interface. Beginning with [C# 8.0](../../whats-new/csharp-8.md#default-interface-methods), you can define an implementation for members declared in an interface. The following sample defines a default implementation for an interface method:
 
 [!code-csharp[NameCollisions](~/samples/snippets/csharp/interfaces/ExplicitImplementation.cs#DefaultImplementation)]
 

--- a/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
+++ b/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
@@ -28,7 +28,7 @@ Explicit implementation is also used to resolve cases where two interfaces each 
 
 [!code-csharp[NameCollisions](~/samples/snippets/csharp/interfaces/ExplicitImplementation.cs#NameCollision)]
 
-If a class inherits a method implementation from an interface, that method is only accessible through a reference of the interface type. The inherited member doesn't appear as part of the public interface. Beginning with [C# 8.0](../../whats-new/csharp-8.md#default-interface-methods), you can define an implementation for members declared in an interface. The following sample defines a default implementation for an interface method:
+Beginning with [C# 8.0](../../whats-new/csharp-8.md#default-interface-methods), you can define an implementation for members declared in an interface. If a class inherits a method implementation from an interface, that method is only accessible through a reference of the interface type. The inherited member doesn't appear as part of the public interface. The following sample defines a default implementation for an interface method:
 
 [!code-csharp[NameCollisions](~/samples/snippets/csharp/interfaces/ExplicitImplementation.cs#DefaultImplementation)]
 


### PR DESCRIPTION
Fixes #17276

Clarify that default interface implementation was added in C# 8.0, and add a link to the what's new section.
