### PR TITLE
Remove duplicate documentation tutorial from C# LINQ

### DIFF
--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -759,18 +759,6 @@
                   href: programming-guide/concepts/linq/intermediate-materialization.md
                 - name: Chaining Standard Query Operators Together
                   href: programming-guide/concepts/linq/chaining-standard-query-operators-together.md
-              - name: "Tutorial: Chaining Queries Together"
-                items:
-                - name: Deferred Execution and Lazy Evaluation in LINQ to XML
-                  href: programming-guide/concepts/linq/deferred-execution-and-lazy-evaluation-in-linq-to-xml.md
-                - name: Deferred Execution Example
-                  href: programming-guide/concepts/linq/deferred-execution-example.md
-                - name: Chaining Queries Example
-                  href: programming-guide/concepts/linq/chaining-queries-example.md
-                - name: Intermediate Materialization
-                  href: programming-guide/concepts/linq/intermediate-materialization.md
-                - name: Chaining Standard Query Operators Together
-                  href: programming-guide/concepts/linq/chaining-standard-query-operators-together.md
               - name: "Tutorial: Manipulating Content in a WordprocessingML Document"
                 items:
                 - name: Shape of WordprocessingML Documents


### PR DESCRIPTION
## Summary

Removes a duplicate tutorial in C# - example page @ https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/deferred-execution-and-lazy-evaluation-in-linq-to-xml

Fixes #Issue_Number (if available)
