### PR TITLE
Fix link to .NET Core CLI overview

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -109,7 +109,7 @@ conceptualContent:
         - url: https://dotnet.microsoft.com/download
           itemType: download
           text: Download the .NET Core SDK
-        - url: core/sdk.md
+        - url: core/tools/index.md
           itemType: overview
           text: .NET Core CLI overview
         - url: core/porting/index.md

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -106,7 +106,7 @@ conceptualContent:
     - title: Develop .NET apps
       summary: Start developing with .NET
       links:
-        - url: https://dotnet.microsoft.com/download
+        - url: core/sdk.md
           itemType: download
           text: Download the .NET Core SDK
         - url: core/tools/index.md


### PR DESCRIPTION
Introduced by #18024 and #18158 by mistake.