### PR TITLE
Remove redundant ToString calls

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.DateTimeOffset.Conceptual/cs/Conceptual2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.DateTimeOffset.Conceptual/cs/Conceptual2.cs
@@ -16,14 +16,14 @@ public class DateManipulation
       DateTime utcTime = DateTime.UtcNow;
 
       Console.WriteLine("Difference between {0} and {1} time: {2}:{3} hours",
-                        localTime.Kind.ToString(),
-                        utcTime.Kind.ToString(),
+                        localTime.Kind,
+                        utcTime.Kind,
                         (localTime - utcTime).Hours,
                         (localTime - utcTime).Minutes);
       Console.WriteLine("The {0} time is {1} the {2} time.",
-                        localTime.Kind.ToString(),
+                        localTime.Kind,
                         Enum.GetName(typeof(TimeComparison), localTime.CompareTo(utcTime)),
-                        utcTime.Kind.ToString());
+                        utcTime.Kind);
    }
 }
 // If run in the U.S. Pacific Standard Time zone, the example displays


### PR DESCRIPTION
These calls are redundant. Removing them makes the samples simpler.
