### PR TITLE
Update labeling rules

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -189,7 +189,7 @@
       },
       "processor-conditional": {
         "type": "query",
-        "value": "PullRequest.base.ref == 'master'",
+        "value": "PullRequest.base.ref != 'live'",
         "processors": {
           "processor-files": {
             "changedfile": {


### PR DESCRIPTION
@Thraka would this work? I've noticed that label doesn't work on PRs when targeting release branches