### PR TITLE
Update chaining-tasks-by-using-continuation-tasks.md

### DIFF
--- a/docs/standard/parallel-programming/chaining-tasks-by-using-continuation-tasks.md
+++ b/docs/standard/parallel-programming/chaining-tasks-by-using-continuation-tasks.md
@@ -140,7 +140,7 @@ Sometimes you may need to chain a continuation that returns a <xref:System.Threa
 The following example shows how to use continuations that wrap additional task returning functions. Each continuation can be unwrapped, exposing the inner task that was wrapped.
 
 :::code language="csharp" source="snippets/cs/unwrap.cs":::
-:::code language="csharp" source="snippets/vb/unwrap.vb":::
+:::code language="vb" source="snippets/vb/unwrap.vb":::
 
 For more information on using <xref:System.Threading.Tasks.TaskExtensions.Unwrap%2A>, see [How to: Unwrap a nested Task](how-to-unwrap-a-nested-task.md).
 


### PR DESCRIPTION
## Summary

Fixing the language identifier, as VB is mistakenly shown as C#.

