### PR TITLE
remove extra spaces in label config

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -239,100 +239,100 @@
                 "labels-add": ":card_file_box: Technology - C# / VB diagnostics"
               },
               "(?i).*docs\/csharp\/whats-new.*": {
-                "labels-add": ":card_file_box: Technology -  C# What's New"
+                "labels-add": ":card_file_box: Technology - C# What's New"
               },
               "(?i).*docs\/csharp\/how-to.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/linq.*": {
-                "labels-add": ":card_file_box: Technology -  LINQ"
+                "labels-add": ":card_file_box: Technology - LINQ"
               },
               "(?i).*docs\/csharp\/programming-guide\/main-and-command-args.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/indexers.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/generics.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/strings.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/types.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/statements-expressions-operators.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/interop.*": {
-                "labels-add": ":card_file_box: Technology -  C# Advanced concepts"
+                "labels-add": ":card_file_box: Technology - C# Advanced concepts"
               },
               "(?i).*docs\/csharp\/programming-guide\/unsafe-code-pointers.*": {
-                "labels-add": ":card_file_box: Technology -  C# Advanced concepts"
+                "labels-add": ":card_file_box: Technology - C# Advanced concepts"
               },
               "(?i).*docs\/csharp\/programming-guide\/exceptions.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/namespaces.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/nullable-types.*": {
-                "labels-add": ":card_file_box: Technology -  C# Null safety"
+                "labels-add": ":card_file_box: Technology - C# Null safety"
               },
               "(?i).*docs\/csharp\/programming-guide\/arrays.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/concepts\/covariance-contravariance.*": {
-                "labels-add": ":card_file_box: Technology -  C# Advanced concepts"
+                "labels-add": ":card_file_box: Technology - C# Advanced concepts"
               },
               "(?i).*docs\/csharp\/programming-guide\/concepts\/serialization.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/concepts\/expression-trees.*": {
-                "labels-add": ":card_file_box: Technology -  C# Advanced concepts"
+                "labels-add": ":card_file_box: Technology - C# Advanced concepts"
               },
               "(?i).*docs\/csharp\/programming-guide\/concepts\/async.*": {
-                "labels-add": ":card_file_box: Technology -  Async Task"
+                "labels-add": ":card_file_box: Technology - Async Task"
               },
               "(?i).*docs\/csharp\/programming-guide\/concepts\/linq.*":  {
-                "labels-add": ":card_file_box: Technology -  LINQ"
+                "labels-add": ":card_file_box: Technology - LINQ"
               },
               "(?i).*docs\/csharp\/programming-guide\/concepts\/attributes.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/xmldoc.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/classes-and-structs.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/delegates.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/file-system.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/events.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/programming-guide\/inside-a-program.*": {
-                "labels-add": ":card_file_box: Technology -  C# Get Started"
+                "labels-add": ":card_file_box: Technology - C# Get Started"
               },
               "(?i).*docs\/csharp\/programming-guide\/interfaces.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/getting-started.*": {
-                "labels-add": ":card_file_box: Technology -  C# Get Started"
+                "labels-add": ":card_file_box: Technology - C# Get Started"
               },
               "(?i).*docs\/csharp\/tutorials\/exploration.*": {
-                "labels-add": ":card_file_box: Technology -  C# Get Started"
+                "labels-add": ":card_file_box: Technology - C# Get Started"
               },
               "(?i).*docs\/csharp\/tutorial\/intro-to-csharp.*": {
-                "labels-add": ":card_file_box: Technology -  C# Get Started"
+                "labels-add": ":card_file_box: Technology - C# Get Started"
               },
               "(?i).*docs\/csharp\/tutorials.*": {
-                "labels-add": ":card_file_box: Technology -  C# Fundamentals"
+                "labels-add": ":card_file_box: Technology - C# Fundamentals"
               },
               "(?i).*docs\/csharp\/language-reference\/compiler-messages.*": {
                 "labels-add": ":card_file_box: Technology - C# / VB diagnostics"
@@ -344,7 +344,7 @@
                 "labels-add": ":card_file_box: Technology - Roslyn APIs"
               },
               "(?i).*docs\/csharp\/tour-of-csharp.*": {
-                "labels-add": ":card_file_box: Technology -  C# Get Started"
+                "labels-add": ":card_file_box: Technology - C# Get Started"
               },
               "(?i).*docs\/desktop-wpf*": {
                 "labels-add": ":books: Area - Desktop Guide,:card_file_box: Technology - WPF"


### PR DESCRIPTION
In my previous edit, several of the label names had an extra space. This PR removes them.
