### PR TITLE
Exclude script engine from running in omnisharp

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -13,5 +13,8 @@
      "CscToolPath": null,
      "CscToolExe": null,
      "loadProjectsOnDemand": false
-  }
+  },
+  "script": {
+    "enabled": false
+ }
 }

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -16,5 +16,5 @@
   },
   "script": {
     "enabled": false
- }
+  }
 }


### PR DESCRIPTION
## Summary

Omnisharp is discovering csx files in the snippets repo. This disables that engine from running in vscode.
