### PR TITLE
Fixed typo on sessionCookieLifetime

### DIFF
--- a/docs/architecture/microservices/secure-net-microservices-web-applications/index.md
+++ b/docs/architecture/microservices/secure-net-microservices-web-applications/index.md
@@ -168,7 +168,7 @@ public void ConfigureServices(IServiceCollection services)
 {
     var identityUrl = Configuration.GetValue<string>("IdentityUrl");
     var callBackUrl = Configuration.GetValue<string>("CallBackUrl");
-    var sessionCookieLifetime = configuration.GetValue("SessionCookieLifetimeMinutes", 60);
+    var sessionCookieLifetime = Configuration.GetValue("SessionCookieLifetimeMinutes", 60);
 
     // Add Authentication services
 


### PR DESCRIPTION
Existing variable was assigning to configuration, not Configuration.

## Summary

The existing variable used lowercase for configuration instead of starting with an uppercase 'C' for the sessionCookieLifetime value in the sample.
