### PR TITLE
Document Kestrel HTTP/2 over TLS breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -16,6 +16,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [HttpSys: Client certificate renegotiation disabled by default](#httpsys-client-certificate-renegotiation-disabled-by-default)
 - [Kestrel: Configuration changes at run time detected by default](#kestrel-configuration-changes-at-run-time-detected-by-default)
 - [Kestrel: Default supported TLS protocol versions changed](#kestrel-default-supported-tls-protocol-versions-changed)
+- [Kestrel: HTTP/2 disabled over TLS on incompatible Windows versions](#kestrel-http2-disabled-over-tls-on-incompatible-windows-versions)
 - [Localization: "Pubternal" APIs removed](#localization-pubternal-apis-removed)
 - [Localization: ResourceManagerWithCultureStringLocalizer class and WithCulture interface member removed](#localization-resourcemanagerwithculturestringlocalizer-class-and-withculture-interface-member-removed)
 - [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
@@ -48,6 +49,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ***
 
 [!INCLUDE[Kestrel: Default supported TLS protocol versions changed](~/includes/core-changes/aspnetcore/5.0/kestrel-default-supported-tls-protocol-versions-changed.md)]
+
+***
+
+[!INCLUDE[Kestrel: HTTP/2 disabled over TLS on incompatible Windows versions](~/includes/core-changes/aspnetcore/5.0/kestrel-disables-http2-over-tls.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -49,6 +49,7 @@ The following breaking changes are documented on this page:
 - [Kestrel: Connection adapters removed](#kestrel-connection-adapters-removed)
 - [Kestrel: Default supported TLS protocol versions changed](#kestrel-default-supported-tls-protocol-versions-changed)
 - [Kestrel: Empty HTTPS assembly removed](#kestrel-empty-https-assembly-removed)
+- [Kestrel: HTTP/2 disabled over TLS on incompatible Windows versions](#kestrel-http2-disabled-over-tls-on-incompatible-windows-versions)
 - [Kestrel: Request trailer headers moved to new collection](#kestrel-request-trailer-headers-moved-to-new-collection)
 - [Kestrel: Transport abstraction layer changes](#kestrel-transport-abstractions-removed-and-made-public)
 - [Localization: APIs marked obsolete](#localization-resourcemanagerwithculturestringlocalizer-and-withculture-marked-obsolete)
@@ -103,6 +104,10 @@ The following breaking changes are documented on this page:
 
 ***
 [!INCLUDE[Kestrel: Default supported TLS protocol versions changed](~/includes/core-changes/aspnetcore/5.0/kestrel-default-supported-tls-protocol-versions-changed.md)]
+
+***
+
+[!INCLUDE[Kestrel: HTTP/2 disabled over TLS on incompatible Windows versions](~/includes/core-changes/aspnetcore/5.0/kestrel-disables-http2-over-tls.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/5.0/kestrel-disables-http2-over-tls.md
+++ b/includes/core-changes/aspnetcore/5.0/kestrel-disables-http2-over-tls.md
@@ -1,0 +1,69 @@
+### Kestrel: HTTP/2 disabled over TLS on incompatible Windows versions
+
+To enable HTTP/2 over Transport Layer Security (TLS) on Windows, two requirements need to be met:
+
+- Application-Layer Protocol Negotiation (ALPN) support, which is available starting with Windows 8.1 and Windows Server 2012 R2.
+- A set of ciphers compatible with HTTP/2, which is available starting with Windows 10 and Windows Server 2016.
+
+As such, Kestrel's behavior when HTTP/2 over TLS is configured has changed to:
+
+- Downgrade to `Http1` and log a message at the `Information` level when [ListenOptions.HttpProtocols](https://github.com/dotnet/aspnetcore/blob/c4c6e25a0660ffbcae2d81c979495ec9533ccaff/src/Servers/Kestrel/Core/src/ListenOptions.cs#L79) is set to `Http1AndHttp2`. `Http1AndHttp2` is the default value for `ListenOptions.HttpProtocols`.
+- Throw a `NotSupportedException` when [ListenOptions.HttpProtocols](https://github.com/dotnet/aspnetcore/blob/c4c6e25a0660ffbcae2d81c979495ec9533ccaff/src/Servers/Kestrel/Core/src/ListenOptions.cs#L79) is set to `Http2`.
+
+For discussion, see issue [dotnet/aspnetcore#23068](https://github.com/dotnet/aspnetcore/issues/23068).
+
+#### Version introduced
+
+ASP.NET Core 5.0 Preview 7
+
+#### Old behavior
+
+The following table outlines the behavior when HTTP/2 over TLS is configured.
+
+| Protocols | Windows 7,<br />Windows Server 2008 R2,<br />or earlier | Windows 8,<br />Windows Server 2012 | Windows 8.1,<br />Windows Server 2012 R2 | Windows 10,<br />Windows Server 2016,<br />or newer |
+|---------------|-----------------------------------------------|--------------------------------|-------------------------------------|------------------------------------------|
+| `Http2`         | Throw `NotSupportedException`                   | Error during TLS handshake     | Error during TLS handshake &ast;     | No error |
+| `Http1AndHttp2` | Downgrade to `Http1`                    | Downgrade to `Http1`     | Error during TLS handshake &ast;     | No error |
+
+&ast; Configure compatible cipher suites to enable these scenarios.
+
+#### New behavior
+
+The following table outlines the behavior when HTTP/2 over TLS is configured.
+
+| Protocols | Windows 7,<br />Windows Server 2008 R2,<br />or earlier | Windows 8,<br />Windows Server 2012 | Windows 8.1,<br />Windows Server 2012 R2 | Windows 10,<br />Windows Server 2016,<br />or newer |
+|---------------|-----------------------------------------------|--------------------------------|-------------------------------------|------------------------------------------|
+| `Http2`         | Throw `NotSupportedException`                   | Throw `NotSupportedException`     | Throw `NotSupportedException` &ast;&ast;     | No error |
+| `Http1AndHttp2` | Downgrade to `Http1`                    | Downgrade to `Http1`     | Downgrade to `Http1` &ast;&ast;     | No error |
+
+&ast;&ast; Configure compatible cipher suites and set the app context switch `Microsoft.AspNetCore.Server.Kestrel.EnableWindows81Http2` to `true` to enable these scenarios.
+
+#### Reason for change
+
+This change ensures compatibility errors for HTTP/2 over TLS on older Windows versions are surfaced as early and as clearly as possible.
+
+#### Recommended action
+
+Ensure HTTP/2 over TLS is disabled on incompatible Windows versions. Windows 8.1 and Windows Server 2012 R2 are incompatible since they lack the necessary ciphers by default. However, it's possible to update the Computer Configuration settings to use HTTP/2 compatible ciphers. For more information, see [TLS cipher suites in Windows 8.1](/windows/win32/secauthn/tls-cipher-suites-in-windows-8-1). Once configured, HTTP/2 over TLS on Kestrel must be enabled by setting the app context switch `Microsoft.AspNetCore.Server.Kestrel.EnableWindows81Http2`. For example:
+
+```csharp
+AppContext.SetSwitch("Microsoft.AspNetCore.Server.Kestrel.EnableWindows81Http2", true);
+```
+
+No underlying support has changed. For example, HTTP/2 over TLS has never worked on Windows 8 or Windows Server 2012. This change modifies how errors in these unsupported scenarios are presented.
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+None
+
+<!--
+
+#### Affected APIs
+
+Not detectable via API analysis
+
+-->

--- a/includes/core-changes/aspnetcore/5.0/kestrel-disables-http2-over-tls.md
+++ b/includes/core-changes/aspnetcore/5.0/kestrel-disables-http2-over-tls.md
@@ -7,8 +7,8 @@ To enable HTTP/2 over Transport Layer Security (TLS) on Windows, two requirement
 
 As such, Kestrel's behavior when HTTP/2 over TLS is configured has changed to:
 
-- Downgrade to `Http1` and log a message at the `Information` level when [ListenOptions.HttpProtocols](https://github.com/dotnet/aspnetcore/blob/c4c6e25a0660ffbcae2d81c979495ec9533ccaff/src/Servers/Kestrel/Core/src/ListenOptions.cs#L79) is set to `Http1AndHttp2`. `Http1AndHttp2` is the default value for `ListenOptions.HttpProtocols`.
-- Throw a `NotSupportedException` when [ListenOptions.HttpProtocols](https://github.com/dotnet/aspnetcore/blob/c4c6e25a0660ffbcae2d81c979495ec9533ccaff/src/Servers/Kestrel/Core/src/ListenOptions.cs#L79) is set to `Http2`.
+- Downgrade to `Http1` and log a message at the `Information` level when [ListenOptions.HttpProtocols](/dotnet/api/microsoft.aspnetcore.server.kestrel.core.httpprotocols) is set to `Http1AndHttp2`. `Http1AndHttp2` is the default value for `ListenOptions.HttpProtocols`.
+- Throw a `NotSupportedException` when `ListenOptions.HttpProtocols` is set to `Http2`.
 
 For discussion, see issue [dotnet/aspnetcore#23068](https://github.com/dotnet/aspnetcore/issues/23068).
 


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/421
