### PR TITLE
Update library-with-visual-studio-code.md

### DIFF
--- a/docs/core/tutorials/library-with-visual-studio-code.md
+++ b/docs/core/tutorials/library-with-visual-studio-code.md
@@ -166,7 +166,7 @@ Initially, the new console app project doesn't have access to the class library.
 1. Run the following command:
 
    ```dotnetcli
-   dotnet add ShowCase/Showcase.csproj reference StringLibrary/StringLibrary.csproj
+   dotnet add ShowCase/ShowCase.csproj reference StringLibrary/StringLibrary.csproj
    ```
 
    The terminal output looks like the following example:


### PR DESCRIPTION
## Summary

Correct the character casing of the project name in the `dotnet` CLI command

Fixes #19447
