### PR TITLE
Update tools documentation

### DIFF
--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -31,11 +31,11 @@ A .NET Core tool is a special NuGet package that contains a console application.
 
 Currently, .NET Core doesn't have a tool search feature. Here are some ways to find tools:
 
+* Search the [NuGet](https://www.nuget.org) website by using the ".NET tool" package type filter. For more information refer to: [Finding and choosing packages](/nuget/consume-packages/finding-and-choosing-packages)
 * See the list of tools in the [natemcmaster/dotnet-tools](https://github.com/natemcmaster/dotnet-tools) GitHub repository.
 * Use [ToolGet](https://www.toolget.net/) to search for .NET tools.
 * See the source code for the tools created by the ASP.NET Core team in the [Tools directory of the dotnet/aspnetcore GitHub repository](https://github.com/dotnet/aspnetcore/tree/master/src/Tools).
 * Learn about diagnostic tools at [.NET Core dotnet diagnostic tools](../diagnostics/index.md#net-core-dotnet-diagnostic-global-tools).
-* Search the [NuGet](https://www.nuget.org) website. However, the NuGet site doesn't yet have a feature that lets you search only for tool packages.
 
 ## Check the author and statistics
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -31,7 +31,7 @@ A .NET Core tool is a special NuGet package that contains a console application.
 
 Currently, .NET Core doesn't have a tool search feature. Here are some ways to find tools:
 
-* Search the [NuGet](https://www.nuget.org) website by using the ".NET tool" package type filter. For more information refer to: [Finding and choosing packages](/nuget/consume-packages/finding-and-choosing-packages)
+* Search the [NuGet](https://www.nuget.org) website by using the ".NET tool" package type filter. For more information, see [Finding and choosing packages](/nuget/consume-packages/finding-and-choosing-packages).
 * See the list of tools in the [natemcmaster/dotnet-tools](https://github.com/natemcmaster/dotnet-tools) GitHub repository.
 * Use [ToolGet](https://www.toolget.net/) to search for .NET tools.
 * See the source code for the tools created by the ASP.NET Core team in the [Tools directory of the dotnet/aspnetcore GitHub repository](https://github.com/dotnet/aspnetcore/tree/master/src/Tools).


### PR DESCRIPTION
## Summary
Nuget.org now offers a new advanced search that allows customers to filter by different package types, including .NET tools. This PR is to update the dotnet tool documentation's "Find a tool" section to reflect that change
