### PR TITLE
Fix incorrect filename for docker-compose override

### DIFF
--- a/docs/architecture/microservices/multi-container-microservice-net-applications/multi-container-applications-docker-compose.md
+++ b/docs/architecture/microservices/multi-container-microservice-net-applications/multi-container-applications-docker-compose.md
@@ -151,7 +151,7 @@ With Docker Compose, you can create and destroy that isolated environment very e
 ```console
 docker-compose -f docker-compose.yml -f docker-compose-test.override.yml up -d
 ./run_unit_tests
-docker-compose -f docker-compose.yml -f docker-compose.test.override.yml down
+docker-compose -f docker-compose.yml -f docker-compose-test.override.yml down
 ```
 
 #### Production deployments


### PR DESCRIPTION
## Summary

There seems to be some inconsistency for the naming of the `docker-compose` override. This change makes both commands use the same filename. The filename corresponds with the following docs:

https://github.com/dotnet/docs/blob/master/docs/architecture/microservices/multi-container-microservice-net-applications/test-aspnet-core-services-web-apps.md#testing-in-eshoponcontainers