### PR TITLE
Update CS0107

### DIFF
--- a/docs/csharp/misc/cs0107.md
+++ b/docs/csharp/misc/cs0107.md
@@ -19,13 +19,8 @@ The following sample generates CS0107:
 // CS0107.cs
 public class C
 {
-   private internal void f()   // CS0107, delete private or internal
-   {
-   }
-
-   public static int Main()
-   {
-      return 1;
-   }
+    private internal void F()   // CS0107, delete private or internal
+    {
+    }
 }
 ```

--- a/docs/csharp/misc/cs0107.md
+++ b/docs/csharp/misc/cs0107.md
@@ -1,30 +1,31 @@
 ---
 title: "Compiler Error CS0107"
-ms.date: 07/20/2015
-f1_keywords: 
+ms.date: 07/04/2020
+f1_keywords:
   - "CS0107"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0107"
 ms.assetid: 505763c5-6d68-4c57-a8bd-7b03682da4c5
 ---
 # Compiler Error CS0107
-More than one protection modifier  
-  
- Only one access modifier ([public](../language-reference/keywords/public.md), [private](../language-reference/keywords/private.md), [protected](../language-reference/keywords/protected.md), or [internal](../language-reference/keywords/internal.md)) is allowed on a class member, with the exception of except **internal protected**.  
-  
- The following sample generates CS0107:  
-  
-```csharp  
-// CS0107.cs  
-public class C  
-{  
-   private internal void f()   // CS0107, delete private or internal  
-   {  
-   }  
-  
-   public static int Main()  
-   {  
-      return 1;  
-   }  
-}  
+
+More than one protection modifier
+
+Only one access modifier ([public](../language-reference/keywords/public.md), [private](../language-reference/keywords/private.md), [protected](../language-reference/keywords/protected.md), or [internal](../language-reference/keywords/internal.md)) is allowed on a class member, with the exception of [**protected internal**](../language-reference/keywords/protected-internal.md) and [**private protected**](../language-reference/keywords/private-protected.md).
+
+The following sample generates CS0107:
+
+```csharp
+// CS0107.cs
+public class C
+{
+   private internal void f()   // CS0107, delete private or internal
+   {
+   }
+
+   public static int Main()
+   {
+      return 1;
+   }
+}
 ```


### PR DESCRIPTION
- Fixes #19307 (a typo)
- Markdown improvements and removing redundant whitespaces
- Making the sentence more accurate by adding "private protected"
- Added links to both protected internal and private protected.
- Swapped the order (internal protected -> protected internal) (See the order preference from dotnet/runtime [here](https://github.com/dotnet/runtime/blob/master/.editorconfig#L38))
- Use 4 spaces instead of 3 in the code snippet.
- Removed the Main to make the snippet more focused.
- Renamed the method from `f` to `F`
- Updated ms.date