### PR TITLE
String concatenation: clarify behavior for null

### DIFF
--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -1,6 +1,6 @@
 ---
 title: "+ and += operators - C# reference"
-ms.date: 05/24/2019
+ms.date: 04/23/2020
 f1_keywords: 
   - "+_CSharpKeyword"
   - "+=_CSharpKeyword"
@@ -22,7 +22,7 @@ For information about the arithmetic `+` operator, see the [Unary plus and minus
 
 ## String concatenation
 
-When one or both operands are of type [string](../builtin-types/reference-types.md#the-string-type), the `+` operator concatenates the string representations of its operands:
+When one or both operands are of type [string](../builtin-types/reference-types.md#the-string-type), the `+` operator concatenates the string representations of its operands (the string representation of `null` is an empty string):
 
 [!code-csharp-interactive[string concatenation](snippets/AdditionOperator.cs#AddStrings)]
 

--- a/docs/csharp/language-reference/operators/snippets/AdditionOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/AdditionOperator.cs
@@ -26,9 +26,11 @@ namespace operators
             // <SnippetAddStrings>
             Console.WriteLine("Forgot" + "white space");
             Console.WriteLine("Probably the oldest constant: " + Math.PI);
+            Console.WriteLine(null + "Nothing to add.");
             // Output:
             // Forgotwhite space
             // Probably the oldest constant: 3.14159265358979
+            // Nothing to add.
             // </SnippetAddStrings>
 
             // <SnippetUseStringInterpolation>

--- a/docs/csharp/language-reference/operators/snippets/Program.cs
+++ b/docs/csharp/language-reference/operators/snippets/Program.cs
@@ -103,7 +103,7 @@ namespace operators
             UserDefinedConversions.Main();
             Console.WriteLine();
 
-            Console.WriteLine("========= switch expression example =========");
+            Console.WriteLine("========= switch expression example ============");
             SwitchExpressions.Examples();
             Console.WriteLine();
 


### PR DESCRIPTION
Fixes #18005
