### PR TITLE
Added details for the missing dotnet tool update command

### DIFF
--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -54,34 +54,6 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 ## Options
 
-- **`--local`**
-
-  Update the tool and the local tool manifest. Can't be combined with the `--global` option or the `--tool-path` option.
-
-- **`--version <VERSION>`**
-
-  The version range of the tool package to update to. This cannot be used to downgrade versions, you must `uninstall` newer versions first.
-
-- **`--tool-manifest <PATH>`**
-
-  Path to the manifest file. Applies only to local tools.
-
-- **`--disable-parallel`**
-
-  Prevent restoring multiple projects in parallel.
-
-- **`--ignore-failed-sources`**
-
-  Treat package source failures as warnings.
-
-- **`--no-cache`**
-
-  Do not cache packages and HTTP requests.
-
-- **`--interactive`**
-
-  Allows the command to stop and wait for user input or action (for example to complete authentication).
-
 - **`--add-source <SOURCE>`**
 
   Adds an additional NuGet package source to use during installation.
@@ -90,9 +62,41 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
   The NuGet configuration (*nuget.config*) file to use.
 
+- **`--disable-parallel`**
+
+  Prevent restoring multiple projects in parallel.
+
 - **`--framework <FRAMEWORK>`**
 
   Specifies the [target framework](../../standard/frameworks.md) to update the tool for.
+
+- **`--ignore-failed-sources`**
+
+  Treat package source failures as warnings.
+
+- **`--interactive`**
+
+  Allows the command to stop and wait for user input or action (for example to complete authentication).
+
+- **`--local`**
+
+  Update the tool and the local tool manifest. Can't be combined with the `--global` option.
+
+- **`--no-cache`**
+
+  Do not cache packages and HTTP requests.
+
+- **`--tool-manifest <PATH>`**
+
+  Path to the manifest file.
+
+- **`--tool-path <PATH>`**
+
+  Specifies the location where the global tool is installed. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be updated is a local tool.
+
+- **`--version <VERSION>`**
+
+  The version range of the tool package to update to. This cannot be used to downgrade versions, you must `uninstall` newer versions first.
 
 - **`-g|--global`**
 
@@ -101,10 +105,6 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 - **`-h|--help`**
 
   Prints out a short help for the command.
-
-- **`--tool-path <PATH>`**
-
-  Specifies the location where the global tool is installed. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be updated is a local tool.
 
 - **`-v|--verbosity <LEVEL>`**
 
@@ -128,17 +128,13 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
   Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) local tool installed for the current directory.
 
-- **`dotnet tool update -g dotnetsay --version *`**
-
-  Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the latest version.
-
 - **`dotnet tool update -g dotnetsay --version 2.0.*`**
 
   Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the latest patch version, with a major version of `2`, and a minor version of `0`.
 
 - **`dotnet tool update -g dotnetsay --version (2.0.*,2.1.4)`**
 
-  Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the lowest tolerable version within the specified range `(> 2.0.0 && < 2.1.4)`, version `2.1.0` would be installed.
+  Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the lowest version within the specified range `(> 2.0.0 && < 2.1.4)`, version `2.1.0` would be installed. For more information on semantic versioning ranges, see [NuGet packaging version ranges](/nuget/concepts/package-versioning#version-ranges).
 
 ## See also
 

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet tool update command
 description: The dotnet tool update command updates the specified .NET Core tool on your machine.
-ms.date: 02/14/2020
+ms.date: 07/08/2020
 ---
 # dotnet tool update
 
@@ -14,17 +14,25 @@ ms.date: 02/14/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet tool update <PACKAGE_NAME> -g|--global
+dotnet tool update <PACKAGE_ID> -g|--global
     [--configfile <FILE>] [--framework <FRAMEWORK>]
     [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 
-dotnet tool update <PACKAGE_NAME> --tool-path <PATH>
+dotnet tool update <PACKAGE_ID> --tool-path <PATH>
     [--configfile <FILE>] [--framework <FRAMEWORK>]
     [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
 
-dotnet tool update <PACKAGE_NAME>
+dotnet tool update <PACKAGE_ID>
     [--configfile <FILE>] [--framework <FRAMEWORK>]
     [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
+
+dotnet tool update <PACKAGE_ID>
+    [--local] [--version <VERSION>]
+    [--tool-manifest <PATH>]
+
+dotnet tool update <PACKAGE_ID>
+    [--version <VERSION>] [--ignore-failed-sources]
+    [--no-cache] [--interactive] [--disable-parallel]
 
 dotnet tool update -h|--help
 ```
@@ -35,17 +43,45 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 * To update a global tool that was installed in the default location, use the `--global` option
 * To update a global tool that was installed in a custom location, use the `--tool-path` option.
-* To update a local tool, omit the `--global` and `--tool-path` options.
+* To update a local tool, use the `--local` and `--tool-manifest` options.
 
 **Local tools are available starting with .NET Core SDK 3.0.**
 
 ## Arguments
 
-- **`PACKAGE_NAME`**
+- **`PACKAGE_ID`**
 
   Name/ID of the NuGet package that contains the .NET Core global tool to update. You can find the package name using the [dotnet tool list](dotnet-tool-list.md) command.
 
 ## Options
+
+- **`--local`**
+
+  Update the tool and the local tool manifest. Can't be combined with the `--global` option.
+
+- **`--version <VERSION>`**
+
+  The version range of the tool package to update to. This cannot be used to downgrade versions, you must `uninstall` newer versions first.
+
+- **`--tool-manifest <PATH>`**
+
+  Path to the manifest file.
+
+- **`--disable-parallel`**
+
+  Prevent restoring multiple projects in parallel.
+
+- **`--ignore-failed-sources`**
+
+  Treat package source failures as warnings.
+
+- **`--no-cache`**
+
+  Do not cache packages and HTTP requests.
+
+- **`--interactive`**
+
+  Allows the command to stop and wait for user input or action (for example to complete authentication).
 
 - **`--add-source <SOURCE>`**
 
@@ -93,8 +129,21 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
   Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) local tool installed for the current directory.
 
+- **`dotnet tool update -g dotnetsay --version *`**
+
+  Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the latest version.
+
+- **`dotnet tool update -g dotnetsay --version 2.0.*`**
+
+  Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the latest patch version, with a major version of `2`, and a minor version of `0`.
+
+- **`dotnet tool update -g dotnetsay --version (2.0.*,2.1.4)`**
+
+  Updates the [dotnetsay](https://www.nuget.org/packages/dotnetsay/) global tool to the lowest tolerable version within the specified range `(> 2.0.0 && < 2.1.4)`, version `2.1.0` would be installed.
+
 ## See also
 
 - [.NET Core tools](global-tools.md)
+- [Semantic versioning](https://semver.org)
 - [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI](global-tools-how-to-use.md)
 - [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -26,7 +26,7 @@ dotnet tool update <PACKAGE_ID> --tool-path <PATH>
     [--ignore-failed-sources] [--interactive] [--no-cache]
     [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
-dotnet tool update <PACKAGE_ID>
+dotnet tool update <PACKAGE_ID> --local
     [--configfile <FILE>] [--framework <FRAMEWORK>]
     [--add-source <SOURCE>] [--disable-parallel]
     [--ignore-failed-sources] [--interactive] [--no-cache]

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -16,23 +16,22 @@ ms.date: 07/08/2020
 ```dotnetcli
 dotnet tool update <PACKAGE_ID> -g|--global
     [--configfile <FILE>] [--framework <FRAMEWORK>]
-    [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
+    [--add-source <SOURCE>] [--disable-parallel]
+    [--ignore-failed-sources] [--interactive] [--no-cache]
+    [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update <PACKAGE_ID> --tool-path <PATH>
     [--configfile <FILE>] [--framework <FRAMEWORK>]
-    [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
+    [--add-source <SOURCE>] [--disable-parallel]
+    [--ignore-failed-sources] [--interactive] [--no-cache]
+    [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update <PACKAGE_ID>
     [--configfile <FILE>] [--framework <FRAMEWORK>]
-    [-v|--verbosity <LEVEL>] [--add-source <SOURCE>]
-
-dotnet tool update <PACKAGE_ID>
-    [--local] [--version <VERSION>]
+    [--add-source <SOURCE>] [--disable-parallel]
+    [--ignore-failed-sources] [--interactive] [--no-cache]
     [--tool-manifest <PATH>]
-
-dotnet tool update <PACKAGE_ID>
-    [--version <VERSION>] [--ignore-failed-sources]
-    [--no-cache] [--interactive] [--disable-parallel]
+    [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update -h|--help
 ```
@@ -43,7 +42,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 * To update a global tool that was installed in the default location, use the `--global` option
 * To update a global tool that was installed in a custom location, use the `--tool-path` option.
-* To update a local tool, use the `--local` and `--tool-manifest` options.
+* To update a local tool, use the `--local` option.
 
 **Local tools are available starting with .NET Core SDK 3.0.**
 
@@ -57,7 +56,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 - **`--local`**
 
-  Update the tool and the local tool manifest. Can't be combined with the `--global` option.
+  Update the tool and the local tool manifest. Can't be combined with the `--global` option or the `--tool-path` option.
 
 - **`--version <VERSION>`**
 
@@ -65,7 +64,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 - **`--tool-manifest <PATH>`**
 
-  Path to the manifest file.
+  Path to the manifest file. Applies only to local tools.
 
 - **`--disable-parallel`**
 


### PR DESCRIPTION
## Summary

Added details for the missing `dotnet tool update` command, including:

- `--disable-parallel`
- `--ignore-failed-sources`
- `--interactive`
- `--local`
- `--no-cache`
- `--tool-manifest <PATH>`
- `--version <VERSION>`

Also, added examples demonstrating semantic versioning and link.

Fixes #19368

### Preview

✔️ [dotnet tool update](https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update?branch=pr-en-us-19369)