### PR TITLE
Update cancellationex13.cs

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex13.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex13.cs
@@ -55,7 +55,6 @@ class WorkerWithTimer
   public WorkerWithTimer()
   {
       internalTokenSource = new CancellationTokenSource();
-      internalToken = internalTokenSource.Token;
 
       // A toy cancellation trigger that times out after 3 seconds
       // if the user does not press 'c'.


### PR DESCRIPTION
The assignment to the field `internalToken` in the constructor appears to be superfluous.

## Summary

I removed an unneeded line in the constructor with the intention to improve clarity. The `internalToken` field is assigned again in `DoWork`, where it is actually referenced. 
