### PR TITLE
disable MD Lint rule 37

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -36,6 +36,7 @@
     },
     "MD034": false,
     "MD036": false,
+    "MD037": false,
     "MD040": false,
     "MD041": false,
     "MD046": {

--- a/docs/core/dependency-loading/loading-resources.md
+++ b/docs/core/dependency-loading/loading-resources.md
@@ -34,6 +34,7 @@ The .NET Core resource fallback process involves the following steps:
         >
         > [!NOTE]
         > On Linux and macOS, the subdirectory is case-sensitive and must either:
+        >
         > - Exactly match case.
         > - Be in lower case.
 


### PR DESCRIPTION
This rule is generating a number of false positives.

It appears to be whenever a paragraph contains a mix of bold an italic, or a `*` in a code fence.
