### PR TITLE
add static local functions to the TOC

### DIFF
--- a/docs/csharp/language-reference/proposals/toc.yml
+++ b/docs/csharp/language-reference/proposals/toc.yml
@@ -74,6 +74,8 @@
       href: ../../../../_csharplang/proposals/csharp-8.0/ranges.md
     - name: Pattern based using and using declarations
       href: ../../../../_csharplang/proposals/csharp-8.0/using.md
+    - name: Static local functions
+      href: ../../../../_csharplang/proposals/csharp-8.0/static-local-functions.md
     - name: Null coalescing assignment
       href: ../../../../_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md
     - name: Readonly instance members


### PR DESCRIPTION
Add the static local functions spec to the C# proposals TOC.
