### PR TITLE
Remove samples repository reference

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -79,11 +79,6 @@
       "path_to_root": "iot-samples",
       "url": "https://github.com/MicrosoftDocs/dotnet-iot-assets",
       "branch": "master"
-    },
-    {
-      "path_to_root": "dotnet-samples",
-      "url": "https://github.com/dotnet/samples",
-      "branch": "master"
     }
   ],
   "docs_build_engine": {

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -25,7 +25,7 @@ With MSTest, tests are automatically ordered by their test name.
 > [!NOTE]
 > A test named `Test14` will run before `Test2` even though the number  `2` is less than `14`. This is because, test name ordering uses the text name of the test.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/MSTest.Project/ByAlphabeticalOrder.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/MSTest.Project/ByAlphabeticalOrder.cs":::
 
 :::zone-end
 :::zone pivot="xunit"
@@ -36,35 +36,35 @@ The xUnit test framework allows for more granularity and control of test run ord
 
 To order test cases by their method name, you implement the `ITestCaseOrderer` and provide an ordering mechanism.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/AlphabeticalOrderer.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/AlphabeticalOrderer.cs":::
 
 Then in a test class you set the test case order with the `TestCaseOrdererAttribute`.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByAlphabeticalOrder.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/ByAlphabeticalOrder.cs":::
 
 ## Order by collection alphabetically
 
 To order test collections by their display name, you implement the `ITestCollectionOrderer` and provide an ordering mechanism.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/DisplayNameOrderer.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/DisplayNameOrderer.cs":::
 
 Since test collections potentially run in parallel, you must explicitly disable test parallelization of the collections with the `CollectionBehaviorAttribute`. Then specify the implementation to the `TestCollectionOrdererAttribute`.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByDisplayName.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/ByDisplayName.cs":::
 
 ## Order by custom attribute
 
 To order xUnit tests with custom attributes, you first need an attribute to rely on. Define a `TestPriorityAttribute` as follows:
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Attributes/TestPriorityAttribute.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/Attributes/TestPriorityAttribute.cs":::
 
 Next, consider the following `PriorityOrderer` implementation of the `ITestCaseOrderer` interface.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/Orderers/PriorityOrderer.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/PriorityOrderer.cs":::
 
 Then in a test class you set the test case order with the `TestCaseOrdererAttribute` to the `PriorityOrderer`.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/XUnit.TestProject/ByPriorityOrder.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/XUnit.TestProject/ByPriorityOrder.cs":::
 
 :::zone-end
 :::zone pivot="nunit"
@@ -73,7 +73,7 @@ Then in a test class you set the test case order with the `TestCaseOrdererAttrib
 
 To order tests explicitly, NUnit provides an [`OrderAttribute`](https://github.com/nunit/docs/wiki/Order-Attribute). Tests with this attribute are started before tests without. The order value is used to determined the order to run the unit tests.
 
-:::code language="csharp" source="~/dotnet-samples/csharp/unit-testing/NUnit.TestProject/ByOrder.cs":::
+:::code language="csharp" source="snippets/order-unit-tests/csharp/NUnit.TestProject/ByOrder.cs":::
 
 :::zone-end
 

--- a/docs/core/testing/snippets/order-unit-tests/csharp/MSTest.Project/ByAlphabeticalOrder.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/MSTest.Project/ByAlphabeticalOrder.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MSTest.Project
+{
+    [TestClass]
+    public class ByAlphabeticalOrder
+    {
+        public static bool Test1Called;
+        public static bool Test2Called;
+        public static bool Test3Called;
+
+        [TestMethod]
+        public void Test2()
+        {
+            Test2Called = true;
+
+            Assert.IsTrue(Test1Called);
+            Assert.IsFalse(Test3Called);
+        }
+
+        [TestMethod]
+        public void Test1()
+        {
+            Test1Called = true;
+
+            Assert.IsFalse(Test2Called);
+            Assert.IsFalse(Test3Called);
+        }
+
+        [TestMethod]
+        public void Test3()
+        {
+            Test3Called = true;
+
+            Assert.IsTrue(Test1Called);
+            Assert.IsTrue(Test2Called);
+        }
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/MSTest.Project/MSTest.Project.csproj
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/MSTest.Project/MSTest.Project.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/docs/core/testing/snippets/order-unit-tests/csharp/NUnit.TestProject/ByOrder.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/NUnit.TestProject/ByOrder.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+
+namespace NUnit.Project
+{
+    public class ByOrder
+    {
+        public static bool Test1Called;
+        public static bool Test2ACalled;
+        public static bool Test2BCalled;
+        public static bool Test3Called;
+
+        [Test, Order(5)]
+        public void Test1()
+        {
+            Test3Called = true;
+
+            Assert.IsTrue(Test1Called);
+            Assert.IsFalse(Test2ACalled);
+            Assert.IsTrue(Test2BCalled);
+        }
+
+        [Test, Order(0)]
+        public void Test2B()
+        {
+            Test2BCalled = true;
+
+            Assert.IsTrue(Test1Called);
+            Assert.IsFalse(Test2ACalled);
+            Assert.IsFalse(Test3Called);
+        }
+
+        [Test]
+        public void Test2A()
+        {
+            Test2ACalled = true;
+
+            Assert.IsTrue(Test1Called);
+            Assert.IsTrue(Test2BCalled);
+            Assert.IsTrue(Test3Called);
+        }
+
+        [Test, Order(-5)]
+        public void Test3()
+        {
+            Test1Called = true;
+
+            Assert.IsFalse(Test2ACalled);
+            Assert.IsFalse(Test2BCalled);
+            Assert.IsFalse(Test3Called);
+        }
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/NUnit.TestProject/NUnit.Project.csproj
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/NUnit.TestProject/NUnit.Project.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+  </ItemGroup>
+
+</Project>

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Attributes/TestPriorityAttribute.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Attributes/TestPriorityAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace XUnit.Project.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class TestPriorityAttribute : Attribute
+    {
+        public int Priority { get; private set; }
+
+        public TestPriorityAttribute(int priority) => Priority = priority;
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/ByAlphabeticalOrder.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/ByAlphabeticalOrder.cs
@@ -1,0 +1,39 @@
+﻿using Xunit;
+
+namespace XUnit.Project
+{
+    [TestCaseOrderer("XUnit.Project.Orderers.AlphabeticalOrderer", "XUnit.Project")]
+    public class ByAlphabeticalOrder
+    {
+        public static bool Test1Called;
+        public static bool Test2Called;
+        public static bool Test3Called;
+
+        [Fact]
+        public void Test1()
+        {
+            Test1Called = true;
+
+            Assert.False(Test2Called);
+            Assert.False(Test3Called);
+        }
+
+        [Fact]
+        public void Test2()
+        {
+            Test2Called = true;
+
+            Assert.True(Test1Called);
+            Assert.False(Test3Called);
+        }
+
+        [Fact]
+        public void Test3()
+        {
+            Test3Called = true;
+
+            Assert.True(Test1Called);
+            Assert.True(Test2Called);
+        }
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/ByDisplayName.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/ByDisplayName.cs
@@ -1,0 +1,56 @@
+﻿using Xunit;
+
+// Need to turn off test parallelization so we can validate the run order
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: TestCollectionOrderer("XUnit.Project.Orderers.DisplayNameOrderer", "XUnit.Project")]
+
+namespace XUnit.Project
+{
+    [Collection("Xzy Test Collection")]
+    public class TestsInCollection1
+    {
+        public static bool Collection1Run;
+
+        [Fact]
+        public static void Test()
+        {
+            Assert.True(TestsInCollection2.Collection2Run);     // Abc
+            Assert.True(TestsInCollection3.Collection3Run);     // Mno
+            Assert.False(TestsInCollection1.Collection1Run);    // Xyz
+
+            Collection1Run = true;
+        }
+    }
+
+    [Collection("Abc Test Collection")]
+    public class TestsInCollection2
+    {
+        public static bool Collection2Run;
+
+        [Fact]
+        public static void Test()
+        {
+            Assert.False(TestsInCollection2.Collection2Run);    // Abc
+            Assert.False(TestsInCollection3.Collection3Run);    // Mno
+            Assert.False(TestsInCollection1.Collection1Run);    // Xyz
+
+            Collection2Run = true;
+        }
+    }
+
+    [Collection("Mno Test Collection")]
+    public class TestsInCollection3
+    {
+        public static bool Collection3Run;
+
+        [Fact]
+        public static void Test()
+        {
+            Assert.True(TestsInCollection2.Collection2Run);     // Abc
+            Assert.False(TestsInCollection3.Collection3Run);    // Mno
+            Assert.False(TestsInCollection1.Collection1Run);    // Xyz
+
+            Collection3Run = true;
+        }
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/ByPriorityOrder.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/ByPriorityOrder.cs
@@ -1,0 +1,54 @@
+﻿using Xunit;
+using XUnit.Project.Attributes;
+
+namespace XUnit.Project
+{
+    [TestCaseOrderer("XUnit.Project.Orderers.PriorityOrderer", "XUnit.Project")]
+    public class ByPriorityOrder
+    {
+        public static bool Test1Called;
+        public static bool Test2ACalled;
+        public static bool Test2BCalled;
+        public static bool Test3Called;
+
+        [Fact, TestPriority(5)]
+        public void Test3()
+        {
+            Test3Called = true;
+
+            Assert.True(Test1Called);
+            Assert.True(Test2ACalled);
+            Assert.True(Test2BCalled);
+        }
+
+        [Fact, TestPriority(0)]
+        public void Test2B()
+        {
+            Test2BCalled = true;
+
+            Assert.True(Test1Called);
+            Assert.True(Test2ACalled);
+            Assert.False(Test3Called);
+        }
+
+        [Fact]
+        public void Test2A()
+        {
+            Test2ACalled = true;
+
+            Assert.True(Test1Called);
+            Assert.False(Test2BCalled);
+            Assert.False(Test3Called);
+        }
+
+        [Fact, TestPriority(-5)]
+        public void Test1()
+        {
+            Test1Called = true;
+
+            Assert.False(Test2ACalled);
+            Assert.False(Test2BCalled);
+            Assert.False(Test3Called);
+        }
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/AlphabeticalOrderer.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/AlphabeticalOrderer.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace XUnit.Project.Orderers
+{
+    public class AlphabeticalOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(
+            IEnumerable<TTestCase> testCases) where TTestCase : ITestCase =>
+            testCases.OrderBy(testCase => testCase.TestMethod.Method.Name);
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/DisplayNameOrderer.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/DisplayNameOrderer.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace XUnit.Project.Orderers
+{
+    public class DisplayNameOrderer : ITestCollectionOrderer
+    {
+        public IEnumerable<ITestCollection> OrderTestCollections(
+            IEnumerable<ITestCollection> testCollections) =>
+            testCollections.OrderBy(collection => collection.DisplayName);
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/PriorityOrderer.cs
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/Orderers/PriorityOrderer.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using XUnit.Project.Attributes;
+
+namespace XUnit.Project.Orderers
+{
+    public class PriorityOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(
+            IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+        {
+            string assemblyName = typeof(TestPriorityAttribute).AssemblyQualifiedName!;
+            var sortedMethods = new SortedDictionary<int, List<TTestCase>>();
+            foreach (TTestCase testCase in testCases)
+            {
+                int priority = testCase.TestMethod.Method
+                    .GetCustomAttributes(assemblyName)
+                    .FirstOrDefault()
+                    ?.GetNamedArgument<int>(nameof(TestPriorityAttribute.Priority)) ?? 0;
+
+                GetOrCreate(sortedMethods, priority).Add(testCase);
+            }
+
+            foreach (TTestCase testCase in
+                sortedMethods.Keys.SelectMany(
+                    priority => sortedMethods[priority].OrderBy(
+                        testCase => testCase.TestMethod.Method.Name)))
+            {
+                yield return testCase;
+            }
+        }
+
+        private static TValue GetOrCreate<TKey, TValue>(
+            IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey : struct
+            where TValue : new() =>
+            dictionary.TryGetValue(key, out TValue result)
+                ? result
+                : (dictionary[key] = new TValue());
+    }
+}

--- a/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/XUnit.Project.csproj
+++ b/docs/core/testing/snippets/order-unit-tests/csharp/XUnit.TestProject/XUnit.Project.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This setting used to exist before. I'm not 100% sure about what it does, but I guess it makes the live docs dependent on the live branch of the samples repo instead of master.

I'm also curious why docs is now dependent again on samples?

cc: @adegeo