### PR TITLE
Update about.md to include download button link for .NET Core

### DIFF
--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -5,6 +5,9 @@ ms.date: 03/26/2020
 ---
 # .NET Core overview
 
+> [!div class="button"]
+> [Download .NET Core](https://dotnet.microsoft.com/download)
+
 .NET Core has the following characteristics:
 
 - **Cross platform:** Runs on Windows, macOS, and Linux [operating systems](https://github.com/dotnet/core/blob/master/os-lifecycle-policy.md).
@@ -14,9 +17,6 @@ ms.date: 03/26/2020
 - **Consistent across environments:** Runs your code with the same behavior on multiple operating systems and architectures, including x64, x86, and ARM.
 - **Command-line tools:**  Includes easy-to-use command-line tools that can be used for local development and for continuous integration.
 - **Flexible deployment:** You can include .NET Core in your app or install it side-by-side (user-wide or system-wide installations). Can be used with [Docker containers](docker/introduction.md).
-
-> [!div class="button"]
-> [Download .NET Core](https://dotnet.microsoft.com/download)
 
 ## Languages
 

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -15,6 +15,9 @@ ms.date: 03/26/2020
 - **Command-line tools:**  Includes easy-to-use command-line tools that can be used for local development and for continuous integration.
 - **Flexible deployment:** You can include .NET Core in your app or install it side-by-side (user-wide or system-wide installations). Can be used with [Docker containers](docker/introduction.md).
 
+> [!div class="button"]
+> [Download .NET Core](https://dotnet.microsoft.com/download)
+
 ## Languages
 
 The [C#](../csharp/index.yml), [Visual Basic](../visual-basic/index.yml), and [F#](../fsharp/index.yml) languages can be used to write applications and libraries for .NET Core. These languages can be used in your favorite text editor or Integrated Development Environment (IDE), including:


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/dotnet/core/about?branch=pr-en-us-19355)

(See download button at top of topic)

Fixes #18012  (Partly)

- Added Download .NET core button above the fold.   I decided not to make an entirely new section just for that and seemed reasonable rather to put it at the end of the first section.  Developers need to be able to select Linux, macOS and Windows, so the link is to the top level download page rather than to a more direct download.

