### PR TITLE
Follow-up to #19375

### DIFF
--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -395,12 +395,14 @@ In <xref:System.Text.Json>, you can simulate callbacks by writing a custom conve
 
 [!code-csharp[](snippets/system-text-json-how-to/csharp/WeatherForecastCallbacksConverter.cs)]
 
-Register this custom converter by [using an attribute on the class](system-text-json-converters-how-to.md#registration-sample---jsonconverter-on-a-type) or by [adding the converter](system-text-json-converters-how-to.md#registration-sample---converters-collection) to the <xref:System.Text.Json.JsonSerializerOptions.Converters> collection.
+Register this custom converter by [adding the converter](system-text-json-converters-how-to.md#registration-sample---converters-collection) to the <xref:System.Text.Json.JsonSerializerOptions.Converters> collection.
 
 If you use a custom converter that follows the preceding sample:
 
 * The `OnDeserializing` code doesn't have access to the new POCO instance. To manipulate the new POCO instance at the start of deserialization, put that code in the POCO constructor.
-* Avoid an infinite loop by registering the converter in the options object and not passing in the options object when recursively calling `Serialize` or `Deserialize`. For more information, see the [Required properties](#required-properties) section earlier in this article.
+* Avoid an infinite loop by registering the converter in the options object and not passing in the options object when recursively calling `Serialize` or `Deserialize`.
+
+For more information about custom converters that recursively call `Serialize` or `Deserialize`, see the [Required properties](#required-properties) section earlier in this article.
 
 ### Public and non-public fields
 


### PR DESCRIPTION
Change the Callbacks section text the same way Required section text was changed, to advise against attribute registration.
