### PR TITLE
Add new articles to TOC & Spark Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /docs/machine-learning/ @luisquintanilla
 
 # The .NET for Apache Spark Guide:
-/docs/spark/ @mamccrea
+/docs/spark/ @luisquintanilla
 
 # The .NET Architecture Guide:
 /docs/architecture/ @nishanil

--- a/docs/spark/toc.yml
+++ b/docs/spark/toc.yml
@@ -39,6 +39,10 @@
     href: how-to-guides/windows-instructions.md
   - name: Install interactive notebooks on Azure HDInsight
     href: how-to-guides/hdinsight-notebook-installation.md
+  - name: Broadcast Guide
+    href: how-to-guides/broadcast-guide.md
+  - name: UDF Guide
+    href: how-to-guides/udf-guide.md        
 - name: Reference
   items:
   - name: API Reference

--- a/docs/spark/toc.yml
+++ b/docs/spark/toc.yml
@@ -25,6 +25,10 @@
     href: tutorials/ml-sentiment-analysis.md
 - name: How-to guides
   items:
+  - name: Broadcast guide
+    href: how-to-guides/broadcast-guide.md
+  - name: UDF guide
+    href: how-to-guides/udf-guide.md
   - name: Debug your application
     href: how-to-guides/debug.md
   - name: Submit jobs to HDInsight
@@ -39,10 +43,7 @@
     href: how-to-guides/windows-instructions.md
   - name: Install interactive notebooks on Azure HDInsight
     href: how-to-guides/hdinsight-notebook-installation.md
-  - name: Broadcast Guide
-    href: how-to-guides/broadcast-guide.md
-  - name: UDF Guide
-    href: how-to-guides/udf-guide.md        
+
 - name: Reference
   items:
   - name: API Reference


### PR DESCRIPTION
## Summary

- Add Broadcast and UDF guides to TOC
- Update CODEOWNERS for .NET for Apache Spark doc set

Preview Link: 

Toc | docs/spark/toc.yml | https://review.docs.microsoft.com/en-us/dotnet/spark?branch=pr-en-us-19015
-- | -- | --


