### PR TITLE
Fix incorrect default value for GCHeapHardLimit

### DIFF
--- a/docs/core/run-time-config/garbage-collector.md
+++ b/docs/core/run-time-config/garbage-collector.md
@@ -234,7 +234,7 @@ Example:
 
 - Specifies the maximum commit size, in bytes, for the GC heap and GC bookkeeping.
 - This setting only applies to 64-bit computers.
-- The default value, which only applies in certain cases, is the lesser of 20 MB or 75% of the memory limit on the container. The default value applies if:
+- The default value, which only applies in certain cases, is the greater of 20 MB or 75% of the memory limit on the container. The default value applies if:
 
   - The process is running inside a container that has a specified memory limit.
   - [System.GC.HeapHardLimitPercent](#systemgcheaphardlimitpercentcomplus_gcheaphardlimitpercent) is not set.


### PR DESCRIPTION
## Summary

GCHeapHardLimit default to the greater of 20MB or 75% of the memory limit. See https://devblogs.microsoft.com/dotnet/running-with-server-gc-in-a-small-container-scenario-part-1-hard-limit-for-the-gc-heap/
