### PR TITLE
Add F1 keywords for combination keywords

### DIFF
--- a/docs/csharp/language-reference/keywords/private-protected.md
+++ b/docs/csharp/language-reference/keywords/private-protected.md
@@ -1,6 +1,8 @@
 ---
 title: "private protected - C# Reference"
 ms.date: 11/15/2017
+f1_keywords:
+  - "privateprotected_CSharpKeyword"
 author: "sputier"
 ---
 # private protected (C# Reference)

--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -1,6 +1,8 @@
 ---
 title: "protected internal - C# Reference"
 ms.date: 11/15/2017
+f1_keywords:
+  - "protectedinternal_CSharpKeyword"
 author: "sputier"
 ---
 # protected internal (C# Reference)

--- a/docs/visual-basic/language-reference/modifiers/private-protected.md
+++ b/docs/visual-basic/language-reference/modifiers/private-protected.md
@@ -1,6 +1,8 @@
 ---
 title: "Private Protected"
 ms.date: 05/10/2018
+f1_keywords:
+  - "vb.PrivateProtected"
 helpviewer_keywords:
   - "Private Protected keyword [Visual Basic]"
   - "Private Protected keyword [Visual Basic], syntax"

--- a/docs/visual-basic/language-reference/modifiers/protected-friend.md
+++ b/docs/visual-basic/language-reference/modifiers/protected-friend.md
@@ -1,6 +1,8 @@
 ---
 title: "Protected Friend"
 ms.date: 05/10/2018
+f1_keywords:
+  - "vb.ProtectedFriend"
 helpviewer_keywords:
   - "Protected Friend keyword [Visual Basic]"
   - "Protected Friend keyword [Visual Basic], syntax"


### PR DESCRIPTION
## Summary

In preparation of fixing https://github.com/dotnet/roslyn/issues/46142 we need to add keywords to the combination modifier pages.

Is there anything else I need to do for this to work, or will indexing pick up these automatically?
