### PR TITLE
Cryptography.Oid property setters

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -168,6 +168,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ***
 
+## Cryptography
+
+- [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only)
+
+[!INCLUDE [cryptography-oid-init-only](../../../includes/core-changes/cryptography/5.0/cryptography-oid-init-only.md)]
+
+***
+
 ## Globalization
 
 - [StringInfo and TextElementEnumerator are now UAX29-compliant](#stringinfo-and-textelementenumerator-are-now-uax29-compliant)

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -9,11 +9,18 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only) | 5.0 |
 | [BEGIN TRUSTED CERTIFICATE syntax no longer supported on Linux](#begin-trusted-certificate-syntax-no-longer-supported-for-root-certificates-on-linux) | 3.0 |
 | [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption) | 3.0 |
 | [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased) | 3.0 |
 | [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x) | 3.0 |
 | [Boolean parameter of SignedCms.ComputeSignature is respected](#boolean-parameter-of-signedcmscomputesignature-is-respected) | 2.1 |
+
+## .NET 5.0
+
+[!INCLUDE [cryptography-oid-init-only](../../../includes/core-changes/cryptography/5.0/cryptography-oid-init-only.md)]
+
+***
 
 ## .NET Core 3.0
 

--- a/includes/core-changes/cryptography/5.0/cryptography-oid-init-only.md
+++ b/includes/core-changes/cryptography/5.0/cryptography-oid-init-only.md
@@ -1,0 +1,39 @@
+### System.Security.Cryptography.Oid is functionally init-only
+
+The <xref:System.Security.Cryptography.Oid?displayProperty=fullName> class, which is used to represent ASN.1 Object Identifier values and their "friendly" names, was previously fully mutable. This mutability was often overlooked or came as a surprise. The property setters now throw a <xref:System.PlatformNotSupportedException> when you attempt to change the value after it's already been assigned.
+
+#### Change description
+
+In previous versions, the property setters on <xref:System.Security.Cryptography.Oid> can be used to change the value of the <xref:System.Security.Cryptography.Oid.FriendlyName> and <xref:System.Security.Cryptography.Oid.Value> properties.
+
+In .NET 5.0 and later versions, the property setters can only be used to initialize the value. Once the property has a value, either from a constructor or a previous call to the property setter, the property setter always throws a <xref:System.PlatformNotSupportedException>.
+
+#### Reason for change
+
+This change enables the reuse of <xref:System.Security.Cryptography.Oid> objects as part of return values in public APIs to reduce object allocation profiles. It avoids the need to create temporary "defensive" copies when <xref:System.Security.Cryptography.Oid> values are used as inputs.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+Avoid using the <xref:System.Security.Cryptography.Oid> property setters other than for object initialization. To represent a new value, use a new instance instead of changing the value on an existing object.
+
+#### Category
+
+Cryptography
+
+#### Affected APIs
+
+- <xref:System.Security.Cryptography.Oid.FriendlyName?displayProperty=fullName>
+- <xref:System.Security.Cryptography.Oid.Value?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Security.Cryptography.Oid.FriendlyName`
+- `P:System.Security.Cryptography.Oid.Value`
+
+-->


### PR DESCRIPTION
Fixes #19680

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19879#systemsecuritycryptographyoid-is-functionally-init-only).