### PR TITLE
Add H1s to style guide and voice recommendations.

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -1,1 +1,3 @@
+# Article template
+
 This content has been moved to the [Contributor guide](https://docs.microsoft.com/contribute/dotnet-style-guide).

--- a/styleguide/voice-tone.md
+++ b/styleguide/voice-tone.md
@@ -1,1 +1,3 @@
+# Voice and tone recommendations
+
 This content has been moved to the [Contributor guide](https://docs.microsoft.com/contribute/dotnet-voice-tone).


### PR DESCRIPTION
Without an H1, these two files generate unnecessary warnings on the docs validation tool.

This is the quickest way to address those warnings.
