### PR TITLE
fix up indentation in formatting guide

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -115,7 +115,7 @@ type C(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
     // ... the body of the class follows
 ```
 
-If there is an explicit return type annotation, it can either be at the end of the `)` and before the `=`, or on a new line. If the return type also has a long name the latter might be preferrable:
+If there is an explicit return type annotation, it can either be at the end of the `)` and before the `=`, or on a new line. If the return type also has a long name, the latter might be preferable:
 
 ```fsharp
 type C() =

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -96,24 +96,22 @@ let myFunBad (a:decimal)(b)c = a + b + c
 
 ### Place parameters on a new line for long member definitions
 
-If you have a very long member definition, place the parameters on new lines and indent them one scope.
+If you have a very long member definition, place the parameters on new lines and indent them to match the indentation level of the subsequent parameter.
 
 ```fsharp
 type C() =
-    member _.LongMethodWithLotsOfParameters(
-        aVeryLongType: AVeryLongTypeThatYouNeedToUse
-        aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse
-        aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
         // ... the body of the method follows
 ```
 
 This also applies to constructors:
 
 ```fsharp
-type C(
-    aVeryLongType: AVeryLongTypeThatYouNeedToUse
-    aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse
-    aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+type C(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+       aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+       aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
     // ... the body of the class follows
 ```
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -115,6 +115,16 @@ type C(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
     // ... the body of the class follows
 ```
 
+If there is an explicit return type annotation, it should be at the end of the `)` and before the `=`:
+
+```fsharp
+type C() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse): ReturnType =
+        // ... the body of the method follows
+```
+
 ### Type annotations
 
 #### Right-pad function argument type annotations

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -115,13 +115,14 @@ type C(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
     // ... the body of the class follows
 ```
 
-If there is an explicit return type annotation, it should be at the end of the `)` and before the `=`:
+If there is an explicit return type annotation, it can either be at the end of the `)` and before the `=`, or on a new line. If the return type also has a long name the latter might be preferrable:
 
 ```fsharp
 type C() =
     member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
                                             aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
-                                            aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse): ReturnType =
+                                            aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            : AVeryLongReturnType =
         // ... the body of the method follows
 ```
 


### PR DESCRIPTION
This was mistakenly suggesting something that won't work. This now uses the formatting that we do in the F# compiler for our own very very long member definitions (sometimes). Fixes https://github.com/dotnet/docs/issues/18637
