### PR TITLE
Update linux package managers

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -163,7 +163,7 @@
     },
     {
       "source_path": "docs/core/install/linux-package-managers.md",
-      "redirect_url": "/dotnet/core/install/linux-package-manager-ubuntu-1904",
+      "redirect_url": "/dotnet/core/install/linux-package-manager-ubuntu-1910",
       "ms.custom": "updateeachrelease"
     },
     {


### PR DESCRIPTION
I was reviewing the links from dot.net to docs and noticed that the redirect was going to the second entry in the TOC. Should it go to the first one?
