### PR TITLE
fix: dotnet/docs#18900, code example now compliant

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -102,8 +102,6 @@ namespace Coding_Conventions_Examples
             //</snippet11>
 
             //<snippet12>
-            // Do not use implicit typing to determine the type of the loop
-            // variable in foreach loops.
             foreach (char ch in laugh)
             {
                 if (ch == 'h')

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -102,7 +102,9 @@ namespace Coding_Conventions_Examples
             //</snippet11>
 
             //<snippet12>
-            foreach (var ch in laugh)
+            // Do not use implicit typing to determine the type of the loop
+            // variable in foreach loops.
+            foreach (char ch in laugh)
             {
                 if (ch == 'h')
                     Console.Write("H");


### PR DESCRIPTION
## Summary

Sample code for `foreach` now uses explicit type instead of var, as per the guideline.

Fixes #18900.
