### PR TITLE
Fixing issue #17807

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
 ms.assetid: 672c87d1-9771-4f64-ab3f-0ad3d4ffb2b4
 ---
 # #region (C# Reference)
-`#region` lets you specify a block of code that you can expand or collapse when using the [outlining](/visualstudio/ide/outlining) feature of the Visual Studio Code Editor. In longer code files, it is convenient to be able to collapse or hide one or more regions so that you can focus on the part of the file that you are currently working on. The following example shows how to define a region:  
+`#region` lets you specify a block of code that you can expand or collapse when using the [outlining](/visualstudio/ide/outlining) feature of the code editor. In longer code files, it is convenient to be able to collapse or hide one or more regions so that you can focus on the part of the file that you are currently working on. The following example shows how to define a region:  
   
 ```csharp
 #region MyClass definition  


### PR DESCRIPTION
Fixes #17807 - replaced "Visual Studio Code Editor" to "code editor", upon the suggestion in the issue's comments.
