### PR TITLE
Add config for build system

### DIFF
--- a/samples/snippets/csharp/roslyn-sdk/SemanticQuickStart/snippets.5000.json
+++ b/samples/snippets/csharp/roslyn-sdk/SemanticQuickStart/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxQuickStart/SyntaxWalker/Program.cs
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxQuickStart/SyntaxWalker/Program.cs
@@ -40,7 +40,7 @@ namespace TopLevel
 }";
         // </Snippet1>
 
-        static void Main(string[] args)
+        static void Main()
         {
             // <Snippet2>
             SyntaxTree tree = CSharpSyntaxTree.ParseText(programText);

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxQuickStart/snippets.5000.json
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxQuickStart/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/ConstructionCS/Program.cs
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/ConstructionCS/Program.cs
@@ -30,7 +30,7 @@ namespace HelloWorld
 }";
         // </SnippetDeclareSampleCode>
 
-        static void Main(string[] args)
+        static void Main()
         {
             // <SnippetCreateIdentifierName>
             NameSyntax name = IdentifierName("System");

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/TransformationCS/Program.cs
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/TransformationCS/Program.cs
@@ -7,7 +7,7 @@ namespace TransformationCS
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             // <SnippetDeclareTestCompilation>
             Compilation test = CreateTestCompilation();

--- a/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/snippets.5000.json
+++ b/samples/snippets/csharp/roslyn-sdk/SyntaxTransformationQuickStart/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}

--- a/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst.Test/MakeConstUnitTests.cs
+++ b/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst.Test/MakeConstUnitTests.cs
@@ -2,9 +2,7 @@
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using TestHelper;
-using MakeConst;
 
 namespace MakeConst.Test
 {

--- a/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConst/snippets.5000.json
+++ b/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConst/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}

--- a/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConstTestProject/MakeConstTestProject/Program.cs
+++ b/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConstTestProject/MakeConstTestProject/Program.cs
@@ -10,7 +10,8 @@ namespace MakeConstTestProject
             int j = 2;
             int k = i + j;
 
-            int x = "abc";
+            // uncomment for analyzer test:
+            //int x = "abc";
 
             object s = "abc";
 

--- a/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConstTestProject/MakeConstTestProject/snippets.5000.json
+++ b/samples/snippets/csharp/roslyn-sdk/Tutorials/MakeConstTestProject/MakeConstTestProject/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}


### PR DESCRIPTION
The roslyn samples must be built using Visual Studio.

This unblocks:

#19214
#19194
#19193
#19190
#19189
#19188
#19146
