### PR TITLE
Fix name of dotnet local tools .json file

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -49,7 +49,7 @@ Global tools are installed in the following directories by default when you spec
 | Linux/macOS | `$HOME/.dotnet/tools`         |
 | Windows     | `%USERPROFILE%\.dotnet\tools` |
 
-Local tools are added to a *tool-manifest.json* file in a *.config* directory under the current directory. If a manifest file doesn't exist yet, create it by running the following command:
+Local tools are added to a *dotnet-tools.json* file in a *.config* directory under the current directory. If a manifest file doesn't exist yet, create it by running the following command:
 
 ```dotnetcli
 dotnet new tool-manifest


### PR DESCRIPTION
It is called `dotnet-tools.json`, not `tool-manifest.json`

