### PR TITLE
Typo in "Default interface methods" #18227

### DIFF
--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -90,7 +90,7 @@ For more information, see the [`readonly` instance members](../language-referenc
 
 You can now add members to interfaces and provide an implementation for those members. This language feature enables API authors to add methods to an interface in later versions without breaking source or binary compatibility with existing implementations of that interface. Existing implementations *inherit* the default implementation. This feature also enables C# to interoperate with APIs that target Android or Swift, which support similar features. Default interface methods also enable scenarios similar to a "traits" language feature.
 
-Default interface methods affects many scenarios and language elements. Our first tutorial covers [updating an interface with default implementations](../tutorials/default-interface-methods-versions.md). Other tutorials and reference updates are coming in time for general release.
+Default interface methods affect many scenarios and language elements. Our first tutorial covers [updating an interface with default implementations](../tutorials/default-interface-methods-versions.md). Other tutorials and reference updates are coming in time for general release.
 
 ## More patterns in more places
 


### PR DESCRIPTION
Fixed typo.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
