### PR TITLE
Fix for issue 15735

### DIFF
--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -46,7 +46,7 @@ A NuGet package supports many [metadata properties](/nuget/reference/nuspec). Th
 | `Description`                      | `description`              | A long description of the package displayed in UI.             |
 | `Authors`                          | `authors`                  | A comma-separated list of package authors, matching the profile names on nuget.org.             |
 | `PackageTags`                      | `tags`                     | A space-delimited list of tags and keywords that describe the package. Tags are used when searching for packages.             |
-| `PackageIcon`                   | `icon`                  | A URL for an image to use as the icon for the package. URL should be HTTPS and the image should be 64x64 and have a transparent background.             |
+| `PackageIcon`                   | `icon`                  | A path to an image in the package to use as a package icon. Read more about [`icon` metadata](/nuget/reference/nuspec#icon). |
 | `PackageProjectUrl`                | `projectUrl`               | A URL for the project homepage or source repository.             |
 | `PackageLicenseExpression`         | `license`                  | The project license's [SPDX identifier](https://spdx.org/licenses/). Only OSI and FSF approved licenses can use an identifier. Other licenses should use `PackageLicenseFile`. Read more about [`license` metadata](/nuget/reference/nuspec#license). |
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -46,7 +46,7 @@ A NuGet package supports many [metadata properties](/nuget/reference/nuspec). Th
 | `Description`                      | `description`              | A long description of the package displayed in UI.             |
 | `Authors`                          | `authors`                  | A comma-separated list of package authors, matching the profile names on nuget.org.             |
 | `PackageTags`                      | `tags`                     | A space-delimited list of tags and keywords that describe the package. Tags are used when searching for packages.             |
-| `PackageIconUrl`                   | `iconUrl`                  | A URL for an image to use as the icon for the package. URL should be HTTPS and the image should be 64x64 and have a transparent background.             |
+| `PackageIcon`                   | `icon`                  | A URL for an image to use as the icon for the package. URL should be HTTPS and the image should be 64x64 and have a transparent background.             |
 | `PackageProjectUrl`                | `projectUrl`               | A URL for the project homepage or source repository.             |
 | `PackageLicenseExpression`         | `license`                  | The project license's [SPDX identifier](https://spdx.org/licenses/). Only OSI and FSF approved licenses can use an identifier. Other licenses should use `PackageLicenseFile`. Read more about [`license` metadata](/nuget/reference/nuspec#license). |
 


### PR DESCRIPTION
## Summary

Swapped deprecated ``PackageIconUrl`` for ``PackageIcon`` and ``IconUrl`` to ``Icon``, respectfully, in [docs/standard/library-guidance/nuget.md](https://github.com/dotnet/docs/blob/master/docs/standard/library-guidance/nuget.md)

Fixes #15735
