### PR TITLE
Category vs. area

### DIFF
--- a/docs/core/compatibility/breaking-changes.md
+++ b/docs/core/compatibility/breaking-changes.md
@@ -5,7 +5,7 @@ ms.date: 11/27/2019
 ---
 # Breaking change selectors
 
-The following version and area selectors provide a filtered list of applicable breaking changes between different versions of .NET Core, ASP.NET Core, and EF Core. You can also browse version-to-version or category articles in the table of contents.
+The following version and area selectors provide a filtered list of applicable breaking changes between different versions of .NET Core, ASP.NET Core, and EF Core. You can also browse version-to-version or technology area articles in the table of contents.
 
 ## By version
 

--- a/docs/core/compatibility/breaking-changes.md
+++ b/docs/core/compatibility/breaking-changes.md
@@ -5,7 +5,7 @@ ms.date: 11/27/2019
 ---
 # Breaking change selectors
 
-The following version and area selectors provide a filtered list of applicable breaking changes between different versions of .NET Core, ASP.NET Core, and EF Core. You can also browse version to version or category articles in the table of contents.
+The following version and area selectors provide a filtered list of applicable breaking changes between different versions of .NET Core, ASP.NET Core, and EF Core. You can also browse version-to-version or category articles in the table of contents.
 
 ## By version
 
@@ -13,7 +13,7 @@ Select the .NET version that you're currently targeting and then the .NET Core v
 
 [!INCLUDE[versionselector](~/includes/core-changes/versionselector.md)]
 
-## By area
+## By technology area
 
 Select the .NET Core technology area that you're interested in. Individual changes are ordered by .NET Core version.
 

--- a/docs/core/compatibility/categories.md
+++ b/docs/core/compatibility/categories.md
@@ -5,14 +5,14 @@ ms.date: 06/10/2019
 ---
 # How code changes can affect compatibility
 
-*Compatibility* refers to the ability to compile or execute code on a version of a .NET implementation other than the one with which the code was originally developed. A particular change can affect compatibility in six different ways. The [individual kinds of changes](index.md) that are considered when evaluating compatibility fall into the following categories:
+*Compatibility* refers to the ability to compile or execute code on a version of a .NET implementation other than the one with which the code was originally developed. A [particular change](index.md) can affect compatibility in six different ways:
 
-- [behavioral change](#behavioral-change)
-- [binary compatibility](#binary-compatibility)
-- [source compatibility](#source-compatibility)
-- [design-time compatibility](#design-time-compatibility)
-- [backwards compatibility](#backwards-compatibility)
-- [forward compatibility](#forward-compatibility) (not a goal of .NET Core)
+- [Behavioral change](#behavioral-change)
+- [Binary compatibility](#binary-compatibility)
+- [Source compatibility](#source-compatibility)
+- [Design-time compatibility](#design-time-compatibility)
+- [Backwards compatibility](#backwards-compatibility)
+- [Forward compatibility](#forward-compatibility) (not a goal of .NET Core)
 
 ## Behavioral change
 

--- a/docs/core/compatibility/categories.md
+++ b/docs/core/compatibility/categories.md
@@ -1,9 +1,9 @@
 ---
-title: Breaking change categories
-description: Learn about the ways in which breaking changes are categorized in .NET Core.
+title: Compatibility
+description: Learn about the ways in which code changes can affect compatibility in .NET.
 ms.date: 06/10/2019
 ---
-# Breaking change categories
+# How code changes can affect compatibility
 
 *Compatibility* refers to the ability to compile or execute code on a version of a .NET implementation other than the one with which the code was originally developed. A particular change can affect compatibility in six different ways. The [individual kinds of changes](index.md) that are considered when evaluating compatibility fall into the following categories:
 

--- a/docs/core/compatibility/index.md
+++ b/docs/core/compatibility/index.md
@@ -18,6 +18,7 @@ This article outlines changes that affect compatibility and the way in which the
 The following sections describe the categories of changes made to .NET Core APIs and their impact on application compatibility. Changes are either allowed ✔️, disallowed ❌, or require judgment and an evaluation of how predictable, obvious, and consistent the previous behavior was ❓.
 
 > [!NOTE]
+>
 > - In addition to serving as a guide to how changes to .NET libraries are evaluated, library developers can also use these criteria to evaluate changes to their libraries that target multiple .NET implementations and versions.
 > - For information about the compatibility categories, for example, forward and backwards compatibility, see [Compatibility](categories.md).
 

--- a/docs/core/compatibility/index.md
+++ b/docs/core/compatibility/index.md
@@ -13,15 +13,13 @@ Throughout its history, .NET has attempted to maintain a high level of compatibi
 
 Along with compatibility across .NET implementations, developers expect a high level of compatibility across .NET Core versions. In particular, code written for an earlier version of .NET Core should run seamlessly on a later version of .NET Core. In fact, many developers expect that the new APIs found in newly released versions of .NET Core should also be compatible with the pre-release versions in which those APIs were introduced.
 
-This article outlines the categories of compatibility changes (or breaking changes) and the way in which the .NET team evaluates changes in each of these categories. Understanding how the .NET team approaches possible breaking changes is particularly helpful for developers who open pull requests in the [dotnet/runtime](https://github.com/dotnet/runtime) GitHub repository that modify the behavior of existing APIs.
-
-> [!NOTE]
-> For a definition of compatibility categories, such as binary compatibility and backward compatibility, see [Breaking change categories](categories.md).
+This article outlines changes that affect compatibility and the way in which the .NET team evaluates each type of change. Understanding how the .NET team approaches possible breaking changes is particularly helpful for developers who open pull requests that modify the behavior of [existing .NET APIs](https://github.com/dotnet/runtime).
 
 The following sections describe the categories of changes made to .NET Core APIs and their impact on application compatibility. Changes are either allowed ✔️, disallowed ❌, or require judgment and an evaluation of how predictable, obvious, and consistent the previous behavior was ❓.
 
 > [!NOTE]
-> In addition to serving as a guide to how changes to .NET Core libraries are evaluated, library developers can also use these criteria to evaluate changes to their libraries that target multiple .NET implementations and versions.
+> - In addition to serving as a guide to how changes to .NET libraries are evaluated, library developers can also use these criteria to evaluate changes to their libraries that target multiple .NET implementations and versions.
+> - For information about the compatibility categories, for example, forward and backwards compatibility, see [Compatibility](categories.md).
 
 ## Modifications to the public contract
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -1,6 +1,6 @@
 - name: What are breaking changes?
   href: index.md
-- name: Categories of breaking changes
+- name: Compatibility
   href: categories.md
 - name: Page selectors
   href: breaking-changes.md
@@ -25,7 +25,7 @@
       href: ../porting/net-framework-tech-unavailable.md?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
     - name: APIs that always throw
       href: unsupported-apis.md
-- name: By area
+- name: By technology area
   expanded: true
   items:
   - name: ASP.NET Core


### PR DESCRIPTION
"Category" was used to refer to two different things, and I thought it was a bit confusing: compatibility categories and technology area categories.