### PR TITLE
F# plaintext printing documentation

### DIFF
--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -11,7 +11,7 @@ This topic describes the command-line options supported by F# Interactive, `fsi.
 
 F# Interactive, `dotnet fsi`, can be launched interactively, or it can be launched from the command line to run a script. The command line syntax is
 
-```console
+```dotnetcli
 > dotnet fsi [options] [ script-file [arguments] ]
 ```
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -96,7 +96,7 @@ fsi.ShowDeclarationValues <- false // Control whether values are shown for decla
 
 Printing in F# Interactive outputs can be customized by using `fsi.AddPrinter` and `fsi.AddPrintTransformer`.
 The first gives text to replace the printing of an object, the second returns a surrogate object to display
-instead. For example, in F# Interactive
+instead. For example, consider the following F# code:
 
 ```fsharp
 open System

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -104,12 +104,12 @@ open System
 fsi.AddPrinter<DateTime>(fun dt -> dt.ToString("s"))
 
 type DateAndLabel =
-  { Date : DateTime
-    Label  : string  }
+    { Date: DateTime
+      Label: string  }
 
 let newYearsDay1999 =
-  { Date = DateTime(1999, 1, 1)
-    Label = "New Year" }
+    { Date = DateTime(1999, 1, 1)
+      Label = "New Year" }
 ```
 
 If you execute the example in F# Interactive, it outputs based on the formatting option set. In this case, it affects the formatting of date and time:

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -5,7 +5,7 @@ ms.date: 07/22/2020
 ---
 # F# Interactive options
 
-This topic describes the command-line options supported by F# Interactive, `fsi.exe`. F# Interactive accepts many of the same command line options as the F# compiler, but also accepts some additional options.
+This article describes the command-line options supported by F# Interactive, `fsi.exe`. F# Interactive accepts many of the same command line options as the F# compiler, but also accepts some additional options.
 
 ## Using F# Interactive for scripting
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -151,7 +151,7 @@ fsi.AddPrintTransformer(fun (x:obj) ->
 let y = "beep"
 ```
 
-gives
+This outputs:
 
 ```console
 val y : string = ["quack"; "quack"; "quack"]

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -1,5 +1,5 @@
 ---
-title: Interactive Options
+title: Interactive options
 description: Learn about the command-line options supported by F# Interactive, fsi.exe.
 ms.date: 07/22/2020
 ---

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -140,7 +140,7 @@ val x : MyList = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
 ```
 
 If the transformer function passed to `fsi,AddPrintTransformer` returns `null` then the print transformer is ignored.
-This can be used to filter any input value by starting with type `obj`.  For example,
+This can be used to filter any input value by starting with type `obj`.  For example:
 
 ```fsharp
 fsi.AddPrintTransformer(fun (x:obj) ->

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -3,7 +3,7 @@ title: Interactive options
 description: Learn about the command-line options supported by F# Interactive, fsi.exe.
 ms.date: 07/22/2020
 ---
-# F# Interactive Options
+# F# Interactive options
 
 This topic describes the command-line options supported by F# Interactive, `fsi.exe`. F# Interactive accepts many of the same command line options as the F# compiler, but also accepts some additional options.
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -133,7 +133,7 @@ fsi.AddPrintTransformer(fun (x:MyList) -> box x.Values)
 let x = MyList([1..10])
 ```
 
-gives
+This outputs:
 
 ```console
 val x : MyList = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -77,19 +77,19 @@ open System.Globalization
 
 fsi.FormatProvider <- CultureInfo("de-DE")  // control the default culture for primitives
 
-fsi.PrintWidth <- 120        // control the width used for structured printing
+fsi.PrintWidth <- 120        // Control the width used for structured printing
 
-fsi.PrintDepth <- 10         // control the maximum depth of nested printing
+fsi.PrintDepth <- 10         // Control the maximum depth of nested printing
 
-fsi.PrintLength <- 10        // control the length of lists and arrays
+fsi.PrintLength <- 10        // Control the length of lists and arrays
 
-fsi.PrintSize <- 100         // control the maximum overall object count
+fsi.PrintSize <- 100         // Control the maximum overall object count
 
-fsi.ShowProperties <- false  // control whether properties of .NET objects are shown by default
+fsi.ShowProperties <- false  // Control whether properties of .NET objects are shown by default
 
-fsi.ShowIEnumerable <- false // control whether sequence values are expanded by default
+fsi.ShowIEnumerable <- false // Control whether sequence values are expanded by default
 
-fsi.ShowDeclarationValues <- false // control whether values are shown for declaration outputs
+fsi.ShowDeclarationValues <- false // Control whether values are shown for declaration outputs
 ```
 
 ### Customizing F# Interactive structured printing with `AddPrinter` and `AddPrintTransformer`

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -57,7 +57,7 @@ Where lists appear in F# Interactive option arguments, list elements are separat
 |**--warnaserror**[**+**&#124;**-**]|Same as the **fsc.exe** compiler option. For more information, see [Compiler Options](compiler-options.md).|
 |**--warnaserror**[**+**&#124;**-**]:**&lt;int-list&gt;**|Same as the **fsc.exe** compiler option. For more information, see [Compiler Options](compiler-options.md).|
 
-## F# Interactive Structured Printing
+## F# Interactive structured printing
 
 F# Interactive (`dotnet fsi`) uses an extended version of [structured plain text formatting](plaintext-formatting.md) to
 report values.

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -92,7 +92,7 @@ fsi.ShowIEnumerable <- false // Control whether sequence values are expanded by 
 fsi.ShowDeclarationValues <- false // Control whether values are shown for declaration outputs
 ```
 
-### Customizing F# Interactive structured printing with `AddPrinter` and `AddPrintTransformer`
+### Customize with `AddPrinter` and `AddPrintTransformer`
 
 Printing in F# Interactive outputs can be customized by using `fsi.AddPrinter` and `fsi.AddPrintTransformer`.
 The first gives text to replace the printing of an object, the second returns a surrogate object to display

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -139,7 +139,7 @@ gives
 val x : MyList = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
 ```
 
-If the transformer function passed to `fsi,AddPrintTransformer` returns `null` then the print transformer is ignored.
+If the transformer function passed to `fsi.AddPrintTransformer` returns `null` then the print transformer is ignored.
 This can be used to filter any input value by starting with type `obj`.  For example:
 
 ```fsharp

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -7,7 +7,7 @@ ms.date: 07/22/2020
 
 This article describes the command-line options supported by F# Interactive, `fsi.exe`. F# Interactive accepts many of the same command line options as the F# compiler, but also accepts some additional options.
 
-## Using F# Interactive for scripting
+## Use F# Interactive for scripting
 
 F# Interactive, `dotnet fsi`, can be launched interactively, or it can be launched from the command line to run a script. The command line syntax is
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -95,7 +95,7 @@ fsi.ShowDeclarationValues <- false // Control whether values are shown for decla
 ### Customize with `AddPrinter` and `AddPrintTransformer`
 
 Printing in F# Interactive outputs can be customized by using `fsi.AddPrinter` and `fsi.AddPrintTransformer`.
-The first gives text to replace the printing of an object, the second returns a surrogate object to display
+The first function gives text to replace the printing of an object. The second function returns a surrogate object to display
 instead. For example, consider the following F# code:
 
 ```fsharp

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -62,7 +62,7 @@ Where lists appear in F# Interactive option arguments, list elements are separat
 F# Interactive (`dotnet fsi`) uses an extended version of [structured plain text formatting](plaintext-formatting.md) to
 report values.
 
-1. All features of `%A` plaintext formatting are supported, and some are additionally customizable (see below).
+1. All features of `%A` plain text formatting are supported, and some are additionally customizable.
 
 2. Printing is colorized if colours are aupported by the output console.
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -1,7 +1,7 @@
 ---
 title: Interactive Options
 description: Learn about the command-line options supported by F# Interactive, fsi.exe.
-ms.date: 22/07/2030
+ms.date: 07/22/2020
 ---
 # F# Interactive Options
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -126,7 +126,7 @@ val newYearsDay1999 : DateAndLabel = { Date = 1999-01-01T00:00:00
 
 ```fsharp
 type MyList(values: int list) =
-    member x.Values = values
+    member _.Values = values
 
 fsi.AddPrintTransformer(fun (x:MyList) -> box x.Values)
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -12,7 +12,7 @@ This topic describes the command-line options supported by F# Interactive, `fsi.
 F# Interactive, `dotnet fsi`, can be launched interactively, or it can be launched from the command line to run a script. The command line syntax is
 
 ```dotnetcli
-> dotnet fsi [options] [ script-file [arguments] ]
+dotnet fsi [options] [ script-file [arguments] ]
 ```
 
 The file extension for F# script files is `.fsx`.

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -112,7 +112,7 @@ let newYearsDay1999 =
     Label = "New Year" }
 ```
 
-gives output that uses the specific date time format:
+If you execute the example in F# Interactive, it outputs based on the formatting option set. In this case, it affects the formatting of date and time:
 
 ```console
 type DateAndLabel =

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -7,7 +7,7 @@ ms.date: 07/22/2020
 
 This topic describes the command-line options supported by F# Interactive, `fsi.exe`. F# Interactive accepts many of the same command line options as the F# compiler, but also accepts some additional options.
 
-## Using F# Interactive for Scripting
+## Using F# Interactive for scripting
 
 F# Interactive, `dotnet fsi`, can be launched interactively, or it can be launched from the command line to run a script. The command line syntax is
 

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -157,7 +157,7 @@ gives
 val y : string = ["quack"; "quack"; "quack"]
 ```
 
-## Related Topics
+## Related topics
 
 |Title|Description|
 |-----|-----------|

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -139,7 +139,7 @@ This outputs:
 val x : MyList = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
 ```
 
-If the transformer function passed to `fsi.AddPrintTransformer` returns `null` then the print transformer is ignored.
+If the transformer function passed to `fsi.AddPrintTransformer` returns `null`, then the print transformer is ignored.
 This can be used to filter any input value by starting with type `obj`.  For example:
 
 ```fsharp

--- a/docs/fsharp/language-reference/fsharp-interactive-options.md
+++ b/docs/fsharp/language-reference/fsharp-interactive-options.md
@@ -64,7 +64,7 @@ report values.
 
 1. All features of `%A` plain text formatting are supported, and some are additionally customizable.
 
-2. Printing is colorized if colours are aupported by the output console.
+2. Printing is colorized if colors are supported by the output console.
 
 3. A limit is placed on the length of strings shown, unless you explicitly evaluate that string.
 

--- a/docs/fsharp/language-reference/index.md
+++ b/docs/fsharp/language-reference/index.md
@@ -45,6 +45,7 @@ The following table shows reference topics available that describe language conc
 |[Signatures](signature-files.md)|Describes signatures and signature files. A signature file contains information about the public signatures of a set of F# program elements, such as types, namespaces, and modules. It can be used to specify the accessibility of these program elements.|
 |[XML Documentation](xml-documentation.md)|Describes support for generating documentation files for XML doc comments, also known as triple slash comments. You can produce documentation from code comments in F# just as in other .NET languages.|
 |[Verbose Syntax](verbose-syntax.md)|Describes the syntax for F# constructs when lightweight syntax is not enabled. Verbose syntax is indicated by the `#light "off"` directive at the top of the code file.|
+|[Plain Text Formatting](plaintext.md)|Learn how to use sprintf and other plain text formatting in F# applications and scripts.|
 
 ## F# Types
 

--- a/docs/fsharp/language-reference/index.md
+++ b/docs/fsharp/language-reference/index.md
@@ -45,7 +45,7 @@ The following table shows reference topics available that describe language conc
 |[Signatures](signature-files.md)|Describes signatures and signature files. A signature file contains information about the public signatures of a set of F# program elements, such as types, namespaces, and modules. It can be used to specify the accessibility of these program elements.|
 |[XML Documentation](xml-documentation.md)|Describes support for generating documentation files for XML doc comments, also known as triple slash comments. You can produce documentation from code comments in F# just as in other .NET languages.|
 |[Verbose Syntax](verbose-syntax.md)|Describes the syntax for F# constructs when lightweight syntax is not enabled. Verbose syntax is indicated by the `#light "off"` directive at the top of the code file.|
-|[Plain Text Formatting](plaintext.md)|Learn how to use sprintf and other plain text formatting in F# applications and scripts.|
+|[Plain Text Formatting](plaintext-formatting.md)|Learn how to use sprintf and other plain text formatting in F# applications and scripts.|
 
 ## F# Types
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -84,7 +84,7 @@ where the type is interpreted as follows:
 | `%O` | any value  |   Formatted by boxing the object and valling its `System.Object.ToString()` method |
 | `%A` | any value  |   Formatted using [structured plain text formatting](plaintext-formatting.md) with the default layout settings |
 | `%a` | any value  |   Requires two arguments - a formatting function accepting a context parameter and the value, and the particular value to print |
-| `%t` | any value  |   Requires one argument, a formatting function accepting a context parameter which either outputs or returns the appropriate text |
+| `%t` | any value  |   Requires one argument, a formatting function accepting a context parameter that either outputs or returns the appropriate text |
 
 Basic integer types are `byte` (`System.Byte`), `sbyte` (`System.SByte`), `int16` (`System.Int16`), `uint16` (`System.UInt16`), `int32` (`System.Int32`), `uint32` (`System.UInt32`), `int64` (`System.Int64`), `uint64` (`System.UInt64`), `nativeint`  (`System.IntPtr`)and `unativeint`  (`System.UIntPtr`).
  Basic floating point types are `float` (`System.Double`) and `float32` (`System.Single`).

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -110,7 +110,7 @@ when they affect the results of `%O` and `%A` formatting. For more information, 
 
 The `%A` format specifier is used to format values in a human-readable way, and can also be useful for reporting diagnostic information.
 
-### `%A` formatting of primitive values
+### Primitive values
 
 When formatting plain text using the `%A` specifier, F# numeric values are formatted
 with their suffix and invariant culture. Floating point values are formatted using

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -63,7 +63,7 @@ Technically speaking, when using `printf` and other related functions, a special
 checks the string literal passed as the format string, ensuring the subsequent arguments applied are of
 the correct type to match the format specifiers used.
 
-## Format Specifiers for `printf`
+## Format specifiers for `printf`
 
 Format specifications for `printf` formats are strings with `%` markers indicating format. Format placeholders consist of `%[flags][width][.precision][type]`
 where the type is interpreted as follows:

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -1,0 +1,339 @@
+---
+title: "Tutorial: Plain Text Formatting"
+description: Learn how to use structured formatted plain text in F# applications and scripts.
+ms.date: 22/07/2020
+---
+
+# Plain Text Formatting
+
+F# allows values to be formatted as structured plain text in a compositional way.
+As a simple example, consider the following and note how the otuput has been formatted as a matrix-like display of tuples.
+
+```console
+dotnet fsi
+
+> let data = [ for i in 1 .. 3 -> [ for j in 1 .. 3 -> (i, j) ] ];;
+
+val data : (int * int) list list =
+  [[(1, 1); (1, 2); (1, 3); (1, 4); (1, 5)];
+   [(2, 1); (2, 2); (2, 3); (2, 4); (2, 5)];
+   [(3, 1); (3, 2); (3, 3); (3, 4); (3, 5)];
+   [(4, 1); (4, 2); (4, 3); (4, 4); (4, 5)];
+   [(5, 1); (5, 2); (5, 3); (5, 4); (5, 5)]]
+
+>  printfn "%A" data;;
+[[(1, 1); (1, 2); (1, 3); (1, 4); (1, 5)];
+ [(2, 1); (2, 2); (2, 3); (2, 4); (2, 5)];
+ [(3, 1); (3, 2); (3, 3); (3, 4); (3, 5)];
+ [(4, 1); (4, 2); (4, 3); (4, 4); (4, 5)];
+ [(5, 1); (5, 2); (5, 3); (5, 4); (5, 5)]]
+```
+
+Plain text formatting is activated when using the `%A` format in printf formatting strings. This has limited customizability.
+It is also used when formatting the output of values in F# interactive, when the output includes extra information and is additionally customizable.
+Plain text formatting is observable through the following:
+
+1. The default results of `x.ToString()` on F# union and record values, when `sprintf "%+A"` is used.
+
+2. The default debug text of F# union and record values (and structured values containing these), when `sprintf "%+A"` is also used.
+
+## `%A` formatting
+
+The `%A` format specifier is used to format values in a human-readable way suitable for interpretation by the F#
+programmer.  It is not suitable for formatting results for other users and should not generally be used to format
+results in a user interface or web programming service.  It is often useful for reporting diagnostic information.
+
+### `%A` formatting of primitive values
+
+When formatting plain text using the `%A` specifier, F# numeric values are formatted
+with their suffix and invariant culture. Floating point values are formatted using
+10 places of floating point precision. For example,
+
+```fsharp
+printfn "%A" (1L, 3n, 5u, 7, 4.03f, 5.000000001, 5.0000000001)
+```
+
+produces
+
+```console
+(1L, 3n, 5u, 7, 4.03000021f, 5.000000001, 5.0)
+```
+
+When using the `%A` specifier, strings are formatted using quotes. Escape codes are not added and instead the raw characters are printed. For example,
+
+```fsharp
+printfn "%A" ("abc", "a\tb\nc\"d")
+
+```
+
+produces
+
+```console
+("abc", "a      b
+c"d")
+```
+
+### `%A` formatting of .NET values
+
+When formatting plain text using the `%A` specifier, non-F# .NET objects are formatted by using `x.ToString()` using the default settings of .NET given by
+`System.Globalization.CultureInfo.CurrentCulture` and `System.Globalization.CultureInfo.CurrentUICulture`.  For example,
+
+```fsharp
+open System.Globalization
+
+let date = System.DateTime(1999, 12, 31)
+
+CultureInfo.CurrentCulture <- CultureInfo.GetCultureInfo("de-DE")
+printfn "Culture 1: %A" date
+
+CultureInfo.CurrentCulture <- CultureInfo.GetCultureInfo("en-US")
+printfn "Culture 2: %A" date
+```
+
+produces
+
+```console
+Culture 1: 31.12.1999 00:00:00
+Culture 2: 12/31/1999 12:00:00 AM
+```
+
+### `%A` formatting of structured values
+
+When formatting plain text using the `%A` specifier, block indentation is used for F# lists and tuples. The is shown in the example above.
+The structure of arrays is also used, including multi-dimensional arrays.  Single-dimensional arrays are shown with `[| ... |]` syntax. For example,
+
+```fsharp
+printfn "%A" [| for i in 1 .. 20 -> (i, i*i) |]
+```
+
+produces
+
+```console
+[|(1, 1); (2, 4); (3, 9); (4, 16); (5, 25); (6, 36); (7, 49); (8, 64); (9, 81);
+  (10, 100); (11, 121); (12, 144); (13, 169); (14, 196); (15, 225); (16, 256);
+  (17, 289); (18, 324); (19, 361); (20, 400)|]
+```
+
+A default print width of 80 is used.  This can be customized by using a print width in the format specifier. For example,
+
+```fsharp
+printfn "%10A" [| for i in 1 .. 5 -> (i, i*i) |]
+
+printfn "%20A" [| for i in 1 .. 5 -> (i, i*i) |]
+
+printfn "%50A" [| for i in 1 .. 5 -> (i, i*i) |]
+```
+
+produces
+
+```console
+[|(1, 1);
+  (2, 4);
+  (3, 9);
+  (4, 16);
+  (5, 25)|]
+[|(1, 1); (2, 4);
+  (3, 9); (4, 16);
+  (5, 25)|]
+[|(1, 1); (2, 4); (3, 9); (4, 16); (5, 25)|]
+```
+
+A depth limit of 4 is used for sequence (IEnumerable) values, which are shown as `seq { ...}`, and a depth limit of 100 is used for list and array values.
+For example,
+
+```fsharp
+printfn "%A" (seq { for i in 1 .. 10 -> (i, i*i) })
+```
+
+produces
+
+```console
+seq [(1, 1); (2, 4); (3, 9); (4, 16); ...]
+```
+
+Block indentation is also used for the the structure of public record and union values. For example,
+
+```fsharp
+type R = { X : int list; Y : string list }
+
+printfn "%A" { X =  [ 1;2;3 ]; Y = ["one"; "two"; "three"] }
+```
+
+produces
+
+```console
+{ X = [1; 2; 3]
+  Y = ["one"; "two"; "three"] }
+```
+
+If `%+A` is used then the private structure of records and unions
+is also revealed by using reflection. For example
+
+```fsharp
+type internal R =
+    { X : int list; Y : string list }
+    override x.ToString() = "R"
+
+let internal data = { X = [ 1;2;3 ]; Y = ["one"; "two"; "three"] }
+
+printfn "external view:\n%A" data
+
+printfn "internal view:\n%+A" data
+
+```
+
+produces
+
+```console
+external view:
+R
+
+internal view:
+{ X = [1; 2; 3]
+  Y = ["one"; "two"; "three"] }
+```
+
+### `%A` formatting of large, cyclic or deeply nested values
+
+Large structured values are formatted to a maximum overall object node count of 10000.
+Deeply nested values are formatted to a depth of 100.  In both cases `...` is used
+to elide some of the output.  For example,
+
+```fsharp
+type Tree = Node of Tree * Tree | Tip
+
+let rec make n = if n = 0 then Tip else Node(Tip, make (n-1))
+
+printfn "%A" (make 1000)
+```
+
+produces a large output with some parts elided
+
+```console
+Node(Tip, Node(Tip, ....Node (..., ...)...))
+```
+
+Cycles are detected in the object graphs and `...` is used at places where cycles are detected. For example
+
+```fsharp
+type R = { mutable Links: R list }
+let r = { Links = [] }
+r.Links <- [r]
+printfn "%A" r
+```
+
+produces
+
+```console
+{ Links = [...] }
+```
+
+### `%A` formatting of lazy, null and function values
+
+Lazy values are printed as `Value is not created` or equivalent text when the value has not yet been evaluated.
+
+Null values are printed as `null` unless the static type of the value is determined to be a union type where `null` is
+a permitted represenation.
+
+F# function values are printed as their internally generated closure name, for example `<fun:it@43-7>`.
+
+### Customizing plain text formatting with `StructuredFormatDisplayAttribute`
+
+When using the `%A` specifier, the presence of `StructuredFormatDisplayAttribute` on type declarations is respected.  This can
+be used to specify surrogate text and property to display a value. For example:
+
+```fsharp
+[<StructuredFormatDisplay("Counts({Clicks})")>]
+type Counts = { Clicks:int list}
+
+printfn "%20A" {Clicks=[0..20]}
+```
+
+produces
+
+```console
+Counts([0; 1; 2; 3;
+        4; 5; 6; 7;
+        8; 9; 10; 11;
+        12; 13; 14;
+        15; 16; 17;
+        18; 19; 20])
+```
+
+### Customizing plain text formatting by overriding `ToString`
+
+The default implementation of `x.ToString()` is observable in F# programming. Often the default results
+are not suitable for use in either programmer-facing information display nor user output, and as a result it
+is common to override the default implementation.  
+
+By default F# record and union types override the implementation of `x.ToString()` with an implementation that
+uses `sprintf "%+A"`.  For example,
+
+```fsharp
+type Counts = { Clicks:int list }
+
+printfn "%s" ({Clicks=[0..10]}.ToString())
+```
+
+produces
+
+```console
+{ Clicks = [0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10] }
+```
+
+For class types, no default implementation of `ToString()` is provided and the .NET default is used, which reports the
+name of the type. For example,
+
+```fsharp
+type MyClassType(clicks: int list) =
+   member x.Clicks = clicks
+
+printfn "The default ToString gives --> %s" (MyClassType([1..5]).ToString())
+```
+
+produces
+
+```console
+The default ToString gives --> MyClassType
+```
+
+Sometimes `sprintf "%A"` plus a `StructuredFormatDisplay` attribute makes for a suitable implementation
+of `ToString`, e.g.
+
+```fsharp
+[<StructuredFormatDisplay("Counts({Clicks})")>]
+type MyClassType(clicks: int list) =
+   member x.Clicks = clicks
+   override x.ToString() = sprintf "%A" x
+
+printfn "ToString now gives --> %s" (MyClassType([1..5]).ToString())
+```
+
+produces
+
+```console
+ToString now gives --> Counts([1; 2; 3; 4; 5])
+```
+
+## F# Interactive Structured Printing
+
+F# Interactive (`dotnet fsi`) uses an extended version of structured plain text formatting to
+report values and allows additional customizability. See [F# Interactive](fsharp-interactive-options.md)
+for details.
+
+## Customizing debug displays using DebuggerDisplayAttribute, DebuggerTypeProxyAttribute and other attributes
+
+Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`
+and these affect the structured display of objects in debugger inspection windows.
+The F# compiler automatically generated these attributes for discriminated union and record types, but
+not class, interface or struct types.
+
+These attributed are ignored in F# plain text formatting, but it can be useful to implement
+these methods to improve displays when debugging F# types.
+
+## See also
+
+- [Strings](strings.md)
+- [Records](records.md)
+- [Discriminated Unions](discriminated-unions.md)
+- [F# Interactive](fsharp-interactive-options.md)

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -258,7 +258,7 @@ Counts([0; 1; 2; 3;
         18; 19; 20])
 ```
 
-### Customizing plain text formatting by overriding `ToString`
+### Customize plain text formatting by overriding `ToString`
 
 The default implementation of `x.ToString()` is observable in F# programming. Often the default results
 are not suitable for use in either programmer-facing information display nor user output, and as a result it

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -39,9 +39,7 @@ Plain text formatting is observable through the following:
 
 ## `%A` formatting
 
-The `%A` format specifier is used to format values in a human-readable way suitable for interpretation by the F#
-programmer.  It is not suitable for formatting results for other users and should not generally be used to format
-results in a user interface or web programming service.  It is often useful for reporting diagnostic information.
+The `%A` format specifier is used to format values in a human-readable way, and can also be useful for reporting diagnostic information.
 
 ### `%A` formatting of primitive values
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -400,8 +400,8 @@ Adding an override for `ToString` can give better formatting.
 
 ```fsharp
 type MyClassType(clicks: int list) =
-   member x.Clicks = clicks
-   override x.ToString() = sprintf "MyClassType(%0A)" clicks
+   member _.Clicks = clicks
+   override _.ToString() = sprintf "MyClassType(%0A)" clicks
 
 let data = [ MyClassType([1..5]); MyClassType([1..5]) ]
 printfn "Now structured print gives this:\n%A" data

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -260,7 +260,7 @@ is also revealed by using reflection. For example
 ```fsharp
 type internal R =
     { X : int list; Y : string list }
-    override x.ToString() = "R"
+    override _.ToString() = "R"
 
 let internal data = { X = [ 1;2;3 ]; Y = ["one"; "two"; "three"] }
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -422,7 +422,7 @@ for details.
 Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`
 and these affect the structured display of objects in debugger inspection windows.
 The F# compiler automatically generated these attributes for discriminated union and record types, but
-not class, interface or struct types.
+not class, interface, or struct types.
 
 These attributes are ignored in F# plain text formatting, but it can be useful to implement
 these methods to improve displays when debugging F# types.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -96,14 +96,14 @@ Valid flags are:
 
 | Flag   | Effect        | Remarks                      |
 |:-------------------|:---------------|:-----------------------------|
-| `0`  | add zeros instead of spaces to make up the required width |    |
-| `-` |  left justify the result within the width specified  |   |
-| `+`  | add a `+` character if the number is positive (to match a `-` sign for negatives) |   |
-| a space character | add an extra space if the number is positive (to match a '-' sign for negatives) |
+| `0`  | Add zeros instead of spaces to make up the required width |    |
+| `-` |  Left justify the result within the specified width |   |
+| `+`  | Add a `+` character if the number is positive (to match a `-` sign for negatives) |   |
+| space character | Add an extra space if the number is positive (to match a '-' sign for negatives) |
 
 The printf `#` flag is invalid and a compile-time error will be reported if it is used.
 
-Values are formatted using invariant culture and culture settings are irrelevant to `printf` formatting except
+Values are formatted using invariant culture. Culture settings are irrelevant to `printf` formatting except
 when they affect the results of `%O` and `%A` formatting. For more information, see [structured plain text formatting](plaintext-formatting.md).
 
 ## `%A` formatting
@@ -166,7 +166,7 @@ Culture 2: 12/31/1999 12:00:00 AM
 
 ### `%A` formatting of structured values
 
-When formatting plain text using the `%A` specifier, block indentation is used for F# lists and tuples. The is shown in the example above.
+When formatting plain text using the `%A` specifier, block indentation is used for F# lists and tuples. The is shown in the previous example.
 The structure of arrays is also used, including multi-dimensional arrays.  Single-dimensional arrays are shown with `[| ... |]` syntax. For example,
 
 ```fsharp
@@ -181,7 +181,7 @@ produces
   (17, 289); (18, 324); (19, 361); (20, 400)|]
 ```
 
-A default print width of 80 is used.  This can be customized by using a print width in the format specifier. For example,
+The default print width is 80.  This width can be customized by using a print width in the format specifier. For example,
 
 ```fsharp
 printfn "%10A" [| for i in 1 .. 5 -> (i, i*i) |]
@@ -226,7 +226,7 @@ def"; "abc
 def"|]
 ```
 
-A depth limit of 4 is used for sequence (IEnumerable) values, which are shown as `seq { ...}`, and a depth limit of 100 is used for list and array values.
+A depth limit of 4 is used for sequence (`IEnumerable`) values, which are shown as `seq { ...}`. A depth limit of 100 is used for list and array values.
 For example,
 
 ```fsharp
@@ -254,7 +254,7 @@ produces
   Y = ["one"; "two"; "three"] }
 ```
 
-If `%+A` is used then the private structure of records and unions
+If `%+A` is used, then the private structure of records and unions
 is also revealed by using reflection. For example
 
 ```fsharp
@@ -295,7 +295,7 @@ let rec make n = if n = 0 then Tip else Node(Tip, make (n-1))
 printfn "%A" (make 1000)
 ```
 
-produces a large output with some parts elided
+produces a large output with some parts elided:
 
 ```console
 Node(Tip, Node(Tip, ....Node (..., ...)...))
@@ -323,7 +323,7 @@ Lazy values are printed as `Value is not created` or equivalent text when the va
 Null values are printed as `null` unless the static type of the value is determined to be a union type where `null` is
 a permitted represenation.
 
-F# function values are printed as their internally generated closure name, for example `<fun:it@43-7>`.
+F# function values are printed as their internally generated closure name, for example, `<fun:it@43-7>`.
 
 ### Customize plain text formatting with `StructuredFormatDisplayAttribute`
 
@@ -350,11 +350,11 @@ Counts([0; 1; 2; 3;
 
 ### Customize plain text formatting by overriding `ToString`
 
-The default implementation of `x.ToString()` is observable in F# programming. Often the default results
-are not suitable for use in either programmer-facing information display nor user output, and as a result it
+The default implementation of `x.ToString()` is observable in F# programming. Often, the default results
+aren't suitable for use in either programmer-facing information display or user output, and as a result it
 is common to override the default implementation.  
 
-By default F# record and union types override the implementation of `x.ToString()` with an implementation that
+By default, F# record and union types override the implementation of `x.ToString()` with an implementation that
 uses `sprintf "%+A"`.  For example,
 
 ```fsharp
@@ -411,10 +411,10 @@ Now ToString gives:
 [MyClassType([1; 2; 3; 4; 5]); MyClassType([1; 2; 3; 4; 5])]
 ```
 
-## F# Interactive Structured Printing
+## F# Interactive structured printing
 
 F# Interactive (`dotnet fsi`) uses an extended version of structured plain text formatting to
-report values and allows additional customizability. See [F# Interactive](fsharp-interactive-options.md)
+report values and allows additional customizability. For more information, see [F# Interactive](fsharp-interactive-options.md).
 
 ## Customize debug displays
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -29,7 +29,7 @@ val data : (int * int) list list =
  [(5, 1); (5, 2); (5, 3); (5, 4); (5, 5)]]
 ```
 
-Plain text formatting is activated when using the `%A` format in printf formatting strings. This has limited customizability.
+Plain text formatting is activated when you use the `%A` format in `printf` formatting strings.
 Plain text formatting is also used when formatting the output of values in F# interactive, when the output includes extra information and is additionally customizable.
 Plain text formatting is observable through the following:
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -424,7 +424,7 @@ and these affect the structured display of objects in debugger inspection window
 The F# compiler automatically generated these attributes for discriminated union and record types, but
 not class, interface or struct types.
 
-These attributed are ignored in F# plain text formatting, but it can be useful to implement
+These attributes are ignored in F# plain text formatting, but it can be useful to implement
 these methods to improve displays when debugging F# types.
 
 ## See also

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -1,5 +1,5 @@
 ---
-title: "Tutorial: Plain Text Formatting"
+title: "Plain Text Formatting"
 description: Learn how to use structured formatted plain text in F# applications and scripts.
 ms.date: 07/22/2020
 ---

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -292,7 +292,11 @@ type Tree =
     | Tip
     | Node of Tree * Tree
 
-let rec make n = if n = 0 then Tip else Node(Tip, make (n-1))
+let rec make n =
+    if n = 0 then
+        Tip
+    else
+        Node(Tip, make (n-1))
 
 printfn "%A" (make 1000)
 ```

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -380,7 +380,7 @@ name of the type. For example,
 
 ```fsharp
 type MyClassType(clicks: int list) =
-   member x.Clicks = clicks
+   member _.Clicks = clicks
 
 let data = [ MyClassType([1..5]); MyClassType([1..5]) ]
 printfn "Default structured print gives this:\n%A" data

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -235,7 +235,7 @@ a permitted represenation.
 
 F# function values are printed as their internally generated closure name, for example `<fun:it@43-7>`.
 
-### Customizing plain text formatting with `StructuredFormatDisplayAttribute`
+### Customize plain text formatting with `StructuredFormatDisplayAttribute`
 
 When using the `%A` specifier, the presence of `StructuredFormatDisplayAttribute` on type declarations is respected.  This can
 be used to specify surrogate text and property to display a value. For example:

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -164,7 +164,7 @@ Culture 1: 31.12.1999 00:00:00
 Culture 2: 12/31/1999 12:00:00 AM
 ```
 
-### `%A` formatting of structured values
+### Structured values
 
 When formatting plain text using the `%A` specifier, block indentation is used for F# lists and tuples. The is shown in the previous example.
 The structure of arrays is also used, including multi-dimensional arrays.  Single-dimensional arrays are shown with `[| ... |]` syntax. For example,

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -396,7 +396,7 @@ Default ToString gives:
 [MyClassType; MyClassType]
 ```
 
-Adding an override for `ToString()` can give better formatting.
+Adding an override for `ToString` can give better formatting.
 
 ```fsharp
 type MyClassType(clicks: int list) =

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -22,7 +22,7 @@ Hello world, 2 + 2 is 4
 ```
 
 F# also allows structured values to be formatted as plain text.
-For example, consider the following and note how the output has been formatted as a matrix-like display of tuples.
+For example, consider the following example that formats the output as a matrix-like display of tuples.
 
 ```console
 dotnet fsi

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -322,7 +322,7 @@ produces
 { Links = [...] }
 ```
 
-### `%A` formatting of lazy, null, and function values
+### Lazy, null, and function values
 
 Lazy values are printed as `Value is not created` or equivalent text when the value has not yet been evaluated.
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -331,7 +331,7 @@ a permitted represenation.
 
 F# function values are printed as their internally generated closure name, for example, `<fun:it@43-7>`.
 
-### Customize plain text formatting with `StructuredFormatDisplayAttribute`
+### Customize plain text formatting with `StructuredFormatDisplay`
 
 When using the `%A` specifier, the presence of `StructuredFormatDisplayAttribute` on type declarations is respected.  This can
 be used to specify surrogate text and property to display a value. For example:

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -319,7 +319,7 @@ F# Interactive (`dotnet fsi`) uses an extended version of structured plain text 
 report values and allows additional customizability. See [F# Interactive](fsharp-interactive-options.md)
 for details.
 
-## Customizing debug displays using DebuggerDisplayAttribute, DebuggerTypeProxyAttribute and other attributes
+## Customize debug displays using `DebuggerDisplayAttribute`, `DebuggerTypeProxyAttribute`, and other attributes
 
 Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`
 and these affect the structured display of objects in debugger inspection windows.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -37,7 +37,7 @@ dotnet fsi
 ```
 
 Structured plain text formatting is activated when you use the `%A` format in `printf` formatting strings.
-and also when formatting the output of values in F# interactive, where the output includes extra information and is additionally customizable.
+It's also activated when formatting the output of values in F# interactive, where the output includes extra information and is additionally customizable.
 Plain text formatting is also observable through any calls to `x.ToString()` on F# union and record values, including those
 that occur implicitly in debugging, logging and other tooling.
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -4,7 +4,7 @@ description: Learn how to use printf and other plain text formatting in F# appli
 ms.date: 07/22/2020
 ---
 
-# Plain Text Formatting
+# Plain text formatting
 
 F# supports type-checked formatting of plain text using `printf`, `printfn`, `sprintf` and related functions.
 For example,

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -415,7 +415,6 @@ Now ToString gives:
 
 F# Interactive (`dotnet fsi`) uses an extended version of structured plain text formatting to
 report values and allows additional customizability. See [F# Interactive](fsharp-interactive-options.md)
-for details.
 
 ## Customize debug displays using `DebuggerDisplayAttribute`, `DebuggerTypeProxyAttribute`, and other attributes
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -360,7 +360,7 @@ The default implementation of `ToString` is observable in F# programming. Often,
 aren't suitable for use in either programmer-facing information display or user output, and as a result it
 is common to override the default implementation.  
 
-By default, F# record and union types override the implementation of `x.ToString()` with an implementation that
+By default, F# record and union types override the implementation of `ToString` with an implementation that
 uses `sprintf "%+A"`.  For example,
 
 ```fsharp

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -104,7 +104,7 @@ Valid flags are:
 The printf `#` flag is invalid and a compile-time error will be reported if it is used.
 
 Values are formatted using invariant culture and culture settings are irrelevant to `printf` formatting except
-when they affect the results of `%O` and `%A` formatting, see [structured plain text formatting](plaintext-formatting.md) for more details.
+when they affect the results of `%O` and `%A` formatting. For more information, see [structured plain text formatting](plaintext-formatting.md).
 
 ## `%A` formatting
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -59,7 +59,7 @@ gives the output
 stdin(3,25): error FS0001: The type 'string' does not match the type 'int'
 ```
 
-Technically speaking, when using `printf` and other related functions a special rule in the F# compiler
+Technically speaking, when using `printf` and other related functions, a special rule in the F# compiler
 checks the string literal passed as the format string, ensuring the subsequent arguments applied are of
 the correct type to match the format specifiers used.
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -7,7 +7,7 @@ ms.date: 07/22/2020
 # Plain Text Formatting
 
 F# allows values to be formatted as structured plain text in a compositional way.
-As a simple example, consider the following and note how the otuput has been formatted as a matrix-like display of tuples.
+For example, consider the following and note how the output has been formatted as a matrix-like display of tuples.
 
 ```console
 dotnet fsi

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -288,7 +288,9 @@ Deeply nested values are formatted to a depth of 100.  In both cases `...` is us
 to elide some of the output.  For example,
 
 ```fsharp
-type Tree = Node of Tree * Tree | Tip
+type Tree =
+    | Tip
+    | Node of Tree * Tree
 
 let rec make n = if n = 0 then Tip else Node(Tip, make (n-1))
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -30,7 +30,7 @@ val data : (int * int) list list =
 ```
 
 Plain text formatting is activated when using the `%A` format in printf formatting strings. This has limited customizability.
-It is also used when formatting the output of values in F# interactive, when the output includes extra information and is additionally customizable.
+Plain text formatting is also used when formatting the output of values in F# interactive, when the output includes extra information and is additionally customizable.
 Plain text formatting is observable through the following:
 
 1. The default results of `x.ToString()` on F# union and record values, when `sprintf "%+A"` is used.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -140,7 +140,7 @@ produces
 c"d")
 ```
 
-### `%A` formatting of .NET values
+### .NET values
 
 When formatting plain text using the `%A` specifier, non-F# .NET objects are formatted by using `x.ToString()` using the default settings of .NET given by
 `System.Globalization.CultureInfo.CurrentCulture` and `System.Globalization.CultureInfo.CurrentUICulture`.  For example,

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -86,7 +86,7 @@ where the type is interpreted as follows:
 | `%a` | any value  |   Requires two arguments - a formatting function accepting a context parameter and the value, and the particular value to print |
 | `%t` | any value  |   Requires one argument, a formatting function accepting a context parameter that either outputs or returns the appropriate text |
 
-Basic integer types are `byte` (`System.Byte`), `sbyte` (`System.SByte`), `int16` (`System.Int16`), `uint16` (`System.UInt16`), `int32` (`System.Int32`), `uint32` (`System.UInt32`), `int64` (`System.Int64`), `uint64` (`System.UInt64`), `nativeint`  (`System.IntPtr`)and `unativeint`  (`System.UIntPtr`).
+Basic integer types are `byte` (`System.Byte`), `sbyte` (`System.SByte`), `int16` (`System.Int16`), `uint16` (`System.UInt16`), `int32` (`System.Int32`), `uint32` (`System.UInt32`), `int64` (`System.Int64`), `uint64` (`System.UInt64`), `nativeint`  (`System.IntPtr`), and `unativeint`  (`System.UIntPtr`).
  Basic floating point types are `float` (`System.Double`) and `float32` (`System.Single`).
 
 The optional width is an integer indicating the minimal width of the result. For instance, `%6d` prints an integer, prefixing it with spaces

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -333,7 +333,7 @@ F# function values are printed as their internally generated closure name, for e
 
 ### Customize plain text formatting with `StructuredFormatDisplay`
 
-When using the `%A` specifier, the presence of `StructuredFormatDisplayAttribute` on type declarations is respected.  This can
+When using the `%A` specifier, the presence of the `StructuredFormatDisplay` attribute on type declarations is respected.  This can
 be used to specify surrogate text and property to display a value. For example:
 
 ```fsharp

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -226,7 +226,7 @@ produces
 { Links = [...] }
 ```
 
-### `%A` formatting of lazy, null and function values
+### `%A` formatting of lazy, null, and function values
 
 Lazy values are printed as `Value is not created` or equivalent text when the value has not yet been evaluated.
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -39,7 +39,7 @@ dotnet fsi
 Structured plain text formatting is activated when you use the `%A` format in `printf` formatting strings.
 It's also activated when formatting the output of values in F# interactive, where the output includes extra information and is additionally customizable.
 Plain text formatting is also observable through any calls to `x.ToString()` on F# union and record values, including those
-that occur implicitly in debugging, logging and other tooling.
+that occur implicitly in debugging, logging, and other tooling.
 
 ## Checking of `printf`-format strings
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -418,7 +418,7 @@ report values and allows additional customizability. See [F# Interactive](fsharp
 
 ## Customize debug displays
 
-Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`
+Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`,
 and these affect the structured display of objects in debugger inspection windows.
 The F# compiler automatically generated these attributes for discriminated union and record types, but
 not class, interface, or struct types.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -424,7 +424,7 @@ report values and allows additional customizability. For more information, see [
 
 ## Customize debug displays
 
-Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`,
+Debuggers for .NET respect the use of attributes such as `DebuggerDisplay` and `DebuggerTypeProxy`,
 and these affect the structured display of objects in debugger inspection windows.
 The F# compiler automatically generated these attributes for discriminated union and record types, but
 not class, interface, or struct types.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -416,7 +416,7 @@ Now ToString gives:
 F# Interactive (`dotnet fsi`) uses an extended version of structured plain text formatting to
 report values and allows additional customizability. See [F# Interactive](fsharp-interactive-options.md)
 
-## Customize debug displays using `DebuggerDisplayAttribute`, `DebuggerTypeProxyAttribute`, and other attributes
+## Customize debug displays
 
 Debuggers for .NET respect the use of attributes such as `DebuggerDisplayAttribute` and `DebuggerTypeProxyAttribute`
 and these affect the structured display of objects in debugger inspection windows.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -356,7 +356,7 @@ Counts([0; 1; 2; 3;
 
 ### Customize plain text formatting by overriding `ToString`
 
-The default implementation of `x.ToString()` is observable in F# programming. Often, the default results
+The default implementation of `ToString` is observable in F# programming. Often, the default results
 aren't suitable for use in either programmer-facing information display or user output, and as a result it
 is common to override the default implementation.  
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -281,7 +281,7 @@ internal view:
   Y = ["one"; "two"; "three"] }
 ```
 
-### `%A` formatting of large, cyclic, or deeply nested values
+### Large, cyclic, or deeply nested values
 
 Large structured values are formatted to a maximum overall object node count of 10000.
 Deeply nested values are formatted to a depth of 100.  In both cases `...` is used

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -36,7 +36,7 @@ dotnet fsi
  [(5, 1); (5, 2); (5, 3); (5, 4); (5, 5)]]
 ```
 
-Structured plain text formatting is activated when you use the `%A` format in [`printf` formatting strings](printf.md)
+Structured plain text formatting is activated when you use the `%A` format in `printf` formatting strings.
 and also when formatting the output of values in F# interactive, where the output includes extra information and is additionally customizable.
 Plain text formatting is also observable through any calls to `x.ToString()` on F# union and record values, including those
 that occur implicitly in debugging, logging and other tooling.

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -191,7 +191,7 @@ internal view:
   Y = ["one"; "two"; "three"] }
 ```
 
-### `%A` formatting of large, cyclic or deeply nested values
+### `%A` formatting of large, cyclic, or deeply nested values
 
 Large structured values are formatted to a maximum overall object node count of 10000.
 Deeply nested values are formatted to a depth of 100.  In both cases `...` is used

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -99,7 +99,7 @@ Valid flags are:
 | `0`  | add zeros instead of spaces to make up the required width |    |
 | `-` |  left justify the result within the width specified  |   |
 | `+`  | add a `+` character if the number is positive (to match a `-` sign for negatives) |   |
-| a space character | add an extra space if the number is positive (to match a '-' sign for negatives) | 
+| a space character | add an extra space if the number is positive (to match a '-' sign for negatives) |
 
 The printf `#` flag is invalid and a compile-time error will be reported if it is used.
 

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Plain Text Formatting"
 description: Learn how to use structured formatted plain text in F# applications and scripts.
-ms.date: 22/07/2020
+ms.date: 07/22/2020
 ---
 
 # Plain Text Formatting

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -6,7 +6,7 @@ ms.date: 07/22/2020
 
 # Plain text formatting
 
-F# supports type-checked formatting of plain text using `printf`, `printfn`, `sprintf` and related functions.
+F# supports type-checked formatting of plain text using `printf`, `printfn`, `sprintf`, and related functions.
 For example,
 
 ```console

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -65,7 +65,7 @@ the correct type to match the format specifiers used.
 
 ## Format specifiers for `printf`
 
-Format specifications for `printf` formats are strings with `%` markers indicating format. Format placeholders consist of `%[flags][width][.precision][type]`
+Format specifications for `printf` formats are strings with `%` markers that indicate format. Format placeholders consist of `%[flags][width][.precision][type]`
 where the type is interpreted as follows:
 
 | Format specifier   | Type(s)        | Remarks                      |

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -375,7 +375,7 @@ produces
 { Clicks = [0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10] }
 ```
 
-For class types, no default implementation of `ToString()` is provided and the .NET default is used, which reports the
+For class types, no default implementation of `ToString` is provided and the .NET default is used, which reports the
 name of the type. For example,
 
 ```fsharp

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -34,8 +34,6 @@ Plain text formatting is also used when formatting the output of values in F# in
 Plain text formatting is also observable through any calls to `x.ToString()` on F# union and record values, including those
 that occur implicitly in debugging, logging and other tooling.
 
-2. The default debug text of F# union and record values (and structured values containing these), when `sprintf "%+A"` is also used.
-
 ## `%A` formatting
 
 The `%A` format specifier is used to format values in a human-readable way, and can also be useful for reporting diagnostic information.
@@ -321,6 +319,7 @@ Default ToString gives:
 ```
 
 Adding an override for `ToString()` can give better formatting.
+
 ```fsharp
 type MyClassType(clicks: int list) =
    member x.Clicks = clicks

--- a/docs/fsharp/toc.yml
+++ b/docs/fsharp/toc.yml
@@ -226,6 +226,8 @@
     href: language-reference/signature-files.md
   - name: Units of Measure
     href: language-reference/units-of-measure.md
+  - name: Plain Text Formatting
+    href: language-reference/plaintext-formatting.md
   - name: XML Documentation
     href: language-reference/xml-documentation.md
   - name: Lazy Expressions


### PR DESCRIPTION
## Summary

Adds information to the F# language guide on structured plaintext printing in F# and the mechanisms available to customize it

cc @cartermp 

(@cartermp  - separately, we should add a page on `printf` in general)