### PR TITLE
exclude placeholder for language specifications.

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -45,7 +45,32 @@
         "exclude": [
           "**/README.md",
           "inactive/**",
-          "rejected/**"        ]
+          "rejected/**",
+
+          "csharp-6.0/enum-base-type.md",
+
+          "csharp-7.0/expression-bodied-everything.md",
+          "csharp-7.0/ref-locals-returns.md",
+          "csharp-7.0/tuples.md",
+          "csharp-7.0/value-task.md",
+
+          "csharp-7.2/readonly-struct.md",
+          "csharp-7.2/ref-extension-methods.md",
+          "csharp-7.2/ref-struct-span.md",
+          "csharp-7.2/span-safety.md",
+
+          "csharp-7.3/enum-delegate-constraint.md",
+          "csharp-7.3/ref-loops.md",
+
+          "csharp-8.0/alternative-interpolated-verbatim.md",
+          "csharp-8.0/async-using.md",
+          "csharp-8.0/constraints-in-overrides.md",
+          "csharp-8.0/constructed-unmanaged.md",
+          "csharp-8.0/notnull-constraint.md",
+          "csharp-8.0/obsolete-accessor.md",
+          "csharp-8.0/shadowing-in-nested-functions.md",
+          "csharp-8.0/unconstrained-null-coalescing.md"
+        ]
       },
       {
         "files": [

--- a/docfx.json
+++ b/docfx.json
@@ -56,10 +56,9 @@
 
           "csharp-7.2/readonly-struct.md",
           "csharp-7.2/ref-extension-methods.md",
-          "csharp-7.2/ref-struct-span.md",
-          "csharp-7.2/span-safety.md",
+          "csharp-7.2/ref-struct-and-span.md",
 
-          "csharp-7.3/enum-delegate-constraint.md",
+          "csharp-7.3/enum-delegate-constraints.md",
           "csharp-7.3/ref-loops.md",
 
           "csharp-8.0/alternative-interpolated-verbatim.md",


### PR DESCRIPTION
This should fix several build warnings.  The C# team has added placeholders for the spec language for some features. Until those articles have text, they should not be published.

[Internal preview URL](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.0/pattern-matching?branch=pr-en-us-17516)
