### PR TITLE
Correct fixed size buffers article

### DIFF
--- a/docs/csharp/programming-guide/unsafe-code-pointers/fixed-size-buffers.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/fixed-size-buffers.md
@@ -1,7 +1,7 @@
 ---
 title: "Fixed Size Buffers - C# Programming Guide"
-ms.date: 04/20/2018
-helpviewer_keywords: 
+ms.date: 04/23/2020
+helpviewer_keywords:
   - "fixed size buffers [C#]"
   - "unsafe buffers [C#]"
   - "unsafe code [C#], fixed size buffers"
@@ -32,15 +32,39 @@ The  preceding example demonstrates accessing `fixed` fields without pinning, wh
 
 Another common fixed-size array is the [bool](../../language-reference/builtin-types/bool.md) array. The elements in a `bool` array are always one byte in size. `bool` arrays are not appropriate for creating bit arrays or buffers.
 
-> [!NOTE]
-> Except for memory created by using [stackalloc](../../language-reference/operators/stackalloc.md), the C# compiler and the common language runtime (CLR) do not perform any security buffer overrun checks. As with all unsafe code, use caution.
+Fixed size buffers are compiled with the <xref:System.Runtime.CompilerServices.UnsafeValueTypeAttribute?displayProperty=nameWithType>, which instructs the common language runtime (CLR) that a type contains an unmanaged array that can potentially overflow. This is similar to memory created using [stackalloc](../../language-reference/operators/stackalloc.md), which automatically enables buffer overrun detection features in the CLR. The previous example shows how a fixed size buffer could exist in an `unsafe struct`.
 
-Unsafe buffers differ from regular arrays in the following ways:
+```csharp
+internal unsafe struct Buffer
+{
+    public fixed char fixedBuffer[128];
+}
+```
 
-- You can only use unsafe buffers in an unsafe context.
-- Unsafe buffers are always vectors, or one-dimensional arrays.
-- The declaration of the array should include a count, such as `char id[8]`. You cannot use `char id[]`.
-- Unsafe buffers can only be instance fields of structs in an unsafe context.
+The compiler generated C# for `Buffer`, is attributed as follows:
+
+```csharp
+internal struct Buffer
+{
+    [StructLayout(LayoutKind.Sequential, Size = 256)]
+    [CompilerGenerated]
+    [UnsafeValueType]
+    public struct <fixedBuffer>e__FixedBuffer
+    {
+        public char FixedElementField;
+    }
+
+    [FixedBuffer(typeof(char), 128)]
+    public <fixedBuffer>e__FixedBuffer fixedBuffer;
+}
+```
+
+Fixed size buffers differ from regular arrays in the following ways:
+
+- May only be used in an [unsafe](../../language-reference/keywords/unsafe.md) context.
+- May only be instance fields of structs.
+- They're always vectors, or one-dimensional arrays.
+- The declaration should include the length, such as `fixed char id[8]`. You cannot use `fixed char id[]`.
 
 ## See also
 

--- a/samples/snippets/csharp/keywords/FixedKeywordExamples.cs
+++ b/samples/snippets/csharp/keywords/FixedKeywordExamples.cs
@@ -192,33 +192,34 @@ namespace keywords
         // </Snippet6>
 
         // <Snippet7>
-        internal unsafe struct MyBuffer
+        internal unsafe struct Buffer
         {
             public fixed char fixedBuffer[128];
         }
 
-        internal unsafe class MyClass
+        internal unsafe class Example
         {
-            public MyBuffer myBuffer = default;
+            public Buffer buffer = default;
         }
 
         private static void AccessEmbeddedArray()
         {
-            MyClass myC = new MyClass();
+            var example = new Example();
 
             unsafe
             {
                 // Pin the buffer to a fixed location in memory.
-                fixed (char* charPtr = myC.myBuffer.fixedBuffer)
+                fixed (char* charPtr = example.buffer.fixedBuffer)
                 {
                     *charPtr = 'A';
                 }
                 // Access safely through the index:
-                char c = myC.myBuffer.fixedBuffer[0];
+                char c = example.buffer.fixedBuffer[0];
                 Console.WriteLine(c);
-                // modify through the index:
-                myC.myBuffer.fixedBuffer[0] = 'B';
-                Console.WriteLine(myC.myBuffer.fixedBuffer[0]);
+
+                // Modify through the index:
+                example.buffer.fixedBuffer[0] = 'B';
+                Console.WriteLine(example.buffer.fixedBuffer[0]);
             }
         }
         // </Snippet7>


### PR DESCRIPTION
## Summary

Correct fixed size buffers article.

- Remove incorrect statement in note alert
- Convert note into paragraph explaining `UnsafeValueTypeAttribute` and `stackalloc`
- Clean up the existing example code snippet
- Continuation of example, but call attention to `UnsafeValueTypeAttribute` attribution in C# compiler-generated bits
- Clean up summarized differentiation wording

Fixes #10545