### PR TITLE
Pin markdownlint-cli version

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,5 +23,5 @@ jobs:
         node-version: 12.x
     - name: Run Markdownlint
       run: |
-        npm i -g markdownlint-cli
+        npm i -g markdownlint-cli@0.22.0
         markdownlint "**/*.md" -i "samples/**/*.md"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -36,7 +36,6 @@
     },
     "MD034": false,
     "MD036": false,
-    "MD037": false,
     "MD040": false,
     "MD041": false,
     "MD046": {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # .NET Docs
 
+![Markdownlint](https://github.com/dotnet/docs/workflows/Markdownlint/badge.svg)
+
 This repository contains the conceptual documentation for .NET. The [.NET documentation site](https://docs.microsoft.com/dotnet) is built from multiple repositories in addition to this one:
 
 - [Code samples and snippets](https://github.com/dotnet/samples)


### PR DESCRIPTION
## Summary

- Pin markdownlint-cli version to `0.22.0`
- Add markdownlint status badge to *README.md*
- Reinstate markdown lint rule: MD037, removed in #18269

Fixes: #18275