### PR TITLE
Add switch expression to language reference

### DIFF
--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -15,6 +15,8 @@ ms.assetid: 44bae8b8-8841-4d85-826b-8a94277daecb
 ---
 # switch (C# reference)
 
+This article covers the `switch` statement. For information on the `switch` expression (introduced in C# 8.0), see the article on [`switch` expressions](../operators/switch.md) in the [expressions and operators](../operators/index.md) section.
+
 `switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *match expression*.
 
 [!code-csharp[switch#1](~/samples/snippets/csharp/language-reference/keywords/switch/switch1.cs#1)]

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -15,7 +15,7 @@ ms.assetid: 44bae8b8-8841-4d85-826b-8a94277daecb
 ---
 # switch (C# reference)
 
-This article covers the `switch` statement. For information on the `switch` expression (introduced in C# 8.0), see the article on [`switch` expressions](../operators/switch.md) in the [expressions and operators](../operators/index.md) section.
+This article covers the `switch` statement. For information on the `switch` expression (introduced in C# 8.0), see the article on [`switch` expressions](../operators/switch-expression.md) in the [expressions and operators](../operators/index.md) section.
 
 `switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *match expression*.
 

--- a/docs/csharp/language-reference/operators/snippets/Program.cs
+++ b/docs/csharp/language-reference/operators/snippets/Program.cs
@@ -102,6 +102,11 @@ namespace operators
             Console.WriteLine("========= conversion operators example =========");
             UserDefinedConversions.Main();
             Console.WriteLine();
+
+            Console.WriteLine("========= switch expression example =========");
+            SwitchExpressions.Examples();
+            Console.WriteLine();
+
         }
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
@@ -24,6 +24,29 @@ namespace operators
     {
         public static void Examples()
         {
+            InitialExample();
+
+            var collection = new int[]{1,2,3,4,5,6,7,8,9};
+            TypeExample(collection);
+            RecursiveExample(collection);
+            RecursiveExample(collection[0..0]);
+            RecursiveExample(collection[0..1]);
+            RecursiveExample(collection[0..2]);
+            CaseGuardExample(collection.AsEnumerable());
+            CaseGuardExample(collection[0..0].AsEnumerable());
+            CaseGuardExample(collection[0..1].AsEnumerable());
+            CaseGuardExample(collection[0..2].AsEnumerable());
+            try {
+                ExhaustiveExample(default(List<int>));
+            } catch (ArgumentNullException e)
+            {
+                Console.WriteLine($"Caught expected exception: {e.Message}");
+            }
+
+        }
+
+        private static void InitialExample()
+        {
             // <SnippetBasicStructure>
             var direction = Directions.Right;
             Console.WriteLine($"Map view direction is {direction}");
@@ -38,6 +61,76 @@ namespace operators
             Console.WriteLine($"Cardinal orientation is {orientation}");
             // </SnippetBasicStructure>
         }
+
+        private static void TypeExample<T>(IEnumerable<T> sequence)
+        {
+            // <SnippetTypePattern>
+            var third = sequence switch
+            {
+                System.Array array => array.GetValue(2),
+                IList<T> list => list[2],
+                IEnumerable<T> seq => seq.Skip(2).First(),
+            };
+            Console.WriteLine(third);
+            // </SnippetTypePattern>
+        }
+
+        private static void RecursiveExample<T>(IEnumerable<T> sequence)
+        {
+            // <SnippetRecursivePattern>
+            var third = sequence switch
+            {
+                System.Array { Length : 0}        => default,
+                System.Array { Length : 1} array => array.GetValue(0),
+                System.Array { Length : 2} array => array.GetValue(1),
+                System.Array array               => array.GetValue(2),
+                IList<T> list                    => list[2],
+                IEnumerable<T> seq               => seq.Skip(2).First(),
+            };
+            Console.WriteLine(third);
+            // </SnippetRecursivePattern>
+        }
+
+        private static void CaseGuardExample<T>(IEnumerable<T> sequence)
+        {
+            // <SnippetGuardCase>
+            var third = sequence switch
+            {
+                System.Array { Length : 0}                => default,
+                System.Array { Length : 1} array          => array.GetValue(0),
+                System.Array { Length : 2} array          => array.GetValue(1),
+                System.Array array                        => array.GetValue(2),
+                IEnumerable<T> list when !list.Any()      => default,
+                IEnumerable<T> list when list.Count() < 3 => list.Last(),
+                IList<T> list                             => list[2],
+                IEnumerable<T> seq                        => seq.Skip(2).First(),
+            };
+            Console.WriteLine(third);
+            // </SnippetGuardCase>
+        }
+
+        private static void ExhaustiveExample<T>(IEnumerable<T> sequence)
+        {
+            // <SnippetExhaustive>
+            var third = sequence switch
+            {
+                System.Array { Length : 0}       => default,
+                System.Array { Length : 1} array => array.GetValue(0),
+                System.Array { Length : 2} array => array.GetValue(1),
+                System.Array array               => array.GetValue(2),
+                IEnumerable<T> list 
+                    when !list.Any()             => default,
+                IEnumerable<T> list 
+                    when list.Count() < 3        => list.Last(),
+                IList<T> list                    => list[2],
+                null                             => throw new ArgumentNullException("null input"),
+                _                                => sequence.Skip(2).First(),
+            };
+            Console.WriteLine(third);
+            // </SnippetExhaustive>
+        }
+
+        
     }
 }
 

--- a/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
@@ -70,68 +70,68 @@ namespace operators
         private static void TypeExample<T>(IEnumerable<T> sequence)
         {
             // <SnippetTypePattern>
-            var third = sequence switch
+            T thirdOrDefault = sequence switch
             {
                 System.Array array => array.GetValue(2),
-                IList<T> list => list[2],
+                IList<T> list      => list[2],
                 IEnumerable<T> seq => seq.Skip(2).First(),
             };
-            Console.WriteLine(third);
+            Console.WriteLine(thirdOrDefault);
             // </SnippetTypePattern>
         }
 
         private static void RecursiveExample<T>(IEnumerable<T> sequence)
         {
             // <SnippetRecursivePattern>
-            var third = sequence switch
+            T thirdOrDefault = sequence switch
             {
-                System.Array { Length : 0}        => default,
+                System.Array { Length : 0}       => default(T),
                 System.Array { Length : 1} array => array.GetValue(0),
                 System.Array { Length : 2} array => array.GetValue(1),
                 System.Array array               => array.GetValue(2),
                 IList<T> list                    => list[2],
                 IEnumerable<T> seq               => seq.Skip(2).First(),
             };
-            Console.WriteLine(third);
+            Console.WriteLine(thirdOrDefault);
             // </SnippetRecursivePattern>
         }
 
         private static void CaseGuardExample<T>(IEnumerable<T> sequence)
         {
             // <SnippetGuardCase>
-            var third = sequence switch
+            T thirdOrDefault = sequence switch
             {
-                System.Array { Length : 0}                => default,
+                System.Array { Length : 0}                => default(T),
                 System.Array { Length : 1} array          => array.GetValue(0),
                 System.Array { Length : 2} array          => array.GetValue(1),
                 System.Array array                        => array.GetValue(2),
-                IEnumerable<T> list when !list.Any()      => default,
+                IEnumerable<T> list when !list.Any()      => default(T),
                 IEnumerable<T> list when list.Count() < 3 => list.Last(),
                 IList<T> list                             => list[2],
                 IEnumerable<T> seq                        => seq.Skip(2).First(),
             };
-            Console.WriteLine(third);
+            Console.WriteLine(thirdOrDefault);
             // </SnippetGuardCase>
         }
 
         private static void ExhaustiveExample<T>(IEnumerable<T> sequence)
         {
             // <SnippetExhaustive>
-            var third = sequence switch
+            T thirdOrDefault = sequence switch
             {
-                System.Array { Length : 0}       => default,
+                System.Array { Length : 0}       => default(T),
                 System.Array { Length : 1} array => array.GetValue(0),
                 System.Array { Length : 2} array => array.GetValue(1),
                 System.Array array               => array.GetValue(2),
                 IEnumerable<T> list 
-                    when !list.Any()             => default,
+                    when !list.Any()             => default(T),
                 IEnumerable<T> list 
                     when list.Count() < 3        => list.Last(),
                 IList<T> list                    => list[2],
                 null                             => throw new ArgumentNullException(nameof(sequence)),
                 _                                => sequence.Skip(2).First(),
             };
-            Console.WriteLine(third);
+            Console.WriteLine(thirdOrDefault);
             // </SnippetExhaustive>
         }
 

--- a/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
@@ -4,27 +4,48 @@ using System.Linq;
 
 namespace operators
 {
-    public enum Directions
-    {
-        Up,
-        Down,
-        Right,
-        Left
-    }
 
-    public enum Orientation
+    // <SnippetBasicStructure>
+    public static class SwitchExample
     {
-        North,
-        South,
-        East,
-        West
+        public enum Directions
+        {
+            Up,
+            Down,
+            Right,
+            Left
+        }
+
+        public enum Orientation
+        {
+            North,
+            South,
+            East,
+            West
+        }
+    
+        public static void Main()
+        {
+            var direction = Directions.Right;
+            Console.WriteLine($"Map view direction is {direction}");
+
+            var orientation = direction switch
+            {
+                Directions.Up    => Orientation.North,
+                Directions.Right => Orientation.East,
+                Directions.Down  => Orientation.South,
+                Directions.Left  => Orientation.West,
+            };
+            Console.WriteLine($"Cardinal orientation is {orientation}");
+        }
     }
+    // </SnippetBasicStructure>
 
     public static class SwitchExpressions
     {
         public static void Examples()
         {
-            InitialExample();
+            SwitchExample.Main();
 
             var collection = new int[]{1,2,3,4,5,6,7,8,9};
             TypeExample(collection);
@@ -45,22 +66,6 @@ namespace operators
 
         }
 
-        private static void InitialExample()
-        {
-            // <SnippetBasicStructure>
-            var direction = Directions.Right;
-            Console.WriteLine($"Map view direction is {direction}");
-
-            var orientation = direction switch
-            {
-                Directions.Up    => Orientation.North,
-                Directions.Right => Orientation.East,
-                Directions.Down  => Orientation.South,
-                Directions.Left  => Orientation.West,
-            };
-            Console.WriteLine($"Cardinal orientation is {orientation}");
-            // </SnippetBasicStructure>
-        }
 
         private static void TypeExample<T>(IEnumerable<T> sequence)
         {

--- a/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
@@ -123,7 +123,7 @@ namespace operators
                 IEnumerable<T> list 
                     when list.Count() < 3        => list.Last(),
                 IList<T> list                    => list[2],
-                null                             => throw new ArgumentNullException("null input"),
+                null                             => throw new ArgumentNullException(nameof(sequence)),
                 _                                => sequence.Skip(2).First(),
             };
             Console.WriteLine(third);
@@ -133,5 +133,4 @@ namespace operators
         
     }
 }
-
 

--- a/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace operators
+{
+    public enum Directions
+    {
+        Up,
+        Down,
+        Right,
+        Left
+    }
+
+    public enum Orientation
+    {
+        North,
+        South,
+        East,
+        West
+    }
+
+    public static class SwitchExpressions
+    {
+        public static void Examples()
+        {
+            // <SnippetBasicStructure>
+            var direction = Directions.Right;
+            Console.WriteLine($"Map view direction is {direction}");
+
+            var orientation = direction switch
+            {
+                Directions.Up    => Orientation.North,
+                Directions.Right => Orientation.East,
+                Directions.Down  => Orientation.South,
+                Directions.Left  => Orientation.West,
+            };
+            Console.WriteLine($"Cardinal orientation is {orientation}");
+            // </SnippetBasicStructure>
+        }
+    }
+}
+
+

--- a/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/SwitchExpressions.cs
@@ -48,17 +48,28 @@ namespace operators
             SwitchExample.Main();
 
             var collection = new int[]{1,2,3,4,5,6,7,8,9};
-            TypeExample(collection);
-            RecursiveExample(collection);
-            RecursiveExample(collection[0..0]);
-            RecursiveExample(collection[0..1]);
-            RecursiveExample(collection[0..2]);
-            CaseGuardExample(collection.AsEnumerable());
-            CaseGuardExample(collection[0..0].AsEnumerable());
-            CaseGuardExample(collection[0..1].AsEnumerable());
-            CaseGuardExample(collection[0..2].AsEnumerable());
+            var item = TypeExample(collection);
+            Console.WriteLine(item);
+            item = RecursiveExample(collection);
+            Console.WriteLine(item);
+
+            item = RecursiveExample(collection[0..0]);
+            Console.WriteLine(item);
+            item = RecursiveExample(collection[0..1]);
+            Console.WriteLine(item);
+            item = RecursiveExample(collection[0..2]);
+            Console.WriteLine(item);
+
+            item = CaseGuardExample(collection.AsEnumerable());
+            Console.WriteLine(item);
+            item = CaseGuardExample(collection[0..0].AsEnumerable());
+            Console.WriteLine(item);
+            item = CaseGuardExample(collection[0..1].AsEnumerable());
+            Console.WriteLine(item);
+            item = CaseGuardExample(collection[0..2].AsEnumerable());
             try {
-                ExhaustiveExample(default(List<int>));
+                item = ExhaustiveExample(default(List<int>));
+                Console.WriteLine(item);
             } catch (ArgumentNullException e)
             {
                 Console.WriteLine($"Caught expected exception: {e.Message}");
@@ -66,63 +77,52 @@ namespace operators
 
         }
 
-
-        private static void TypeExample<T>(IEnumerable<T> sequence)
-        {
-            // <SnippetTypePattern>
-            T thirdOrDefault = sequence switch
+        // <SnippetTypePattern>
+        public static T TypeExample<T>(IEnumerable<T> sequence) =>
+            sequence switch
             {
-                System.Array array => array.GetValue(2),
+                System.Array array => (T)array.GetValue(2),
                 IList<T> list      => list[2],
                 IEnumerable<T> seq => seq.Skip(2).First(),
             };
-            Console.WriteLine(thirdOrDefault);
-            // </SnippetTypePattern>
-        }
+        // </SnippetTypePattern>
 
-        private static void RecursiveExample<T>(IEnumerable<T> sequence)
-        {
-            // <SnippetRecursivePattern>
-            T thirdOrDefault = sequence switch
+        // <SnippetRecursivePattern>
+        public static T RecursiveExample<T>(IEnumerable<T> sequence) =>
+            sequence switch
             {
                 System.Array { Length : 0}       => default(T),
-                System.Array { Length : 1} array => array.GetValue(0),
-                System.Array { Length : 2} array => array.GetValue(1),
-                System.Array array               => array.GetValue(2),
+                System.Array { Length : 1} array => (T)array.GetValue(0),
+                System.Array { Length : 2} array => (T)array.GetValue(1),
+                System.Array array               => (T)array.GetValue(2),
                 IList<T> list                    => list[2],
                 IEnumerable<T> seq               => seq.Skip(2).First(),
             };
-            Console.WriteLine(thirdOrDefault);
-            // </SnippetRecursivePattern>
-        }
+        // </SnippetRecursivePattern>
 
-        private static void CaseGuardExample<T>(IEnumerable<T> sequence)
-        {
-            // <SnippetGuardCase>
-            T thirdOrDefault = sequence switch
+        // <SnippetGuardCase>
+        public static T CaseGuardExample<T>(IEnumerable<T> sequence) =>
+            sequence switch
             {
                 System.Array { Length : 0}                => default(T),
-                System.Array { Length : 1} array          => array.GetValue(0),
-                System.Array { Length : 2} array          => array.GetValue(1),
-                System.Array array                        => array.GetValue(2),
+                System.Array { Length : 1} array          => (T)array.GetValue(0),
+                System.Array { Length : 2} array          => (T)array.GetValue(1),
+                System.Array array                        => (T)array.GetValue(2),
                 IEnumerable<T> list when !list.Any()      => default(T),
                 IEnumerable<T> list when list.Count() < 3 => list.Last(),
                 IList<T> list                             => list[2],
                 IEnumerable<T> seq                        => seq.Skip(2).First(),
             };
-            Console.WriteLine(thirdOrDefault);
-            // </SnippetGuardCase>
-        }
+        // </SnippetGuardCase>
 
-        private static void ExhaustiveExample<T>(IEnumerable<T> sequence)
-        {
-            // <SnippetExhaustive>
-            T thirdOrDefault = sequence switch
+        // <SnippetExhaustive>
+        public static T ExhaustiveExample<T>(IEnumerable<T> sequence) =>
+            sequence switch
             {
                 System.Array { Length : 0}       => default(T),
-                System.Array { Length : 1} array => array.GetValue(0),
-                System.Array { Length : 2} array => array.GetValue(1),
-                System.Array array               => array.GetValue(2),
+                System.Array { Length : 1} array => (T)array.GetValue(0),
+                System.Array { Length : 2} array => (T)array.GetValue(1),
+                System.Array array               => (T)array.GetValue(2),
                 IEnumerable<T> list 
                     when !list.Any()             => default(T),
                 IEnumerable<T> list 
@@ -131,11 +131,7 @@ namespace operators
                 null                             => throw new ArgumentNullException(nameof(sequence)),
                 _                                => sequence.Skip(2).First(),
             };
-            Console.WriteLine(thirdOrDefault);
-            // </SnippetExhaustive>
-        }
-
-        
+        // </SnippetExhaustive>
     }
 }
 

--- a/docs/csharp/language-reference/operators/switch-expression.md
+++ b/docs/csharp/language-reference/operators/switch-expression.md
@@ -5,13 +5,13 @@ ms.date: 03/19/2020
 ---
 # switch expression (C# reference)
 
-This article covers the `switch` expression, introduced in C# 8.0. For information on the `switch` statement, see the article on the [`switch` statement](../statements/switch.md) in the [statements](../statements/index.md) section.
+This article covers the `switch` expression, introduced in C# 8.0. For information on the `switch` statement, see the article on the [`switch` statement](../keywords/switch.md) in the [statements](../keywords/index.md) section.
 
 ## Basic example
 
 The `switch` expression provides for `switch`-like semantics in an expression context. It provides a concise syntax when the switch arms produce a value. The following example shows the structure of a switch expression. It translates values from an `enum` representing visual directions in an online map to the corresponding cardinal direction:
 
-:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetBasicStructure" interactive="csharp-interactive":::
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetBasicStructure" interactive="csharp-interactive-class":::
 
 The preceding sample shows the basic elements of a switch expression:
 

--- a/docs/csharp/language-reference/operators/switch-expression.md
+++ b/docs/csharp/language-reference/operators/switch-expression.md
@@ -11,7 +11,7 @@ This article covers the `switch` expression, introduced in C# 8.0. For informati
 
 The `switch` expression provides for `switch`-like semantics in an expression context. It provides a concise syntax when the switch arms produce a value. The following example shows the structure of a switch expression. It translates values from an `enum` representing visual directions in an online map to the corresponding cardinal direction:
 
-:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetBasicStructure" interactive="csharp-interactive-class":::
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetBasicStructure":::
 
 The preceding sample shows the basic elements of a switch expression:
 
@@ -38,9 +38,11 @@ Recursive patterns can examine properties of the range expression, but can't exe
 
 Finally, you can add the `_` pattern and the `null` pattern to catch arguments that aren't processed by any other switch expression arm. That makes the switch expression *exhaustive*, meaning any possible value of the range expression is handled. The following example adds those expression arms:
 
-:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetExhaustive" interactive="csharp-interactive":::
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetExhaustive":::
 
 The preceding example adds a `null` pattern, and changes the `IEnumerable<T>` type pattern to a `_` pattern. The `null` pattern provides a null check as a switch expression arm. The expression for that arm throws an <xref:System.ArgumentNullException>. The `_` pattern matches all inputs that haven't been matched by previous arms. It must come after the `null` check, or it would match `null` inputs.
+
+You can read more in the C# language spec proposal for [recursive patterns](~/_csharplang/proposals/csharp-8.0/patterns.md#switch-expression).
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/switch.md
+++ b/docs/csharp/language-reference/operators/switch.md
@@ -9,30 +9,41 @@ This article covers the `switch` expression, introduced in C# 8.0. For informati
 
 ## Basic example
 
-The `switch` expression provides for `switch`-like semantics in an expression context. This provides a concise syntax when the switch arms produce a value. The following example shows the structure of a switch expression. It translates values from an `enum` representing visual directions in an online map to the corresponding cardinal direction:
+The `switch` expression provides for `switch`-like semantics in an expression context. It provides a concise syntax when the switch arms produce a value. The following example shows the structure of a switch expression. It translates values from an `enum` representing visual directions in an online map to the corresponding cardinal direction:
 
 :::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetBasicStructure" interactive="csharp-interactive":::
 
 The preceding sample shows the basic elements of a switch expression:
 
 - The *range expression*: The preceding example uses the variable `direction` as the range expression.
-- The *switch expression arms*: Each switch expression arm contains a *pattern*, an optional *case guard* , the `=>` token, and an *expression*.
+- The *switch expression arms*: Each switch expression arm contains a *pattern*, an optional *case guard*, the `=>` token, and an *expression*.
 
-The result of the *switch expression* is the value of the expression of the first *switch expression arm* whose pattern matches the *range expression* and whose *cause guard*, if present, evaluates to `true`. The *expression* on the right of the `=>` token can't be an expression statement.
+The result of the *switch expression* is the value of the expression of the first *switch expression arm* whose *pattern* matches the *range expression* and whose *cause guard*, if present, evaluates to `true`. The *expression* on the right of the `=>` token can't be an expression statement.
 
-Each *switch expression arm* is evaluated in text order. The compiler issues an error if later switch expression arms can't be chosen because an earlier *switch expression arm* always matches first.
+Each *switch expression arm* is evaluated in text order. The compiler issues an error when later switch expression arms can't be chosen because an earlier *switch expression arm* matches all its values.
 
 ## Patterns and case guards
 
--- type pattern
--- value pattern
--- recursive patterns.
+Many patterns are supported in switch expression arms. The preceding example used a *value pattern*. A *value pattern* compares the range expression to a value. That value must be a compile time constant. The *type pattern* compares the range expression to a known type. The following example retrieves the third element from a sequence. It uses different methods based on the type of the sequence:
 
--- fluent switch expressions
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetTypePattern":::
 
--- special cases: null, _, var
+Patterns can be recursive, where a pattern tests a type, and if that type matches, the pattern matches one or more property values on the range expression. You can use recursive patterns to extend the preceding example. You add switch expression arms for arrays that have fewer than 3 elements. Recursive patterns are shown in the following example:
+
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetRecursivePattern":::
+
+Recursive patterns can examine properties of the range expression, but can't execute arbitrary code. You can use a *case guard*, specified in a `when` clause, to provide similar checks for other sequence types:
+
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetGuardCase":::
+
+Finally, you can add the `_` pattern and the `null` pattern to catch arguments that aren't processed by any other switch expression arm. That makes the switch expression *exhaustive*, meaning any possible value of the range expression is handled. The following example adds those expression arms:
+
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetExhaustive" interactive="csharp-interactive":::
+
+The preceding example adds a `null` pattern, and changes the `IEnumerable<T>` type pattern to a `_` pattern. The `null` pattern provides a null check as a switch expression arm. The expression for that arm throws a null argument exception. The `_` pattern matches all inputs that haven't been matched by a previous arm. It must come after the `null` check, or it would match `null` inputs.
 
 ## See also
 
 - [C# reference](../index.md)
 - [C# expressions and operators](index.md)
+- [Pattern matching](../../pattern-matching.md)

--- a/docs/csharp/language-reference/operators/switch.md
+++ b/docs/csharp/language-reference/operators/switch.md
@@ -22,4 +22,4 @@ This article covers the `switch` expression, introduced in C# 8.0. For informati
 ## See also
 
 - [C# reference](../index.md)
-- [C# operators](index.md)
+- [C# expressions and operators](index.md)

--- a/docs/csharp/language-reference/operators/switch.md
+++ b/docs/csharp/language-reference/operators/switch.md
@@ -1,0 +1,25 @@
+---
+title: "switch expressions - C# reference"
+description: Learn how to use the C# switch expression for pattern matching and other data introspection
+ms.date: 03/13/2020
+---
+# switch expressions (C# reference)
+
+This article covers the `switch` expression, introduced in C# 8.0. For information on the `switch` statement, see the article on the [`switch` statement](../statements/switch.md) in the [statements](../statements/index.md) section.
+
+## Basic example
+
+## Structure
+
+-- switch variable
+
+-- case arms
+
+-- recursive patterns.
+
+## Fluent nature
+
+## See also
+
+- [C# reference](../index.md)
+- [C# operators](index.md)

--- a/docs/csharp/language-reference/operators/switch.md
+++ b/docs/csharp/language-reference/operators/switch.md
@@ -1,7 +1,7 @@
 ---
 title: "switch expressions - C# reference"
 description: Learn how to use the C# switch expression for pattern matching and other data introspection
-ms.date: 03/13/2020
+ms.date: 03/19/2020
 ---
 # switch expressions (C# reference)
 
@@ -9,15 +9,28 @@ This article covers the `switch` expression, introduced in C# 8.0. For informati
 
 ## Basic example
 
-## Structure
+The `switch` expression provides for `switch`-like semantics in an expression context. This provides a concise syntax when the switch arms produce a value. The following example shows the structure of a switch expression. It translates values from an `enum` representing visual directions in an online map to the corresponding cardinal direction:
 
--- switch variable
+:::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetBasicStructure" interactive="csharp-interactive":::
 
--- case arms
+The preceding sample shows the basic elements of a switch expression:
 
+- The *range expression*: The preceding example uses the variable `direction` as the range expression.
+- The *switch expression arms*: Each switch expression arm contains a *pattern*, an optional *case guard* , the `=>` token, and an *expression*.
+
+The result of the *switch expression* is the value of the expression of the first *switch expression arm* whose pattern matches the *range expression* and whose *cause guard*, if present, evaluates to `true`. The *expression* on the right of the `=>` token can't be an expression statement.
+
+Each *switch expression arm* is evaluated in text order. The compiler issues an error if later switch expression arms can't be chosen because an earlier *switch expression arm* always matches first.
+
+## Patterns and case guards
+
+-- type pattern
+-- value pattern
 -- recursive patterns.
 
-## Fluent nature
+-- fluent switch expressions
+
+-- special cases: null, _, var
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/switch.md
+++ b/docs/csharp/language-reference/operators/switch.md
@@ -1,9 +1,9 @@
 ---
-title: "switch expressions - C# reference"
+title: "switch expression - C# reference"
 description: Learn how to use the C# switch expression for pattern matching and other data introspection
 ms.date: 03/19/2020
 ---
-# switch expressions (C# reference)
+# switch expression (C# reference)
 
 This article covers the `switch` expression, introduced in C# 8.0. For information on the `switch` statement, see the article on the [`switch` statement](../statements/switch.md) in the [statements](../statements/index.md) section.
 
@@ -20,7 +20,7 @@ The preceding sample shows the basic elements of a switch expression:
 
 The result of the *switch expression* is the value of the expression of the first *switch expression arm* whose *pattern* matches the *range expression* and whose *cause guard*, if present, evaluates to `true`. The *expression* on the right of the `=>` token can't be an expression statement.
 
-Each *switch expression arm* is evaluated in text order. The compiler issues an error when later switch expression arms can't be chosen because an earlier *switch expression arm* matches all its values.
+The *switch expression arms* are evaluated in text order. The compiler issues an error when a lower *switch expression arm* can't be chosen because a higher *switch expression arm* matches all its values.
 
 ## Patterns and case guards
 
@@ -40,10 +40,10 @@ Finally, you can add the `_` pattern and the `null` pattern to catch arguments t
 
 :::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetExhaustive" interactive="csharp-interactive":::
 
-The preceding example adds a `null` pattern, and changes the `IEnumerable<T>` type pattern to a `_` pattern. The `null` pattern provides a null check as a switch expression arm. The expression for that arm throws a null argument exception. The `_` pattern matches all inputs that haven't been matched by a previous arm. It must come after the `null` check, or it would match `null` inputs.
+The preceding example adds a `null` pattern, and changes the `IEnumerable<T>` type pattern to a `_` pattern. The `null` pattern provides a null check as a switch expression arm. The expression for that arm throws an <xref:System.ArgumentNullException>. The `_` pattern matches all inputs that haven't been matched by previous arms. It must come after the `null` check, or it would match `null` inputs.
 
 ## See also
 
 - [C# reference](../index.md)
-- [C# expressions and operators](index.md)
+- [C# operators](index.md)
 - [Pattern matching](../../pattern-matching.md)

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1611,9 +1611,6 @@
     - name: Member access operators and expressions
       href: language-reference/operators/member-access-operators.md
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation, ^, index from end, hat, .., range"
-    - name: switch expression
-      href: language-reference/operators/switch-expression.md
-      displayName: "switch, pattern matching, patterns"
     - name: Type-testing and cast operators
       href: language-reference/operators/type-testing-and-cast.md
       displayName: "is operator, is keyword, as operator, as keyword, typeof, (), explicit, conversion"
@@ -1667,6 +1664,9 @@
     - name: stackalloc expression
       href: language-reference/operators/stackalloc.md
       displayName: stack allocation, span, stackalloc operator
+    - name: switch expression
+      href: language-reference/operators/switch-expression.md
+      displayName: "switch, pattern matching, patterns"
     - name: true and false operators
       href: language-reference/operators/true-false-operators.md
     - name: Operator overloading

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1612,7 +1612,7 @@
       href: language-reference/operators/member-access-operators.md
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation, ^, index from end, hat, .., range"
     - name: switch expression
-      href: language-reference/operators/switch.md
+      href: language-reference/operators/switch-expression.md
       displayName: "switch, pattern matching, patterns"
     - name: Type-testing and cast operators
       href: language-reference/operators/type-testing-and-cast.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1611,7 +1611,7 @@
     - name: Member access operators and expressions
       href: language-reference/operators/member-access-operators.md
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation, ^, index from end, hat, .., range"
-    - name: switch expressions
+    - name: switch expression
       href: language-reference/operators/switch.md
       displayName: "switch, pattern matching, patterns"
     - name: Type-testing and cast operators

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1611,6 +1611,9 @@
     - name: Member access operators and expressions
       href: language-reference/operators/member-access-operators.md
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation, ^, index from end, hat, .., range"
+    - name: switch expressions
+      href: language-reference/operators/switch.md
+      displayName: "switch, pattern matching, patterns"
     - name: Type-testing and cast operators
       href: language-reference/operators/type-testing-and-cast.md
       displayName: "is operator, is keyword, as operator, as keyword, typeof, (), explicit, conversion"


### PR DESCRIPTION
Fixes #14889 

Add a new article for the language reference on switch expressions.

Also, provide links between the articles on the switch statement and switch expression. I made that choice because the switch statement article was already rather long.

[Internal review link](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/switch-expression?branch=pr-en-us-17512)