### PR TITLE
Add back source code to fix doc

### DIFF
--- a/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/ConstructionCS/Program.cs
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/ConstructionCS/Program.cs
@@ -1,7 +1,11 @@
-﻿using System;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+// <SnippetStaticUsings>
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static System.Console;
+// </SnippetStaticUsings>
 
 namespace ConstructionCS
 {
@@ -29,18 +33,18 @@ namespace HelloWorld
         static void Main(string[] args)
         {
             // <SnippetCreateIdentifierName>
-            NameSyntax name = SyntaxFactory.IdentifierName("System");
-            Console.WriteLine($"\tCreated the identifier {name.ToString()}");
+            NameSyntax name = IdentifierName("System");
+            WriteLine($"\tCreated the identifier {name}");
             // </SnippetCreateIdentifierName>
 
             // <SnippetCreateQualifiedIdentifierName>
-            name = SyntaxFactory.QualifiedName(name, SyntaxFactory.IdentifierName("Collections"));
-            Console.WriteLine(name.ToString());
+            name = QualifiedName(name, IdentifierName("Collections"));
+            WriteLine(name.ToString());
             // </SnippetCreateQualifiedIdentifierName>
 
             // <SnippetCreateFullNamespace>
-            name = SyntaxFactory.QualifiedName(name, SyntaxFactory.IdentifierName("Generic"));
-            Console.WriteLine(name.ToString());
+            name = QualifiedName(name, IdentifierName("Generic"));
+            WriteLine(name.ToString());
             // </SnippetCreateFullNamespace>
 
             // <SnippetCreateParseTree>
@@ -51,15 +55,15 @@ namespace HelloWorld
             // <SnippetBuildNewUsing>
             var oldUsing = root.Usings[1];
             var newUsing = oldUsing.WithName(name);
-            Console.WriteLine(root.ToString());
+            WriteLine(root.ToString());
             // </SnippetBuildNewUsing>
 
-            Console.WriteLine();
-            Console.WriteLine();
+            WriteLine();
+            WriteLine();
 
             // <SnippetTransformTree>
             root = root.ReplaceNode(oldUsing, newUsing);
-            Console.WriteLine(root.ToString());
+            WriteLine(root.ToString());
             // </SnippetTransformTree>
         }
     }

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/TransformationCS/Program.cs
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/TransformationCS/Program.cs
@@ -35,13 +35,13 @@ namespace TransformationCS
         private static Compilation CreateTestCompilation()
         {
             // <SnippetCreateTestCompilation>
-            String programPath = @"..\..\Program.cs";
+            String programPath = @"..\..\..\Program.cs";
             String programText = File.ReadAllText(programPath);
             SyntaxTree programTree =
                            CSharpSyntaxTree.ParseText(programText)
                                            .WithFilePath(programPath);
 
-            String rewriterPath = @".\..\TypeInferenceRewriter.cs";
+            String rewriterPath = @"..\..\..\TypeInferenceRewriter.cs";
             String rewriterText = File.ReadAllText(rewriterPath);
             SyntaxTree rewriterTree =
                            CSharpSyntaxTree.ParseText(rewriterText)

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/TransformationCS/TypeInferenceRewriter.cs
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/TransformationCS/TypeInferenceRewriter.cs
@@ -1,8 +1,7 @@
-﻿// <SnippetAddUsings>
+// <SnippetAddUsings>
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
 // </SnippetAddUsings>
 
 namespace TransformationCS
@@ -32,20 +31,20 @@ namespace TransformationCS
             // </SnippetExclusions>
 
             // <SnippetExtractTypeSymbol>
-            VariableDeclaratorSyntax declarator = node.Declaration.Variables.First();
-            TypeSyntax variableTypeName = node.Declaration.Type;
+            var declarator = node.Declaration.Variables.First();
+            var variableTypeName = node.Declaration.Type;
 
-            ITypeSymbol variableType = (ITypeSymbol)SemanticModel
+            var variableType = (ITypeSymbol)SemanticModel
                 .GetSymbolInfo(variableTypeName)
                 .Symbol;
             // </SnippetExtractTypeSymbol>
 
             // <SnippetBindInitializer>
-            TypeInfo initializerInfo = SemanticModel.GetTypeInfo(declarator.Initializer.Value);
+            var initializerInfo = SemanticModel.GetTypeInfo(declarator.Initializer.Value);
             // </SnippetBindInitializer>
 
             // <SnippetReplaceNode>
-            if (variableType == initializerInfo.Type)
+            if (SymbolEqualityComparer.Default.Equals(variableType, initializerInfo.Type))
             {
                 TypeSyntax varTypeName = SyntaxFactory.IdentifierName("var")
                     .WithLeadingTrivia(variableTypeName.GetLeadingTrivia())


### PR DESCRIPTION
## Summary

Fix source code issue, the removed code in doc. Compiles now and runs successfully, locally. Also, fixed a bug where the paths were incorrect for the relative *Progam.cs*, and *TypeInterfenceRewriter.cs*.

Fixes #19264

#### Preview

✔️ [Get started with syntax transformation](https://review.docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/get-started/syntax-transformation?branch=pr-en-us-19292)