### PR TITLE
Document breaking change for SignalR MessagePack Hub Protocol

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -10,14 +10,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ## ASP.NET Core
 
 - [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
-- [SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-v2x-package)
+- [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
 
 [!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
 
 ***
 
-[!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
+[!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
 
 ***
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 3.1 to 5.0
 description: Lists the breaking changes from version 3.1 to version 5.0 of .NET, ASP.NET Core, and EF Core.
-ms.date: 03/25/2020
+ms.date: 03/26/2020
 ---
 # Breaking changes for migration from version 3.1 to 5.0
 
@@ -10,9 +10,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ## ASP.NET Core
 
 - [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
+- [SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-v2x-package)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
 
 [!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
+
+***
+
+[!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -60,7 +60,7 @@ The following breaking changes are documented on this page:
 - [SignalR: HubConnection methods removed](#signalr-hubconnection-resetsendping-and-resettimeout-methods-removed)
 - [SignalR: HubConnectionContext constructors changed](#signalr-hubconnectioncontext-constructors-changed)
 - [SignalR: JavaScript client package name change](#signalr-javascript-client-package-name-changed)
-- [SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-v2x-package)
+- [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
 - [SignalR: Obsolete APIs](#signalr-usesignalr-and-useconnections-methods-marked-obsolete)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
 - [SPAs: SpaServices and NodeServices console logger fallback default change](#spas-spaservices-and-nodeservices-no-longer-fall-back-to-console-logger)
@@ -73,7 +73,7 @@ The following breaking changes are documented on this page:
 
 ***
 
-[!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
+[!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -2,9 +2,9 @@
 title: ASP.NET Core breaking changes
 titleSuffix: ""
 description: Lists the breaking changes in ASP.NET Core.
-ms.date: "03/25/2020"
-author: "scottaddie"
-ms.author: "scaddie"
+ms.date: 03/26/2020
+author: scottaddie
+ms.author: scaddie
 ---
 # ASP.NET Core breaking changes
 
@@ -60,15 +60,20 @@ The following breaking changes are documented on this page:
 - [SignalR: HubConnection methods removed](#signalr-hubconnection-resetsendping-and-resettimeout-methods-removed)
 - [SignalR: HubConnectionContext constructors changed](#signalr-hubconnectioncontext-constructors-changed)
 - [SignalR: JavaScript client package name change](#signalr-javascript-client-package-name-changed)
+- [SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-v2x-package)
 - [SignalR: Obsolete APIs](#signalr-usesignalr-and-useconnections-methods-marked-obsolete)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
-- [SPAs: SpaServices and NodeServices marked obsolete](#spas-spaservices-and-nodeservices-marked-obsolete)
 - [SPAs: SpaServices and NodeServices console logger fallback default change](#spas-spaservices-and-nodeservices-no-longer-fall-back-to-console-logger)
+- [SPAs: SpaServices and NodeServices marked obsolete](#spas-spaservices-and-nodeservices-marked-obsolete)
 - [Target framework: .NET Framework not supported](#target-framework-net-framework-support-dropped)
 
 ## ASP.NET Core 5.0
 
 [!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
+
+***
+
+[!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
+++ b/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
@@ -18,7 +18,7 @@ ASP.NET Core SignalR uses the MessagePack 2.x package to serialize and deseriali
 
 #### Reason for change
 
-MessagePack 2.x adds useful functionality by adopting the latest improvements in that package.
+The latest improvements in the MessagePack 2.x package add useful functionality.
 
 #### Recommended action
 

--- a/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
+++ b/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
@@ -1,0 +1,46 @@
+### SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package
+
+The ASP.NET Core SignalR [MessagePack Hub Protocol](/aspnet/core/signalr/messagepackhubprotocol) uses the [MessagePack NuGet package](https://www.nuget.org/packages/MessagePack) for MessagePack serialization. ASP.NET Core 5.0 upgrades from 1.x to the latest 2.x package version.
+
+For discussion on this issue, see [dotnet/aspnetcore#18692](https://github.com/dotnet/aspnetcore/issues/18692).
+
+#### Version introduced
+
+5.0 Preview 1
+
+#### Old behavior
+
+ASP.NET Core SignalR used the MessagePack 1.x package to serialize and deserialize MessagePack messages.
+
+#### New behavior
+
+ASP.NET Core SignalR will use the MessagePack 2.x package to serialize and deserialize MessagePack messages.
+
+#### Reason for change
+
+MessagePack v2.x adds useful functionality by adopting the latest improvements in that package.
+
+#### Recommended action
+
+This breaking change applies when:
+
+* Setting or configuring values on <xref:Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions>.
+* Using the MessagePack APIs directly and using the ASP.NET Core SignalR MessagePack Hub Protocol in the same project. The newer version will be loaded instead of the previous version.
+
+For migration guidance from the package authors, see [Migrating from MessagePack v1.x to MessagePack v2.x](https://github.com/neuecc/MessagePack-CSharp/blob/master/doc/migration.md). Some aspects of message serialization and deserialization are affected. Specifically, there are [behavioral changes to how DateTime values are serialized](https://github.com/neuecc/MessagePack-CSharp/blob/master/doc/migration.md#behavioral-changes).
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+<xref:Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions?displayProperty=nameWithType>
+
+<!--
+
+#### Affected APIs
+
+`T:Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions`
+
+-->

--- a/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
+++ b/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
@@ -1,4 +1,4 @@
-### SignalR: MessagePack Hub Protocol moved to MessagePack v2.x package
+### SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package
 
 The ASP.NET Core SignalR [MessagePack Hub Protocol](/aspnet/core/signalr/messagepackhubprotocol) uses the [MessagePack NuGet package](https://www.nuget.org/packages/MessagePack) for MessagePack serialization. ASP.NET Core 5.0 upgrades from 1.x to the latest 2.x package version.
 
@@ -18,7 +18,7 @@ ASP.NET Core SignalR will use the MessagePack 2.x package to serialize and deser
 
 #### Reason for change
 
-MessagePack v2.x adds useful functionality by adopting the latest improvements in that package.
+MessagePack 2.x adds useful functionality by adopting the latest improvements in that package.
 
 #### Recommended action
 

--- a/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
+++ b/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md
@@ -1,6 +1,6 @@
 ### SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package
 
-The ASP.NET Core SignalR [MessagePack Hub Protocol](/aspnet/core/signalr/messagepackhubprotocol) uses the [MessagePack NuGet package](https://www.nuget.org/packages/MessagePack) for MessagePack serialization. ASP.NET Core 5.0 upgrades from 1.x to the latest 2.x package version.
+The ASP.NET Core SignalR [MessagePack Hub Protocol](/aspnet/core/signalr/messagepackhubprotocol) uses the [MessagePack NuGet package](https://www.nuget.org/packages/MessagePack) for MessagePack serialization. ASP.NET Core 5.0 upgrades the package from 1.x to the latest 2.x package version.
 
 For discussion on this issue, see [dotnet/aspnetcore#18692](https://github.com/dotnet/aspnetcore/issues/18692).
 
@@ -14,7 +14,7 @@ ASP.NET Core SignalR used the MessagePack 1.x package to serialize and deseriali
 
 #### New behavior
 
-ASP.NET Core SignalR will use the MessagePack 2.x package to serialize and deserialize MessagePack messages.
+ASP.NET Core SignalR uses the MessagePack 2.x package to serialize and deserialize MessagePack messages.
 
 #### Reason for change
 


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/404

[Internal review page](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-17610#signalr-messagepack-hub-protocol-moved-to-messagepack-v2x-package)