### PR TITLE
Corrected dev lang identifier, from console to dotnetcli

### DIFF
--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -35,7 +35,7 @@ dotnet run
 
 The program produces the following output:
 
-```console
+```dotnetcli
 Hello, World!
 ```
 

--- a/docs/csharp/tour-of-csharp/program-structure.md
+++ b/docs/csharp/tour-of-csharp/program-structure.md
@@ -11,7 +11,7 @@ The key organizational concepts in C# are ***programs***, ***namespaces***, ***t
 
 You can create a library project named *acme* using the `dotnet new` command:
 
-```console
+```dotnetcli
 dotnet new classlib -o acme
 ```
 
@@ -21,7 +21,7 @@ In that project, declare a class named `Stack` in a namespace called `Acme.Colle
 
 The fully qualified name of this class is `Acme.Collections.Stack`. The class contains several members: a field named `top`, two methods named `Push` and `Pop`, and a nested class named `Entry`. The `Entry` class further contains three members: a field named `next`, a field named `data`, and a constructor. The command:
 
-```console
+```dotnetcli
 dotnet build
 ```
 
@@ -43,7 +43,7 @@ The *csproj* file for the preceding program's project must include a reference n
 
 After that addition, `dotnet build` creates an executable assembly named `example.exe`, which, when run, produces the output:
 
-```console
+```dotnetcli
 100
 10
 1


### PR DESCRIPTION
## Summary

Corrected dev lang identifier, from `console` to `dotnetcli`

