### PR TITLE
Fix dotnet-sdk-2.1 version recommendation: SDK

### DIFF
--- a/docs/core/distribution-packaging.md
+++ b/docs/core/distribution-packaging.md
@@ -105,7 +105,7 @@ The rest of the version isn't included in the version name. This allows the OS p
 The following lists the recommended packages:
 
 - `dotnet-sdk-[major].[minor]` - Installs the latest sdk for specific runtime
-  - **Version:** \<runtime version>
+  - **Version:** \<sdk version>
   - **Example:** dotnet-sdk-2.1
   - **Contains:** (3),(4)
   - **Dependencies:** `dotnet-runtime-[major].[minor]`, `aspnetcore-runtime-[major].[minor]`, `dotnet-targeting-pack-[major].[minor]`, `aspnetcore-targeting-pack-[major].[minor]`, `netstandard-targeting-pack-[netstandard_major].[netstandard_minor]`, `dotnet-apphost-pack-[major].[minor]`, `dotnet-templates-[major].[minor]`


### PR DESCRIPTION
I think this is wrong and the SDK package should use `<sdk version>`:

> - `dotnet-sdk-[major].[minor]` - Installs the latest sdk for specific runtime
>   - **Version:** \<runtime version>

It looks like this started with a mistake in my suggestion at https://github.com/dotnet/docs/pull/13196#discussion_r301634357, so I doubt there was any reason for it to be `<runtime version>`.

/cc @tmds @omajid
