### PR TITLE
Dataflow example code fails, datasource is gzipped

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/tpldataflow_palindromes/cs/dataflowpalindromes.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpldataflow_palindromes/cs/dataflowpalindromes.cs
@@ -22,7 +22,7 @@ static class DataflowReversedWords
       {
          Console.WriteLine("Downloading '{0}'...", uri);
 
-         return await new HttpClient().GetStringAsync(uri);
+         return await new HttpClient(new HttpClientHandler{ AutomaticDecompression = System.Net.DecompressionMethods.GZip }).GetStringAsync(uri);
       });
 
       // Separates the specified text into an array of words.


### PR DESCRIPTION
# Fix-up httpclient in example code so that it can download sample data

## Summary

Implement HttpClientHandler with Gzip set. 

Fixes #16027

Tested https://dotnetfiddle.net/vLbr6x 
