### PR TITLE
Update architecture landing page

### DIFF
--- a/docs/architecture/index.yml
+++ b/docs/architecture/index.yml
@@ -1,31 +1,42 @@
-### YamlMime:YamlDocument
-documentType: LandingData
-title: .NET Application Architecture Guidance
+### YamlMime:Landing
+
+title: .NET application architecture guidance
+summary: Learn how to build production-ready .NET apps from an application architecture perspective.
+
 metadata:
-  title: .NET Application Architecture Guidance
-  meta.description: Learn about recommended practices for architecting, designing and building .NET software.
+  title: .NET application architecture guidance
+  description: Learn recommended practices for architecting, designing, and building .NET software.
   ms.topic: landing-page
-  ms.date: 10/22/2019
-abstract:
-  description: Learn how to build production-ready .NET apps with free application architecture guidance.
-sections:
-- title: Published e-books
-  items:
-  - html: '<ul><li><p><a href="grpc-for-wcf-developers/index">ASP.NET Core gRPC for WCF Developers</a></p>'
-  - html: '<p>This guide explains what gRPC is, relating each concept to the equivalent features of WCF, and offers guidance for migrating an existing WCF app to gRPC.</p></li></ul>'
-  - html: '<ul><li><p><a href="containerized-lifecycle/index">Containerized Docker application lifecycle with the Microsoft platform and tools</a></p>'
-  - html: '<p>This guide is an introduction to the recommended end to end lifecycle processes you''ll use to develop, validate, and deploy containerized Docker applications using Visual Studio and Microsoft Azure.</p></li></ul>'
-  - html: '<ul><li><p><a href="modernize-with-azure-containers/index">Modernize existing .NET applications with Azure cloud and Windows containers</a></p>'
-  - html: '<p>This guide is an introduction to the strategies you''ll need to migrate existing web applications to the Azure cloud and Windows containers. You''ll learn about code strategies, data migration, orchestrators, and CI/CD processes.</p></li></ul>'
-  - html: '<ul><li><p><a href="modern-web-apps-azure/index">Architect modern web applications with ASP.NET Core and Azure</a></p>'
-  - html: '<p>This guide is an introduction to the recommended architecture, design, and deployment processes you''ll use to build ASP.NET and ASP.NET Core applications and host those applications in Azure.</p></li></ul>'
-  - html: '<ul><li><p><a href="microservices/index">Architecting container and microservice-based applications</a></p>'
-  - html: '<p>This guide is an introduction to developing microservices-based applications and managing them using containers. It discusses architectural design and implementation approaches using .NET Core and Docker containers.</p></li></ul>'
-  - html: '<ul><li><p><a href="serverless/index">Serverless apps: Architecture, patterns, and Azure implementation</a></p>'
-  - html: '<p>This is a guide for building serverless applications with examples using Azure. It discusses various architecture and design approaches, the benefits and challenges that come with serverless, and provides scenarios and use cases for serverless apps.</p></li></ul>'
-- title: Preview e-books
-  items:
-  - html: '<ul><li><p><a href="cloud-native/index">Architecting cloud-native .NET apps for Azure</a></p>'
-  - html: '<p>This guide defines what cloud native is, introduces a sample app built using cloud-native principles, and covers topics common to most cloud-native applications.</p></li></ul>'
-  - html: '<ul><li><p><a href="blazor-for-web-forms-developers/index">Blazor for ASP.NET Web Forms Developers</a></p>'
-  - html: '<p>An introduction to Blazor for ASP.NET Web Forms developers. Learn how to build full-stack web apps with .NET using Blazor and .NET Core in a simple and familiar way.</p></li></ul>'
+  ms.date: 03/18/2020
+
+# linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
+
+landingContent:
+
+  # Card
+  - title: Published e-books
+    linkLists:
+      - linkListType: architecture
+        links:
+          - text: ASP.NET Core gRPC for WCF developers
+            url: grpc-for-wcf-developers/index.md
+          - text: Containerized Docker app lifecycle with the Microsoft platform and tools
+            url: containerized-lifecycle/index.md
+          - text: Modernize existing .NET apps with Azure cloud and Windows containers
+            url: modernize-with-azure-containers/index.md
+          - text: Architect modern web apps with ASP.NET Core and Azure
+            url: modern-web-apps-azure/index.md
+          - text: Architect container and microservice-based apps
+            url: microservices/index.md
+          - text: "Serverless apps: Architecture, patterns, and Azure implementation"
+            url: serverless/index.md
+
+  # Card
+  - title: Preview e-books
+    linkLists:
+      - linkListType: architecture
+        links:
+          - text: Architect cloud-native .NET apps for Azure
+            url: cloud-native/index.md
+          - text: Blazor for ASP.NET Web Forms developers
+            url: blazor-for-web-forms-developers/index.md

--- a/docs/architecture/index.yml
+++ b/docs/architecture/index.yml
@@ -1,13 +1,13 @@
 ### YamlMime:Landing
 
 title: .NET application architecture documentation
-summary: Learn how to build production-ready .NET apps from an application architecture perspective.
+summary: Learn how to build production-ready .NET apps or migrate existing apps to the cloud.
 
 metadata:
   title: .NET application architecture documentation
-  description: Learn recommended practices for architecting, designing, and building .NET software.
+  description: Learn recommended practices for architecting, building, and migrating .NET apps.
   ms.topic: landing-page
-  ms.date: 03/18/2020
+  ms.date: 03/19/2020
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
 
@@ -28,20 +28,6 @@ landingContent:
             url: ../azure/migration/app-service.md
             
   # Card
-  - title: Develop Microservices-based apps
-    linkLists:
-      - linkListType: concept
-        links:
-          - text: ".NET Microservices: Architecture for containerized .NET applications"
-            url: microservices/index.md
-          - text: Architecting cloud-native .NET apps for Azure
-            url: cloud-native/index.md
-      - linkListType: learn
-        links:
-          - text: Hello World Microservice tutorial
-            url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
-            
-  # Card
   - title: Develop .NET apps for Azure
     linkLists:
       - linkListType: concept
@@ -60,6 +46,18 @@ landingContent:
             url: modernize-with-azure-containers/index.md
           - text: Migrate your .NET web app or service to Azure App Service
             url: ../azure/migration/app-service.md
+            
+  # Card
+  - title: Develop Microservices-based apps
+    linkLists:
+      - linkListType: concept
+        links:
+          - text: ".NET Microservices: Architecture for containerized .NET applications"
+            url: microservices/index.md
+      - linkListType: learn
+        links:
+          - text: Hello World Microservice tutorial
+            url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
             
   # Card
   - title: Understand DevOps for .NET

--- a/docs/architecture/index.yml
+++ b/docs/architecture/index.yml
@@ -1,10 +1,10 @@
 ### YamlMime:Landing
 
-title: .NET application architecture guidance
+title: .NET application architecture documentation
 summary: Learn how to build production-ready .NET apps from an application architecture perspective.
 
 metadata:
-  title: .NET application architecture guidance
+  title: .NET application architecture documentation
   description: Learn recommended practices for architecting, designing, and building .NET software.
   ms.topic: landing-page
   ms.date: 03/18/2020
@@ -14,29 +14,59 @@ metadata:
 landingContent:
 
   # Card
-  - title: Published e-books
+  - title: Develop ASP.NET Core apps
     linkLists:
-      - linkListType: architecture
+      - linkListType: concept
         links:
-          - text: ASP.NET Core gRPC for WCF developers
-            url: grpc-for-wcf-developers/index.md
-          - text: Containerized Docker app lifecycle with the Microsoft platform and tools
-            url: containerized-lifecycle/index.md
-          - text: Modernize existing .NET apps with Azure cloud and Windows containers
-            url: modernize-with-azure-containers/index.md
           - text: Architect modern web apps with ASP.NET Core and Azure
             url: modern-web-apps-azure/index.md
-          - text: Architect container and microservice-based apps
-            url: microservices/index.md
-          - text: "Serverless apps: Architecture, patterns, and Azure implementation"
-            url: serverless/index.md
-
-  # Card
-  - title: Preview e-books
-    linkLists:
-      - linkListType: architecture
-        links:
-          - text: Architect cloud-native .NET apps for Azure
-            url: cloud-native/index.md
           - text: Blazor for ASP.NET Web Forms developers
             url: blazor-for-web-forms-developers/index.md
+          - text: ASP.NET Core gRPC for WCF developers
+            url: grpc-for-wcf-developers/index.md
+          - text: Migrate your .NET web app or service to Azure App Service
+            url: ../azure/migration/app-service.md
+            
+  # Card
+  - title: Develop Microservices-based apps
+    linkLists:
+      - linkListType: concept
+        links:
+          - text: ".NET Microservices: Architecture for containerized .NET applications"
+            url: microservices/index.md
+          - text: Architecting cloud-native .NET apps for Azure
+            url: cloud-native/index.md
+      - linkListType: learn
+        links:
+          - text: Hello World Microservice tutorial
+            url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
+            
+  # Card
+  - title: Develop .NET apps for Azure
+    linkLists:
+      - linkListType: concept
+        links:
+          - text: Architecting cloud-native .NET apps for Azure
+            url: cloud-native/index.md
+          - text: "Serverless apps: Architecture, patterns, and Azure implementation"
+            url: serverless/index.md
+            
+  # Card
+  - title: Migrate .NET apps to Azure
+    linkLists:
+      - linkListType: concept
+        links:
+          - text: Modernize existing .NET apps with Azure cloud and Windows containers
+            url: modernize-with-azure-containers/index.md
+          - text: Migrate your .NET web app or service to Azure App Service
+            url: ../azure/migration/app-service.md
+            
+  # Card
+  - title: Understand DevOps for .NET
+    linkLists:
+      - linkListType: concept
+        links:
+          - text: Containerized Docker application lifecycle with Microsoft platform and tools
+            url: containerized-lifecycle/index.md
+          - text: ASP.NET Core DevOps with Azure
+            url: /aspnet/core/azure/devops/

--- a/docs/architecture/index.yml
+++ b/docs/architecture/index.yml
@@ -20,22 +20,26 @@ landingContent:
         links:
           - text: Architect modern web apps with ASP.NET Core and Azure
             url: modern-web-apps-azure/index.md
-          - text: Blazor for ASP.NET Web Forms developers
+          - text: Blazor for ASP.NET Web Forms developers (Preview)
             url: blazor-for-web-forms-developers/index.md
           - text: ASP.NET Core gRPC for WCF developers
             url: grpc-for-wcf-developers/index.md
-          - text: Migrate your .NET web app or service to Azure App Service
-            url: ../azure/migration/app-service.md
             
   # Card
-  - title: Develop .NET apps for Azure
+  - title: Develop cloud-native .NET apps for Azure
     linkLists:
       - linkListType: concept
         links:
-          - text: Architecting cloud-native .NET apps for Azure
+          - text: Architecting cloud-native .NET apps for Azure (Preview)
             url: cloud-native/index.md
           - text: "Serverless apps: Architecture, patterns, and Azure implementation"
             url: serverless/index.md
+          - text: ".NET Microservices: Architecture for containerized .NET applications"
+            url: microservices/index.md
+      - linkListType: learn
+        links:
+          - text: Hello World Microservice tutorial
+            url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
             
   # Card
   - title: Migrate .NET apps to Azure
@@ -44,20 +48,8 @@ landingContent:
         links:
           - text: Modernize existing .NET apps with Azure cloud and Windows containers
             url: modernize-with-azure-containers/index.md
-          - text: Migrate your .NET web app or service to Azure App Service
-            url: ../azure/migration/app-service.md
-            
-  # Card
-  - title: Develop Microservices-based apps
-    linkLists:
-      - linkListType: concept
-        links:
-          - text: ".NET Microservices: Architecture for containerized .NET applications"
-            url: microservices/index.md
-      - linkListType: learn
-        links:
-          - text: Hello World Microservice tutorial
-            url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
+          - text: Migrate your .NET app to Azure
+            url: https://dotnet.microsoft.com/apps/cloud/migrate-to-azure
             
   # Card
   - title: Understand DevOps for .NET

--- a/docs/architecture/toc.yml
+++ b/docs/architecture/toc.yml
@@ -1,17 +1,17 @@
-- name: .NET Application Architecture Guide
+- name: .NET app architecture guide
   href: index.yml
 - name: E-books
   expanded: true
   items:
     - name: Architect modern web applications with ASP.NET Core and Microsoft Azure
       href: modern-web-apps-azure/
-    - name: ASP.NET Core gRPC for WCF Developers
+    - name: ASP.NET Core gRPC for WCF developers
       href: grpc-for-wcf-developers/
     - name: Modernize existing .NET applications with Azure cloud and Windows Containers
       href: modernize-with-azure-containers/
-    - name: Containerized Docker application lifecycle with the Microsoft platform and tools
+    - name: Containerized Docker application lifecycle with Microsoft platform and tools
       href: containerized-lifecycle/
-    - name: ".NET Microservices: architecture for containerized .NET applications"
+    - name: ".NET Microservices: Architecture for containerized .NET applications"
       href: microservices/
     - name: "Serverless apps: Architecture, patterns, and Azure implementation"
       href: serverless/
@@ -20,5 +20,5 @@
   items:
     - name: "Architecting cloud-native .NET apps for Azure"
       href: cloud-native/
-    - name: Blazor for ASP.NET Web Forms Developers
+    - name: Blazor for ASP.NET Web Forms developers
       href: blazor-for-web-forms-developers/

--- a/docs/azure/migration/app-service.md
+++ b/docs/azure/migration/app-service.md
@@ -6,7 +6,7 @@ ms.date: 08/11/2018
 ---
 # Migrate your .NET web app or service to Azure App Service
 
-[App Service](https://docs.microsoft.com/azure/app-service/app-service-web-overview#why-use-web-apps) is a fully-managed compute platform service that's optimized for hosting scalable websites and web applications. This article provides information on how to lift-and-shift an existing application to Azure App Service, modifications to consider, and additional resources for [moving to the cloud](https://azure.microsoft.com/migration/web-applications/). Most ASP.NET websites (Webforms, MVC) and services (Web API, WCF) can move directly to Azure App Service with no changes. Some may need minor changes while others may need some refactoring.
+[App Service](https://docs.microsoft.com/azure/app-service/app-service-web-overview#why-use-web-apps) is a fully managed compute platform service that's optimized for hosting scalable websites and web applications. This article provides information on how to lift-and-shift an existing application to Azure App Service, modifications to consider, and additional resources for [moving to the cloud](https://azure.microsoft.com/migration/web-applications/). Most ASP.NET websites (Webforms, MVC) and services (Web API, WCF) can move directly to Azure App Service with no changes. Some may need minor changes while others may need some refactoring.
 
 Ready to get started? [Publish your ASP.NET + SQL application to Azure App Service](https://tutorials.visualstudio.com/azure-webapp-migrate/intro).
 
@@ -47,7 +47,7 @@ Azure App Service supports anonymous authentication by default and Forms authent
 This isn't supported. Consider copying required assemblies to the app's *\bin* folder. Custom *.msi* files installed on the server (for example, PDF generators) cannot be used.
 
 ### IIS settings
-Everything traditionally configured via applicationHost.config in your application can now be configured through the Azure portal. This applies to AppPool bitness, enable/disable websockets, managed pipeline version, .NET Framework version (2.0/4.0), and so on. To modify your [application settings](https://docs.microsoft.com/azure/app-service/web-sites-configure), navigate to the [Azure portal](https://portal.azure.com), open the blade for your web app, and then select the **Application Settings** tab.
+Everything traditionally configured via applicationHost.config in your application can now be configured through the Azure portal. This applies to AppPool bitness, enable/disable WebSockets, managed pipeline version, .NET Framework version (2.0/4.0), and so on. To modify your [application settings](https://docs.microsoft.com/azure/app-service/web-sites-configure), navigate to the [Azure portal](https://portal.azure.com), open the blade for your web app, and then select the **Application Settings** tab.
 
 #### IIS5 Compatibility Mode
 IIS5 Compatibility Mode is not supported. In Azure App Service, each web app and all of the applications under it run in the same worker process with a specific set of [application pools](https://technet.microsoft.com/library/cc735247(v=WS.10).aspx).

--- a/docs/azure/migration/app-service.md
+++ b/docs/azure/migration/app-service.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate your .NET web app or service to Azure App Service
 description: Learn about migrating a .NET web app or service from on-premises to Azure App Service.
-ms.topic: concept
+ms.topic: conceptual
 ms.date: 08/11/2018
 ---
 # Migrate your .NET web app or service to Azure App Service

--- a/docs/azure/migration/app-service.md
+++ b/docs/azure/migration/app-service.md
@@ -1,15 +1,14 @@
 ---
 title: Migrate your .NET web app or service to Azure App Service
-description: Learn how to migrate a .NET web app or service from on-premises to Azure App Service.
-ms.topic: how-to
+description: Learn about migrating a .NET web app or service from on-premises to Azure App Service.
+ms.topic: concept
 ms.date: 08/11/2018
 ---
-
 # Migrate your .NET web app or service to Azure App Service
 
-[App Service](https://docs.microsoft.com/azure/app-service/app-service-web-overview#why-use-web-apps) is a fully-managed compute platform service that is optimized for hosting scalable websites and web applications. This document provides information on how to lift-and-shift an existing application to Azure App Service, modifications to consider, and additional resources for [moving to the cloud](https://azure.microsoft.com/migration/web-applications/). Most ASP.NET websites (Webforms, MVC) and services (Web API, WCF) can move directly to Azure App Service with no changes. Some may need minor changes while others may need some refactoring.
+[App Service](https://docs.microsoft.com/azure/app-service/app-service-web-overview#why-use-web-apps) is a fully-managed compute platform service that's optimized for hosting scalable websites and web applications. This article provides information on how to lift-and-shift an existing application to Azure App Service, modifications to consider, and additional resources for [moving to the cloud](https://azure.microsoft.com/migration/web-applications/). Most ASP.NET websites (Webforms, MVC) and services (Web API, WCF) can move directly to Azure App Service with no changes. Some may need minor changes while others may need some refactoring.
 
-Ready to get started? [Publish your ASP.NET + SQL application to Azure App Service](https://go.microsoft.com/fwlink/?linkid=863214).
+Ready to get started? [Publish your ASP.NET + SQL application to Azure App Service](https://tutorials.visualstudio.com/azure-webapp-migrate/intro).
 
 ## Considerations
 
@@ -20,7 +19,7 @@ Verify access to on-premises resources as these may need to be migrated or chang
 * Create a VPN connecting App Service to on-premises resources using [Azure Virtual Networks](https://docs.microsoft.com/azure/app-service/web-sites-integrate-with-vnet).
 * Securely expose on-premises services to the cloud without firewall changes using [Azure Relay](https://docs.microsoft.com/azure/service-bus-relay/relay-what-is-it).
 * Migrate dependencies such as a [SQL database](https://go.microsoft.com/fwlink/?linkid=863217) to Azure.
-* Use platform-as-a-service offerings in the cloud to reduce dependecies. For example, rather than connect to an on-premises mail server, consider using [SendGrid](https://docs.microsoft.com/azure/sendgrid-dotnet-how-to-send-email).
+* Use platform-as-a-service offerings in the cloud to reduce dependencies. For example, rather than connect to an on-premises mail server, consider using [SendGrid](https://docs.microsoft.com/azure/sendgrid-dotnet-how-to-send-email).
 
 ### Port Bindings
 
@@ -45,31 +44,31 @@ Azure App Service supports anonymous authentication by default and Forms authent
 
 ### Assemblies in the GAC (Global Assembly Cache)
 
-This isn't supported. Consider copying required assemblies to the app's `\bin` folder. Custom .MSIs installed on the server (e.g. PDF generators, etc.) cannot be used.
+This isn't supported. Consider copying required assemblies to the app's *\bin* folder. Custom *.msi* files installed on the server (for example, PDF generators) cannot be used.
 
 ### IIS settings
-Everything traditionally configured via applicationHost.config in your application can now be configured through the Azure portal. This applies to AppPool bitness, enable/disable websockets, managed pipeline version, .NET Framework version (2.0/4.0), etc. To modify your [application settings](https://docs.microsoft.com/azure/app-service/web-sites-configure), navigate to the [Azure portal](https://portal.azure.com), open the blade for your web app, and then select the **Application Settings** tab.
+Everything traditionally configured via applicationHost.config in your application can now be configured through the Azure portal. This applies to AppPool bitness, enable/disable websockets, managed pipeline version, .NET Framework version (2.0/4.0), and so on. To modify your [application settings](https://docs.microsoft.com/azure/app-service/web-sites-configure), navigate to the [Azure portal](https://portal.azure.com), open the blade for your web app, and then select the **Application Settings** tab.
 
 #### IIS5 Compatibility Mode
-IIS5 Compatibility Mode is not supported. In Azure App Service each Web App and all of the applications under it run in the same worker process with a specific set of [application pool](https://technet.microsoft.com/library/cc735247(v=WS.10).aspx).
+IIS5 Compatibility Mode is not supported. In Azure App Service, each web app and all of the applications under it run in the same worker process with a specific set of [application pools](https://technet.microsoft.com/library/cc735247(v=WS.10).aspx).
 
 #### IIS7+ schema compliance  
 Some elements and attributes are not defined in the Azure App Service IIS schema. If you encounter issues, consider using [XDT transforms](https://azure.microsoft.com/documentation/articles/web-sites-transform-extend/).
 
 #### Single application pool per site  
-In Azure App Service each Web App and all of the applications under it run in the same application pool. Consider establishing a single application pool with common settings or creating a separate Web App for each application.
+In Azure App Service, each web app and all of the applications under it run in the same application pool. Consider establishing a single application pool with common settings or creating a separate web app for each application.
 
 ### COM and COM+ components  
-Azure App Service does not allow the registration of COM components on the platform. If your app makes use of any COM components, these would need to be rewritten in managed code and deployed with the site or application.
+Azure App Service does not allow the registration of COM components on the platform. If your app makes use of any COM components, these need to be rewritten in managed code and deployed with the site or application.
 
 ### Physical directories
-Azure App Service does not allow physical drive access. You may need to use a [Azure Files](https://docs.microsoft.com/azure/storage/files/storage-files-introduction) to access files via SMB. [Azure Blob Storage](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction) can store files for access via HTTPS.
+Azure App Service does not allow physical drive access. You may need to use [Azure Files](https://docs.microsoft.com/azure/storage/files/storage-files-introduction) to access files via SMB. [Azure Blob Storage](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction) can store files for access via HTTPS.
 
 ### ISAPI filters  
 Azure App Service can support the use of ISAPI Filters, however, the ISAPI DLL must be deployed with your site and registered via web.config.
 
 ### HTTPS bindings and SSL
-HTTPS bindings will not be migrated, nor will the SSL certificates associated with your web sites. [SSL certificates can be manually uploaded](https://docs.microsoft.com/azure/app-service/app-service-web-tutorial-custom-ssl) after site migration is completed, however.
+HTTPS bindings are not migrated, nor are the SSL certificates associated with your web sites. [SSL certificates can be manually uploaded](https://docs.microsoft.com/azure/app-service/app-service-web-tutorial-custom-ssl) after site migration is completed, however.
 
 ### SharePoint and FrontPage
 SharePoint and FrontPage Server Extensions (FPSE) are not supported.
@@ -95,8 +94,8 @@ You may need to update DNS configurations based on the requirements of your appl
 ## Azure App Service with Windows Containers
 If your app cannot be migrated directly to App Service, consider App Service using Windows Containers, which enables usage of the GAC, COM components, MSIs, full access to .NET FX APIs, DirectX, and more.
 
-## Additional reading
+## See also
 
 * [How to determine if your app qualifies for App Service](https://appmigration.microsoft.com/)
 * [Moving your database to the cloud](https://go.microsoft.com/fwlink/?linkid=863217)
-* [Azure Web App sandbox details and restrictions](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)
+* [Azure web app sandbox details and restrictions](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)


### PR DESCRIPTION
Contributes to #17502.

Internal preview URL: https://review.docs.microsoft.com/en-us/dotnet/architecture/?branch=pr-en-us-17503

I didn't do a straight lift-and-shift to the new YAML format. The [guidance](https://review.docs.microsoft.com/en-us/help/contribute/contribute-how-to-write-landing-page?branch=master#landing-page-template) says not to duplicate the TOC, for one thing. Also, cards are supposed to start with a verb, and I didn't think the differentiation of e-book vs. preview e-book is really that important to the reader. I thought grouping by concept was more useful.