### PR TITLE
Definition of examineNumber was never used

### DIFF
--- a/samples/snippets/fsharp/lang-ref-2/snippet5005.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5005.fs
@@ -10,12 +10,6 @@ let (|Cube|_|) (x : int) =
   if isNearlyIntegral ((float x) ** ( 1.0 / 3.0)) then Some(x)
   else None
 
-let examineNumber x =
-   match x with
-      | Cube x -> printfn "%d is a cube" x
-      | Square x -> printfn "%d is a square" x
-      | _ -> ()
-
 let findSquareCubes x =
    match x with
        | Cube x & Square _ -> printfn "%d is a cube and a square" x


### PR DESCRIPTION
## Summary

The second sample for Partial Active Patterns in F# defined a function `examineNumber`, but this function was never used in printing the output of squares and cubes. I believe it is leftover after an older example was changed, and should be removed as it's confusing for someone new to active patterns.

