### PR TITLE
Replace Github link with Sample browser link

### DIFF
--- a/docs/standard/assembly/inspect-contents-using-metadataloadcontext.md
+++ b/docs/standard/assembly/inspect-contents-using-metadataloadcontext.md
@@ -35,4 +35,4 @@ The following code sample creates <xref:System.Reflection.MetadataLoadContext>, 
 
 ## Example
 
-For a complete code example, see the [Inspect assembly contents using MetadataLoadContext sample](https://github.com/dotnet/samples/tree/master/core/assembly/MetadataLoadContext).
+For a complete code example, see the [Inspect assembly contents using MetadataLoadContext sample](https://docs.microsoft.com/samples/dotnet/samples/inspect-assembly-contents-using-metadataloadcontext/).


### PR DESCRIPTION
Sample is now correctly displayed in Sample Browser. So we can replace link to go there to let people download Zip.

Closes https://github.com/dotnet/docs/issues/17740
