### PR TITLE
Fix .NET being referred to as a language

### DIFF
--- a/docs/spark/what-is-spark.md
+++ b/docs/spark/what-is-spark.md
@@ -78,7 +78,7 @@ Apache Spark supports the following programming languages:
 * Java
 * SQL
 * R
-* .NET
+* .NET languages (C#/VB/F#)
 
 ## Spark APIs
 

--- a/docs/spark/what-is-spark.md
+++ b/docs/spark/what-is-spark.md
@@ -78,7 +78,7 @@ Apache Spark supports the following programming languages:
 * Java
 * SQL
 * R
-* .NET languages (C#/VB/F#)
+* .NET languages (C#/F#)
 
 ## Spark APIs
 


### PR DESCRIPTION
The previous sentence before the list says: `Apache Spark supports the following programming languages:`. However, .NET isn't a language.