### PR TITLE
Document the removal of ASP.NET Core / Azure SDK integration packages

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 3.1 to 5.0
 description: Lists the breaking changes from version 3.1 to version 5.0 of .NET, ASP.NET Core, and EF Core.
-ms.date: 03/24/2020
+ms.date: 03/25/2020
 ---
 # Breaking changes for migration from version 3.1 to 5.0
 
@@ -9,6 +9,13 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## ASP.NET Core
 
+- [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
 
+[!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
+
+***
+
 [!INCLUDE[SignalR: UseSignalR and UseConnections methods removed](~/includes/core-changes/aspnetcore/5.0/signalr-usesignalr-useconnections-removed.md)]
+
+***

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core breaking changes
 titleSuffix: ""
 description: Lists the breaking changes in ASP.NET Core.
-ms.date: "03/24/2020"
+ms.date: "03/25/2020"
 author: "scottaddie"
 ms.author: "scaddie"
 ---
@@ -20,6 +20,7 @@ The following breaking changes are documented on this page:
 - [Authorization: AddAuthorization overload moved to different assembly](#authorization-addauthorization-overload-moved-to-different-assembly)
 - [Authorization: IAllowAnonymous removed from AuthorizationFilterContext.Filters](#authorization-iallowanonymous-removed-from-authorizationfiltercontextfilters)
 - [Authorization: IAuthorizationPolicyProvider implementations require new method](#authorization-iauthorizationpolicyprovider-implementations-require-new-method)
+- [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
 - [Caching: CompactOnMemoryPressure property removed](#caching-compactonmemorypressure-property-removed)
 - [Caching: Microsoft.Extensions.Caching.SqlServer uses new SqlClient package](#caching-microsoftextensionscachingsqlserver-uses-new-sqlclient-package)
 - [Caching: ResponseCaching "pubternal" types changed to internal](#caching-responsecaching-pubternal-types-changed-to-internal)
@@ -67,7 +68,11 @@ The following breaking changes are documented on this page:
 
 ## ASP.NET Core 5.0
 
-[!INCLUDE[SignalR: UseSignalR and UseConnections methods removed](../../../includes/core-changes/aspnetcore/5.0/signalr-usesignalr-useconnections-removed.md)]
+[!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
+
+***
+
+[!INCLUDE[SignalR: UseSignalR and UseConnections methods removed](~/includes/core-changes/aspnetcore/5.0/signalr-usesignalr-useconnections-removed.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md
+++ b/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md
@@ -2,8 +2,8 @@
 
 The following `Microsoft.*` packages that provide integration between ASP.NET Core and Azure SDKs aren't included in ASP.NET Core 5.0:
 
-* [Microsoft.Extensions.Configuration.AzureKeyVault](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/), which integrates Azure Key Vault into the Configuration system.
-* [Microsoft.AspNetCore.DataProtection.AzureKeyVault](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureKeyVault/), which integrates Azure Key Vault into the ASP.NET Core Data Protection system.
+* [Microsoft.Extensions.Configuration.AzureKeyVault](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/), which integrates Azure Key Vault into the [Configuration system](/aspnet/core/fundamentals/configuration/).
+* [Microsoft.AspNetCore.DataProtection.AzureKeyVault](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureKeyVault/), which integrates Azure Key Vault into the [ASP.NET Core Data Protection system](/aspnet/core/security/data-protection/introduction).
 * [Microsoft.AspNetCore.DataProtection.AzureStorage](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureStorage/), which integrates Azure Blob Storage into the ASP.NET Core Data Protection system.
 
 For discussion on this issue, see [dotnet/aspnetcore#19570](https://github.com/dotnet/aspnetcore/issues/19570).

--- a/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md
+++ b/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md
@@ -1,0 +1,67 @@
+### Azure: Microsoft-prefixed Azure integration packages removed
+
+The following `Microsoft.*` packages that provide integration between ASP.NET Core and Azure SDKs aren't included in ASP.NET Core 5.0:
+
+* [Microsoft.Extensions.Configuration.AzureKeyVault](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/), which integrates Azure Key Vault into the Configuration system.
+* [Microsoft.AspNetCore.DataProtection.AzureKeyVault](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureKeyVault/), which integrates Azure Key Vault into the ASP.NET Core Data Protection system.
+* [Microsoft.AspNetCore.DataProtection.AzureStorage](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureStorage/), which integrates Azure Blob Storage into the ASP.NET Core Data Protection system.
+
+For discussion on this issue, see [dotnet/aspnetcore#19570](https://github.com/dotnet/aspnetcore/issues/19570).
+
+#### Version introduced
+
+5.0 Preview 1
+
+#### Old behavior
+
+The `Microsoft.*` packages integrated Azure services with the Configuration and Data Protection APIs.
+
+#### New behavior
+
+New `Azure.*` packages integrate Azure services with the Configuration and Data Protection APIs.
+
+#### Reason for change
+
+The change was made because the `Microsoft.*` packages were:
+
+* Using outdated versions of the Azure SDK. Simple updates weren't possible because the new versions of the Azure SDK included breaking changes.
+* Tied to the .NET Core release schedule. Transferring ownership of the packages to the Azure SDK team enables package updates as the Azure SDK is updated.
+
+#### Recommended action
+
+In ASP.NET Core 2.1 or later projects, replace the old `Microsoft.*` with the new `Azure.*` packages.
+
+| Old | New |
+|--|--|
+| `Microsoft.AspNetCore.DataProtection.AzureKeyVault` | [Azure.AspNetCore.DataProtection.Keys](https://www.nuget.org/packages/Azure.AspNetCore.DataProtection.Keys) |
+| `Microsoft.AspNetCore.DataProtection.AzureStorage` | [Azure.AspNetCore.DataProtection.Blobs](https://www.nuget.org/packages/Azure.AspNetCore.DataProtection.Blobs) |
+| `Microsoft.Extensions.Configuration.AzureKeyVault` | [Azure.Extensions.Configuration.Secrets](https://www.nuget.org/packages/Azure.Extensions.Configuration.Secrets) |
+
+The new packages use a new version of the Azure SDK that includes breaking changes. The general usage patterns are unchanged. Some overloads and options may differ to adapt to changes in the underlying Azure SDK APIs.
+
+The old packages will:
+
+* Be supported by the ASP.NET Core team for the lifetime of .NET Core 2.1 and 3.1.
+* Not be included in .NET 5.
+
+When upgrading your project to .NET 5, transition to the `Azure.*` packages to maintain support.
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+- <xref:Microsoft.Extensions.Configuration.AzureKeyVaultConfigurationExtensions.AddAzureKeyVault%2A?displayProperty=nameWithType>
+- <xref:Microsoft.AspNetCore.DataProtection.AzureDataProtectionBuilderExtensions.ProtectKeysWithAzureKeyVault%2A?displayProperty=nameWithType>
+- <xref:Microsoft.AspNetCore.DataProtection.AzureDataProtectionBuilderExtensions.PersistKeysToAzureBlobStorage%2A?displayProperty=nameWithType>
+
+<!--
+
+#### Affected APIs
+
+- `Overload:Microsoft.Extensions.Configuration.AzureKeyVaultConfigurationExtensions.AddAzureKeyVault`
+- `Overload:Microsoft.AspNetCore.DataProtection.AzureDataProtectionBuilderExtensions.ProtectKeysWithAzureKeyVault`
+- `Overload:Microsoft.AspNetCore.DataProtection.AzureDataProtectionBuilderExtensions.PersistKeysToAzureBlobStorage`
+
+-->

--- a/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md
+++ b/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md
@@ -2,9 +2,9 @@
 
 The following `Microsoft.*` packages that provide integration between ASP.NET Core and Azure SDKs aren't included in ASP.NET Core 5.0:
 
-* [Microsoft.Extensions.Configuration.AzureKeyVault](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/), which integrates Azure Key Vault into the [Configuration system](/aspnet/core/fundamentals/configuration/).
+* [Microsoft.Extensions.Configuration.AzureKeyVault](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/), which integrates [Azure Key Vault](/azure/key-vault/) into the [Configuration system](/aspnet/core/fundamentals/configuration/).
 * [Microsoft.AspNetCore.DataProtection.AzureKeyVault](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureKeyVault/), which integrates Azure Key Vault into the [ASP.NET Core Data Protection system](/aspnet/core/security/data-protection/introduction).
-* [Microsoft.AspNetCore.DataProtection.AzureStorage](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureStorage/), which integrates Azure Blob Storage into the ASP.NET Core Data Protection system.
+* [Microsoft.AspNetCore.DataProtection.AzureStorage](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.AzureStorage/), which integrates [Azure Blob Storage](/azure/storage/blobs/) into the ASP.NET Core Data Protection system.
 
 For discussion on this issue, see [dotnet/aspnetcore#19570](https://github.com/dotnet/aspnetcore/issues/19570).
 


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/409

[Internal review page](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-17600#azure-microsoft-prefixed-azure-integration-packages-removed)