### PR TITLE
Fix typo

### DIFF
--- a/docs/architecture/microservices/net-core-net-framework-containers/net-core-container-scenarios.md
+++ b/docs/architecture/microservices/net-core-net-framework-containers/net-core-container-scenarios.md
@@ -21,7 +21,7 @@ Clearly, if your goal is to have an application (web app or service) that can ru
 
 [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) is an IDE, evolution of Xamarin Studio, that runs on macOS and supports Docker-based application development. This should be the preferred choice for developers working in Mac machines who also want to use a powerful IDE.
 
-You can also use [Visual Studio Code](https://code.visualstudio.com/) on macOS, Linux, and Windows. Visual Studio Code fully supports .NET Core, including IntelliSense and debugging. Because VS Code is a lightweight editor, you can use it to develop containerized apps on the Mac in conjunction with the Docker CLI and the [.NET Core CLI](../../../core/tools/index.md). You can also target .NET Core with most third-party editors like Sublime, Emacs, vi, and the open-source OmniSharp project, which also provides IntelliSense support.
+You can also use [Visual Studio Code](https://code.visualstudio.com/) on macOS, Linux, and Windows. Visual Studio Code fully supports .NET Core, including IntelliSense and debugging. Because VS Code is a lightweight editor, you can use it to develop containerized apps on the machine in conjunction with the Docker CLI and the [.NET Core CLI](../../../core/tools/index.md). You can also target .NET Core with most third-party editors like Sublime, Emacs, vi, and the open-source OmniSharp project, which also provides IntelliSense support.
 
 In addition to the IDEs and editors, you can use the [.NET Core CLI](../../../core/tools/index.md) for all supported platforms.
 


### PR DESCRIPTION
## Summary

I think this is what it meant to say considering the context. There's no reason it should specify a "Mac" rather than a machine because the environment mentioned is cross-platform.
