### PR TITLE
Document removal of localization pubternal APIs in 5.0

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -13,6 +13,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [Extensions: Package reference changes affecting some NuGet packages](#extensions-package-reference-changes-affecting-some-nuget-packages)
 - [HTTP: HttpClient instances created by IHttpClientFactory log integer status codes](#http-httpclient-instances-created-by-ihttpclientfactory-log-integer-status-codes)
 - [HTTP: Kestrel and IIS BadHttpRequestException types marked obsolete and replaced](#http-kestrel-and-iis-badhttprequestexception-types-marked-obsolete-and-replaced)
+- [Localization: "Pubternal" APIs removed](#localization-pubternal-apis-removed)
 - [Localization: ResourceManagerWithCultureStringLocalizer class and WithCulture interface member removed](#localization-resourcemanagerwithculturestringlocalizer-class-and-withculture-interface-member-removed)
 - [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
 - [SignalR: MessagePack Hub Protocol options type changed](#signalr-messagepack-hub-protocol-options-type-changed)
@@ -32,6 +33,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ***
 
 [!INCLUDE[HTTP: Kestrel and IIS BadHttpRequestException types marked obsolete and replaced](~/includes/core-changes/aspnetcore/5.0/http-badhttprequestexception-obsolete.md)]
+
+***
+
+[!INCLUDE [Localization: "Pubternal" APIs removed](~/includes/core-changes/aspnetcore/5.0/localization-pubternal-apis-removed.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -49,6 +49,7 @@ The following breaking changes are documented on this page:
 - [Kestrel: Request trailer headers moved to new collection](#kestrel-request-trailer-headers-moved-to-new-collection)
 - [Kestrel: Transport abstraction layer changes](#kestrel-transport-abstractions-removed-and-made-public)
 - [Localization: APIs marked obsolete](#localization-resourcemanagerwithculturestringlocalizer-and-withculture-marked-obsolete)
+- [Localization: "Pubternal" APIs removed](#localization-pubternal-apis-removed)
 - [Localization: ResourceManagerWithCultureStringLocalizer class and WithCulture interface member removed](#localization-resourcemanagerwithculturestringlocalizer-class-and-withculture-interface-member-removed)
 - [Logging: DebugLogger class made internal](#logging-debuglogger-class-made-internal)
 - [MVC: Controller action Async suffix removed](#mvc-async-suffix-trimmed-from-controller-action-names)
@@ -88,6 +89,10 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE[HTTP: Kestrel and IIS BadHttpRequestException types marked obsolete and replaced](~/includes/core-changes/aspnetcore/5.0/http-badhttprequestexception-obsolete.md)]
+
+***
+
+[!INCLUDE [Localization: "Pubternal" APIs removed](~/includes/core-changes/aspnetcore/5.0/localization-pubternal-apis-removed.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/3.0/pubternal-apis-removed.md
+++ b/includes/core-changes/aspnetcore/3.0/pubternal-apis-removed.md
@@ -14,7 +14,7 @@ The affected APIs are marked with the `public` access modifier and exist in `*.I
 
 #### New behavior
 
-The affected APIs are marked with the [internal(~/docs/csharp/language-reference/keywords/internal.md) access modifier and can no longer be used by code outside that assembly.
+The affected APIs are marked with the [internal](/dotnet/csharp/language-reference/keywords/internal) access modifier and can no longer be used by code outside that assembly.
 
 #### Reason for change
 

--- a/includes/core-changes/aspnetcore/5.0/localization-pubternal-apis-removed.md
+++ b/includes/core-changes/aspnetcore/5.0/localization-pubternal-apis-removed.md
@@ -1,0 +1,59 @@
+### Localization: "Pubternal" APIs removed
+
+To better maintain the public API surface of ASP.NET Core, some :::no-loc text="\"pubternal\""::: localization APIs were removed. A :::no-loc text="\"pubternal\""::: API has a `public` access modifier and is defined in a namespace that implies an [internal](/dotnet/csharp/language-reference/keywords/internal) intent.
+
+For discussion, see [dotnet/aspnetcore#22291](https://github.com/dotnet/aspnetcore/issues/22291).
+
+#### Version introduced
+
+5.0 Preview 6
+
+#### Old behavior
+
+The following APIs were `public`:
+
+- `Microsoft.Extensions.Localization.Internal.AssemblyWrapper`
+- `Microsoft.Extensions.Localization.Internal.IResourceStringProvider`
+- `Microsoft.Extensions.Localization.ResourceManagerStringLocalizer` constructor overloads accepting either of the following parameter types:
+  - `AssemblyWrapper`
+  - `IResourceStringProvider`
+
+#### New behavior
+
+The following list outlines the changes:
+
+- `Microsoft.Extensions.Localization.Internal.AssemblyWrapper` became `Microsoft.Extensions.Localization.AssemblyWrapper` and is now `internal`.
+- `Microsoft.Extensions.Localization.Internal.IResourceStringProvider` became `Microsoft.Extensions.Localization.Internal.IResourceStringProvider` and is now `internal`.
+- `Microsoft.Extensions.Localization.ResourceManagerStringLocalizer` constructor overloads accepting either of the following parameter types are now `internal`:
+  - `AssemblyWrapper`
+  - `IResourceStringProvider`
+
+#### Reason for change
+
+Explained more thoroughly at [aspnet/Announcements#377](https://github.com/aspnet/Announcements/issues/377#issue-473651882), :::no-loc text="\"pubternal\""::: types were removed from the `public` API surface. These changes adapt more classes to that design decision. The classes in question were intended as extension points for the team's internal testing.
+
+#### Recommended action
+
+Although it's unlikely, some apps may intentionally or accidentally depend upon the :::no-loc text="\"pubternal\""::: types. See the [New behavior](#new-behavior) sections to determine how to migrate away from the types.
+
+If you've identified a scenario which the public API allowed before this change but doesn't now, file an issue at [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore/issues).
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+- `Microsoft.Extensions.Localization.Internal.AssemblyWrapper`
+- `Microsoft.Extensions.Localization.Internal.IResourceStringProvider`
+- <xref:Microsoft.Extensions.Localization.ResourceManagerStringLocalizer.%23ctor%2A?displayProperty=nameWithType>
+
+<!--
+
+#### Affected APIs
+
+- `T:Microsoft.Extensions.Localization.Internal.AssemblyWrapper`
+- `T:Microsoft.Extensions.Localization.Internal.IResourceStringProvider`
+- `Overload:Microsoft.Extensions.Localization.ResourceManagerStringLocalizer.#ctor`
+
+-->


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/417

[Internal review page](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-18775#localization-pubternal-apis-removed)