### PR TITLE
Update Hub + Landing pages to prep for L2 removal

### DIFF
--- a/docs/framework/index.yml
+++ b/docs/framework/index.yml
@@ -40,12 +40,14 @@ landingContent:
   # Card
   - title: Install .NET Framework
     linkLists:
+      - linkListType: download
+        links:
+        - text: Download the .NET SDK
+          url: https://dotnet.microsoft.com/download
       - linkListType: overview
         links:
           - text: Installation guide 
             url: install/index.md
-          - text: Download the .NET SDK
-            url: https://dotnet.microsoft.com/download
       - linkListType: concept
         links:
           - text: .NET Framework & Windows OS versions 

--- a/docs/framework/index.yml
+++ b/docs/framework/index.yml
@@ -12,7 +12,7 @@ metadata:
     - "f61f02f2-2f20-483d-8f56-a9c8f3a54986"
   helpviewer_keywords: 
     - ".NET Framework guide"
-  ms.date: 03/23/2020
+  ms.date: 04/22/2020
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
 
@@ -44,6 +44,8 @@ landingContent:
         links:
           - text: Installation guide 
             url: install/index.md
+          - text: Download the .NET SDK
+            url: https://dotnet.microsoft.com/download
       - linkListType: concept
         links:
           - text: .NET Framework & Windows OS versions 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,13 +12,17 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 12/19/2019
+  ms.date: 04/21/2020
 
 # highlightedContent section (optional)
 # Maximum of 8 items
 highlightedContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
   items:
+    # Card
+    - title: "Download .NET"
+      itemType: download
+      url: https://dotnet.microsoft.com/download
     # Card
     - title: "C# introduction. A quick interactive start."
       itemType: get-started
@@ -64,6 +68,12 @@ conceptualContent:
         - url: core/tutorials/index.md
           itemType: tutorial
           text: Tutorials
+        - url: https://dotnet.microsoft.com/platform/community
+          itemType: whats-new
+          text: Community
+        - url: https://dotnetfoundation.org/
+          itemType: overview
+          text: .NET Foundation
     # Card
     - title: .NET concepts
       summary: Learn the fundamental concepts of .NET
@@ -99,7 +109,7 @@ conceptualContent:
         - url: core/sdk.md
           itemType: download
           text: Download the .NET Core SDK
-        - url: core/tools/index.md
+        - url: https://dotnet.microsoft.com/download
           itemType: overview
           text: .NET Core CLI overview
         - url: core/porting/index.md

--- a/docs/standard/index.yml
+++ b/docs/standard/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: .NET documentation
   description: Learn about .NET, an open-source developer platform for building many different types of applications.
   ms.topic: landing-page
-  ms.date: 03/27/2020
+  ms.date: 04/22/2020
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
 
@@ -18,6 +18,8 @@ landingContent:
     linkLists:
       - linkListType: overview
         links:
+          - text: Download the .NET SDK
+            url: https://dotnet.microsoft.com/download
           - text: Tour of .NET
             url: tour.md
           - text: What is .NET?

--- a/docs/standard/index.yml
+++ b/docs/standard/index.yml
@@ -16,10 +16,12 @@ landingContent:
   # Card
   - title: Learn about .NET
     linkLists:
+      - linkListType: download
+        links:
+        - text: Download the .NET SDK
+          url: https://dotnet.microsoft.com/download
       - linkListType: overview
         links:
-          - text: Download the .NET SDK
-            url: https://dotnet.microsoft.com/download
           - text: Tour of .NET
             url: tour.md
           - text: What is .NET?

--- a/docs/visual-basic/index.yml
+++ b/docs/visual-basic/index.yml
@@ -20,7 +20,7 @@ landingContent:
       - linkListType: get-started
         links:
           - text: Download the .NET Core SDK
-            url: core/sdk.md
+            url: https://dotnet.microsoft.com/download
           - text: Build a "Hello World" app with .NET Core
             url: ../core/tutorials/vb-with-visual-studio.md
           - text: Build a class library with .NET Standard

--- a/docs/visual-basic/index.yml
+++ b/docs/visual-basic/index.yml
@@ -17,10 +17,12 @@ landingContent:
   # Card (optional)
   - title: Get started
     linkLists:
+      - linkListType: download
+        links:
+        - text: Download the .NET SDK
+          url: https://dotnet.microsoft.com/download
       - linkListType: get-started
         links:
-          - text: Download the .NET Core SDK
-            url: https://dotnet.microsoft.com/download
           - text: Build a "Hello World" app with .NET Core
             url: ../core/tutorials/vb-with-visual-studio.md
           - text: Build a class library with .NET Standard

--- a/docs/visual-basic/index.yml
+++ b/docs/visual-basic/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: "Visual Basic docs - get started, tutorials, reference."
   description: "Learn Visual Basic programming in .NET - for beginning developers, developers new to Visual Basic, and experienced Visual Basic developers"
   ms.topic: landing-page # Required
-  ms.date: 11/27/2019
+  ms.date: 04/22/2020
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
 
@@ -19,6 +19,8 @@ landingContent:
     linkLists:
       - linkListType: get-started
         links:
+          - text: Download the .NET Core SDK
+            url: core/sdk.md
           - text: Build a "Hello World" app with .NET Core
             url: ../core/tutorials/vb-with-visual-studio.md
           - text: Build a class library with .NET Standard

--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -47,11 +47,11 @@ landingContent:
             url: https://github.com/dotnet/dotnet-api-docs/blob/master/CONTRIBUTING.md
           - text: ".NET samples contributor guide"
             url: https://github.com/dotnet/samples/blob/master/CONTRIBUTING.md
-  -title: "Community"
-   linkLists:
+  - title: "Community"
+    linkLists:
       - linkListType: whats-new
         links:
-          - text: "Community"
+          - text: Community
             url: https://dotnet.microsoft.com/platform/community
   - title: "Related what's new pages"
     linkLists:

--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -35,8 +35,6 @@ landingContent:
             url: https://github.com/dotnet/docs/blob/master/README.md
           - text: Project structure and labels for issues and pull requests
             url: https://docs.microsoft.com/contribute/dotnet/labels-projects
-          - text: "Community"
-            url: https://dotnet.microsoft.com/platform/community
           - text: ".NET Foundation"
             url: https://dotnetfoundation.org/
       - linkListType: concept
@@ -49,7 +47,12 @@ landingContent:
             url: https://github.com/dotnet/dotnet-api-docs/blob/master/CONTRIBUTING.md
           - text: ".NET samples contributor guide"
             url: https://github.com/dotnet/samples/blob/master/CONTRIBUTING.md
-
+  -title: "Community"
+   linkLists:
+      - linkListType: whats-new
+        links:
+          - text: "Community"
+            url: https://dotnet.microsoft.com/platform/community
   - title: "Related what's new pages"
     linkLists:
       - linkListType: whats-new

--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -34,7 +34,7 @@ landingContent:
           - text: ".NET docs repository"
             url: https://github.com/dotnet/docs/blob/master/README.md
           - text: Project structure and labels for issues and pull requests
-            url: https://github.com/dotnet/docs/blob/master/styleguide/labels-projects.md
+            url: https://docs.microsoft.com/contribute/dotnet/labels-projects
           - text: "Community"
             url: https://dotnet.microsoft.com/platform/community
           - text: ".NET Foundation"

--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: .NET documentation what's new?
   description: "Learn about new and updated content in .NET docs."
   ms.topic: landing-page
-  ms.date: 12/12/2019
+  ms.date: 04/22/2020
 
 landingContent:
   - title: "Find .NET updates"
@@ -27,7 +27,7 @@ landingContent:
           - text: October 2019
             url: 2019-10.md
 
-  - title: "Get involved - contribute to .NET docs"
+  - title: "Get involved - contribute"
     linkLists:
       - linkListType: overview
         links:
@@ -35,6 +35,10 @@ landingContent:
             url: https://github.com/dotnet/docs/blob/master/README.md
           - text: Project structure and labels for issues and pull requests
             url: https://github.com/dotnet/docs/blob/master/styleguide/labels-projects.md
+          - text: "Community"
+            url: https://dotnet.microsoft.com/platform/community
+          - text: ".NET Foundation"
+            url: https://dotnetfoundation.org/
       - linkListType: concept
         links:
           - text: Microsoft docs contributor guide


### PR DESCRIPTION
PR updates part 1 for #18011

[Internal Review - Hub](https://review.docs.microsoft.com/en-us/dotnet/?branch=pr-en-us-18024)
[Internal Review - Framework Landing Page](https://review.docs.microsoft.com/en-us/dotnet/framework/?branch=pr-en-us-18024)
[Internal Review - Standard Landing Page](https://review.docs.microsoft.com/en-us/dotnet/standard/?branch=pr-en-us-18024)
[Internal Review - What's New](https://review.docs.microsoft.com/en-us/dotnet/whats-new/?branch=pr-en-us-18024)
[Internal Review - Visual Basic Landing Page](https://review.docs.microsoft.com/en-us/dotnet/visual-basic/?branch=pr-en-us-18024)


Hub page:
- Add Download .NET highlight card to top left.
- Add a "Community" link plus a .NET Foundation link to the open source card

What's New page:
- Add a “Community” link to the “Get Involved” card.

.NET Framework landing page:
- Add link to .NET Download on "Install .NET Framework section"

.NET Standard landing Page:
- Add link to .NET Download as first link in Learn about .NET section

What's New page:
- Add Community and .NET Foundation links to "Get involved - contribute" section.

The L2 itself will be removed in a separate PR once these changes are merged.
