### PR TITLE
Update NullableReferenceTypes.cs

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/NullableReferenceTypes.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/NullableReferenceTypes.cs
@@ -44,7 +44,8 @@ namespace builtin_types
                 if (detailedDescription.Length == 0) // Warning! dereference possible null
                 {
                     return shortDescription;
-                } else
+                }
+                else
                 {
                     return $"{shortDescription}\n{detailedDescription}";
                 }
@@ -55,7 +56,8 @@ namespace builtin_types
                 if (detailedDescription == null)
                 {
                     return shortDescription;
-                } else if (detailedDescription.Length > 0) // OK, detailedDescription can't be null.
+                }
+                else if (detailedDescription.Length > 0) // OK, detailedDescription can't be null.
                 {
                     return $"{shortDescription}\n{detailedDescription}";
                 }


### PR DESCRIPTION
Proposed formatting change to move else conditions to their own line.

## Summary

Moved else conditions to their own line to better align the formatting with other areas of the docs.

Fixes #Issue_Number (if available)
