### PR TITLE
Update dotnet build docs

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -17,7 +17,7 @@ ms.date: 02/14/2020
 dotnet build [<PROJECT>|<SOLUTION>] [-c|--configuration <CONFIGURATION>]
     [-f|--framework <FRAMEWORK>] [--force] [--interactive] [--no-dependencies]
     [--no-incremental] [--no-restore] [--nologo] [-o|--output <OUTPUT_DIRECTORY>]
-    [-r|--runtime <RUNTIME_IDENTIFIER>] [-s|--source <SOURCE>]
+    [-r|--runtime <RUNTIME_IDENTIFIER>] [--source <SOURCE>]
     [-v|--verbosity <LEVEL>] [--version-suffix <VERSION_SUFFIX>]
 
 dotnet build -h|--help

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -115,7 +115,7 @@ The project or solution file to build. If a project or solution file isn't speci
 
   Specifies the target runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
 
-- **`-s|--source <SOURCE>`**
+- **`--source <SOURCE>`**
 
   The URI of the NuGet package source to use during the restore operation.
 


### PR DESCRIPTION
## Summary

The -s flag is not supported for dotnet build as stated earlier in these docs. So it should be removed as an option.
