### PR TITLE
Add note about interactions in operators

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -132,6 +132,9 @@ In the preceding example, if you don't use the `??` operator, `numbers?.Length <
 
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
+> [!NOTE]
+> The null conditional operators can interact with the [null forgiving operator](null-forgiving.md) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+
 ### Thread-safe delegate invocation
 
 Use the `?.` operator to check if a delegate is non-null and invoke it in a thread-safe way (for example, when you [raise an event](../../../standard/events/how-to-raise-and-consume-events.md)), as the following code shows:

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -133,7 +133,7 @@ In the preceding example, if you don't use the `??` operator, `numbers?.Length <
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 > [!NOTE]
-> In C# 8, the null-conditional operators can interact with the [null-forgiving operator](null-forgiving.md) in unexpected ways. For example, the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation, `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
+> In C# 8, the null-conditional operators interacts with the [null-forgiving operator](null-forgiving.md) in an unexpected way. For example, the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation, `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
 
 ### Thread-safe delegate invocation
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -133,7 +133,7 @@ In the preceding example, if you don't use the `??` operator, `numbers?.Length <
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 > [!NOTE]
-> The null conditional operators can interact with the [null forgiving operator](null-forgiving.md) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+> The null-conditional operators can interact with the [null-forgiving-operator](null-forgiving.md) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
 
 ### Thread-safe delegate invocation
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -133,7 +133,7 @@ In the preceding example, if you don't use the `??` operator, `numbers?.Length <
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 > [!NOTE]
-> The null-conditional operators can interact with the [null-forgiving operator](null-forgiving.md) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+> In C# 8, the null-conditional operators can interact with the [null-forgiving operator](null-forgiving.md) in unexpected ways. For example, the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation, `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
 
 ### Thread-safe delegate invocation
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -133,7 +133,7 @@ In the preceding example, if you don't use the `??` operator, `numbers?.Length <
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 > [!NOTE]
-> The null-conditional operators can interact with the [null-forgiving-operator](null-forgiving.md) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+> The null-conditional operators can interact with the [null-forgiving operator](null-forgiving.md) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
 
 ### Thread-safe delegate invocation
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -14,7 +14,7 @@ Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiv
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
 > [!NOTE]
-> The null-forgiving operator can interact with the [null-conditional operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+> In C# 8 the null-forgiving operator can interact with the [null-conditional operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. The expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
 
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -13,6 +13,9 @@ Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiv
 
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
+> [!NOTE]
+> The null forgiving operator can interact with the [null conditional operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 
 ## Examples

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -14,7 +14,7 @@ Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiv
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
 > [!NOTE]
-> The null-forgiving operator can interact with the [null-conditional-operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+> The null-forgiving operator can interact with the [null-conditional operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
 
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -14,7 +14,7 @@ Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiv
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
 > [!NOTE]
-> The null forgiving operator can interact with the [null conditional operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
+> The null-forgiving operator can interact with the [null-conditional-operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. In C# 8 the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is null, which may result in a <xref:System.NullReferenceException>.
 
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -14,7 +14,7 @@ Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiv
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
 > [!NOTE]
-> In C# 8 the null-forgiving operator can interact with the [null-conditional operators](member-access-operators.md#null-conditional-operators--and-) in unexpected ways. The expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
+> In C# 8 the null-forgiving operator interacts with the [null-conditional operators](member-access-operators.md#null-conditional-operators--and-) in an unexpected way. The expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
 
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 


### PR DESCRIPTION
Fixes #17988.  See https://github.com/dotnet/docs/issues/17988#issuecomment-620310292

The null conditional operators and null forgiving operators interact in interesting ways. Add notes on both pages to explain those interactions.
