### PR TITLE
Remove hyphen

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -39,7 +39,7 @@ highlightedContent:
 # conceptualContent section (optional)
 conceptualContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
-  title: ".NET: Free. Cross-platform. Open source." # < 60 chars (optional)
+  title: ".NET: Free. Cross platform. Open source." # < 60 chars (optional)
   summary: "A developer platform for building all your apps: web, mobile, desktop, gaming, IoT, and more. Supported on Windows, Linux, and macOS."
   items:
     # Card


### PR DESCRIPTION
It seemed weird that cross-platform was hyphenated but open source wasn't.