### PR TITLE
Fix typos in databricks commands

### DIFF
--- a/docs/spark/tutorials/databricks-deployment.md
+++ b/docs/spark/tutorials/databricks-deployment.md
@@ -151,7 +151,7 @@ In this section, you upload several files to DBFS so that your cluster has every
    ```console
    databricks fs cp db-init.sh dbfs:/spark-dotnet/db-init.sh
    databricks fs cp install-worker.sh dbfs:/spark-dotnet/install-worker.sh
-   databricks fs cp Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.6.0.tar.gz dbfs:/spark-dotnet/   Microsoft.Spark.Worker.netcoreapp2.1.linux-x64-0.6.0.tar.gz
+   databricks fs cp Microsoft.Spark.Worker.netcoreapp3.1.linux-x64-0.6.0.tar.gz dbfs:/spark-dotnet/Microsoft.Spark.Worker.netcoreapp2.1.linux-x64-0.6.0.tar.gz
    ```
 
 2. Run the following commands to upload the remaining files your cluster will need to run your app: the zipped publish folder, *input.txt*, and *microsoft-spark-2.4.x-0.3.1.jar*.

--- a/docs/spark/tutorials/databricks-deployment.md
+++ b/docs/spark/tutorials/databricks-deployment.md
@@ -161,7 +161,7 @@ In this section, you upload several files to DBFS so that your cluster has every
    databricks fs cp input.txt dbfs:/input.txt
 
    cd mySparkApp\bin\Release\netcoreapp3.1\ubuntu.16.04-x64 directory
-   databricks fs cp mySparkApp.zip dbfs:/spark-dotnet/publish.zip
+   databricks fs cp publish.zip dbfs:/spark-dotnet/publish.zip
    databricks fs cp microsoft-spark-2.4.x-0.6.0.jar dbfs:/spark-dotnet/microsoft-spark-2.4.x-0.6.0.jar
    ```
 


### PR DESCRIPTION
## Summary

The destination path of the databricks copy command is invalid and this breaks the copy job.

Also think the release zip filename needs to be changed considering the previous steps used ```publish.zip``` as the filename.
Otherwise, there should be a step stating that the zip file should be renamed to ```mySparkApp.zip```
