### PR TITLE
Fix inverted bool value for pragma case_sensitive_like

### DIFF
--- a/docs/standard/data/sqlite/collation.md
+++ b/docs/standard/data/sqlite/collation.md
@@ -26,7 +26,7 @@ The LIKE operator in SQLite doesn't honor collations. The default implementation
 You can easily make the LIKE operator case-sensitive by using the following pragma statement:
 
 ```sql
-PRAGMA case_sensitive_like = 0
+PRAGMA case_sensitive_like = 1
 ```
 
 See [User-defined functions](user-defined-functions.md) for details on overriding the implementation of the LIKE operator.


### PR DESCRIPTION
## Summary

I think the instruction for enabling case-sensitive `LIKE` uses the wrong value in the current docs.

> You can easily make the LIKE operator case-sensitive by using the following pragma statement:

Current:

```sql
PRAGMA case_sensitive_like = 0
```

Should be:

```sql
PRAGMA case_sensitive_like = 1
```

https://sqlite.org/pragma.html#pragma_case_sensitive_like