### PR TITLE
Add ArgumentOutOfRangeExceptions for Preview 5 and 6

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -91,6 +91,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [Removed status bar controls](#removed-status-bar-controls)
 - [WinForms methods now throw ArgumentException](#winforms-methods-now-throw-argumentexception)
 - [WinForms methods now throw ArgumentNullException](#winforms-methods-now-throw-argumentnullexception)
+- [WinForms properties now throw ArgumentOutOfRangeException](#winforms-properties-now-throw-argumentoutofrangeexception)
 
 [!INCLUDE [winforms-deprecated-controls](../../../includes/core-changes/windowsforms/5.0/winforms-deprecated-controls.md)]
 
@@ -101,5 +102,9 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ***
 
 [!INCLUDE [null-args-cause-argumentnullexception](../../../includes/core-changes/windowsforms/5.0/null-args-cause-argumentnullexception.md)]
+
+***
+
+[!INCLUDE [invalid-args-cause-argumentoutofrangeexception](../../../includes/core-changes/windowsforms/5.0/invalid-args-cause-argumentoutofrangeexception.md)]
 
 ***

--- a/docs/core/compatibility/winforms.md
+++ b/docs/core/compatibility/winforms.md
@@ -14,6 +14,7 @@ The following breaking changes are documented on this page:
 | [Removed status bar controls](#removed-status-bar-controls) | 5.0 |
 | [WinForms methods now throw ArgumentException](#winforms-methods-now-throw-argumentexception) | 5.0 |
 | [WinForms methods now throw ArgumentNullException](#winforms-methods-now-throw-argumentnullexception) | 5.0 |
+| [WinForms properties now throw ArgumentOutOfRangeException](#winforms-properties-now-throw-argumentoutofrangeexception) | 5.0 |
 | [Removed controls](#removed-controls) | 3.1 |
 | [CellFormatting event not raised if tooltip is shown](#cellformatting-event-not-raised-if-tooltip-is-shown) | 3.1 |
 | [Control.DefaultFont changed to Segoe UI 9 pt](#default-control-font-changed-to-segoe-ui-9-pt) | 3.0 |
@@ -41,6 +42,10 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE [null-args-cause-argumentnullexception](../../../includes/core-changes/windowsforms/5.0/null-args-cause-argumentnullexception.md)]
+
+***
+
+[!INCLUDE [invalid-args-cause-argumentoutofrangeexception](../../../includes/core-changes/windowsforms/5.0/invalid-args-cause-argumentoutofrangeexception.md)]
 
 ***
 

--- a/includes/core-changes/windowsforms/5.0/invalid-args-cause-argumentexception.md
+++ b/includes/core-changes/windowsforms/5.0/invalid-args-cause-argumentexception.md
@@ -11,7 +11,7 @@ Throwing an <xref:System.ArgumentException> conforms to the behavior of the .NET
 The following table lists the affected methods and parameters:
 
 | Method | Parameter name | Condition | Version added |
-|-|-|-|
+|-|-|-|-|
 | <xref:System.Windows.Forms.TabControl.GetToolTipText(System.Object)?displayProperty=fullName> | `item` | Argument is not of type <xref:System.Windows.Forms.TabPage>. | 5.0 Preview 1 |
 | <xref:System.Windows.Forms.DataFormats.GetFormat(System.String)?displayProperty=fullName> | `format` | Argument is `null`, <xref:System.String.Empty?displayProperty=nameWithType>, or white space. | 5.0 Preview 5 |
 

--- a/includes/core-changes/windowsforms/5.0/invalid-args-cause-argumentoutofrangeexception.md
+++ b/includes/core-changes/windowsforms/5.0/invalid-args-cause-argumentoutofrangeexception.md
@@ -1,0 +1,43 @@
+### WinForms properties now throw ArgumentOutOfRangeException
+
+Some Windows Forms properties now throw an <xref:System.ArgumentOutOfRangeException> for invalid arguments, where previously they did not.
+
+#### Change description
+
+Previously, these properties threw various exceptions, such as <xref:System.NullReferenceException>, <xref:System.IndexOutOfRangeException>, or <xref:System.ArgumentException>, when passed out-of-range arguments. Starting in .NET 5.0, these properties now throw an <xref:System.ArgumentOutOfRangeException> when passed arguments that are out of range.
+
+Throwing an <xref:System.ArgumentOutOfRangeException> conforms to the behavior of the .NET runtime. It also improves the debugging experience by clearly communicating which argument is invalid.
+
+#### Version introduced
+
+.NET 5.0
+
+#### Recommended action
+
+- Update the code to prevent passing invalid arguments.
+- If necessary, handle an <xref:System.ArgumentOutOfRangeException> when setting the property.
+
+#### Category
+
+Windows Forms
+
+#### Affected APIs
+
+The following table lists the affected properties and parameters:
+
+> [!div class="mx-tdBreakAll"]
+> | Property | Parameter name | Version added |
+> |-|-|-|
+> | <xref:System.Windows.Forms.ListBox.IntegerCollection.Item(System.Int32)?displayProperty=nameWithType> | `index` | 5.0 Preview 5 |
+> | <xref:System.Windows.Forms.TreeNode.ImageIndex?displayProperty=nameWithType> | `value` | 5.0 Preview 6 |
+> | <xref:System.Windows.Forms.TreeNode.SelectedImageIndex?displayProperty=nameWithType> | `value` | 5.0 Preview 6 |
+
+<!-- 
+
+#### Affected APIs
+
+- `P:System.Windows.Forms.ListBox.IntegerCollection.Item(System.Int32)`
+- `P:System.Windows.Forms.TreeNode.ImageIndex`
+- `P:System.Windows.Forms.TreeNode.SelectedImageIndex`
+
+-->


### PR DESCRIPTION
Contributes to #18029.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/winforms?branch=pr-en-us-18888#winforms-properties-now-throw-argumentoutofrangeexception).