### PR TITLE
Add defaults to dotnet test 

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -127,7 +127,7 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
   Example: `dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True`
 
-  For more information, see [vstest.console.exe: Passing RunSettings args](https://github.com/Microsoft/vstest-docs/blob/master/docs/RunSettingsArguments.md).
+  For more information, see [Passing RunSettings arguments through command line](https://github.com/Microsoft/vstest-docs/blob/master/docs/RunSettingsArguments.md).
 
 ## Examples
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -63,7 +63,7 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
 - **`-d|--diag <PATH_TO_DIAGNOSTICS_FILE>`**
 
-  Enables diagnostic mode for the test platform and write diagnostic messages to the specified file.
+  Enables diagnostic mode for the test platform and writes diagnostic messages to the specified file.
 
 - **`-f|--framework <FRAMEWORK>`**
 
@@ -99,11 +99,12 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
 - **`-o|--output <OUTPUT_DIRECTORY>`**
 
-  Directory in which to find the binaries to run.
+  Directory in which to find the binaries to run. If not specified, the default path is `./bin/<configuration>/<framework>/`.  For projects with multiple target frameworks (via the `TargetFrameworks` property), you also need to define `--framework` when you specify this option.
 
 - **`-r|--results-directory <PATH>`**
 
-  The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created.
+  The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is `TestResults` in the directory that contains the project file.
+
 
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 
@@ -121,7 +122,7 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
   Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `minimal`. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity>.
 
-- `RunSettings` arguments
+- **`RunSettings`** arguments
 
   Arguments are passed as `RunSettings` configurations for the test. Arguments are specified as `[name]=[value]` pairs after "-- " (note the space after --). A space is used to separate multiple `[name]=[value]` pairs.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -105,7 +105,6 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
   The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is `TestResults` in the directory that contains the project file.
 
-
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 
   The target runtime to test for.


### PR DESCRIPTION
Fixes #15591
Verbosity default was added earlier by https://github.com/dotnet/docs/pull/17701

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-17987)