### PR TITLE
Update source link page with deterministic builds

### DIFF
--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -32,6 +32,10 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 
 > For the best debugging experience your library should publish symbol files as well as use Source Link. For more information about symbol files and symbol packages, see [Symbol packages](./nuget.md#symbol-packages).
 
+✔️ CONSIDER enabling deterministic builds.
+
+> Deterministic builds enable verification that the resulting binary was built from the specified source and provides traceability. For more information about deterministic builds, and instructions for enabling them, see [Deterministic Builds](https://github.com/clairernovotny/DeterministicBuilds).
+
 >[!div class="step-by-step"]
 >[Previous](dependencies.md)
 >[Next](publish-nuget-package.md)

--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -34,7 +34,7 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 
 ✔️ CONSIDER enabling deterministic builds.
 
-> Deterministic builds enable verification that the resulting binary was built from the specified source and provides traceability. For more information about deterministic builds, and instructions for enabling them, see [Deterministic Builds](https://github.com/clairernovotny/DeterministicBuilds).
+> Deterministic builds enable verification that the resulting binary was built from the specified source and provide traceability. For more information about deterministic builds and instructions for enabling them, see [Deterministic Builds](https://github.com/clairernovotny/DeterministicBuilds).
 
 >[!div class="step-by-step"]
 >[Previous](dependencies.md)


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/17735
Fixes https://github.com/dotnet/docs/issues/17710

I think longer term we would want to link to instructions provided by the Source Link or NuGet repo, but https://github.com/clairernovotny/DeterministicBuilds seems fine to me for now.

@clairernovotny @tkp1n @mgravell