### PR TITLE
Adding -nullable C# compiler option details

### DIFF
--- a/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
+++ b/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
@@ -1,6 +1,6 @@
 ---
 title: "C# Compiler Options Listed Alphabetically"
-ms.date: 05/15/2018
+ms.date: 06/04/2020
 helpviewer_keywords:
   - "compiler options [C#], listed alphabetically"
   - "C# language, compiler options listed alphabetically"
@@ -55,6 +55,7 @@ The following compiler options are sorted alphabetically. For a categorical list
 |[-nostdlib](nostdlib-compiler-option.md)|Instructs the compiler not to reference standard library (mscorlib.dll).|
 |[-nowarn](nowarn-compiler-option.md)|Disables specific warning messages|
 |[-nowin32manifest](nowin32manifest-compiler-option.md)|Instructs the compiler not to embed an application manifest in the executable file.|
+|[-nullable](nullable-compiler-option.md)|Specifies nullable context option.|
 |[-optimize](optimize-compiler-option.md)|Enables/disables optimizations.|
 |[-out](out-compiler-option.md)|Specifies the output file name (default: base name of file with main class or first file).|
 |-parallel[+&#124;-]|Specifies whether to use concurrent build (+).|

--- a/docs/csharp/language-reference/compiler-options/listed-by-category.md
+++ b/docs/csharp/language-reference/compiler-options/listed-by-category.md
@@ -1,12 +1,13 @@
 ---
 title: "C# Compiler Options Listed by Category"
-ms.date: 05/15/2018
+ms.date: 06/04/2020
 helpviewer_keywords: 
   - "Visual C# compiler, options listed by category"
   - "compiler options [C#], listed by category"
   - "Visual C#, compiler options listed by category"
 ms.assetid: 96437ecc-6502-4cd3-b070-e9386a298e83
 ---
+
 # C# Compiler Options Listed by Category
 
 The following compiler options are sorted by category. For an alphabetical list, see [C# Compiler Options Listed Alphabetically](listed-alphabetically.md).
@@ -50,6 +51,7 @@ The following compiler options are sorted by category. For an alphabetical list,
 |-additionalfile|Names additional files that don't directly affect code generation but may be used by analyzers for producing errors or warnings.|
 |-embed|Embed all source files in the PDB.|
 |-embed:\<file list>|Embed specific files in the PDB.|
+
 ## Debugging/Error Checking
 
 |Option|Purpose|
@@ -60,6 +62,7 @@ The following compiler options are sorted by category. For an alphabetical list,
 |[-errorreport](errorreport-compiler-option.md)|Sets error reporting behavior.|
 |[-fullpaths](fullpaths-compiler-option.md)|Specifies the absolute path to the file in compiler output.|
 |[-nowarn](nowarn-compiler-option.md)|Suppresses the compiler's generation of specified warnings.|
+|[-nullable](nullable-compiler-option.md)|Specifies nullable context option.|
 |[-warn](warn-compiler-option.md)|Sets the warning level.|
 |[-warnaserror](warnaserror-compiler-option.md)|Promotes warnings to errors.|
 |-ruleset:\<file>|Specify a ruleset file that disables specific diagnostics.|

--- a/docs/csharp/language-reference/compiler-options/nullable-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/nullable-compiler-option.md
@@ -1,0 +1,61 @@
+---
+title: "-nullable (C# Compiler Options)"
+ms.date: 06/04/2020
+f1_keywords:
+  - "/nullable"
+helpviewer_keywords:
+  - "nullable compiler option [C#]"
+  - "/nullable compiler option [C#]"
+  - "-nullable compiler option [C#]"
+---
+
+# -nullable (C# Compiler Options)
+
+The **-nullable** option lets you specify the desired nullable context.
+
+## Syntax
+
+```console
+-nullable[+ | -]
+-nullable:{enable | disable | warnings | annotations}
+```
+
+## Arguments
+
+`+` &#124; `-`  
+Specifying `+`, or just **-nullable**, causes the compiler to enable nullable context. Specifying `-`, which is in effect if you do not specify **-nullable**, disables nullable context.
+
+`enable` &#124; `disable` &#124; `warnings` &#124; `annotations`  
+Specifies the nullable context option. Similar to `+` or `-`, to enable and disable, but allows for more granularity of nullable context specificity. The `enable` argument, which is in effect the same as if you specify **-nullable**, enables the nullable context. Specifying `disable` will disable nullable context. When providing the `warnings` argument, **-nullable:warnings**, the nullable warning context is enabled. When specifying the `annotations` argument, **-nullable:annotations**, the nullable annotation context is enabled.
+
+## Remarks
+
+Flow analysis is used to infer the nullability of variables within executable code. The inferred nullability of a variable is independent of the variable's declared nullability. Method calls are analyzed even when they are conditionally omitted. For instance, <xref:System.Diagnostics.Debug.Assert%2A?displayProperty=nameWithType> in release mode.
+
+Invocation of methods annotated with the following attributes will also affect flow analysis:
+
+- Simple pre-conditions: <xref:System.Diagnostics.CodeAnalysis.AllowNullAttribute> and <xref:System.Diagnostics.CodeAnalysis.DisallowNullAttribute>
+- Simple post-conditions: <xref:System.Diagnostics.CodeAnalysis.MaybeNullAttribute> and <xref:System.Diagnostics.CodeAnalysis.NotNullAttribute>
+- Conditional post-conditions: <xref:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute> and <xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute>
+- <xref:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute> (e.g. `DoesNotReturnIf(false)` for <xref:System.Diagnostics.Debug.Assert%2A?displayProperty=nameWithType>) and <xref:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute>
+- <xref:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute>
+- Member post-conditions: <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.%23ctor(System.String)> and <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.%23ctor(System.String[])>
+
+### To set this compiler option in a project
+
+Edit the *.csproj* to add the `<Nullable>` tag within a `Project/PropertyGroup` hierarchy:
+
+```xml
+<Project Sdk="...">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>
+```
+
+## See also
+
+- [C# Compiler Options](./index.md)
+- [Nullable reference types](../../nullable-references.md)

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -124,3 +124,4 @@ You add attributes to APIs that provide the compiler more information about when
 - [Draft nullable reference types specification](~/_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md)
 - [Intro to nullable references tutorial](tutorials/nullable-reference-types.md)
 - [Migrate an existing codebase to nullable references](tutorials/upgrade-to-nullable-references.md)
+- [-nullable (C# Compiler option)](language-reference/compiler-options/nullable-compiler-option.md)

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1788,6 +1788,8 @@
         href: language-reference/compiler-options/nowarn-compiler-option.md
       - name: -nowin32manifest
         href: language-reference/compiler-options/nowin32manifest-compiler-option.md
+      - name: -nullable
+        href: language-reference/compiler-options/nullable-compiler-option.md
       - name: -optimize
         href: language-reference/compiler-options/optimize-compiler-option.md
       - name: -out


### PR DESCRIPTION
## Summary

- Added `-nullable` C# compiler option article
- Added TOC entry
- Added new article to two existing compiler option list docs
- Added **See also** section link from conceptual doc

Fixes #18467

### Previews

✔️  [C# Compiler Options Listed Alphabetically](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/listed-alphabetically?branch=pr-en-us-18791)
✔️ [C# Compiler Options Listed by Category](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/listed-by-category?branch=pr-en-us-18791)
✔️ [-nullable (C# Compiler Options)](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/nullable-compiler-option?branch=pr-en-us-18791)
✔️ [Nullable reference types](https://review.docs.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-18791)






