### PR TITLE
Removed multiple enumerations and handled nulls, to address #18023

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
@@ -20,26 +20,28 @@ public static class LINQExtension
 {
     public static double Median(this IEnumerable<double> source)
     {
-        if (source.Count() == 0)
+        var countOfElementsInTheSet = source?.Count();
+
+        if (source == null || countOfElementsInTheSet == 0)
         {
-            throw new InvalidOperationException("Cannot compute median for an empty set.");
+            throw new InvalidOperationException("Cannot compute median for a null or empty set.");
         }
 
-        var sortedList = from number in source
+        var sortedList = (from number in source
                          orderby number
-                         select number;
+                         select number).ToList();
 
-        int itemIndex = (int)sortedList.Count() / 2;
+        int itemIndex = (int)countOfElementsInTheSet / 2;
 
-        if (sortedList.Count() % 2 == 0)
+        if (countOfElementsInTheSet % 2 == 0)
         {
             // Even number of items.
-            return (sortedList.ElementAt(itemIndex) + sortedList.ElementAt(itemIndex - 1)) / 2;
+            return (sortedList[itemIndex] + sortedList[itemIndex - 1]) / 2;
         }
         else
         {
             // Odd number of items.
-            return sortedList.ElementAt(itemIndex);
+            return sortedList[itemIndex];
         }
     }
 }

--- a/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
@@ -31,7 +31,7 @@ public static class LINQExtension
                          orderby number
                          select number).ToList();
 
-        int itemIndex = (int)countOfElementsInTheSet / 2;
+        int itemIndex = countOfElementsInTheSet / 2;
 
         if (countOfElementsInTheSet % 2 == 0)
         {

--- a/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
@@ -20,7 +20,7 @@ public static class LINQExtension
 {
     public static double Median(this IEnumerable<double> source)
     {
-        var countOfElementsInTheSet = source?.Count();
+        var countOfElementsInTheSet = source?.Count() ?? 0;
 
         if (source == null || countOfElementsInTheSet == 0)
         {

--- a/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
@@ -22,7 +22,7 @@ public static class LINQExtension
     {
         var countOfElementsInTheSet = source?.Count() ?? 0;
 
-        if (source == null || countOfElementsInTheSet == 0)
+        if (countOfElementsInTheSet == 0)
         {
             throw new InvalidOperationException("Cannot compute median for a null or empty set.");
         }


### PR DESCRIPTION
Issue #18023 talks about .count being called multiple times, and elementAt being used

The proposed change gets rid of the elementAt calls, and uses Count only once

In addition, a null check was added to handle the case where the extension method is called for a null array

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
