### PR TITLE
Fix wrong note about default implementation

### DIFF
--- a/docs/csharp/tutorials/mixins-with-default-interface-methods.md
+++ b/docs/csharp/tutorials/mixins-with-default-interface-methods.md
@@ -111,7 +111,7 @@ This scenario shows a base interface without any implementations. Adding a metho
 
 [!code-csharp[Enumeration for power status](~/samples/snippets/csharp/tutorials/mixins-with-interfaces/ILight.cs?name=SnippetPowerStatus)]
 
-The default implementation assumes AC power:
+The default implementation assumes no power:
 
 [!code-csharp[Report a default power status](~/samples/snippets/csharp/tutorials/mixins-with-interfaces/ILight.cs?name=SnippetILightInterface)]
 


### PR DESCRIPTION
The text states that the default is `PowerStatus.ACPower`, however In the actual implementation the default is `PowerStatus.NoPower`.

https://github.com/dotnet/docs/blob/12d15a050e67a7fa66d743cb96c9ee331daf3c36/samples/snippets/csharp/tutorials/mixins-with-interfaces/ILight.cs#L24