### PR TITLE
Clarified "microsoft identity platform"

### DIFF
--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -96,7 +96,7 @@ conceptualContent:
     - title: Authentication and security
       links:
         - itemType: overview
-          text: Microsoft identity platform
+          text: Microsoft identity platform (Azure AD)
           url: https://docs.microsoft.com/azure/active-directory/develop/
         - itemType: tutorial
           text: Use Azure Key Vault with ASP.NET Core

--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -96,7 +96,7 @@ conceptualContent:
     - title: Authentication and security
       links:
         - itemType: overview
-          text: Microsoft identity platform (Azure AD)
+          text: Microsoft identity platform (Azure Active Directory)
           url: https://docs.microsoft.com/azure/active-directory/develop/
         - itemType: tutorial
           text: Use Azure Key Vault with ASP.NET Core

--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -96,7 +96,7 @@ conceptualContent:
     - title: Authentication and security
       links:
         - itemType: overview
-          text: Microsoft identity platform (Azure Active Directory)
+          text: Microsoft identity platform (Azure AD)
           url: https://docs.microsoft.com/azure/active-directory/develop/
         - itemType: tutorial
           text: Use Azure Key Vault with ASP.NET Core


### PR DESCRIPTION
## Summary

Telemetry indicates "Microsoft identity platform" link is lower traffic than I would expect. Clarifying that it's the new "Azure Active Directory." This adds more text to that link.
