### PR TITLE
fix: automate-training-with-cli.md

### DIFF
--- a/docs/machine-learning/automate-training-with-cli.md
+++ b/docs/machine-learning/automate-training-with-cli.md
@@ -41,7 +41,7 @@ mlnet auto-train --task binary-classification --dataset "customer-feedback.tsv" 
 
 ![image](media/automate-training-with-cli/cli-model-generation.gif)
 
-You can run it the same way on *Windows PowerShell*, *macOS/Linux bash, or *Windows CMD*. However, tabular auto-completion (parameter suggestions) won't work on *Windows CMD*.
+You can run it the same way on *Windows PowerShell*, *macOS/Linux bash*, or *Windows CMD*. However, tabular auto-completion (parameter suggestions) won't work on *Windows CMD*.
 
 ## Output assets generated
 


### PR DESCRIPTION
Close emphasis before comma

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)

Related to https://github.com/dotnet/docs/pull/18269#issuecomment-626270342

/cc @DavidAnson