### PR TITLE
Update snippet1901.fs

### DIFF
--- a/samples/snippets/fsharp/lang-ref-1/snippet1901.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet1901.fs
@@ -1,10 +1,10 @@
 // Labels are separated by semicolons when defined on the same line.
 type Point = { X: float; Y: float; Z: float; }
 
-// You can define labels on their own line with a semicolon.
+// You can define labels on their own line with or without a semicolon.
 type Customer = 
     { First: string
-      Last: string
+      Last: string;
       SSN: uint32
       AccountNumber: uint32; }
 


### PR DESCRIPTION
## Summary

Make it clear that semicolons are optional for labels on separate lines in a record.
