### PR TITLE
Add WinForms breaking change for 5.0

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -40,7 +40,12 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Windows Forms
 
+- [Removed status bar controls](#removed-status-bar-controls)
 - [WinForms APIs now throw ArgumentNullException](#winforms-apis-now-throw-argumentnullexception)
+
+[!INCLUDE [winforms-deprecated-controls](../../../includes/core-changes/windowsforms/5.0/winforms-deprecated-controls.md)]
+
+***
 
 [!INCLUDE [null-args-cause-argumentnullexception](../../../includes/core-changes/windowsforms/5.0/null-args-cause-argumentnullexception.md)]
 

--- a/docs/core/compatibility/winforms.md
+++ b/docs/core/compatibility/winforms.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Removed status bar controls](#removed-status-bar-controls) | 5.0 |
 | [WinForms APIs now throw ArgumentNullException](#winforms-apis-now-throw-argumentnullexception) | 5.0 |
 | [Removed controls](#removed-controls) | 3.1 |
 | [CellFormatting event not raised if tooltip is shown](#cellformatting-event-not-raised-if-tooltip-is-shown) | 3.1 |
@@ -29,6 +30,10 @@ The following breaking changes are documented on this page:
 | [Duplicated APIs removed from Windows Forms](#duplicated-apis-removed-from-windows-forms) | 3.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [winforms-deprecated-controls](../../../includes/core-changes/windowsforms/5.0/winforms-deprecated-controls.md)]
+
+***
 
 [!INCLUDE [null-args-cause-argumentnullexception](../../../includes/core-changes/windowsforms/5.0/null-args-cause-argumentnullexception.md)]
 

--- a/includes/core-changes/windowsforms/5.0/winforms-deprecated-controls.md
+++ b/includes/core-changes/windowsforms/5.0/winforms-deprecated-controls.md
@@ -1,0 +1,64 @@
+### Removed status bar controls
+
+Starting in .NET 5.0 Preview 1, some Windows Forms controls are no longer available.
+
+#### Change description
+
+Starting with .NET 5.0 Preview 1, some of the status bar-related Windows Forms controls are no longer available. Replacement controls that have better design and support were introduced in .NET Framework 2.0. The deprecated controls were previously removed from designer toolboxes but were still available to be used. Now, they have been completely removed.
+
+The following types are no longer available:
+
+* `StatusBar`
+* `StatusBarDrawItemEventArgs`
+* `StatusBarDrawItemEventHandler`
+* `StatusBarPanel`
+* `StatusBarPanelAutoSize`
+* `StatusBarPanelBorderStyle`
+* `StatusBarPanelClickEventArgs`
+* `StatusBarPanelClickEventHandler`
+* `StatusBarPanelStyle`
+
+#### Version introduced
+
+5.0 Preview 1
+
+#### Recommended action
+
+Move to the replacement APIs for these controls and their scenarios:
+
+| Old Control (API) | Recommended Replacement                          |
+|-------------------|--------------------------------------------------|
+| StatusBar         | <xref:System.Windows.Forms.StatusStrip>          |
+| StatusBarPanel    | <xref:System.Windows.Forms.ToolStripStatusLabel> |
+
+#### Category
+
+Windows Forms
+
+#### Affected APIs
+
+- <xref:System.Windows.Forms.StatusBar?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarDrawItemEventArgs?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarDrawItemEventHandler?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarPanel?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarPanelAutoSize?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarPanelBorderStyle?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarPanelClickEventArgs?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarPanelClickEventHandler?displayProperty=fullName>
+- <xref:System.Windows.Forms.StatusBarPanelStyle?displayProperty=fullName>
+
+<!-- 
+
+### Affected APIs
+
+- `T:System.Windows.Forms.StatusBar`
+- `T:System.Windows.Forms.StatusBarDrawItemEventArgs`
+- `T:System.Windows.Forms.StatusBarDrawItemEventHandler`
+- `T:System.Windows.Forms.StatusBarPanel`
+- `T:System.Windows.Forms.StatusBarPanelAutoSize`
+- `T:System.Windows.Forms.StatusBarPanelBorderStyle`
+- `T:System.Windows.Forms.StatusBarPanelClickEventArgs`
+- `T:System.Windows.Forms.StatusBarPanelClickEventHandler`
+- `T:System.Windows.Forms.StatusBarPanelStyle` 
+
+-->


### PR DESCRIPTION
fixes #17008

[Internal preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-18045#removed-status-bar-controls).