### PR TITLE
Added docs for broadcast and UDF guide

### DIFF
--- a/docs/spark/how-to-guides/broadcast-guide.md
+++ b/docs/spark/how-to-guides/broadcast-guide.md
@@ -1,0 +1,92 @@
+# Guide to using Broadcast Variables
+
+This is a guide to show how to use broadcast variables in .NET for Apache Spark.
+
+## What are Broadcast Variables
+
+[Broadcast variables in Apache Spark](https://spark.apache.org/docs/2.2.0/rdd-programming-guide.html#broadcast-variables) are a mechanism for sharing variables across executors that are meant to be read-only. They allow the programmer to keep a read-only variable cached on each machine rather than shipping a copy of it with tasks. They can be used, for example, to give every node a copy of a large input dataset in an efficient manner.
+
+### How to use broadcast variables in .NET for Apache Spark
+
+Broadcast variables are created from a variable `v` by calling `SparkContext.Broadcast(v)`. The broadcast variable is a wrapper around `v`, and its value can be accessed by calling the `Value()` method. 
+
+Example:
+
+```csharp
+string v = "Variable to be broadcasted";
+Broadcast<string> bv = SparkContext.Broadcast(v);
+
+// Using the broadcast variable in a UDF:
+Func<Column, Column> udf = Udf<string, string>(
+    str => $"{str}: {bv.Value()}");
+```
+
+The type parameter for `Broadcast` should be the type of the variable being broadcasted.
+
+### Deleting broadcast variables
+
+The broadcast variable can be deleted from all executors by calling the `Destroy()` method on it.
+
+```csharp
+// Destroying the broadcast variable bv:
+bv.Destroy();
+```
+
+> Note: `Destroy()` deletes all data and metadata related to the broadcast variable. Use this with caution - once a broadcast variable has been destroyed, it cannot be used again.
+
+#### Caveat of using Destroy
+
+One important thing to keep in mind while using broadcast variables in UDFs is to limit the scope of the variable to only the UDF that is referencing it. The [guide to using UDFs](udf-guide.md) describes this phenomenon in detail. This is especially crucial when calling `Destroy` on the broadcast variable. If the broadcast variable that has been destroyed is visible to or accessible from other UDFs, it gets picked up for serialization by all those UDFs, even if it is not being referenced by them. This will throw an error as .NET for Apache Spark is not able to serialize the destroyed broadcast variable.
+
+Example to demonstrate:
+
+```csharp
+string v = "Variable to be broadcasted";
+Broadcast<string> bv = SparkContext.Broadcast(v);
+
+// Using the broadcast variable in a UDF:
+Func<Column, Column> udf1 = Udf<string, string>(
+    str => $"{str}: {bv.Value()}");
+
+// Destroying bv
+bv.Destroy();
+
+// Calling udf1 after destroying bv throws the following expected exception:
+// org.apache.spark.SparkException: Attempted to use Broadcast(0) after it was destroyed
+df.Select(udf1(df["_1"])).Show();
+
+// Different UDF udf2 that is not referencing bv
+Func<Column, Column> udf2 = Udf<string, string>(
+    str => $"{str}: not referencing broadcast variable");
+
+// Calling udf2 throws the following (unexpected) exception:
+// [Error] [JvmBridge] org.apache.spark.SparkException: Task not serializable
+df.Select(udf2(df["_1"])).Show();
+```
+
+The recommended way of implementing above desired behavior:
+
+```csharp
+string v = "Variable to be broadcasted";
+// Restricting the visibility of bv to only the UDF referencing it
+{
+    Broadcast<string> bv = SparkContext.Broadcast(v);
+
+    // Using the broadcast variable in a UDF:
+    Func<Column, Column> udf1 = Udf<string, string>(
+        str => $"{str}: {bv.Value()}");
+
+    // Destroying bv
+    bv.Destroy();
+}
+
+// Different UDF udf2 that is not referencing bv
+Func<Column, Column> udf2 = Udf<string, string>(
+    str => $"{str}: not referencing broadcast variable");
+
+// Calling udf2 works fine as expected
+df.Select(udf2(df["_1"])).Show();
+```
+ This ensures that destroying `bv` doesn't affect calling `udf2` because of unexpected serialization behavior. 
+
+ Broadcast variables are useful for transmitting read-only data to all executors, as the data is sent only once and this can give performance benefits when compared with using local variables that get shipped to the executors with each task. Please refer to the [official documentation](https://spark.apache.org/docs/2.2.0/rdd-programming-guide.html#broadcast-variables) to get a deeper understanding of broadcast variables and why they are used.

--- a/docs/spark/how-to-guides/broadcast-guide.md
+++ b/docs/spark/how-to-guides/broadcast-guide.md
@@ -14,9 +14,9 @@ Because the data is sent only once, broadcast variables have performance benefit
 
 ## Create broadcast variables
 
-To create a broadcast variable, call `SparkContext.Broadcast(v)` for any variable `v`. The broadcast variable is a wrapper around the variable `v`, and its value can be accessed by calling the `Value()` method. 
+To create a broadcast variable, call `SparkContext.Broadcast(v)` for any variable `v`. The broadcast variable is a wrapper around the variable `v`, and its value can be accessed by calling the `Value()` method.
 
-In the following code snippet, a string variable `v` is created, and a broadcast variable `bv` is created when `SparkContext.Broadcast(v)`is called. Notice the type parameter for `Broadcast`, string, matches the type of the variable being broadcasted. The user-defined function (UDF) returns the value of `bv`. 
+In the following code snippet, a string variable `v` is created, and a broadcast variable `bv` is created when `SparkContext.Broadcast(v)`is called. Notice the type parameter for `Broadcast`, string, matches the type of the variable being broadcasted. The user-defined function (UDF) returns the value of `bv`.
 
 ```csharp
 string v = "Variable to be broadcasted";
@@ -38,7 +38,7 @@ bv.Destroy();
 
 ## Limit broadcast variable scope in UDFs
 
-When you use broadcast variables in UDFs, you need to limit the scope of the variable to only the UDF that is referencing the variable. The [guide to using UDFs](udf-guide.md) describes this phenomenon in detail. Scope is especially crucial when you call `Destroy()` on the broadcast variable. 
+When you use broadcast variables in UDFs, you need to limit the scope of the variable to only the UDF that is referencing the variable. The [guide to using UDFs](udf-guide.md) describes this phenomenon in detail. Scope is especially crucial when you call `Destroy()` on the broadcast variable.
 
 If the broadcast variable that has been destroyed is visible to or accessible from other UDFs, it gets picked up for serialization by all of the UDFs, even if it is not being referenced by them. .NET for Apache Spark is unable to serialize the destroyed broadcast variable, which results in an error. The following code snippet demonstrates this error:
 
@@ -88,8 +88,8 @@ Func<Column, Column> udf2 = Udf<string, string>(
 
 // Calling udf2 works fine as expected
 df.Select(udf2(df["_1"])).Show();
-``` 
- 
+```
+
  ## Next steps
  
 * [Get started with .NET for Apache Spark](../tutorials/get-started.md)

--- a/docs/spark/how-to-guides/broadcast-guide.md
+++ b/docs/spark/how-to-guides/broadcast-guide.md
@@ -1,44 +1,46 @@
-# Guide to using Broadcast Variables
+---
+title: Use broadcast variables in .NET for Apache Spark
+description: Learn how to use broadcast variables in .NET for Apache Spark applications.
+ms.date: 06/11/2020
+ms.topic: conceptual
+ms.custom: mvc,how-to
+---
 
-This is a guide to show how to use broadcast variables in .NET for Apache Spark.
+# Use broadcast variables in .NET for Apache Spark
 
-## What are Broadcast Variables
+In this article, you learn how to use broadcast variables in .NET for Apache Spark. [Broadcast variables in Apache Spark](https://spark.apache.org/docs/2.2.0/rdd-programming-guide.html#broadcast-variables) are mechanisms for sharing variables across executors that are meant to be read-only. Broadcast variables allow you to keep a read-only variable cached on each machine rather than shipping a copy of it with tasks. You can use broadcast variables to give every node a copy of a large input dataset in an efficient manner.
 
-[Broadcast variables in Apache Spark](https://spark.apache.org/docs/2.2.0/rdd-programming-guide.html#broadcast-variables) are a mechanism for sharing variables across executors that are meant to be read-only. They allow the programmer to keep a read-only variable cached on each machine rather than shipping a copy of it with tasks. They can be used, for example, to give every node a copy of a large input dataset in an efficient manner.
+Because the data is sent only once, broadcast variables have performance benefits when compared to local variables that are shipped to the executors with each task. Refer to the [official broadcast variable documentation](https://spark.apache.org/docs/2.2.0/rdd-programming-guide.html#broadcast-variables) to get a deeper understanding of broadcast variables and why they are used.
 
-### How to use broadcast variables in .NET for Apache Spark
+## Create broadcast variables
 
-Broadcast variables are created from a variable `v` by calling `SparkContext.Broadcast(v)`. The broadcast variable is a wrapper around `v`, and its value can be accessed by calling the `Value()` method. 
+To create a broadcast variable, call `SparkContext.Broadcast(v)` for any variable `v`. The broadcast variable is a wrapper around the variable `v`, and its value can be accessed by calling the `Value()` method. 
 
-Example:
+In the following code snippet, a string variable `v` is created, and a broadcast variable `bv` is created when `SparkContext.Broadcast(v)`is called. Notice the type parameter for `Broadcast`, string, matches the type of the variable being broadcasted. The user-defined function (UDF) returns the value of `bv`. 
 
 ```csharp
 string v = "Variable to be broadcasted";
 Broadcast<string> bv = SparkContext.Broadcast(v);
 
-// Using the broadcast variable in a UDF:
 Func<Column, Column> udf = Udf<string, string>(
     str => $"{str}: {bv.Value()}");
 ```
 
-The type parameter for `Broadcast` should be the type of the variable being broadcasted.
+## Delete broadcast variables
 
-### Deleting broadcast variables
-
-The broadcast variable can be deleted from all executors by calling the `Destroy()` method on it.
+The broadcast variable can be deleted from all executors by calling the `Destroy()` method.
 
 ```csharp
-// Destroying the broadcast variable bv:
 bv.Destroy();
 ```
 
-> Note: `Destroy()` deletes all data and metadata related to the broadcast variable. Use this with caution - once a broadcast variable has been destroyed, it cannot be used again.
+`Destroy()` deletes all data and metadata related to the broadcast variable and should be used with caution. Once a broadcast variable is destroyed, it can't be used again.
 
-#### Caveat of using Destroy
+## Limit broadcast variable scope in UDFs
 
-One important thing to keep in mind while using broadcast variables in UDFs is to limit the scope of the variable to only the UDF that is referencing it. The [guide to using UDFs](udf-guide.md) describes this phenomenon in detail. This is especially crucial when calling `Destroy` on the broadcast variable. If the broadcast variable that has been destroyed is visible to or accessible from other UDFs, it gets picked up for serialization by all those UDFs, even if it is not being referenced by them. This will throw an error as .NET for Apache Spark is not able to serialize the destroyed broadcast variable.
+When you use broadcast variables in UDFs, you need to limit the scope of the variable to only the UDF that is referencing the variable. The [guide to using UDFs](udf-guide.md) describes this phenomenon in detail. Scope is especially crucial when you call `Destroy()` on the broadcast variable. 
 
-Example to demonstrate:
+If the broadcast variable that has been destroyed is visible to or accessible from other UDFs, it gets picked up for serialization by all of the UDFs, even if it is not being referenced by them. .NET for Apache Spark is unable to serialize the destroyed broadcast variable, which results in an error. The following code snippet demonstrates this error:
 
 ```csharp
 string v = "Variable to be broadcasted";
@@ -64,7 +66,7 @@ Func<Column, Column> udf2 = Udf<string, string>(
 df.Select(udf2(df["_1"])).Show();
 ```
 
-The recommended way of implementing above desired behavior:
+The following code snippet demonstrates how to ensure that destroying `bv` doesn't affect `udf2` because of an unexpected serialization behavior:
 
 ```csharp
 string v = "Variable to be broadcasted";
@@ -86,7 +88,10 @@ Func<Column, Column> udf2 = Udf<string, string>(
 
 // Calling udf2 works fine as expected
 df.Select(udf2(df["_1"])).Show();
-```
- This ensures that destroying `bv` doesn't affect calling `udf2` because of unexpected serialization behavior. 
-
- Broadcast variables are useful for transmitting read-only data to all executors, as the data is sent only once and this can give performance benefits when compared with using local variables that get shipped to the executors with each task. Please refer to the [official documentation](https://spark.apache.org/docs/2.2.0/rdd-programming-guide.html#broadcast-variables) to get a deeper understanding of broadcast variables and why they are used.
+``` 
+ 
+ ## Next steps
+ 
+* [Get started with .NET for Apache Spark](../tutorials/get-started.md)
+* [Debug a .NET for Apache Spark application on Windows](debug.md)
+* [Deploy .NET for Apache Spark worker and user-defined function binaries](deploy-worker-udf-binaries.md)

--- a/docs/spark/how-to-guides/broadcast-guide.md
+++ b/docs/spark/how-to-guides/broadcast-guide.md
@@ -90,8 +90,8 @@ Func<Column, Column> udf2 = Udf<string, string>(
 df.Select(udf2(df["_1"])).Show();
 ```
 
- ## Next steps
- 
+## Next steps
+
 * [Get started with .NET for Apache Spark](../tutorials/get-started.md)
 * [Debug a .NET for Apache Spark application on Windows](debug.md)
 * [Deploy .NET for Apache Spark worker and user-defined function binaries](deploy-worker-udf-binaries.md)

--- a/docs/spark/how-to-guides/udf-guide.md
+++ b/docs/spark/how-to-guides/udf-guide.md
@@ -1,0 +1,171 @@
+# Guide to User-Defined Functions (UDFs)
+
+This is a guide to show how to use UDFs in .NET for Apache Spark.
+
+## What are UDFs
+
+[User-Defined Functions (UDFs)](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/expressions/UserDefinedFunction.html) are a feature of Spark that allow developers to use custom functions to extend the system's built-in functionality. They transform values from a single row within a table to produce a single corresponding output value per row based on the logic defined in the UDF.
+
+Let's take the following as an example for a UDF definition:
+
+```csharp
+string s1 = "hello";
+Func<Column, Column> udf = Udf<string, string>(
+    str => $"{s1} {str}");
+
+```
+The above defined UDF takes a `string` as an input (in the form of a [Column](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Column.cs#L14) of a [Dataframe](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/DataFrame.cs#L24)), and returns a `string` with `hello` appended in front of the input.
+
+For a sample Dataframe, let's take the following Dataframe `df`:
+
+```text
++-------+
+|   name|
++-------+
+|Michael|
+|   Andy|
+| Justin|
++-------+
+```
+
+Now let's apply the above defined `udf` to the dataframe `df`:
+
+```csharp
+DataFrame udfResult = df.Select(udf(df["name"]));
+```
+
+This would return the below as the Dataframe `udfResult`:
+
+```text
++-------------+
+|         name|
++-------------+
+|hello Michael|
+|   hello Andy|
+| hello Justin|
++-------------+
+```
+To get a better understanding of how to implement UDFs, please take a look at the [UDF helper functions](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Functions.cs#L3616) and some [test examples](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs#L49).
+
+## UDF serialization
+
+Since UDFs are functions that need to be executed on the workers, they have to be serialized and sent to the workers as part of the payload from the driver. This involves serializing the [delegate](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/) which is a reference to the method, along with its [target](https://docs.microsoft.com/en-us/dotnet/api/system.delegate.target?view=netframework-4.8) which is the class instance on which the current delegate invokes the instance method. Please take a look at this [code](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs#L149) to get a better understanding of how UDF serialization is being done.
+
+## Good to know while implementing UDFs
+
+One behavior to be aware of while implementing UDFs in .NET for Apache Spark is how the target of the UDF gets serialized. .NET for Apache Spark uses .NET Core, which does not support serializing delegates, so it is instead done by using reflection to serialize the target where the delegate is defined. When multiple delegates are defined in a common scope, they have a shared closure that becomes the target of reflection for serialization. Let's take an example to illustrate what that means.
+
+The following code snippet defines two string variables that are being referenced in two function delegates that return the respective strings as result:
+
+```csharp
+using System;
+
+public class C {
+    public void M() {
+        string s1 = "s1";
+        string s2 = "s2";
+        Func<string, string> a = str => s1;
+        Func<string, string> b = str => s2;
+    }
+}
+```
+
+The above C# code generates the following C# disassembly (credit source: [sharplab.io](https://sharplab.io)) code from the compiler:
+
+```csharp
+public class C
+{
+    [CompilerGenerated]
+    private sealed class <>c__DisplayClass0_0
+    {
+        public string s1;
+
+        public string s2;
+
+        internal string <M>b__0(string str)
+        {
+            return s1;
+        }
+
+        internal string <M>b__1(string str)
+        {
+            return s2;
+        }
+    }
+
+    public void M()
+    {
+        <>c__DisplayClass0_0 <>c__DisplayClass0_ = new <>c__DisplayClass0_0();
+        <>c__DisplayClass0_.s1 = "s1";
+        <>c__DisplayClass0_.s2 = "s2";
+        Func<string, string> func = new Func<string, string>(<>c__DisplayClass0_.<M>b__0);
+        Func<string, string> func2 = new Func<string, string>(<>c__DisplayClass0_.<M>b__1);
+    }
+}
+```
+As can be seen in the above decompiled code, both `func` and `func2` share the same closure `<>c__DisplayClass0_0`, which is the target that is serialized when serializing the delegates `func` and `func2`. Hence, even though `Func<string, string> a` is only referencing `s1`, `s2` also gets serialized when sending over the bytes to the workers.
+
+This can lead to some unexpected behaviors at runtime (like in the case of using [broadcast variables](broadcast-guide.md)), which is why we recommend restricting the visibility of the variables used in a function to that function's scope.
+
+Going back to the above example, the following is the recommended way to implement the desired behavior of previous code snippet:
+
+```csharp
+using System;
+
+public class C {
+    public void M() {
+        {
+            string s1 = "s1";
+            Func<string, string> a = str => s1;
+        }
+        {
+            string s2 = "s2";
+            Func<string, string> b = str => s2;
+        }
+    }
+}
+```
+
+The above C# code generates the following C# disassembly (credit source: [sharplab.io](https://sharplab.io)) code from the compiler:
+
+```csharp
+public class C
+{
+    [CompilerGenerated]
+    private sealed class <>c__DisplayClass0_0
+    {
+        public string s1;
+
+        internal string <M>b__0(string str)
+        {
+            return s1;
+        }
+    }
+
+    [CompilerGenerated]
+    private sealed class <>c__DisplayClass0_1
+    {
+        public string s2;
+
+        internal string <M>b__1(string str)
+        {
+            return s2;
+        }
+    }
+
+    public void M()
+    {
+        <>c__DisplayClass0_0 <>c__DisplayClass0_ = new <>c__DisplayClass0_0();
+        <>c__DisplayClass0_.s1 = "s1";
+        Func<string, string> func = new Func<string, string>(<>c__DisplayClass0_.<M>b__0);
+        <>c__DisplayClass0_1 <>c__DisplayClass0_2 = new <>c__DisplayClass0_1();
+        <>c__DisplayClass0_2.s2 = "s2";
+        Func<string, string> func2 = new Func<string, string>(<>c__DisplayClass0_2.<M>b__1);
+    }
+}
+```
+
+Here we see that `func` and `func2` no longer share a closure and have their own separate closures `<>c__DisplayClass0_0` and `<>c__DisplayClass0_1` respectively. When used as the target for serialization, nothing other than the referenced variables will get serialized for the delegate.
+
+This behavior is important to keep in mind while implementing multiple UDFs in a common scope. 
+To learn more about UDFs in general, please review the following articles that explain UDFs and how to use them: [UDFs in databricks(scala)](https://docs.databricks.com/spark/latest/spark-sql/udf-scala.html), [Spark UDFs and some gotchas](https://medium.com/@achilleus/spark-udfs-we-can-use-them-but-should-we-use-them-2c5a561fde6d).

--- a/docs/spark/how-to-guides/udf-guide.md
+++ b/docs/spark/how-to-guides/udf-guide.md
@@ -18,8 +18,8 @@ Review the following UDF definition:
 string s1 = "hello";
 Func<Column, Column> udf = Udf<string, string>(
     str => $"{s1} {str}");
-
 ```
+
 The UDF takes a `string` as an input in the form of a [Column](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Column.cs#L14) of a [Dataframe](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/DataFrame.cs#L24)) and returns a `string` with `hello` appended in front of the input.
 
 The following DataFrame `df` contains a list of names:
@@ -173,7 +173,7 @@ public class C
 }
 ```
 
-Notice that `func` and `func2` no longer share a closure, and they have their own separate closures `<>c__DisplayClass0_0` and `<>c__DisplayClass0_1` respectively. When used as the target for serialization, nothing other than the referenced variables will get serialized for the delegate. This behavior is important to keep in mind while implementing multiple UDFs in a common scope. 
+Notice that `func` and `func2` no longer share a closure, and they have their own separate closures `<>c__DisplayClass0_0` and `<>c__DisplayClass0_1` respectively. When used as the target for serialization, nothing other than the referenced variables will get serialized for the delegate. This behavior is important to keep in mind while implementing multiple UDFs in a common scope.
 
 To learn more about UDFs in general, please review the following articles that explain UDFs and how to use them: [UDFs in databricks(scala)](https://docs.databricks.com/spark/latest/spark-sql/udf-scala.html), [Spark UDFs and some gotchas](https://medium.com/@achilleus/spark-udfs-we-can-use-them-but-should-we-use-them-2c5a561fde6d).
 

--- a/docs/spark/how-to-guides/udf-guide.md
+++ b/docs/spark/how-to-guides/udf-guide.md
@@ -168,4 +168,10 @@ public class C
 Here we see that `func` and `func2` no longer share a closure and have their own separate closures `<>c__DisplayClass0_0` and `<>c__DisplayClass0_1` respectively. When used as the target for serialization, nothing other than the referenced variables will get serialized for the delegate.
 
 This behavior is important to keep in mind while implementing multiple UDFs in a common scope. 
-To learn more about UDFs in general, please review the following articles that explain UDFs and how to use them: [UDFs in databricks(scala)](https://docs.databricks.com/spark/latest/spark-sql/udf-scala.html), [Spark UDFs and some gotchas](https://medium.com/@achilleus/spark-udfs-we-can-use-them-but-should-we-use-them-2c5a561fde6d).
+
+## Some Spark UDF caveats
+
+* Null values in UDFs can throw exceptions. It's the responsibility of the developer to handle them.
+* UDFs don't leverage the optimizations provided by Spark's built-in functions, so it's recommended to use built-in functions where possible.
+
+To learn more about UDFs in general, please review the following articles that explain UDFs and how to use them: [UDFs in databricks(scala)](https://docs.databricks.com/spark/latest/spark-sql/udf-scala.html)

--- a/docs/spark/how-to-guides/udf-guide.md
+++ b/docs/spark/how-to-guides/udf-guide.md
@@ -1,12 +1,18 @@
-# Guide to User-Defined Functions (UDFs)
+---
+title: Create user-defined functions (UDF) in .NET for Apache Spark
+description: Learn how to implement user-defined functions (UDF) in .NET for Apache Spark applications.
+ms.date: 06/11/2020
+ms.topic: conceptual
+ms.custom: mvc,how-to
+---
 
-This is a guide to show how to use UDFs in .NET for Apache Spark.
+# Create user-defined functions (UDF) in .NET for Apache Spark
 
-## What are UDFs
+In this article, you learn how to use user-defined functions (UDF) in .NET for Apache Spark. [UDFs)](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/expressions/UserDefinedFunction.html) are a Spark feature that allow you to use custom functions to extend the system's built-in functionality. UDFs transform values from a single row within a table to produce a single corresponding output value per row based on the logic defined in the UDF.
 
-[User-Defined Functions (UDFs)](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/expressions/UserDefinedFunction.html) are a feature of Spark that allow developers to use custom functions to extend the system's built-in functionality. They transform values from a single row within a table to produce a single corresponding output value per row based on the logic defined in the UDF.
+## Define UDFs
 
-Let's take the following as an example for a UDF definition:
+Review the following UDF definition:
 
 ```csharp
 string s1 = "hello";
@@ -14,9 +20,9 @@ Func<Column, Column> udf = Udf<string, string>(
     str => $"{s1} {str}");
 
 ```
-The above defined UDF takes a `string` as an input (in the form of a [Column](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Column.cs#L14) of a [Dataframe](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/DataFrame.cs#L24)), and returns a `string` with `hello` appended in front of the input.
+The UDF takes a `string` as an input in the form of a [Column](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Column.cs#L14) of a [Dataframe](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/DataFrame.cs#L24)) and returns a `string` with `hello` appended in front of the input.
 
-For a sample Dataframe, let's take the following Dataframe `df`:
+The following DataFrame `df` contains a list of names:
 
 ```text
 +-------+
@@ -28,13 +34,13 @@ For a sample Dataframe, let's take the following Dataframe `df`:
 +-------+
 ```
 
-Now let's apply the above defined `udf` to the dataframe `df`:
+Now let's apply the above defined `udf` to the DataFrame `df`:
 
 ```csharp
 DataFrame udfResult = df.Select(udf(df["name"]));
 ```
 
-This would return the below as the Dataframe `udfResult`:
+The following DataFrame `udfResult` is the result of the UDF:
 
 ```text
 +-------------+
@@ -45,17 +51,18 @@ This would return the below as the Dataframe `udfResult`:
 | hello Justin|
 +-------------+
 ```
-To get a better understanding of how to implement UDFs, please take a look at the [UDF helper functions](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Functions.cs#L3616) and some [test examples](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs#L49).
+
+To better understand how to implement UDFs, review the [UDF helper functions](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Sql/Functions.cs#L3616) and [examples](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark.E2ETest/UdfTests/UdfSimpleTypesTests.cs#L49) on GitHub.
 
 ## UDF serialization
 
-Since UDFs are functions that need to be executed on the workers, they have to be serialized and sent to the workers as part of the payload from the driver. This involves serializing the [delegate](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/) which is a reference to the method, along with its [target](https://docs.microsoft.com/en-us/dotnet/api/system.delegate.target?view=netframework-4.8) which is the class instance on which the current delegate invokes the instance method. Please take a look at this [code](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs#L149) to get a better understanding of how UDF serialization is being done.
+Because UDFs are functions that need to be executed on workers, they have to be serialized and sent to the workers as part of the payload from the driver. The [delegate](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/), which is a reference to the method, needs to be serialized as well as its [target](https://docs.microsoft.com/en-us/dotnet/api/system.delegate.target?view=netframework-4.8) which is the class instance on which the current delegate invokes the instance method. Review this [code example in GitHub](https://github.com/dotnet/spark/blob/master/src/csharp/Microsoft.Spark/Utils/CommandSerDe.cs#L149) to get a better understanding of how UDF serialization is being done.
 
-## Good to know while implementing UDFs
+.NET for Apache Spark uses .NET Core, which doesn't support serializing delegates. Instead, reflection is used to serialize the target where the delegate is defined. When multiple delegates are defined in a common scope, they have a shared closure that becomes the target of reflection for serialization.
 
-One behavior to be aware of while implementing UDFs in .NET for Apache Spark is how the target of the UDF gets serialized. .NET for Apache Spark uses .NET Core, which does not support serializing delegates, so it is instead done by using reflection to serialize the target where the delegate is defined. When multiple delegates are defined in a common scope, they have a shared closure that becomes the target of reflection for serialization. Let's take an example to illustrate what that means.
+### Serialization example
 
-The following code snippet defines two string variables that are being referenced in two function delegates that return the respective strings as result:
+The following code snippet defines two string variables that are being referenced in two function delegates that return the respective strings as a result:
 
 ```csharp
 using System;
@@ -103,11 +110,12 @@ public class C
     }
 }
 ```
-As can be seen in the above decompiled code, both `func` and `func2` share the same closure `<>c__DisplayClass0_0`, which is the target that is serialized when serializing the delegates `func` and `func2`. Hence, even though `Func<string, string> a` is only referencing `s1`, `s2` also gets serialized when sending over the bytes to the workers.
 
-This can lead to some unexpected behaviors at runtime (like in the case of using [broadcast variables](broadcast-guide.md)), which is why we recommend restricting the visibility of the variables used in a function to that function's scope.
+Both `func` and `func2` share the same closure `<>c__DisplayClass0_0`, which is the target that is serialized when serializing the delegates `func` and `func2`. Even though `Func<string, string> a` is only referencing `s1`, `s2` is also serialized when the bytes are sent to the workers.
 
-Going back to the above example, the following is the recommended way to implement the desired behavior of previous code snippet:
+This can lead to some unexpected behaviors at runtime (like in the case of using [broadcast variables](broadcast-guide.md)), which is why we recommend that you restrict the visibility of the variables used in a function to that function's scope.
+
+The following code snippet is the recommended way to implement the desired serialization behavior:
 
 ```csharp
 using System;
@@ -165,7 +173,11 @@ public class C
 }
 ```
 
-Here we see that `func` and `func2` no longer share a closure and have their own separate closures `<>c__DisplayClass0_0` and `<>c__DisplayClass0_1` respectively. When used as the target for serialization, nothing other than the referenced variables will get serialized for the delegate.
+Notice that `func` and `func2` no longer share a closure, and they have their own separate closures `<>c__DisplayClass0_0` and `<>c__DisplayClass0_1` respectively. When used as the target for serialization, nothing other than the referenced variables will get serialized for the delegate. This behavior is important to keep in mind while implementing multiple UDFs in a common scope. 
 
-This behavior is important to keep in mind while implementing multiple UDFs in a common scope. 
 To learn more about UDFs in general, please review the following articles that explain UDFs and how to use them: [UDFs in databricks(scala)](https://docs.databricks.com/spark/latest/spark-sql/udf-scala.html), [Spark UDFs and some gotchas](https://medium.com/@achilleus/spark-udfs-we-can-use-them-but-should-we-use-them-2c5a561fde6d).
+
+## Next steps
+
+* [Get started with .NET for Apache Spark](../tutorials/get-started.md)
+* [Debug a .NET for Apache Spark application on Windows](debug.md)


### PR DESCRIPTION
This PR adds the following two docs to the dotnet docs:

1. Broadcast guide - guide on how to use broadcast variables inside .NET for Apache Spark
2. UDF guide - guide on UDF serialization and caveats

Preview Links: 


File Type | File Name | Published Url
-- | -- | --
Content | docs/spark/how-to-guides/broadcast-guide.md | https://review.docs.microsoft.com/en-us/dotnet/spark/how-to-guides/broadcast-guide?branch=pr-en-us-18710
Content | docs/spark/how-to-guides/udf-guide.md | https://review.docs.microsoft.com/en-us/dotnet/spark/how-to-guides/udf-guide?branch=pr-en-us-18710
