### PR TITLE
Corrections to the lists of Linux package dependencies

### DIFF
--- a/docs/core/install/dependencies.md
+++ b/docs/core/install/dependencies.md
@@ -241,16 +241,17 @@ Based on your linux distribution, you may need to install additional dependencie
 
 Ubuntu distributions require the following libraries to be installed:
 
-- liblttng-ust0
-- libcurl3 (for 14.x and 16.x)
-- libcurl4 (for 18.x)
-- libssl1.0.0
-- libkrb5-3
-- zlib1g
+- libc6
+- libgcc1
+- libgssapi-krb5-2
 - libicu52 (for 14.x)
 - libicu55 (for 16.x)
-- libicu57 (for 17.x)
 - libicu60 (for 18.x)
+- libicu66 (for 20.x)
+- libssl1.0.0 (for 14.x, 16.x)
+- libssl1.1 (for 18.x, 20.x)
+- libstdc++6
+- zlib1g
 
 For .NET Core apps that use the *System.Drawing.Common* assembly, you also need the following dependency:
 
@@ -265,19 +266,11 @@ For .NET Core apps that use the *System.Drawing.Common* assembly, you also need 
 
 CentOS distributions require the following libraries installed:
 
-- lttng-ust
-- libcurl
 - openssl-libs
 - krb5-libs
 - libicu
-- zlib
 
 Fedora users: If your OpenSSL's version >= 1.1, you'll need to install **compat-openssl10**.
-
-For .NET Core 2.0, the following dependencies are also required:
-
-- libunwind
-- libuuid
 
 For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/master/Documentation/self-contained-linux-apps.md).
 
@@ -296,12 +289,10 @@ Alpine distributions require the following libraries to be installed:
 
 - icu-libs (this is not needed if globalization is disabled)
 - krb5-libs
-- libcurl
+- libgcc
 - libintl
 - libssl1.1 (for Alpine 3.9 or later) or libssl1.0 (for older ones)
 - libstdc++
-- lttng-ust
-- numactl (optional, useful only for devices with NUMA enabled)
 - zlib
 
 For .NET Core apps that use the *System.Drawing.Common* assembly, you also need the following dependency:

--- a/docs/core/install/includes/linux-rpm-install-dependencies.md
+++ b/docs/core/install/includes/linux-rpm-install-dependencies.md
@@ -1,14 +1,9 @@
 
 When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
-- lttng-ust
-- libcurl
-- openssl-libs
 - krb5-libs
 - libicu
-- zlib
-- libunwind
-- libuuid
+- openssl-libs
 
 If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need to install **compat-openssl10**.
 

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -42,12 +42,11 @@ The following versions of .NET Core are no longer supported. The downloads for t
 
 - icu-libs
 - krb5-libs
+- libgcc
 - libintl
 - libssl1.1 (Alpine v3.9 or greater)
-- libssl1.0 (Alpine v3.8)
+- libssl1.0 (Alpine v3.8 or lower)
 - libstdc++
-- lttng-ust
-- numactl (optional)
 - zlib
 
 ## Scripted install

--- a/docs/core/install/linux-centos.md
+++ b/docs/core/install/linux-centos.md
@@ -69,7 +69,7 @@ This section provides information on common errors you may get while using the p
 
 ## Dependencies
 
-[!INCLUDE [linux-install-dependencies](includes/linux-install-dependencies.md)]
+[!INCLUDE [linux-rpm-install-dependencies](includes/linux-rpm-install-dependencies.md)]
 
 ## Scripted install
 

--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -122,7 +122,7 @@ sudo apt-get update; \
 
 ## Dependencies
 
-[!INCLUDE [linux-install-dependencies](includes/linux-install-dependencies.md)]
+[!INCLUDE [linux-rpm-install-dependencies](includes/linux-rpm-install-dependencies.md)]
 
 ## Scripted install
 

--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -122,7 +122,26 @@ sudo apt-get update; \
 
 ## Dependencies
 
-[!INCLUDE [linux-rpm-install-dependencies](includes/linux-rpm-install-dependencies.md)]
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
+
+- libc6
+- libgcc1
+- libgssapi-krb5-2
+- libicu52 (for 8.x)
+- libicu57 (for 9.x)
+- libicu63 (for 10.x)
+- libicu67 (for 11.x)
+- libssl1.0.0 (for 8.x)
+- libssl1.1 (for 9.x-11.x)
+- libstdc++6
+- zlib1g
+
+For .NET Core apps that use the *System.Drawing.Common* assembly, you also need the following dependency:
+
+- libgdiplus (version 6.0.1 or later)
+
+  > [!WARNING]
+  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
 
 ## Scripted install
 

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -124,7 +124,7 @@ This section provides information on common errors you may get while using the p
 
 ## Dependencies
 
-[!INCLUDE [linux-install-dependencies](includes/linux-install-dependencies.md)]
+[!INCLUDE [linux-rpm-install-dependencies](includes/linux-rpm-install-dependencies.md)]
 
 ## Scripted install
 

--- a/docs/core/install/linux-opensuse.md
+++ b/docs/core/install/linux-opensuse.md
@@ -64,7 +64,22 @@ This section provides information on common errors you may get while using the p
 
 ## Dependencies
 
-[!INCLUDE [linux-install-dependencies](includes/linux-install-dependencies.md)]
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
+
+- krb5
+- libicu
+- libopenssl1_0_0
+
+If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need to install **compat-openssl10**.
+
+For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/master/Documentation/self-contained-linux-apps.md).
+
+For .NET Core apps that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
+
+- [libgdiplus (version 6.0.1 or later)](https://www.mono-project.com/docs/gui/libgdiplus/)
+
+  > [!WARNING]
+  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
 
 ## Scripted install
 

--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -95,7 +95,7 @@ As an alternative to the ASP.NET Core Runtime, you can install the .NET Core Run
 
 ## Dependencies
 
-[!INCLUDE [linux-install-dependencies](includes/linux-install-dependencies.md)]
+[!INCLUDE [linux-rpm-install-dependencies](includes/linux-rpm-install-dependencies.md)]
 
 ## Scripted install
 

--- a/docs/core/install/linux-sles.md
+++ b/docs/core/install/linux-sles.md
@@ -73,7 +73,22 @@ This section provides information on common errors you may get while using the p
 
 ## Dependencies
 
-[!INCLUDE [linux-install-dependencies](includes/linux-install-dependencies.md)]
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
+
+- krb5
+- libicu
+- libopenssl1_1
+
+If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need to install **compat-openssl10**.
+
+For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/master/Documentation/self-contained-linux-apps.md).
+
+For .NET Core apps that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
+
+- [libgdiplus (version 6.0.1 or later)](https://www.mono-project.com/docs/gui/libgdiplus/)
+
+  > [!WARNING]
+  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
 
 ## Scripted install
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -196,16 +196,17 @@ sudo apt-get update; \
 
 When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
-- liblttng-ust0
-- libcurl3 (for 14.x and 16.x)
-- libcurl4 (for 18.x)
-- libssl1.0.0
-- libkrb5-3
-- zlib1g
+- libc6
+- libgcc1
+- libgssapi-krb5-2
 - libicu52 (for 14.x)
 - libicu55 (for 16.x)
-- libicu57 (for 17.x)
 - libicu60 (for 18.x)
+- libicu66 (for 20.x)
+- libssl1.0.0 (for 14.x, 16.x)
+- libssl1.1 (for 18.x, 20.x)
+- libstdc++6
+- zlib1g
 
 For .NET Core apps that use the *System.Drawing.Common* assembly, you also need the following dependency:
 


### PR DESCRIPTION
The current set of Linux package dependencies across the supported set of distros have some inaccuracies.  There are cases of packages that aren't listed, packages that shouldn't be listed, and updates to package versions that are needed.

cc @Thraka, @dagood, @MichaelSimons 