### PR TITLE
Add missing back-tick

### DIFF
--- a/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
+++ b/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
@@ -43,7 +43,7 @@ However, the fully qualified name is only needed to avoid ambiguity when the cla
 string IEmployee.this[int index]
 {
 }
-``
+```
 
 implements the indexer on the `IEmployee` interface, while the following declaration:
 


### PR DESCRIPTION
## Summary
Missing back-tick was screwing up markdown formatting on page. Added a back-tick to fix this.


Fixes #18709
