### PR TITLE
Adding Markdown link syntax for URL

### DIFF
--- a/docs/architecture/cloud-native/index.md
+++ b/docs/architecture/cloud-native/index.md
@@ -29,7 +29,7 @@ This book is provided "as-is" and expresses the author's views and opinions. The
 
 Some examples depicted herein are provided for illustration only and are fictitious. No real association or connection is intended or should be inferred.
 
-Microsoft and the trademarks listed at https://www.microsoft.com on the "Trademarks" webpage are trademarks of the Microsoft group of companies.
+Microsoft and the trademarks listed at [https://www.microsoft.com](https://www.microsoft.com) on the "Trademarks" webpage are trademarks of the Microsoft group of companies.
 
 Mac and macOS are trademarks of Apple Inc.
 


### PR DESCRIPTION
URL without using Markdown link syntax can cause broken hyperlink for localized languages, so adding the syntax to resolve the issue.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
