### PR TITLE
add missing global attribs to toc

### DIFF
--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1683,6 +1683,7 @@
     items:
     - name: Global attributes
       displayName: AssemblyName, AssemblyVersion, AssemblyCulture, AssemblyFlags, AssemblyProduct, AssemblyTrademark, AssemblyInformationalVersion, AssemblyCompany, AssemblyCopyright, AssemblyFileVersion, CLSCompliant, AssemblyTitle, AssemblyDescription, AssemblyConfiguration, AssemblyDefaultAlias
+      href: language-reference/attributes/global.md
     - name: General
       displayName: Conditional, Obsolete, AttributeUsage
       href: language-reference/attributes/general.md


### PR DESCRIPTION
## Summary

Add the global.md to the toc for csharp area.

Fixes #18212
