### PR TITLE
adding mobile-apps azure dev page to tools section - mobile card

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -212,6 +212,8 @@ additionalContent:
             text: Xamarin.Android
           - url: /xamarin/xamarin-forms
             text: Xamarin.Forms
+          - url: /azure/developer/mobile-apps
+            text: Develop Xamarin apps with Azure
       # Card
       - title: Desktop
         links:


### PR DESCRIPTION
## Summary

Adding a link to the /azure/developer/mobile-apps documentation page from the tools / mobile card on the hub page.
