### PR TITLE
Readonly struct members can access non-readonly members

### DIFF
--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -108,7 +108,7 @@ public struct Point3D
 
 The preceding sample shows many of the locations where you can apply the `readonly` modifier: methods, properties, and property accessors. If you use auto-implemented properties, the compiler adds the `readonly` modifier to the `get` accessor for read-write properties. The compiler adds the `readonly` modifier to the auto-implemented property declarations for properties with only a `get` accessor.
 
-Adding the `readonly` modifier to members that don't mutate state provides two related benefits. First, the compiler enforces your intent. That member can't mutate the struct's state, nor can it access a member that isn't also marked `readonly`. Second, the compiler won't create defensive copies of `in` parameters when accessing a `readonly` member. The compiler can make this optimization safely because it guarantees that the `struct` is not modified by a `readonly` member.
+Adding the `readonly` modifier to members that don't mutate state provides two related benefits. First, the compiler enforces your intent. That member can't mutate the struct's state. Second, the compiler won't create defensive copies of `in` parameters when accessing a `readonly` member. The compiler can make this optimization safely because it guarantees that the `struct` is not modified by a `readonly` member.
 
 ## Use `ref readonly return` statements for large structures when possible
 


### PR DESCRIPTION
The following code compiles and runs:

```csharp
using System;

struct Point 
{
    public double x;
    public override string ToString()
    {
        x = 4;
        return x.ToString();
    }
}
struct Container
{
    readonly Point p;

    public readonly void M()
    {
        string s = p.ToString();
        Console.WriteLine(s);  //  output: 4
        string s1 = this.ToString();
        Console.WriteLine(s1);  // output: 0
    }
    public override string ToString() => p.x.ToString();
}

class Program
{
    static void Main()
    {
        var c = new Container();
        c.M();
    }
}
```

Both calls, `string s = p.ToString();` and `string s1 = this.ToString();` create defensive copies. [Remark: the `this.ToString()` results in the warning about an implicit copy of `this`, while `p.ToString()` — not, no warnings. As far as I understand, that is because the introduction of such a warning would be a breaking change.]