### PR TITLE
Added clarification around event handlers

### DIFF
--- a/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
+++ b/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
@@ -1,75 +1,77 @@
 ---
 title: "How to publish events that conform to .NET Framework Guidelines - C# Programming Guide"
-ms.date: 07/20/2015
-helpviewer_keywords: 
+ms.date: 05/26/2020
+helpviewer_keywords:
   - "events [C#], implementation guidelines"
 ms.assetid: 9310ae16-8627-44a2-b08c-05e5976202b1
 ---
+
 # How to publish events that conform to .NET Framework Guidelines (C# Programming Guide)
-The following procedure demonstrates how to add events that follow the standard .NET Framework pattern to your classes and structs. All events in the .NET Framework class library are based on the <xref:System.EventHandler> delegate, which is defined as follows:  
-  
-```csharp  
-public delegate void EventHandler(object sender, EventArgs e);  
-```  
-  
+
+The following procedure demonstrates how to add events that follow the standard .NET Framework pattern to your classes and structs. All events in the .NET Framework class library are based on the <xref:System.EventHandler> delegate, which is defined as follows:
+
+```csharp
+public delegate void EventHandler(object sender, EventArgs e);
+```
+
 > [!NOTE]
-> The .NET Framework 2.0 introduces a generic version of this delegate, <xref:System.EventHandler%601>. The following examples show how to use both versions.  
-  
- Although events in classes that you define can be based on any valid delegate type, even delegates that return a value, it is generally recommended that you base your events on the .NET Framework pattern by using <xref:System.EventHandler>, as shown in the following example.  
-  
-### To publish events based on the EventHandler pattern  
-  
-1. (Skip this step and go to Step 3a if you do not have to send custom data with your event.) Declare the class for your custom data at a scope that is visible to both your publisher and subscriber classes. Then add the required members to hold your custom event data. In this example, a simple string is returned.  
-  
-    ```csharp  
-    public class CustomEventArgs : EventArgs  
-    {  
-        public CustomEventArgs(string s)  
-        {  
-            msg = s;  
-        }  
-        private string msg;  
-        public string Message  
-        {  
-            get { return msg; }  
+> The .NET Framework 2.0 introduces a generic version of this delegate, <xref:System.EventHandler%601>. The following examples show how to use both versions.
+
+Although events in classes that you define can be based on any valid delegate type, even delegates that return a value, it is generally recommended that you base your events on the .NET Framework pattern by using <xref:System.EventHandler>, as shown in the following example.
+
+The name `EventHandler` can lead to a bit of confusion, as the delegate itself doesn't actually handle the event but instead is used to raise the event. The <xref:System.EventHandler>, and generic <xref:System.EventHandler%601> are intended to represent a method that will handle an event.
+
+### To publish events based on the EventHandler pattern
+
+1. (Skip this step and go to Step 3a if you do not have to send custom data with your event.) Declare the class for your custom data at a scope that is visible to both your publisher and subscriber classes. Then add the required members to hold your custom event data. In this example, a simple string is returned.
+
+    ```csharp
+    public class CustomEventArgs : EventArgs
+    {
+        public CustomEventArgs(string message)
+        {
+            Message = message;
         }
-    }  
-    ```  
-  
-2. (Skip this step if you are using the generic version of <xref:System.EventHandler%601> .) Declare a delegate in your publishing class. Give it a name that ends with *EventHandler*. The second parameter specifies your custom EventArgs type.  
-  
-    ```csharp  
-    public delegate void CustomEventHandler(object sender, CustomEventArgs a);  
-    ```  
-  
-3. Declare the event in your publishing class by using one of the following steps.  
-  
-    1. If you have no custom EventArgs class, your Event type will be the non-generic EventHandler delegate. You do not have to declare the delegate because it is already declared in the <xref:System> namespace that is included when you create your C# project. Add the following code to your publisher class.  
-  
-        ```csharp  
-        public event EventHandler RaiseCustomEvent;  
-        ```  
-  
-    2. If you are using the non-generic version of <xref:System.EventHandler> and you have a custom class derived from <xref:System.EventArgs>, declare your event inside your publishing class and use your delegate from step 2 as the type.  
-  
-        ```csharp  
-        public event CustomEventHandler RaiseCustomEvent;  
-        ```  
-  
-    3. If you are using the generic version, you do not need a custom delegate. Instead, in your publishing class, you specify your event type as `EventHandler<CustomEventArgs>`, substituting the name of your own class between the angle brackets.  
-  
-        ```csharp  
-        public event EventHandler<CustomEventArgs> RaiseCustomEvent;  
-        ```  
-  
-## Example  
- The following example demonstrates the previous steps by using a custom EventArgs class and <xref:System.EventHandler%601> as the event type.  
-  
- [!code-csharp[csProgGuideEvents#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs#2)]  
-  
+
+        public string Message { get; set; }
+    }
+    ```
+
+2. (Skip this step if you are using the generic version of <xref:System.EventHandler%601>.) Declare a delegate in your publishing class. Give it a name that ends with `EventHandler`. The second parameter specifies your custom `EventArgs` type.
+
+    ```csharp
+    public delegate void CustomEventHandler(object sender, CustomEventArgs args);
+    ```
+
+3. Declare the event in your publishing class by using one of the following steps.
+
+    1. If you have no custom EventArgs class, your Event type will be the non-generic EventHandler delegate. You do not have to declare the delegate because it is already declared in the <xref:System> namespace that is included when you create your C# project. Add the following code to your publisher class.
+
+        ```csharp
+        public event EventHandler RaiseCustomEvent;
+        ```
+
+    2. If you are using the non-generic version of <xref:System.EventHandler> and you have a custom class derived from <xref:System.EventArgs>, declare your event inside your publishing class and use your delegate from step 2 as the type.
+
+        ```csharp
+        public event CustomEventHandler RaiseCustomEvent;
+        ```
+
+    3. If you are using the generic version, you do not need a custom delegate. Instead, in your publishing class, you specify your event type as `EventHandler<CustomEventArgs>`, substituting the name of your own class between the angle brackets.
+
+        ```csharp
+        public event EventHandler<CustomEventArgs> RaiseCustomEvent;
+        ```
+
+## Example
+
+The following example demonstrates the previous steps by using a custom EventArgs class and <xref:System.EventHandler%601> as the event type.
+
+[!code-csharp[csProgGuideEvents#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs#2)]
+
 ## See also
 
 - <xref:System.Delegate>
 - [C# Programming Guide](../index.md)
-- [Events](./index.md)
+- [Events](index.md)
 - [Delegates](../delegates/index.md)

--- a/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
+++ b/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
@@ -19,7 +19,7 @@ public delegate void EventHandler(object sender, EventArgs e);
 
 Although events in classes that you define can be based on any valid delegate type, even delegates that return a value, it is generally recommended that you base your events on the .NET Framework pattern by using <xref:System.EventHandler>, as shown in the following example.
 
-The name `EventHandler` can lead to a bit of confusion, as the delegate itself doesn't actually handle the event but instead is used to raise the event. The <xref:System.EventHandler>, and generic <xref:System.EventHandler%601> are intended to represent a method that will handle an event.
+The name `EventHandler` can lead to a bit of confusion as it doesn't actually handle the event. The <xref:System.EventHandler>, and generic <xref:System.EventHandler%601> are delegate types. A method or lambda expression whose signature matches the delegate definition is the *event handler* and will be invoked when the event is raised.
 
 ### To publish events based on the EventHandler pattern
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
@@ -7,34 +7,28 @@ using System.Text;
 
 namespace BaseClassEvents
 {
-    using System;
-    using System.Collections.Generic;
-
     // Special EventArgs class to hold info about Shapes.
     public class ShapeEventArgs : EventArgs
     {
-        private double newArea;
+        public ShapeEventArgs(double area)
+        {
+            NewArea = area;
+        }
 
-        public ShapeEventArgs(double d)
-        {
-            newArea = d;
-        }
-        public double NewArea
-        {
-            get { return newArea; }
-        }
+        public double NewArea { get; }
     }
 
     // Base class event publisher
     public abstract class Shape
     {
-        protected double area;
+        protected double _area;
 
         public double Area
         {
-            get { return area; }
-            set { area = value; }
+            get => _area;
+            set => _area = value;
         }
+
         // The event. Note that by using the generic EventHandler<T> event type
         // we do not need to declare a separate delegate type.
         public event EventHandler<ShapeEventArgs> ShapeChanged;
@@ -44,31 +38,28 @@ namespace BaseClassEvents
         //The event-invoking method that derived classes can override.
         protected virtual void OnShapeChanged(ShapeEventArgs e)
         {
-            // Make a temporary copy of the event to avoid possibility of
-            // a race condition if the last subscriber unsubscribes
-            // immediately after the null check and before the event is raised.
-            EventHandler<ShapeEventArgs> handler = ShapeChanged;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            // Safely raise the event for all subscribers
+            ShapeChanged?.Invoke(this, e);
         }
     }
 
     public class Circle : Shape
     {
-        private double radius;
-        public Circle(double d)
+        private double _radius;
+
+        public Circle(double radius)
         {
-            radius = d;
-            area = 3.14 * radius * radius;
+            _radius = radius;
+            _area = 3.14 * _radius * _radius;
         }
+
         public void Update(double d)
         {
-            radius = d;
-            area = 3.14 * radius * radius;
-            OnShapeChanged(new ShapeEventArgs(area));
+            _radius = d;
+            _area = 3.14 * _radius * _radius;
+            OnShapeChanged(new ShapeEventArgs(_area));
         }
+
         protected override void OnShapeChanged(ShapeEventArgs e)
         {
             // Do any circle-specific processing here.
@@ -76,6 +67,7 @@ namespace BaseClassEvents
             // Call the base class event invocation method.
             base.OnShapeChanged(e);
         }
+
         public override void Draw()
         {
             Console.WriteLine("Drawing a circle");
@@ -84,21 +76,24 @@ namespace BaseClassEvents
 
     public class Rectangle : Shape
     {
-        private double length;
-        private double width;
+        private double _length;
+        private double _width;
+
         public Rectangle(double length, double width)
         {
-            this.length = length;
-            this.width = width;
-            area = length * width;
+            _length = length;
+            _width = width;
+            _area = _length * _width;
         }
+
         public void Update(double length, double width)
         {
-            this.length = length;
-            this.width = width;
-            area = length * width;
-            OnShapeChanged(new ShapeEventArgs(area));
+            _length = length;
+            _width = width;
+            _area = _length * _width;
+            OnShapeChanged(new ShapeEventArgs(_area));
         }
+
         protected override void OnShapeChanged(ShapeEventArgs e)
         {
             // Do any rectangle-specific processing here.
@@ -106,6 +101,7 @@ namespace BaseClassEvents
             // Call the base class event invocation method.
             base.OnShapeChanged(e);
         }
+
         public override void Draw()
         {
             Console.WriteLine("Drawing a rectangle");
@@ -117,55 +113,56 @@ namespace BaseClassEvents
     // when to redraw a shape.
     public class ShapeContainer
     {
-        List<Shape> _list;
+        private readonly List<Shape> _list;
 
         public ShapeContainer()
         {
             _list = new List<Shape>();
         }
 
-        public void AddShape(Shape s)
+        public void AddShape(Shape shape)
         {
-            _list.Add(s);
+            _list.Add(shape);
+
             // Subscribe to the base class event.
-            s.ShapeChanged += HandleShapeChanged;
+            shape.ShapeChanged += HandleShapeChanged;
         }
 
         // ...Other methods to draw, resize, etc.
 
         private void HandleShapeChanged(object sender, ShapeEventArgs e)
         {
-            Shape s = (Shape)sender;
+            if (sender is Shape shape)
+            {
+                // Diagnostic message for demonstration purposes.
+                Console.WriteLine($"Received event. Shape area is now {e.NewArea}");
 
-            // Diagnostic message for demonstration purposes.
-            Console.WriteLine("Received event. Shape area is now {0}", e.NewArea);
-
-            // Redraw the shape here.
-            s.Draw();
+                // Redraw the shape here.
+                shape.Draw();
+            }
         }
     }
 
     class Test
     {
-
-        static void Main(string[] args)
+        static void Main()
         {
             //Create the event publishers and subscriber
-            Circle c1 = new Circle(54);
-            Rectangle r1 = new Rectangle(12, 9);
-            ShapeContainer sc = new ShapeContainer();
+            var circle = new Circle(54);
+            var rectangle = new Rectangle(12, 9);
+            var container = new ShapeContainer();
 
             // Add the shapes to the container.
-            sc.AddShape(c1);
-            sc.AddShape(r1);
+            container.AddShape(circle);
+            container.AddShape(rectangle);
 
             // Cause some events to be raised.
-            c1.Update(57);
-            r1.Update(7, 7);
+            circle.Update(57);
+            rectangle.Update(7, 7);
 
             // Keep the console window open in debug mode.
-            System.Console.WriteLine("Press any key to exit.");
-            System.Console.ReadKey();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
         }
     }
 }
@@ -180,31 +177,24 @@ namespace BaseClassEvents
 //--------------------------------------------------------------------------------------
 
 //<Snippet2>
+using System;
+
 namespace DotNetEvents
 {
-    using System;
-    using System.Collections.Generic;
-
     // Define a class to hold custom event info
     public class CustomEventArgs : EventArgs
     {
-        public CustomEventArgs(string s)
+        public CustomEventArgs(string message)
         {
-            message = s;
+            Message = message;
         }
-        private string message;
 
-        public string Message
-        {
-            get { return message; }
-            set { message = value; }
-        }
+        public string Message { get; set; }
     }
 
     // Class that publishes an event
     class Publisher
     {
-
         // Declare the event using EventHandler<T>
         public event EventHandler<CustomEventArgs> RaiseCustomEvent;
 
@@ -213,7 +203,7 @@ namespace DotNetEvents
             // Write some code that does something useful here
             // then raise the event. You can also raise an event
             // before you execute a block of code.
-            OnRaiseCustomEvent(new CustomEventArgs("Did something"));
+            OnRaiseCustomEvent(new CustomEventArgs("Event triggered"));
         }
 
         // Wrap event invocations inside a protected virtual method
@@ -223,16 +213,16 @@ namespace DotNetEvents
             // Make a temporary copy of the event to avoid possibility of
             // a race condition if the last subscriber unsubscribes
             // immediately after the null check and before the event is raised.
-            EventHandler<CustomEventArgs> handler = RaiseCustomEvent;
+            EventHandler<CustomEventArgs> raiseEvent = RaiseCustomEvent;
 
             // Event will be null if there are no subscribers
-            if (handler != null)
+            if (raiseEvent != null)
             {
                 // Format the string to send inside the CustomEventArgs parameter
                 e.Message += $" at {DateTime.Now}";
 
-                // Use the () operator to raise the event.
-                handler(this, e);
+                // Call to raise the event.
+                raiseEvent(this, e);
             }
         }
     }
@@ -240,34 +230,36 @@ namespace DotNetEvents
     //Class that subscribes to an event
     class Subscriber
     {
-        private string id;
-        public Subscriber(string ID, Publisher pub)
+        private readonly string _id;
+
+        public Subscriber(string id, Publisher pub)
         {
-            id = ID;
-            // Subscribe to the event using C# 2.0 syntax
+            _id = id;
+
+            // Subscribe to the event
             pub.RaiseCustomEvent += HandleCustomEvent;
         }
 
         // Define what actions to take when the event is raised.
         void HandleCustomEvent(object sender, CustomEventArgs e)
         {
-            Console.WriteLine(id + " received this message: {0}", e.Message);
+            Console.WriteLine($"{_id} received this message: {e.Message}");
         }
     }
 
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
-            Publisher pub = new Publisher();
-            Subscriber sub1 = new Subscriber("sub1", pub);
-            Subscriber sub2 = new Subscriber("sub2", pub);
+            var pub = new Publisher();
+            var sub1 = new Subscriber("sub1", pub);
+            var sub2 = new Subscriber("sub2", pub);
 
             // Call the method that raises the event.
             pub.DoSomething();
 
             // Keep the console window open
-            Console.WriteLine("Press Enter to close this window.");
+            Console.WriteLine("Press any key to continue...");
             Console.ReadLine();
         }
     }


### PR DESCRIPTION
## Summary

- Freshen up doc
- Modernize C#
- Add clarification on `EventHandler` naming

Fixes #18624

#### Preview

✔️ [How to publish events that conform to .NET Framework Guidelines](https://review.docs.microsoft.com/en-us/dotnet/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines?branch=pr-en-us-18642)
✔️ [How to raise base class events in derived classes](https://review.docs.microsoft.com/en-us/dotnet/csharp/programming-guide/events/how-to-raise-base-class-events-in-derived-classes?branch=pr-en-us-18642)