### PR TITLE
At runtime -> at run time

### DIFF
--- a/docs/core/additional-tools/dotnet-svcutil.xmlserializer-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil.xmlserializer-guide.md
@@ -92,4 +92,4 @@ To use `dotnet-svcutil.xmlserializer` in a .NET Core console application:
 
 6. Build the application by running `dotnet build`. If everything succeeds, an assembly named *MyWCFClient.XmlSerializers.dll* is generated in the output folder. If the tool failed to generate the assembly, you'll see warnings in the build output.
 
-7. Start the WCF service by, for example, running `http://localhost:2561/Service1.svc` in the browser. Then start the client application, and it will automatically load and use the pre-generated serializers at runtime.
+7. Start the WCF service by, for example, running `http://localhost:2561/Service1.svc` in the browser. Then start the client application, and it will automatically load and use the pre-generated serializers at run time.

--- a/docs/core/additional-tools/xml-serializer-generator.md
+++ b/docs/core/additional-tools/xml-serializer-generator.md
@@ -97,7 +97,7 @@ var serializer = new System.Xml.Serialization.XmlSerializer(typeof(MyClass));
 
 ### Build and run the application
 
-Still within the *MyApp* folder, run the application via [`dotnet run`](../tools/dotnet-run.md) and it automatically loads and uses the pre-generated serializers at runtime.
+Still within the *MyApp* folder, run the application via [`dotnet run`](../tools/dotnet-run.md) and it automatically loads and uses the pre-generated serializers at run time.
 
 Type the following command in your console window:
 

--- a/docs/core/dependency-loading/overview.md
+++ b/docs/core/dependency-loading/overview.md
@@ -13,7 +13,7 @@ Every .NET Core application has dependencies. Even the simple `hello world` app 
 
 Understanding .NET Core default assembly loading logic can help understanding and debugging typical deployment issues.
 
-In some applications, dependencies are dynamically determined at runtime. In these situations, it's critical to understand how managed assemblies and unmanaged dependencies are loaded.
+In some applications, dependencies are dynamically determined at run time. In these situations, it's critical to understand how managed assemblies and unmanaged dependencies are loaded.
 
 ## Understanding AssemblyLoadContext
 

--- a/docs/core/tools/dotnet-migrate.md
+++ b/docs/core/tools/dotnet-migrate.md
@@ -26,7 +26,7 @@ dotnet migrate -h|--help
 
 This command is deprecated. The `dotnet migrate` command is no longer available starting with .NET Core 3.0 SDK. It can only migrate a Preview 2 .NET Core project to a 1.x .NET Core project, which is out of support.
 
-By default, the command migrates the root project and any project references that the root project contains. This behavior is disabled using the `--skip-project-references` option at runtime.
+By default, the command migrates the root project and any project references that the root project contains. This behavior is disabled using the `--skip-project-references` option at run time.
 
 Migration can be performed on the following assets:
 

--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -111,7 +111,7 @@ Common properties include:
 * `TRUSTED_PLATFORM_ASSEMBLIES`
    This is a list of assembly paths (delimited by ';' on Windows and ':' on Linux) which the runtime will be able to resolve by default. Some hosts have hard-coded manifests listing assemblies they can load. Others will put any library in certain locations (next to *coreclr.dll*, for example) on this list.
 * `APP_PATHS`
-   This is a list of paths to probe in for an assembly if it can't be found in the trusted platform assemblies (TPA) list. Because the host has more control over which assemblies are loaded using the TPA list, it is a best practice for hosts to determine which assemblies they expect to load and list them explicitly. If probing at runtime is needed, however, this property can enable that scenario.
+   This is a list of paths to probe in for an assembly if it can't be found in the trusted platform assemblies (TPA) list. Because the host has more control over which assemblies are loaded using the TPA list, it is a best practice for hosts to determine which assemblies they expect to load and list them explicitly. If probing at run time is needed, however, this property can enable that scenario.
 * `APP_NI_PATHS`
    This list is similar to APP_PATHS except that it's meant to be paths that will be probed for native images.
 * `NATIVE_DLL_SEARCH_DIRECTORIES`
@@ -214,7 +214,7 @@ Common AppDomain properties include:
 * `TRUSTED_PLATFORM_ASSEMBLIES`
    This is a list of assembly paths (delimited by `;` on Windows and `:` on Linux/macOS) which the AppDomain should prioritize loading and give full trust to (even in partially trusted domains). This list is meant to contain 'Framework' assemblies and other trusted modules, similar to the GAC in .NET Framework scenarios. Some hosts will put any library next to *coreclr.dll* on this list, others have hard-coded manifests listing trusted assemblies for their purposes.
 * `APP_PATHS`
-   This is a list of paths to probe in for an assembly if it can't be found in the trusted platform assemblies (TPA) list. Because the host has more control over which assemblies are loaded using the TPA list, it is a best practice for hosts to determine which assemblies they expect to load and list them explicitly. If probing at runtime is needed, however, this property can enable that scenario.
+   This is a list of paths to probe in for an assembly if it can't be found in the trusted platform assemblies (TPA) list. Because the host has more control over which assemblies are loaded using the TPA list, it is a best practice for hosts to determine which assemblies they expect to load and list them explicitly. If probing at run time is needed, however, this property can enable that scenario.
 * `APP_NI_PATHS`
    This list is very similar to APP_PATHS except that it's meant to be paths that will be probed for native images.
 * `NATIVE_DLL_SEARCH_DIRECTORIES`

--- a/docs/core/whats-new/dotnet-core-2-1.md
+++ b/docs/core/whats-new/dotnet-core-2-1.md
@@ -85,7 +85,7 @@ In .NET Core 2.1 SDK, all tools operations use the `dotnet tool` command. The fo
 
 All .NET Core applications starting with .NET Core 2.0 automatically roll forward to the latest *minor version* installed on a system.
 
-Starting with .NET Core 2.0, if the version of .NET Core that an application was built with is not present at runtime, the application automatically runs against the latest installed *minor version* of .NET Core. In other words, if an application is built with .NET Core 2.0, and .NET Core 2.0 is not present on the host system but .NET Core 2.1 is, the application runs with .NET Core 2.1.
+Starting with .NET Core 2.0, if the version of .NET Core that an application was built with is not present at run time, the application automatically runs against the latest installed *minor version* of .NET Core. In other words, if an application is built with .NET Core 2.0, and .NET Core 2.0 is not present on the host system but .NET Core 2.1 is, the application runs with .NET Core 2.1.
 
 > [!IMPORTANT]
 > This roll-forward behavior doesn't apply to preview releases. By default, it also doesn't apply to major releases, but this can be changed with the settings below.

--- a/docs/standard/assembly/file-format.md
+++ b/docs/standard/assembly/file-format.md
@@ -29,4 +29,4 @@ Assembly Headers from ECMA 335 II.25.1, Structure of the runtime file format.
 
 ## Process the assemblies
 
-It is possible to write tools or APIs to process assemblies. Assembly information enables making programmatic decisions at runtime, re-writing assemblies, providing API IntelliSense in an editor and generating documentation. <xref:System.Reflection?displayProperty=nameWithType>, <xref:System.Reflection.MetadataLoadContext?displayProperty=nameWithType>, and [Mono.Cecil](https://www.mono-project.com/docs/tools+libraries/libraries/Mono.Cecil/) are good examples of tools that are frequently used for this purpose.
+It is possible to write tools or APIs to process assemblies. Assembly information enables making programmatic decisions at run time, re-writing assemblies, providing API IntelliSense in an editor and generating documentation. <xref:System.Reflection?displayProperty=nameWithType>, <xref:System.Reflection.MetadataLoadContext?displayProperty=nameWithType>, and [Mono.Cecil](https://www.mono-project.com/docs/tools+libraries/libraries/Mono.Cecil/) are good examples of tools that are frequently used for this purpose.

--- a/docs/standard/base-types/compilation-and-reuse-in-regular-expressions.md
+++ b/docs/standard/base-types/compilation-and-reuse-in-regular-expressions.md
@@ -21,7 +21,7 @@ You can optimize the performance of applications that make extensive use of regu
   
  If a <xref:System.Text.RegularExpressions.Regex> object is constructed with the <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType> option, it compiles the regular expression to explicit MSIL code instead of high-level regular expression internal instructions. This allows .NET's just-in-time (JIT) compiler to convert the expression to native machine code for higher performance.  The cost of constructing the <xref:System.Text.RegularExpressions.Regex> object may be higher, but the cost of performing matches with it is likely to be much smaller.
 
- An alternative is to use precompiled regular expressions. You can compile all of your expressions into a reusable DLL by using the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A> method. This avoids the need to compile at runtime while still benefiting from the speed of compiled regular expressions.  
+ An alternative is to use precompiled regular expressions. You can compile all of your expressions into a reusable DLL by using the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A> method. This avoids the need to compile at run time while still benefiting from the speed of compiled regular expressions.  
   
 ## The Regular Expressions Cache  
  To improve performance, the regular expression engine maintains an application-wide cache of compiled regular expressions. The cache stores regular expression patterns that are used only in static method calls. (Regular expression patterns supplied to instance methods are not cached.) This avoids the need to reparse an expression into high-level byte code each time it is used.  

--- a/docs/standard/base-types/composite-formatting.md
+++ b/docs/standard/base-types/composite-formatting.md
@@ -64,7 +64,7 @@ The composite formatting feature is supported by methods such as the following:
  [!code-csharp[Formatting.Composite#10](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Composite/cs/index1.cs#10)]
  [!code-vb[Formatting.Composite#10](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Composite/vb/index1.vb#10)]  
   
- Each format item can refer to any object in the list. For example, if there are three objects, you can format the second, first, and third object by specifying a composite format string like this: "{1} {0} {2}". An object that is not referenced by a format item is ignored. A <xref:System.FormatException> is thrown at runtime if a parameter specifier designates an item outside the bounds of the list of objects.  
+ Each format item can refer to any object in the list. For example, if there are three objects, you can format the second, first, and third object by specifying a composite format string like this: "{1} {0} {2}". An object that is not referenced by a format item is ignored. A <xref:System.FormatException> is thrown at run time if a parameter specifier designates an item outside the bounds of the list of objects.  
   
 ### Alignment Component  
  The optional *alignment* component is a signed integer indicating the preferred formatted field width. If the value of *alignment* is less than the length of the formatted string, *alignment* is ignored and the length of the formatted string is used as the field width. The formatted data in the field is right-aligned if *alignment* is positive and left-aligned if *alignment* is negative. If padding is necessary, white space is used. The comma is required if *alignment*  is specified.  

--- a/docs/standard/design-guidelines/attributes.md
+++ b/docs/standard/design-guidelines/attributes.md
@@ -1,6 +1,6 @@
 ---
 title: "Attributes"
-ms.date: "10/22/2008"
+ms.date: 10/22/2008
 ms.technology: dotnet-standard
 helpviewer_keywords:
   - "attributes [.NET Framework], about"
@@ -8,15 +8,16 @@ helpviewer_keywords:
 ms.assetid: ee0038ef-b247-4747-a650-3c5c5cd58d8b
 ---
 # Attributes
+
 <xref:System.Attribute?displayProperty=nameWithType> is a base class used to define custom attributes.
 
- Attributes are annotations that can be added to programming elements such as assemblies, types, members, and parameters. They are stored in the metadata of the assembly and can be accessed at run time using the reflection APIs. For example, the Framework defines the <xref:System.ObsoleteAttribute>, which can be applied to a type or a member to indicate that the type or member has been deprecated.
+ Attributes are annotations that can be added to programming elements such as assemblies, types, members, and parameters. They are stored in the metadata of the assembly and can be accessed at run time using the reflection APIs. For example, .NET defines the <xref:System.ObsoleteAttribute> attribute, which can be applied to a type or a member to indicate that the type or member has been deprecated.
 
- Attributes can have one or more properties that carry additional data related to the attribute. For example, `ObsoleteAttribute` could carry additional information about the release in which a type or a member got deprecated and the description of the new APIs replacing the obsolete API.
+ Attributes can have one or more properties that carry additional data related to the attribute. For example, `ObsoleteAttribute` could carry additional information about the release in which a type or a member got deprecated and a description of the new API that replaces the obsolete API.
 
  Some properties of an attribute must be specified when the attribute is applied. These are referred to as the required properties or required arguments, because they are represented as positional constructor parameters. For example, the <xref:System.Diagnostics.ConditionalAttribute.ConditionString%2A> property of the <xref:System.Diagnostics.ConditionalAttribute> is a required property.
 
- Properties that do not necessarily have to be specified when the attribute is applied are called optional properties (or optional arguments). They are represented by settable properties. Compilers provide special syntax to set these properties when an attribute is applied. For example, the <xref:System.AttributeUsageAttribute.Inherited%2A?displayProperty=nameWithType> property represents an optional argument.
+ Properties that don't necessarily have to be specified when the attribute is applied are called optional properties (or optional arguments). They are represented by settable properties. Compilers provide special syntax to set these properties when an attribute is applied. For example, the <xref:System.AttributeUsageAttribute.Inherited%2A?displayProperty=nameWithType> property represents an optional argument.
 
  ✔️ DO name custom attribute classes with the suffix "Attribute."
 
@@ -38,7 +39,7 @@ ms.assetid: ee0038ef-b247-4747-a650-3c5c5cd58d8b
 
  ✔️ DO seal custom attribute classes, if possible. This makes the look-up for the attribute faster.
 
- *Portions © 2005, 2009 Microsoft Corporation. All rights reserved.*
+ *Portions &copy; 2005, 2009 Microsoft Corporation. All rights reserved.*
 
  *Reprinted by permission of Pearson Education, Inc. from [Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries, 2nd Edition](https://www.informit.com/store/framework-design-guidelines-conventions-idioms-and-9780321545619) by Krzysztof Cwalina and Brad Abrams, published Oct 22, 2008 by Addison-Wesley Professional as part of the Microsoft Windows Development Series.*
 

--- a/docs/standard/design-guidelines/attributes.md
+++ b/docs/standard/design-guidelines/attributes.md
@@ -10,7 +10,7 @@ ms.assetid: ee0038ef-b247-4747-a650-3c5c5cd58d8b
 # Attributes
 <xref:System.Attribute?displayProperty=nameWithType> is a base class used to define custom attributes.
 
- Attributes are annotations that can be added to programming elements such as assemblies, types, members, and parameters. They are stored in the metadata of the assembly and can be accessed at runtime using the reflection APIs. For example, the Framework defines the <xref:System.ObsoleteAttribute>, which can be applied to a type or a member to indicate that the type or member has been deprecated.
+ Attributes are annotations that can be added to programming elements such as assemblies, types, members, and parameters. They are stored in the metadata of the assembly and can be accessed at run time using the reflection APIs. For example, the Framework defines the <xref:System.ObsoleteAttribute>, which can be applied to a type or a member to indicate that the type or member has been deprecated.
 
  Attributes can have one or more properties that carry additional data related to the attribute. For example, `ObsoleteAttribute` could carry additional information about the release in which a type or a member got deprecated and the description of the new APIs replacing the obsolete API.
 

--- a/docs/standard/design-guidelines/events-and-callbacks.md
+++ b/docs/standard/design-guidelines/events-and-callbacks.md
@@ -24,7 +24,7 @@ Callbacks are extensibility points that allow a framework to call back into user
 
  ✔️ DO use the new `Func<...>`, `Action<...>`, or `Expression<...>` types instead of custom delegates, when defining APIs with callbacks.
 
- `Func<...>` and `Action<...>` represent generic delegates. `Expression<...>` represents function definitions that can be compiled and subsequently invoked at runtime but can also be serialized and passed to remote processes.
+ `Func<...>` and `Action<...>` represent generic delegates. `Expression<...>` represents function definitions that can be compiled and subsequently invoked at run time but can also be serialized and passed to remote processes.
 
  ✔️ DO measure and understand performance implications of using `Expression<...>`, instead of using `Func<...>` and `Action<...>` delegates.
 

--- a/docs/standard/design-guidelines/extension-methods.md
+++ b/docs/standard/design-guidelines/extension-methods.md
@@ -21,7 +21,7 @@ Extension methods are a language feature that allows static methods to be called
 
  ❌ AVOID defining extension methods on <xref:System.Object?displayProperty=nameWithType>.
 
- Visual Basic users will not be able to call such methods on object references using the extension method syntax. Visual Basic does not support calling such methods because, in Visual Basic, declaring a reference as Object forces all method invocations on it to be late bound (actual member called is determined at runtime), while bindings to extension methods are determined at compile-time (early bound).
+ Visual Basic users will not be able to call such methods on object references using the extension method syntax. Visual Basic does not support calling such methods because, in Visual Basic, declaring a reference as Object forces all method invocations on it to be late bound (actual member called is determined at run time), while bindings to extension methods are determined at compile-time (early bound).
 
  Note that the guideline applies to other languages where the same binding behavior is present, or where extension methods are not supported.
 

--- a/docs/standard/design-guidelines/extension-methods.md
+++ b/docs/standard/design-guidelines/extension-methods.md
@@ -10,7 +10,7 @@ Extension methods are a language feature that allows static methods to be called
 
  The class that defines an extension method is referred to as the "sponsor" class, and it must be declared as `static`. To use extension methods, you must import the namespace that defines the sponsor class.
 
- ❌ AVOID frivolously defining extension methods, especially on types you don't own.
+ ❌ AVOID overuse of extension methods, especially on types you don't own.
 
  If you do own source code of a type, consider using regular instance methods instead. If you don't own the source code and you want to add a method, be very careful. Liberal use of extension methods has the potential of cluttering APIs of types that were not designed to have these methods.
 

--- a/docs/standard/design-guidelines/extension-methods.md
+++ b/docs/standard/design-guidelines/extension-methods.md
@@ -4,26 +4,27 @@ ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 5de945cb-88f4-49d7-b0e6-f098300cf357
 ---
-# Extension Methods
-Extension methods are a language feature that allows static methods to be called using instance method call syntax. These methods must take at least one parameter, which represents the instance the method is to operate on.
+# Extension methods
 
- The class that defines such extension methods is referred to as the "sponsor" class, and it must be declared as static. To use extension methods, one must import the namespace defining the sponsor class.
+Extension methods are a language feature that allows static methods to be called using instance-method call syntax. These methods must take at least one parameter, which represents the instance the method is to operate on.
 
- ❌ AVOID frivolously defining extension methods, especially on types you don’t own.
+ The class that defines an extension method is referred to as the "sponsor" class, and it must be declared as `static`. To use extension methods, you must import the namespace that defines the sponsor class.
 
- If you do own source code of a type, consider using regular instance methods instead. If you don’t own, and you want to add a method, be very careful. Liberal use of extension methods has the potential of cluttering APIs of types that were not designed to have these methods.
+ ❌ AVOID frivolously defining extension methods, especially on types you don't own.
+
+ If you do own source code of a type, consider using regular instance methods instead. If you don't own the source code and you want to add a method, be very careful. Liberal use of extension methods has the potential of cluttering APIs of types that were not designed to have these methods.
 
  ✔️ CONSIDER using extension methods in any of the following scenarios:
 
-- To provide helper functionality relevant to every implementation of an interface, if said functionality can be written in terms of the core interface. This is because concrete implementations cannot otherwise be assigned to interfaces. For example, the `LINQ to Objects` operators are implemented as extension methods for all <xref:System.Collections.Generic.IEnumerable%601> types. Thus, any `IEnumerable<>` implementation is automatically LINQ-enabled.
+- To provide helper functionality relevant to every implementation of an interface, if said functionality can be written in terms of the core interface. This is because concrete implementations cannot otherwise be assigned to interfaces. For example, the LINQ to Objects operators are implemented as extension methods for all <xref:System.Collections.Generic.IEnumerable%601> types. Thus, any `IEnumerable<>` implementation is automatically LINQ-enabled.
 
 - When an instance method would introduce a dependency on some type, but such a dependency would break dependency management rules. For example, a dependency from <xref:System.String> to <xref:System.Uri?displayProperty=nameWithType> is probably not desirable, and so `String.ToUri()` instance method returning `System.Uri` would be the wrong design from a dependency management perspective. A static extension method `Uri.ToUri(this string str)` returning `System.Uri` would be a much better design.
 
  ❌ AVOID defining extension methods on <xref:System.Object?displayProperty=nameWithType>.
 
- Visual Basic users will not be able to call such methods on object references using the extension method syntax. Visual Basic does not support calling such methods because, in Visual Basic, declaring a reference as Object forces all method invocations on it to be late bound (actual member called is determined at run time), while bindings to extension methods are determined at compile-time (early bound).
+ Visual Basic users will not be able to call such methods on object references using the extension method syntax. In Visual Basic, declaring a reference as `Object` forces all method invocations on it to be late bound (which means the actual member called is determined at run time). Bindings to extension methods are determined at compile time (early bound).
 
- Note that the guideline applies to other languages where the same binding behavior is present, or where extension methods are not supported.
+ This guideline applies to other languages where the same binding behavior is present or where extension methods are not supported.
 
  ❌ DO NOT put extension methods in the same namespace as the extended type unless it is for adding methods to interfaces or for dependency management.
 
@@ -35,7 +36,7 @@ Extension methods are a language feature that allows static methods to be called
 
  ❌ AVOID generic naming of namespaces dedicated to extension methods (e.g., "Extensions"). Use a descriptive name (e.g., "Routing") instead.
 
- *Portions © 2005, 2009 Microsoft Corporation. All rights reserved.*
+ *Portions &copy; 2005, 2009 Microsoft Corporation. All rights reserved.*
 
  *Reprinted by permission of Pearson Education, Inc. from [Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries, 2nd Edition](https://www.informit.com/store/framework-design-guidelines-conventions-idioms-and-9780321545619) by Krzysztof Cwalina and Brad Abrams, published Oct 22, 2008 by Addison-Wesley Professional as part of the Microsoft Windows Development Series.*
 

--- a/docs/standard/design-guidelines/virtual-members.md
+++ b/docs/standard/design-guidelines/virtual-members.md
@@ -13,7 +13,7 @@ Virtual members can be overridden, thus changing the behavior of the subclass. T
 
  Virtual members perform better than callbacks and events, but do not perform better than non-virtual methods.
 
- The main disadvantage of virtual members is that the behavior of a virtual member can only be modified at the time of compilation. The behavior of a callback can be modified at runtime.
+ The main disadvantage of virtual members is that the behavior of a virtual member can only be modified at the time of compilation. The behavior of a callback can be modified at run time.
 
  Virtual members, like callbacks (and maybe more than callbacks), are costly to design, test, and maintain because any call to a virtual member can be overridden in unpredictable ways and can execute arbitrary code. Also, much more effort is usually required to clearly define the contract of virtual members, so the cost of designing and documenting them is higher.
 

--- a/docs/standard/glossary.md
+++ b/docs/standard/glossary.md
@@ -12,7 +12,7 @@ The primary goal of this glossary is to clarify meanings of selected terms and a
 
 Ahead-of-time compiler.
 
-Similar to [JIT](#jit), this compiler also translates [IL](#il) to machine code. In contrast to JIT compilation, AOT compilation happens before the application is executed and is usually performed on a different machine. Because AOT tool chains don't compile at runtime, they don't have to minimize time spent compiling. That means they can spend more time optimizing. Since the context of AOT is the entire application, the AOT compiler also performs cross-module linking and whole-program analysis, which means that all references are followed and a single executable is produced.
+Similar to [JIT](#jit), this compiler also translates [IL](#il) to machine code. In contrast to JIT compilation, AOT compilation happens before the application is executed and is usually performed on a different machine. Because AOT tool chains don't compile at run time, they don't have to minimize time spent compiling. That means they can spend more time optimizing. Since the context of AOT is the entire application, the AOT compiler also performs cross-module linking and whole-program analysis, which means that all references are followed and a single executable is produced.
 
 See [CoreRT](#corert) and [.NET Native](#net-native).
 

--- a/docs/standard/library-guidance/dependencies.md
+++ b/docs/standard/library-guidance/dependencies.md
@@ -18,7 +18,7 @@ At build time, NuGet analyzes all the packages that a project depends on, includ
 Most diamond dependencies are easily resolved; however, they can create issues in certain circumstances:
 
 1. **Conflicting NuGet package references** prevent a version from being resolved during package restore.
-2. **Breaking changes between the versions** cause bugs and exceptions at runtime.
+2. **Breaking changes between the versions** cause bugs and exceptions at run time.
 3. **The package assembly is strong named**, the assembly version changed, and the app is running on the .NET Framework. Assembly binding redirects are required.
 
 It's not possible to know what packages will be used alongside your own. A good way to reduce the likelihood of a diamond dependency breaking your library is to minimize the number of packages you depend on.

--- a/docs/standard/library-guidance/versioning.md
+++ b/docs/standard/library-guidance/versioning.md
@@ -37,15 +37,15 @@ Because the NuGet package version is the most visible version to developers, it'
 
 ### Assembly version
 
-The assembly version is what the CLR uses at runtime to select which version of an assembly to load. Selecting an assembly using versioning only applies to assemblies with a strong name.
+The assembly version is what the CLR uses at run time to select which version of an assembly to load. Selecting an assembly using versioning only applies to assemblies with a strong name.
 
 ```xml
 <AssemblyVersion>1.0.0.0</AssemblyVersion>
 ```
 
-The Windows .NET Framework CLR demands an exact match to load a strong named assembly. For example, `Libary1, Version=1.0.0.0` was compiled with a reference to `Newtonsoft.Json, Version=11.0.0.0`. The .NET Framework will only load that exact version `11.0.0.0`. To load a different version at runtime, a binding redirect must be added to the .NET application's config file.
+The Windows .NET Framework CLR demands an exact match to load a strong named assembly. For example, `Libary1, Version=1.0.0.0` was compiled with a reference to `Newtonsoft.Json, Version=11.0.0.0`. The .NET Framework will only load that exact version `11.0.0.0`. To load a different version at run time, a binding redirect must be added to the .NET application's config file.
 
-Strong naming combined with assembly version enables [strict assembly version loading](../assembly/versioning.md). While strong naming a library has a number of benefits, it often results in runtime exceptions that an assembly can't be found and [requires binding redirects](../../framework/configure-apps/redirect-assembly-versions.md) in `app.config`/`web.config` to be fixed. .NET Core assembly loading has been relaxed, and the .NET Core CLR will automatically load assemblies at runtime with a higher version.
+Strong naming combined with assembly version enables [strict assembly version loading](../assembly/versioning.md). While strong naming a library has a number of benefits, it often results in runtime exceptions that an assembly can't be found and [requires binding redirects](../../framework/configure-apps/redirect-assembly-versions.md) in `app.config`/`web.config` to be fixed. .NET Core assembly loading has been relaxed, and the .NET Core CLR will automatically load assemblies at run time with a higher version.
 
 ✔️ CONSIDER only including a major version in the AssemblyVersion.
 

--- a/docs/standard/library-guidance/versioning.md
+++ b/docs/standard/library-guidance/versioning.md
@@ -5,7 +5,7 @@ ms.date: 12/10/2018
 ---
 # Versioning
 
-A software library is rarely complete in version 1.0. Good libraries evolve over time, adding features, fixing bugs and improving performance. It is important that you can release new versions of a .NET library, providing additional value with each version, without breaking existing users.
+A software library is rarely complete in version 1.0. Good libraries evolve over time, adding features, fixing bugs, and improving performance. It is important that you can release new versions of a .NET library, providing additional value with each version, without breaking existing users.
 
 ## Breaking changes
 
@@ -43,9 +43,9 @@ The assembly version is what the CLR uses at run time to select which version of
 <AssemblyVersion>1.0.0.0</AssemblyVersion>
 ```
 
-The Windows .NET Framework CLR demands an exact match to load a strong named assembly. For example, `Libary1, Version=1.0.0.0` was compiled with a reference to `Newtonsoft.Json, Version=11.0.0.0`. The .NET Framework will only load that exact version `11.0.0.0`. To load a different version at run time, a binding redirect must be added to the .NET application's config file.
+The .NET Framework CLR demands an exact match to load a strong-named assembly. For example, `Libary1, Version=1.0.0.0` was compiled with a reference to `Newtonsoft.Json, Version=11.0.0.0`. .NET Framework will only load that exact version `11.0.0.0`. To load a different version at run time, a binding redirect must be added to the .NET application's config file.
 
-Strong naming combined with assembly version enables [strict assembly version loading](../assembly/versioning.md). While strong naming a library has a number of benefits, it often results in runtime exceptions that an assembly can't be found and [requires binding redirects](../../framework/configure-apps/redirect-assembly-versions.md) in `app.config`/`web.config` to be fixed. .NET Core assembly loading has been relaxed, and the .NET Core CLR will automatically load assemblies at run time with a higher version.
+Strong naming combined with assembly version enables [strict assembly version loading](../assembly/versioning.md). While strong naming a library has a number of benefits, it often results in run-time exceptions that an assembly can't be found and [requires binding redirects](../../framework/configure-apps/redirect-assembly-versions.md) in `app.config` or `web.config` to be fixed. In .NET Core, assembly loading is more relaxed. The .NET Core runtime automatically loads assemblies with a higher version at run time.
 
 ✔️ CONSIDER only including a major version in the AssemblyVersion.
 
@@ -61,7 +61,7 @@ Strong naming combined with assembly version enables [strict assembly version lo
 
 ### Assembly file version
 
-The assembly file version is used to display a file version in Windows and has no effect on runtime behavior. Setting this version is optional. It's visible in the File Properties dialog in Windows Explorer:
+The assembly file version is used to display a file version in Windows and has no effect on run-time behavior. Setting this version is optional. It's visible in the File Properties dialog in Windows Explorer:
 
 ```xml
 <FileVersion>11.0.2.21924</FileVersion>

--- a/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
+++ b/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
@@ -15,7 +15,7 @@ The .NET Standard is a specification that defines the types and members that mus
 
 If you've developed a library that targets the .NET Standard, your library can be consumed by any .NET implementation that supports the .NET Standard. This means that you cannot know in advance whether a particular type is serializable; you can only determine whether it is serializable at run time.
 
-You can determine whether an object is serializable at runtime by retrieving the value of the <xref:System.Type.IsSerializable> property of a <xref:System.Type> object that represents that object's type. The following example provides one implementation. It defines an `IsSerializable(Object)` extension method that indicates whether any <xref:System.Object> instance can be serialized.
+You can determine whether an object is serializable at run time by retrieving the value of the <xref:System.Type.IsSerializable> property of a <xref:System.Type> object that represents that object's type. The following example provides one implementation. It defines an `IsSerializable(Object)` extension method that indicates whether any <xref:System.Object> instance can be serialized.
 
 [!code-csharp[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#2)]
 [!code-vb[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/library.vb#2)]

--- a/docs/standard/serialization/serialization-guidelines.md
+++ b/docs/standard/serialization/serialization-guidelines.md
@@ -74,7 +74,7 @@ This document lists the guidelines to consider when designing an API to be seria
      [!code-csharp[SerializationGuidelines#4](../../../samples/snippets/csharp/VS_Snippets_CFX/serializationguidelines/cs/source.cs#4)]
      [!code-vb[SerializationGuidelines#4](../../../samples/snippets/visualbasic/VS_Snippets_CFX/serializationguidelines/vb/source.vb#4)]  
   
-     In cases where the list of known types is not known statically (when the **Person** class is compiled), the **KnownTypeAttribute** can also point to a method that returns a list of known types at runtime.  
+     In cases where the list of known types is not known statically (when the **Person** class is compiled), the **KnownTypeAttribute** can also point to a method that returns a list of known types at run time.  
   
 5. DO consider backward and forward compatibility when creating or changing serializable types.  
   

--- a/docs/standard/serialization/system-text-json-converters-how-to.md
+++ b/docs/standard/serialization/system-text-json-converters-how-to.md
@@ -42,7 +42,7 @@ Some examples of types that can be handled by the basic pattern include:
 * `DateTime`
 * `Int32`
 
-The basic pattern creates a class that can handle one type. The factory pattern creates a class that determines at runtime which specific type is required and dynamically creates the appropriate converter.
+The basic pattern creates a class that can handle one type. The factory pattern creates a class that determines at run time which specific type is required and dynamically creates the appropriate converter.
 
 ## Sample basic converter
 
@@ -52,7 +52,7 @@ The following sample is a converter that overrides default serialization for an 
 
 ## Sample factory pattern converter
 
-The following code shows a custom converter that works with `Dictionary<Enum,TValue>`. The code follows the factory pattern because the first generic type parameter is `Enum` and the second is open. The `CanConvert` method returns `true` only for a `Dictionary` with two generic parameters, the first of which is an `Enum` type. The inner converter gets an existing converter to handle whichever type is provided at runtime for `TValue`.
+The following code shows a custom converter that works with `Dictionary<Enum,TValue>`. The code follows the factory pattern because the first generic type parameter is `Enum` and the second is open. The `CanConvert` method returns `true` only for a `Dictionary` with two generic parameters, the first of which is an `Enum` type. The inner converter gets an existing converter to handle whichever type is provided at run time for `TValue`.
 
 [!code-csharp[](snippets/system-text-json-how-to/csharp/DictionaryTKeyEnumTValueConverter.cs)]
 
@@ -75,7 +75,7 @@ The following steps explain how to create a converter by following the factory p
 
 * Create a class that derives from <xref:System.Text.Json.Serialization.JsonConverterFactory>.
 * Override the `CanConvert` method to return true when the type to convert is one that the converter can handle. For example, if the converter is for `List<T>` it might only handle `List<int>`, `List<string>`, and `List<DateTime>`.
-* Override the `CreateConverter` method to return an instance of a converter class that will handle the type-to-convert that is provided at runtime.
+* Override the `CreateConverter` method to return an instance of a converter class that will handle the type-to-convert that is provided at run time.
 * Create the converter class that the `CreateConverter` method instantiates.
 
 The factory pattern is required for open generics because the code to convert an object to and from a string isn't the same for all types. A converter for an open generic type (`List<T>`, for example) has to create a converter for a closed generic type (`List<DateTime>`, for example) behind the scenes. Code must be written to handle each closed-generic type that the converter can handle.
@@ -250,7 +250,7 @@ The [unit tests folder](https://github.com/dotnet/runtime/blob/81bf79fd9aa75305e
 
 Built-in features provide a limited range of [polymorphic serialization](system-text-json-how-to.md#serialize-properties-of-derived-classes) but no support for deserialization at all. Deserialization requires a custom converter.
 
-Suppose, for example, you have a `Person` abstract base class, with `Employee` and `Customer` derived classes. Polymorphic deserialization means that at design time you can specify `Person` as the deserialization target, and `Customer` and `Employee` objects in the JSON are correctly deserialized at runtime. During deserialization, you have to find clues that identify the required type in the JSON. The kinds of clues available vary with each scenario. For example, a discriminator property might be available or you might have to rely on the presence or absence of a particular property. The current release of `System.Text.Json` doesn't provide attributes to specify how to handle polymorphic deserialization scenarios, so custom converters are required.
+Suppose, for example, you have a `Person` abstract base class, with `Employee` and `Customer` derived classes. Polymorphic deserialization means that at design time you can specify `Person` as the deserialization target, and `Customer` and `Employee` objects in the JSON are correctly deserialized at run time. During deserialization, you have to find clues that identify the required type in the JSON. The kinds of clues available vary with each scenario. For example, a discriminator property might be available or you might have to rely on the presence or absence of a particular property. The current release of `System.Text.Json` doesn't provide attributes to specify how to handle polymorphic deserialization scenarios, so custom converters are required.
 
 The following code shows a base class, two derived classes, and a custom converter for them. The converter uses a discriminator property to do polymorphic deserialization. The type discriminator isn't in the class definitions but is created during serialization and is read during deserialization.
 

--- a/docs/standard/serialization/system-text-json-converters-how-to.md
+++ b/docs/standard/serialization/system-text-json-converters-how-to.md
@@ -42,7 +42,7 @@ Some examples of types that can be handled by the basic pattern include:
 * `DateTime`
 * `Int32`
 
-The basic pattern creates a class that can handle one type. The factory pattern creates a class that determines at run time which specific type is required and dynamically creates the appropriate converter.
+The basic pattern creates a class that can handle one type. The factory pattern creates a class that determines, at run time, which specific type is required and dynamically creates the appropriate converter.
 
 ## Sample basic converter
 

--- a/docs/standard/serialization/system-text-json-how-to.md
+++ b/docs/standard/serialization/system-text-json-how-to.md
@@ -485,7 +485,7 @@ This behavior is intended to help prevent accidental exposure of data in a deriv
 
 To serialize the properties of the derived type in the preceding example, use one of the following approaches:
 
-* Call an overload of <xref:System.Text.Json.JsonSerializer.Serialize%2A> that lets you specify the type at runtime:
+* Call an overload of <xref:System.Text.Json.JsonSerializer.Serialize%2A> that lets you specify the type at run time:
 
   [!code-csharp[](snippets/system-text-json-how-to/csharp/SerializePolymorphic.cs?name=SnippetSerializeGetType)]
 

--- a/docs/standard/threading/managed-threading-best-practices.md
+++ b/docs/standard/threading/managed-threading-best-practices.md
@@ -73,7 +73,7 @@ else {
 
 Whether there are multiple processors or only one processor available on a system can influence multithreaded architecture. For more information, see [Number of Processors](https://docs.microsoft.com/previous-versions/dotnet/netframework-1.1/1c9txz50(v%3dvs.71)#number-of-processors).
 
-Use the <xref:System.Environment.ProcessorCount?displayProperty=nameWithType> property to determine the number of processors available at runtime.
+Use the <xref:System.Environment.ProcessorCount?displayProperty=nameWithType> property to determine the number of processors available at run time.
   
 ## General recommendations  
  Consider the following guidelines when using multiple threads:  


### PR DESCRIPTION
Plus a few other small fixes in /core and /standard.