### PR TITLE
Snippets add NuGet ENV VAR to automatically trigger restore

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -23,6 +23,7 @@ on:
 env:
   DOTNET_INSTALLER_CHANNEL: 'release/5.0.1xx-preview7'
   DOTNET_DO_INSTALL: 'true'
+  EnableNuGetPackageRestore: 'True'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/dependencies/Get-MSBuildResults.ps1
+++ b/.github/workflows/dependencies/Get-MSBuildResults.ps1
@@ -148,7 +148,7 @@ foreach ($item in $workingSet) {
 
                     # Create the visual studio build command
                     "CALL `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat`"`n" +
-                    "msbuild.exe `"$projectFile`"" `
+                    "msbuild.exe `"$projectFile`" -restore:True" `
                     | Out-File ".\run.bat"
                 }
             }


### PR DESCRIPTION
@BillWagner
This should automatically trigger nuget restore on Visual Studio MSBUILD processes, at least according to the docs here: https://docs.microsoft.com/en-us/nuget/consume-packages/package-restore#restore-packages-manually-using-visual-studio

Same change that was completed in the samples repo.