### PR TITLE
Added mention of href as valid attribute

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/see.md
+++ b/docs/csharp/programming-guide/xmldoc/see.md
@@ -27,7 +27,7 @@ ms.assetid: 0200de01-7e2f-45c4-9094-829d61236383
 
 ## Remarks
 
-The `<see>` tag lets you specify a link from within text. Use [\<seealso>](./seealso.md) to indicate that text should be placed in a See Also section. Use the [cref Attribute](./cref-attribute.md) to create internal hyperlinks to documentation pages for code elements.
+The `<see>` tag lets you specify a link from within text. Use [\<seealso>](./seealso.md) to indicate that text should be placed in a See Also section. Use the [cref Attribute](./cref-attribute.md) to create internal hyperlinks to documentation pages for code elements. Also, ``href`` is a valid Attribute that will function as a hyperlink.
 
 Compile with [-doc](../../language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.
 


### PR DESCRIPTION
## Summary

At of the end of the first paragraph in the Remarks section, I've added that ``href`` can also be used as a valid Attribute.

Fixes #19284 