### PR TITLE
Clarified the type of a null-conditional expression for value-type expressions

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -215,4 +215,3 @@ For more information about indices and ranges, see the [feature proposal note](~
 - [C# operators](index.md)
 - [?? (null-coalescing operator)](null-coalescing-operator.md)
 - [:: operator](namespace-alias-qualifier.md)
- 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -124,7 +124,7 @@ The following example demonstrates the usage of the `?.` and `?[]` operators:
 
 The preceding example also uses the [null-coalescing operator `??`](null-coalescing-operator.md) to specify an alternative expression to evaluate in case the result of a null-conditional operation is `null`.
 
-If `a.x` or `a[x]` is of a non-nullable value type `T`, `a?.x` or `a?[x]` is of the corresponding nullable value type `T?`. If you need an expression of type `T`, apply the null-coalescing operator `??` to a null-conditional expression, as the following example shows:
+If `a.x` or `a[x]` is of a non-nullable value type `T`, `a?.x` or `a?[x]` is of the corresponding [nullable value type](../builtin-types/nullable-value-types.md) `T?`. If you need an expression of type `T`, apply the null-coalescing operator `??` to a null-conditional expression, as the following example shows:
 
 [!code-csharp-interactive[null-conditional with null-coalescing](snippets/MemberAccessOperators.cs#NullConditionalWithNullCoalescing)]
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -1,7 +1,7 @@
 ---
 title: "Member access operators and expressions - C# reference"
 description: "Learn about C# operators that you can use to access type members."
-ms.date: 09/18/2019
+ms.date: 03/31/2020
 author: pkulikov
 f1_keywords: 
   - "._CSharpKeyword"

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -124,6 +124,12 @@ The following example demonstrates the usage of the `?.` and `?[]` operators:
 
 The preceding example also uses the [null-coalescing operator `??`](null-coalescing-operator.md) to specify an alternative expression to evaluate in case the result of a null-conditional operation is `null`.
 
+If `a.x` or `a[x]` is of a non-nullable value type `T`, `a?.x` or `a?[x]` is of the corresponding nullable value type `T?`. If you need an expression of type `T`, apply the null-coalescing operator `??` to a null-conditional expression, as the following example shows:
+
+[!code-csharp-interactive[null-conditional with null-coalescing](snippets/MemberAccessOperators.cs#NullConditionalWithNullCoalescing)]
+
+In the preceding example, if you don't use the `??` operator, `numbers?.Length < 2` evaluates to `false` when `numbers` is `null`.
+
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 ### Thread-safe delegate invocation
@@ -209,3 +215,4 @@ For more information about indices and ranges, see the [feature proposal note](~
 - [C# operators](index.md)
 - [?? (null-coalescing operator)](null-coalescing-operator.md)
 - [:: operator](namespace-alias-qualifier.md)
+ 

--- a/docs/csharp/language-reference/operators/snippets/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/MemberAccessOperators.cs
@@ -14,6 +14,7 @@ namespace operators
             Arrays();
             Indexers();
             NullConditional();
+            NullConditionalWithNullCoalescing();
             Invocation();
             IndexFromEnd();
             Ranges();

--- a/docs/csharp/language-reference/operators/snippets/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/MemberAccessOperators.cs
@@ -96,6 +96,24 @@ namespace operators
             // </SnippetNullConditional>
         }
 
+        private static void NullConditionalWithNullCoalescing()
+        {
+            // <SnippetNullConditionalWithNullCoalescing>
+            int GetSumOfFirstTwoOrDefault(int[] numbers)
+            {
+                if ((numbers?.Length ?? 0) < 2)
+                {
+                    return 0;
+                }
+                return numbers[0] + numbers[1];
+            }
+
+            Console.WriteLine(GetSumOfFirstTwoOrDefault(null));  // output: 0
+            Console.WriteLine(GetSumOfFirstTwoOrDefault(new int[0]));  // output: 0
+            Console.WriteLine(GetSumOfFirstTwoOrDefault(new[] { 3, 4, 5 }));  // output: 7
+            // </SnippetNullConditionalWithNullCoalescing>
+        }
+
         private static void Invocation()
         {
             // <SnippetInvocation>


### PR DESCRIPTION
Fixes #17618

/cc: @redmondgiant
