### PR TITLE
Fix C# interactive experience

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/ValueTuples.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/ValueTuples.cs
@@ -71,8 +71,8 @@ namespace builtin_types
             // Limits of [4 7 9] are 4 and 9
 
             var ys = new[] { -9, 0, 67, 100 };
-            var (min, max) = FindMinMax(ys);
-            Console.WriteLine($"Limits of [{string.Join(" ", ys)}] are {min} and {max}");
+            var (minimum, maximum) = FindMinMax(ys);
+            Console.WriteLine($"Limits of [{string.Join(" ", ys)}] are {minimum} and {maximum}");
             // Output:
             // Limits of [-9 0 67 100] are -9 and 100
 


### PR DESCRIPTION
Somehow, as it is, `min` and `max` local variables clash with the same-named variables in a local function. This is the error message, when running the snippet from the article in C# interactive (code runs without problems on desktop):

> (20,9): error CS0136: A local or parameter named 'min' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter

So, I've just renamed the variables and it worked in interactive.

Link to the article in question: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-tuples#use-cases-of-tuples