### PR TITLE
Sample code error

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/consuming-the-task-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/consuming-the-task-based-asynchronous-pattern.md
@@ -221,7 +221,7 @@ string [] pages = await Task.WhenAll(
  You can use the same exception-handling techniques we discussed in the previous void-returning scenario:
 
 ```csharp
-Task [] asyncOps =
+Task<string> [] asyncOps =
     (from url in urls select DownloadStringAsync(url)).ToArray();
 try
 {


### PR DESCRIPTION
Task need a TResult

## Summary
Hi all, Thanks for the tutorial, and I really learn a lot from it.
Here is a sample code error I found when I am coding in Visual Studio.
Adding a TResult after task then it works well.
Modified line is Task[] => Task []

Fixes #18898
