### PR TITLE
Update outdated repo urls

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -156,9 +156,9 @@
       "feedback_product_url": {
         "docs/azure/sdk/**/**.md": "https://github.com/azure/azure-sdk-for-net",
         "docs/azure/sdk/**/**.yml": "https://github.com/azure/azure-sdk-for-net",
-        "docs/fsharp/**/**.md": "https://github.com/Microsoft/visualfsharp",
+        "docs/fsharp/**/**.md": "https://github.com/dotnet/fsharp",
         "docs/machine-learning/**/**.md": "https://github.com/dotnet/machinelearning",
-        "docs/standard/data/sqlite/**/*.md": "https://github.com/aspnet/EntityFrameworkCore",
+        "docs/standard/data/sqlite/**/*.md": "https://github.com/dotnet/efcore",
         "docs/spark/**/**.md": "https://github.com/dotnet/spark"
       },
       "ms.prod": {


### PR DESCRIPTION
This will avoid a redirection from the old url to the new one.