### PR TITLE
Use "Attribute" suffix in example defining a new attribute

### DIFF
--- a/docs/csharp/programming-guide/concepts/attributes/creating-custom-attributes.md
+++ b/docs/csharp/programming-guide/concepts/attributes/creating-custom-attributes.md
@@ -10,12 +10,12 @@ You can create your own custom attributes by defining an attribute class, a clas
 [System.AttributeUsage(System.AttributeTargets.Class |  
                        System.AttributeTargets.Struct)  
 ]  
-public class Author : System.Attribute  
+public class AuthorAttribute : System.Attribute  
 {  
     private string name;  
     public double version;  
   
-    public Author(string name)  
+    public AuthorAttribute(string name)  
     {  
         this.name = name;  
         version = 1.0;  
@@ -23,7 +23,7 @@ public class Author : System.Attribute
 }  
 ```  
   
- The class name is the attribute's name, `Author`. It is derived from `System.Attribute`, so it is a custom attribute class. The constructor's parameters are the custom attribute's positional parameters. In this example, `name` is a positional parameter. Any public read-write fields or properties are named parameters. In this case, `version` is the only named parameter. Note the use of the `AttributeUsage` attribute to make the `Author` attribute valid only on class and `struct` declarations.  
+ The class name `AuthorAttribute` is the attribute's name, `Author`, plus the `Attribute` suffix. It is derived from `System.Attribute`, so it is a custom attribute class. The constructor's parameters are the custom attribute's positional parameters. In this example, `name` is a positional parameter. Any public read-write fields or properties are named parameters. In this case, `version` is the only named parameter. Note the use of the `AttributeUsage` attribute to make the `Author` attribute valid only on class and `struct` declarations.  
   
  You could use this new attribute as follows:  
   
@@ -42,7 +42,7 @@ class SampleClass
                        System.AttributeTargets.Struct,  
                        AllowMultiple = true)  // multiuse attribute  
 ]  
-public class Author : System.Attribute  
+public class AuthorAttribute : System.Attribute  
 ```  
   
  In the following code example, multiple attributes of the same type are applied to a class.  


### PR DESCRIPTION
## Summary

The example to create a custom attribute in C# creates an attribute called `Author` and defines it using a class called `Author`. Although this works, it causes warning CA1710, which encourages using preferred suffixes for types like this. This changes the name of the class to `AuthorAttribute` to follow this guidance.
