### PR TITLE
Remove reference to "Future" in ML.NET docs

### DIFF
--- a/docs/machine-learning/automate-training-with-cli.md
+++ b/docs/machine-learning/automate-training-with-cli.md
@@ -31,7 +31,10 @@ Currently, the ML Tasks supported by the ML.NET CLI are:
 - `binary-classification`
 - `multiclass-classification`
 - `regression`
-- Future: other machine learning tasks such as `recommendation`, `ranking`, `anomaly-detection`, `clustering`
+- `recommendation`
+- `ranking`
+- `anomaly-detection`
+- `clustering`
 
 Example of usage:
 

--- a/docs/machine-learning/automate-training-with-cli.md
+++ b/docs/machine-learning/automate-training-with-cli.md
@@ -32,9 +32,6 @@ Currently, the ML Tasks supported by the ML.NET CLI are:
 - `multiclass-classification`
 - `regression`
 - `recommendation`
-- `ranking`
-- `anomaly-detection`
-- `clustering`
 
 Example of usage:
 


### PR DESCRIPTION
## Summary
Removed the notion of future in the ML.NET documentation and added them to the list as they are now available.

Fixes #Issue_Number (if available)
https://github.com/dotnet/machinelearning/issues/4886

Preview Link: https://review.docs.microsoft.com/en-us/dotnet/machine-learning/automate-training-with-cli?branch=pr-en-us-18239

