### PR TITLE
Add Vector<T> breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 3.1 to 5.0
 description: Lists the breaking changes from version 3.1 to version 5.0 of .NET, ASP.NET Core, and EF Core.
-ms.date: 07/17/2020
+ms.date: 07/27/2020
 ---
 # Breaking changes for migration from version 3.1 to 5.0
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,11 +122,16 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [Vector<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types)
 - [Default ActivityIdFormat is W3C](#default-activityidformat-is-w3c)
 - [Behavior change for Vector2.Lerp and Vector4.Lerp](#behavior-change-for-vector2lerp-and-vector4lerp)
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [vectort-throws-notsupportedexception](../../../includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md)]
+
+***
 
 [!INCLUDE [default-activityidformat-changed](../../../includes/core-changes/corefx/5.0/default-activityidformat-changed.md)]
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,7 +122,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
-- [Vector<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types)
+- [Vector\<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types)
 - [Default ActivityIdFormat is W3C](#default-activityidformat-is-w3c)
 - [Behavior change for Vector2.Lerp and Vector4.Lerp](#behavior-change-for-vector2lerp-and-vector4lerp)
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Vector<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types) | 5.0 |
 | [Default ActivityIdFormat is W3C](#default-activityidformat-is-w3c) | 5.0 |
 | [Behavior change for Vector2.Lerp and Vector4.Lerp](#behavior-change-for-vector2lerp-and-vector4lerp) | 5.0 |
 | [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs) | 5.0 |
@@ -39,6 +40,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [vectort-throws-notsupportedexception](../../../includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md)]
+
+***
 
 [!INCLUDE [default-activityidformat-changed](../../../includes/core-changes/corefx/5.0/default-activityidformat-changed.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -1,7 +1,7 @@
 ---
 title: Base class library breaking changes
 description: Lists the breaking changes in core .NET libraries.
-ms.date: 09/20/2019
+ms.date: 07/27/2020
 ---
 # Core .NET libraries breaking changes
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,7 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
-| [Vector<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types) | 5.0 |
+| [Vector\<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types) | 5.0 |
 | [Default ActivityIdFormat is W3C](#default-activityidformat-is-w3c) | 5.0 |
 | [Behavior change for Vector2.Lerp and Vector4.Lerp](#behavior-change-for-vector2lerp-and-vector4lerp) | 5.0 |
 | [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs) | 5.0 |

--- a/includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md
+++ b/includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md
@@ -1,4 +1,4 @@
-### Vector<T> always throws NotSupportedException for unsupported types
+### Vector\<T> always throws NotSupportedException for unsupported types
 
 <xref:System.Numerics.Vector%601?displayProperty=nameWithType> now always throws a <xref:System.NotSupportedException> for unsupported type parameters.
 

--- a/includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md
+++ b/includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md
@@ -1,0 +1,50 @@
+### Vector<T> always throws NotSupportedException for unsupported types
+
+<xref:System.Numerics.Vector%601?displayProperty=nameWithType> now always throws a <xref:System.NotSupportedException> for unsupported type parameters.
+
+#### Change description
+
+Previously, members of <xref:System.Numerics.Vector%601> would not always throw a <xref:System.NotSupportedException> when `T` was an [unsupported type](#unsupported-types). The exception wasn't always thrown because of code paths that supported hardware acceleration. For example, `Vector<bool> + Vector<bool>` returned `default` instead of throwing an exception on platforms that have no hardware acceleration, such as ARM32. For unsupported types, <xref:System.Numerics.Vector%601> members exhibited inconsistent behavior across different platforms and hardware configurations.
+
+Starting in .NET 5.0, <xref:System.Numerics.Vector%601> members always throw a <xref:System.NotSupportedException> on all hardware configurations when `T` is not a supported type.
+
+##### Unsupported types
+
+The supported types for the type parameter of <xref:System.Numerics.Vector%601> are:
+
+- `byte`
+- `sbyte`
+- `short`
+- `ushort`
+- `int`
+- `uint`
+- `long`
+- `ulong`
+- `float`
+- `double`
+
+The supported types have not changed, however, they may change in the future.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+Don't use an unsupported type for the type parameter of <xref:System.Numerics.Vector%601>.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Numerics.Vector%601?displayProperty=fullName> and all its members
+
+<!--
+
+#### Affected APIs
+
+- ``T:System.Numerics.Vector`1``
+
+-->

--- a/includes/core-changes/globalization/5.0/icu-globalization-api.md
+++ b/includes/core-changes/globalization/5.0/icu-globalization-api.md
@@ -35,7 +35,7 @@ Globalization
 
 #### Affected APIs
 
-- `T:System.Span%601`
+- ``T:System.Span`1``
 - `T:System.String`
 - `N:System.Globalization`
 


### PR DESCRIPTION
Fixes #19197.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19721#vector-always-throws-notsupportedexception-for-unsupported-types).