### PR TITLE
Align version in sample with narrative

### DIFF
--- a/samples/snippets/core/tutorials/cli-create-console-app/HelloMsBuild/csharp/Hello.csproj
+++ b/samples/snippets/core/tutorials/cli-create-console-app/HelloMsBuild/csharp/Hello.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The narrative is about building a Netcore 3.1 app, but the sample showed 2.2.

## Summary

Update the Getting Started documentation sample of the project file to show netcore 3.1 rather than 2.2
