### PR TITLE
Add install instructions for CentOS 8

### DIFF
--- a/docs/core/install/linux-package-manager-centos8.md
+++ b/docs/core/install/linux-package-manager-centos8.md
@@ -16,7 +16,7 @@ This article describes how to use a package manager to install .NET Core on Cent
 
 ## Install the .NET Core SDK
 
-In your terminal, run the following commands.
+In your terminal, run the following command.
 
 ```bash
 sudo dnf install dotnet-sdk-3.1
@@ -24,7 +24,7 @@ sudo dnf install dotnet-sdk-3.1
 
 ## Install the ASP.NET Core Runtime
 
-In your terminal, run the following commands.
+In your terminal, run the following command.
 
 ```bash
 sudo dnf install aspnetcore-runtime-3.1
@@ -32,7 +32,7 @@ sudo dnf install aspnetcore-runtime-3.1
 
 ## Install the .NET Core Runtime
 
-In your terminal, run the following commands.
+In your terminal, run the following command.
 
 ```bash
 sudo dnf install dotnet-runtime-3.1

--- a/docs/core/install/linux-package-manager-centos8.md
+++ b/docs/core/install/linux-package-manager-centos8.md
@@ -1,0 +1,43 @@
+---
+title: Install .NET Core on Linux CentOS 8 package manager - .NET Core
+description: Use a package manager to install .NET Core SDK and runtime on CentOS 8.
+author: thraka
+ms.author: adegeo
+ms.date: 05/01/2020
+---
+
+# CentOS 8 Package Manager - Install .NET Core
+
+[!INCLUDE [package-manager-switcher](includes/package-manager-switcher.md)]
+
+This article describes how to use a package manager to install .NET Core on CentOS 8.
+
+[!INCLUDE [package-manager-intro-sdk-vs-runtime](includes/package-manager-intro-sdk-vs-runtime.md)]
+
+## Install the .NET Core SDK
+
+In your terminal, run the following commands.
+
+```bash
+sudo dnf install dotnet-sdk-3.1
+```
+
+## Install the ASP.NET Core Runtime
+
+In your terminal, run the following commands.
+
+```bash
+sudo dnf install aspnetcore-runtime-3.1
+```
+
+## Install the .NET Core Runtime
+
+In your terminal, run the following commands.
+
+```bash
+sudo dnf install dotnet-runtime-3.1
+```
+
+## How to install other versions
+
+[!INCLUDE [package-manager-switcher](./includes/package-manager-heading-hack-pkgname.md)]

--- a/docs/core/install/linux-package-manager-rhel8.md
+++ b/docs/core/install/linux-package-manager-rhel8.md
@@ -20,7 +20,7 @@ To install .NET Core from Red Hat on RHEL, you first need to register using the 
 
 ## Install the .NET Core SDK
 
-After registering with the Subscription Manager, you're ready to install and enable the .NET Core SDK. In your terminal, run the following commands.
+After registering with the Subscription Manager, you're ready to install and enable the .NET Core SDK. In your terminal, run the following command.
 
 ```bash
 sudo dnf install dotnet-sdk-3.1
@@ -28,7 +28,7 @@ sudo dnf install dotnet-sdk-3.1
 
 ## Install the ASP.NET Core Runtime
 
-After registering with the Subscription Manager, you're ready to install and enable the ASP.NET Core Runtime. In your terminal, run the following commands.
+After registering with the Subscription Manager, you're ready to install and enable the ASP.NET Core Runtime. In your terminal, run the following command.
 
 ```bash
 sudo dnf install aspnetcore-runtime-3.1
@@ -36,7 +36,7 @@ sudo dnf install aspnetcore-runtime-3.1
 
 ## Install the .NET Core Runtime
 
-After registering with the Subscription Manager, you're ready to install and enable the .NET Core Runtime. In your terminal, run the following commands.
+After registering with the Subscription Manager, you're ready to install and enable the .NET Core Runtime. In your terminal, run the following command.
 
 ```bash
 sudo dnf install dotnet-runtime-3.1

--- a/docs/core/install/linux-package-manager-rhel8.md
+++ b/docs/core/install/linux-package-manager-rhel8.md
@@ -3,14 +3,14 @@ title: Install .NET Core on Linux RHEL 8 package manager - .NET Core
 description: Use a package manager to install .NET Core SDK and runtime on RHEL 8.
 author: thraka
 ms.author: adegeo
-ms.date: 03/17/2020
+ms.date: 05/01/2020
 ---
 
 # RHEL 8 Package Manager - Install .NET Core
 
 [!INCLUDE [package-manager-switcher](includes/package-manager-switcher.md)]
 
-This article describes how to use a package manager to install .NET Core on RHEL 8.
+This article describes how to use a package manager to install .NET Core on Red Hat Enterprise Linux (RHEL) 8.
 
 [!INCLUDE [package-manager-intro-sdk-vs-runtime](includes/package-manager-intro-sdk-vs-runtime.md)]
 
@@ -23,7 +23,6 @@ To install .NET Core from Red Hat on RHEL, you first need to register using the 
 After registering with the Subscription Manager, you're ready to install and enable the .NET Core SDK. In your terminal, run the following commands.
 
 ```bash
-sudo dnf update
 sudo dnf install dotnet-sdk-3.1
 ```
 
@@ -32,7 +31,6 @@ sudo dnf install dotnet-sdk-3.1
 After registering with the Subscription Manager, you're ready to install and enable the ASP.NET Core Runtime. In your terminal, run the following commands.
 
 ```bash
-sudo dnf update
 sudo dnf install aspnetcore-runtime-3.1
 ```
 
@@ -41,9 +39,12 @@ sudo dnf install aspnetcore-runtime-3.1
 After registering with the Subscription Manager, you're ready to install and enable the .NET Core Runtime. In your terminal, run the following commands.
 
 ```bash
-sudo dnf update
 sudo dnf install dotnet-runtime-3.1
 ```
+
+## How to install other versions
+
+[!INCLUDE [package-manager-switcher](./includes/package-manager-heading-hack-pkgname.md)]
 
 ## See also
 


### PR DESCRIPTION
This is basically the exact same set of instructions as RHEL 8, with the steps for registration and links to official RHEL docs removed.

Fixes: #18019