### PR TITLE
Add missing whitespace

### DIFF
--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -245,7 +245,7 @@ Remove a tool by using the [dotnet tool uninstall](dotnet-tool-uninstall.md) com
 
 ```dotnetcli
 dotnet tool uninstall --global <packagename>
-dotnet tool uninstall --tool-path<packagename>
+dotnet tool uninstall --tool-path <packagename>
 dotnet tool uninstall <packagename>
 ```
 


### PR DESCRIPTION
## Summary

Fixes simple typo of missing whitespace between option and its value.

As per dotnet tool uninstall output it should be `--tool-path <PATH>`