### PR TITLE
Add Action Links section to dotnet-architecture/eShopOnWeb book intro

### DIFF
--- a/docs/architecture/modern-web-apps-azure/index.md
+++ b/docs/architecture/modern-web-apps-azure/index.md
@@ -46,6 +46,12 @@ Editors:
 
 > **Maira Wenzel**
 
+## Action links
+
+- This e-book is also available in a PDF format (English version only) [Download](https://aka.ms/webappebook)
+
+- Clone/Fork the reference application [eShopOnWeb on GitHub](https://github.com/dotnet-architecture/eShopOnWeb)
+
 ## Introduction
 
 .NET Core and ASP.NET Core offer several advantages over traditional .NET development. You should use .NET Core for your server applications if some or all of the following are important to your application's success:


### PR DESCRIPTION
Fixes #16847

## Summary
This makes the links to the e-book of the ["Architect Modern Web Applications with ASP.NET Core and Azure"](https://docs.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/)  easily available, similar to how it is done on the [".NET Microservices: Architecture for Containerized .NET Applications"](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/#action-links), as discussed in #16847.

I've left out the bottom two links (such as the link to the Channel9 video), as I couldn't find version of that.


