### PR TITLE
Fix snippet reference

### DIFF
--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -83,7 +83,7 @@ Enhance the application to prompt the user for their name and display it along w
 
 1. Replace the contents of the `Main` method in *Program.cs*, which is the line that calls `Console.WriteLine`, with the following code:
 
-   :::code language="csharp" source="./snippets/with-visual-studio/csharp/Program.cs" id="Snippet1":::
+   [!code-csharp[GettingStarted#1](./snippets/with-visual-studio/csharp/Program.cs#1)]
 
    This code displays "What is your name?" in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date`. Finally, it displays these values in the console window.
 

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -83,7 +83,7 @@ Enhance the application to prompt the user for their name and display it along w
 
 1. Replace the contents of the `Main` method in *Program.cs*, which is the line that calls `Console.WriteLine`, with the following code:
 
-   [!code-csharp[GettingStarted#1](./snippets/with-visual-studio/csharp/Program.cs#1)]
+   :::code language="csharp" source="./snippets/with-visual-studio/csharp/Program.cs" id="1":::
 
    This code displays "What is your name?" in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date`. Finally, it displays these values in the console window.
 

--- a/docs/core/tutorials/with-visual-studio-mac.md
+++ b/docs/core/tutorials/with-visual-studio-mac.md
@@ -78,7 +78,7 @@ Enhance the application to prompt the user for their name and display it along w
 
 1. In *Program.cs*, replace the contents of the `Main` method, which is the line that calls `Console.WriteLine`, with the following code:
 
-   [!code-csharp[GettingStarted#1](./snippets/with-visual-studio/csharp/Program.cs#1)]
+   :::code language="csharp" source="./snippets/with-visual-studio/csharp/Program.cs" id="1":::
 
    This code displays "What is your name?" in the console window and waits until the user enters a string followed by the <kbd>enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date`. Finally, it displays these values in the console window.
 

--- a/docs/core/tutorials/with-visual-studio-mac.md
+++ b/docs/core/tutorials/with-visual-studio-mac.md
@@ -78,7 +78,7 @@ Enhance the application to prompt the user for their name and display it along w
 
 1. In *Program.cs*, replace the contents of the `Main` method, which is the line that calls `Console.WriteLine`, with the following code:
 
-   :::code language="csharp" source="./snippets/with-visual-studio/csharp/Program.cs" id="Snippet1":::
+   [!code-csharp[GettingStarted#1](./snippets/with-visual-studio/csharp/Program.cs#1)]
 
    This code displays "What is your name?" in the console window and waits until the user enters a string followed by the <kbd>enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date`. Finally, it displays these values in the console window.
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -87,8 +87,8 @@ Enhance the application to prompt the user for their name and display it along w
 
 1. In *Program.cs* or *Program.vb*, replace the contents of the `Main` method, which is the line that calls `Console.WriteLine`, with the following code:
 
-   [!code-csharp[GettingStarted#1](./snippets/with-visual-studio/csharp/Program.cs#1)]
-   [!code-vb[GettingStarted#1](./snippets/with-visual-studio/vb/Program.vb#1)]
+   :::code language="csharp" source="./snippets/with-visual-studio/csharp/Program.cs" id="1":::
+   :::code language="vb" source="./snippets/with-visual-studio/vb/Program.vb" id="1":::
 
    This code displays "What is your name?" in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). Finally, it displays these values in the console window.
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -87,8 +87,8 @@ Enhance the application to prompt the user for their name and display it along w
 
 1. In *Program.cs* or *Program.vb*, replace the contents of the `Main` method, which is the line that calls `Console.WriteLine`, with the following code:
 
-   :::code language="csharp" source="./snippets/with-visual-studio/csharp/Program.cs" id="1":::
-   :::code language="vb" source="./snippets/with-visual-studio/vb/Program.vb" id="1":::
+   [!code-csharp[GettingStarted#1](./snippets/with-visual-studio/csharp/Program.cs#1)]
+   [!code-vb[GettingStarted#1](./snippets/with-visual-studio/vb/Program.vb#1)]
 
    This code displays "What is your name?" in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). Finally, it displays these values in the console window.
 


### PR DESCRIPTION
Fixes #18906 

Using new snippet syntax with id=1 instead of id=Snippet1.  In future will avoid "Snippet" in snippet tags.
