### PR TITLE
Adding dotnet-core-uninstall to list of allowed elevated commands

### DIFF
--- a/docs/core/tools/elevated-access.md
+++ b/docs/core/tools/elevated-access.md
@@ -12,6 +12,7 @@ The following commands can be run elevated:
 
 - `dotnet tool` commands, such as [dotnet tool install](dotnet-tool-install.md).
 - `dotnet run --no-build`
+- `dotnet-core-uninstall`
 
 We don't recommend running other commands elevated. In particular, we don't recommend elevation with commands that use MSBuild, such as [dotnet restore](dotnet-restore.md), [dotnet build](dotnet-build.md), and [dotnet run](dotnet-run.md). The primary issue is permission management problems when a user transitions back and forth between root and a restricted account after issuing dotnet commands. You may find as a restricted user that you don't have access to the file built by a root user. There are ways to resolve this situation, but they're unnecessary to get into in the first place.
 


### PR DESCRIPTION
## Summary

See https://docs.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool for main documentation

cc @wli3 @vatsan-madhavan 