### PR TITLE
Correct .NET Core SDK and CLI overview links

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -106,10 +106,10 @@ conceptualContent:
     - title: Develop .NET apps
       summary: Start developing with .NET
       links:
-        - url: core/sdk.md
+        - url: https://dotnet.microsoft.com/download
           itemType: download
           text: Download the .NET Core SDK
-        - url: https://dotnet.microsoft.com/download
+        - url: core/sdk.md
           itemType: overview
           text: .NET Core CLI overview
         - url: core/porting/index.md


### PR DESCRIPTION
These had gotten swapped somehow.

cc @mairaw 