### PR TITLE
Document dotnet-gcdump tool

### DIFF
--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -19,6 +19,8 @@ The [.NET Core Uninstall Tool](https://github.com/dotnet/cli-lab/releases) (`dot
 
 [dotnet-dump](../diagnostics/dotnet-dump.md) provides a way to collect and analyze Windows and Linux core dumps without a native debugger.
 
+[dotnet-gcdump](../diagnostics/dotnet-gcdump.md) provides a way to collect gcdumps of live .NET processes.
+
 [dotnet-trace](../diagnostics/dotnet-trace.md) collects profiling data from your app that can help in scenarios where you need to find out what causes an app to run slow.
 
 ## WCF Web Service Reference tool

--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -19,7 +19,7 @@ The [.NET Core Uninstall Tool](https://github.com/dotnet/cli-lab/releases) (`dot
 
 [dotnet-dump](../diagnostics/dotnet-dump.md) provides a way to collect and analyze Windows and Linux core dumps without a native debugger.
 
-[dotnet-gcdump](../diagnostics/dotnet-gcdump.md) provides a way to collect gcdumps of live .NET processes.
+[dotnet-gcdump](../diagnostics/dotnet-gcdump.md) provides a way to collect GC (Garbage Collector) dumps of live .NET processes.
 
 [dotnet-trace](../diagnostics/dotnet-trace.md) collects profiling data from your app that can help in scenarios where you need to find out what causes an app to run slow.
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -111,7 +111,7 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 
 ## Viewing the GC dump captured from dotnet-gcdump
 
-On Windows, `.gcdump` files can be viewed in PerfView (https://github.com/microsoft/perfview) for analysis or in Visual Studio. Currently, There is no way of opening a `.gcdump` on non-Windows platforms.
+On Windows, `.gcdump` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio. Currently, There is no way of opening a `.gcdump` on non-Windows platforms.
 
 You can collect multiple `.gcdump`s and open them simultaneously in Visual Studio to get a comparison experience.
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -115,7 +115,7 @@ On Windows, `.gcdump` files can be viewed in PerfView (https://github.com/micros
 
 You can collect multiple `.gcdump`s and open them simultaneously in Visual Studio to get a comparison experience.
 
-## Known caveats
+## Troubleshoot
 
 - There is no type information in the gcdump.
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -108,3 +108,20 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 - **`-t|--report-type <HeapStat>`**
 
   The type of report to generate. Available options: heapstat (default).
+
+## Viewing the GC dump captured from dotnet-gcdump
+
+On Windows, `.gcdump` files can be viewed in PerfView (https://github.com/microsoft/perfview) for analysis or in Visual Studio. Currently, There is no way of opening a `.gcdump` on non-Windows platforms.
+
+You can collect multiple `.gcdump`s and open them simultaneously in Visual Studio to get a comparison experience.
+
+## Known caveats
+
+- There is no type information in the gcdump.
+
+   Prior to .NET Core 3.1, there was an issue where a type cache was not cleared between gcdumps when they were invoked with EventPipe. This resulted in the events needed for determining type information not being sent for the second and subsequent gcdumps. This was fixed in .NET Core 3.1-preview2.
+
+
+- COM and static types aren't in the GC dump.
+
+   Prior to .NET Core 3.1-preview2, there was an issue where static and COM types weren't sent when the GC dump was invoked via EventPipe. This has been fixed in .NET Core 3.1-preview2.

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -1,0 +1,110 @@
+---
+title: dotnet-gcdump - .NET Core
+description: Installing and using the dotnet-gcdump command-line tool.
+ms.date: 07/26/2020
+---
+# Heap analysis tool (`dotnet-gcdump`)
+
+**This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
+
+## Installing `dotnet-gcdump`
+
+To install the latest release version of the `dotnet-gcdump` [NuGet package](https://www.nuget.org/packages/dotnet-gcdump), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
+
+```dotnetcli
+dotnet tool install -g dotnet-gcdump
+```
+
+## Synopsis
+
+```console
+dotnet-gcdump [-h|--help] [--version] <command>
+```
+
+## Description
+
+The `dotnet-gcdump` global tool is a way to collect gcdumps of live .NET processes. It is built using the EventPipe technology which is a cross-platform alternative to ETW on Windows. Gcdumps are created by triggering a GC in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for gcdumps to be collected while the process is running with minimal overhead. These dumps are useful for several scenarios:
+
+- comparing the number of objects on the heap at several points in time.
+- analyzing roots of objects (answering questions like, "what still has a reference to this type?").
+- collecting general statistics about the counts of objects on the heap.
+
+## Options
+
+- **`--version`**
+
+  Displays the version of the `dotnet-gcdump` utility.
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+## `dotnet-gcdump collect`
+
+Collects a gcdump from a currently running process.
+
+### Synopsis
+
+```console
+dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-file-path>] [-v|--verbose] [-t|--timeout <timeout>] [-n|--name <name>]
+```
+
+### Options
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+- **`-p|--process-id <pid>`**
+
+  The process id to collect the gcdump.
+
+- **`-o|--output <gcdump-file-path>`**
+
+  The path where collected gcdumps should be written. Defaults to *.\YYYYMMDD_HHMMSS_<pid>.gcdump*.
+
+- **`-v|--verbose`**
+
+  Output the log while collecting the gcdump.
+
+- **`-t|--timeout <timeout>`**
+
+  Give up on collecting the gcdump if it takes longer than this many seconds. The default value is 30s.
+
+- **`-n|--name <name>`**
+
+  The name of the process to collect the gcdump.
+
+## `dotnet-gcdump ps`
+
+Lists the dotnet processes that gcdumps can be collected.
+
+### Synopsis
+
+```console
+dotnet-gcdump ps
+```
+
+## `dotnet-gcdump report <gcdump_filename>`
+
+Generate report into stdout from a previously generated gcdump or from a running process.
+
+### Synopsis
+
+```console
+dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <HeapStat>]
+```
+
+### Options
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+- **`-p|--process-id <pid>`**
+
+  The process id to collect the trace.
+
+- **`-t|--report-type <HeapStat>`**
+
+  The type of report to generate. Available options: heapstat (default).

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -69,7 +69,7 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 
 - **`-t|--timeout <timeout>`**
 
-  Give up on collecting the GC dump if it takes longer than this many seconds. The default value is 30s.
+  Give up on collecting the GC dump if it takes longer than this many seconds. The default value is 30.
 
 - **`-n|--name <name>`**
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -3,7 +3,7 @@ title: dotnet-gcdump - .NET Core
 description: Installing and using the dotnet-gcdump command-line tool.
 ms.date: 07/26/2020
 ---
-# Heap analysis tool (`dotnet-gcdump`)
+# Heap analysis tool (dotnet-gcdump)
 
 **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -61,7 +61,7 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 
 - **`-o|--output <gcdump-file-path>`**
 
-  The path where collected gcdumps should be written. Defaults to *.\YYYYMMDD_HHMMSS_<pid>.gcdump*.
+  The path where collected gcdumps should be written. Defaults to *.\\YYYYMMDD\_HHMMSS\_\<pid>.gcdump*.
 
 - **`-v|--verbose`**
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -77,7 +77,7 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 
 ## `dotnet-gcdump ps`
 
-Lists the dotnet processes that gcdumps can be collected.
+Lists the dotnet processes that gcdumps can be collected for.
 
 ### Synopsis
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -7,7 +7,7 @@ ms.date: 07/26/2020
 
 **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 
-## Installing `dotnet-gcdump`
+## Install dotnet-gcdump
 
 To install the latest release version of the `dotnet-gcdump` [NuGet package](https://www.nuget.org/packages/dotnet-gcdump), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
@@ -25,9 +25,9 @@ dotnet-gcdump [-h|--help] [--version] <command>
 
 The `dotnet-gcdump` global tool is a way to collect gcdumps of live .NET processes. It is built using the EventPipe technology which is a cross-platform alternative to ETW on Windows. Gcdumps are created by triggering a GC in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for gcdumps to be collected while the process is running with minimal overhead. These dumps are useful for several scenarios:
 
-- comparing the number of objects on the heap at several points in time.
-- analyzing roots of objects (answering questions like, "what still has a reference to this type?").
-- collecting general statistics about the counts of objects on the heap.
+- Comparing the number of objects on the heap at several points in time.
+- Analyzing roots of objects (answering questions like, "what still has a reference to this type?").
+- Collecting general statistics about the counts of objects on the heap.
 
 ## Options
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -73,7 +73,7 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 
 - **`-n|--name <name>`**
 
-  The name of the process to collect the dump for.
+  The name of the process to collect the gcdump for.
 
 ## `dotnet-gcdump ps`
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -87,7 +87,7 @@ dotnet-gcdump ps
 
 ## `dotnet-gcdump report <gcdump_filename>`
 
-Generate report into stdout from a previously generated GC dump or from a running process.
+Generate a report from a previously generated GC dump or from a running process, and write to `stdout`.
 
 ### Synopsis
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -73,7 +73,7 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 
 - **`-n|--name <name>`**
 
-  The name of the process to collect the gcdump.
+  The name of the process to collect the dump for.
 
 ## `dotnet-gcdump ps`
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -29,6 +29,12 @@ The `dotnet-gcdump` global tool is a way to collect GC (Garbage Collector) dumps
 - Analyzing roots of objects (answering questions like, "what still has a reference to this type?").
 - Collecting general statistics about the counts of objects on the heap.
 
+### View the GC dump captured from dotnet-gcdump
+
+On Windows, `.gcdump` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio. Currently, There is no way of opening a `.gcdump` on non-Windows platforms.
+
+You can collect multiple `.gcdump`s and open them simultaneously in Visual Studio to get a comparison experience.
+
 ## Options
 
 - **`--version`**
@@ -108,12 +114,6 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 - **`-t|--report-type <HeapStat>`**
 
   The type of report to generate. Available options: heapstat (default).
-
-## Viewing the GC dump captured from dotnet-gcdump
-
-On Windows, `.gcdump` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio. Currently, There is no way of opening a `.gcdump` on non-Windows platforms.
-
-You can collect multiple `.gcdump`s and open them simultaneously in Visual Studio to get a comparison experience.
 
 ## Troubleshoot
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -23,7 +23,7 @@ dotnet-gcdump [-h|--help] [--version] <command>
 
 ## Description
 
-The `dotnet-gcdump` global tool is a way to collect gcdumps of live .NET processes. It is built using the EventPipe technology which is a cross-platform alternative to ETW on Windows. Gcdumps are created by triggering a GC in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for gcdumps to be collected while the process is running with minimal overhead. These dumps are useful for several scenarios:
+The `dotnet-gcdump` global tool is a way to collect GC (Garbage Collector) dumps of live .NET processes. It is built using the EventPipe technology which is a cross-platform alternative to ETW on Windows. GC dumps are created by triggering a GC in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for GC dumps to be collected while the process is running with minimal overhead. These dumps are useful for several scenarios:
 
 - Comparing the number of objects on the heap at several points in time.
 - Analyzing roots of objects (answering questions like, "what still has a reference to this type?").
@@ -41,7 +41,7 @@ The `dotnet-gcdump` global tool is a way to collect gcdumps of live .NET process
 
 ## `dotnet-gcdump collect`
 
-Collects a gcdump from a currently running process.
+Collects a GC dump from a currently running process.
 
 ### Synopsis
 
@@ -57,27 +57,27 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 
 - **`-p|--process-id <pid>`**
 
-  The process id to collect the gcdump.
+  The process id to collect the GC dump from.
 
 - **`-o|--output <gcdump-file-path>`**
 
-  The path where collected gcdumps should be written. Defaults to *.\\YYYYMMDD\_HHMMSS\_\<pid>.gcdump*.
+  The path where collected GC dumps should be written. Defaults to *.\\YYYYMMDD\_HHMMSS\_\<pid>.gcdump*.
 
 - **`-v|--verbose`**
 
-  Output the log while collecting the gcdump.
+  Output the log while collecting the GC dump.
 
 - **`-t|--timeout <timeout>`**
 
-  Give up on collecting the gcdump if it takes longer than this many seconds. The default value is 30s.
+  Give up on collecting the GC dump if it takes longer than this many seconds. The default value is 30s.
 
 - **`-n|--name <name>`**
 
-  The name of the process to collect the gcdump for.
+  The name of the process to collect the GC dump from.
 
 ## `dotnet-gcdump ps`
 
-Lists the dotnet processes that gcdumps can be collected for.
+Lists the dotnet processes that GC dumps can be collected for.
 
 ### Synopsis
 
@@ -87,7 +87,7 @@ dotnet-gcdump ps
 
 ## `dotnet-gcdump report <gcdump_filename>`
 
-Generate report into stdout from a previously generated gcdump or from a running process.
+Generate report into stdout from a previously generated GC dump or from a running process.
 
 ### Synopsis
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -103,7 +103,7 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 
 - **`-p|--process-id <pid>`**
 
-  The process id to collect the trace.
+  The process id to collect the GC dump from.
 
 - **`-t|--report-type <HeapStat>`**
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -121,7 +121,6 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 
    Prior to .NET Core 3.1, there was an issue where a type cache was not cleared between gcdumps when they were invoked with EventPipe. This resulted in the events needed for determining type information not being sent for the second and subsequent gcdumps. This was fixed in .NET Core 3.1-preview2.
 
-
 - COM and static types aren't in the GC dump.
 
    Prior to .NET Core 3.1-preview2, there was an issue where static and COM types weren't sent when the GC dump was invoked via EventPipe. This has been fixed in .NET Core 3.1-preview2.

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -23,7 +23,7 @@ dotnet-gcdump [-h|--help] [--version] <command>
 
 ## Description
 
-The `dotnet-gcdump` global tool is a way to collect GC (Garbage Collector) dumps of live .NET processes. It is built using the EventPipe technology which is a cross-platform alternative to ETW on Windows. GC dumps are created by triggering a GC in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for GC dumps to be collected while the process is running with minimal overhead. These dumps are useful for several scenarios:
+The `dotnet-gcdump` global tool is a way to collect GC (Garbage Collector) dumps of live .NET processes. It uses the EventPipe technology, which is a cross-platform alternative to ETW on Windows. GC dumps are created by triggering a GC in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for GC dumps to be collected while the process is running, with minimal overhead. These dumps are useful for several scenarios:
 
 - Comparing the number of objects on the heap at several points in time.
 - Analyzing roots of objects (answering questions like, "what still has a reference to this type?").

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -33,6 +33,10 @@ This article helps you find the various tools you need.
 
 The [dotnet-dump](dotnet-dump.md) tool is a way to collect and analyze Windows and Linux core dumps without a native debugger.
 
+### dotnet-gcdump
+
+The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect gcdumps of live .NET processes.
+
 ### dotnet-trace
 
 .NET Core includes what is called the `EventPipe` through which diagnostics data is exposed. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root cause apps running slow.

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -35,7 +35,7 @@ The [dotnet-dump](dotnet-dump.md) tool is a way to collect and analyze Windows a
 
 ### dotnet-gcdump
 
-The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect gcdumps of live .NET processes.
+The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Collector) dumps of live .NET processes.
 
 ### dotnet-trace
 

--- a/docs/core/toc.yml
+++ b/docs/core/toc.yml
@@ -298,6 +298,8 @@ items:
       href: diagnostics/dotnet-counters.md
     - name: dotnet-dump
       href: diagnostics/dotnet-dump.md
+    - name: dotnet-gcdump
+      href: diagnostics/dotnet-gcdump.md
     - name: dotnet-trace
       href: diagnostics/dotnet-trace.md
   - name: .NET Core diagnostics tutorials


### PR DESCRIPTION
Fixes #18935

[Information source](https://github.com/dotnet/diagnostics/blob/f63dc82eb4d92b8e057f7e3b5855cdf06f985f8c/documentation/dotnet-gcdump-instructions.md).

[Internal review link](https://review.docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-gcdump?branch=pr-en-us-19697).