### PR TITLE
Update dotnet-remove-reference.md

### DIFF
--- a/docs/core/tools/dotnet-remove-reference.md
+++ b/docs/core/tools/dotnet-remove-reference.md
@@ -9,12 +9,13 @@ ms.date: 02/14/2020
 
 ## Name
 
-`dotnet remove reference` - Removes project-to-project references.
+`dotnet remove reference` - Removes project-to-project (P2P) references.
 
 ## Synopsis
 
 ```dotnetcli
-dotnet remove [<PROJECT>] reference [-f|--framework <FRAMEWORK>] <PROJECT_REFERENCES>
+dotnet remove [<PROJECT>] reference [-f|--framework <FRAMEWORK>]
+     <PROJECT_REFERENCES>
 
 dotnet remove reference -h|--help
 ```
@@ -41,7 +42,7 @@ Project-to-project (P2P) references to remove. You can specify one or multiple p
 
 - **`-f|--framework <FRAMEWORK>`**
 
-  Removes the reference only when targeting a specific [framework](../../standard/frameworks.md).
+  Removes the reference only when targeting a specific [framework](../../standard/frameworks.md) using the TFM format.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Add (P2P)  in the primary description to be consistent with the add references documentation.  Moved <PROJECT_REFERENCES> to the second line also to be consistent with the other documentation (and fit better on narrower screens).  Clarified the TFM format for the framework.
