### PR TITLE
Fix enum value casing

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings.md
@@ -20,8 +20,8 @@ Configures the Hypertext Transfer Protocol (HTTP) proxy server.
   
 ```xml  
 <defaultProxy  
-  enabled="true|false"  
-  useDefaultCredentials="true|false">  
+  enabled="True|False"  
+  useDefaultCredentials="True|False">  
     <bypasslist>...</bypasslist>  
     <proxy>...</proxy>  
     <module>...</module>  
@@ -35,8 +35,8 @@ Configures the Hypertext Transfer Protocol (HTTP) proxy server.
   
 |**Element**|**Description**|  
 |-----------------|---------------------|  
-|`enabled`|Specifies whether a web proxy is used. The default value is `true`.|  
-|`useDefaultCredentials`|Specifies whether the default credentials for this host are used to access the web proxy. The default value is `false`.|  
+|`enabled`|Specifies whether a web proxy is used. The default value is `True`.|  
+|`useDefaultCredentials`|Specifies whether the default credentials for this host are used to access the web proxy. The default value is `False`.|  
   
 ### Child Elements  
   
@@ -68,9 +68,9 @@ Configures the Hypertext Transfer Protocol (HTTP) proxy server.
   <system.net>  
     <defaultProxy>  
       <proxy  
-        usesystemdefault="true"  
+        usesystemdefault="True"  
         proxyaddress="http://192.168.1.10:3128"  
-        bypassonlocal="true"  
+        bypassonlocal="True"  
       />  
       <bypasslist>  
         <add address="[a-z]+\.contoso\.com$" />  

--- a/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
@@ -21,11 +21,11 @@ Defines a proxy server.
   
 ```xml  
 <proxy
-  autoDetect="true|false|unspecified"
-  bypassonlocal="true|false|unspecified"
+  autoDetect="True|False|Unspecified"
+  bypassonlocal="True|False|Unspecified"
   proxyaddress="uriString"
   scriptLocation="uriString"
-  usesystemdefault="true|false|unspecified"
+  usesystemdefault="True|False|Unspecified"
 />
 ```  
   
@@ -36,11 +36,11 @@ Defines a proxy server.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`autoDetect`|Specifies whether the proxy is automatically detected. The default value is `unspecified`.|  
-|`bypassonlocal`|Specifies whether the proxy is bypassed for local resources. Local resources include the local server (`http://localhost`, `http://loopback`, or `http://127.0.0.1`) and a URI without a period (`http://webserver`). The default value is `unspecified`.|  
+|`autoDetect`|Specifies whether the proxy is automatically detected. The default value is `Unspecified`.|  
+|`bypassonlocal`|Specifies whether the proxy is bypassed for local resources. Local resources include the local server (`http://localhost`, `http://loopback`, or `http://127.0.0.1`) and a URI without a period (`http://webserver`). The default value is `Unspecified`.|  
 |`proxyaddress`|Specifies the proxy URI to use.|  
 |`scriptLocation`|Specifies the location of the configuration script. Do not use the `bypassonlocal` attribute with this attribute. |  
-|`usesystemdefault`|Specifies whether to use Internet Explorer proxy settings. If set to `true`, subsequent attributes will override Internet Explorer proxy settings. The default value is `unspecified`.|  
+|`usesystemdefault`|Specifies whether to use Internet Explorer proxy settings. If set to `True`, subsequent attributes will override Internet Explorer proxy settings. The default value is `Unspecified`.|  
   
 ### Child Elements  
  None.  

--- a/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
@@ -75,9 +75,9 @@ Defines a proxy server.
   <system.net>  
     <defaultProxy>  
       <proxy  
-        usesystemdefault="true"  
+        usesystemdefault="True"  
         proxyaddress="http://192.168.1.10:3128"  
-        bypassonlocal="true"  
+        bypassonlocal="True"  
       />  
     </defaultProxy>  
   </system.net>  

--- a/docs/framework/network-programming/proxy-configuration.md
+++ b/docs/framework/network-programming/proxy-configuration.md
@@ -60,7 +60,7 @@ A proxy server handles client requests for resources. A proxy can return a reque
 <system.net>  
     <defaultProxy>  
         <proxy  proxyaddress="http://proxy.contoso.com:3128"  
-                bypassonlocal="true"  
+                bypassonlocal="True"  
         />  
         <bypasslist>  
             <add address="[a-z]+.blueyonderairlines.com$" />  


### PR DESCRIPTION
Fixes the casings to what the validation scheme in VS is happy with.

Actual config parsing code is case-insensitive, this just gets rid of the warnings when users copy-paste the config.