### PR TITLE
switch expression: fixed the name of a pattern

### DIFF
--- a/docs/csharp/language-reference/operators/switch-expression.md
+++ b/docs/csharp/language-reference/operators/switch-expression.md
@@ -24,7 +24,7 @@ The *switch expression arms* are evaluated in text order. The compiler issues an
 
 ## Patterns and case guards
 
-Many patterns are supported in switch expression arms. The preceding example used a *value pattern*. A *value pattern* compares the range expression to a value. That value must be a compile time constant. The *type pattern* compares the range expression to a known type. The following example retrieves the third element from a sequence. It uses different methods based on the type of the sequence:
+Many patterns are supported in switch expression arms. The preceding example uses a *constant pattern*. A *constant pattern* compares the range expression to a value. That value must be a compile-time constant. The *type pattern* compares the range expression to a known type. The following example retrieves the third element from a sequence. It uses different methods based on the type of the sequence:
 
 :::code language="csharp" source="snippets/SwitchExpressions.cs" id="SnippetTypePattern":::
 


### PR DESCRIPTION
Throughout the docs, this is called "constant pattern":
- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/switch#constant-pattern
- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/is#constant-pattern

As well as in the language spec proposal: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.0/pattern-matching#constant-pattern
