### PR TITLE
Remove using static as keyword, update docs

### DIFF
--- a/docs/csharp/language-reference/keywords/index.md
+++ b/docs/csharp/language-reference/keywords/index.md
@@ -3,7 +3,7 @@ title: "C# Keywords"
 ms.date: 03/07/2017
 f1_keywords: 
   - "cs.keywords"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "keywords [C#]"
   - "C# language, keywords"
   - "Visual C#, keywords"
@@ -36,8 +36,8 @@ Keywords are predefined, reserved identifiers that have special meanings to the 
 |[struct](../builtin-types/struct.md)|[switch](switch.md)|[this](this.md)|[throw](throw.md)|
 |[true](../builtin-types/bool.md)|[try](try-catch.md)|[typeof](../operators/type-testing-and-cast.md#typeof-operator)|[uint](../builtin-types/integral-numeric-types.md)|
 |[ulong](../builtin-types/integral-numeric-types.md)|[unchecked](unchecked.md)|[unsafe](unsafe.md)|[ushort](../builtin-types/integral-numeric-types.md)|
-|[using](using.md)|[using static](using-static.md)|[virtual](virtual.md)|[void](../builtin-types/void.md)|
-|[volatile](volatile.md)|[while](while.md)|
+|[using](using.md)|[virtual](virtual.md)|[void](../builtin-types/void.md)|[volatile](volatile.md)|
+|[while](while.md)|
 
 ## Contextual keywords
 

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -1,6 +1,6 @@
 ---
 title: "static modifier - C# Reference"
-ms.date: 01/22/2020
+ms.date: 04/22/2020
 f1_keywords: 
   - "static"
   - "static_CSharpKeyword"
@@ -10,7 +10,7 @@ ms.assetid: 5509e215-2183-4da3-bab4-6b7e607a4fdf
 ---
 # static (C# Reference)
 
-This page covers the `static` modifier keyword. The `static` keyword is also part of the [using static](using-static.md) directive.
+This page covers the `static` modifier keyword. The `static` keyword is also part of the [`using static`](using-static.md) directive.
 
 Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare `static` classes. In classes, interfaces, and structs, you may add the `static` modifier to fields, methods, properties, operators, events, and constructors. The `static` modifier can't be used with indexers or finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
 

--- a/docs/csharp/language-reference/keywords/static.md
+++ b/docs/csharp/language-reference/keywords/static.md
@@ -10,9 +10,11 @@ ms.assetid: 5509e215-2183-4da3-bab4-6b7e607a4fdf
 ---
 # static (C# Reference)
 
+This page covers the `static` modifier keyword. The `static` keyword is also part of the [using static](using-static.md) directive.
+
 Use the `static` modifier to declare a static member, which belongs to the type itself rather than to a specific object. The `static` modifier can be used to declare `static` classes. In classes, interfaces, and structs, you may add the `static` modifier to fields, methods, properties, operators, events, and constructors. The `static` modifier can't be used with indexers or finalizers. For more information, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
 
-## Example
+## Example - static class
 
 The following class is declared as `static` and contains only `static` methods:
 
@@ -41,13 +43,13 @@ Classes, interfaces, and `static` classes may have `static` constructors. A `sta
 
 To demonstrate `static` members, consider a class that represents a company employee. Assume that the class contains a method to count employees and a field to store the number of employees. Both the method and the field don't belong to any one employee instance. Instead, they belong to the class of employees as a whole. They should be declared as `static` members of the class.
 
-## Example
+## Example - static field and method
 
 This example reads the name and ID of a new employee, increments the employee counter by one, and displays the information for the new employee and the new number of employees. This program reads the current number of employees from the keyboard.
 
 [!code-csharp[csrefKeywordsModifiers#20](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#20)]  
 
-## Example
+## Example - static initialization
 
 This example shows that you can initialize a `static` field by using another `static` field that is not yet declared. The results will be undefined until you explicitly assign a value to the `static` field.
 
@@ -63,4 +65,5 @@ This example shows that you can initialize a `static` field by using another `st
 - [C# Programming Guide](../../programming-guide/index.md)
 - [C# Keywords](index.md)
 - [Modifiers](index.md)
+- [using static directive](using-static.md)
 - [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md)


### PR DESCRIPTION
## Summary

The `using static` directive is not a keyword, but rather two keywords. Remove it as a keyword, and update the `using` and `static` docs to ensure they mention / link back to the `using static` doc.

Fixes #17970
