### PR TITLE
Use when filter rather than if else throw.

### DIFF
--- a/includes/core-changes/serialization/5.0/binaryformatter-deserialize-rewraps-exceptions.md
+++ b/includes/core-changes/serialization/5.0/binaryformatter-deserialize-rewraps-exceptions.md
@@ -28,16 +28,9 @@ catch (MyException myEx)
 {
     // Handle 'myEx' here in case it was thrown directly.
 }
-catch (SerializationException serEx)
+catch (SerializationException serEx) when (serEx.InnerException is MyException myEx)
 {
-    if (serEx.InnerException is MyException myEx)
-    {
-        // Handle 'myEx' here in case it was wrapped in SerializationException.
-    }
-    else
-    {
-        throw;
-    }
+    // Handle 'myEx' here in case it was wrapped in SerializationException.
 }
 ```
 


### PR DESCRIPTION
## Summary

Change the documentation to use a when filter.
The when filter has existed since C# 6 and is the more correct way to handle this situation.


