### PR TITLE
Add arguments to synopsis sections of CLI ref

### DIFF
--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -13,7 +13,14 @@ ms.date: 02/14/2020
 
 ## Synopsis
 
-`dotnet add [<PROJECT>] package <PACKAGE_NAME> [-h|--help] [-f|--framework] [--interactive] [-n|--no-restore] [--package-directory] [-s|--source] [-v|--version]`
+```dotnetcli
+dotnet add [<PROJECT>] package <PACKAGE_NAME>
+    [-f|--framework <FRAMEWORK>] [--interactive]
+    [-n|--no-restore] [--package-directory <PACKAGE_DIRECTORY>]
+    [-s|--source <SOURCE>] [-v|--version <VERSION>]
+
+dotnet add package -h|--help
+```
 
 ## Description
 

--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -7,17 +7,18 @@ ms.date: 02/14/2020
 
 **This article applies to:** ✔️ .NET Core 2.x SDK and later versions
 
-<!-- todo: uncomment when all CLI commands are reviewed
-[!INCLUDE [topic-appliesto-net-core-all](../../../includes/topic-appliesto-net-core-all.md)]
--->
-
 ## Name
 
 `dotnet add reference` - Adds project-to-project (P2P) references.
 
 ## Synopsis
 
-`dotnet add [<PROJECT>] reference [-f|--framework] <PROJECT_REFERENCES> [-h|--help] [--interactive]`
+```dotnetcli
+dotnet add [<PROJECT>] reference [-f|--framework <FRAMEWORK>]
+     [--interactive] <PROJECT_REFERENCES>
+
+dotnet add reference -h|--help
+```
 
 ## Description
 
@@ -43,13 +44,13 @@ The `dotnet add reference` command provides a convenient option to add project r
 
 ## Options
 
-- **`-h|--help`**
-
-  Prints out a short help for the command.
-
 - **`-f|--framework <FRAMEWORK>`**
 
   Adds project references only when targeting a specific [framework](../../standard/frameworks.md).
+
+- **`-h|--help`**
+
+  Prints out a short help for the command.
 
 - **`--interactive`**
 

--- a/docs/core/tools/dotnet-build-server.md
+++ b/docs/core/tools/dotnet-build-server.md
@@ -15,8 +15,10 @@ ms.date: 02/14/2020
 
 ```dotnetcli
 dotnet build-server shutdown [--msbuild] [--razor] [--vbcscompiler]
-dotnet build-server shutdown [-h|--help]
-dotnet build-server [-h|--help]
+
+dotnet build-server shutdown -h|--help
+
+dotnet build-server -h|--help
 ```
 
 ## Commands

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -14,11 +14,13 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet build [<PROJECT>|<SOLUTION>] [-c|--configuration] [-f|--framework] [--force]
-    [--interactive] [--no-dependencies] [--no-incremental] [--no-restore] [--nologo]
-    [-o|--output] [-r|--runtime] [-v|--verbosity] [--version-suffix]
+dotnet build [<PROJECT>|<SOLUTION>] [-c|--configuration <CONFIGURATION>]
+    [-f|--framework <FRAMEWORK>] [--force] [--interactive] [--no-dependencies]
+    [--no-incremental] [--no-restore] [--nologo] [-o|--output <OUTPUT_DIRECTORY>]
+    [-r|--runtime <RUNTIME_IDENTIFIER>] [-v|--verbosity <LEVEL>]
+    [--version-suffix <VERSION_SUFFIX>]
 
-dotnet build [-h|--help]
+dotnet build -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -14,9 +14,12 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet clean [<PROJECT>|<SOLUTION>] [-c|--configuration] [-f|--framework] [--interactive]
-    [--nologo] [-o|--output] [-r|--runtime] [-v|--verbosity]
-dotnet clean [-h|--help]
+dotnet clean [<PROJECT>|<SOLUTION>] [-c|--configuration <CONFIGURATION>]
+    [-f|--framework <FRAMEWORK>] [--interactive]
+    [--nologo] [-o|--output <OUTPUT_DIRECTORY>]
+    [-r|--runtime <RUNTIME_IDENTIFIER>] [-v|--verbosity <LEVEL>]
+
+dotnet clean -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-help.md
+++ b/docs/core/tools/dotnet-help.md
@@ -13,7 +13,9 @@ ms.date: 02/14/2020
 
 ## Synopsis
 
-`dotnet help <COMMAND_NAME> [-h|--help]`
+```dotnetcli
+dotnet help <COMMAND_NAME> [-h|--help]
+```
 
 ## Description
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -14,17 +14,28 @@ ms.date: 01/23/2020
 Windows:
 
 ```powershell
-dotnet-install.ps1 [-Channel] [-Version] [-JSonFile] [-InstallDir] [-Architecture]
-    [-Runtime] [-DryRun] [-NoPath] [-Verbose] [-AzureFeed] [-UncachedFeed] [-NoCdn] [-FeedCredential]
-    [-ProxyAddress] [-ProxyUseDefaultCredentials] [-SkipNonVersionedFiles] [-Help]
+dotnet-install.ps1 [-Architecture <ARCHITECTURE>] [-AzureFeed]
+    [-Channel <CHANNEL>] [-DryRun] [-FeedCredential]
+    [-InstallDir <DIRECTORY>] [-JSonFile <JSONFILE>]
+    [-NoCdn] [-NoPath] [-ProxyAddress]
+    [-ProxyUseDefaultCredentials] [-Runtime <RUNTIME>]
+    [-SkipNonVersionedFiles] [-UncachedFeed] [-Verbose]
+    [-Version <VERSION>]
+
+dotnet-install.ps1 -Help
 ```
 
 Linux/macOs:
 
 ```bash
-dotnet-install.sh [--channel] [--version] [--jsonfile] [--install-dir] [--architecture]
-    [--runtime] [--dry-run] [--no-path] [--verbose] [--azure-feed] [--uncached-feed] [--no-cdn] [--feed-credential]
-    [--runtime-id] [--skip-non-versioned-files] [--help]
+dotnet-install.sh  [--architecture <ARCHITECTURE>] [--azure-feed]
+    [--channel <CHANNEL>] [--dry-run] [--feed-credential]
+    [--install-dir <DIRECTORY>] [--jsonfile <JSONFILE>]
+    [--no-cdn] [--no-path] [--runtime <RUNTIME>] [--runtime-id <RID>]
+    [--skip-non-versioned-files] [--uncached-feed] [--verbose]
+    [--version <VERSION>]
+
+dotnet-install.sh --help
 ```
 
 ## Description
@@ -48,6 +59,14 @@ You can install a specific version using the `-Version|--version` argument. The 
 
 ## Options
 
+- **`-Architecture|--architecture <ARCHITECTURE>`**
+
+  Architecture of the .NET Core binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, and `arm`. The default value is `<auto>`, which represents the currently running OS architecture.
+
+- **`-AzureFeed|--azure-feed`**
+
+  Specifies the URL for the Azure feed to the installer. We recommended that you don't change this value. The default value is `https://dotnetcli.azureedge.net/dotnet`.
+
 - **`-Channel|--channel <CHANNEL>`**
 
   Specifies the source channel for the installation. The possible values are:
@@ -59,74 +78,33 @@ You can install a specific version using the `-Version|--version` argument. The 
 
   The default value is `LTS`. For more information on .NET support channels, see the [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) page.
 
-- **`-Version|--version <VERSION>`**
-
-  Represents a specific build version. The possible values are:
-
-  - `latest` - Latest build on the channel (used with the `-Channel` option).
-  - `coherent` - Latest coherent build on the channel; uses the latest stable package combination (used with Branch name `-Channel` options).
-  - Three-part version in X.Y.Z format representing a specific build version; supersedes the `-Channel` option. For example: `2.0.0-preview2-006120`.
-
-  If not specified, `-Version` defaults to `latest`.
-
-- **`-JSonFile|--jsonfile <JSONFILE>`**
-
-  Specifies a path to a [global.json](global-json.md) file that will be used to determine the SDK version. The *global.json* file must have a value for `sdk:version`.
-
-- **`-InstallDir|--install-dir <DIRECTORY>`**
-
-  Specifies the installation path. The directory is created if it doesn't exist. The default value is *%LocalAppData%\Microsoft\dotnet*. Binaries are placed directly in this directory.
-
-- **`-Architecture|--architecture <ARCHITECTURE>`**
-
-  Architecture of the .NET Core binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, and `arm`. The default value is `<auto>`, which represents the currently running OS architecture.
-
-- **`-SharedRuntime|--shared-runtime`**
-
-  > [!NOTE]
-  > This parameter is obsolete and may be removed in a future version of the script. The recommended alternative is the `-Runtime|--runtime` option.
-
-  Installs just the shared runtime bits, not the entire SDK. This option is equivalent to specifying `-Runtime|--runtime dotnet`.
-
-- **`-Runtime|--runtime <RUNTIME>`**
-
-  Installs just the shared runtime, not the entire SDK. The possible values are:
-
-  - `dotnet` - the `Microsoft.NETCore.App` shared runtime.
-  - `aspnetcore` - the `Microsoft.AspNetCore.App` shared runtime.
-  - `windowsdesktop` - the `Microsoft.WindowsDesktop.App` shared runtime.
-
 - **`-DryRun|--dry-run`**
 
   If set, the script won't perform the installation. Instead, it displays what command line to use to consistently install the currently requested version of the .NET Core CLI. For example, if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
-
-- **`-NoPath|--no-path`**
-
-  If set, the installation folder isn't exported to the path for the current session. By default, the script modifies the PATH, which makes the .NET Core CLI available immediately after install.
-
-- **`-Verbose|--verbose`**
-
-  Displays diagnostics information.
-
-- **`-AzureFeed|--azure-feed`**
-
-  Specifies the URL for the Azure feed to the installer. We recommended that you don't change this value. The default value is `https://dotnetcli.azureedge.net/dotnet`.
-
-- **`-UncachedFeed|--uncached-feed`**
-
-  Allows changing the URL for the uncached feed used by this installer. We recommended that you don't change this value.
-
-- **`-NoCdn|--no-cdn`**
-
-  Disables downloading from the [Azure Content Delivery Network (CDN)](https://docs.microsoft.com/azure/cdn/cdn-overview) and uses the uncached feed directly.
 
 - **`-FeedCredential|--feed-credential`**
 
   Used as a query string to append to the Azure feed. It allows changing the URL to use non-public blob storage accounts.
 
-- **`--runtime-id`**
+- **`-Help|--help`**
 
-  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS)
+  Prints out help for the script.
+
+- **`-InstallDir|--install-dir <DIRECTORY>`**
+
+  Specifies the installation path. The directory is created if it doesn't exist. The default value is *%LocalAppData%\Microsoft\dotnet*. Binaries are placed directly in this directory.
+
+- **`-JSonFile|--jsonfile <JSONFILE>`**
+
+  Specifies a path to a [global.json](global-json.md) file that will be used to determine the SDK version. The *global.json* file must have a value for `sdk:version`.
+
+- **`-NoCdn|--no-cdn`**
+
+  Disables downloading from the [Azure Content Delivery Network (CDN)](https://docs.microsoft.com/azure/cdn/cdn-overview) and uses the uncached feed directly.
+
+- **`-NoPath|--no-path`**
+
+  If set, the installation folder isn't exported to the path for the current session. By default, the script modifies the PATH, which makes the .NET Core CLI available immediately after install.
 
 - **`-ProxyAddress`**
 
@@ -136,13 +114,46 @@ You can install a specific version using the `-Version|--version` argument. The 
 
   If set, the installer uses the credentials of the current user when using proxy address. (Only valid for Windows)
 
+- **`-Runtime|--runtime <RUNTIME>`**
+
+  Installs just the shared runtime, not the entire SDK. The possible values are:
+
+  - `dotnet` - the `Microsoft.NETCore.App` shared runtime.
+  - `aspnetcore` - the `Microsoft.AspNetCore.App` shared runtime.
+  - `windowsdesktop` - the `Microsoft.WindowsDesktop.App` shared runtime.
+
+- **`--runtime-id <RID>`**
+
+  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS)
+
+- **`-SharedRuntime|--shared-runtime`**
+
+  > [!NOTE]
+  > This parameter is obsolete and may be removed in a future version of the script. The recommended alternative is the `-Runtime|--runtime` option.
+
+  Installs just the shared runtime bits, not the entire SDK. This option is equivalent to specifying `-Runtime|--runtime dotnet`.
+
 - **`-SkipNonVersionedFiles|--skip-non-versioned-files`**
 
   Skips installing non-versioned files, such as *dotnet.exe*, if they already exist.
 
-- **`-Help|--help`**
+- **`-UncachedFeed|--uncached-feed`**
 
-  Prints out help for the script.
+  Allows changing the URL for the uncached feed used by this installer. We recommended that you don't change this value.
+
+- **`-Verbose|--verbose`**
+
+  Displays diagnostics information.
+
+- **`-Version|--version <VERSION>`**
+
+  Represents a specific build version. The possible values are:
+
+  - `latest` - Latest build on the channel (used with the `-Channel` option).
+  - `coherent` - Latest coherent build on the channel; uses the latest stable package combination (used with Branch name `-Channel` options).
+  - Three-part version in X.Y.Z format representing a specific build version; supersedes the `-Channel` option. For example: `2.0.0-preview2-006120`.
+
+  If not specified, `-Version` defaults to `latest`.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -108,11 +108,11 @@ You can install a specific version using the `-Version|--version` argument. The 
 
 - **`-ProxyAddress`**
 
-  If set, the installer uses the proxy when making web requests. (Only valid for Windows)
+  If set, the installer uses the proxy when making web requests. (Only valid for Windows.)
 
 - **`ProxyUseDefaultCredentials`**
 
-  If set, the installer uses the credentials of the current user when using proxy address. (Only valid for Windows)
+  If set, the installer uses the credentials of the current user when using proxy address. (Only valid for Windows.)
 
 - **`-Runtime|--runtime <RUNTIME>`**
 
@@ -124,7 +124,7 @@ You can install a specific version using the `-Version|--version` argument. The 
 
 - **`--runtime-id <RID>`**
 
-  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS)
+  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS.)
 
 - **`-SharedRuntime|--shared-runtime`**
 

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -14,9 +14,12 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet list [<PROJECT>|<SOLUTION>] package [--config] [--framework] [--highest-minor] [--highest-patch]
-   [--include-prerelease] [--include-transitive] [--interactive] [--outdated] [--source]
-dotnet list package [-h|--help]
+dotnet list [<PROJECT>|<SOLUTION>] package [--config <SOURCE>]
+    [--framework <FRAMEWORK>] [--highest-minor] [--highest-patch]
+    [--include-prerelease] [--include-transitive] [--interactive]
+    [--outdated] [--source <SOURCE>]
+
+dotnet list package -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-list-reference.md
+++ b/docs/core/tools/dotnet-list-reference.md
@@ -13,7 +13,11 @@ ms.date: 02/14/2020
 
 ## Synopsis
 
-`dotnet list [<PROJECT>|<SOLUTION>] reference [-h|--help]`
+```dotnetcli
+dotnet list [<PROJECT>|<SOLUTION>] reference
+
+dotnet list -h|--help
+```
 
 ## Description
 

--- a/docs/core/tools/dotnet-migrate.md
+++ b/docs/core/tools/dotnet-migrate.md
@@ -14,8 +14,12 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet migrate [<SOLUTION_FILE|PROJECT_DIR>] [--format-report-file-json] [-r|--report-file] [-s|--skip-project-references] [--skip-backup] [-t|--template-file] [-v|--sdk-package-version] [-x|--xproj-file]
-dotnet migrate [-h|--help]
+dotnet migrate [<SOLUTION_FILE|PROJECT_DIR>] [--format-report-file-json <REPORT_FILE>]
+    [-r|--report-file <REPORT_FILE>] [-s|--skip-project-references [Debug|Release]]
+    [--skip-backup] [-t|--template-file <TEMPLATE_FILE>] [-v|--sdk-package-version]
+    [-x|--xproj-file]
+
+dotnet migrate -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -13,7 +13,11 @@ ms.date: 02/14/2020
 
 ## Synopsis
 
-`dotnet msbuild <msbuild_arguments> [-h]`
+```dotnetcli
+dotnet msbuild <msbuild_arguments>
+
+dotnet msbuild -h
+```
 
 ## Description
 

--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -14,7 +14,7 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet msbuild <msbuild_arguments>
+dotnet msbuild <MSBUILD_ARGUMENTS>
 
 dotnet msbuild -h
 ```

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -14,10 +14,14 @@ ms.date: 04/10/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet new <TEMPLATE> [--dry-run] [--force] [-i|--install] [-lang|--language] [-n|--name]
-    [--nuget-source] [-o|--output] [-u|--uninstall] [--update-apply] [--update-check] [Template options]
-dotnet new <TEMPLATE> [-l|--list] [--type]
-dotnet new [-h|--help]
+dotnet new <TEMPLATE> [--dry-run] [--force] [-i|--install {PATH|NUGET_ID}]
+    [-lang|--language {C#|F#|VB}] [-n|--name <OUTPUT_NAME>]
+    [--nuget-source <SOURCE>] [-o|--output <OUTPUT_DIRECTORY>]
+    [-u|--uninstall] [--update-apply] [--update-check] [Template options]
+
+dotnet new <TEMPLATE> [-l|--list] [--type <TYPE>]
+
+dotnet new -h|--help
 ```
 
 ## Description
@@ -115,7 +119,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
   The name for the created output. If no name is specified, the name of the current directory is used.
 
-- **`--nuget-source`**
+- **`--nuget-source <SOURCE>`**
 
   Specifies a NuGet source to use during install. Available since .NET Core 2.1 SDK.
 
@@ -123,7 +127,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
   Location to place the generated output. The default is the current directory.
 
-- **`--type`**
+- **`--type <TYPE>`**
 
   Filters templates based on available types. Predefined values are "project", "item", or "other".
 

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -129,7 +129,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
 - **`--type <TYPE>`**
 
-  Filters templates based on available types. Predefined values are "project", "item", or "other".
+  Filters templates based on available types. Predefined values are `project`, `item`, or `other`.
 
 - **`-u|--uninstall [PATH|NUGET_ID]`**
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -14,10 +14,11 @@ ms.date: 03/20/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget add source <PACKAGE_SOURCE_PATH> [--name] [--username]
-    [--password] [--store-password-in-clear-text] [--valid-authentication-types]
-    [--configfile]
-dotnet nuget add source [-h|--help]
+dotnet nuget add source <PACKAGE_SOURCE_PATH> [--name <SOURCE_NAME>] [--username <USER>]
+    [--password <PASSWORD>] [--store-password-in-clear-text]
+    [--valid-authentication-types <TYPES>] [--configfile <FILE>]
+
+dotnet nuget add source -h|--help
 ```
 
 ## Description
@@ -32,15 +33,15 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
 ## Options
 
-- **`--configfile`**
+- **`--configfile <FILE>`**
 
   The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
-- **`-n|--name`**
+- **`-n|--name <SOURCE_NAME>`**
 
   Name of the source.
 
-- **`-p|--password`**
+- **`-p|--password <PASSWORD>`**
 
   Password to be used when connecting to an authenticated source.
 
@@ -48,11 +49,11 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
   Enables storing portable package source credentials by disabling password encryption.
 
-- **`-u|--username`**
+- **`-u|--username <USER>`**
 
   Username to be used when connecting to an authenticated source.
 
-- **`--valid-authentication-types`**
+- **`--valid-authentication-types <TYPES>`**
 
   Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful.
 

--- a/docs/core/tools/dotnet-nuget-delete.md
+++ b/docs/core/tools/dotnet-nuget-delete.md
@@ -19,9 +19,11 @@ ms.date: 06/26/2019
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [--interactive] [-k|--api-key] [--no-service-endpoint]
-    [--non-interactive] [-s|--source]
-dotnet nuget delete [-h|--help]
+dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output]
+    [--interactive] [-k|--api-key <API_KEY>] [--no-service-endpoint]
+    [--non-interactive] [-s|--source <SOURCE>]
+
+dotnet nuget delete -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-nuget-disable-source.md
+++ b/docs/core/tools/dotnet-nuget-disable-source.md
@@ -14,8 +14,9 @@ ms.date: 03/20/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget disable source <NAME> [--configfile]
-dotnet nuget disable source [-h|--help]
+dotnet nuget disable source <NAME> [--configfile <FILE>]
+
+dotnet nuget disable source -h|--help
 ```
 
 ## Description
@@ -30,7 +31,7 @@ The `dotnet nuget disable source` command disables an existing source in your Nu
 
 ## Options
 
-- **`--configfile`**
+- **`--configfile <FILE>`**
 
   The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 

--- a/docs/core/tools/dotnet-nuget-enable-source.md
+++ b/docs/core/tools/dotnet-nuget-enable-source.md
@@ -14,8 +14,9 @@ ms.date: 03/20/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget enable source <NAME> [--configfile]
-dotnet nuget enable source [-h|--help]
+dotnet nuget enable source <NAME> [--configfile <FILE>]
+
+dotnet nuget enable source -h|--help
 ```
 
 ## Description
@@ -30,7 +31,7 @@ The `dotnet nuget enable source` command enables an existing source in your NuGe
 
 ## Options
 
-- **`--configfile`**
+- **`--configfile <FILE>`**
 
   The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 

--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -14,8 +14,9 @@ ms.date: 03/20/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget list source [--format] [--configfile]
-dotnet nuget list source [-h|--help]
+dotnet nuget list source [--format [Detailed|Short]] [--configfile <FILE>]
+
+dotnet nuget list source -h|--help
 ```
 
 ## Description
@@ -24,11 +25,11 @@ The `dotnet nuget list source` command lists all existing sources from your NuGe
 
 ## Options
 
-- **`--configfile`**
+- **`--configfile <FILE>`**
 
   The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
-- **`--format`**
+- **`--format [Detailed|Short]`**
 
   The format of the list command output: `Detailed` (the default) and `Short`.
 

--- a/docs/core/tools/dotnet-nuget-locals.md
+++ b/docs/core/tools/dotnet-nuget-locals.md
@@ -16,7 +16,8 @@ ms.date: 02/14/2020
 
 ```dotnetcli
 dotnet nuget locals <CACHE_LOCATION> [(-c|--clear)|(-l|--list)] [--force-english-output]
-dotnet nuget locals [-h|--help]
+
+dotnet nuget locals -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -15,9 +15,13 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [--interactive] [-k|--api-key] [-n|--no-symbols]
-    [--no-service-endpoint] [-s|--source] [--skip-duplicate] [-sk|--symbol-api-key] [-ss|--symbol-source] [-t|--timeout]
-dotnet nuget push [-h|--help]
+dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output]
+    [--interactive] [-k|--api-key <API_KEY>] [-n|--no-symbols]
+    [--no-service-endpoint] [-s|--source <SOURCE>] [--skip-duplicate]
+    [-sk|--symbol-api-key <API_KEY>] [-ss|--symbol-source <SOURCE>]
+    [-t|--timeout <TIMEOUT>]
+
+dotnet nuget push -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-nuget-remove-source.md
+++ b/docs/core/tools/dotnet-nuget-remove-source.md
@@ -14,8 +14,9 @@ ms.date: 03/20/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget remove source <NAME> [--configfile]
-dotnet nuget remove source [-h|--help]
+dotnet nuget remove source <NAME> [--configfile <FILE>]
+
+dotnet nuget remove source -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -14,10 +14,11 @@ ms.date: 03/20/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget update source <NAME> [--source] [--username]
-    [--password] [--store-password-in-clear-text] [--valid-authentication-types]
-    [--configfile]
-dotnet nuget update source [-h|--help]
+dotnet nuget update source <NAME> [--source <SOURCE>] [--username <USER>]
+    [--password <PASSWORD>] [--store-password-in-clear-text]
+    [--valid-authentication-types <TYPES>] [--configfile <FILE>]
+
+dotnet nuget update source -h|--help
 ```
 
 ## Description
@@ -32,15 +33,15 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
 ## Options
 
-- **`--configfile`**
+- **`--configfile <FILE>`**
 
   The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
-- **`-p|--password`**
+- **`-p|--password <PASSWORD>`**
 
   Password to be used when connecting to an authenticated source.
 
-- **`-s|--source`**
+- **`-s|--source <SOURCE>`**
 
   Path to the package source.
 
@@ -48,11 +49,11 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
   Enables storing portable package source credentials by disabling password encryption.
 
-- **`-u|--username`**
+- **`-u|--username <USER>`**
 
   Username to be used when connecting to an authenticated source.
 
-- **`--valid-authentication-types`**
+- **`--valid-authentication-types <TYPES>`**
 
   Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful.
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -14,10 +14,14 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet pack [<PROJECT>|<SOLUTION>] [-c|--configuration] [--force] [--include-source] [--include-symbols] [--interactive]
-    [--no-build] [--no-dependencies] [--no-restore] [--nologo] [-o|--output] [--runtime] [-s|--serviceable]
-    [-v|--verbosity] [--version-suffix]
-dotnet pack [-h|--help]
+dotnet pack [<PROJECT>|<SOLUTION>] [-c|--configuration <CONFIGURATION>]
+    [--force] [--include-source] [--include-symbols] [--interactive]
+    [--no-build] [--no-dependencies] [--no-restore] [--nologo]
+    [-o|--output <OUTPUT_DIRECTORY>] [--runtime <RUNTIME_IDENTIFIER>]
+    [-s|--serviceable] [-v|--verbosity <LEVEL>]
+    [--version-suffix <VERSION_SUFFIX>]
+
+dotnet pack -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -14,14 +14,16 @@ ms.date: 02/24/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet publish [<PROJECT>|<SOLUTION>] [-c|--configuration]
-    [-f|--framework] [--force] [--interactive] [--manifest]
-    [--no-build] [--no-dependencies] [--no-restore] [--nologo]
-    [-o|--output] [-p:PublishReadyToRun] [-p:PublishSingleFile]
-    [-p:PublishTrimmed] [-r|--runtime] [--self-contained]
-    [--no-self-contained] [-v|--verbosity] [--version-suffix]
+dotnet publish [<PROJECT>|<SOLUTION>] [-c|--configuration <CONFIGURATION>]
+    [-f|--framework <FRAMEWORK>] [--force] [--interactive]
+    [--manifest <PATH_TO_MANIFEST_FILE>] [--no-build] [--no-dependencies]
+    [--no-restore] [--nologo] [-o|--output <OUTPUT_DIRECTORY>]
+    [-p:PublishReadyToRun] [-p:PublishSingleFile] [-p:PublishTrimmed]
+    [-r|--runtime <RUNTIME_IDENTIFIER>] [--self-contained [true|false]]
+    [--no-self-contained] [-v|--verbosity <LEVEL>]
+    [--version-suffix <VERSION_SUFFIX>]
 
-dotnet publish [-h|--help]
+dotnet publish -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-remove-package.md
+++ b/docs/core/tools/dotnet-remove-package.md
@@ -14,7 +14,9 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet remove [<PROJECT>] package <PACKAGE_NAME> [-h|--help]
+dotnet remove [<PROJECT>] package <PACKAGE_NAME>
+
+dotnet remove package -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-remove-reference.md
+++ b/docs/core/tools/dotnet-remove-reference.md
@@ -14,7 +14,9 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet remove [<PROJECT>] reference [-f|--framework] <PROJECT_REFERENCES> [-h|--help]
+dotnet remove [<PROJECT>] reference [-f|--framework <FRAMEWORK>] <PROJECT_REFERENCES>
+
+dotnet remove reference -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -14,13 +14,14 @@ ms.date: 02/27/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet restore [<ROOT>] [--configfile] [--disable-parallel]
+dotnet restore [<ROOT>] [--configfile <FILE>] [--disable-parallel]
     [-f|--force] [--force-evaluate] [--ignore-failed-sources]
-    [--interactive] [--lock-file-path] [--locked-mode]
-    [--no-cache] [--no-dependencies] [--packages] [-r|--runtime]
-    [-s|--source] [--use-lockfile] [-v|--verbosity]
+    [--interactive] [--lock-file-path <LOCK_FILE_PATH>] [--locked-mode]
+    [--no-cache] [--no-dependencies] [--packages <PACKAGES_DIRECTORY>]
+    [-r|--runtime <RUNTIME_IDENTIFIER>] [-s|--source <SOURCE>]
+    [--use-lockfile] [-v|--verbosity <LEVEL>]
 
-dotnet restore [-h|--help]
+dotnet restore -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -14,10 +14,13 @@ ms.date: 02/19/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet run [-c|--configuration] [-f|--framework] [--force] [--interactive] [--launch-profile]
-    [--no-build] [--no-dependencies] [--no-launch-profile] [--no-restore] [-p|--project]
-    [-r|--runtime] [-v|--verbosity] [[--] [application arguments]]
-dotnet run [-h|--help]
+dotnet run [-c|--configuration <CONFIGURATION>] [-f|--framework <FRAMEWORK>]
+[--force] [--interactive] [--launch-profile <NAME>] [--no-build]
+[--no-dependencies] [--no-launch-profile] [--no-restore]
+[-p|--project <PATH>] [-r|--runtime <RUNTIME_IDENTIFIER>]
+[-v|--verbosity <LEVEL>] [[--] [application arguments]]
+
+dotnet run -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -15,10 +15,10 @@ ms.date: 02/19/2020
 
 ```dotnetcli
 dotnet run [-c|--configuration <CONFIGURATION>] [-f|--framework <FRAMEWORK>]
-[--force] [--interactive] [--launch-profile <NAME>] [--no-build]
-[--no-dependencies] [--no-launch-profile] [--no-restore]
-[-p|--project <PATH>] [-r|--runtime <RUNTIME_IDENTIFIER>]
-[-v|--verbosity <LEVEL>] [[--] [application arguments]]
+    [--force] [--interactive] [--launch-profile <NAME>] [--no-build]
+    [--no-dependencies] [--no-launch-profile] [--no-restore]
+    [-p|--project <PATH>] [-r|--runtime <RUNTIME_IDENTIFIER>]
+    [-v|--verbosity <LEVEL>] [[--] [application arguments]]
 
 dotnet run -h|--help
 ```

--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -14,7 +14,9 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet sln [<SOLUTION_FILE>] [command] [-h|--help]
+dotnet sln [<SOLUTION_FILE>] [command]
+
+dotnet sln [command] -h|--help
 ```
 
 ## Description
@@ -70,7 +72,7 @@ Adds one or more projects to the solution file.
 #### Synopsis
 
 ```dotnetcli
-dotnet sln [<SOLUTION_FILE>] add [--in-root] [-s|--solution-folder] <PROJECT_PATH> [<PROJECT_PATH>...]
+dotnet sln [<SOLUTION_FILE>] add [--in-root] [-s|--solution-folder <PATH>] <PROJECT_PATH> [<PROJECT_PATH>...]
 dotnet sln add [-h|--help]
 ```
 
@@ -94,7 +96,7 @@ dotnet sln add [-h|--help]
 
   Places the projects in the root of the solution, rather than creating a solution folder. Available since .NET Core 3.0 SDK.
 
-- **`-s|--solution-folder`**
+- **`-s|--solution-folder <PATH>`**
 
   The destination solution folder path to add the projects to. Available since .NET Core 3.0 SDK.
 

--- a/docs/core/tools/dotnet-store.md
+++ b/docs/core/tools/dotnet-store.md
@@ -14,7 +14,13 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet store -m|--manifest -f|--framework -r|--runtime  [--framework-version] [-h|--help] [--output] [--skip-optimization] [--skip-symbols] [-v|--verbosity] [--working-dir]
+dotnet store -m|--manifest <PATH_TO_MANIFEST_FILE>
+    -f|--framework <FRAMEWORK_VERSION> -r|--runtime <RUNTIME_IDENTIFIER>
+    [--framework-version <FRAMEWORK_VERSION>] [--output <OUTPUT_DIRECTORY>]
+    [--skip-optimization] [--skip-symbols] [-v|--verbosity <LEVEL>]
+    [--working-dir <WORKING_DIRECTORY>]
+
+dotnet store -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -15,14 +15,18 @@ ms.date: 02/27/2020
 
 ```dotnetcli
 dotnet test [<PROJECT> | <SOLUTION>]
-    [-a|--test-adapter-path] [--blame] [-c|--configuration]
-    [--collect] [-d|--diag] [-f|--framework] [--filter]
-    [--interactive] [-l|--logger] [--no-build] [--nologo]
-    [--no-restore] [-o|--output] [-r|--results-directory]
-    [--runtime] [-s|--settings] [-t|--list-tests]
-    [-v|--verbosity] [[--] <RunSettings arguments>]
+    [-a|--test-adapter-path <PATH_TO_ADAPTER>] [--blame]
+    [-c|--configuration <CONFIGURATION>]
+    [--collect <DATA_COLLECTOR_FRIENDLY_NAME>]
+    [-d|--diag <PATH_TO_DIAGNOSTICS_FILE>] [-f|--framework <FRAMEWORK>]
+    [--filter <EXPRESSION>] [--interactive]
+    [-l|--logger <LOGGER_URI/FRIENDLY_NAME>] [--no-build]
+    [--nologo] [--no-restore] [-o|--output <OUTPUT_DIRECTORY>]
+    [-r|--results-directory <PATH>] [--runtime <RUNTIME_IDENTIFIER>]
+    [-s|--settings <SETTINGS_FILE>] [-t|--list-tests]
+    [-v|--verbosity <LEVEL>] [[--] <RunSettings arguments>]
 
-dotnet test [-h|--help]
+dotnet test -h|--help
 ```
 
 ## Description
@@ -77,7 +81,7 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
   Allows the command to stop and wait for user input or action. For example, to complete authentication. Available since .NET Core 3.0 SDK.
 
-- **`l|--logger <LoggerUri/FriendlyName>`**
+- **`l|--logger <LOGGER_URI/FRIENDLY_NAME>`**
 
   Specifies a logger for test results. Unlike MSBuild, dotnet test doesn't accept abbreviations: instead of `-l "console;v=d"` use `-l "console;verbosity=detailed"`.
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -14,19 +14,22 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet tool install <PACKAGE_NAME> <-g|--global>
-    [--add-source] [--configfile] [--framework]
-    [-v|--verbosity] [--version]
+dotnet tool install <PACKAGE_NAME> -g|--global
+    [--add-source <SOURCE>] [--configfile <FILE>]
+    [--framework <FRAMEWORK>] [-v|--verbosity <LEVEL>]
+    [--version <VERSION_NUMBER>]
 
-dotnet tool install <PACKAGE_NAME> <--tool-path>
-    [--add-source] [--configfile] [--framework]
-    [-v|--verbosity] [--version]
+dotnet tool install <PACKAGE_NAME> --tool-path <PATH>
+    [--add-source <SOURCE>] [--configfile <FILE>]
+    [--framework <FRAMEWORK>] [-v|--verbosity <LEVEL>]
+    [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME>
-    [--add-source] [--configfile] [--framework]
-    [-v|--verbosity] [--version]
+    [--add-source <SOURCE>] [--configfile <FILE>]
+    [--framework <FRAMEWORK>] [-v|--verbosity <LEVEL>]
+    [--version <VERSION_NUMBER>]
 
-dotnet tool install <-h|--help>
+dotnet tool install -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-tool-list.md
+++ b/docs/core/tools/dotnet-tool-list.md
@@ -14,13 +14,13 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet tool list <-g|--global>
+dotnet tool list -g|--global
 
-dotnet tool list <--tool-path>
+dotnet tool list --tool-path <PATH>
 
 dotnet tool list
 
-dotnet tool list <-h|--help>
+dotnet tool list -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-tool-restore.md
+++ b/docs/core/tools/dotnet-tool-restore.md
@@ -15,11 +15,12 @@ ms.date: 02/14/2020
 
 ```dotnetcli
 dotnet tool restore <PACKAGE_NAME>
-    [--configfile] [--add-source] [tool-manifest]
-    [--disable-parallel] [--ignore-failed-sources]
-    [--no-cache] [--interactive] [-v|--verbosity]
+    [--configfile <FILE>] [--add-source <SOURCE>]
+    [tool-manifest <PATH_TO_MANIFEST_FILE>] [--disable-parallel]
+    [--ignore-failed-sources] [--no-cache] [--interactive]
+    [-v|--verbosity <LEVEL>]
 
-dotnet tool restore <-h|--help>
+dotnet tool restore -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-tool-run.md
+++ b/docs/core/tools/dotnet-tool-run.md
@@ -16,7 +16,7 @@ ms.date: 02/14/2020
 ```dotnetcli
 dotnet tool run <COMMAND NAME>
 
-dotnet tool run <-h|--help>
+dotnet tool run -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-tool-uninstall.md
+++ b/docs/core/tools/dotnet-tool-uninstall.md
@@ -14,9 +14,9 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet tool uninstall <PACKAGE_NAME> <-g|--global>
+dotnet tool uninstall <PACKAGE_NAME> -g|--global
 
-dotnet tool uninstall <PACKAGE_NAME> <--tool-path <PATH>>
+dotnet tool uninstall <PACKAGE_NAME> --tool-path <PATH>
 
 dotnet tool uninstall <PACKAGE_NAME>
 

--- a/docs/core/tools/dotnet-tool-uninstall.md
+++ b/docs/core/tools/dotnet-tool-uninstall.md
@@ -16,11 +16,11 @@ ms.date: 02/14/2020
 ```dotnetcli
 dotnet tool uninstall <PACKAGE_NAME> <-g|--global>
 
-dotnet tool uninstall <PACKAGE_NAME> <--tool-path>
+dotnet tool uninstall <PACKAGE_NAME> <--tool-path <PATH>>
 
 dotnet tool uninstall <PACKAGE_NAME>
 
-dotnet tool uninstall <-h|--help>
+dotnet tool uninstall -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -14,11 +14,11 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet tool update <PACKAGE_NAME> <-g|--global>
+dotnet tool update <PACKAGE_NAME> -g|--global
     [--configfile <FILE>] [--framework <FRAMEWORK>]
     [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 
-dotnet tool update <PACKAGE_NAME> <--tool-path <PATH>>
+dotnet tool update <PACKAGE_NAME> --tool-path <PATH>
     [--configfile <FILE>] [--framework <FRAMEWORK>]
     [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -15,18 +15,18 @@ ms.date: 02/14/2020
 
 ```dotnetcli
 dotnet tool update <PACKAGE_NAME> <-g|--global>
-    [--configfile] [--framework] [-v|--verbosity]
-    [--add-source]
+    [--configfile <FILE>] [--framework <FRAMEWORK>]
+    [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 
-dotnet tool update <PACKAGE_NAME> <--tool-path>
-    [--configfile] [--framework] [-v|--verbosity]
-    [--add-source]
+dotnet tool update <PACKAGE_NAME> <--tool-path <PATH>>
+    [--configfile <FILE>] [--framework <FRAMEWORK>]
+    [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 
 dotnet tool update <PACKAGE_NAME>
-    [--configfile] [--framework] [-v|--verbosity]
-    [--add-source]
+    [--configfile <FILE>] [--framework <FRAMEWORK>]
+    [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 
-dotnet tool update <-h|--help>
+dotnet tool update -h|--help
 ```
 
 ## Description

--- a/docs/core/tools/dotnet-vstest.md
+++ b/docs/core/tools/dotnet-vstest.md
@@ -14,11 +14,15 @@ ms.date: 02/27/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet vstest [<TEST_FILE_NAMES>] [--Blame] [--Diag]
-    [--Framework] [--InIsolation] [-lt|--ListTests] [--logger]
-    [--Parallel] [--ParentProcessId] [--Platform] [--Port]
-    [--ResultsDirectory] [--Settings] [--TestAdapterPath]
-    [--TestCaseFilter] [--Tests] [[--] <args>...]] [-?|--Help]
+dotnet vstest [<TEST_FILE_NAMES>] [--Blame] [--Diag <PATH_TO_LOG_FILE>]
+    [--Framework <FRAMEWORK>] [--InIsolation] [-lt|--ListTests <FILE_NAME>]
+    [--logger <LOGGER_URI/FRIENDLY_NAME>] [--Parallel]
+    [--ParentProcessId <PROCESS_ID>] [--Platform] <PLATFORM_TYPE>
+    [--Port <PORT>] [--ResultsDirectory<PATH>] [--Settings <SETTINGS_FILE>]
+    [--TestAdapterPath <PATH>] [--TestCaseFilter <EXPRESSION>]
+    [--Tests <TEST_NAMES>] [[--] <args>...]]
+
+dotnet vstest -?|--Help
 ```
 
 ## Description
@@ -37,11 +41,11 @@ The `dotnet-vstest` command runs the `VSTest.Console` command-line application t
 
   Runs the tests in blame mode. This option is helpful in isolating the problematic tests causing test host to crash. It creates an output file in the current directory as *Sequence.xml* that captures the order of tests execution before the crash.
 
-- **`--Diag <Path to log file>`**
+- **`--Diag <PATH_TO_LOG_FILE>`**
 
   Enables verbose logs for the test platform. Logs are written to the provided file.
 
-- **`--Framework <Framework Version>`**
+- **`--Framework <FRAMEWORK>`**
 
   Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework40`, `Framework45`, `FrameworkCore10`, and `FrameworkUap10`.
 
@@ -49,11 +53,11 @@ The `dotnet-vstest` command runs the `VSTest.Console` command-line application t
 
   Runs the tests in an isolated process. This makes *vstest.console.exe* process less likely to be stopped on an error in the tests, but tests may run slower.
 
-- **`-lt|--ListTests <File Name>`**
+- **`-lt|--ListTests <FILE_NAME>`**
 
   Lists all discovered tests from the given test container.
 
-- **`--logger <Logger Uri/FriendlyName>`**
+- **`--logger <LOGGER_URI/FRIENDLY_NAME>`**
 
   Specify a logger for test results.
 
@@ -79,35 +83,35 @@ The `dotnet-vstest` command runs the `VSTest.Console` command-line application t
 
   Run tests in parallel. By default, all available cores on the machine are available for use. Specify an explicit number of cores by setting the `MaxCpuCount` property under the `RunConfiguration` node in the *runsettings* file.
 
-- **`--ParentProcessId <ParentProcessId>`**
+- **`--ParentProcessId <PROCESS_ID>`**
 
   Process ID of the parent process responsible for launching the current process.
 
-- **`--Platform <Platform type>`**
+- **`--Platform <PLATFORM_TYPE>`**
 
   Target platform architecture used for test execution. Valid values are `x86`, `x64`, and `ARM`.
 
-- **`--Port <Port>`**
+- **`--Port <PORT>`**
 
   Specifies the port for the socket connection and receiving the event messages.
 
-- **`--ResultsDirectory:<PathToResulsDirectory>`**
+- **`--ResultsDirectory:<PATH>`**
 
   Test results directory will be created in specified path if not exists.
 
-- **`--Settings <Settings File>`**
+- **`--Settings <SETTINGS_FILE>`**
 
   Settings to use when running tests.
 
-- **`--TestAdapterPath`**
+- **`--TestAdapterPath <PATH>`**
 
   Use custom test adapters from a given path (if any) in the test run.
 
-- **`--TestCaseFilter <Expression>`**
+- **`--TestCaseFilter <EXPRESSION>`**
 
-  Run tests that match the given expression. `<Expression>` is of the format `<property>Operator<value>[|&<Expression>]`, where Operator is one of `=`, `!=`, or `~`. Operator `~` has 'contains' semantics and is applicable for string properties like `DisplayName`. Parentheses `()` are used to group subexpressions. For more information, see [TestCase filter](https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md).
+  Run tests that match the given expression. `<EXPRESSION>` is of the format `<property>Operator<value>[|&<EXPRESSION>]`, where Operator is one of `=`, `!=`, or `~`. Operator `~` has 'contains' semantics and is applicable for string properties like `DisplayName`. Parentheses `()` are used to group subexpressions. For more information, see [TestCase filter](https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md).
 
-- **`--Tests <Test Names>`**
+- **`--Tests <TEST_NAMES>`**
 
   Run tests with names that match the provided values. Separate multiple values with commas.
 

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -16,26 +16,27 @@ ms.date: 02/13/2020
 To get information about the available commands and the environment:
 
 ```dotnetcli
-dotnet [-h|--help] [--version] [--info]
-    [--list-runtimes] [--list-sdks]
+dotnet [--version] [--info] [--list-runtimes] [--list-sdks]
+
+dotnet -h|--help
 ```
 
 To run a command (requires SDK installation):
 
 ```dotnetcli
-dotnet <COMMAND> [-d|--diagnostics] [-h|--help] [--verbosity]
+dotnet <COMMAND> [-d|--diagnostics] [-h|--help] [--verbosity <LEVEL>]
     [command-options] [arguments]
 ```
 
 To run an application:
 
 ```dotnetcli
-dotnet [--additionalprobingpath] [--additional-deps]
-    [--fx-version]  [--roll-forward]
+dotnet [--additionalprobingpath <PATH>] [--additional-deps <PATH>]
+    [--fx-version <VERSION>]  [--roll-forward <SETTING>]
     <PATH_TO_APPLICATION> [arguments]
 
-dotnet exec [--additionalprobingpath] [--additional-deps]
-    [--fx-version]  [--roll-forward]
+dotnet exec [--additionalprobingpath] [--additional-deps <PATH>]
+    [--fx-version <VERSION>]  [--roll-forward <SETTING>]
     <PATH_TO_APPLICATION> [arguments]
 ```
 


### PR DESCRIPTION
Fixes #17398 

Also put the options section of dotnet-install-scripts in alphabetical order.