### PR TITLE
Choosing between anonymous and tuple types

### DIFF
--- a/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
@@ -7,7 +7,7 @@ ms.technology: dotnet-standard
 
 # Choosing between anonymous and tuple types
 
-As a developer, choosing the appropriate type involves considering a types usability, performance, and tradeoffs compared to other types. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. Since then new options have been introduced with language level support, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article, you'll learn when it's appropriate to choose one type over the other.
+Choosing the appropriate type involves considering its usability, performance, and tradeoffs compared to other types. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. Since then new options have been introduced with language level support, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article, you'll learn when it's appropriate to choose one type over the other.
 
 ## Usability and functionality
 
@@ -106,11 +106,11 @@ You might want to always use <xref:System.ValueTuple> over <xref:System.Tuple>, 
 
 ### Serialization
 
-One important consideration when choosing a type, is whether or not it will need to be serialized. Serialization is the process of converting the state of an object into a form that can be persisted or transported. For more information, see [serialization](../../csharp/programming-guide/concepts/serialization/index.md). With anonymous types, and tuple types it is not recommended to use them if you need to serialization. While it is possible to use them with serialization, it is not fully supported, and requires workarounds.
+One important consideration when choosing a type, is whether or not it will need to be serialized. Serialization is the process of converting the state of an object into a form that can be persisted or transported. For more information, see [serialization](../../csharp/programming-guide/concepts/serialization/index.md). When serialization is important, creating a `class` or `struct` is preferred over anonymous types or tuple types.
 
 ## Performance
 
-Performance is always a topic of discussion when referring to value types vs reference types, often leading to conversations of stack versus heap allocations. However, performance between these types is fairly similar with each other - in other words, performance differences are negligible. The micro-optimizations you might gain from choosing tuples over anonymous types is more often than not irrelevant.
+Performance between these types depends on the scenario. The major impact involves the tradeoff between allocations and copying. In most scenarios, the impact is small. When major impacts could arise, measurements should be taken to inform the decision.
 
 ## Conclusion
 

--- a/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
@@ -1,13 +1,13 @@
 ---
-title: "Choosing between anonymous and tuple types"
+title: Choosing between anonymous and tuple types
 description: Learn how to decide whether to design a type as a class, or to design a type as a struct.
-ms.date: 06/24/2020
+ms.date: 06/26/2020
 ms.technology: dotnet-standard
 ---
 
 # Choosing between anonymous and tuple types
 
-As a developer, choosing the appropriate type can be scary task. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. There are more modern options that exist, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article, you'll learn when it's appropriate to choose one type over the other.
+As a developer, choosing the appropriate type involves considering a types usability, performance, and tradeoffs compared to other types. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. Since then new options have been introduced with language level support, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article, you'll learn when it's appropriate to choose one type over the other.
 
 ## Usability and functionality
 
@@ -65,7 +65,7 @@ foreach (var tuple in
 }
 ```
 
-With the <xref:System.Tuple%602?displayProperty=nameWithType>, the instance exposes numbered item properties, such as `Item1`, and `Item2`. These property names can make it more difficult to understand the intent of the property values, as the property name only provides the ordinal. Furthermore, the `System.Tuple` types are reference `class` types. The <xref:System.ValueTuple%602?displayProperty=nameWithType> however, is a value `struct` type.
+With the <xref:System.Tuple%602?displayProperty=nameWithType>, the instance exposes numbered item properties, such as `Item1`, and `Item2`. These property names can make it more difficult to understand the intent of the property values, as the property name only provides the ordinal. Furthermore, the `System.Tuple` types are reference `class` types. The <xref:System.ValueTuple%602?displayProperty=nameWithType> however, is a value `struct` type. The following C# snippet, uses `ValueTuple<string, long>` to project into. In doing so, it assigns using a literal syntax.
 
 ```csharp-interactive
 var dates = new[]
@@ -83,23 +83,30 @@ foreach (var (formatted, ticks) in
 }
 ```
 
-The previous examples are all functionally equivalent, however; there are slight differences in their usability and their underlying implementations. One nicety with <xref:System.ValueTuple> is the ability to deconstruct the tuple into its members.
+C# provides language support of tuples with the <xref:System.ValueTuple> type, and semantics for:
 
-## Limitations
+- [Tuple assignment](../../csharp/tuples.md#assignment-and-tuples)
+- [Tuple deconstruction](../../csharp/deconstruct.md) (not limited to tuples)
+- [Tuple equality checks](../../csharp/tuples.md#equality-and-tuples)
+- [Tuple projection initializers](../../csharp/tuples.md#tuple-projection-initializers)
 
-While it might seem as though you should always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types - there are tradeoffs you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot.
+The previous examples are all functionally equivalent, however; there are slight differences in their usability and their underlying implementations.
+
+## Tradeoffs
+
+While it might seem as though you should always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types - there are tradeoffs you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot. The following table is an overview of some of the key differences.
 
 ### Key differences
 
-| Name                     | Type     | Custom property name | Deconstruction support | Expression tree support |
-|--------------------------|----------|----------------------|------------------------|-------------------------|
-| Anonymous types          | `class`  | ✔️                  | ❌                      | ✔️                     |
-| <xref:System.Tuple>      | `class`  | ❌                   | ❌                      | ✔️                     |
-| <xref:System.ValueTuple> | `struct` | ✔️                  | ✔️                     | ❌                      |
+| Name                     | Access modifier | Type     | Custom property name | Deconstruction support | Expression tree support |
+|--------------------------|-----------------|----------|----------------------|------------------------|-------------------------|
+| Anonymous types          | `internal`      | `class`  | ✔️                   | ❌                     | ✔️                     |
+| <xref:System.Tuple>      | `public`        | `class`  | ❌                   | ❌                     | ✔️                     |
+| <xref:System.ValueTuple> | `public`        | `struct` | ✔️                   | ✔️                     | ❌                     |
 
 ## Performance
 
-Performance is always a topic of discussion when referring to value types vs reference types, often leading to conversations of stack versus heap allocations. However, performance between these types is fairly similar with each other - in other words, performance is irrelevant. The micro-optimizations you might gain from choosing tuples over anonymous types is more often than not negligible.
+Performance is always a topic of discussion when referring to value types vs reference types, often leading to conversations of stack versus heap allocations. However, performance between these types is fairly similar with each other - in other words, performance differences are negligible. The micro-optimizations you might gain from choosing tuples over anonymous types is more often than not irrelevant.
 
 ## Conclusion
 

--- a/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
@@ -94,7 +94,7 @@ The previous examples are all functionally equivalent, however; there are slight
 
 ## Tradeoffs
 
-While it might seem as though you should always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types - there are tradeoffs you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot. The following table is an overview of some of the key differences.
+You might want to always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types, but there are tradeoffs you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot. The following table is an overview of some of the key differences.
 
 ### Key differences
 
@@ -103,6 +103,10 @@ While it might seem as though you should always use <xref:System.ValueTuple> ove
 | Anonymous types          | `internal`      | `class`  | ✔️                   | ❌                     | ✔️                     |
 | <xref:System.Tuple>      | `public`        | `class`  | ❌                   | ❌                     | ✔️                     |
 | <xref:System.ValueTuple> | `public`        | `struct` | ✔️                   | ✔️                     | ❌                     |
+
+### Serialization
+
+One important consideration when choosing a type, is whether or not it will need to be serialized. Serialization is the process of converting the state of an object into a form that can be persisted or transported. For more information, see [serialization](../../csharp/programming-guide/concepts/serialization/index.md). With anonymous types, and tuple types it is not recommended to use them if you need to serialization. While it is possible to use them with serialization, it is not fully supported, and requires workarounds.
 
 ## Performance
 

--- a/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
@@ -11,7 +11,7 @@ As a developer, choosing the appropriate type can be scary task. Anonymous types
 
 ## Usability and functionality
 
-With the advent of C# 3.0, when anonymous types were introduced so to were Language-Integrated Query (LINQ) expressions. With LINQ, developers often project results from queries into anonymous types that hold a few select properties from the objects their working with. Consider the following example, that instantiates an array of <xref:System.DateTime> objects, and iterates through them projecting into an anonymous type with two properties.
+Anonymous types were introduced in C# 3.0 with Language-Integrated Query (LINQ) expressions. With LINQ, developers often project results from queries into anonymous types that hold a few select properties from the objects they're working with. Consider the following example, that instantiates an array of <xref:System.DateTime> objects, and iterates through them projecting into an anonymous type with two properties.
 
 ```csharp-interactive
 var dates = new[]
@@ -29,9 +29,9 @@ foreach (var anonymous in
 }
 ```
 
-Anonymous types are instantiated by using the [`new`](../../csharp/language-reference/operators/new-operator.md) operator, and the property names and types are inferred from the declaration. If two or more anonymous object initializers in an assembly specify a sequence of properties that are in the same order and that have the same names and types, the compiler treats the objects as instances of the same type. They share the same compiler-generated type information.
+Anonymous types are instantiated by using the [`new`](../../csharp/language-reference/operators/new-operator.md) operator, and the property names and types are inferred from the declaration. If two or more anonymous object initializers in the same assembly specify a sequence of properties that are in the same order and that have the same names and types, the compiler treats the objects as instances of the same type. They share the same compiler-generated type information.
 
-The previous C# snippet projects an anonymous type that would be defined with two properties, much like the following compiler-generated C# class:
+The previous C# snippet projects an anonymous type with two properties, much like the following compiler-generated C# class:
 
 ```csharp
 internal sealed class f__AnonymousType0
@@ -47,7 +47,7 @@ internal sealed class f__AnonymousType0
 }
 ```
 
-For more information, see [anonymous types](../../csharp/programming-guide/classes-and-structs/anonymous-types.md). The same functionality exists with tuples when projecting into LINQ queries, you can select properties and put them into tuples. These tuples flow through the query, just as anonymous types would. Now consider the following example using the `System.Tuple<string, long>`.
+For more information, see [anonymous types](../../csharp/programming-guide/classes-and-structs/anonymous-types.md). The same functionality exists with tuples when projecting into LINQ queries, you can select properties into tuples. These tuples flow through the query, just as anonymous types would. Now consider the following example using the `System.Tuple<string, long>`.
 
 ```csharp-interactive
 var dates = new[]
@@ -83,11 +83,11 @@ foreach (var (formatted, ticks) in
 }
 ```
 
-The previous examples are all functionally equivalent, however; there are slight differences in their usability and their underlying implementations. One nicety with <xref:System.ValueTuple> is the ability to deconstruct.
+The previous examples are all functionally equivalent, however; there are slight differences in their usability and their underlying implementations. One nicety with <xref:System.ValueTuple> is the ability to deconstruct the tuple into its members.
 
 ## Limitations
 
-While it might seem as though you should always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types - there are some limitations that you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot.
+While it might seem as though you should always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types - there are tradeoffs you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot.
 
 ### Key differences
 

--- a/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
@@ -1,0 +1,92 @@
+---
+title: "Choosing between anonymous and tuple types"
+description: Learn how to decide whether to design a type as a class, or to design a type as a struct.
+ms.date: 06/23/2020
+ms.technology: dotnet-standard
+---
+
+# Choosing between anonymous and tuple types
+
+As a developer, choosing the appropriate type can be scary task. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. There are more modern options that exist, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article you'll learn some of the limitations of these various type options, and when it's appropriate to choose one over the other.
+
+## Usability and functionality
+
+With the advent of C# 3.0, when anonymous types were introduced so too were Language-Integrated Query (LINQ) expressions. With LINQ, developers often project results from queries into anonymous types that hold a few select properties from the objects their working with. This can also be achieved with tuples.
+
+```csharp-interactive
+var dates = new[]
+{
+    DateTime.UtcNow.AddHours(-1),
+    DateTime.UtcNow,
+    DateTime.UtcNow.AddHours(1),
+};
+
+foreach (var anonymous in
+             dates.Select(
+                 date => new { Formatted = $"{date:MMM dd, yyyy at hh:mm zzz}", date.Ticks }))
+{
+    Console.WriteLine($"Ticks: {anonymous.Ticks}, formatted: {anonymous.Formatted}");
+}
+```
+
+The previous example C# snippet projects an anonymous type that would be defined with two properties.
+
+```csharp
+internal sealed class f__AnonymousType0
+{
+    public string Formatted { get; }
+    public long Ticks { get; }
+
+    public f__AnonymousType0(string formatted, long ticks)
+    {
+        Formatted = formatted;
+        Ticks = ticks;
+    }
+}
+```
+
+```csharp-interactive
+var dates = new[]
+{
+    DateTime.UtcNow.AddHours(-1),
+    DateTime.UtcNow,
+    DateTime.UtcNow.AddHours(1),
+};
+
+foreach (var anonymous in
+             dates.Select(
+                 date => (Formatted: $"{date:MMM dd, yyyy at hh:mm zzz}", date.Ticks)))
+{
+    Console.WriteLine($"Ticks: {anonymous.ticks}, formatted: {anonymous.formatted}");
+}
+```
+
+## Legacy tuples
+
+## Language tuples
+
+## Performance
+
+
+
+NOTES:
+
+Anonymous types can be included in expression trees, tuples can't.
+
+On a performance and functionality basis anonymous types and Tuple<...> are basically on par. Their implementation is roughly the same. The difference though is usability because you can name anonymous type fields but not Tuple<...> fields.
+
+Language tuples (...) and anonymous types have about the same usability but different performance (struct vs. class).
+
+That being said I haven't explicitly used anonymous types, except as a transparent proxy in a LINQ query, in some time.
+
+✔️ CONSIDER ...
+
+❌ AVOID ...
+
+## See also
+
+- [Anonymous types](../../csharp/programming-guide/classes-and-structs/anonymous-types.md)
+- [Expression trees](../../csharp/expression-trees.md)
+- [Framework design guidelines](index.md)
+- [Tuple types](../../csharp/tuples.md)
+- [Type design guidelines](type.md)

--- a/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/design-guidelines/choosing-between-anonymous-and-tuple.md
@@ -1,17 +1,17 @@
 ---
 title: "Choosing between anonymous and tuple types"
 description: Learn how to decide whether to design a type as a class, or to design a type as a struct.
-ms.date: 06/23/2020
+ms.date: 06/24/2020
 ms.technology: dotnet-standard
 ---
 
 # Choosing between anonymous and tuple types
 
-As a developer, choosing the appropriate type can be scary task. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. There are more modern options that exist, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article you'll learn some of the limitations of these various type options, and when it's appropriate to choose one over the other.
+As a developer, choosing the appropriate type can be scary task. Anonymous types have been available since C# 3.0, while generic <xref:System.Tuple%602?displayProperty=nameWithType> types were introduced with .NET Framework 4.0. There are more modern options that exist, such as <xref:System.ValueTuple%602?displayProperty=nameWithType> - which as the name implies, provide a value type with the flexibility of anonymous types. In this article, you'll learn when it's appropriate to choose one type over the other.
 
 ## Usability and functionality
 
-With the advent of C# 3.0, when anonymous types were introduced so too were Language-Integrated Query (LINQ) expressions. With LINQ, developers often project results from queries into anonymous types that hold a few select properties from the objects their working with. This can also be achieved with tuples.
+With the advent of C# 3.0, when anonymous types were introduced so to were Language-Integrated Query (LINQ) expressions. With LINQ, developers often project results from queries into anonymous types that hold a few select properties from the objects their working with. Consider the following example, that instantiates an array of <xref:System.DateTime> objects, and iterates through them projecting into an anonymous type with two properties.
 
 ```csharp-interactive
 var dates = new[]
@@ -23,13 +23,15 @@ var dates = new[]
 
 foreach (var anonymous in
              dates.Select(
-                 date => new { Formatted = $"{date:MMM dd, yyyy at hh:mm zzz}", date.Ticks }))
+                 date => new { Formatted = $"{date:MMM dd, yyyy hh:mm zzz}", date.Ticks }))
 {
     Console.WriteLine($"Ticks: {anonymous.Ticks}, formatted: {anonymous.Formatted}");
 }
 ```
 
-The previous example C# snippet projects an anonymous type that would be defined with two properties.
+Anonymous types are instantiated by using the [`new`](../../csharp/language-reference/operators/new-operator.md) operator, and the property names and types are inferred from the declaration. If two or more anonymous object initializers in an assembly specify a sequence of properties that are in the same order and that have the same names and types, the compiler treats the objects as instances of the same type. They share the same compiler-generated type information.
+
+The previous C# snippet projects an anonymous type that would be defined with two properties, much like the following compiler-generated C# class:
 
 ```csharp
 internal sealed class f__AnonymousType0
@@ -45,6 +47,8 @@ internal sealed class f__AnonymousType0
 }
 ```
 
+For more information, see [anonymous types](../../csharp/programming-guide/classes-and-structs/anonymous-types.md). The same functionality exists with tuples when projecting into LINQ queries, you can select properties and put them into tuples. These tuples flow through the query, just as anonymous types would. Now consider the following example using the `System.Tuple<string, long>`.
+
 ```csharp-interactive
 var dates = new[]
 {
@@ -53,35 +57,53 @@ var dates = new[]
     DateTime.UtcNow.AddHours(1),
 };
 
-foreach (var anonymous in
-             dates.Select(
-                 date => (Formatted: $"{date:MMM dd, yyyy at hh:mm zzz}", date.Ticks)))
+foreach (var tuple in
+            dates.Select(
+                date => new Tuple<string, long>($"{date:MMM dd, yyyy hh:mm zzz}", date.Ticks)))
 {
-    Console.WriteLine($"Ticks: {anonymous.ticks}, formatted: {anonymous.formatted}");
+    Console.WriteLine($"Ticks: {tuple.Item2}, formatted: {tuple.Item1}");
 }
 ```
 
-## Legacy tuples
+With the <xref:System.Tuple%602?displayProperty=nameWithType>, the instance exposes numbered item properties, such as `Item1`, and `Item2`. These property names can make it more difficult to understand the intent of the property values, as the property name only provides the ordinal. Furthermore, the `System.Tuple` types are reference `class` types. The <xref:System.ValueTuple%602?displayProperty=nameWithType> however, is a value `struct` type.
 
-## Language tuples
+```csharp-interactive
+var dates = new[]
+{
+    DateTime.UtcNow.AddHours(-1),
+    DateTime.UtcNow,
+    DateTime.UtcNow.AddHours(1),
+};
+
+foreach (var (formatted, ticks) in
+            dates.Select(
+                date => (Formatted: $"{date:MMM dd, yyyy at hh:mm zzz}", date.Ticks)))
+{
+    Console.WriteLine($"Ticks: {ticks}, formatted: {formatted}");
+}
+```
+
+The previous examples are all functionally equivalent, however; there are slight differences in their usability and their underlying implementations. One nicety with <xref:System.ValueTuple> is the ability to deconstruct.
+
+## Limitations
+
+While it might seem as though you should always use <xref:System.ValueTuple> over <xref:System.Tuple>, and anonymous types - there are some limitations that you should consider. The <xref:System.ValueTuple> types are mutable, whereas <xref:System.Tuple> are read-only. Anonymous types can be used in expression trees, while tuples cannot.
+
+### Key differences
+
+| Name                     | Type     | Custom property name | Deconstruction support | Expression tree support |
+|--------------------------|----------|----------------------|------------------------|-------------------------|
+| Anonymous types          | `class`  | ✔️                  | ❌                      | ✔️                     |
+| <xref:System.Tuple>      | `class`  | ❌                   | ❌                      | ✔️                     |
+| <xref:System.ValueTuple> | `struct` | ✔️                  | ✔️                     | ❌                      |
 
 ## Performance
 
+Performance is always a topic of discussion when referring to value types vs reference types, often leading to conversations of stack versus heap allocations. However, performance between these types is fairly similar with each other - in other words, performance is irrelevant. The micro-optimizations you might gain from choosing tuples over anonymous types is more often than not negligible.
 
+## Conclusion
 
-NOTES:
-
-Anonymous types can be included in expression trees, tuples can't.
-
-On a performance and functionality basis anonymous types and Tuple<...> are basically on par. Their implementation is roughly the same. The difference though is usability because you can name anonymous type fields but not Tuple<...> fields.
-
-Language tuples (...) and anonymous types have about the same usability but different performance (struct vs. class).
-
-That being said I haven't explicitly used anonymous types, except as a transparent proxy in a LINQ query, in some time.
-
-✔️ CONSIDER ...
-
-❌ AVOID ...
+As a developer choosing between tuples and anonymous types, there are several factors to consider. Generally speaking, if you're not working with [expression trees](../../csharp/expression-trees.md), and you're comfortable with tuple syntax then choose <xref:System.ValueTuple> as they provide a value type with the flexibility to name properties. If you're working with expression trees, and you'd prefer to name properties, choose anonymous types. Otherwise, use <xref:System.Tuple>.
 
 ## See also
 

--- a/docs/standard/toc.yml
+++ b/docs/standard/toc.yml
@@ -639,6 +639,8 @@
     items:
     - name: Choose between class and struct
       href: design-guidelines/choosing-between-class-and-struct.md
+    - name: Choose between anonymous and tuple types
+      href: design-guidelines/choosing-between-anonymous-and-tuple.md
     - name: Abstract class design
       href: design-guidelines/abstract-class.md
     - name: Static class design


### PR DESCRIPTION
## Summary

Added new article explaining some of the key differences between anonymous types, `System.Tuple`, and `System.ValueTuple` types.

### Preview

✔️ [Choosing between anonymous and tuple types](https://review.docs.microsoft.com/en-us/dotnet/standard/design-guidelines/choosing-between-anonymous-and-tuple?branch=pr-en-us-19201)

Fixes #1575
