### PR TITLE
Update inheritance.md

### DIFF
--- a/docs/csharp/tutorials/inheritance.md
+++ b/docs/csharp/tutorials/inheritance.md
@@ -26,7 +26,7 @@ To create and run the examples in this tutorial, you use the [dotnet](../../core
 
 1. Enter the [dotnet run](../../core/tools/dotnet-run.md) command to compile and execute the example.
 
-## Background: What is inheritance?
+## Background: what is inheritance?
 
 *Inheritance* is one of the fundamental attributes of object-oriented programming. It allows you to define a child class that reuses (inherits), extends, or modifies the behavior of a parent class. The class whose members are inherited is called the *base class*. The class that inherits the members of the base class is called the *derived class*.
 


### PR DESCRIPTION
The first word after a colon should not be capitalised.

## Summary

One of the titles feature a capitalised word after a colon- this should not be the case
