### PR TITLE
A/W suffix for P/Invokes

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -188,7 +188,12 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Interop
 
+- [No A/W suffix probing on non-Windows platforms](#no-aw-suffix-probing-on-non-windows-platforms)
 - [Built-in support for WinRT is removed from .NET](#built-in-support-for-winrt-is-removed-from-net)
+
+[!INCLUDE [function-suffix-pinvoke](../../../includes/core-changes/interop/5.0/function-suffix-pinvoke.md)]
+
+***
 
 [!INCLUDE [built-in-support-for-winrt-removed](~/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md)]
 

--- a/docs/core/compatibility/interop.md
+++ b/docs/core/compatibility/interop.md
@@ -9,9 +9,14 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [No A/W suffix probing on non-Windows platforms](#no-aw-suffix-probing-on-non-windows-platforms) | 5.0 |
 | [Built-in support for WinRT is removed from .NET](#built-in-support-for-winrt-is-removed-from-net) | 5.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [function-suffix-pinvoke](../../../includes/core-changes/interop/5.0/function-suffix-pinvoke.md)]
+
+***
 
 [!INCLUDE [built-in-support-for-winrt-removed](~/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md)]
 

--- a/includes/core-changes/interop/5.0/function-suffix-pinvoke.md
+++ b/includes/core-changes/interop/5.0/function-suffix-pinvoke.md
@@ -1,0 +1,40 @@
+### No A/W suffix probing on non-Windows platforms
+
+The .NET runtimes no longer add an `A` or `W` suffix to function export names during probing for P/Invokes on non-Windows platforms.
+
+#### Version introduced
+
+5.0 Preview 4
+
+#### Change description
+
+[Windows has a convention](/windows/win32/intl/conventions-for-function-prototypes) of adding an `A` or `W` suffix to Windows SDK function names, which correspond to the Windows code page and Unicode versions, respectively. In previous versions of .NET, both the CoreCLR and Mono runtimes add an `A` or `W` suffix to the export name during export discovery for P/Invokes *on all platforms*. In .NET 5.0 and later versions, an `A` or `W` suffix is added to the export name during export discovery on Windows only. On Unix platforms, the suffix is *not* added. The semantics of both runtimes on the Windows platform remain unchanged.
+
+#### Reason for change
+
+This change was made to simplify cross-platform probing. It's overhead that shouldn't be incurred, given that non-Windows platforms don't contain this semantic.
+
+#### Recommended action
+
+To mitigate the change, you can manually add the desired suffix on non-Windows platforms. For example:
+
+```csharp
+[DllImport(...)]
+extern static void SetWindowTextW();
+```
+
+#### Category
+
+Interop
+
+#### Affected APIs
+
+- <xref:System.Runtime.InteropServices.DllImportAttribute?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Runtime.InteropServices.DllImportAttribute`
+
+-->

--- a/includes/core-changes/interop/5.0/function-suffix-pinvoke.md
+++ b/includes/core-changes/interop/5.0/function-suffix-pinvoke.md
@@ -8,7 +8,11 @@ The .NET runtimes no longer add an `A` or `W` suffix to function export names du
 
 #### Change description
 
-[Windows has a convention](/windows/win32/intl/conventions-for-function-prototypes) of adding an `A` or `W` suffix to Windows SDK function names, which correspond to the Windows code page and Unicode versions, respectively. In previous versions of .NET, both the CoreCLR and Mono runtimes add an `A` or `W` suffix to the export name during export discovery for P/Invokes *on all platforms*. In .NET 5.0 and later versions, an `A` or `W` suffix is added to the export name during export discovery on Windows only. On Unix platforms, the suffix is *not* added. The semantics of both runtimes on the Windows platform remain unchanged.
+[Windows has a convention](/windows/win32/intl/conventions-for-function-prototypes) of adding an `A` or `W` suffix to Windows SDK function names, which correspond to the Windows code page and Unicode versions, respectively.
+
+In previous versions of .NET, both the CoreCLR and Mono runtimes add an `A` or `W` suffix to the export name during export discovery for P/Invokes *on all platforms*.
+
+In .NET 5.0 and later versions, an `A` or `W` suffix is added to the export name during export discovery *on Windows only*. On Unix platforms, the suffix is not added. The semantics of both runtimes on the Windows platform remain unchanged.
 
 #### Reason for change
 


### PR DESCRIPTION
Fixes #19681.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19912#no-aw-suffix-probing-on-non-windows-platforms).