### PR TITLE
Clarify requirement of virtual keyword (#18277)

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
@@ -10,14 +10,14 @@ ms.assetid: 88247d07-bd0d-49e9-a619-45ccbbfdf0c5
 The C# language is designed so that versioning between [base](../../language-reference/keywords/base.md) and derived classes in different libraries can evolve and maintain backward compatibility. This means, for example, that the introduction of a new member in a base [class](../../language-reference/keywords/class.md) with the same name as a member in a derived class is completely supported by C# and does not lead to unexpected behavior. It also means that a class must explicitly state whether a method is intended to override an inherited method, or whether a method is a new method that hides a similarly named inherited method.  
   
  In C#, derived classes can contain methods with the same name as base class methods.  
-  
-- The base class method must be defined [virtual](../../language-reference/keywords/virtual.md).  
-  
+
 - If the method in the derived class is not preceded by [new](../../language-reference/keywords/new-modifier.md) or [override](../../language-reference/keywords/override.md) keywords, the compiler will issue a warning and the method will behave as if the `new` keyword were present.  
   
 - If the method in the derived class is preceded with the `new` keyword, the method is defined as being independent of the method in the base class.  
   
 - If the method in the derived class is preceded with the `override` keyword, objects of the derived class will call that method instead of the base class method.  
+
+- In order to apply the `override` keyword to the method in the derived class, the base class method must be defined [virtual](../../language-reference/keywords/virtual.md).
   
 - The base class method can be called from within the derived class using the `base` keyword.  
   


### PR DESCRIPTION
Fixes #18277

## Summary

As pointed out in the issue, in the original docs the first statement seems untrue. Explaining the requirement and moving the requirement for the override keyword until after the explanation of how to use it seems clearer.
