### PR TITLE
Bergerb tutorialfix webapiclient

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -46,7 +46,7 @@ directory. Enter the following command in a console window:
 dotnet new console --name WebAPIClient
 ```
 
-This creates the starter files for a basic "Hello World" application. The project name is "WebApiClient". As this is a new project, none of the dependencies are in place. The first run will download the .NET Core framework, install a development certificate, and run the NuGet package manager to restore missing dependencies.
+This creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient". As this is a new project, none of the dependencies are in place. The first run will download the .NET Core framework, install a development certificate, and run the NuGet package manager to restore missing dependencies.
 
 Before you start making modifications, type
 `dotnet run` ([see note](#dotnet-restore-note)) at the command prompt to

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -43,7 +43,7 @@ create a new directory for your application. Make that the current
 directory. Enter the following command in a console window:
 
 ```dotnetcli
-dotnet new console --name WebApiClient
+dotnet new console --name WebAPIClient
 ```
 
 This creates the starter files for a basic "Hello World" application. The project name is "WebApiClient". As this is a new project, none of the dependencies are in place. The first run will download the .NET Core framework, install a development certificate, and run the NuGet package manager to restore missing dependencies.


### PR DESCRIPTION
When creating this project the namespace you create via the instructions is: WebApiClient.  Subsequent references WebAPIClient.  This may cause an issue for users spinning up the project and would need to also reference WebAPIClient to get the code to compile.

Fix Casing

## Summary

Update the dotnet new console line and additional project reference name

Fixes #18539 
