### PR TITLE
Update dotnet-vstest.md

### DIFF
--- a/docs/core/tools/dotnet-vstest.md
+++ b/docs/core/tools/dotnet-vstest.md
@@ -7,7 +7,8 @@ ms.date: 02/27/2020
 
 **This article applies to:** ✔️ .NET Core 2.1 SDK and later versions
 
-> `dotnet vstest` was superseded by `dotnet test` which can now be used to run assemblies. See https://github.com/dotnet/docs/blob/master/docs/core/tools/dotnet-test.md
+> [!IMPORTANT]
+> The `dotnet vstest` command is superseded by `dotnet test`, which can now be used to run assemblies. See [`dotnet test`](dotnet-test.md).
 
 ## Name
 

--- a/docs/core/tools/dotnet-vstest.md
+++ b/docs/core/tools/dotnet-vstest.md
@@ -7,9 +7,11 @@ ms.date: 02/27/2020
 
 **This article applies to:** ✔️ .NET Core 2.1 SDK and later versions
 
+> `dotnet vstest` was superseded by `dotnet test` which can now be used to run assemblies. See https://github.com/dotnet/docs/blob/master/docs/core/tools/dotnet-test.md
+
 ## Name
 
-`dotnet-vstest` - Runs tests from the specified files.
+`dotnet-vstest` - Runs tests from the specified assemblies.
 
 ## Synopsis
 


### PR DESCRIPTION
## Summary

Add notice about dotnet vstest being replaced by dotnet test, but still available.

Fixes #15529
