### PR TITLE
Expand introductory text for JSON migration doc

### DIFF
--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -15,6 +15,12 @@ helpviewer_keywords:
 
 This article shows how to migrate from [Newtonsoft.Json](https://www.newtonsoft.com/json) to <xref:System.Text.Json>.
 
+The `System.Text.Json` namespace provides functionality for serializing to and deserializing from JavaScript Object Notation (JSON). The `System.Text.Json` library is included in the [.NET Core 3.0](https://aka.ms/netcore3download) shared framework. For other target frameworks, install the [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) NuGet package. The package supports:
+
+* .NET Standard 2.0 and later versions
+* .NET Framework 4.7.2 and later versions
+* .NET Core 2.0, 2.1, and 2.2
+
 `System.Text.Json` focuses primarily on performance, security, and standards compliance. It has some key differences in default behavior and doesn't aim to have feature parity with `Newtonsoft.Json`. For some scenarios, `System.Text.Json` has no built-in functionality, but there are recommended workarounds. For other scenarios, workarounds are impractical. If your application depends on a missing feature, consider [filing an issue](https://github.com/dotnet/runtime/issues/new) to find out if support for your scenario can be added.
 
 <!-- For information about which features might be added in future releases, see the [Roadmap](https://github.com/dotnet/runtime/tree/81bf79fd9aa75305e55abe2f7e9ef3f60624a3a1/src/libraries/System.Text.Json/roadmap/README.md). [Restore this when the roadmap is updated.]-->


### PR DESCRIPTION
Contributes to #16732 

Adding some text from the overview to attempt to address issue that some queries that include "Core" are not finding the doc.

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?branch=pr-en-us-17561)
