### PR TITLE
Document Blazor components insignificant whitespace breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 3.1 to 5.0
 description: Lists the breaking changes from version 3.1 to version 5.0 of .NET, ASP.NET Core, and EF Core.
-ms.date: 06/23/2020
+ms.date: 07/08/2020
 ---
 # Breaking changes for migration from version 3.1 to 5.0
 
@@ -10,6 +10,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ## ASP.NET Core
 
 - [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
+- [Blazor: Insignificant whitespace trimmed from components at compile time](#blazor-insignificant-whitespace-trimmed-from-components-at-compile-time)
 - [Extensions: Package reference changes affecting some NuGet packages](#extensions-package-reference-changes-affecting-some-nuget-packages)
 - [HTTP: HttpClient instances created by IHttpClientFactory log integer status codes](#http-httpclient-instances-created-by-ihttpclientfactory-log-integer-status-codes)
 - [HTTP: Kestrel and IIS BadHttpRequestException types marked obsolete and replaced](#http-kestrel-and-iis-badhttprequestexception-types-marked-obsolete-and-replaced)
@@ -26,6 +27,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [Static files: CSV content type changed to standards-compliant](#static-files-csv-content-type-changed-to-standards-compliant)
 
 [!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
+
+***
+
+[!INCLUDE[Blazor: Insignificant whitespace trimmed from components at compile time](~/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core breaking changes
 titleSuffix: ""
 description: Lists the breaking changes in ASP.NET Core.
-ms.date: 06/23/2020
+ms.date: 07/08/2020
 author: scottaddie
 ms.author: scaddie
 ---
@@ -21,6 +21,7 @@ The following breaking changes are documented on this page:
 - [Authorization: IAllowAnonymous removed from AuthorizationFilterContext.Filters](#authorization-iallowanonymous-removed-from-authorizationfiltercontextfilters)
 - [Authorization: IAuthorizationPolicyProvider implementations require new method](#authorization-iauthorizationpolicyprovider-implementations-require-new-method)
 - [Azure: Microsoft-prefixed Azure integration packages removed](#azure-microsoft-prefixed-azure-integration-packages-removed)
+- [Blazor: Insignificant whitespace trimmed from components at compile time](#blazor-insignificant-whitespace-trimmed-from-components-at-compile-time)
 - [Caching: CompactOnMemoryPressure property removed](#caching-compactonmemorypressure-property-removed)
 - [Caching: Microsoft.Extensions.Caching.SqlServer uses new SqlClient package](#caching-microsoftextensionscachingsqlserver-uses-new-sqlclient-package)
 - [Caching: ResponseCaching "pubternal" types changed to internal](#caching-responsecaching-pubternal-types-changed-to-internal)
@@ -82,6 +83,10 @@ The following breaking changes are documented on this page:
 ## ASP.NET Core 5.0
 
 [!INCLUDE[Azure: Microsoft-prefixed Azure integration packages removed](~/includes/core-changes/aspnetcore/5.0/azure-integration-packages-removed.md)]
+
+***
+
+[!INCLUDE[Blazor: Insignificant whitespace trimmed from components at compile time](~/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
+++ b/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
@@ -1,0 +1,73 @@
+### Blazor: Insignificant whitespace trimmed from components at compile time
+
+Starting with .NET 5 Preview 7, the Razor compiler omits insignificant whitespace in Blazor components (*.razor* files) at compile time. For discussion, see issue [dotnet/aspnetcore#23568](https://github.com/dotnet/aspnetcore/issues/23568).
+
+#### Version introduced
+
+5.0 Preview 7
+
+#### Old behavior
+
+In 3.x versions of Blazor Server and Blazor WebAssembly, *.razor* files preserved whitespace in the text context of the rendered output. Consider the following Blazor component code:
+
+```razor
+<ul>
+    @foreach (var item in Items)
+    {
+        <li>
+            @item.Text
+        </li>
+    }
+</ul>
+```
+
+The preceding example renders two whitespace nodes:
+
+* Outside of the `@foreach` code block.
+* Around the `<li>` element.
+* Around the `@item.Text` output.
+
+A list containing 100 items results in 402 whitespace nodes. That's over half of all nodes rendered, even though none of the whitespace nodes visually affect the rendered output.
+
+When rendering static HTML for components, whitespace inside a tag header wasn't preserved. For example, view the source of the following rendered component. You'll notice that whitespace wasn't preserved.
+
+```razor
+<foo        bar="baz"     />
+```
+
+#### New behavior
+
+Unless the `@preservewhitespace` directive is used with value `true`, whitespace nodes are removed if they:
+
+* Are leading or trailing within an element.
+* Are leading or trailing within a `RenderFragment` parameter. For example, child content being passed to another component.
+* Precede or follow a C# code block such as `@if` and `@foreach`.
+
+#### Reason for change
+
+A goal for Blazor in .NET 5 is to improve performance for rendering and diffing. Insignificant whitespace tree nodes consumed up to 40 percent of the rendering time in benchmarks.
+
+#### Recommended action
+
+In most cases, the visual layout of the rendered component is unaffected. However, the whitespace removal might affect the rendered output when using a CSS rule like `white-space: pre`. To disable this performance optimization and preserve the whitespace, take one of the following actions:
+
+* Add the `@preservewhitespace true` directive at the top of the *.razor* file to apply the preference to a specific component.
+* Add the `@preservewhitespace true` directive inside an *_Imports.razor* file to apply the preference to an entire subdirectory or the entire project.
+
+In most cases, no action is required, as applications will typically continue to behave normally (but faster). If the whitespace stripping causes any problems for a particular component, use `@preservewhitespace true` in that component to disable this optimization.
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+None
+
+<!--
+
+#### Affected APIs
+
+Not detectable via API analysis
+
+-->

--- a/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
+++ b/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
@@ -8,7 +8,9 @@ Starting with ASP.NET Core 5.0 Preview 7, the Razor compiler omits insignificant
 
 #### Old behavior
 
-In 3.x versions of Blazor Server and Blazor WebAssembly, *.razor* files preserved whitespace in the text context of the rendered output. Consider the following Blazor component code:
+In 3.x versions of Blazor Server and Blazor WebAssembly, whitespace is honored in a component's source code. Whitespace-only text nodes render in the browser's Document Object Model (DOM) even when there's no visual effect.
+
+Consider the following Blazor component code:
 
 ```razor
 <ul>
@@ -29,10 +31,16 @@ The preceding example renders two whitespace nodes:
 
 A list containing 100 items results in 402 whitespace nodes. That's over half of all nodes rendered, even though none of the whitespace nodes visually affect the rendered output.
 
-When rendering static HTML for components, whitespace inside a tag header wasn't preserved. For example, view the source of the following rendered component. You'll notice that whitespace wasn't preserved.
+When rendering static HTML for components, whitespace inside a tag wasn't preserved. For example, view the source of the following rendered component:
 
 ```razor
 <foo        bar="baz"     />
+```
+
+You'll notice that whitespace wasn't preserved. The pre-rendered output is:
+
+```razor
+<foo bar="baz" />
 ```
 
 #### New behavior
@@ -45,7 +53,7 @@ Unless the `@preservewhitespace` directive is used with value `true`, whitespace
 
 #### Reason for change
 
-A goal for Blazor in ASP.NET Core 5.0 is to improve performance for rendering and diffing. Insignificant whitespace tree nodes consumed up to 40 percent of the rendering time in benchmarks.
+A goal for Blazor in ASP.NET Core 5.0 is to improve the performance of rendering and diffing. Insignificant whitespace tree nodes consumed up to 40 percent of the rendering time in benchmarks.
 
 #### Recommended action
 

--- a/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
+++ b/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
@@ -31,13 +31,13 @@ The preceding example renders two whitespace nodes:
 
 A list containing 100 items results in 402 whitespace nodes. That's over half of all nodes rendered, even though none of the whitespace nodes visually affect the rendered output.
 
-When rendering static HTML for components, whitespace inside a tag wasn't preserved. For example, view the source of the following rendered component:
+When rendering static HTML for components, whitespace inside a tag wasn't preserved. For example, view the source of the following component:
 
 ```razor
 <foo        bar="baz"     />
 ```
 
-You'll notice that whitespace wasn't preserved. The pre-rendered output is:
+Whitespace isn't preserved. The pre-rendered output is:
 
 ```razor
 <foo bar="baz" />

--- a/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
+++ b/includes/core-changes/aspnetcore/5.0/blazor-components-trim-insignificant-whitespace.md
@@ -1,6 +1,6 @@
 ### Blazor: Insignificant whitespace trimmed from components at compile time
 
-Starting with .NET 5 Preview 7, the Razor compiler omits insignificant whitespace in Blazor components (*.razor* files) at compile time. For discussion, see issue [dotnet/aspnetcore#23568](https://github.com/dotnet/aspnetcore/issues/23568).
+Starting with ASP.NET Core 5.0 Preview 7, the Razor compiler omits insignificant whitespace in Blazor components (*.razor* files) at compile time. For discussion, see issue [dotnet/aspnetcore#23568](https://github.com/dotnet/aspnetcore/issues/23568).
 
 #### Version introduced
 
@@ -45,7 +45,7 @@ Unless the `@preservewhitespace` directive is used with value `true`, whitespace
 
 #### Reason for change
 
-A goal for Blazor in .NET 5 is to improve performance for rendering and diffing. Insignificant whitespace tree nodes consumed up to 40 percent of the rendering time in benchmarks.
+A goal for Blazor in ASP.NET Core 5.0 is to improve performance for rendering and diffing. Insignificant whitespace tree nodes consumed up to 40 percent of the rendering time in benchmarks.
 
 #### Recommended action
 


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/426

[Internal review page](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19363#blazor-insignificant-whitespace-trimmed-from-components-at-compile-time)