### PR TITLE
Fix "tar balls" to "tarballs"

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -18,7 +18,7 @@ You can get .NET Core in the following ways:
 * [Installers for Windows and macOS](https://dotnet.microsoft.com/download)
 * [Linux packages](https://docs.microsoft.com/dotnet/core/install/linux-package-managers)
 * [Docker containers](https://hub.docker.com/_/microsoft-dotnet-core/)
-* [Zips and tar balls](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+* [Zips and tarballs](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 * [Install scripts](https://dotnet.microsoft.com/download/dotnet-core/scripts)
 * [Release notes](https://github.com/dotnet/core/tree/master/release-notes)
 


### PR DESCRIPTION
Currently, "tar balls" is being over-localized by Machine Translation in Italian.
The [source string](https://docs.microsoft.com/en-us/dotnet/core/introduction) is currently “Zips and tar balls”, but it seems like the computing term should be one word “tarballs”? 
I tried in Bing translator and changing the source to “Tarballs” should fix the Italian Machine Translation back to keeping it in English.

Fixes [https://github.com/dotnet/docs.it-it/pull/83](https://github.com/dotnet/docs.it-it/pull/83)
