### PR TITLE
Check runtime

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/cds_blockingcollection/cs/example01.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cds_blockingcollection/cs/example01.cs
@@ -1,62 +1,70 @@
 ﻿//<snippet01>
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 class Program
 {
-   static void Main()
-   {
-      // Increase or decrease this value as desired.
-      int itemsToAdd = 500;
+    static void Main()
+    {
+        // Increase or decrease this value as desired.
+        int itemsToAdd = 500;
 
-      // Preserve all the display output for Adds and Takes
-      Console.SetBufferSize(80, (itemsToAdd * 2) + 3);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            int width = Math.Max(Console.BufferWidth, 80);
+            int height = Math.Max(Console.BufferHeight, itemsToAdd * 2 + 3);
 
-      // A bounded collection. Increase, decrease, or remove the
-      // maximum capacity argument to see how it impacts behavior.
-      BlockingCollection<int> numbers = new BlockingCollection<int>(50);
+            // Preserve all the display output for Adds and Takes
+            Console.SetBufferSize(width, height);
+        }
 
-      // A simple blocking consumer with no cancellation.
-      Task.Run(() =>
-      {
-          int i = -1;
-          while (!numbers.IsCompleted)
-          {
-              try
-              {
-                  i = numbers.Take();
-              }
-              catch (InvalidOperationException)
-              {
-                  Console.WriteLine("Adding was completed!");
-                  break;
-              }
-              Console.WriteLine("Take:{0} ", i);
+        // A bounded collection. Increase, decrease, or remove the
+        // maximum capacity argument to see how it impacts behavior.
+        var numbers = new BlockingCollection<int>(50);
 
-              // Simulate a slow consumer. This will cause
-              // collection to fill up fast and thus Adds wil block.
-              Thread.SpinWait(100000);
-          }
+        // A simple blocking consumer with no cancellation.
+        Task.Run(() =>
+        {
+            int i = -1;
+            while (!numbers.IsCompleted)
+            {
+                try
+                {
+                    i = numbers.Take();
+                }
+                catch (InvalidOperationException)
+                {
+                    Console.WriteLine("Adding was completed!");
+                    break;
+                }
+                Console.WriteLine("Take:{0} ", i);
 
-          Console.WriteLine("\r\nNo more items to take. Press the Enter key to exit.");
-      });
+                // Simulate a slow consumer. This will cause
+                // collection to fill up fast and thus Adds wil block.
+                Thread.SpinWait(100000);
+            }
 
-      // A simple blocking producer with no cancellation.
-      Task.Run(() =>
-      {
-          for (int i = 0; i < itemsToAdd; i++) {
-              numbers.Add(i);
-              Console.WriteLine("Add:{0} Count={1}", i, numbers.Count);
-          }
+            Console.WriteLine("\r\nNo more items to take. Press the Enter key to exit.");
+        });
 
-          // See documentation for this method.
-          numbers.CompleteAdding();
-      });
+        // A simple blocking producer with no cancellation.
+        Task.Run(() =>
+        {
+            for (int i = 0; i < itemsToAdd; i++)
+            {
+                numbers.Add(i);
+                Console.WriteLine("Add:{0} Count={1}", i, numbers.Count);
+            }
 
-      // Keep the console display open in debug mode.
-      Console.ReadLine();
-   }
+            // See documentation for this method.
+            numbers.CompleteAdding();
+        });
+
+        // Keep the console display open in debug mode.
+        Console.ReadLine();
+    }
 }
 //</snippet01>

--- a/samples/snippets/csharp/VS_Snippets_Misc/cds_blockingcollection/cs/example02.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cds_blockingcollection/cs/example02.cs
@@ -1,30 +1,38 @@
 ﻿//<snippet02>
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 class ProgramWithCancellation
 {
-
     static int inputs = 2000;
 
     static void Main()
     {
         // The token source for issuing the cancelation request.
-        CancellationTokenSource cts = new CancellationTokenSource();
+        var cts = new CancellationTokenSource();
 
         // A blocking collection that can hold no more than 100 items at a time.
-        BlockingCollection<int> numberCollection = new BlockingCollection<int>(100);
+        var numberCollection = new BlockingCollection<int>(100);
 
-        // Set console buffer to hold our prodigious output.
-        Console.SetBufferSize(80, 2000);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            int width = Math.Max(Console.BufferWidth, 80);
+            int height = Math.Max(Console.BufferHeight, 8000);
+
+            // Preserve all the display output for Adds and Takes
+            Console.SetBufferSize(width, height);
+        }
 
         // The simplest UI thread ever invented.
         Task.Run(() =>
         {
             if (Console.ReadKey(true).KeyChar == 'c')
+            {
                 cts.Cancel();
+            }
         });
 
         // Start one producer and one consumer.


### PR DESCRIPTION
## Summary

- Clean up C#
- Add runtime check to avoid not supported platform exception
- Use `Math.Max` to get the max number - again, to avoid exceptions from setting buffer too small

Fixes #18842
