### PR TITLE
Correcting mislabeled slot numbers

### DIFF
--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescdata-method.md
@@ -57,7 +57,7 @@ HRESULT GetMethodDescData(
 
 ## Remarks
 
-The provided method is part of the `ISOSDacInterface` interface and corresponds to the 20th slot of the virtual method table. To be able to use them, [`CLRDATA_ADDRESS`](../common-data-types-unmanaged-api-reference.md) must be defined as a 64-bit unsigned integer.
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 21st slot of the virtual method table. To be able to use them, [`CLRDATA_ADDRESS`](../common-data-types-unmanaged-api-reference.md) must be defined as a 64-bit unsigned integer.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescptrfromip-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescptrfromip-method.md
@@ -41,7 +41,7 @@ HRESULT GetMethodDescPtrFromIP(
 
 ## Remarks
 
-The provided method is part of the [`ISOSDacInterface` interface](isosdacinterface-interface.md) and corresponds to the 21st slot of the virtual method table.
+The provided method is part of the [`ISOSDacInterface` interface](isosdacinterface-interface.md) and corresponds to the 22nd slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmoduledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmoduledata-method.md
@@ -41,7 +41,7 @@ HRESULT GetModuleData(
 
 ## Remarks
 
-The provided method is part of the `ISOSDacInterface` interface and corresponds to the 13th slot of the virtual method table.
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 14th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamethoddefinition-endenuminstances-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamethoddefinition-endenuminstances-method.md
@@ -37,7 +37,7 @@ HRESULT EndEnumInstances(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataMethodDefinition` interface and corresponds to the fifth slot of the virtual method table.
+The provided method is part of the `IXCLRDataMethodDefinition` interface and corresponds to the 7th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamethoddefinition-enuminstance-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamethoddefinition-enuminstance-method.md
@@ -41,7 +41,7 @@ HRESULT EnumInstance(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataMethodDefinition` interface and corresponds to the fourth slot of the virtual method table.
+The provided method is part of the `IXCLRDataMethodDefinition` interface and corresponds to the 6th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamethoddefinition-startenuminstances-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamethoddefinition-startenuminstances-method.md
@@ -41,7 +41,7 @@ HRESULT StartEnumInstances(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataMethodDefinition` interface and corresponds to the third slot of the virtual method table.
+The provided method is part of the `IXCLRDataMethodDefinition` interface and corresponds to the 5th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamethodinstance-getiladdressmap-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamethodinstance-getiladdressmap-method.md
@@ -45,7 +45,7 @@ HRESULT GetILAddressMap(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataMethodInstance` interface and corresponds to the 14th slot of the virtual method table.
+The provided method is part of the `IXCLRDataMethodInstance` interface and corresponds to the 15th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamethodinstance-getrepresentativeentryaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamethodinstance-getrepresentativeentryaddress-method.md
@@ -37,7 +37,7 @@ HRESULT GetRepresentativeEntryAddress(
 
 ## Remarks
 
-The provided method is part of the [`IXCLRDataMethodInstance` interface](ixclrdatamethodinstance-interface.md) and corresponds to the 19th slot of the virtual method table.
+The provided method is part of the [`IXCLRDataMethodInstance` interface](ixclrdatamethodinstance-interface.md) and corresponds to the 20th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getmethoddefinitionbytoken-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getmethoddefinitionbytoken-method.md
@@ -41,7 +41,7 @@ HRESULT GetMethodDefinitionByToken(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataModule` interface and corresponds to the 25th slot of the virtual method table.
+The provided method is part of the `IXCLRDataModule` interface and corresponds to the 26th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getversionid-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getversionid-method.md
@@ -37,7 +37,7 @@ HRESULT GetVersionId(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataModule` interface and corresponds to the 40th slot of the virtual method table.
+The provided method is part of the `IXCLRDataModule` interface and corresponds to the 41st slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-request-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-request-method.md
@@ -51,7 +51,7 @@ HRESULT Request([in] ULONG32 reqCode,
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataModule` interface and corresponds to the 36th slot of the virtual method table.
+The provided method is part of the `IXCLRDataModule` interface and corresponds to the 37th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-endenummethodinstancesbyaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-endenummethodinstancesbyaddress-method.md
@@ -37,7 +37,7 @@ HRESULT EndEnumMethodInstancesByAddress(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 29th slot of the virtual method table.
+The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 30th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-enummethodinstancebyaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-enummethodinstancebyaddress-method.md
@@ -41,7 +41,7 @@ HRESULT EnumMethodInstanceByAddress(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 28th slot of the virtual method table.
+The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 29th slot of the virtual method table.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-startenummethodinstancesbyaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-startenummethodinstancesbyaddress-method.md
@@ -45,7 +45,7 @@ HRESULT StartEnumMethodInstancesByAddress(
 
 ## Remarks
 
-The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 27th slot of the virtual method table.
+The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 28th slot of the virtual method table.
 
 ## Requirements
 


### PR DESCRIPTION
Previously some slot numbers were 0-based counts, some were 1-based counts, and some were 2-based counts.
Now all slot numbers are consistently 1-based counts.

