### PR TITLE
Add callout about existing object pool type and clean up C# bits

### DIFF
--- a/docs/standard/collections/thread-safe/how-to-create-an-object-pool.md
+++ b/docs/standard/collections/thread-safe/how-to-create-an-object-pool.md
@@ -1,6 +1,6 @@
 ---
 title: "Create an object pool by using a ConcurrentBag"
-ms.date: 04/30/2020
+ms.date: 05/01/2020
 ms.technology: dotnet-standard
 dev_langs:
   - "csharp"

--- a/docs/standard/collections/thread-safe/how-to-create-an-object-pool.md
+++ b/docs/standard/collections/thread-safe/how-to-create-an-object-pool.md
@@ -1,23 +1,29 @@
 ---
-title: "How to: Create an Object Pool by Using a ConcurrentBag"
-ms.date: "03/30/2017"
+title: "Create an object pool by using a ConcurrentBag"
+ms.date: 04/30/2020
 ms.technology: dotnet-standard
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "object pool, in .NET Framework"
 ms.assetid: 0480e7ff-b6f9-480e-a889-2ed4264d8372
 ---
-# How to: Create an Object Pool by Using a ConcurrentBag
-This example shows how to use a concurrent bag to implement an object pool. Object pools can improve application performance in situations where you require multiple instances of a class and the class is expensive to create or destroy. When a client program requests a new object, the object pool first attempts to provide one that has already been created and returned to the pool. If none is available, only then is a new object created.  
-  
- <xref:System.Collections.Concurrent.ConcurrentBag%601> is used to store the objects because it supports fast insertion and removal, especially when the same thread is both adding and removing items. This example could be further augmented to be built around a <xref:System.Collections.Concurrent.IProducerConsumerCollection%601>, which the bag data structure implements, as do <xref:System.Collections.Concurrent.ConcurrentQueue%601> and <xref:System.Collections.Concurrent.ConcurrentStack%601>.  
-  
-## Example  
- [!code-csharp[CDS#04](../../../../samples/snippets/csharp/VS_Snippets_Misc/cds/cs/objectpool.cs#04)]
- [!code-vb[CDS#04](../../../../samples/snippets/visualbasic/VS_Snippets_Misc/cds/vb/objectpool04.vb#04)]  
-  
+
+# Create an object pool by using a ConcurrentBag
+
+This example shows how to use a <xref:System.Collections.Concurrent.ConcurrentBag%601> to implement an object pool. Object pools can improve application performance in situations where you require multiple instances of a class and the class is expensive to create or destroy. When a client program requests a new object, the object pool first attempts to provide one that has already been created and returned to the pool. If none is available, only then is a new object created.
+
+The <xref:System.Collections.Concurrent.ConcurrentBag%601> is used to store the objects because it supports fast insertion and removal, especially when the same thread is both adding and removing items. This example could be further augmented to be built around a <xref:System.Collections.Concurrent.IProducerConsumerCollection%601>, which the bag data structure implements, as do <xref:System.Collections.Concurrent.ConcurrentQueue%601> and <xref:System.Collections.Concurrent.ConcurrentStack%601>.
+
+> [!TIP]
+> This article defines how to write your own implementation of an object pool with an underlying concurrent type to store objects for reuse. However, the <xref:Microsoft.Extensions.ObjectPool.ObjectPool%601?displayProperty=nameWithType> type already exists under the <xref:Microsoft.Extensions.ObjectPool?displayProperty=fullName> namespace. Consider using the available type before creating your own implementation, which includes many additional features.
+
+## Example
+
+[!code-csharp[CDS#04](../../../../samples/snippets/csharp/VS_Snippets_Misc/cds/cs/objectpool.cs#04)]
+[!code-vb[CDS#04](../../../../samples/snippets/visualbasic/VS_Snippets_Misc/cds/vb/objectpool04.vb#04)]
+
 ## See also
 
 - [Thread-Safe Collections](../../../../docs/standard/collections/thread-safe/index.md)

--- a/samples/snippets/csharp/VS_Snippets_Misc/cds/cs/objectpool.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cds/cs/objectpool.cs
@@ -8,79 +8,75 @@ namespace ObjectPoolExample
 {
     public class ObjectPool<T>
     {
-        private ConcurrentBag<T> _objects;
-        private Func<T> _objectGenerator;
+        private readonly ConcurrentBag<T> _objects;
+        private readonly Func<T> _objectGenerator;
 
         public ObjectPool(Func<T> objectGenerator)
         {
-            if (objectGenerator == null) throw new ArgumentNullException("objectGenerator");
             _objects = new ConcurrentBag<T>();
-            _objectGenerator = objectGenerator;
+            _objectGenerator = objectGenerator ?? throw new ArgumentNullException(nameof(objectGenerator));
         }
 
-        public T GetObject()
-        {
-            T item;
-            if (_objects.TryTake(out item)) return item;
-            return _objectGenerator();
-        }
+        public T Get() => _objects.TryTake(out T item) ? item : _objectGenerator();
 
-        public void PutObject(T item)
-        {
-            _objects.Add(item);
-        }
+        public void Return(T item) => _objects.Add(item);
     }
 
     class Program
     {
-       static void Main(string[] args)
+        static void Main(string[] args)
         {
-            CancellationTokenSource cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
 
             // Create an opportunity for the user to cancel.
             Task.Run(() =>
+            {
+                if (Console.ReadKey().KeyChar == 'c' || Console.ReadKey().KeyChar == 'C')
                 {
-                    if (Console.ReadKey().KeyChar == 'c' || Console.ReadKey().KeyChar == 'C')
-                        cts.Cancel();
-                });
+                    cts.Cancel();
+                }
+            });
 
-            ObjectPool<MyClass> pool = new ObjectPool<MyClass> (() => new MyClass());
+            var pool = new ObjectPool<ExampleObject>(() => new ExampleObject());
 
             // Create a high demand for MyClass objects.
             Parallel.For(0, 1000000, (i, loopState) =>
-                {
-                    MyClass mc = pool.GetObject();
-                    Console.CursorLeft = 0;
-                    // This is the bottleneck in our application. All threads in this loop
-                    // must serialize their access to the static Console class.
-                    Console.WriteLine("{0:####.####}", mc.GetValue(i));
+            {
+                var mc = pool.Get();
+                Console.CursorLeft = 0;
+                // This is the bottleneck in our application. All threads in this loop
+                // must serialize their access to the static Console class.
+                Console.WriteLine("{0:####.####}", mc.GetValue(i));
 
-                    pool.PutObject(mc);
-                    if (cts.Token.IsCancellationRequested)
-                        loopState.Stop();
-                });
+                pool.Return(mc);
+                if (cts.Token.IsCancellationRequested)
+                {
+                    loopState.Stop();
+                }
+            });
+
             Console.WriteLine("Press the Enter key to exit.");
             Console.ReadLine();
-            cts.Dispose();
         }
     }
 
     // A toy class that requires some resources to create.
     // You can experiment here to measure the performance of the
     // object pool vs. ordinary instantiation.
-    class MyClass
+    class ExampleObject
     {
-        public int[] Nums {get; set;}
-        public double GetValue(long i)
-        {
-            return Math.Sqrt(Nums[i]);
-        }
-        public MyClass()
+        public int[] Nums { get; set; }
+
+        public double GetValue(long i) => Math.Sqrt(Nums[i]);
+
+        public ExampleObject()
         {
             Nums = new int[1000000];
-            Random rand = new Random();
+            var rand = new Random();
             for (int i = 0; i < Nums.Length; i++)
+            {
                 Nums[i] = rand.Next();
+            }
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_Misc/cds/cs/objectpool.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cds/cs/objectpool.cs
@@ -29,9 +29,9 @@ namespace ObjectPoolExample
             using var cts = new CancellationTokenSource();
 
             // Create an opportunity for the user to cancel.
-            Task.Run(() =>
+            _ = Task.Run(() =>
             {
-                if (Console.ReadKey().KeyChar == 'c' || Console.ReadKey().KeyChar == 'C')
+                if (char.ToUpperInvariant(Console.ReadKey().KeyChar) == 'C')
                 {
                     cts.Cancel();
                 }


### PR DESCRIPTION
## Summary

- Add callout about existing object pool type 
- Clean up C# example source

Fixes #9880
