### PR TITLE
Type casting

### DIFF
--- a/docs/csharp/programming-guide/types/casting-and-type-conversions.md
+++ b/docs/csharp/programming-guide/types/casting-and-type-conversions.md
@@ -24,7 +24,7 @@ i = "Hello";
 
 However, you might sometimes need to copy a value into a variable or method parameter of another type. For example, you might have an integer variable that you need to pass to a method whose parameter is typed as `double`. Or you might need to assign a class variable to a variable of an interface type. These kinds of operations are called *type conversions*. In C#, you can perform the following kinds of conversions:
 
-- **Implicit conversions**: No special syntax is required because the conversion is type safe and no data will be lost. Examples include conversions from smaller to larger integral types, and conversions from derived classes to base classes.
+- **Implicit conversions**: No special syntax is required because the conversion always succeeds and no data will be lost. Examples include conversions from smaller to larger integral types, and conversions from derived classes to base classes.
 
 - **Explicit conversions (casts)**: Explicit conversions require a [cast expression](../../language-reference/operators/type-testing-and-cast.md#cast-expression). Casting is required when information might be lost in the conversion, or when the conversion might not succeed for other reasons. Typical examples include numeric conversion to a type that has less precision or a smaller range, and conversion of a base-class instance to a derived class.
 
@@ -51,7 +51,7 @@ Base b = d;
 
 ## Explicit conversions
 
-However, if a conversion cannot be made without a risk of losing information, the compiler requires that you perform an explicit conversion, which is called a *cast*. A cast is a way of explicitly informing the compiler that you intend to make the conversion and that you are aware that data loss might occur. To perform a cast, specify the type that you are casting to in parentheses in front of the value or variable to be converted. The following program casts a [double](../../language-reference/builtin-types/floating-point-numeric-types.md) to an [int](../../language-reference/builtin-types/integral-numeric-types.md). The program will not compile without the cast.
+However, if a conversion cannot be made without a risk of losing information, the compiler requires that you perform an explicit conversion, which is called a *cast*. A cast is a way of explicitly informing the compiler that you intend to make the conversion and that you are aware that data loss might occur, or the cast may fail at runtime. To perform a cast, specify the type that you are casting to in parentheses in front of the value or variable to be converted. The following program casts a [double](../../language-reference/builtin-types/floating-point-numeric-types.md) to an [int](../../language-reference/builtin-types/integral-numeric-types.md). The program will not compile without the cast.
 
 [!code-csharp[csProgGuideTypes#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#2)]
 

--- a/docs/csharp/programming-guide/types/casting-and-type-conversions.md
+++ b/docs/csharp/programming-guide/types/casting-and-type-conversions.md
@@ -81,7 +81,7 @@ In some reference type conversions, the compiler cannot determine whether a cast
 
 [!code-csharp[csProgGuideTypes#41](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#41)]
 
-C# provides the [is](../../language-reference/operators/type-testing-and-cast.md#is-operator) operator to enable you to test for compatibility before actually performing a cast. For more information, see [How to safely cast using pattern matching and the as and is operators](../../how-to/safely-cast-using-pattern-matching-is-and-as-operators.md).
+The `Test` method has an `Animal` parameter, thus explicitly casting the argument `a` to a `Reptile` makes a dangerous assumption. It is safer to not make assumptions, but rather check the type. C# provides the [is](../../language-reference/operators/type-testing-and-cast.md#is-operator) operator to enable you to test for compatibility before actually performing a cast. For more information, see [How to safely cast using pattern matching and the as and is operators](../../how-to/safely-cast-using-pattern-matching-is-and-as-operators.md).
 
 ## C# language specification
 

--- a/docs/csharp/programming-guide/types/casting-and-type-conversions.md
+++ b/docs/csharp/programming-guide/types/casting-and-type-conversions.md
@@ -1,6 +1,6 @@
 ---
 title: "Casting and type conversions - C# Programming Guide"
-ms.date: 07/20/2015
+ms.date: 07/06/2020
 helpviewer_keywords: 
   - "type conversion [C#]"
   - "data type conversion [C#]"
@@ -10,74 +10,79 @@ helpviewer_keywords:
   - "converting types [C#]"
 ms.assetid: 568df58a-d292-4b55-93ba-601578722878
 ---
+
 # Casting and type conversions (C# Programming Guide)
 
 Because C# is statically-typed at compile time, after a variable is declared, it cannot be declared again or assigned a value of another type unless that type is implicitly convertible to the variable's type. For example, the `string` cannot be implicitly converted to `int`. Therefore, after you declare `i` as an `int`, you cannot assign the string "Hello" to it, as the following code shows:
-  
-```csharp  
-int i;  
-i = "Hello"; // error CS0029: Cannot implicitly convert type 'string' to 'int'
-```  
-  
- However, you might sometimes need to copy a value into a variable or method parameter of another type. For example, you might have an integer variable that you need to pass to a method whose parameter is typed as `double`. Or you might need to assign a class variable to a variable of an interface type. These kinds of operations are called *type conversions*. In C#, you can perform the following kinds of conversions:  
-  
-- **Implicit conversions**: No special syntax is required because the conversion is type safe and no data will be lost. Examples include conversions from smaller to larger integral types, and conversions from derived classes to base classes.  
-  
-- **Explicit conversions (casts)**: Explicit conversions require a [cast expression](../../language-reference/operators/type-testing-and-cast.md#cast-expression). Casting is required when information might be lost in the conversion, or when the conversion might not succeed for other reasons. Typical examples include numeric conversion to a type that has less precision or a smaller range, and conversion of a base-class instance to a derived class.  
-  
-- **User-defined conversions**: User-defined conversions are performed by special methods that you can define to enable explicit and implicit conversions between custom types that do not have a base class–derived class relationship. For more information, see [User-defined conversion operators](../../language-reference/operators/user-defined-conversion-operators.md).  
-  
+
+```csharp
+int i;
+
+// error CS0029: Cannot implicitly convert type 'string' to 'int'
+i = "Hello";
+```
+
+However, you might sometimes need to copy a value into a variable or method parameter of another type. For example, you might have an integer variable that you need to pass to a method whose parameter is typed as `double`. Or you might need to assign a class variable to a variable of an interface type. These kinds of operations are called *type conversions*. In C#, you can perform the following kinds of conversions:
+
+- **Implicit conversions**: No special syntax is required because the conversion is type safe and no data will be lost. Examples include conversions from smaller to larger integral types, and conversions from derived classes to base classes.
+
+- **Explicit conversions (casts)**: Explicit conversions require a [cast expression](../../language-reference/operators/type-testing-and-cast.md#cast-expression). Casting is required when information might be lost in the conversion, or when the conversion might not succeed for other reasons. Typical examples include numeric conversion to a type that has less precision or a smaller range, and conversion of a base-class instance to a derived class.
+
+- **User-defined conversions**: User-defined conversions are performed by special methods that you can define to enable explicit and implicit conversions between custom types that do not have a base class–derived class relationship. For more information, see [User-defined conversion operators](../../language-reference/operators/user-defined-conversion-operators.md).
+
 - **Conversions with helper classes**: To convert between non-compatible types, such as integers and <xref:System.DateTime?displayProperty=nameWithType> objects, or hexadecimal strings and byte arrays, you can use the <xref:System.BitConverter?displayProperty=nameWithType> class, the <xref:System.Convert?displayProperty=nameWithType> class, and the `Parse` methods of the built-in numeric types, such as <xref:System.Int32.Parse%2A?displayProperty=nameWithType>. For more information, see [How to convert a byte array to an int](./how-to-convert-a-byte-array-to-an-int.md), [How to convert a string to a number](./how-to-convert-a-string-to-a-number.md), and [How to convert between hexadecimal strings and numeric types](./how-to-convert-between-hexadecimal-strings-and-numeric-types.md).
-  
+
 ## Implicit conversions
 
- For built-in numeric types, an implicit conversion can be made when the value to be stored can fit into the variable without being truncated or rounded off. For integral types, this means the range of the source type is a proper subset of the range for the target type. For example, a variable of type [long](../../language-reference/builtin-types/integral-numeric-types.md) (64-bit integer) can store any value that an [int](../../language-reference/builtin-types/integral-numeric-types.md) (32-bit integer) can store. In the following example, the compiler implicitly converts the value of `num` on the right to a type `long` before assigning it to `bigNum`.  
-  
- [!code-csharp[csProgGuideTypes#34](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#34)]  
-  
- For a complete list of all implicit numeric conversions, see the [Implicit numeric conversions](../../language-reference/builtin-types/numeric-conversions.md#implicit-numeric-conversions) section of the [Built-in numeric conversions](../../language-reference/builtin-types/numeric-conversions.md) article.
-  
- For reference types, an implicit conversion always exists from a class to any one of its direct or indirect base classes or interfaces. No special syntax is necessary because a derived class always contains all the members of a base class.  
-  
+For built-in numeric types, an implicit conversion can be made when the value to be stored can fit into the variable without being truncated or rounded off. For integral types, this means the range of the source type is a proper subset of the range for the target type. For example, a variable of type [long](../../language-reference/builtin-types/integral-numeric-types.md) (64-bit integer) can store any value that an [int](../../language-reference/builtin-types/integral-numeric-types.md) (32-bit integer) can store. In the following example, the compiler implicitly converts the value of `num` on the right to a type `long` before assigning it to `bigNum`.
+
+[!code-csharp[csProgGuideTypes#34](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#34)]
+
+For a complete list of all implicit numeric conversions, see the [Implicit numeric conversions](../../language-reference/builtin-types/numeric-conversions.md#implicit-numeric-conversions) section of the [Built-in numeric conversions](../../language-reference/builtin-types/numeric-conversions.md) article.
+
+For reference types, an implicit conversion always exists from a class to any one of its direct or indirect base classes or interfaces. No special syntax is necessary because a derived class always contains all the members of a base class.
+
 ```csharp
-Derived d = new Derived();  
-Base b = d; // Always OK.  
-```  
-  
+Derived d = new Derived();
+
+// Always OK.
+Base b = d;
+```
+
 ## Explicit conversions
 
- However, if a conversion cannot be made without a risk of losing information, the compiler requires that you perform an explicit conversion, which is called a *cast*. A cast is a way of explicitly informing the compiler that you intend to make the conversion and that you are aware that data loss might occur. To perform a cast, specify the type that you are casting to in parentheses in front of the value or variable to be converted. The following program casts a [double](../../language-reference/builtin-types/floating-point-numeric-types.md) to an [int](../../language-reference/builtin-types/integral-numeric-types.md). The program will not compile without the cast.  
-  
- [!code-csharp[csProgGuideTypes#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#2)]  
-  
- For a complete list of supported explicit numeric conversions, see the [Explicit numeric conversions](../../language-reference/builtin-types/numeric-conversions.md#explicit-numeric-conversions) section of the [Built-in numeric conversions](../../language-reference/builtin-types/numeric-conversions.md) article.
-  
- For reference types, an explicit cast is required if you need to convert from a base type to a derived type:  
-  
-```csharp  
-// Create a new derived type.  
-Giraffe g = new Giraffe();  
-  
-// Implicit conversion to base type is safe.  
-Animal a = g;  
-  
-// Explicit conversion is required to cast back  
-// to derived type. Note: This will compile but will  
-// throw an exception at run time if the right-side  
-// object is not in fact a Giraffe.  
-Giraffe g2 = (Giraffe) a;  
-```  
-  
- A cast operation between reference types does not change the run-time type of the underlying object; it only changes the type of the value that is being used as a reference to that object. For more information, see [Polymorphism](../classes-and-structs/polymorphism.md).  
-  
+However, if a conversion cannot be made without a risk of losing information, the compiler requires that you perform an explicit conversion, which is called a *cast*. A cast is a way of explicitly informing the compiler that you intend to make the conversion and that you are aware that data loss might occur. To perform a cast, specify the type that you are casting to in parentheses in front of the value or variable to be converted. The following program casts a [double](../../language-reference/builtin-types/floating-point-numeric-types.md) to an [int](../../language-reference/builtin-types/integral-numeric-types.md). The program will not compile without the cast.
+
+[!code-csharp[csProgGuideTypes#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#2)]
+
+For a complete list of supported explicit numeric conversions, see the [Explicit numeric conversions](../../language-reference/builtin-types/numeric-conversions.md#explicit-numeric-conversions) section of the [Built-in numeric conversions](../../language-reference/builtin-types/numeric-conversions.md) article.
+
+For reference types, an explicit cast is required if you need to convert from a base type to a derived type:
+
+```csharp
+// Create a new derived type.
+Giraffe g = new Giraffe();
+
+// Implicit conversion to base type is safe.
+Animal a = g;
+
+// Explicit conversion is required to cast back
+// to derived type. Note: This will compile but will
+// throw an exception at run time if the right-side
+// object is not in fact a Giraffe.
+Giraffe g2 = (Giraffe)a;
+```
+
+A cast operation between reference types does not change the run-time type of the underlying object; it only changes the type of the value that is being used as a reference to that object. For more information, see [Polymorphism](../classes-and-structs/polymorphism.md).
+
 ## Type conversion exceptions at run time
 
- In some reference type conversions, the compiler cannot determine whether a cast will be valid. It is possible for a cast operation that compiles correctly to fail at run time. As shown in the following example, a type cast that fails at run time will cause an <xref:System.InvalidCastException> to be thrown.  
-  
- [!code-csharp[csProgGuideTypes#41](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#41)]  
-  
- C# provides the [is](../../language-reference/operators/type-testing-and-cast.md#is-operator) operator to enable you to test for compatibility before actually performing a cast. For more information, see [How to safely cast using pattern matching and the as and is operators](../../how-to/safely-cast-using-pattern-matching-is-and-as-operators.md).  
-  
+In some reference type conversions, the compiler cannot determine whether a cast will be valid. It is possible for a cast operation that compiles correctly to fail at run time. As shown in the following example, a type cast that fails at run time will cause an <xref:System.InvalidCastException> to be thrown.
+
+[!code-csharp[csProgGuideTypes#41](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#41)]
+
+C# provides the [is](../../language-reference/operators/type-testing-and-cast.md#is-operator) operator to enable you to test for compatibility before actually performing a cast. For more information, see [How to safely cast using pattern matching and the as and is operators](../../how-to/safely-cast-using-pattern-matching-is-and-as-operators.md).
+
 ## C# language specification
 
 For more information, see the [Conversions](~/_csharplang/spec/conversions.md) section of the [C# language specification](~/_csharplang/spec/introduction.md).

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
@@ -687,17 +687,15 @@ namespace CsProgGuideTypes
     //</snippet40>
 
     //<snippet41>
-
     using System;
 
     class Animal
     {
-        public void Eat() { Console.WriteLine("Eating."); }
-        public override string ToString()
-        {
-            return "I am an animal.";
-        }
+        public void Eat() => Console.WriteLine("Eating.");
+
+        public override string ToString() => "I am an animal.";
     }
+
     class Reptile : Animal { }
     class Mammal : Animal { }
 
@@ -714,8 +712,8 @@ namespace CsProgGuideTypes
 
         static void Test(Animal a)
         {
-            // Cause InvalidCastException at run time
-            // because Mammal is not convertible to Reptile.
+            // System.InvalidCastException at run time
+            // Unable to cast object of type 'Mammal' to type 'Reptile'
             Reptile r = (Reptile)a;
         }
     }

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
@@ -687,11 +687,9 @@ namespace CsProgGuideTypes
     //</snippet40>
 
     //<snippet41>
-    using System;
-
     class Animal
     {
-        public void Eat() => Console.WriteLine("Eating.");
+        public void Eat() => System.Console.WriteLine("Eating.");
 
         public override string ToString() => "I am an animal.";
     }
@@ -706,8 +704,8 @@ namespace CsProgGuideTypes
             Test(new Mammal());
 
             // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
+            System.Console.WriteLine("Press any key to exit.");
+            System.Console.ReadKey();
         }
 
         static void Test(Animal a)


### PR DESCRIPTION
## Summary

There was a bit of confusion around the type casting documentation, specifically the [Casting and type conversion](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/casting-and-type-conversions) article.

- Added details about why the type explicit type cast fails
- Minor C# code clean up
- Doc clean up, formatting

Fixes #18779

### Preview

✔️ [Casting and type conversions](https://review.docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/casting-and-type-conversions?branch=pr-en-us-19334)