### PR TITLE
Add breaking change for Process.StartInfo

### DIFF
--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -32,6 +32,7 @@ The following breaking changes are documented on this page:
 | [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes) | 1.0 |
 | [Handling corrupted-process-state exceptions is not supported](#handling-corrupted-state-exceptions-is-not-supported) | 1.0 |
 | [UriBuilder properties no longer prepend leading characters](#uribuilder-properties-no-longer-prepend-leading-characters) | 1.0 |
+| [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
 
@@ -124,3 +125,8 @@ The following breaking changes are documented on this page:
 [!INCLUDE [uribuilder-behavior-changes](../../../includes/core-changes/corefx/1.0/uribuilder-behavior-changes.md)]
 
 ***
+
+[!INCLUDE [startinfo-throws-exception](../../../includes/core-changes/corefx/1.0/startinfo-throws-exception.md)]
+
+***
+

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -129,4 +129,3 @@ The following breaking changes are documented on this page:
 [!INCLUDE [startinfo-throws-exception](../../../includes/core-changes/corefx/1.0/startinfo-throws-exception.md)]
 
 ***
-

--- a/docs/core/compatibility/fx-core.md
+++ b/docs/core/compatibility/fx-core.md
@@ -17,6 +17,7 @@ If you're migrating an app from .NET Framework to .NET Core, the breaking change
 - [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes)
 - [Handling corrupted-process-state exceptions is not supported](#handling-corrupted-state-exceptions-is-not-supported)
 - [UriBuilder properties no longer prepend leading characters](#uribuilder-properties-no-longer-prepend-leading-characters)
+- [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start)
 
 ### .NET Core 2.1
 
@@ -35,6 +36,10 @@ If you're migrating an app from .NET Framework to .NET Core, the breaking change
 ***
 
 [!INCLUDE [uribuilder-behavior-changes](../../../includes/core-changes/corefx/1.0/uribuilder-behavior-changes.md)]
+
+***
+
+[!INCLUDE [startinfo-throws-exception](../../../includes/core-changes/corefx/1.0/startinfo-throws-exception.md)]
 
 ***
 

--- a/includes/core-changes/corefx/1.0/startinfo-throws-exception.md
+++ b/includes/core-changes/corefx/1.0/startinfo-throws-exception.md
@@ -1,0 +1,33 @@
+### Process.StartInfo throws InvalidOperationException for processes you didn't start
+
+Reading the <xref:System.Diagnostics.Process.StartInfo?displayProperty=nameWithType> property for processes that your code didn't start throws an <xref:System.InvalidOperationException>.
+
+#### Change description
+
+In .NET Framework, accessing the <xref:System.Diagnostics.Process.StartInfo?displayProperty=nameWithType> property for processes that your code didn't start returns a dummy <xref:System.Diagnostics.ProcessStartInfo> object. The dummy object contains default values for all of its properties except <xref:System.Diagnostics.ProcessStartInfo.EnvironmentVariables>.
+
+Starting in .NET Core 1.0, if you read the <xref:System.Diagnostics.Process.StartInfo?displayProperty=nameWithType> property for a process that you didn't start (that is, by calling <xref:System.Diagnostics.Process.Start%2A?displayProperty=nameWithType>), an <xref:System.InvalidOperationException> is thrown.
+
+#### Version introduced
+
+1.0
+
+#### Recommended action
+
+Do not access the <xref:System.Diagnostics.Process.StartInfo?displayProperty=nameWithType> property for processes that your code didn't start. For example, don't read this property for processes returned by <xref:System.Diagnostics.Process.GetProcesses%2A?displayProperty=nameWithType>.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Diagnostics.Process.StartInfo?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Diagnostics.Process.StartInfo`
+
+-->


### PR DESCRIPTION
Fixes #18310

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-18441#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start)