### PR TITLE
Unit testing order

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -77,8 +77,8 @@
     },
     {
       "path_to_root": "dotnet-samples",
-      "url": "https://github.com/IEvangelist/samples",
-      "branch": "unit-testing"
+      "url": "https://github.com/dotnet/samples",
+      "branch": "master"
     }
   ],
   "docs_build_engine": {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -74,6 +74,11 @@
       "path_to_root": "machinelearning-samples",
       "url": "https://github.com/dotnet/machinelearning-samples",
       "branch": "master"
+    },
+    {
+      "path_to_root": "dotnet-samples",
+      "url": "https://github.com/IEvangelist/samples",
+      "branch": "unit-testing"
     }
   ],
   "docs_build_engine": {

--- a/docfx.json
+++ b/docfx.json
@@ -46,21 +46,16 @@
           "**/README.md",
           "inactive/**",
           "rejected/**",
-
           "csharp-6.0/enum-base-type.md",
-
           "csharp-7.0/expression-bodied-everything.md",
           "csharp-7.0/ref-locals-returns.md",
           "csharp-7.0/tuples.md",
           "csharp-7.0/value-task.md",
-
           "csharp-7.2/readonly-struct.md",
           "csharp-7.2/ref-extension-methods.md",
           "csharp-7.2/ref-struct-and-span.md",
-
           "csharp-7.3/enum-delegate-constraints.md",
           "csharp-7.3/ref-loops.md",
-
           "csharp-8.0/alternative-interpolated-verbatim.md",
           "csharp-8.0/async-using.md",
           "csharp-8.0/constraints-in-overrides.md",
@@ -123,21 +118,21 @@
       "ms.prod":"dotnet",
       "ms.topic": "conceptual",
       "_op_documentIdPathDepotMapping": {
-	"docs/architecture/containerized-lifecycle/": {
-	   "folder_relative_path_in_docset": "docs/standard/containerized-lifecycle-architecture/"
-	},
-	"docs/architecture/microservices/": {
-	   "folder_relative_path_in_docset": "docs/standard/microservices-architecture/"
-	},
-	"docs/architecture/modern-web-apps-azure/": {
-	   "folder_relative_path_in_docset": "docs/standard/modern-web-apps-azure-architecture/"
-	},
-	"docs/architecture/modernize-with-azure-containers/": {
-	   "folder_relative_path_in_docset": "docs/standard/modernize-with-azure-and-containers/"
-	},
-	"docs/architecture/serverless/": {
-	   "folder_relative_path_in_docset": "docs/standard/serverless-architecture/"
-	}
+        "docs/architecture/containerized-lifecycle/": {
+          "folder_relative_path_in_docset": "docs/standard/containerized-lifecycle-architecture/"
+        },
+        "docs/architecture/microservices/": {
+          "folder_relative_path_in_docset": "docs/standard/microservices-architecture/"
+        },
+        "docs/architecture/modern-web-apps-azure/": {
+          "folder_relative_path_in_docset": "docs/standard/modern-web-apps-azure-architecture/"
+        },
+        "docs/architecture/modernize-with-azure-containers/": {
+     "folder_relative_path_in_docset": "docs/standard/modernize-with-azure-and-containers/"
+  },
+  "docs/architecture/serverless/": {
+     "folder_relative_path_in_docset": "docs/standard/serverless-architecture/"
+  }
       },
       "feedback_system": "GitHub",
       "feedback_github_repo": "dotnet/docs",
@@ -561,7 +556,7 @@
         "docs/visual-basic/**/**.md": "Visual Basic"
       },
       "open_to_public_contributors": {
-	      "docs/standard/design-guidelines/**.md": false
+        "docs/standard/design-guidelines/**.md": false
       }
     },
     "dest": "_site",

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -4,6 +4,7 @@ description: This article gives a brief overview of unit testing for .NET Core a
 author: ardalis
 ms.author: wiwagn
 ms.date: 05/18/2020
+zone_pivot_groups: unit-testing-framework-set-one
 ---
 
 # Unit testing in .NET Core and .NET Standard
@@ -45,25 +46,27 @@ You can also choose between several unit test frameworks:
 
 You can learn more in the following walkthroughs:
 
-## [MSTest](#tab/mstest)
+:::zone pivot="mstest"
 
 - Create unit tests using [*MSTest* and *C#* with the .NET Core CLI](unit-testing-with-mstest.md).
 - Create unit tests using [*MSTest* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-mstest.md).
 - Create unit tests using [*MSTest* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-mstest.md).
 
-## [xUnit](#tab/xunit)
+:::zone-end
+:::zone pivot="xunit"
 
 - Create unit tests using [*xUnit* and *C#* with the .NET Core CLI](unit-testing-with-dotnet-test.md).
 - Create unit tests using [*xUnit* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-dotnet-test.md).
 - Create unit tests using [*xUnit* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-dotnet-test.md).
 
-## [NUnit](#tab/nunit)
+:::zone-end
+:::zone pivot="nunit"
 
 - Create unit tests using [*NUnit* and *C#* with the .NET Core CLI](unit-testing-with-nunit.md).
 - Create unit tests using [*NUnit* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-nunit.md).
 - Create unit tests using [*NUnit* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-nunit.md).
 
----
+:::zone-end
 
 You can learn more in the following articles:
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -3,7 +3,7 @@ title: Unit testing in .NET Core and .NET Standard
 description: This article gives a brief overview of unit testing for .NET Core and .NET Standard projects.
 author: ardalis
 ms.author: wiwagn
-ms.date: 08/30/2017
+ms.date: 05/18/2020
 ---
 
 # Unit testing in .NET Core and .NET Standard
@@ -37,23 +37,33 @@ More information on unit testing in .NET Core projects:
 - [F#](../../fsharp/index.yml)
 - [Visual Basic](../../visual-basic/index.yml)
 
-You can also choose between:
+You can also choose between several unit test frameworks:
 
-- [xUnit](https://xunit.github.io)
+- [xUnit](https://xunit.net/)
 - [NUnit](https://nunit.org)
 - [MSTest](https://github.com/Microsoft/testfx-docs)
 
 You can learn more in the following walkthroughs:
 
-- Create unit tests using [*xUnit* and *C#* with the .NET Core CLI](unit-testing-with-dotnet-test.md).
-- Create unit tests using [*NUnit* and *C#* with the .NET Core CLI](unit-testing-with-nunit.md).
+## [MSTest](#tab/mstest)
+
 - Create unit tests using [*MSTest* and *C#* with the .NET Core CLI](unit-testing-with-mstest.md).
-- Create unit tests using [*xUnit* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-dotnet-test.md).
-- Create unit tests using [*NUnit* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-nunit.md).
 - Create unit tests using [*MSTest* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-mstest.md).
-- Create unit tests using [*xUnit* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-dotnet-test.md).
-- Create unit tests using [*NUnit* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-nunit.md).
 - Create unit tests using [*MSTest* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-mstest.md).
+
+## [xUnit](#tab/xunit)
+
+- Create unit tests using [*xUnit* and *C#* with the .NET Core CLI](unit-testing-with-dotnet-test.md).
+- Create unit tests using [*xUnit* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-dotnet-test.md).
+- Create unit tests using [*xUnit* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-dotnet-test.md).
+
+## [NUnit](#tab/nunit)
+
+- Create unit tests using [*NUnit* and *C#* with the .NET Core CLI](unit-testing-with-nunit.md).
+- Create unit tests using [*NUnit* and *F#* with the .NET Core CLI](unit-testing-fsharp-with-nunit.md).
+- Create unit tests using [*NUnit* and *Visual Basic* with the .NET Core CLI](unit-testing-visual-basic-with-nunit.md).
+
+---
 
 You can learn more in the following articles:
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -1,0 +1,88 @@
+---
+title: Order unit tests
+description: Learn how to order unit tests with .NET Core.
+author: IEvangelist
+ms.date: 05/15/2020
+---
+
+# Order unit tests
+
+Occasionally, you may want to have unit tests run in a specific order. Ideally, the order in which unit tests run should _not_ matter, and it is [best practice](unit-testing-best-practices.md) to avoid ordering unit tests. Regardless, there may be a need to do so. In that case, this article demonstrates how to order test runs.
+
+If you prefer to browse the source code, see the [order .NET Core unit tests](/samples/dotnet/samples/order-unit-tests-cs) sample repository.
+
+> [!TIP]
+> In addition to the ordering capabilities outlined in this article, consider [creating custom playlists with Visual Studio](/visualstudio/test/run-unit-tests-with-test-explorer?view=vs-2019#create-custom-playlists) as an alternative.
+
+## [MSTest](#tab/mstest)
+
+### Order alphabetically
+
+With MSTest, tests are automatically ordered by their test name.
+
+> [!NOTE]
+> A test named `Test14` will run before `Test2` even though `2` comes before `14`. This is because, test name ordering does _not_ use natural language sorting.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/MSTest.Project/ByAlphabeticalOrder.cs":::
+
+## [xUnit](#tab/xunit)
+
+The xUnit test framework allows for more granularity and control of test run order. The `ITestCaseOrderer` and `ITestCollectionOrderer` interfaces can be implemented to control the order of test cases for a class, or test collections.
+
+### Order by test case alphabetically
+
+To order test cases by their method name, you could implement the `ITestCaseOrderer` and provide an ordering mechanism.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/AlphabeticalOrderer.cs":::
+
+Then in a test class you would set the test case order with the `TestCaseOrdererAttribute`.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByAlphabeticalOrder.cs":::
+
+### Order by collection alphabetically
+
+To order test collections by their display name, you could implement the `ITestCollectionOrderer` and provide an ordering mechanism.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/DisplayNameOrderer.cs":::
+
+Since test collections have the potential to run in parallel, you need to explicitly disable test parallelization of the collections with the `CollectionBehaviorAttribute`. Then you need to specify the implementation to the `TestCollectionOrdererAttribute`.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByDisplayName.cs":::
+
+### Order by custom attribute
+
+To order xUnit tests with custom attributes, you first need an attribute to rely on. Define a `TestPriorityAttribute` as follows:
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Attributes/TestPriorityAttribute.cs":::
+
+Next, consider the following `PriorityOrderer` implementation of the `ITestCaseOrderer` interface.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/PriorityOrderer.cs":::
+
+Then in a test class you would set the test case order with the `TestCaseOrdererAttribute` to the `PriorityOrderer`.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByPriorityOrder.cs":::
+
+## [NUnit](#tab/nunit)
+
+### Order alphabetically
+
+With NUnit, tests are automatically ordered by their test name.
+
+> [!NOTE]
+> A test named `Test14` will run before `Test2` even though `2` comes before `14`. This is because, test name ordering does _not_ use natural language sorting.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.Project/ByAlphabeticalOrder.cs":::
+
+### Order by priority
+
+To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.com/nunit/docs/wiki/Order-Attribute). Tests with this attribute are started before tests without. The order value is used to determined the order to run the unit tests.
+
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.Project/ByOrder.cs":::
+
+---
+
+## Nest Steps
+
+> [!div class="nextstepaction"]
+> [Unit testing best practices](unit-testing-best-practices.md)

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -17,7 +17,7 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 
 :::zone pivot="mstest"
 
-### Order alphabetically
+## Order alphabetically
 
 With MSTest, tests are automatically ordered by their test name.
 
@@ -31,7 +31,7 @@ With MSTest, tests are automatically ordered by their test name.
 
 The xUnit test framework allows for more granularity and control of test run order. The `ITestCaseOrderer` and `ITestCollectionOrderer` interfaces can be implemented to control the order of test cases for a class, or test collections.
 
-### Order by test case alphabetically
+## Order by test case alphabetically
 
 To order test cases by their method name, you could implement the `ITestCaseOrderer` and provide an ordering mechanism.
 
@@ -41,7 +41,7 @@ Then in a test class you would set the test case order with the `TestCaseOrderer
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByAlphabeticalOrder.cs":::
 
-### Order by collection alphabetically
+## Order by collection alphabetically
 
 To order test collections by their display name, you could implement the `ITestCollectionOrderer` and provide an ordering mechanism.
 
@@ -51,7 +51,7 @@ Since test collections have the potential to run in parallel, you need to explic
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByDisplayName.cs":::
 
-### Order by custom attribute
+## Order by custom attribute
 
 To order xUnit tests with custom attributes, you first need an attribute to rely on. Define a `TestPriorityAttribute` as follows:
 
@@ -68,7 +68,7 @@ Then in a test class you would set the test case order with the `TestCaseOrderer
 :::zone-end
 :::zone pivot="nunit"
 
-### Order by priority
+## Order by priority
 
 To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.com/nunit/docs/wiki/Order-Attribute). Tests with this attribute are started before tests without. The order value is used to determined the order to run the unit tests.
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -22,32 +22,32 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 With MSTest, tests are automatically ordered by their test name.
 
 > [!NOTE]
-> A test named `Test14` will run before `Test2` even though `2` comes before `14`. This is because, test name ordering does _not_ use natural language sorting.
+> A test named `Test14` will run before `Test2` even though the number  `2` is less than `14`. This is because, test name ordering uses the text name of the test.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/MSTest.Project/ByAlphabeticalOrder.cs":::
 
 :::zone-end
 :::zone pivot="xunit"
 
-The xUnit test framework allows for more granularity and control of test run order. The `ITestCaseOrderer` and `ITestCollectionOrderer` interfaces can be implemented to control the order of test cases for a class, or test collections.
+The xUnit test framework allows for more granularity and control of test run order. You implement the `ITestCaseOrderer` and `ITestCollectionOrderer` interfaces to control the order of test cases for a class, or test collections.
 
 ## Order by test case alphabetically
 
-To order test cases by their method name, you could implement the `ITestCaseOrderer` and provide an ordering mechanism.
+To order test cases by their method name, you implement the `ITestCaseOrderer` and provide an ordering mechanism.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/AlphabeticalOrderer.cs":::
 
-Then in a test class you would set the test case order with the `TestCaseOrdererAttribute`.
+Then in a test class you set the test case order with the `TestCaseOrdererAttribute`.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByAlphabeticalOrder.cs":::
 
 ## Order by collection alphabetically
 
-To order test collections by their display name, you could implement the `ITestCollectionOrderer` and provide an ordering mechanism.
+To order test collections by their display name, you implement the `ITestCollectionOrderer` and provide an ordering mechanism.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/DisplayNameOrderer.cs":::
 
-Since test collections have the potential to run in parallel, you need to explicitly disable test parallelization of the collections with the `CollectionBehaviorAttribute`. Then you need to specify the implementation to the `TestCollectionOrdererAttribute`.
+Since test collections potentially run in parallel, you must explicitly disable test parallelization of the collections with the `CollectionBehaviorAttribute`. Then specify the implementation to the `TestCollectionOrdererAttribute`.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByDisplayName.cs":::
 
@@ -61,7 +61,7 @@ Next, consider the following `PriorityOrderer` implementation of the `ITestCaseO
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/PriorityOrderer.cs":::
 
-Then in a test class you would set the test case order with the `TestCaseOrdererAttribute` to the `PriorityOrderer`.
+Then in a test class you set the test case order with the `TestCaseOrdererAttribute` to the `PriorityOrderer`.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByPriorityOrder.cs":::
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -3,6 +3,7 @@ title: Order unit tests
 description: Learn how to order unit tests with .NET Core.
 author: IEvangelist
 ms.date: 05/18/2020
+zone_pivot_groups: unit-testing-framework-set-one
 ---
 
 # Order unit tests
@@ -14,7 +15,7 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 > [!TIP]
 > In addition to the ordering capabilities outlined in this article, consider [creating custom playlists with Visual Studio](/visualstudio/test/run-unit-tests-with-test-explorer?view=vs-2019#create-custom-playlists) as an alternative.
 
-## [MSTest](#tab/mstest)
+:::zone pivot="mstest"
 
 ### Order alphabetically
 
@@ -25,7 +26,7 @@ With MSTest, tests are automatically ordered by their test name.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/MSTest.Project/ByAlphabeticalOrder.cs":::
 
-## [xUnit](#tab/xunit)
+:::zone pivot="xunit"
 
 The xUnit test framework allows for more granularity and control of test run order. The `ITestCaseOrderer` and `ITestCollectionOrderer` interfaces can be implemented to control the order of test cases for a class, or test collections.
 
@@ -63,7 +64,7 @@ Then in a test class you would set the test case order with the `TestCaseOrderer
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByPriorityOrder.cs":::
 
-## [NUnit](#tab/nunit)
+:::zone pivot="nunit"
 
 ### Order by priority
 
@@ -71,7 +72,7 @@ To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.c
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.TestProject/ByOrder.cs":::
 
----
+:::zone-end
 
 ## Next Steps
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -72,13 +72,13 @@ With NUnit, tests are automatically ordered by their test name.
 > [!NOTE]
 > A test named `Test14` will run before `Test2` even though `2` comes before `14`. This is because, test name ordering does _not_ use natural language sorting.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.Project/ByAlphabeticalOrder.cs":::
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.TestProject/ByAlphabeticalOrder.cs":::
 
 ### Order by priority
 
 To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.com/nunit/docs/wiki/Order-Attribute). Tests with this attribute are started before tests without. The order value is used to determined the order to run the unit tests.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.Project/ByOrder.cs":::
+:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.TestProject/ByOrder.cs":::
 
 ---
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -26,6 +26,7 @@ With MSTest, tests are automatically ordered by their test name.
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/MSTest.Project/ByAlphabeticalOrder.cs":::
 
+:::zone-end
 :::zone pivot="xunit"
 
 The xUnit test framework allows for more granularity and control of test run order. The `ITestCaseOrderer` and `ITestCollectionOrderer` interfaces can be implemented to control the order of test cases for a class, or test collections.
@@ -64,6 +65,7 @@ Then in a test class you would set the test case order with the `TestCaseOrderer
 
 :::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByPriorityOrder.cs":::
 
+:::zone-end
 :::zone pivot="nunit"
 
 ### Order by priority

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -2,7 +2,7 @@
 title: Order unit tests
 description: Learn how to order unit tests with .NET Core.
 author: IEvangelist
-ms.date: 05/15/2020
+ms.date: 05/18/2020
 ---
 
 # Order unit tests
@@ -65,15 +65,6 @@ Then in a test class you would set the test case order with the `TestCaseOrderer
 
 ## [NUnit](#tab/nunit)
 
-### Order alphabetically
-
-With NUnit, tests are automatically ordered by their test name.
-
-> [!NOTE]
-> A test named `Test14` will run before `Test2` even though `2` comes before `14`. This is because, test name ordering does _not_ use natural language sorting.
-
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.TestProject/ByAlphabeticalOrder.cs":::
-
 ### Order by priority
 
 To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.com/nunit/docs/wiki/Order-Attribute). Tests with this attribute are started before tests without. The order value is used to determined the order to run the unit tests.
@@ -82,7 +73,7 @@ To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.c
 
 ---
 
-## Nest Steps
+## Next Steps
 
 > [!div class="nextstepaction"]
 > [Unit testing best practices](unit-testing-best-practices.md)

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -20,7 +20,7 @@ dotnet test --filter FullyQualifiedName\!~IntegrationTests
 ```
 
 > [!IMPORTANT]
-> Notice the backslash that precedes the exclamation mark, that indicates it is an escaped character `\!`.
+> The backslash precedes the exclamation mark to indicate it is an escaped character `\!`.
 
 For `FullyQualifiedName` values that include a comma for generic type parameters, escape the comma with `%2C`. For example:
 

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -3,6 +3,7 @@ title: Run selective unit tests
 description: How to use a filter expression to run selective unit tests with the dotnet test command in .NET Core.
 author: smadala
 ms.date: 05/18/2020
+zone_pivot_groups: unit-testing-framework-set-one
 ---
 
 # Run selective unit tests
@@ -27,7 +28,7 @@ For `FullyQualifiedName` values that include a comma for generic type parameters
 dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1%2CParameterType2>.MyTestMethod"
 ```
 
-## [MSTest](#tab/mstest)
+:::zone pivot="mstest"
 
 ```csharp
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -79,7 +80,7 @@ To run tests that have either <xref:System.Reflection.Module.FullyQualifiedName>
 dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1"
 ```
 
-## [xUnit](#tab/xunit)
+:::zone pivot="xunit"
 
 ```csharp
 using Xunit;
@@ -134,7 +135,7 @@ To run tests that have either <xref:System.Reflection.Module.FullyQualifiedName>
 dotnet test --filter "(FullyQualifiedName~TestClass1&Category=CategoryA)|Priority=1"
 ```
 
-## [NUnit](#tab/nunit)
+:::zone pivot="nunit"
 
 ```csharp
 using NUnit.Framework;
@@ -187,7 +188,7 @@ dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Prio
 
 For more information, see [TestCase filter](https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md).
 
----
+:::zone-end
 
 ## See also
 

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -1,5 +1,5 @@
 ---
-title: Running selective unit tests
+title: Run selective unit tests
 description: How to use a filter expression to run selective unit tests with the dotnet test command in .NET Core.
 author: smadala
 ms.date: 05/15/2020
@@ -187,3 +187,8 @@ For more information, see [TestCase filter](https://github.com/Microsoft/vstest-
 
 - [dotnet test](../tools/dotnet-test.md)
 - [dotnet test --filter](../tools/dotnet-test.md#filter-option-details)
+
+## Next steps
+
+> [!div class="nextstepaction"]
+> [Order unit tests](order-unit-tests.md)

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -80,6 +80,7 @@ To run tests that have either <xref:System.Reflection.Module.FullyQualifiedName>
 dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1"
 ```
 
+:::zone-end
 :::zone pivot="xunit"
 
 ```csharp
@@ -135,6 +136,7 @@ To run tests that have either <xref:System.Reflection.Module.FullyQualifiedName>
 dotnet test --filter "(FullyQualifiedName~TestClass1&Category=CategoryA)|Priority=1"
 ```
 
+:::zone-end
 :::zone pivot="nunit"
 
 ```csharp

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -2,7 +2,7 @@
 title: Run selective unit tests
 description: How to use a filter expression to run selective unit tests with the dotnet test command in .NET Core.
 author: smadala
-ms.date: 05/15/2020
+ms.date: 05/18/2020
 ---
 
 # Run selective unit tests
@@ -11,9 +11,15 @@ With the [`dotnet test`](../tools/dotnet-test.md) command in .NET Core, you can 
 
 ## Character escaping
 
-Using filters that include exclamation mark (!) on `*nix` requires escaping since `!` is reserved. For example, this filter
-skips all tests if the namespace contains IntegrationTests: `dotnet test --filter FullyQualifiedName\!~IntegrationTests`.
-Note the backslash that precedes the exclamation mark.
+Using filters that include exclamation mark `!` on `*nix` requires escaping since `!` is reserved. For example, this filter
+skips all tests if the namespace contains IntegrationTests:
+
+```dotnetcli
+dotnet test --filter FullyQualifiedName\!~IntegrationTests
+```
+
+> [!IMPORTANT]
+> Notice the backslash that precedes the exclamation mark, that indicates it is an escaped character `\!`.
 
 For `FullyQualifiedName` values that include a comma for generic type parameters, escape the comma with `%2C`. For example:
 
@@ -55,7 +61,7 @@ namespace MSTestNamespace
 
 Examples using the conditional operators `|` and `&`:
 
-To run tests that have `UnitTest1` in their <xref:System.Reflection.Module.FullyQualifiedName> **or** <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute> is `CategoryA`.
+To run tests that have `UnitTest1` in their <xref:System.Reflection.Module.FullyQualifiedName> **or** <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute> is `"CategoryA"`.
 
 ```dotnetcli
 dotnet test --filter "FullyQualifiedName~UnitTest1|TestCategory=CategoryA"

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -2,12 +2,12 @@
 title: Running selective unit tests
 description: How to use a filter expression to run selective unit tests with the dotnet test command in .NET Core.
 author: smadala
-ms.date: 04/29/2020
+ms.date: 05/15/2020
 ---
 
 # Run selective unit tests
 
-With the `dotnet test` command in .NET Core, you can use a filter expression to run selective tests. This article demonstrates how to filter which tests are run. The following examples use `dotnet test`. If you're using `vstest.console.exe`, replace `--filter` with `--testcasefilter:`.
+With the [`dotnet test`](../tools/dotnet-test.md) command in .NET Core, you can use a filter expression to run selective tests. This article demonstrates how to filter which tests are run. The following examples use `dotnet test`. If you're using `vstest.console.exe`, replace `--filter` with `--testcasefilter:`.
 
 ## Character escaping
 
@@ -21,7 +21,7 @@ For `FullyQualifiedName` values that include a comma for generic type parameters
 dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1%2CParameterType2>.MyTestMethod"
 ```
 
-## MSTest
+## [MSTest](#tab/mstest)
 
 ```csharp
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,15 +31,12 @@ namespace MSTestNamespace
     [TestClass]
     public class UnitTest1
     {
-        [TestCategory("CategoryA")]
-        [Priority(1)]
-        [TestMethod]
+        [TestMethod, Priority(1), TestCategory("CategoryA")]
         public void TestMethod1()
         {
         }
 
-        [Priority(2)]
-        [TestMethod]
+        [TestMethod, Priority(2)]
         public void TestMethod2()
         {
         }
@@ -48,23 +45,35 @@ namespace MSTestNamespace
 ```
 
 | Expression | Result |
-| ---------- | ------ |
-| `dotnet test --filter Method` | Runs tests whose `FullyQualifiedName` contains `Method`. Available in `vstest 15.1+`. |
+|--|--|
+| `dotnet test --filter Method` | Runs tests whose <xref:System.Reflection.Module.FullyQualifiedName> contains `Method`. Available in `vstest 15.1+`. |
 | `dotnet test --filter Name~TestMethod1` | Runs tests whose name contains `TestMethod1`. |
 | `dotnet test --filter ClassName=MSTestNamespace.UnitTest1` | Runs tests that are in class `MSTestNamespace.UnitTest1`.<br>**Note:** The `ClassName` value should have a namespace, so `ClassName=UnitTest1` won't work. |
 | `dotnet test --filter FullyQualifiedName!=MSTestNamespace.UnitTest1.TestMethod1` | Runs all tests except `MSTestNamespace.UnitTest1.TestMethod1`. |
 | `dotnet test --filter TestCategory=CategoryA` | Runs tests that are annotated with `[TestCategory("CategoryA")]`. |
-| `dotnet test --filter Priority=2` | Runs tests that are annotated with `[Priority(2)]`.<br>
+| `dotnet test --filter Priority=2` | Runs tests that are annotated with `[Priority(2)]`. |
 
-**Using conditional operators | and &amp;**
+Examples using the conditional operators `|` and `&`:
 
-| Expression | Result |
-| ---------- | ------ |
-| <code>dotnet test --filter "FullyQualifiedName~UnitTest1&#124;TestCategory=CategoryA"</code> | Runs tests that have `UnitTest1` in `FullyQualifiedName` **or** `TestCategory` is `CategoryA`. |
-| `dotnet test --filter "FullyQualifiedName~UnitTest1&TestCategory=CategoryA"` | Runs tests that have `UnitTest1` in `FullyQualifiedName` **and** `TestCategory` is `CategoryA`. |
-| <code>dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)&#124;Priority=1"</code> | Runs tests that have either `FullyQualifiedName` containing `UnitTest1` **and** `TestCategory` is `CategoryA` **or** `Priority` is 1. |
+To run tests that have `UnitTest1` in their <xref:System.Reflection.Module.FullyQualifiedName> **or** <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute> is `CategoryA`.
 
-## xUnit
+```dotnetcli
+dotnet test --filter "FullyQualifiedName~UnitTest1|TestCategory=CategoryA"
+```
+
+To run tests that have `UnitTest1` in their <xref:System.Reflection.Module.FullyQualifiedName> **and** have a <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute> of `"CategoryA"`.
+
+```dotnetcli
+dotnet test --filter "FullyQualifiedName~UnitTest1&TestCategory=CategoryA"
+```
+
+To run tests that have either <xref:System.Reflection.Module.FullyQualifiedName> containing `UnitTest1` **and** have a <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute> of `"CategoryA"` **or** have a <xref:Microsoft.VisualStudio.TestTools.UnitTesting.PriorityAttribute> with a priority of `1`.
+
+```dotnetcli
+dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1"
+```
+
+## [xUnit](#tab/xunit)
 
 ```csharp
 using Xunit;
@@ -73,15 +82,12 @@ namespace XUnitNamespace
 {
     public class TestClass1
     {
-        [Trait("Category", "CategoryA")]
-        [Trait("Priority", "1")]
-        [Fact]
+        [Fact, Trait("Priority", "1"), Trait("Category", "CategoryA")]
         public void Test1()
         {
         }
 
-        [Trait("Priority", "2")]
-        [Fact]
+        [Fact, Trait("Priority", "2")]
         public void Test2()
         {
         }
@@ -90,27 +96,39 @@ namespace XUnitNamespace
 ```
 
 | Expression | Result |
-| ---------- | ------ |
+|--|--|
 | `dotnet test --filter DisplayName=XUnitNamespace.TestClass1.Test1` | Runs only one test, `XUnitNamespace.TestClass1.Test1`. |
 | `dotnet test --filter FullyQualifiedName!=XUnitNamespace.TestClass1.Test1` | Runs all tests except `XUnitNamespace.TestClass1.Test1`. |
 | `dotnet test --filter DisplayName~TestClass1` | Runs tests whose display name contains `TestClass1`. |
 
-In the code example, the defined traits with keys `Category` and `Priority` can be used for filtering.
+In the code example, the defined traits with keys `"Category"` and `"Priority"` can be used for filtering.
 
 | Expression | Result |
-| ---------- | ------ |
-| `dotnet test --filter XUnit` | Runs tests whose `FullyQualifiedName` contains `XUnit`.  Available in `vstest 15.1+`. |
+|--|--|
+| `dotnet test --filter XUnit` | Runs tests whose <xref:System.Reflection.Module.FullyQualifiedName> contains `XUnit`.  Available in `vstest 15.1+`. |
 | `dotnet test --filter Category=CategoryA` | Runs tests that have `[Trait("Category", "CategoryA")]`. |
 
-**Using conditional operators | and &amp;**
+Examples using the conditional operators `|` and `&`:
 
-| Expression | Result |
-| ---------- | ------ |
-| <code>dotnet test --filter "FullyQualifiedName~TestClass1&#124;Category=CategoryA"</code> | Runs tests that have `TestClass1` in `FullyQualifiedName` **or** `Category` is `CategoryA`. |
-| `dotnet test --filter "FullyQualifiedName~TestClass1&Category=CategoryA"` | Runs tests that have `TestClass1` in `FullyQualifiedName` **and** `Category` is `CategoryA`. |
-| <code>dotnet test --filter "(FullyQualifiedName~TestClass1&Category=CategoryA)&#124;Priority=1"</code> | Runs tests that have either `FullyQualifiedName` containing `TestClass1` **and** `Category` is `CategoryA` **or** `Priority` is 1. |
+To run tests that have `TestClass1` in their <xref:System.Reflection.Module.FullyQualifiedName> **or** have a `Trait` with a key of `"Category"` and value of `"CategoryA"`.
 
-## NUnit
+```dotnetcli
+dotnet test --filter "FullyQualifiedName~TestClass1|Category=CategoryA"
+```
+
+To run tests that have `TestClass1` in their <xref:System.Reflection.Module.FullyQualifiedName> **and** have a `Trait` with a key of `"Category"` and value of `"CategoryA"`.
+
+```dotnetcli
+dotnet test --filter "FullyQualifiedName~TestClass1&Category=CategoryA"
+```
+
+To run tests that have either <xref:System.Reflection.Module.FullyQualifiedName> containing `TestClass1` **and** have a `Trait` with a key of `"Category"` and value of `"CategoryA"` **or** have a `Trait` with a key of `"Priority"` and value of `1`.
+
+```dotnetcli
+dotnet test --filter "(FullyQualifiedName~TestClass1&Category=CategoryA)|Priority=1"
+```
+
+## [NUnit](#tab/nunit)
 
 ```csharp
 using NUnit.Framework;
@@ -119,15 +137,12 @@ namespace NUnitNamespace
 {
     public class UnitTest1
     {
-        [Category("CategoryA")]
-        [Property("Priority", 1)]
-        [Test]
+        [Test, Property("Priority", 1), Category("CategoryA")]
         public void TestMethod1()
         {
         }
 
-        [Property("Priority", 2)]
-        [Test]
+        [Test, Property("Priority", 2)]
         public void TestMethod2()
         {
         }
@@ -136,20 +151,39 @@ namespace NUnitNamespace
 ```
 
 | Expression | Result |
-| ---------- | ------ |
-| `dotnet test --filter Method` | Runs tests whose `FullyQualifiedName` contains `Method`. Available in `vstest 15.1+`. |
+|--|--|
+| `dotnet test --filter Method` | Runs tests whose <xref:System.Reflection.Module.FullyQualifiedName> contains `Method`. Available in `vstest 15.1+`. |
 | `dotnet test --filter Name~TestMethod1` | Runs tests whose name contains `TestMethod1`. |
-| `dotnet test --filter FullyQualifiedName~NUnitNamespace.UnitTest1` | Runs tests that are in class `NUnitNamespace.UnitTest1`.<br>
+| `dotnet test --filter FullyQualifiedName~NUnitNamespace.UnitTest1` | Runs tests that are in class `NUnitNamespace.UnitTest1`. |
 | `dotnet test --filter FullyQualifiedName!=NUnitNamespace.UnitTest1.TestMethod1` | Runs all tests except `NUnitNamespace.UnitTest1.TestMethod1`. |
 | `dotnet test --filter TestCategory=CategoryA` | Runs tests that are annotated with `[Category("CategoryA")]`. |
-| `dotnet test --filter Priority=2` | Runs tests that are annotated with `[Priority(2)]`.<br>
+| `dotnet test --filter Priority=2` | Runs tests that are annotated with `[Priority(2)]`. |
 
-**Using conditional operators | and &amp;**
+Examples using the conditional operators `|` and `&`:
 
-| Expression | Result |
-| ---------- | ------ |
-| <code>dotnet test --filter "FullyQualifiedName~UnitTest1&#124;TestCategory=CategoryA"</code> | Runs tests that have `UnitTest1` in `FullyQualifiedName` **or** `TestCategory` is `CategoryA`. |
-| `dotnet test --filter "FullyQualifiedName~UnitTest1&TestCategory=CategoryA"` | Runs tests that have `UnitTest1` in `FullyQualifiedName` **and** `TestCategory` is `CategoryA`. |
-| <code>dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)&#124;Priority=1"</code> | Runs tests that have either `FullyQualifiedName` containing `UnitTest1` **and** `TestCategory` is `CategoryA` **or** `Priority` is 1. |
+To run tests that have `UnitTest1` in their <xref:System.Reflection.Module.FullyQualifiedName> **or** have a `Category` of `"CategoryA"`.
+
+```dotnetcli
+dotnet test --filter "FullyQualifiedName~UnitTest1|TestCategory=CategoryA"
+```
+
+To run tests that have `UnitTest1` in their <xref:System.Reflection.Module.FullyQualifiedName> **and** have a `Category` of `"CategoryA"`.
+
+```dotnetcli
+dotnet test --filter "FullyQualifiedName~UnitTest1&TestCategory=CategoryA"
+```
+
+To run tests that have either a <xref:System.Reflection.Module.FullyQualifiedName> containing `UnitTest1` **and** have a `Category` of `"CategoryA"` **or** have a `Property` with a `"Priority"` of `1`.
+
+```dotnetcli
+dotnet test --filter "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1"
+```
 
 For more information, see [TestCase filter](https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md).
+
+---
+
+## See also
+
+- [dotnet test](../tools/dotnet-test.md)
+- [dotnet test --filter](../tools/dotnet-test.md#filter-option-details)

--- a/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
@@ -222,6 +222,6 @@ The completed `IsPrime` method is not an efficient algorithm for testing primali
 
 ### Additional resources
 
-- [xUnit.net official site](https://xunit.github.io)
+- [xUnit.net official site](https://xunit.net/)
 - [Testing controller logic in ASP.NET Core](/aspnet/core/mvc/controllers/testing)
 - [`dotnet add reference`](../tools/dotnet-add-reference.md)

--- a/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
@@ -7,7 +7,7 @@ ms.date: 05/18/2020
 ---
 # Unit testing Visual Basic .NET Core libraries using dotnet test and xUnit
 
-This tutorial shows how to build a solution containing a unit test project and source code project. To follow the tutorial using a pre-built solution, [view or download the sample code](https://github.com/dotnet/samples/tree/master/core/getting-started/unit-testing-using-dotnet-test/). For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#viewing-and-downloading-samples).
+This tutorial shows how to build a solution containing a unit test project and library project. To follow the tutorial using a pre-built solution, [view or download the sample code](https://github.com/dotnet/samples/tree/master/core/getting-started/unit-testing-using-dotnet-test/). For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#viewing-and-downloading-samples).
 
 ## Create the solution
 

--- a/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
@@ -3,97 +3,139 @@ title: Unit testing Visual Basic in .NET Core with dotnet test and xUnit
 description: Learn unit test concepts in .NET Core through an interactive experience building a sample Visual Basic solution step-by-step using dotnet test and xUnit.
 author: billwagner
 ms.author: wiwagn
-ms.date: 09/01/2017
+ms.date: 05/18/2020
 ---
 # Unit testing Visual Basic .NET Core libraries using dotnet test and xUnit
 
-This tutorial takes you through an interactive experience building a sample solution step-by-step to learn unit testing concepts. If you prefer to follow the tutorial using a pre-built solution, [view or download the sample code](https://github.com/dotnet/samples/tree/master/core/getting-started/unit-testing-vb-dotnet-test) before you begin. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#viewing-and-downloading-samples).
+This tutorial shows how to build a solution containing a unit test project and source code project. To follow the tutorial using a pre-built solution, [view or download the sample code](https://github.com/dotnet/samples/tree/master/core/getting-started/unit-testing-using-dotnet-test/). For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#viewing-and-downloading-samples).
 
-[!INCLUDE [testing an ASP.NET Core project from .NET Core](../../../includes/core-testing-note-aspnet.md)]
+## Create the solution
 
-## Creating the source project
-
-Open a shell window. Create a directory called *unit-testing-vb-using-dotnet-test* to hold the solution.
-Inside this new directory, run [`dotnet new sln`](../tools/dotnet-new.md) to create a new solution. This practice
-makes it easier to manage both the class library and the unit test project.
-Inside the solution directory, create a *PrimeService* directory. You have the following directory and file structure thus far:
+In this section, a solution is created that contains the source and test projects. The completed solution has the following directory structure:
 
 ```
 /unit-testing-using-dotnet-test
     unit-testing-using-dotnet-test.sln
     /PrimeService
-```
-
-Make *PrimeService* the current directory and run [`dotnet new classlib -lang VB`](../tools/dotnet-new.md) to create the source project. Rename *Class1.VB* to *PrimeService.VB*. You create a failing implementation of the `PrimeService` class:
-
-```vb
-Namespace Prime.Services
-    Public Class PrimeService
-        Public Function IsPrime(candidate As Integer) As Boolean
-            Throw New NotImplementedException("Please create a test first")
-        End Function
-    End Class
-End Namespace
-```
-
-Change the directory back to the *unit-testing-vb-using-dotnet-test* directory. Run [`dotnet sln add .\PrimeService\PrimeService.vbproj`](../tools/dotnet-sln.md) to add the class library project to the solution.
-
-## Creating the test project
-
-Next, create the *PrimeService.Tests* directory. The following outline shows the directory structure:
-
-```
-/unit-testing-vb-using-dotnet-test
-    unit-testing-vb-using-dotnet-test.sln
-    /PrimeService
-        Source Files
+        PrimeService.vb
         PrimeService.vbproj
     /PrimeService.Tests
-```
-
-Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new xunit -lang VB`](../tools/dotnet-new.md). This command creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *PrimeServiceTests.vbproj*:
-
-```xml
-<ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-  <PackageReference Include="xunit" Version="2.2.0" />
-  <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-</ItemGroup>
-```
-
-The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added xUnit and the xUnit runner. Now, add the `PrimeService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
-
-```dotnetcli
-dotnet add reference ../PrimeService/PrimeService.vbproj
-```
-
-You can see the entire file in the [samples repository](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-vb-dotnet-test/PrimeService.Tests/PrimeService.Tests.vbproj) on GitHub.
-
-You have the following final folder layout:
-
-```
-/unit-testing-using-dotnet-test
-    unit-testing-using-dotnet-test.sln
-    /PrimeService
-        Source Files
-        PrimeService.vbproj
-    /PrimeService.Tests
-        Test Source Files
+        PrimeService_IsPrimeShould.vb
         PrimeServiceTests.vbproj
 ```
 
-Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.vbproj`](../tools/dotnet-sln.md) in the *unit-testing-vb-using-dotnet-test* directory.
+The following instructions provide the steps to create the test solution. See [Commands to create test solution](#create-test-cmd) for instructions to create the test solution in one step.
 
-## Creating the first test
+* Open a shell window.
+* Run the following command:
 
-You write one failing test, make it pass, then repeat the process. Remove *UnitTest1.vb* from the *PrimeService.Tests* directory and create a new Visual Basic file named *PrimeService_IsPrimeShould.VB*. Add the following code:
+  ```dotnetcli
+  dotnet new sln -o unit-testing-using-dotnet-test
+  ```
+
+  The [`dotnet new sln`](../tools/dotnet-new.md) command creates a new solution in the *unit-testing-using-dotnet-test* directory.
+* Change directory to the *unit-testing-using-dotnet-test* folder.
+* Run the following command:
+
+  ```dotnetcli
+  dotnet new classlib -o PrimeService --lang VB
+  ```
+
+   The [`dotnet new classlib`](../tools/dotnet-new.md) command creates a new class library project  in the *PrimeService* folder. The new class library will contain the code to be tested.
+* Rename *Class1.vb* to *PrimeService.vb*.
+* Replace the code in *PrimeService.vb* with the following code:
+  
+  ```vb
+  Imports System
+  
+  Namespace Prime.Services
+      Public Class PrimeService
+          Public Function IsPrime(candidate As Integer) As Boolean
+              Throw New NotImplementedException("Not implemented.")
+          End Function
+      End Class
+  End Namespace
+  ```
+
+* The preceding code:
+  * Throws a <xref:System.NotImplementedException> with a message indicating it's not implemented.
+  * Is updated later in the tutorial.
+
+<!-- preceding code shows an english bias. Message makes no sense outside english -->
+
+* In the *unit-testing-using-dotnet-test* directory, run the following command to add the class library project to the solution:
+
+  ```dotnetcli
+  dotnet sln add ./PrimeService/PrimeService.vbproj
+  ```
+
+* Create the *PrimeService.Tests* project by running the following command:
+
+  ```dotnetcli
+  dotnet new xunit -o PrimeService.Tests
+  ```
+
+* The preceding command:
+  * Creates the *PrimeService.Tests* project in the *PrimeService.Tests* directory. The test project uses [xUnit](https://xunit.net/) as the test library.
+  * Configures the test runner by adding the following `<PackageReference />`elements to the project file:
+    * "Microsoft.NET.Test.Sdk"
+    * "xunit"
+    * "xunit.runner.visualstudio"
+
+* Add the test project to the solution file by running the following command:
+
+  ```dotnetcli
+  dotnet sln add ./PrimeService.Tests/PrimeService.Tests.vbproj
+  ```
+
+* Add the `PrimeService` class library as a dependency to the *PrimeService.Tests* project:
+
+  ```dotnetcli
+  dotnet add ./PrimeService.Tests/PrimeService.Tests.vbproj reference ./PrimeService/PrimeService.vbproj  
+  ```
+
+<a name="create-test-cmd"></a>
+
+### Commands to create the solution
+
+This section summarizes all the commands in the previous section. Skip this section if you've completed the steps in the previous section.
+
+The following commands create the test solution on a windows machine. For macOS and Unix, update the `ren` command to the OS version of `ren` to rename a file:
+
+```dotnetcli
+dotnet new sln -o unit-testing-using-dotnet-test
+cd unit-testing-using-dotnet-test
+dotnet new classlib -o PrimeService
+ren .\PrimeService\Class1.vb PrimeService.vb
+dotnet sln add ./PrimeService/PrimeService.vbproj
+dotnet new xunit -o PrimeService.Tests
+dotnet add ./PrimeService.Tests/PrimeService.Tests.vbproj reference ./PrimeService/PrimeService.vbproj
+dotnet sln add ./PrimeService.Tests/PrimeService.Tests.vbproj
+```
+
+Follow the instructions for "Replace the code in *PrimeService.vb* with the following code" in the previous section.
+
+## Create a test
+
+A popular approach in test driven development (TDD) is to write a test before implementing the target code. This tutorial uses the TDD approach. The `IsPrime` method is callable, but not implemented. A test call to `IsPrime` fails. With TDD, a test is written that is known to fail. The target code is updated to make the test pass. You keep repeating this approach, writing a failing test and then updating the target code to pass.
+
+Update the *PrimeService.Tests* project:
+
+* Delete *PrimeService.Tests/UnitTest1.vb*.
+* Create a *PrimeService.Tests/PrimeService_IsPrimeShould.vb*  file.
+* Replace the code in *PrimeService_IsPrimeShould.vb* with the following code:
 
 ```vb
 Imports Xunit
 
 Namespace PrimeService.Tests
     Public Class PrimeService_IsPrimeShould
-        Private _primeService As Prime.Services.PrimeService = New Prime.Services.PrimeService()
+        Private ReadOnly _primeService As Prime.Services.PrimeService
+
+        Public Sub New()
+            _primeService = New Prime.Services.PrimeService()
+        End Sub
+
 
         <Fact>
         Sub IsPrime_InputIs1_ReturnFalse()
@@ -106,35 +148,80 @@ Namespace PrimeService.Tests
 End Namespace
 ```
 
-The `<Fact>` attribute denotes a test method that is run by the test runner. From the *unit-testing-using-dotnet-test*, execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The xUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
+The `[Fact]` attribute declares a test method that's run by the test runner. From the *PrimeService.Tests* folder, run `dotnet test`. The [dotnet test](../tools/dotnet-test.md) command builds both projects and runs the tests. The xUnit test runner contains the program entry point to run the tests. `dotnet test` starts the test runner using the unit test project.
 
-Your test fails. You haven't created the implementation yet. Make this test pass by writing the simplest code in the `PrimeService` class that works:
+The test fails because `IsPrime` hasn't been implemented. Using the TDD approach, write only enough code so this test passes. Update `IsPrime` with the following code:
 
 ```vb
 Public Function IsPrime(candidate As Integer) As Boolean
     If candidate = 1 Then
         Return False
     End If
-    Throw New NotImplementedException("Please create a test first.")
+    Throw New NotImplementedException("Not implemented.")
 End Function
 ```
 
-In the *unit-testing-vb-using-dotnet-test* directory, run `dotnet test` again. The `dotnet test` command runs a build for the `PrimeService` project and then for the `PrimeService.Tests` project. After building both projects, it runs this single test. It passes.
+Run `dotnet test`. The test passes.
 
-## Adding more features
+### Add more tests
 
-Now that you've made one test pass, it's time to write more. There are a few other simple cases for prime numbers: 0, -1. You could add those cases as new tests with the `<Fact>` attribute, but that quickly becomes tedious. There are other xUnit attributes that enable you to write a suite of similar tests.  A `<Theory>` attribute represents a suite of tests that execute the same code but have different input arguments. You can use the `<InlineData>` attribute to specify values for those inputs.
-
-Instead of creating new tests, apply these two attributes to create a single theory. The theory is a method that tests several values less than two, which is the lowest prime number:
-
-[!code-vb[Sample_TestCode](../../../samples/snippets/core/testing/unit-testing-vb-dotnet-test/vb/PrimeService.Tests/PrimeService_IsPrimeShould.vb?name=Sample_TestCode)]
-
-Run `dotnet test`, and two of these tests fail. To make all of the tests pass, change the `if` clause at the beginning of the method:
+Add prime number tests for 0 and -1. You could copy the preceding test and change the following code to use 0 and -1:
 
 ```vb
-if candidate < 2
+Dim result As Boolean = _primeService.IsPrime(1)
+
+Assert.False(result, "1 should not be prime")
 ```
 
-Continue to iterate by adding more tests, more theories, and more code in the main library. You have the [finished version of the tests](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-vb-dotnet-test/PrimeService.Tests/PrimeService_IsPrimeShould.vb) and the [complete implementation of the library](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-vb-dotnet-test/PrimeService/PrimeService.vb).
+Copying test code when only a parameter changes results in code duplication and test bloat. The following xUnit attributes enable writing a suite of similar tests:
 
-You've built a small library and a set of unit tests for that library. You've structured the solution so that adding new packages and tests is part of the normal workflow. You've concentrated most of your time and effort on solving the goals of the application.
+- `[Theory]` represents a suite of tests that execute the same code but have different input arguments.
+- `[InlineData]` attribute specifies values for those inputs.
+
+Rather than creating new tests, apply the preceding xUnit attributes to create a single theory. Replace the following code:
+
+```vb
+<Fact>
+Sub IsPrime_InputIs1_ReturnFalse()
+    Dim result As Boolean = _primeService.IsPrime(1)
+
+    Assert.False(result, "1 should not be prime")
+End Sub
+```
+
+with the following code:
+
+```vb
+<Theory>
+<InlineData(-1)>
+<InlineData(0)>
+<InlineData(1)>
+Sub IsPrime_ValuesLessThan2_ReturnFalse(ByVal value As Integer)
+    Dim result As Boolean = _primeService.IsPrime(value)
+
+    Assert.False(result, $"{value} should not be prime")
+End Sub
+```
+
+In the preceding code, `[Theory]` and `[InlineData]` enable testing several values less than two. Two is the smallest prime number.
+
+Run `dotnet test`, two of the tests fail. To make all of the tests pass, update the `IsPrime` method with the following code:
+
+```vb
+Public Function IsPrime(candidate As Integer) As Boolean
+    If candidate < 2 Then
+        Return False
+    End If
+    Throw New NotImplementedException("Not fully implemented.")
+End Function
+```
+
+Following the TDD approach, add more failing tests, then update the target code. See the [finished version of the tests](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService_IsPrimeShould.vb) and the [complete implementation of the library](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-using-dotnet-test/PrimeService/PrimeService.vb).
+
+The completed `IsPrime` method is not an efficient algorithm for testing primality.
+
+### Additional resources
+
+- [xUnit.net official site](https://xunit.github.io)
+- [Testing controller logic in ASP.NET Core](/aspnet/core/mvc/controllers/testing)
+- [`dotnet add reference`](../tools/dotnet-add-reference.md)

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -223,6 +223,6 @@ The completed `IsPrime` method is not an efficient algorithm for testing primali
 
 ### Additional resources
 
-- [xUnit.net official site](https://xunit.github.io)
+- [xUnit.net official site](https://xunit.net)
 - [Testing controller logic in ASP.NET Core](/aspnet/core/mvc/controllers/testing)
 - [`dotnet add reference`](../tools/dotnet-add-reference.md)

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -46,18 +46,18 @@ The following instructions provide the steps to create the test solution. See [C
 * Replace the code in *PrimeService.cs* with the following code:
   
   ```csharp
-    using System;
+  using System;
 
-    namespace Prime.Services
-    {
-        public class PrimeService
-        {
-            public bool IsPrime(int candidate)
-            {
-                throw new NotImplementedException("Not implemented.");
-            }
-        }
-    }
+  namespace Prime.Services
+  {
+      public class PrimeService
+      {
+          public bool IsPrime(int candidate)
+          {
+              throw new NotImplementedException("Not implemented.");
+          }
+      }
+  }
   ```
 
 * The preceding code:
@@ -79,7 +79,7 @@ The following instructions provide the steps to create the test solution. See [C
   ```
 
 * The preceding command:
-  * Creates the *PrimeService.Tests* project in the *PrimeService.Tests* directory. The test project uses [xUnit](https://xunit.github.io/) as the test library.
+  * Creates the *PrimeService.Tests* project in the *PrimeService.Tests* directory. The test project uses [xUnit](https://xunit.net/) as the test library.
   * Configures the test runner by adding the following `<PackageReference />`elements to the project file:
     * "Microsoft.NET.Test.Sdk"
     * "xunit"
@@ -184,7 +184,6 @@ Assert.False(result, "1 should not be prime");
 Copying test code when only a parameter changes results in code duplication and test bloat. The following xUnit attributes enable writing a suite of similar tests:
 
 - `[Theory]` represents a suite of tests that execute the same code but have different input arguments.
-
 - `[InlineData]` attribute specifies values for those inputs.
 
 Rather than creating new tests, apply the preceding xUnit attributes to create a single theory. Replace the following code:

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -379,10 +379,6 @@
       href: testing/unit-testing-fsharp-with-dotnet-test.md
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-dotnet-test.md
-    - name: Run selective unit tests
-      href: testing/selective-unit-tests.md?tabs=xunit
-    - name: Order unit tests
-      href: testing/order-unit-tests.md?tabs=xunit
   - name: NUnit
     items:
     - name: C# unit testing
@@ -391,10 +387,6 @@
       href: testing/unit-testing-fsharp-with-nunit.md
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-nunit.md
-    - name: Run selective unit tests
-      href: testing/selective-unit-tests.md?tabs=nunit
-    - name: Order unit tests
-      href: testing/order-unit-tests.md?tabs=nunit
   - name: MSTest
     items:
     - name: C# unit testing
@@ -403,10 +395,10 @@
       href: testing/unit-testing-fsharp-with-mstest.md
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-mstest.md
-    - name: Run selective unit tests
-      href: testing/selective-unit-tests.md?tabs=mstest
-    - name: Order unit tests
-      href: testing/order-unit-tests.md?tabs=mstest
+  - name: Run selective unit tests
+    href: testing/selective-unit-tests.md
+  - name: Order unit tests
+    href: testing/order-unit-tests.md
   - name: Unit test published output
     href: testing/unit-testing-published-output.md
   - name: Live unit test .NET Core projects with Visual Studio

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -371,7 +371,7 @@
     href: testing/index.md
   - name: Unit testing best practices
     href: testing/unit-testing-best-practices.md
-  - name: xUnit:
+  - name: xUnit
     items:
     - name: C# unit testing
       href: testing/unit-testing-with-dotnet-test.md
@@ -383,7 +383,7 @@
       href: testing/selective-unit-tests.md?tab=xunit
     - name: Order unit tests
       href: testing/order-unit-tests.md?tab=xunit
-  - name: NUnit:
+  - name: NUnit
     items:
     - name: C# unit testing
       href: testing/unit-testing-with-nunit.md
@@ -395,7 +395,7 @@
       href: testing/selective-unit-tests.md?tab=nunit
     - name: Order unit tests
       href: testing/order-unit-tests.md?tab=nunit
-  - name: MSTest:
+  - name: MSTest
     - name: C# unit testing
       href: testing/unit-testing-with-mstest.md
     - name: F# unit testing

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -371,7 +371,7 @@
     href: testing/index.md
   - name: Unit testing best practices
     href: testing/unit-testing-best-practices.md
-  - xUnit:
+  - name: xUnit:
     items:
     - name: C# unit testing
       href: testing/unit-testing-with-dotnet-test.md
@@ -383,7 +383,7 @@
       href: testing/selective-unit-tests.md?tab=xunit
     - name: Order unit tests
       href: testing/order-unit-tests.md?tab=xunit
-  - NUnit:
+  - name: NUnit:
     items:
     - name: C# unit testing
       href: testing/unit-testing-with-nunit.md
@@ -395,7 +395,7 @@
       href: testing/selective-unit-tests.md?tab=nunit
     - name: Order unit tests
       href: testing/order-unit-tests.md?tab=nunit
-  - MSTest:
+  - name: MSTest:
     - name: C# unit testing
       href: testing/unit-testing-with-mstest.md
     - name: F# unit testing

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -380,9 +380,9 @@
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-dotnet-test.md
     - name: Run selective unit tests
-      href: testing/selective-unit-tests.md?tab=xunit
+      href: testing/selective-unit-tests.md?tabs=xunit
     - name: Order unit tests
-      href: testing/order-unit-tests.md?tab=xunit
+      href: testing/order-unit-tests.md?tabs=xunit
   - name: NUnit
     items:
     - name: C# unit testing
@@ -392,9 +392,9 @@
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-nunit.md
     - name: Run selective unit tests
-      href: testing/selective-unit-tests.md?tab=nunit
+      href: testing/selective-unit-tests.md?tabs=nunit
     - name: Order unit tests
-      href: testing/order-unit-tests.md?tab=nunit
+      href: testing/order-unit-tests.md?tabs=nunit
   - name: MSTest
     items:
     - name: C# unit testing
@@ -404,9 +404,9 @@
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-mstest.md
     - name: Run selective unit tests
-      href: testing/selective-unit-tests.md?tab=mstest
+      href: testing/selective-unit-tests.md?tabs=mstest
     - name: Order unit tests
-      href: testing/order-unit-tests.md?tab=mstest
+      href: testing/order-unit-tests.md?tabs=mstest
   - name: Unit test published output
     href: testing/unit-testing-published-output.md
   - name: Live unit test .NET Core projects with Visual Studio

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -379,6 +379,10 @@
       href: testing/unit-testing-fsharp-with-dotnet-test.md
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-dotnet-test.md
+    - name: Run selective unit tests
+      href: testing/selective-unit-tests.md?tab=xunit
+    - name: Order unit tests
+      href: testing/order-unit-tests.md?tab=xunit
   - NUnit:
     items:
     - name: C# unit testing
@@ -387,6 +391,10 @@
       href: testing/unit-testing-fsharp-with-nunit.md
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-nunit.md
+    - name: Run selective unit tests
+      href: testing/selective-unit-tests.md?tab=nunit
+    - name: Order unit tests
+      href: testing/order-unit-tests.md?tab=nunit
   - MSTest:
     - name: C# unit testing
       href: testing/unit-testing-with-mstest.md
@@ -394,8 +402,10 @@
       href: testing/unit-testing-fsharp-with-mstest.md
     - name: VB unit testing
       href: testing/unit-testing-visual-basic-with-mstest.md
-  - name: Run selective unit tests
-    href: testing/selective-unit-tests.md
+    - name: Run selective unit tests
+      href: testing/selective-unit-tests.md?tab=mstest
+    - name: Order unit tests
+      href: testing/order-unit-tests.md?tab=mstest
   - name: Unit test published output
     href: testing/unit-testing-published-output.md
   - name: Live unit test .NET Core projects with Visual Studio

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -365,30 +365,35 @@
   - name: Port C++/CLI projects
     href: porting/cpp-cli.md
 - name: Unit testing
-  href: testing/index.md
+  displayName: xUnit,NUnit,MSTest,unit testing,testing
   items:
   - name: Overview
     href: testing/index.md
   - name: Unit testing best practices
     href: testing/unit-testing-best-practices.md
-  - name: C# unit testing with xUnit
-    href: testing/unit-testing-with-dotnet-test.md
-  - name: C# unit testing with NUnit
-    href: testing/unit-testing-with-nunit.md
-  - name: C# unit testing with MSTest
-    href: testing/unit-testing-with-mstest.md
-  - name: F# unit testing with xUnit
-    href: testing/unit-testing-fsharp-with-dotnet-test.md
-  - name: F# unit testing with NUnit
-    href: testing/unit-testing-fsharp-with-nunit.md
-  - name: F# unit testing with MSTest
-    href: testing/unit-testing-fsharp-with-mstest.md
-  - name: VB unit testing with xUnit
-    href: testing/unit-testing-visual-basic-with-dotnet-test.md
-  - name: VB unit testing with NUnit
-    href: testing/unit-testing-visual-basic-with-nunit.md
-  - name: VB unit testing with MSTest
-    href: testing/unit-testing-visual-basic-with-mstest.md
+  - xUnit:
+    items:
+    - name: C# unit testing
+      href: testing/unit-testing-with-dotnet-test.md
+    - name: F# unit testing
+      href: testing/unit-testing-fsharp-with-dotnet-test.md
+    - name: VB unit testing
+      href: testing/unit-testing-visual-basic-with-dotnet-test.md
+  - NUnit:
+    items:
+    - name: C# unit testing
+      href: testing/unit-testing-with-nunit.md
+    - name: F# unit testing
+      href: testing/unit-testing-fsharp-with-nunit.md
+    - name: VB unit testing
+      href: testing/unit-testing-visual-basic-with-nunit.md
+  - MSTest:
+    - name: C# unit testing
+      href: testing/unit-testing-with-mstest.md
+    - name: F# unit testing
+      href: testing/unit-testing-fsharp-with-mstest.md
+    - name: VB unit testing
+      href: testing/unit-testing-visual-basic-with-mstest.md
   - name: Run selective unit tests
     href: testing/selective-unit-tests.md
   - name: Unit test published output

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -396,6 +396,7 @@
     - name: Order unit tests
       href: testing/order-unit-tests.md?tab=nunit
   - name: MSTest
+    items:
     - name: C# unit testing
       href: testing/unit-testing-with-mstest.md
     - name: F# unit testing

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -1,12 +1,22 @@
 ### YamlMime:ZonePivotGroups
 groups:
- - id: operating-systems-set-one
-   title: Operating System
-   prompt: Choose an operating system
-   pivots:
-   - id: os-windows
-     title: Windows
-   - id: os-linux
-     title: Linux
-   - id: os-macos
-     title: macOS
+- id: operating-systems-set-one
+  title: Operating System
+  prompt: Choose an operating system
+  pivots:
+  - id: os-windows
+    title: Windows
+  - id: os-linux
+    title: Linux
+  - id: os-macos
+    title: macOS
+- id: unit-testing-framework-set-one
+  title: Unit testing framework
+  prompt: Choose a unit testing framework
+  pivots:
+    - id: mstest
+      title: MSTest
+    - id: xunit
+      title: xUnit
+    - id: nunit
+      title: NUnit


### PR DESCRIPTION
## Summary

- Wrote new article "Order unit tests" for MSTest, xUnit, and NUnit
- Remove duplicate TOC entry, "Unit testing" and "Overview" were the same
- Add `xref` where possible in "Selective unit tests" doc
- Allow TOC to scope to test framework
- Add `dotnet/samples` repo to *.openpublishing.publish.config.json*
- Corrected redirect link, https://xunit.net/
- Add zone pivots def to *docs/zone-pivot-groups.yml*
- Use zone pivots for different test frameworks
  - Overview, Run select unit tests, and Order unit tests
- Break out long `dotnet test --filter` commands into code blocks for readability
- Normalize *docfx.json* file
- Fixed heading that use "ing"
- Add `dotnet *` links where missing
- Add `displayName` to help with filtering
- Rewrite VB article per #16129

Fixes #18432, fixes #16129, closes #8117 (as this was explored as part of this effort)

### Preview links

✔️ [Unit testing overview](https://review.docs.microsoft.com/en-us/dotnet/core/testing/?branch=pr-en-us-18456)
✔️ [Run selective unit tests](https://review.docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?branch=pr-en-us-18456)
✔️ [Order unit tests](https://review.docs.microsoft.com/en-us/dotnet/core/testing/order-unit-tests?branch=pr-en-us-18456)