### PR TITLE
Typo fixed

### DIFF
--- a/docs/standard/exceptions/how-to-create-localized-exception-messages.md
+++ b/docs/standard/exceptions/how-to-create-localized-exception-messages.md
@@ -147,12 +147,12 @@ To create the localized exception messages:
 1. You throw the exception with code like the following:
 
     ```csharp
-    var resourceManager = new ResourceManager("FULLY_QIALIFIED_NAME_OF_RESOURCE_FILE", Assembly.GetExecutingAssembly());
+    var resourceManager = new ResourceManager("FULLY_QUALIFIED_NAME_OF_RESOURCE_FILE", Assembly.GetExecutingAssembly());
     throw new StudentNotFoundException(resourceManager.GetString("StudentNotFound"), "John");
     ```
 
     ```vb
-    Dim resourceManager As New ResourceManager("FULLY_QIALIFIED_NAME_OF_RESOURCE_FILE", Assembly.GetExecutingAssembly())
+    Dim resourceManager As New ResourceManager("FULLY_QUALIFIED_NAME_OF_RESOURCE_FILE", Assembly.GetExecutingAssembly())
     Throw New StudentNotFoundException(resourceManager.GetString("StudentNotFound"), "John")
     ```
 


### PR DESCRIPTION
## Summary

Fixes typo in docs/standard/exceptions/how-to-create-localized-exception-messages.md