### PR TITLE
C# array guide initialisation length

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideArrays/CS/Arrays.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideArrays/CS/Arrays.cs
@@ -328,7 +328,7 @@ class TestArraysClass
 {
     static void Main()
     {
-        // Declare a single-dimensional array.
+        // Declare a single-dimensional array of 5 integers.
         int[] array1 = new int[5];
 
         // Declare and set array element values.


### PR DESCRIPTION
## Summary

Adds description of setting length in C# array initialisation on https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/. 

This makes it closer to the VB.Net documentation array example (https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/arrays/) and C# single array initialisation. (https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/single-dimensional-arrays)

This is important as the number passed to array initialisation in C# is the length whereas in VB.Net is the maximum index so length + 1.