### PR TITLE
Fix anchors to headers in switch.md

### DIFF
--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -80,7 +80,7 @@ Execution of the statement list in the switch section with a case label that mat
 
 Each case label specifies a pattern to compare to the match expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the match expression, control is transferred to the section with the `default` case label, if there's one. If there's no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
 
-For information on the `switch` statement and pattern matching, see the [Pattern matching with the `switch` statement](#pattern) section.
+For information on the `switch` statement and pattern matching, see the [Pattern matching with the `switch` statement](#pattern-matching with-the-switch-statement) section.
 
 Because C# 6 supports only the constant pattern and doesn't allow the repetition of constant values, case labels define mutually exclusive values, and only one pattern can match the match expression. As a result, the order in which `case` statements appear is unimportant.
 
@@ -94,7 +94,7 @@ You can correct this issue and eliminate the compiler warning in one of two ways
 
 - By changing the order of the switch sections.
 
-- By using a [when clause](#when) in the `case` label.
+- By using a [when clause](#the-case-statement-and-the-when-clause) in the `case` label.
 
 ## The `default` case
 
@@ -102,7 +102,7 @@ The `default` case specifies the switch section to execute if the match expressi
 
 The `default` case can appear in any order in the `switch` statement. Regardless of its order in the source code, it's always evaluated last, after all `case` labels have been evaluated.
 
-## <a name="pattern"></a> Pattern matching with the `switch` statement
+## Pattern matching with the `switch` statement
 
 Each `case` statement defines a pattern that, if it matches the match expression, causes its  containing switch section to be executed. All versions of C# support the constant pattern. The remaining patterns are supported beginning with C# 7.0.
 
@@ -179,7 +179,7 @@ Without pattern matching, this code might be written as follows. The use of type
 
 [!code-csharp[type-pattern2#1](~/samples/snippets/csharp/language-reference/keywords/switch/type-pattern2.cs#1)]
 
-## <a name="when" /> The `case` statement and the `when` clause
+## The `case` statement and the `when` clause
 
 Starting with C# 7.0, because case statements need not be mutually exclusive, you can add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value.
 


### PR DESCRIPTION
## Summary

Currently, `Pattern matching with the switch statement` and `The case statement and the when clause` paragraphs are displayed in a browser (Chrome) as a link (when you put a cursor on it the browser highlights the whole text as a link). I propose to use valid anchors links to headers in md docs.
