### PR TITLE
Add installation instructions for Fedora 32

### DIFF
--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -9,6 +9,7 @@
 > - [CentOS 7 - x64](../linux-package-manager-centos7.md)
 > - [Debian 10 - x64](../linux-package-manager-debian10.md)
 > - [Debian 9 - x64](../linux-package-manager-debian9.md)
+> - [Fedora 32 - x64](../linux-package-manager-fedora32.md)
 > - [Fedora 31 - x64](../linux-package-manager-fedora31.md)
 > - [Fedora 30 - x64](../linux-package-manager-fedora30.md)
 > - [Fedora 29 - x64](../linux-package-manager-fedora29.md)

--- a/docs/core/install/linux-package-manager-fedora32.md
+++ b/docs/core/install/linux-package-manager-fedora32.md
@@ -1,0 +1,45 @@
+---
+title: Install .NET Core on Fedora 32 - package manager - .NET Core
+description: Use a package manager to install .NET Core SDK and runtime on Fedora 32.
+author: thraka
+ms.author: adegeo
+ms.date: 04/28/2020
+---
+
+# Fedora 32 Package Manager - Install .NET Core
+
+[!INCLUDE [package-manager-switcher](./includes/package-manager-switcher.md)]
+
+This article describes how to use a package manager to install .NET Core on Fedora 32.
+
+[!INCLUDE [package-manager-intro-sdk-vs-runtime](includes/package-manager-intro-sdk-vs-runtime.md)]
+
+Starting with Fedora 32, .NET Core 3.1 is available in the default package repositories in Fedora.
+
+## Install the .NET Core SDK
+
+Install the .NET Core SDK. In your terminal, run the following command.
+
+```bash
+sudo dnf install dotnet-sdk-3.1
+```
+
+## Install the ASP.NET Core runtime
+
+Install the ASP.NET runtime. In your terminal, run the following command.
+
+```bash
+sudo dnf install aspnetcore-runtime-3.1
+```
+
+## Install the .NET Core runtime
+
+Install the .NET Core runtime. In your terminal, run the following command.
+
+```bash
+sudo dnf install dotnet-runtime-3.1
+```
+
+## How to install other versions
+
+To install other versions of .NET Core, manually install [the .NET Core SDK](sdk.md?pivots=os-linux#download-and-manually-install) or [the .NET Core Runtime](runtime.md?pivots=os-linux#download-and-manually-install).

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -36,6 +36,8 @@
       href: install/linux-package-manager-debian10.md
     - name: Debian 9
       href: install/linux-package-manager-debian9.md
+    - name: Fedora 32
+      href: install/linux-package-manager-fedora32.md
     - name: Fedora 31
       href: install/linux-package-manager-fedora31.md
     - name: Fedora 30


### PR DESCRIPTION
This is based off the existing instructions for Fedora 31, with a few changes:

- .NET Core (3.1) packages are part of the default package repositories in Fedora 32. No extra repositories need to be enabled to be able to install .NET Core 3.1.

- Only 3.1 is available in the Fedora package repositories. So I added a comment suggesting users to install other SDK/Runtime versions manually. The other versions need to be a manual install because mixing dotnet packages from package repositories is a bad idea. For example, it might pull down sdk bits built by Microsoft but everything else built by Fedora. And that doesn't work: https://github.com/dotnet/core/issues/4605

- The package manager troubleshooting comments are all specific to the Microsoft repository. So I didn't add them here.

Fixes: #18038