### PR TITLE
Add `linux-arm64` to the portable RID list

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -111,8 +111,8 @@ Only common values are listed. For the latest and complete version, see the [run
 - Portable (.NET Core 2.0 or later versions)
   - `linux-x64` (Most desktop distributions like CentOS, Debian, Fedora, Ubuntu, and derivatives)
   - `linux-musl-x64` (Lightweight distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) like Alpine Linux)
-  - `linux-arm` (Linux distributions running on ARM like Raspberry Pi)
-  - `linux-arm64` (Linux distributions running on 64-bit ARM like Raspberry Pi Model 4)
+  - `linux-arm` (Linux distributions running on ARM like Raspbian on Raspberry Pi Model 2+)
+  - `linux-arm64` (Linux distributions running on 64-bit ARM like Ubuntu Server 64-bit on Raspberry Pi Model 3+)
 - Red Hat Enterprise Linux
   - `rhel-x64` (Superseded by `linux-x64` for RHEL above version 6)
   - `rhel.6-x64` (.NET Core 2.0 or later versions)

--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -112,6 +112,7 @@ Only common values are listed. For the latest and complete version, see the [run
   - `linux-x64` (Most desktop distributions like CentOS, Debian, Fedora, Ubuntu, and derivatives)
   - `linux-musl-x64` (Lightweight distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) like Alpine Linux)
   - `linux-arm` (Linux distributions running on ARM like Raspberry Pi)
+  - `linux-arm64` (Linux distributions running on 64-bit ARM like Raspberry Pi Model 4)
 - Red Hat Enterprise Linux
   - `rhel-x64` (Superseded by `linux-x64` for RHEL above version 6)
   - `rhel.6-x64` (.NET Core 2.0 or later versions)


### PR DESCRIPTION
Some users seem to be picking a non-portable RID instead. See https://github.com/dotnet/core/issues/4634.

I am not sure if this is 100% correct. Anyone more familiar with RIDs than me?