### PR TITLE
Fix signature of Async.StartChild

### DIFF
--- a/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
+++ b/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
@@ -141,7 +141,7 @@ Starts a child computation within an asynchronous computation. This allows multi
 Signature:
 
 ```fsharp
-computation: Async<'T> - timeout: ?int -> Async<Async<'T>>
+computation: Async<'T> * timeout: ?int -> Async<Async<'T>>
 ```
 
 When to use:


### PR DESCRIPTION
## Summary

Just fixing the signature of `Async.StartChild` to use `*` instead of an errant `-` in the tuple parameter.