### PR TITLE
Add principal permission attribute breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,6 +122,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [PrincipalPermissionAttribute is obsolete as error](#principalpermissionattribute-is-obsolete-as-error)
 - [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps](#binaryformatter-serialization-methods-are-obsolete-and-prohibited-in-aspnet-apps)
 - [UTF-7 code paths are obsolete](#utf-7-code-paths-are-obsolete)
 - [Vector\<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types)
@@ -130,6 +131,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [principalpermissionattribute-obsolete](../../../includes/core-changes/corefx/5.0/principalpermissionattribute-obsolete.md)]
+
+***
 
 [!INCLUDE [binaryformatter-serialization-obsolete](../../../includes/core-changes/corefx/5.0/binaryformatter-serialization-obsolete.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [PrincipalPermissionAttribute is obsolete as error](#principalpermissionattribute-is-obsolete-as-error) | 5.0 |
 | [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps](#binaryformatter-serialization-methods-are-obsolete-and-prohibited-in-aspnet-apps) | 5.0 |
 | [UTF-7 code paths are obsolete](#utf-7-code-paths-are-obsolete) | 5.0 |
 | [Vector\<T> always throws NotSupportedException for unsupported types](#vectort-always-throws-notsupportedexception-for-unsupported-types) | 5.0 |
@@ -41,6 +42,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [principalpermissionattribute-obsolete](../../../includes/core-changes/corefx/5.0/principalpermissionattribute-obsolete.md)]
+
+***
 
 [!INCLUDE [binaryformatter-serialization-obsolete](../../../includes/core-changes/corefx/5.0/binaryformatter-serialization-obsolete.md)]
 

--- a/includes/core-changes/corefx/5.0/principalpermissionattribute-obsolete.md
+++ b/includes/core-changes/corefx/5.0/principalpermissionattribute-obsolete.md
@@ -1,0 +1,90 @@
+### PrincipalPermissionAttribute is obsolete as error
+
+The <xref:System.Security.Permissions.PrincipalPermissionAttribute> constructor is obsolete and produces a compile-time error. You cannot instantiate this attribute or apply it to a method.
+
+#### Change description
+
+On .NET Framework and .NET Core, you can annotate methods with the <xref:System.Security.Permissions.PrincipalPermissionAttribute> attribute. For example:
+
+```csharp
+[PrincipalPermission(SecurityAction.Demand, Role = "Administrators")]
+public void MyMethod()
+{
+    // Code that should only run when the current user is an administrator.
+}
+```
+
+Starting in .NET 5.0, you cannot apply the <xref:System.Security.Permissions.PrincipalPermissionAttribute> attribute to a method. The constructor for the attribute is obsolete and produces a compile-time error. Unlike other obsoletion warnings, you can't suppress the error.
+
+#### Reason for change
+
+The <xref:System.Security.Permissions.PrincipalPermissionAttribute> type, like other types that subclass <xref:System.Security.Permissions.SecurityAttribute>, is part of .NET's Code Access Security (CAS) infrastructure. In .NET Framework 2.x - 4.x, the runtime enforces <xref:System.Security.Permissions.PrincipalPermissionAttribute> annotations on method entry, even if the application is running under a full-trust scenario. .NET Core and .NET 5.0 and later don't support CAS attributes, and the runtime ignores them.
+
+This difference in behavior from .NET Framework to .NET Core and .NET 5.0 can result in a "fail open" scenario, where access should have been blocked but instead has been allowed. To prevent the "fail open" scenario, you can no longer apply the attribute in code that targets .NET 5.0 or later.
+
+#### Version introduced
+
+5.0 Preview 7
+
+#### Recommended action
+
+If you encounter the obsoletion error, you must take action.
+
+- **If you're applying the attribute to an ASP.NET MVC action method:**
+
+  Consider using ASP.NET's built-in authorization infrastructure. The following code snippet demonstrates annotating a controller with an <xref:System.Web.Mvc.AuthorizeAttribute> attribute. The ASP.NET runtime will authorize the user before performing the action.
+
+  ```csharp
+  using Microsoft.AspNetCore.Authorization;
+
+  namespace MySampleApp
+  {
+      [Authorize(Roles = "Administrator")]
+      public class AdministrationController : Controller
+      {
+          public ActionResult MyAction()
+          {
+              // This code won't run unless the current user
+              // is in the 'Administrator' role.
+          }
+      }
+  }
+  ```
+
+  For more information, see [Role-based authorization in ASP.NET Core](/aspnet/core/security/authorization/roles) and [Introduction to authorization in ASP.NET Core](/aspnet/core/security/authorization/introduction).
+
+- **If you're applying the attribute to library code outside the context of a web app:**
+
+  Perform the checks manually at the beginning of your method. This can be done by using the <xref:System.Security.Principal.IPrincipal.IsInRole(System.String)?displayProperty=nameWithType> method.
+
+  ```csharp
+  using System.Threading;
+
+  void DoSomething()
+  {
+      if (Thread.CurrentPrincipal == null
+          || !Thread.CurrentPrincipal.IsInRole("Administrators"))
+      {
+          throw new Exception("User is anonymous or isn't an admin.");
+      }
+
+      // Code that should run only when user is an administrator.
+  }
+  ```
+
+#### Category
+
+- Core .NET libraries
+- Security
+
+#### Affected APIs
+
+- <xref:System.Security.Permissions.PrincipalPermissionAttribute?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Security.Permissions.PrincipalPermissionAttribute`
+
+-->

--- a/includes/core-changes/corefx/5.0/principalpermissionattribute-obsolete.md
+++ b/includes/core-changes/corefx/5.0/principalpermissionattribute-obsolete.md
@@ -32,7 +32,7 @@ If you encounter the obsoletion error, you must take action.
 
 - **If you're applying the attribute to an ASP.NET MVC action method:**
 
-  Consider using ASP.NET's built-in authorization infrastructure. The following code snippet demonstrates annotating a controller with an <xref:System.Web.Mvc.AuthorizeAttribute> attribute. The ASP.NET runtime will authorize the user before performing the action.
+  Consider using ASP.NET's built-in authorization infrastructure. The following code demonstrates how to annotate a controller with an <xref:System.Web.Mvc.AuthorizeAttribute> attribute. The ASP.NET runtime will authorize the user before performing the action.
 
   ```csharp
   using Microsoft.AspNetCore.Authorization;


### PR DESCRIPTION
Fixes #19624.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19778#principalpermissionattribute-is-obsolete-as-error).