### PR TITLE
Use async and await all the way

### DIFF
--- a/samples/snippets/csharp/programming-guide/discards/standalone-discard1.cs
+++ b/samples/snippets/csharp/programming-guide/discards/standalone-discard1.cs
@@ -3,9 +3,9 @@ using System.Threading.Tasks;
 
 public class Example
 {
-   public static void Main()
+   public static async Task Main(string[] args)
    {
-      ExecuteAsyncMethods().Wait();
+      await ExecuteAsyncMethods();
    }
 
    private static async Task ExecuteAsyncMethods()


### PR DESCRIPTION
## Summary

Set the entry point (Main method) to async to leverage await. This is to avoid spreading a bad practice of code that could potentially deadlock.

Fixes #17507 
