### PR TITLE
Add exception handling breaking change

### DIFF
--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -29,6 +29,7 @@ The following breaking changes are documented on this page:
 | [Change in default value of UseShellExecute](#change-in-default-value-of-useshellexecute) | 2.1 |
 | [OpenSSL versions on macOS](#openssl-versions-on-macos) | 2.1 |
 | [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes) | 1.0 |
+| [Handling corrupted-process-state exceptions is not supported](#handling-corrupted-state-exceptions-is-not-supported) | 1.0 |
 
 ## .NET Core 3.0
 
@@ -105,5 +106,9 @@ The following breaking changes are documented on this page:
 ## .NET Core 1.0
 
 [!INCLUDE [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](~/includes/core-changes/corefx/1.0/filesysteminfo-attributes-exceptions.md)]
+
+***
+
+[!INCLUDE [corrupted-state-exceptions](~/includes/core-changes/corefx/1.0/corrupted-state-exceptions.md)]
 
 ***

--- a/docs/core/compatibility/fx-core.md
+++ b/docs/core/compatibility/fx-core.md
@@ -15,6 +15,7 @@ If you're migrating an app from .NET Framework to .NET Core, the breaking change
 
 - [Change in default value of UseShellExecute](#change-in-default-value-of-useshellexecute)
 - [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes)
+- [Handling corrupted-process-state exceptions is not supported](#handling-corrupted-state-exceptions-is-not-supported)
 
 ### .NET Core 2.1
 
@@ -25,6 +26,10 @@ If you're migrating an app from .NET Framework to .NET Core, the breaking change
 ### .NET Core 1.0
 
 [!INCLUDE [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](~/includes/core-changes/corefx/1.0/filesysteminfo-attributes-exceptions.md)]
+
+***
+
+[!INCLUDE [corrupted-state-exceptions](~/includes/core-changes/corefx/1.0/corrupted-state-exceptions.md)]
 
 ***
 

--- a/includes/core-changes/corefx/1.0/corrupted-state-exceptions.md
+++ b/includes/core-changes/corefx/1.0/corrupted-state-exceptions.md
@@ -1,0 +1,34 @@
+### Handling corrupted state exceptions is not supported
+
+Handling corrupted-process-state exceptions in .NET Core is not supported.
+
+#### Change description
+
+Previously, corrupted-process-state exceptions could be caught and handled by managed code exception handlers, for example, by using a [try-catch](../../../../docs/csharp/language-reference/keywords/try-catch.md) statement in C#.
+
+Starting in .NET Core 1.0, corrupted-process-state exceptions cannot be handled by managed code. The common language runtime doesn't deliver corrupted-process-state exceptions to managed code.
+
+#### Version introduced
+
+1.0
+
+#### Recommended action
+
+Avoid the need to handle corrupted-process-state exceptions by addressing the situations that lead to them instead. If it's absolutely necessary to handle corrupted-process-state exceptions, write the exception handler in C or C++ code.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute?displayProperty=fullName>
+- [legacyCorruptedStateExceptionsPolicy element](~/docs/framework/configure-apps/file-schema/runtime/legacycorruptedstateexceptionspolicy-element.md)
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute`
+
+-->


### PR DESCRIPTION
Fixes #17893

[Internal preview [](link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-18026#handling-corrupted-state-exceptions-is-not-supported).)