### PR TITLE
Updated DefaultOperator.cs

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/DefaultOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/DefaultOperator.cs
@@ -39,7 +39,7 @@ namespace operators
             {
                 if (length < 0)
                 {
-                    return default;
+                    throw new ArgumentOutOfRangeException(nameof(length), "Array length must be nonnegative.");
                 }
 
                 var array = new T[length];


### PR DESCRIPTION
## Summary

Updated InitializeArray() method to throw ArgumentOutOfRangeException when length parameter is negative.

Fixes #19919 
