### PR TITLE
Add CentOS 8 to TOC and package-manger switcher

### DIFF
--- a/docs/core/install/includes/package-manager-switcher.md
+++ b/docs/core/install/includes/package-manager-switcher.md
@@ -5,6 +5,7 @@
 > - [Ubuntu 19.04 - x64](../linux-package-manager-ubuntu-1904.md)
 > - [Ubuntu 18.04 - x64](../linux-package-manager-ubuntu-1804.md)
 > - [Ubuntu 16.04 - x64](../linux-package-manager-ubuntu-1604.md)
+> - [CentOS 8 - x64](../linux-package-manager-centos8.md)
 > - [CentOS 7 - x64](../linux-package-manager-centos7.md)
 > - [Debian 10 - x64](../linux-package-manager-debian10.md)
 > - [Debian 9 - x64](../linux-package-manager-debian9.md)

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -32,6 +32,8 @@
       href: install/linux-package-manager-ubuntu-1804.md
     - name: Ubuntu 16.04
       href: install/linux-package-manager-ubuntu-1604.md
+    - name: CentOS 8
+      href: install/linux-package-manager-centos8.md
     - name: CentOS 7
       href: install/linux-package-manager-centos7.md
     - name: Debian 10


### PR DESCRIPTION
This should have been done as part of #18071.

Pointed out by @Mizux  at https://github.com/dotnet/docs/issues/18019#issuecomment-623358936