### PR TITLE
Document the SignalR MessagePack Hub Protocol options type change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -12,6 +12,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
 - [Extensions: Package reference changes affecting some NuGet packages](#extensions-package-reference-changes-affecting-some-nuget-packages)
 - [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
+- [SignalR: MessagePack Hub Protocol options type changed](#signalr-messagepack-hub-protocol-options-type-changed)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
 - [Static files: CSV content type changed to standards-compliant](#static-files-csv-content-type-changed-to-standards-compliant)
 
@@ -24,6 +25,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ***
 
 [!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
+
+***
+
+[!INCLUDE[SignalR: MessagePack Hub Protocol options type changed](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-hub-protocol-options-changed.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -62,6 +62,7 @@ The following breaking changes are documented on this page:
 - [SignalR: HubConnectionContext constructors changed](#signalr-hubconnectioncontext-constructors-changed)
 - [SignalR: JavaScript client package name change](#signalr-javascript-client-package-name-changed)
 - [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
+- [SignalR: MessagePack Hub Protocol options type changed](#signalr-messagepack-hub-protocol-options-type-changed)
 - [SignalR: Obsolete APIs](#signalr-usesignalr-and-useconnections-methods-marked-obsolete)
 - [SignalR: UseSignalR and UseConnections methods removed](#signalr-usesignalr-and-useconnections-methods-removed)
 - [SPAs: SpaServices and NodeServices console logger fallback default change](#spas-spaservices-and-nodeservices-no-longer-fall-back-to-console-logger)
@@ -80,6 +81,10 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE[SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-package.md)]
+
+***
+
+[!INCLUDE[SignalR: MessagePack Hub Protocol options type changed](~/includes/core-changes/aspnetcore/5.0/signalr-messagepack-hub-protocol-options-changed.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/5.0/signalr-messagepack-hub-protocol-options-changed.md
+++ b/includes/core-changes/aspnetcore/5.0/signalr-messagepack-hub-protocol-options-changed.md
@@ -1,0 +1,84 @@
+### SignalR: MessagePack Hub Protocol options type changed
+
+The ASP.NET Core SignalR MessagePack Hub Protocol options type has changed from `IList<MessagePack.IFormatterResolver>` to the [MessagePack](https://www.nuget.org/packages/MessagePack) library's `MessagePackSerializerOptions` type.
+
+For discussion on this change, see [dotnet/aspnetcore#20506](https://github.com/dotnet/aspnetcore/issues/20506).
+
+#### Version introduced
+
+5.0 Preview 4
+
+#### Old behavior
+
+You can add to the options as shown in the following example:
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.FormatterResolvers.Add(MessagePack.Resolvers.StandardResolver.Instance);
+    });
+```
+
+And replace the options as follows:
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.FormatterResolvers = new List<MessagePack.IFormatterResolver>()
+        {
+            MessagePack.Resolvers.StandardResolver.Instance
+        };
+    });
+```
+
+#### New behavior
+
+You can add to the options as shown in the following example:
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.SerializerOptions =
+            options.SerializeOptions.WithResolver(MessagePack.Resolvers.StandardResolver.Instance);
+    });
+```
+
+And replace the options as follows:
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.SerializerOptions = MessagePackSerializerOptions
+                .Standard
+                .WithResolver(MessagePack.Resolvers.StandardResolver.Instance)
+                .WithSecurity(MessagePackSecurity.UntrustedData);
+    });
+```
+
+#### Reason for change
+
+This change is part of moving to MessagePack v2.x, which was announced in [aspnet/Announcements#404](https://github.com/aspnet/Announcements/issues/404). The v2.x library has added an options API that's easier to use and provides more features than the list of `MessagePack.IFormatterResolver` that was exposed before.
+
+#### Recommended action
+
+This breaking change affects anyone who is configuring values on <xref:Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions>. If you're using the ASP.NET Core SignalR MessagePack Hub Protocol and modifying the options, update your usage to use the new options API as shown above.
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+<xref:Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions?displayProperty=nameWithType>
+
+<!--
+
+#### Affected APIs
+
+`T:Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions`
+
+-->


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/413.