### PR TITLE
Update dotnet test doc

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -69,7 +69,6 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates a sequence file in `TestResults/<Guid>/<Guid>_Sequence.xml` that captures the order of tests that were run before the crash.
 
-
 - **`--blame-crash`**
 
   Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH. Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. The tools can be downloaded [here](https://docs.microsoft.com/sysinternals/downloads/procdump). Implies `--blame`.

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -71,7 +71,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 - **`--blame-crash`**
 
-  Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH. Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. The tools can be downloaded [here](https://docs.microsoft.com/sysinternals/downloads/procdump). Implies `--blame`.
+  Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option is only supported on Windows. A directory that contains *procdump.exe* and *procdump64.exe* must be in the PATH or PROCDUMP_PATH environment variable. [Download the tools](https://docs.microsoft.com/sysinternals/downloads/procdump). Implies `--blame`.
 
 - **`--blame-crash-dump-type <DUMP_TYPE>`**
 
@@ -79,19 +79,26 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 - **`--blame-crash-collect-always`**
 
-  Enables collecting crash dump on expected as well as unexpected testhost exit.
+  Collects a crash dump on expected as well as unexpected test host exit.
 
 - **`--blame-hang`**
 
-  Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies `--blame-hang`.
+  Run the tests in blame mode and collects a hang dump when a test exceeds the given timeout.
 
 - **`--blame-hang-dump-type <DUMP_TYPE>`**
 
-  The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies `--blame-hang`.
+  The type of crash dump to be collected. It should be `full`, `mini`, or `none`. When `none` is specified, test host is terminated on timeout, but no dump is collected. Implies `--blame-hang`.
 
 - **`--blame-hang-timeout <TIMESPAN>`**
 
-  Per-test timeout, after which hang dump is triggered and the testhost process is terminated. The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (for example, 5400000), the value is assumed to be in milliseconds. When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case. For MSTest, the timeout is used for all testcases. This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.
+  Per-test timeout, after which a hang dump is triggered and the test host process is terminated. The timeout value is specified in one of the following formats:
+  
+    - 1.5h
+    - 90m
+    - 5400s
+    - 5400000ms
+
+  When no unit is used (for example, 5400000), the value is assumed to be in milliseconds. When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case. For MSTest, the timeout is used for all testcases. This option is supported on Windows with netcoreapp2.1 and later, and on Linux with netcoreapp3.1 and later. macOS is not supported.
 
 - **`-c|--configuration <CONFIGURATION>`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -97,7 +97,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Defines the build configuration. The default value is `Debug`, but your project's configuration could override this default SDK setting.
 
-- **`--collect <DATA_COLLECTOR_FRIENDLY_NAME>`**
+- **`--collect <DATA_COLLECTOR_NAME>`**
 
   Enables data collector for the test run. For more information, see [Monitor and analyze test run](https://aka.ms/vstest-collect).
   
@@ -105,7 +105,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   On Windows, you can collect code coverage by using the `--collect "Code Coverage"` option. This option generates a *.coverage* file, which can be opened in Visual Studio 2019 Enterprise. For more information, see [Use code coverage](/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested) and [Customize code coverage analysis](/visualstudio/test/customizing-code-coverage-analysis).
 
-- **`-d|--diag <PATH_TO_DIAGNOSTICS_FILE>`**
+- **`-d|--diag <LOG_FILE>`**
 
   Enables diagnostic mode for the test platform and writes diagnostic messages to the specified file and to files next to it. The process that is logging the messages determines which files are created, such as `*.host_<date>.txt` for test host log, and `*.datacollector_<date>.txt` for data collector log.
 
@@ -125,7 +125,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Allows the command to stop and wait for user input or action. For example, to complete authentication. Available since .NET Core 3.0 SDK.
 
-- **`-l|--logger <LOGGER_URI/FRIENDLY_NAME>`**
+- **`-l|--logger <LOGGER>`**
 
   Specifies a logger for test results. Unlike MSBuild, dotnet test doesn't accept abbreviations: instead of `-l "console;v=d"` use `-l "console;verbosity=detailed"`.
 
@@ -145,7 +145,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Directory in which to find the binaries to run. If not specified, the default path is `./bin/<configuration>/<framework>/`.  For projects with multiple target frameworks (via the `TargetFrameworks` property), you also need to define `--framework` when you specify this option. `dotnet test` always runs tests from the output directory. You can use <xref:System.AppDomain.BaseDirectory%2A?displayProperty=nameWithType> to consume test assets in the output directory.
 
-- **`-r|--results-directory <PATH>`**
+- **`-r|--results-directory <RESULTS_DIR>`**
 
   The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is `TestResults` in the directory that contains the project file.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -15,14 +15,17 @@ ms.date: 04/29/2020
 
 ```dotnetcli
 dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL>]
-    [-a|--test-adapter-path <PATH_TO_ADAPTER>] [--blame]
+    [-a|--test-adapter-path <ADAPTER_PATH>] [--blame] [--blame-crash]
+    [--blame-crash-dump-type <DUMP_TYPE>] [--blame-crash-collect-always]
+    [--blame-hang] [--blame-hang-dump-type <DUMP_TYPE>]
+    [--blame-hang-timeout <TIMESPAN>]
     [-c|--configuration <CONFIGURATION>]
-    [--collect <DATA_COLLECTOR_FRIENDLY_NAME>]
-    [-d|--diag <PATH_TO_DIAGNOSTICS_FILE>] [-f|--framework <FRAMEWORK>]
+    [--collect <DATA_COLLECTOR_NAME>]
+    [-d|--diag <LOG_FILE>] [-f|--framework <FRAMEWORK>]
     [--filter <EXPRESSION>] [--interactive]
-    [-l|--logger <LOGGER_URI/FRIENDLY_NAME>] [--no-build]
+    [-l|--logger <LOGGER>] [--no-build]
     [--nologo] [--no-restore] [-o|--output <OUTPUT_DIRECTORY>]
-    [-r|--results-directory <PATH>] [--runtime <RUNTIME_IDENTIFIER>]
+    [-r|--results-directory <RESULTS_DIR>] [--runtime <RUNTIME_IDENTIFIER>]
     [-s|--settings <SETTINGS_FILE>] [-t|--list-tests]
     [-v|--verbosity <LEVEL>] [[--] <RunSettings arguments>]
 
@@ -58,13 +61,38 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 ## Options
 
-- **`-a|--test-adapter-path <PATH_TO_ADAPTER>`**
+- **`-a|--test-adapter-path <ADAPTER_PATH>`**
 
   Path to a directory to be searched for additional test adapters. Only *.dll* files with suffix `.TestAdapter.dll` are inspected. If not specified, the directory of the test *.dll* is searched.
 
 - **`--blame`**
 
   Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates a sequence file in `TestResults/<Guid>/<Guid>_Sequence.xml` that captures the order of tests that were run before the crash.
+
+
+- **`--blame-crash`**
+
+  Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH. Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. The tools can be downloaded [here](https://docs.microsoft.com/sysinternals/downloads/procdump). Implies `--blame`.
+
+- **`--blame-crash-dump-type <DUMP_TYPE>`**
+
+  The type of crash dump to be collected. Implies `--blame-crash`.
+
+- **`--blame-crash-collect-always`**
+
+  Enables collecting crash dump on expected as well as unexpected testhost exit.
+
+- **`--blame-hang`**
+
+  Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies `--blame-hang`.
+
+- **`--blame-hang-dump-type <DUMP_TYPE>`**
+
+  The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies `--blame-hang`.
+
+- **`--blame-hang-timeout <TIMESPAN>`**
+
+  Per-test timeout, after which hang dump is triggered and the testhost process is terminated. The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (for example, 5400000), the value is assumed to be in milliseconds. When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case. For MSTest, the timeout is used for all testcases. This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.
 
 - **`-c|--configuration <CONFIGURATION>`**
 
@@ -135,7 +163,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 - **`-t|--list-tests`**
 
-  List all of the discovered tests in the current project.
+  List the discovered tests instead of running the tests.
 
 - **`-v|--verbosity <LEVEL>`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -69,34 +69,34 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates a sequence file in `TestResults/<Guid>/<Guid>_Sequence.xml` that captures the order of tests that were run before the crash.
 
-- **`--blame-crash`**
+- **`--blame-crash`** (Available since .NET 5.0 preview SDK)
 
   Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option is only supported on Windows. A directory that contains *procdump.exe* and *procdump64.exe* must be in the PATH or PROCDUMP_PATH environment variable. [Download the tools](https://docs.microsoft.com/sysinternals/downloads/procdump). Implies `--blame`.
 
-- **`--blame-crash-dump-type <DUMP_TYPE>`**
+- **`--blame-crash-dump-type <DUMP_TYPE>`** (Available since .NET 5.0 preview SDK)
 
   The type of crash dump to be collected. Implies `--blame-crash`.
 
-- **`--blame-crash-collect-always`**
+- **`--blame-crash-collect-always`** (Available since .NET 5.0 preview SDK)
 
   Collects a crash dump on expected as well as unexpected test host exit.
 
-- **`--blame-hang`**
+- **`--blame-hang`** (Available since .NET 5.0 preview SDK)
 
   Run the tests in blame mode and collects a hang dump when a test exceeds the given timeout.
 
-- **`--blame-hang-dump-type <DUMP_TYPE>`**
+- **`--blame-hang-dump-type <DUMP_TYPE>`** (Available since .NET 5.0 preview SDK)
 
   The type of crash dump to be collected. It should be `full`, `mini`, or `none`. When `none` is specified, test host is terminated on timeout, but no dump is collected. Implies `--blame-hang`.
 
-- **`--blame-hang-timeout <TIMESPAN>`**
+- **`--blame-hang-timeout <TIMESPAN>`** (Available since .NET 5.0 preview SDK)
 
   Per-test timeout, after which a hang dump is triggered and the test host process is terminated. The timeout value is specified in one of the following formats:
   
-    - 1.5h
-    - 90m
-    - 5400s
-    - 5400000ms
+  - 1.5h
+  - 90m
+  - 5400s
+  - 5400000ms
 
   When no unit is used (for example, 5400000), the value is assumed to be in milliseconds. When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case. For MSTest, the timeout is used for all testcases. This option is supported on Windows with netcoreapp2.1 and later, and on Linux with netcoreapp3.1 and later. macOS is not supported.
 


### PR DESCRIPTION
Fixes #19670 and adds other undocumented options that I found when I run `dotnet test -h` on my machine.

**Note:** I've `5.0.100-preview.6.20318.15`. I don't know if the new options added with this PR existed before or not. If they're new with .NET 5.0, I don't know if you will want to document these now or wait for the stable .NET 5.0 release.