### PR TITLE
Correct ICorDebugHeapSegmentEnum's enumeration type

### DIFF
--- a/docs/framework/unmanaged-api/debugging/icordebugheapsegmentenum-interface.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugheapsegmentenum-interface.md
@@ -22,12 +22,12 @@ Provides an enumerator for the memory regions of the managed heap. This interfac
   
 |Method|Description|  
 |------------|-----------------|  
-|[Next Method](icordebugheapsegmentenum-next-method.md)|Gets the specified number of [COR_HEAPOBJECT](cor-heapobject-structure.md) instances that contain information about regions of the managed heap.|  
+|[Next Method](icordebugheapsegmentenum-next-method.md)|Gets the specified number of [COR_SEGMENT](cor-segment-structure.md) instances that contain information about regions of the managed heap.|  
   
 ## Remarks  
  The `ICorDebugHeapSegmentEnum` interface implements the ICorDebugEnum interface.  
   
- An `ICorDebugHeapSegmentEnum` instance is populated with [COR_HEAPOBJECT](cor-heapobject-structure.md) instances by calling the [ICorDebugProcess5::EnumerateHeapRegions](icordebugprocess5-enumerateheapregions-method.md) method. The [COR_HEAPOBJECT](cor-heapobject-structure.md) objects in the collection can be enumerated by calling the [ICorDebugHeapSegmentEnum::Next](icordebugheapsegmentenum-next-method.md) method.  
+ An `ICorDebugHeapSegmentEnum` instance is populated with [COR_SEGMENT](cor-segment-structure.md) instances by calling the [ICorDebugProcess5::EnumerateHeapRegions](icordebugprocess5-enumerateheapregions-method.md) method. The [COR_SEGMENT](cor-segment-structure.md) objects in the collection can be enumerated by calling the [ICorDebugHeapSegmentEnum::Next](icordebugheapsegmentenum-next-method.md) method.  
   
  An `ICorDebugHeapSegmentEnum` collection object enumerates all memory regions that may contain managed objects, but it does not guarantee that managed objects actually reside in those regions. It may include information about empty or reserved memory regions.  
   

--- a/docs/framework/unmanaged-api/debugging/icordebugheapsegmentenum-next-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugheapsegmentenum-next-method.md
@@ -17,7 +17,7 @@ topic_type:
   - "apiref"
 ---
 # ICorDebugHeapSegmentEnum::Next Method
-Gets the specified number of [COR_HEAPOBJECT](cor-heapobject-structure.md) instances that contain information about memory regions of the managed heap.  
+Gets the specified number of [COR_SEGMENT](cor-segment-structure.md) instances that contain information about memory regions of the managed heap.  
   
 ## Syntax  
   
@@ -33,10 +33,10 @@ HRESULT Next(
  [in] The number of segments to be retrieved.  
   
  segments  
- [out] An array of pointers, each of which points to a [COR_HEAPOBJECT](cor-heapobject-structure.md) object that provides information about a region of memory in the managed heap.  
+ [out] An array of pointers, each of which points to a [COR_SEGMENT](cor-segment-structure.md) object that provides information about a region of memory in the managed heap.  
   
  pceltFetched  
- [out] A pointer to the number of [COR_HEAPOBJECT](cor-heapobject-structure.md) objects actually returned in `segments`. This value may be `null` if `celt` is 1.  
+ [out] A pointer to the number of [COR_SEGMENT](cor-segment-structure.md) objects actually returned in `segments`. This value may be `null` if `celt` is 1.  
   
 ## Remarks  
   


### PR DESCRIPTION
## Summary

Corrects the return type for the ICorDebugHeapSegmentEnum methods and interfaces.

Fixes #18930
