### PR TITLE
Fix ms.date

### DIFF
--- a/docs/csharp/deconstruct.md
+++ b/docs/csharp/deconstruct.md
@@ -2,10 +2,9 @@
 title: Deconstructing tuples and other types
 description: Learn how to deconstruct tuples and other types.
 ms.technology: csharp-fundamentals
-ms.date: 07/18/2016
+ms.date: 11/23/2017
 ms.assetid: 0b0c4b0f-4a47-4f66-9b8e-f5c63b195960
 ---
-
 # Deconstructing tuples and other types
 
 A tuple provides a lightweight way to retrieve multiple values from a method call. But once you retrieve the tuple, you have to handle its individual elements. Doing this on an element-by-element basis is cumbersome, as the following example shows. The `QueryCityData` method returns a 3-tuple, and each of its elements is assigned to a variable in a separate operation.


### PR DESCRIPTION
Year 2016 doesn't look correct for the article about C# 7.0 feature (which was released in 2017). I've updated the date based on the last large update of the article: #3776
