### PR TITLE
How to safely cast with is and as: updated the example

### DIFF
--- a/docs/csharp/how-to/safely-cast-using-pattern-matching-is-and-as-operators.md
+++ b/docs/csharp/how-to/safely-cast-using-pattern-matching-is-and-as-operators.md
@@ -11,19 +11,19 @@ helpviewer_keywords:
 
 Because objects are polymorphic, it's possible for a variable of a base class type to hold a derived [type](../programming-guide/types/index.md). To access the derived type's instance members, it's necessary to [cast](../programming-guide/types/casting-and-type-conversions.md) the value back to the derived type. However, a cast creates the risk of throwing an <xref:System.InvalidCastException>. C# provides [pattern matching](../pattern-matching.md) statements that perform a cast conditionally only when it will succeed. C# also provides the [is](../language-reference/operators/type-testing-and-cast.md#is-operator) and [as](../language-reference/operators/type-testing-and-cast.md#as-operator) operators to test if a value is of a certain type.
 
-The following code demonstrates the pattern matching `is` statement. It contains methods that test a method argument to determine if it is one of a possible set of derived types:
+The following example shows how to use the pattern matching `is` statement:
 
 [!code-csharp[Pattern matching is statement](../../../samples/snippets/csharp/how-to/safelycast/patternmatching/Program.cs#PatternMatchingIs)]
 
-The preceding sample demonstrates a few features of pattern matching syntax. The `if (a is Mammal m)` and `if (o is Mammal m)` statements combine the test with an initialization assignment. The assignment occurs only when the test succeeds. The variable `m` is only in scope in the embedded `if` statement where it has been assigned. You cannot access `m` later in the same method. Try it in the interactive window.
+The preceding sample demonstrates a few features of pattern matching syntax. The `if (a is Mammal m)` statement combines the test with an initialization assignment. The assignment occurs only when the test succeeds. The variable `m` is only in scope in the embedded `if` statement where it has been assigned. You cannot access `m` later in the same method. The preceding example also shows how to use the [`as` operator](../language-reference/operators/type-testing-and-cast.md#as-operator) to convert an object to a specified type.
 
-You can also use the same syntax for testing if a [nullable value type](../language-reference/builtin-types/nullable-value-types.md) has a value, as shown in the following sample code:
+You can also use the same syntax for testing if a [nullable value type](../language-reference/builtin-types/nullable-value-types.md) has a value, as shown in the following example:
 
 [!code-csharp[Pattern matching with nullable types](../../../samples/snippets/csharp/how-to/safelycast/nullablepatternmatching/Program.cs#PatternMatchingNullable)]
 
 The preceding sample demonstrates other features of pattern matching to use with conversions. You can test a variable for the null pattern by checking specifically for the `null` value. When the runtime value of the variable is `null`, an `is` statement checking for a type always returns `false`. The pattern matching `is` statement doesn't allow a nullable value type, such as `int?` or `Nullable<int>`, but you can test for any other value type. The `is` patterns from the preceding example are not limited to the nullable value types. You also can use those patterns to test if a variable of a reference type has a value or it's `null`.
 
-The preceding sample also shows how you use the pattern matching `is` expression in a `switch` statement where the variable may be one of many different types.
+The preceding sample also shows how you use the type pattern in a `switch` statement where the variable may be one of many different types.
 
 If you want to test if a variable is a given type, but not assign it to a new variable, you can use the `is` and `as` operators for reference types and nullable types. The following code shows how to use the `is` and `as` statements that were part of the C# language before pattern matching was introduced to test if a variable is of a given type:
 

--- a/samples/snippets/csharp/how-to/safelycast/patternmatching/Program.cs
+++ b/samples/snippets/csharp/how-to/safelycast/patternmatching/Program.cs
@@ -20,36 +20,46 @@ namespace patternmatching
     {
         static void Main(string[] args)
         {
-            Giraffe g = new Giraffe();
+            var g = new Giraffe();
+            var a = new Animal();
             FeedMammals(g);
-
-            TestForMammals(g);
+            FeedMammals(a);
+            // Output:
+            // Eating.
+            // Animal is not a Mammal
 
             SuperNova sn = new SuperNova();
+            TestForMammals(g);
             TestForMammals(sn);
+            // Output:
+            // I am an animal.
+            // SuperNova is not a Mammal
         }
 
         static void FeedMammals(Animal a)
         {
-            // Use the is operator to verify the type
-            // before performing a cast.
             if (a is Mammal m)
             {
                 m.Eat();
+            }
+            else
+            {
+                // variable 'm' is not in scope here, and can't be used.
+                Console.WriteLine($"{a.GetType().Name} is not a Mammal");
             }
         }
 
         static void TestForMammals(object o)
         {
-            // Alternatively, use the as operator and test for null
+            // You also can use the as operator and test for null
             // before referencing the variable.
-            if (o is Mammal m)
+            var m = o as Mammal;
+            if (m != null)
             {
                 Console.WriteLine(m.ToString());
             }
             else
             {
-                // variable 'm' is not in scope here, and can't be used.
                 Console.WriteLine($"{o.GetType().Name} is not a Mammal");
             }
         }


### PR DESCRIPTION
Fixes #17469
