### PR TITLE
Fix the wrong sample code in WebRequestGetExample

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Network/RequestDataUsingWebRequest/cs/WebRequestGetExample.cs
+++ b/samples/snippets/csharp/VS_Snippets_Network/RequestDataUsingWebRequest/cs/WebRequestGetExample.cs
@@ -8,6 +8,9 @@ namespace Examples.System.Net
     {
         public static void Main()
         {
+            // If required url's protocol is TLS, set securityprotocol.
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+            
             // Create a request for the URL.   
             WebRequest request = WebRequest.Create(
               "https://docs.microsoft.com");

--- a/samples/snippets/visualbasic/VS_Snippets_Network/RequestDataUsingWebRequest/vb/WebRequestGetExample.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Network/RequestDataUsingWebRequest/vb/WebRequestGetExample.vb
@@ -4,6 +4,8 @@ Imports System.Net
 Namespace Examples.System.Net
     Public Class WebRequestGetExample
         Public Shared Sub Main()
+            ' If required url's protocol is TLS, set securityprotocol.
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 Or SecurityProtocolType.Tls11
             ' Create a request for the URL.   
             Dim request As WebRequest =
               WebRequest.Create("https://docs.microsoft.com")


### PR DESCRIPTION
## Summary

The source code may cause the following exception:

```
System.Net.WebException
  HResult=0x80131509
  Message=请求被中止: 未能创建 SSL/TLS 安全通道。
  Source=System
```

So set `SecurityProtocol` is **necessary** to request `HTTPS` url.