### PR TITLE
Remove extra "preview" word

### DIFF
--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -154,7 +154,7 @@ This approach lets you install different versions into separate locations and ch
 
 ## Install with Visual Studio for Mac
 
-Visual Studio for Mac installs the .NET Core SDK when the **.NET Core** workload is selected. To get started with .NET Core development on macOS, see [Install Visual Studio 2019 for Mac](/visualstudio/mac/installation). For the latest release, .NET Core 3.1, you must use the Visual Studio for Mac 8.4 Preview.
+Visual Studio for Mac installs the .NET Core SDK when the **.NET Core** workload is selected. To get started with .NET Core development on macOS, see [Install Visual Studio 2019 for Mac](/visualstudio/mac/installation). For the latest release, .NET Core 3.1, you must use the Visual Studio for Mac 8.4.
 
 [![macOS Visual Studio 2019 for Mac with .NET Core workload feature](media/install-sdk/mac-install-selection.png)](media/install-sdk/mac-install-selection.png#lightbox)
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -20,7 +20,7 @@ In this article, various names are used to identify types of files used for migr
 
 ## Prerequisites
 
-- [Visual Studio 2019 version 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
+- [Visual Studio 2019 version 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&rel=16) for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
 
   Install the following Visual Studio workloads:
   

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -31,7 +31,7 @@ In this article, various names are used to identify types of files used for migr
 - A project coded in C#.
 
 > [!NOTE]
-> .NET Core 3.0 projects are only supported in **Visual Studio 2019** or a later version. Starting with **Visual Studio 2019 version 16.5**, the .NET Core Windows Forms designer is also supported.
+> .NET Core Windows Forms projects are supported in Visual Studio 2019 and later versions. The .NET Core Windows Forms designer is supported starting in Visual Studio 2019 version 16.5.
 >
 > To enable the designer, go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -30,8 +30,8 @@ In this article, various names are used to identify types of files used for migr
 - A working Windows Forms project in a solution that builds and runs without issue.
 - A project coded in C#.
 
-> [!NOTE] <!-- TODO: (Need guidance on how this note should be changed) -->
-> .NET Core 3.0 projects are only supported in **Visual Studio 2019** or a later version. Starting with **Visual Studio 2019 version 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
+> [!NOTE]
+> .NET Core 3.0 projects are only supported in **Visual Studio 2019** or a later version. Starting with **Visual Studio 2019 version 16.5**, the .NET Core Windows Forms designer is also supported.
 >
 > To enable the designer, go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.
 

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -20,7 +20,7 @@ In this article, various names are used to identify types of files used for migr
 
 ## Prerequisites
 
-- [Visual Studio 2019 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) or later for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
+- [Visual Studio 2019 version 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) or later for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
 
   Install the following Visual Studio workloads:
   

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -20,7 +20,7 @@ In this article, various names are used to identify types of files used for migr
 
 ## Prerequisites
 
-- [Visual Studio 2019 16.5 Preview 1](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) or later for any designer work you want to do. We recommend to update to the latest [Preview version of Visual Studio](https://visualstudio.microsoft.com/vs/preview/).
+- [Visual Studio 2019 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) or later for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
 
   Install the following Visual Studio workloads:
   
@@ -30,7 +30,7 @@ In this article, various names are used to identify types of files used for migr
 - A working Windows Forms project in a solution that builds and runs without issue.
 - A project coded in C#.
 
-> [!NOTE]
+> [!NOTE] <!-- TODO: (Need guidance on how this note should be changed) -->
 > .NET Core 3.0 projects are only supported in **Visual Studio 2019** or a later version. Starting with **Visual Studio 2019 version 16.5 Preview 1**, the .NET Core Windows Forms designer is also supported.
 >
 > To enable the designer, go to **Tools** > **Options** > **Environment** > **Preview Features** and select the **Use the preview Windows Forms designer for .NET Core apps** option.

--- a/docs/core/porting/winforms.md
+++ b/docs/core/porting/winforms.md
@@ -20,7 +20,7 @@ In this article, various names are used to identify types of files used for migr
 
 ## Prerequisites
 
-- [Visual Studio 2019 version 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) or later for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
+- [Visual Studio 2019 version 16.5 or later](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16) for any designer work you want to do. We recommend to update to the [latest version of Visual Studio](https://visualstudio.microsoft.com/vs/).
 
   Install the following Visual Studio workloads:
   


### PR DESCRIPTION
The preview version of VS for Mac now is 8.7, and the current release is 8.6.
So, 8.4 is no longer preview.