### PR TITLE
Rename function parameter name that could be misleading

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks ConnectionStrings.Encrypt/CS/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks ConnectionStrings.Encrypt/CS/source.cs
@@ -8,7 +8,7 @@ class Program
     {
     }
     // <Snippet1>
-    static void ToggleConfigEncryption(string exeConfigName)
+    static void ToggleConfigEncryption(string exeFile)
     {
         // Takes the executable file name without the
         // .config extension.


### PR DESCRIPTION
exeConfigName lead me to pass the config file path. Which did not produce expected results. 
Passing the executable file path worked as expected

## Summary

Describe your changes here.
exeConfigName parameter name lead me to pass the config file path. Which did not produce expected results. 
Passing the executable file path worked as expected
Fixes #Issue_Number (if available)
