### PR TITLE
DataTable.Columns.Add only works if you add all columns

### DIFF
--- a/docs/framework/data/adonet/dataset-datatable-dataview/security-guidance.md
+++ b/docs/framework/data/adonet/dataset-datatable-dataview/security-guidance.md
@@ -33,6 +33,8 @@ If the incoming XML data contains an object whose type is not in this list:
 
 When loading XML into an existing `DataSet` or `DataTable` instance, the existing column definitions are also taken into account. If the table already contains a column definition of a custom type, that type is temporarily added to the allow list for the duration of the XML deserialization operation.
 
+Note: Once you add columns to a DataTable, ReadXml will not read the schema from the Xml, and if the schema does not match it will also not read in the records, so you will need to add all the columns yourself to use this method.
+
 ```cs
 XmlReader xmlReader = GetXmlReader();
 

--- a/docs/framework/data/adonet/dataset-datatable-dataview/security-guidance.md
+++ b/docs/framework/data/adonet/dataset-datatable-dataview/security-guidance.md
@@ -33,7 +33,8 @@ If the incoming XML data contains an object whose type is not in this list:
 
 When loading XML into an existing `DataSet` or `DataTable` instance, the existing column definitions are also taken into account. If the table already contains a column definition of a custom type, that type is temporarily added to the allow list for the duration of the XML deserialization operation.
 
-Note: Once you add columns to a DataTable, ReadXml will not read the schema from the Xml, and if the schema does not match it will also not read in the records, so you will need to add all the columns yourself to use this method.
+> [!NOTE]
+> Once you add columns to a `DataTable`, `ReadXml` will not read the schema from the XML, and if the schema does not match it will also not read in the records, so you will need to add all the columns yourself to use this method.
 
 ```cs
 XmlReader xmlReader = GetXmlReader();


### PR DESCRIPTION
## Summary

The example suggests you can add a column to bypass the security, with no other work needed, but ReadXml then does not import any records because the schema is wrong. This note lets us know to add all columns if we wish this technique to work.

