### PR TITLE
Update hub page heading

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -255,8 +255,8 @@ additionalContent:
           - url: https://www.nuget.org/packages/System.Device.Gpio
             text: System.Device.Gpio NuGet package
 
-    - title: API reference sections # < 60 chars (optional)
-      summary: Search the .NET API reference documentation, scoped to your interest. # < 160 chars (optional)
+    - title: API and language reference # < 60 chars (optional)
+      summary: Search the .NET API and language reference documentation. # < 160 chars (optional)
       items:
         # Card
       - title: ".NET Core API reference"


### PR DESCRIPTION
The section was called API reference, but it has language reference cards.