### PR TITLE
Add entry for breaking change doc for 5.0

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -58,8 +58,13 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ## Core .NET libraries
 
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
+- [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecounterset-now-throws-invalidoperationexception-if-instance-already-exist)
 
 [!INCLUDE [sse-comparegreaterthan-intrinsics](../../../includes/core-changes/corefx/5.0/sse-comparegreaterthan-intrinsics.md)]
+
+***
+
+[!INCLUDE [createcountersetinstance-throws-invalidoperation](../../../includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md)]
 
 ***
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -58,7 +58,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ## Core .NET libraries
 
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
-- [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecounterset-now-throws-invalidoperationexception-if-instance-already-exist)
+- [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 
 [!INCLUDE [sse-comparegreaterthan-intrinsics](../../../includes/core-changes/corefx/5.0/sse-comparegreaterthan-intrinsics.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -12,6 +12,7 @@ The following breaking changes are documented on this page:
 | Breaking change | Version introduced |
 | - | :-: |
 | [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs) | 5.0 |
+| [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecounterset-now-throws-invalidoperationexception-if-instance-already-exist) | 5.0 |
 | [APIs that report version now report product and not file version](#apis-that-report-version-now-report-product-and-not-file-version) | 3.0 |
 | [Custom EncoderFallbackBuffer instances cannot fall back recursively](#custom-encoderfallbackbuffer-instances-cannot-fall-back-recursively) | 3.0 |
 | [Floating point formatting and parsing behavior changes](#floating-point-formatting-and-parsing-behavior-changed) | 3.0 |
@@ -37,6 +38,10 @@ The following breaking changes are documented on this page:
 ## .NET 5.0
 
 [!INCLUDE [sse-comparegreaterthan-intrinsics](../../../includes/core-changes/corefx/5.0/sse-comparegreaterthan-intrinsics.md)]
+
+***
+
+[!INCLUDE [createcountersetinstance-throws-invalidoperation](../../../includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md)]
 
 ***
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -12,7 +12,7 @@ The following breaking changes are documented on this page:
 | Breaking change | Version introduced |
 | - | :-: |
 | [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs) | 5.0 |
-| [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecounterset-now-throws-invalidoperationexception-if-instance-already-exist) | 5.0 |
+| [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists) | 5.0 |
 | [APIs that report version now report product and not file version](#apis-that-report-version-now-report-product-and-not-file-version) | 3.0 |
 | [Custom EncoderFallbackBuffer instances cannot fall back recursively](#custom-encoderfallbackbuffer-instances-cannot-fall-back-recursively) | 3.0 |
 | [Floating point formatting and parsing behavior changes](#floating-point-formatting-and-parsing-behavior-changed) | 3.0 |

--- a/includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md
+++ b/includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md
@@ -1,0 +1,33 @@
+### CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist
+
+Starting in .NET Core 5.0, <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>(string `instanceName`) throws <xref:System.InvalidOperationException> instead of <xref:System.ArgumentException> if user attempt to create already existing instance.
+
+#### Change description
+
+In .NET Framework and versions of .NET Core prior to 5.0, you could create an instance of the counter set by calling <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>. However, if counter set already exist it would throw ArgumentException exception.
+
+In .NET Core 5.0 and later versions, when you call <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance> and if the counter set exist then <xref:System.InvalidOperationException> would be thrown.
+
+#### Version introduced
+
+5.0 Preview 5
+
+#### Recommended action
+
+Catching ArgumentException is not recommended, but if you are catching <xref:System.ArgumentException> in your app, you might want to consider also catching <xref:System.InvalidOperationException>.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>
+
+<!--
+
+#### Affected APIs
+
+- `M:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance(System.String)`
+
+-->

--- a/includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md
+++ b/includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md
@@ -1,12 +1,12 @@
-### CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist
+### CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exists
 
 Starting in .NET 5.0, <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance(System.String)?displayProperty=nameWithType> throws an <xref:System.InvalidOperationException> instead of an <xref:System.ArgumentException> if the counter set already exists.
 
 #### Change description
 
-In .NET Framework and .NET Core 1.0 to 3.1, you can create an instance of the counter set by calling <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>. However, if the counter set already exists, the method throws an <xref:System.ArgumentException> exception.
+In .NET Framework and .NET Core 1.0 to 3.1, you can create an instance of the counter set by calling <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance%2A>. However, if the counter set already exists, the method throws an <xref:System.ArgumentException> exception.
 
-In .NET 5.0 and later versions, when you call <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance> and the counter set exists, an <xref:System.InvalidOperationException> exception is thrown.
+In .NET 5.0 and later versions, when you call <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance%2A> and the counter set exists, an <xref:System.InvalidOperationException> exception is thrown.
 
 #### Version introduced
 
@@ -14,7 +14,7 @@ In .NET 5.0 and later versions, when you call <xref:System.Diagnostics.Performan
 
 #### Recommended action
 
-If you catch <xref:System.ArgumentException> exceptions in your app, consider also catching <xref:System.InvalidOperationException> exceptions.
+If you catch <xref:System.ArgumentException> exceptions in your app when calling <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance%2A>, consider also catching <xref:System.InvalidOperationException> exceptions.
 
 > [!NOTE]
 > Catching <xref:System.ArgumentException> exceptions is not recommended.

--- a/includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md
+++ b/includes/core-changes/corefx/5.0/createcountersetinstance-throws-invalidoperation.md
@@ -1,12 +1,12 @@
 ### CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist
 
-Starting in .NET Core 5.0, <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>(string `instanceName`) throws <xref:System.InvalidOperationException> instead of <xref:System.ArgumentException> if user attempt to create already existing instance.
+Starting in .NET 5.0, <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance(System.String)?displayProperty=nameWithType> throws an <xref:System.InvalidOperationException> instead of an <xref:System.ArgumentException> if the counter set already exists.
 
 #### Change description
 
-In .NET Framework and versions of .NET Core prior to 5.0, you could create an instance of the counter set by calling <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>. However, if counter set already exist it would throw ArgumentException exception.
+In .NET Framework and .NET Core 1.0 to 3.1, you can create an instance of the counter set by calling <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>. However, if the counter set already exists, the method throws an <xref:System.ArgumentException> exception.
 
-In .NET Core 5.0 and later versions, when you call <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance> and if the counter set exist then <xref:System.InvalidOperationException> would be thrown.
+In .NET 5.0 and later versions, when you call <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance> and the counter set exists, an <xref:System.InvalidOperationException> exception is thrown.
 
 #### Version introduced
 
@@ -14,7 +14,10 @@ In .NET Core 5.0 and later versions, when you call <xref:System.Diagnostics.Perf
 
 #### Recommended action
 
-Catching ArgumentException is not recommended, but if you are catching <xref:System.ArgumentException> in your app, you might want to consider also catching <xref:System.InvalidOperationException>.
+If you catch <xref:System.ArgumentException> exceptions in your app, consider also catching <xref:System.InvalidOperationException> exceptions.
+
+> [!NOTE]
+> Catching <xref:System.ArgumentException> exceptions is not recommended.
 
 #### Category
 
@@ -22,7 +25,7 @@ Core .NET libraries
 
 #### Affected APIs
 
-- <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance>
+- <xref:System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance%2A?displayProperty=fullName>
 
 <!--
 


### PR DESCRIPTION
## InvalidOperationException instead ArgumentException breaking change update

Starting in .NET Core 5.0, `System.Diagnostics.PerformanceData.CounterSet.CreateCounterSetInstance(string instanceName)` throws <xref:System.InvalidOperationException> instead of <xref:System.ArgumentException> if user attempt to create already existing instance.

Related to https://github.com/dotnet/runtime/pull/35717
