### PR TITLE
Document ISosDacInterface::GetCCWData and the corresponding struct

### DIFF
--- a/docs/framework/unmanaged-api/debugging/dacpccwdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpccwdata-structure.md
@@ -1,0 +1,79 @@
+---
+title: "DacpCcwData Structure"
+ms.date: "06/02/2020"
+api.name:
+  - "DacpCcwData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpCcwData Structure"
+helpviewer.keywords:
+  - "DacpCcwData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+author: "chuckries"
+ms.author: "chuckr"
+---
+# DacpCcwData Structure
+
+Defines data related to an instance of a [Com Callable Wrapper](../../../standard/native-interop/com-callable-wrapper.md).
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpCcwData
+{
+    CLRDATA_ADDRESS reserved0;
+    CLRDATA_ADDRESS managedObject;
+    CLRDATA_ADDRESS reserved2;
+    CLRDATA_ADDRESS reserved3;
+    LONG            reserved4;
+    LONG            reserved5;
+    BOOL            isNeutered;
+    LONG            reserved7;
+    BOOL            reserved8;
+    BOOL            reserved9;
+    BOOL            reserved10;
+    BOOL            reserved11;
+    BOOL            reserved12;
+};
+```
+
+## Members
+
+| Member                       | Description                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `reserved0`                  | This field is reserved for internal use.                                                                     |
+| `managedObject`              | The address of the managed object that this CCW represents. This value may change due to garbage collection. |
+| `reserved2`                  | This field is reserved for internal use.                                                                     |
+| `reserved3`                  | This field is reserved for internal use.                                                                     |
+| `reserved4`                  | This field is reserved for internal use.                                                                     |
+| `isNeutered`                 | Set to true if this CCW has been disconnected from its managed object.                                       |
+| `reserved6`                  | This field is reserved for internal use.                                                                     |
+| `reserved7`                  | This field is reserved for internal use.                                                                     |
+| `reserved8`                  | This field is reserved for internal use.                                                                     |
+| `reserved9`                  | This field is reserved for internal use.                                                                     |
+| `reserved10`                 | This field is reserved for internal use.                                                                     |
+| `reserved11`                 | This field is reserved for internal use.                                                                     |
+| `reserved12`                 | This field is reserved for internal use.                                                                     |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)
+- [Common Data Types](../common-data-types-unmanaged-api-reference.md)
+- [Com Callable Wrapper](../../../standard/native-interop/com-callable-wrapper.md)

--- a/docs/framework/unmanaged-api/debugging/debugging-structures.md
+++ b/docs/framework/unmanaged-api/debugging/debugging-structures.md
@@ -75,6 +75,9 @@ This section describes the unmanaged structures that the debugging API uses.
  [CorDebugGuidToTypeMapping Structure](cordebugguidtotypemapping-structure.md)
  Maps a Windows Runtime GUID to its corresponding [ICorDebugType](icordebugtype-interface.md) object.
 
+ [DacpCCWData Structure](dacpccwdata-structure.md)
+ Defines data associated with a [Com Callable Wrapper](../../../standard/native-interop/com-callable-wrapper.md).
+
  [DacpGetModuleAddress Structure](dacpgetmoduleaddress-structure.md)
  Defines the container for a module address request.
 

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwdata-method.md
@@ -1,0 +1,56 @@
+---
+title: "ISOSDacInterface::GetCCWData Method"
+ms.date: "06/02/20202"
+api.name:
+  - "ISOSDacInterface::GetCCWData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetCCWData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetCCWData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+author: "chuckries"
+ms.author: "chuckr"
+---
+# ISOSDacInterface::GetCCWData Method
+
+Gets the data for the given Com Callable Wrapper pointer.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetCCWData(
+    CLRDATA_ADDRESS ccw
+    DacpCCWData *ccwData
+);
+```
+
+## Parameters
+
+`ccw`\
+[in] The address of the CCW pointer.
+
+`ccwData`\
+[out] The data associated with the CCW.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 77th slot of the virtual method table. To be able to use them, [`CLRDATA_ADDRESS`](../common-data-types-unmanaged-api-reference.md) must be defined as a 64-bit unsigned integer.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-interface.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-interface.md
@@ -1,6 +1,6 @@
 ---
 title: "ISOSDacInterface Interface"
-ms.date: "02/01/2019"
+ms.date: "06/02/2020"
 api.name:
   - "ISOSDacInterface Interface"
 api.location:
@@ -13,8 +13,8 @@ helpviewer.keywords:
   - "ISOSDacInterface Interface [.NET Framework debugging]"
 topic_type:
   - "apiref"
-author: "cshung"
-ms.author: "andrewau"
+author: "chuckries"
+ms.author: "chuckr"
 ---
 # ISOSDacInterface Interface
 
@@ -26,6 +26,7 @@ Provides helper methods to access data from `SOS`.
 
 | Method                                                                                                               | Description                                                                                                                   |
 | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [GetCCWData](isosdacinterface-getccwdata-method.md) | Gets the data for the given Com Callable Wrapper pointer. |
 | [GetMethodDescData](isosdacinterface-getmethoddescdata-method.md) | Gets the data for the given MethodDesc pointer. |
 | [GetMethodDescPtrFromIP](isosdacinterface-getmethoddescptrfromip-method.md) | Retrieves the pointer of the MethodDesc corresponding the method containing the given native instruction address. |
 | [GetModuleData](isosdacinterface-getmoduledata-method.md)| Fetches the data corresponding to the module loaded at a given address. |

--- a/docs/framework/unmanaged-api/debugging/toc.yml
+++ b/docs/framework/unmanaged-api/debugging/toc.yml
@@ -1415,6 +1415,8 @@
     - name: ISOSDacInterface Interface
       href: isosdacinterface-interface.md
       items:
+      - name: GetCCWData
+        href: isosdacinterface-getccwdata-method.md
       - name: GetMethodDescData
         href: isosdacinterface-getmethoddescdata-method.md
       - name: GetMethodDescPtrFromIP
@@ -1608,6 +1610,8 @@
       href: cordebugexceptionobjectstackframe-structure.md
     - name: CorDebugGuidToTypeMapping Structure
       href: cordebugguidtotypemapping-structure.md
+      name: DacpCCWData Structure
+      href: dacpccwdata-structure.md
     - name: DacpGetModuleAddress Structure
       href: dacpgetmoduleaddress-structure.md
       items:


### PR DESCRIPTION
## Summary

This is being documented in order to allow the Visual Studio Debugger to
decode CCW's while debugging.
