### PR TITLE
not changed method, but changed initial data

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/LambdaOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/LambdaOperator.cs
@@ -21,7 +21,7 @@ namespace operators
               .Min(w => w.Length);
             Console.WriteLine(minimalLength);   // output: 5
 
-            int[] numbers = { 1, 4, 7, 10 };
+            int[] numbers = { 4, 7, 10 };
             int product = numbers.Aggregate(1, (interim, next) => interim * next);
             Console.WriteLine(product);   // output: 280
             // </SnippetInferredTypes>
@@ -30,7 +30,7 @@ namespace operators
         private static void WithExplicitTypes()
         {
             // <SnippetExplicitTypes>
-            int[] numbers = { 1, 4, 7, 10 };
+            int[] numbers = { 4, 7, 10 };
             int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
             Console.WriteLine(product);   // output: 280
             // </SnippetExplicitTypes>


### PR DESCRIPTION
Because currently used the Aggregate<TSource,TAccumulate>(IEnumerable, TAccumulate, Func<TAccumulate,TSource,TAccumulate>) variant is more interesting that I proposed earlier, i decided that will be more appropriate not change method, but change initial data (the result which showing in comments doesn't change).

## Summary

Describe your changes here.

Fixes #18920
