### PR TITLE
Add nested loops

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -310,7 +310,7 @@ for (int row = 1; row < 11; row++)
 }
 ```
 
-You can see that the outer out loop increments once for each iteration of the inner loop. Reverse the row and column nesting, and see the changes for yourself.
+You can see that the outer loop increments once for each full run of the inner loop. Reverse the row and column nesting, and see the changes for yourself.
 
 ## Combine branches and loops
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -283,7 +283,7 @@ A `while`, `do` or `for` loop can be nested inside another loop to create a matr
 One `for` loop can generate the rows:
 
 ```csharp
-for (int row = 1; number < 11; number++)
+for (int row = 1; row < 11; row++)
 {
     Console.WriteLine($"The row is {row}");
 }
@@ -301,7 +301,7 @@ for (char column = 'a'; column < 'k'; column++)
 You can nest one loop inside the other to form pairs:
 
 ```csharp
-for (int row = 1; number < 11; number++)
+for (int row = 1; row < 11; row++)
 {
     for (char column = 'a'; column < 'k'; column++)
     {

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -299,7 +299,7 @@ for (char column = 'a'; column < 'k'; column++)
 ```
 
 You can nest one loop inside the other to form pairs:
-      
+
 ```csharp
 for (int row = 1; number < 11; number++)
 {

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -276,6 +276,42 @@ Experiment with these yourself. Try each of the following:
 When you're done, let's move on to write some code yourself to
 use what you've learned.
 
+## Created nested loops
+
+A `while`, `do` or `for` loop can be nested inside another loop to create a matrix using the combination of each item in the outer loop with each item in the inner loop. Let's do that to build a set of alpha-numeric pairs to represent rows and columns.
+
+One `for` loop can generate the rows:
+
+```csharp
+for (int row = 1; number < 11; number++)
+{
+    Console.WriteLine($"The row is {row}");
+}
+```
+
+Another loop can generate the columns:
+
+```csharp
+for (char column = 'a'; column < 'k'; column++)
+{
+    Console.WriteLine($"The column is {column}");
+}
+```
+
+You can nest one loop inside the other to form pairs:
+      
+```csharp
+for (int row = 1; number < 11; number++)
+{
+    for (char column = 'a'; column < 'k'; column++)
+    {
+        Console.WriteLine($"The cell is ({row}, {column})");
+    }
+}
+```
+
+You can see that the outer out loop increments once for each iteration of the inner loop. Reverse the row and column nesting, and see the changes for yourself.
+
 ## Combine branches and loops
 
 Now that you've seen the `if` statement and the looping

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -278,7 +278,7 @@ use what you've learned.
 
 ## Created nested loops
 
-A `while`, `do` or `for` loop can be nested inside another loop to create a matrix using the combination of each item in the outer loop with each item in the inner loop. Let's do that to build a set of alpha-numeric pairs to represent rows and columns.
+A `while`, `do` or `for` loop can be nested inside another loop to create a matrix using the combination of each item in the outer loop with each item in the inner loop. Let's do that to build a set of alphanumeric pairs to represent rows and columns.
 
 One `for` loop can generate the rows:
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -274,7 +274,7 @@ items:
     }
     ```
 
-    You can see that the outer out loop increments once for each iteration of the
+    You can see that the outer loop increments once for each full run of the
     inner loop. Reverse the row and column nesting, and see the changes for yourself.
 
 - title: Combine branches and loops

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -242,7 +242,7 @@ items:
   content: |
     A `while`, `do` or `for` loop can be nested inside another loop to create a matrix 
     using the combination of each item in the outer loop with each item in the inner
-    loop. Let's do that to build a set of alpha-numeric pairs to represent rows and columns.
+    loop. Let's do that to build a set of alphanumeric pairs to represent rows and columns.
 
     One `for` loop can generate the rows:
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -237,6 +237,46 @@ items:
     > [!NOTE]
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
+- title: Created nested loops
+  durationInMinutes: 10
+  content: |
+    A `while`, `do` or `for` loop can be nested inside another loop to create a matrix 
+    using the combination of each item in the outer loop with each item in the inner
+    loop. Let's do that to build a set of alpha-numeric pairs to represent rows and columns.
+
+    One `for` loop can generate the rows:
+
+    ```csharp
+    for (int row = 1; number < 11; number++)
+    {
+      Console.WriteLine($"The row is {row}");
+    }
+    ```
+
+    Another loop can generate the columns:
+
+    ```csharp
+    for (char column = 'a'; column < 'k'; column++)
+    {
+      Console.WriteLine($"The column is {column}");
+    }
+    ```
+
+    You can nest one loop inside the other to form pairs:
+      
+    ```csharp
+    for (int row = 1; number < 11; number++)
+    {
+      for (char column = 'a'; column < 'k'; column++)
+      {
+        Console.WriteLine($"The cell is ({row}, {column})");
+      }
+    }
+    ```
+
+    You can see that the outer out loop increments once for each iteration of the
+    inner loop. Reverse the row and column nesting, and see the changes for yourself.
+
 - title: Combine branches and loops
   durationInMinutes: 12
   content: |

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -247,7 +247,7 @@ items:
     One `for` loop can generate the rows:
 
     ```csharp
-    for (int row = 1; number < 11; number++)
+    for (int row = 1; row < 11; row++)
     {
       Console.WriteLine($"The row is {row}");
     }
@@ -265,7 +265,7 @@ items:
     You can nest one loop inside the other to form pairs:
       
     ```csharp
-    for (int row = 1; number < 11; number++)
+    for (int row = 1; row < 11; row++)
     {
       for (char column = 'a'; column < 'k'; column++)
       {


### PR DESCRIPTION
The beginner loops tutorial does not contain any examples of nested loops.

Add a beginner example to both the interactive and local versions.

Fixes #17208

[internal review link - interactive](https://review.docs.microsoft.com/en-us/dotnet/csharp/tutorials/intro-to-csharp/branches-and-loops?branch=pr-en-us-18039&tutorial-step=5)
[Internal review link - local](https://review.docs.microsoft.com/en-us/dotnet/csharp/tutorials/intro-to-csharp/branches-and-loops-local?branch=pr-en-us-18039#created-nested-loops)
