### PR TITLE
Updated link to original single-file specification

### DIFF
--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -103,7 +103,7 @@ To publish a single-file executable, set the `PublishSingleFile` in your project
 dotnet publish -r win10-x64 -p:PublishSingleFile=true
 ```
 
-For more information about single-file publishing, see the [single-file bundler design document](https://github.com/dotnet/designs/blob/master/accepted/single-file/design.md).
+For more information about single-file publishing, see the [single-file bundler design document](https://github.com/dotnet/designs/blob/master/accepted/2020/single-file/design_3_0.md).
 
 ### Assembly linking
 


### PR DESCRIPTION
## Summary

The link to the _single-file bundler design document_, which was outdated after a reorganization of the design documents into date-based folders and version-based suffixes. This is especially relevant since the design document doesn't _appear_ to be picked up by Google, and is thus really difficult to find if you don't know where to look for it.  

Fixes #17583
