### PR TITLE
adding more links to mobile card

### DIFF
--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -87,9 +87,15 @@ conceptualContent:
           url: /visualstudio/containers/hosting-web-apps-in-docker?view=vs-2019
     - title: Create mobile apps
       links:
+        - itemType: learn
+          text: Consume REST services from Azure in Xamarin apps
+          url: /learn/modules/consume-rest-services/
         - itemType: quickstart
           text: Create a Xamarin.Forms app with .NET SDK and Azure Cosmos DB's API for MongoDB
           url: /azure/cosmos-db/create-mongodb-xamarin
+        - itemType: quickstart
+          text: Azure Blob storage client library with Xamarin.Forms
+          url: /azure/storage/blobs/storage-quickstart-blobs-xamarin
         - itemType: tutorial
           text: Send push notifications to Xamarin.Forms apps using ASP.NET Core and Azure Notification Hubs
           url: /azure/notification-hubs/notification-hubs-backend-service-xamarin-forms


### PR DESCRIPTION
## Summary

Adding links to the mobile card on the .NET Azure hub to represent common tasks of creating Xamarin + Azure apps
