### PR TITLE
Azure hub btn

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 04/21/2020
+  ms.date: 07/10/2020
 
 # highlightedContent section (optional)
 # Maximum of 8 items

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -39,6 +39,10 @@ highlightedContent:
     - title: "What's new in .NET docs"
       itemType: whats-new
       url: whats-new/index.yml
+    # Card
+    - title: "Azure for .NET developers"
+      itemType: how-to-guide
+      url: azure/index.yml
 
 # conceptualContent section (optional)
 conceptualContent:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
       url: whats-new/index.yml
     # Card
     - title: "Azure for .NET developers"
-      itemType: how-to-guide
+      itemType: overview
       url: azure/index.yml
 
 # conceptualContent section (optional)


### PR DESCRIPTION
## Summary

Adding a Hub page link to the newly renovated Azure for .NET developers hub page. Filling the empty spot for more visibility.

**Before**
![image](https://user-images.githubusercontent.com/7679720/87042512-6244ad80-c1b9-11ea-9276-789ec4da4944.png)

**After**
![image](https://user-images.githubusercontent.com/7679720/87043443-a2f0f680-c1ba-11ea-9fa7-e4e927e22de7.png)

/cc @CamSoper 

### Preview

✔️ [.NET documentation](https://review.docs.microsoft.com/en-us/dotnet/?branch=pr-en-us-19381)