### PR TITLE
Document ProtoBuf repeated/map use read-only props

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/protobuf-maps.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-maps.md
@@ -44,8 +44,8 @@ public Order CreateOrder(Dictionary<string, string> attributes)
 
 For more information about Protobuf, see the official [Protobuf documentation](https://developers.google.com/protocol-buffers/docs/overview).
 
+[map-field]: https://developers.google.cn/protocol-buffers/docs/reference/csharp/class/google/protobuf/collections/map-field-t-key-t-value-
+
 >[!div class="step-by-step"]
 >[Previous](protobuf-enums.md)
 >[Next](wcf-services-to-grpc-comparison.md)
-
-[map-field]: https://developers.google.cn/protocol-buffers/docs/reference/csharp/class/google/protobuf/collections/map-field-t-key-t-value-

--- a/docs/architecture/grpc-for-wcf-developers/protobuf-maps.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-maps.md
@@ -14,7 +14,7 @@ message StockPrices {
 }
 ```
 
-In the generated code, `map` fields use the `Google.Protobuf.Collections.MapField<TKey, TValue>` class. This class implements the standard .NET collection interfaces, including <xref:System.Collections.Generic.IDictionary%602>.
+In the generated code, `map` fields are represented by read-only properties of the [`Google.Protobuf.Collections.MapField<TKey, TValue>`][map-field] type. This type implements the standard .NET collection interfaces, including <xref:System.Collections.Generic.IDictionary%602>.
 
 Map fields can't be directly repeated in a message definition. But you can create a nested message that contains a map and use `repeated` on the message type, as in the following example:
 
@@ -47,3 +47,5 @@ For more information about Protobuf, see the official [Protobuf documentation](h
 >[!div class="step-by-step"]
 >[Previous](protobuf-enums.md)
 >[Next](wcf-services-to-grpc-comparison.md)
+
+[map-field]: https://developers.google.cn/protocol-buffers/docs/reference/csharp/class/google/protobuf/collections/map-field-t-key-t-value-

--- a/docs/architecture/grpc-for-wcf-developers/protobuf-repeated.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-repeated.md
@@ -19,8 +19,8 @@ In the generated code, `repeated` fields are represented by read-only properties
 
 The `RepeatedField<T>` type includes the code required to serialize and deserialize the list to the binary wire format.
 
+[repeated-field]: https://developers.google.cn/protocol-buffers/docs/reference/csharp/class/google/protobuf/collections/repeated-field-t-
+
 >[!div class="step-by-step"]
 >[Previous](protobuf-nested-types.md)
 >[Next](protobuf-reserved.md)
-
-[repeated-field]: https://developers.google.cn/protocol-buffers/docs/reference/csharp/class/google/protobuf/collections/repeated-field-t-

--- a/docs/architecture/grpc-for-wcf-developers/protobuf-repeated.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-repeated.md
@@ -15,10 +15,12 @@ message Person {
 }
 ```
 
-In the generated code, `repeated` fields are represented by the `Google.Protobuf.Collections.RepeatedField<T>` generic type rather than any of the built-in .NET collection types.
+In the generated code, `repeated` fields are represented by read-only properties of the [`Google.Protobuf.Collections.RepeatedField<T>`][repeated-field] type rather than any of the built-in .NET collection types. This type implements all the standard .NET collection interfaces, such as <xref:System.Collections.Generic.IList%601> and <xref:System.Collections.Generic.IEnumerable%601>. So you can use LINQ queries or convert it to an array or a list easily.
 
-The `RepeatedField<T>` type includes the code required to serialize and deserialize the list to the binary wire format. It implements all the standard .NET collection interfaces, such as <xref:System.Collections.Generic.IList%601> and <xref:System.Collections.Generic.IEnumerable%601>. So you can use LINQ queries or convert it to an array or a list easily.
+The `RepeatedField<T>` type includes the code required to serialize and deserialize the list to the binary wire format.
 
 >[!div class="step-by-step"]
 >[Previous](protobuf-nested-types.md)
 >[Next](protobuf-reserved.md)
+
+[repeated-field]: https://developers.google.cn/protocol-buffers/docs/reference/csharp/class/google/protobuf/collections/repeated-field-t-


### PR DESCRIPTION
Document that the Protocol Buffer generated C# code for repeated and map
fields use read-only properties that have mutable instances. Include
links to the reference documentation for `RepeatedField<T>` and
`MapField<K, V>`.

These improvements are based on
https://github.com/grpc/grpc-dotnet/issues/1012