### PR TITLE
Add UTF-7 breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,12 +122,17 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [UTF-7 code paths are obsolete](#utf-7-code-paths-are-obsolete)
 - [Vector\<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types)
 - [Default ActivityIdFormat is W3C](#default-activityidformat-is-w3c)
 - [Behavior change for Vector2.Lerp and Vector4.Lerp](#behavior-change-for-vector2lerp-and-vector4lerp)
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [utf-7-code-paths-obsolete](../../../includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md)]
+
+***
 
 [!INCLUDE [vectort-throws-notsupportedexception](../../../includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [UTF-7 code paths are obsolete](#utf-7-code-paths-are-obsolete) | 5.0 |
 | [Vector\<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types) | 5.0 |
 | [Default ActivityIdFormat is W3C](#default-activityidformat-is-w3c) | 5.0 |
 | [Behavior change for Vector2.Lerp and Vector4.Lerp](#behavior-change-for-vector2lerp-and-vector4lerp) | 5.0 |
@@ -40,6 +41,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [utf-7-code-paths-obsolete](../../../includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md)]
+
+***
 
 [!INCLUDE [vectort-throws-notsupportedexception](../../../includes/core-changes/corefx/5.0/vectort-throws-notsupportedexception.md)]
 

--- a/includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md
+++ b/includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md
@@ -1,6 +1,6 @@
 ### UTF-7 code paths are obsolete
 
-The UTF-7 encoding is no longer in wide use among applications, and many specs now forbid its use in interchange. It's also occasionally used as an attack vector in applications that don't anticipate encountering UTF-7-encoded data. Microsoft warns against use of <xref:System.Text.UTF7Encoding?displayProperty=nameWithType> in application code.
+The UTF-7 encoding is no longer in wide use among applications, and many specs now [forbid its use](https://security.stackexchange.com/a/68609/3573) in interchange. It's also occasionally [used as an attack vector](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=utf-7) in applications that don't anticipate encountering UTF-7-encoded data. Microsoft warns against use of <xref:System.Text.UTF7Encoding?displayProperty=nameWithType> because it doesn't provide error detection.
 
 Consequently, the <xref:System.Text.Encoding.UTF7?displayProperty=nameWithType> property and <xref:System.Text.UTF7Encoding.%23ctor%2A> constructors are now obsolete. Additionally, <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType> and <xref:System.Text.Encoding.GetEncodings%2A?displayProperty=nameWithType> no longer allow you to specify `UTF-7`.
 
@@ -57,7 +57,7 @@ In most cases, you don't need to take any action. However, for apps that have pr
 
 - If your app calls <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType> with unknown encoding names provided by an untrusted source:
 
-  Instead, compare the encoding names against a configurable allow list. The configurable allow list should at minimum include the industry-standard "utf-8". Depending on your clients and regulatory requirements, you may also need to allow region-specific encodings such as "GB18030".
+  Instead, compare the encoding names against a configurable allow list. The configurable allow list should at minimum include the industry-standard "utf-8". Depending on your clients and regulatory requirements, you may also need to allow region-specific encodings, such as "GB18030".
 
   If you don't implement an allow list, <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType> will return any <xref:System.Text.Encoding> that's built into the system or that's registered via a custom <xref:System.Text.EncodingProvider>. Audit your service's requirements to validate that this is the desired behavior. UTF-7 continues to be disabled by default unless your application re-enables the compatibility switch mentioned later in this article.
 
@@ -101,7 +101,7 @@ In most cases, you don't need to take any action. However, for apps that have pr
   <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
      <TargetFramework>net5.0</TargetFramework>
-     <!-- NoWarn below will suppress SYSLIB0001 project-wide -->
+     <!-- NoWarn below suppresses SYSLIB0001 project-wide -->
      <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
     </PropertyGroup>
   </Project>
@@ -112,7 +112,7 @@ In most cases, you don't need to take any action. However, for apps that have pr
 
 - If you must support `Encoding.GetEncoding("utf-7", ...)`:
 
-  You can re-enable support for this via a compatibility switch. This compatibility switch can be specified in the application's *.csproj* file or in a [run-time configuration file](../../../../docs/core/run-time-config/index.md).
+  You can re-enable support for this via a compatibility switch. This compatibility switch can be specified in the application's *.csproj* file or in a [run-time configuration file](../../../../docs/core/run-time-config/index.md), as shown in the following examples.
 
   In the application's *.csproj* file:
 
@@ -136,7 +136,8 @@ In most cases, you don't need to take any action. However, for apps that have pr
   }
   ```
 
-  If you re-enable support for UTF-7, you should perform a security review of code that calls <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType>.
+  > [!TIP]
+  > If you re-enable support for UTF-7, you should perform a security review of code that calls <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType>.
 
 #### Category
 

--- a/includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md
+++ b/includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md
@@ -92,7 +92,7 @@ In most cases, you don't need to take any action. However, for apps that have pr
   You can suppress the `SYSLIB0001` warning in code or within your project's *.csproj* file.
 
   ```csharp
-  #pragma warning suppress SYSLIB0001 // Disable the warning.
+  #pragma warning disable SYSLIB0001 // Disable the warning.
   Encoding enc = Encoding.UTF7;
   #pragma warning restore SYSLIB0001 // Re-enable the warning.
   ```

--- a/includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md
+++ b/includes/core-changes/corefx/5.0/utf-7-code-paths-obsolete.md
@@ -1,0 +1,87 @@
+### UTF-7 code paths are obsolete
+
+The UTF-7 encoding is no longer in wide use among applications, and many specs now forbid its use in interchange. It's also occasionally used as an attack vector in applications that don't anticipate encountering UTF-7-encoded data. Microsoft warns against use of <xref:System.Text.UTF7Encoding?displayProperty=nameWithType> in application code.
+
+Consequently, the <xref:System.Text.Encoding.UTF7?displayProperty=nameWithType> property and <xref:System.Text.UTF7Encoding.%23ctor%2A> constructors are now obsolete. Additionally, <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType> and <xref:System.Text.Encoding.GetEncodings%2A?displayProperty=nameWithType> no longer allow you to specify `UTF-7`.
+
+#### Change description
+
+Previously, you could create an instance of the UTF-7 encoding by using the <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType> APIs. For example:
+
+```csharp
+Encoding enc1 = Encoding.GetEncoding("utf-7"); // By name.
+Encoding enc2 = Encoding.GetEncoding(65000); // By code page.
+```
+
+Additionally, an instance that represents the UTF-7 encoding was enumerated by the <xref:System.Text.Encoding.GetEncodings?displayProperty=nameWithType> method, which enumerates all the <xref:System.Text.Encoding> instances registered on the system.
+
+Starting in .NET 5.0, the <xref:System.Text.Encoding.UTF7?displayProperty=nameWithType> property and <xref:System.Text.UTF7Encoding.%23ctor%2A> constructors are obsolete and produce warning `SYSLIB0001` (or `MSLIB0001` in preview versions). However, to reduce the number of warnings that callers receive when using the <xref:System.Text.UTF7Encoding> class, the <xref:System.Text.UTF7Encoding> type itself is not marked obsolete.
+
+```csharp
+// The next line generates warning SYSLIB0001.
+UTF7Encoding enc = new UTF7Encoding();
+// The next line does not generate a warning.
+byte[] bytes = enc.GetBytes("Hello world!");
+```
+
+Additionally, the <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=nameWithType> methods treat the encoding name `utf-7` and the code page `65000` as `unknown`. Treating the encoding as `unknown` causes the method to throw an <xref:System.ArgumentException>.
+
+```csharp
+// Throws ArgumentException, same as calling Encoding.GetEncoding("unknown").
+Encoding enc = Encoding.GetEncoding("utf-7");
+```
+
+Finally, the <xref:System.Text.Encoding.GetEncodings?displayProperty=nameWithType> method doesn't include the UTF-7 encoding in the <xref:System.Text.EncodingInfo> array that it returns. The encoding is excluded because it cannot be instantiated.
+
+```csharp
+foreach (EncodingInfo encInfo in Encoding.GetEncodings())
+{
+    // The next line would throw if GetEncodings included UTF-7.
+    Encoding enc = Encoding.GetEncoding(encInfo.Name);
+}
+```
+
+#### Reason for change
+
+Many applications call `Encoding.GetEncoding("encoding-name")` with an encoding name value that's provided by an untrusted source. For example, a web client or server might take the `charset` portion of the `Content-Type` header and pass the value directly to `Encoding.GetEncoding` without validating it. This could allow a malicious endpoint to specify `Content-Type: ...; charset=utf-7`, which could cause the receiving application to misbehave.
+
+Additionally, disabling UTF-7 code paths allows optimizing compilers, such as those used by Blazor, to remove these code paths entirely from the resulting application. As a result, the compiled applications run more efficiently and take less disk space.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+
+
+#### Category
+
+- Core .NET libraries
+- Security
+
+#### Affected APIs
+
+- <xref:System.Text.Encoding.UTF7?displayProperty=fullName>
+- <xref:System.Text.UTF7Encoding.%23ctor>
+- <xref:System.Text.UTF7Encoding.%23ctor(System.Boolean)>
+- <xref:System.Text.Encoding.GetEncoding(System.Int32)?displayProperty=fullName>
+- <xref:System.Text.Encoding.GetEncoding(System.String)?displayProperty=fullName>
+- <xref:System.Text.Encoding.GetEncoding(System.Int32,System.Text.EncoderFallback,System.Text.DecoderFallback)?displayProperty=fullName>
+- <xref:System.Text.Encoding.GetEncoding(System.String,System.Text.EncoderFallback,System.Text.DecoderFallback)?displayProperty=fullName>
+- <xref:System.Text.Encoding.GetEncodings?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `System.Text.Encoding.UTF7`
+- `System.Text.UTF7Encoding.#ctor`
+- `System.Text.UTF7Encoding.#ctor(System.Boolean)`
+- `System.Text.Encoding.GetEncoding(System.Int32)`
+- `System.Text.Encoding.GetEncoding(System.String)`
+- `System.Text.Encoding.GetEncoding(System.Int32,System.Text.EncoderFallback,System.Text.DecoderFallback)`
+- `System.Text.Encoding.GetEncoding(System.String,System.Text.EncoderFallback,System.Text.DecoderFallback)`
+- `System.Text.Encoding.GetEncodings`
+
+-->


### PR DESCRIPTION
Fixes #19274.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19733#utf-7-code-paths-are-obsolete).