### PR TITLE
Fix typo in code snippet

### DIFF
--- a/samples/snippets/fsharp/lang-ref-1/snippet1506.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet1506.fs
@@ -1,1 +1,1 @@
-seq { for n in 1 .. 100 -> if isprime n then n }
+seq { for n in 1 .. 100 do if isprime n then n }


### PR DESCRIPTION
`do` should be used here, because the if expression is missing an else branch - as explained in F# language reference where this code snippet is used: https://github.com/dotnet/docs/edit/master/docs/fsharp/language-reference/sequences.md
