### PR TITLE
Improve wording regarding interaction of null-forgiving and null-conditional operators

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -133,7 +133,7 @@ In the preceding example, if you don't use the `??` operator, `numbers?.Length <
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 > [!NOTE]
-> In C# 8, the null-conditional operators interacts with the [null-forgiving operator](null-forgiving.md) in an unexpected way. For example, the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation, `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
+> In C# 8, the [null-forgiving operator](null-forgiving.md) terminates the list of preceding null-conditional operations. For example, the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation, `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
 
 ### Thread-safe delegate invocation
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -14,7 +14,7 @@ Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiv
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
 > [!NOTE]
-> In C# 8 the null-forgiving operator interacts with the [null-conditional operators](member-access-operators.md#null-conditional-operators--and-) in an unexpected way. The expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
+> In C# 8, the null-forgiving operator terminates the list of preceding [null-conditional](member-access-operators.md#null-conditional-operators--and-) operations. For example, the expression `x?.y!.z` is parsed as `(x?.y)!.z`. Due to this interpretation, `z` is evaluated even if `x` is `null`, which may result in a <xref:System.NullReferenceException>.
 
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 


### PR DESCRIPTION
Changes are described in these two comments:
https://github.com/dotnet/docs/pull/18124#discussion_r417651475
https://github.com/dotnet/docs/pull/18124#discussion_r417653229

The content of both notes is identical except for the link location.