### PR TITLE
Fixed snippets and added behaviors to address WCF article issue

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CFX/c_howto_hostiniis/common/web.config
+++ b/samples/snippets/csharp/VS_Snippets_CFX/c_howto_hostiniis/common/web.config
@@ -19,7 +19,7 @@
 
     <behaviors>
       <serviceBehaviors>
-        <behavior name="CalculatorServiceBehaviors" >
+        <behavior name="CalculatorServiceBehaviors">
           <!-- Add the following element to your service behavior configuration. -->
           <serviceMetadata httpGetEnabled="true" />
         </behavior>

--- a/samples/snippets/csharp/VS_Snippets_CFX/c_howto_hostiniis/common/web.config
+++ b/samples/snippets/csharp/VS_Snippets_CFX/c_howto_hostiniis/common/web.config
@@ -1,24 +1,31 @@
 <!-- <snippet100> -->
-
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.serviceModel>
     <services>
-      <service name="Microsoft.ServiceModel.Samples.CalculatorService">
+      <service name="Microsoft.ServiceModel.Samples.CalculatorService" behaviorConfiguration="CalculatorServiceBehaviors">
 
         <!-- This endpoint is exposed at the base address provided by host: http://localhost/servicemodelsamples/service.svc -->
         <endpoint address=""
                   binding="wsHttpBinding"
                   contract="Microsoft.ServiceModel.Samples.ICalculator" />
 
-        <!-- The mex endpoint is explosed at http://localhost/servicemodelsamples/service.svc/mex -->
+        <!-- The mex endpoint is exposed at http://localhost/servicemodelsamples/service.svc/mex -->
         <endpoint address="mex"
                   binding="mexHttpBinding"
                   contract="IMetadataExchange" />
       </service>
     </services>
+
+    <behaviors>
+      <serviceBehaviors>
+        <behavior name="CalculatorServiceBehaviors" >
+          <!-- Add the following element to your service behavior configuration. -->
+          <serviceMetadata httpGetEnabled="true" />
+        </behavior>
+      </serviceBehaviors>
+    </behaviors>
   </system.serviceModel>
 
 </configuration>
-
 <!-- </snippet100> -->

--- a/samples/snippets/csharp/VS_Snippets_CFX/c_howto_hostiniis/cs/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/c_howto_hostiniis/cs/source.cs
@@ -43,14 +43,6 @@ namespace Microsoft.ServiceModel.Samples
         return n1 / n2;
      }
   }
-
     //</snippet12>
-//</snippet1>
-
-    public class Test
-    {
-        public static void Main()
-        {
-        }
-    }
 }
+//</snippet1>


### PR DESCRIPTION
Fixes #12247

The first issues is the snippets were in the wrong places.  This inserted a blank line at the start of the config file that casused an error and also hid a closing brace in the full sample code causing another error for anyone who copied and pasted, so I fixed both of those.  I also fixed a typo in the comments.

Second problem was that you need a behavior defined in the config file to be able to hit the page for the metadata service.  Without this an error is thrown.  So I added the appropriate behavior config.  I verified this sample works