### PR TITLE
Removed L2 nav header from docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -118,7 +118,7 @@
       "author": "dotnet-bot",
       "ms.author": "dotnetcontent",
       "searchScope": [".NET"],
-      "uhfHeaderId": "MSDocsHeader-DotNet",
+      "uhfHeaderId": [],
       "apiPlatform": "dotnet",
       "ms.prod":"dotnet",
       "ms.topic": "conceptual",


### PR DESCRIPTION
[Internal Review - Verify Layer 2 navigation header removed](https://review.docs.microsoft.com/en-us/dotnet/core/introduction?branch=pr-en-us-18164)

Fixes #18011       
As final step after prep work was completed earlier.

Removed L2 nav header from docfx.json

