### PR TITLE
Replace legacy Code Gallery links with Samples browser

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -114,7 +114,7 @@ For a class library that you implemented, you shouldn't use extension methods to
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Parallel Programming Samples (these include many example extension methods)](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)
+- [Parallel Programming Samples (these include many example extension methods)](/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)
 - [Lambda Expressions](../statements-expressions-operators/lambda-expressions.md)
 - [Standard Query Operators Overview](../concepts/linq/standard-query-operators-overview.md)
 - [Conversion rules for Instance parameters and their impact](https://docs.microsoft.com/archive/blogs/sreekarc/conversion-rules-for-instance-parameters-and-their-impact)

--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -114,7 +114,7 @@ For a class library that you implemented, you shouldn't use extension methods to
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Parallel Programming Samples (these include many example extension methods)](https://code.msdn.microsoft.com/Samples-for-Parallel-b4b76364)
+- [Parallel Programming Samples (these include many example extension methods)](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)
 - [Lambda Expressions](../statements-expressions-operators/lambda-expressions.md)
 - [Standard Query Operators Overview](../concepts/linq/standard-query-operators-overview.md)
 - [Conversion rules for Instance parameters and their impact](https://docs.microsoft.com/archive/blogs/sreekarc/conversion-rules-for-instance-parameters-and-their-impact)

--- a/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
+++ b/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
@@ -16,7 +16,7 @@ The following resources contain additional information about parallel programmin
 
 - The [Parallel Programming with .NET](https://devblogs.microsoft.com/pfxteam/) blog contains many in-depth articles about parallel programming in .NET.
 
-- The [Samples for Parallel Programming with the .NET Core & .NET Standard](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel) page contains many samples that demonstrate intermediate and advanced parallel programming techniques.
+- The [Samples for Parallel Programming with the .NET Core & .NET Standard](/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel) page contains many samples that demonstrate intermediate and advanced parallel programming techniques.
 
 ## See also
 

--- a/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
+++ b/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
@@ -16,7 +16,7 @@ The following resources contain additional information about parallel programmin
 
 - The [Parallel Programming with .NET](https://devblogs.microsoft.com/pfxteam/) blog contains many in-depth articles about parallel programming in .NET.
 
-- The [Samples for Parallel Programming with the .NET Framework](https://code.msdn.microsoft.com/ParExtSamples) page contains many samples that demonstrate intermediate and advanced parallel programming techniques.
+- The [Samples for Parallel Programming with the .NET Core & .NET Standard](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel) page contains many samples that demonstrate intermediate and advanced parallel programming techniques.
 
 ## See also
 

--- a/docs/standard/parallel-programming/task-based-asynchronous-programming.md
+++ b/docs/standard/parallel-programming/task-based-asynchronous-programming.md
@@ -284,4 +284,4 @@ If you must inherit from <xref:System.Threading.Tasks.Task> or <xref:System.Thre
 ## See also
 
 - [Parallel Programming](../../../docs/standard/parallel-programming/index.md)
-- [Samples for Parallel Programming with the .NET Framework](https://code.msdn.microsoft.com/Samples-for-Parallel-b4b76364)
+- [Samples for Parallel Programming with the .NET Core & .NET Standard](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)

--- a/docs/standard/parallel-programming/task-based-asynchronous-programming.md
+++ b/docs/standard/parallel-programming/task-based-asynchronous-programming.md
@@ -284,4 +284,4 @@ If you must inherit from <xref:System.Threading.Tasks.Task> or <xref:System.Thre
 ## See also
 
 - [Parallel Programming](../../../docs/standard/parallel-programming/index.md)
-- [Samples for Parallel Programming with the .NET Core & .NET Standard](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)
+- [Samples for Parallel Programming with the .NET Core & .NET Standard](/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)

--- a/docs/standard/parallel-programming/task-parallel-library-tpl.md
+++ b/docs/standard/parallel-programming/task-parallel-library-tpl.md
@@ -27,4 +27,4 @@ The Task Parallel Library (TPL) is a set of public types and APIs in the <xref:S
   
 ## See also
 
-- [Samples for Parallel Programming with the .NET Core & .NET Standard](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)
+- [Samples for Parallel Programming with the .NET Core & .NET Standard](/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)

--- a/docs/standard/parallel-programming/task-parallel-library-tpl.md
+++ b/docs/standard/parallel-programming/task-parallel-library-tpl.md
@@ -27,4 +27,4 @@ The Task Parallel Library (TPL) is a set of public types and APIs in the <xref:S
   
 ## See also
 
-- [Samples for Parallel Programming with the .NET Framework](https://code.msdn.microsoft.com/Samples-for-Parallel-b4b76364)
+- [Samples for Parallel Programming with the .NET Core & .NET Standard](~/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)

--- a/docs/standard/parallel-programming/tpl-and-traditional-async-programming.md
+++ b/docs/standard/parallel-programming/tpl-and-traditional-async-programming.md
@@ -109,7 +109,7 @@ The .NET Framework provides the following two standard patterns for performing I
  [!code-vb[FromAsync#09](../../../samples/snippets/visualbasic/VS_Snippets_Misc/fromasync/vb/module1.vb#09)]  
   
 ## Using the StreamExtensions Sample Code  
- The *StreamExtensions.cs* file, in the [.NET Standard parallel extensions extras](~/samples/dotnet/samples/parallel-programming-extensions-extras-cs/) repository, contains several reference implementations that use `Task` objects for asynchronous file and network I/O.
+ The *StreamExtensions.cs* file, in the [.NET Standard parallel extensions extras](/samples/dotnet/samples/parallel-programming-extensions-extras-cs/) repository, contains several reference implementations that use `Task` objects for asynchronous file and network I/O.
   
 ## See also
 

--- a/docs/standard/parallel-programming/tpl-and-traditional-async-programming.md
+++ b/docs/standard/parallel-programming/tpl-and-traditional-async-programming.md
@@ -109,7 +109,7 @@ The .NET Framework provides the following two standard patterns for performing I
  [!code-vb[FromAsync#09](../../../samples/snippets/visualbasic/VS_Snippets_Misc/fromasync/vb/module1.vb#09)]  
   
 ## Using the StreamExtensions Sample Code  
- The Streamextensions.cs file, in [Samples for Parallel Programming with the .NET Framework 4](https://code.msdn.microsoft.com/ParExtSamples), contains several reference implementations that use Task objects for asynchronous file and network I/O.  
+ The *StreamExtensions.cs* file, in the [.NET Standard parallel extensions extras](~/samples/dotnet/samples/parallel-programming-extensions-extras-cs/) repository, contains several reference implementations that use `Task` objects for asynchronous file and network I/O.
   
 ## See also
 


### PR DESCRIPTION
## Summary

Replace legacy Code Gallery links with Samples browser

Fixes #17342, part of #13649
