### PR TITLE
Sales tax typo in csharp-8.md / ComputeSalesTax()

### DIFF
--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -177,7 +177,7 @@ public static decimal ComputeSalesTax(Address location, decimal salePrice) =>
     location switch
     {
         { State: "WA" } => salePrice * 0.06M,
-        { State: "MN" } => salePrice * 0.75M,
+        { State: "MN" } => salePrice * 0.075M,
         { State: "MI" } => salePrice * 0.05M,
         // other cases removed for brevity...
         _ => 0M


### PR DESCRIPTION
# Summary

It's a minor typo of no real importance, as a non-American I was just shocked to see a 75% sales tax.

https://files.taxfoundation.org/20200115132659/State-and-Local-Sales-Tax-Rates-2020.pdf (second page)

https://en.wikipedia.org/wiki/Sales_taxes_in_the_United_States#Minnesota