### PR TITLE
LINQ OrderBy breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,6 +122,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [Complexity of LINQ OrderBy increased](#complexity-of-linq-orderby-increased)
 - [IntPtr and UIntPtr implement IFormattable](#intptr-and-uintptr-implement-iformattable)
 - [PrincipalPermissionAttribute is obsolete as error](#principalpermissionattribute-is-obsolete-as-error)
 - [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps](#binaryformatter-serialization-methods-are-obsolete-and-prohibited-in-aspnet-apps)
@@ -132,6 +133,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [orderby-firstordefault-complexity-increase](../../../includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md)]
+
+***
 
 [!INCLUDE [intptr-uintptr-implement-iformattable](../../../includes/core-changes/corefx/5.0/intptr-uintptr-implement-iformattable.md)]
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,7 +122,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
-- [Complexity of LINQ OrderBy increased](#complexity-of-linq-orderby-increased)
+- [Complexity of LINQ OrderBy.First{OrDefault} increased](#complexity-of-linq-orderbyfirstordefault-increased)
 - [IntPtr and UIntPtr implement IFormattable](#intptr-and-uintptr-implement-iformattable)
 - [PrincipalPermissionAttribute is obsolete as error](#principalpermissionattribute-is-obsolete-as-error)
 - [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps](#binaryformatter-serialization-methods-are-obsolete-and-prohibited-in-aspnet-apps)

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Complexity of LINQ OrderBy increased](#complexity-of-linq-orderby-increased) | 5.0 |
 | [IntPtr and UIntPtr implement IFormattable](#intptr-and-uintptr-implement-iformattable) | 5.0 |
 | [PrincipalPermissionAttribute is obsolete as error](#principalpermissionattribute-is-obsolete-as-error) | 5.0 |
 | [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps](#binaryformatter-serialization-methods-are-obsolete-and-prohibited-in-aspnet-apps) | 5.0 |
@@ -39,6 +40,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [orderby-firstordefault-complexity-increase](../../../includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md)]
+
+***
 
 [!INCLUDE [intptr-uintptr-implement-iformattable](../../../includes/core-changes/corefx/5.0/intptr-uintptr-implement-iformattable.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,7 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
-| [Complexity of LINQ OrderBy increased](#complexity-of-linq-orderby-increased) | 5.0 |
+| [Complexity of LINQ OrderBy.First{OrDefault} increased](#complexity-of-linq-orderbyfirstordefault-increased) | 5.0 |
 | [IntPtr and UIntPtr implement IFormattable](#intptr-and-uintptr-implement-iformattable) | 5.0 |
 | [PrincipalPermissionAttribute is obsolete as error](#principalpermissionattribute-is-obsolete-as-error) | 5.0 |
 | [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps](#binaryformatter-serialization-methods-are-obsolete-and-prohibited-in-aspnet-apps) | 5.0 |

--- a/includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md
+++ b/includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md
@@ -1,0 +1,40 @@
+### Complexity of LINQ OrderBy increased
+
+The implementation of <xref:System.Linq.Enumerable.OrderBy%2A> has changed, resulting in an increased complexity.
+
+#### Change description
+
+In .NET Core 1.x - 3.x, `OrderBy().First()` and `OrderBy().FirstOrDefault()` operate with `O(N)` complexity. Since only the first (or default) element is required, only one enumeration is required to find it. However, the supplied predicate is invoked exactly `N` times, where `N` is the length of the sequence.
+
+In .NET 5.0 and later versions, a [change was made](https://github.com/dotnet/runtime/pull/36643) such that `OrderBy().First()` and `OrderBy().FirstOrDefault()` operate with `O(N log N)` complexity. However, the predicate may be invoked less than `N` times, which is more important for overall performance.
+
+> [!NOTE]
+> This change matches the implementation and complexity of the operation in .NET Framework.
+
+#### Reason for change
+
+The cost of potentially invoking the predicate more times is too great, even with the benefit of a lower overall complexity.
+
+#### Version introduced
+
+5.0
+
+#### Recommended action
+
+No action is required.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Linq.Enumerable.OrderBy%2A?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `Overload:System.Linq.Enumerable.OrderBy`
+
+-->

--- a/includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md
+++ b/includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md
@@ -1,19 +1,19 @@
-### Complexity of LINQ OrderBy increased
+### Complexity of LINQ OrderBy.First{OrDefault} increased
 
-The implementation of <xref:System.Linq.Enumerable.OrderBy%2A> has changed, resulting in an increased complexity.
+The implementation of <xref:System.Linq.Enumerable.OrderBy%2A>`.`<xref:System.Linq.Enumerable.First%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> and <xref:System.Linq.Enumerable.OrderBy%2A>`.`<xref:System.Linq.Enumerable.FirstOrDefault%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> has changed, resulting in increased complexity for the operation.
 
 #### Change description
 
-In .NET Core 1.x - 3.x, `OrderBy().First()` and `OrderBy().FirstOrDefault()` operate with `O(N)` complexity. Since only the first (or default) element is required, only one enumeration is required to find it. However, the supplied predicate is invoked exactly `N` times, where `N` is the length of the sequence.
+In .NET Core 1.x - 3.x, calling <xref:System.Linq.Enumerable.OrderBy%2A> or <xref:System.Linq.Enumerable.OrderByDescending%2A> followed by <xref:System.Linq.Enumerable.First%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> or <xref:System.Linq.Enumerable.FirstOrDefault%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> operates with `O(N)` complexity. Since only the first (or default) element is required, only one enumeration is required to find it. However, the predicate that's supplied to <xref:System.Linq.Enumerable.First%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> or <xref:System.Linq.Enumerable.FirstOrDefault%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> is invoked exactly `N` times, where `N` is the length of the sequence.
 
-In .NET 5.0 and later versions, a [change was made](https://github.com/dotnet/runtime/pull/36643) such that `OrderBy().First()` and `OrderBy().FirstOrDefault()` operate with `O(N log N)` complexity. However, the predicate may be invoked less than `N` times, which is more important for overall performance.
+In .NET 5.0 and later versions, a [change was made](https://github.com/dotnet/runtime/pull/36643) such that calling <xref:System.Linq.Enumerable.OrderBy%2A> or <xref:System.Linq.Enumerable.OrderByDescending%2A> followed by <xref:System.Linq.Enumerable.First%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> or <xref:System.Linq.Enumerable.FirstOrDefault%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> operates with `O(N log N)` complexity instead of `O(N)` complexity. However, the predicate that's supplied to <xref:System.Linq.Enumerable.First%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> or <xref:System.Linq.Enumerable.FirstOrDefault%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})> may be invoked *less* than `N` times, which is more important for overall performance.
 
 > [!NOTE]
 > This change matches the implementation and complexity of the operation in .NET Framework.
 
 #### Reason for change
 
-The benefit of invoking the predicate fewer times outweighs a lower overall complexity, so the implementation that was introduced in .NET Core 1.0 was reverted.
+The benefit of invoking the predicate fewer times outweighs a lower overall complexity, so the implementation that was introduced in .NET Core 1.0 was reverted. For more information, see [this dotnet/runtime issue](https://github.com/dotnet/runtime/issues/31554).
 
 #### Version introduced
 
@@ -21,7 +21,7 @@ The benefit of invoking the predicate fewer times outweighs a lower overall comp
 
 #### Recommended action
 
-No action is required.
+No action is required on the developer's part.
 
 #### Category
 
@@ -30,11 +30,17 @@ Core .NET libraries
 #### Affected APIs
 
 - <xref:System.Linq.Enumerable.OrderBy%2A?displayProperty=fullName>
+- <xref:System.Linq.Enumerable.OrderByDescending%2A?displayProperty=fullName>
+- <xref:System.Linq.Enumerable.First%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})?displayProperty=fullName>
+- <xref:System.Linq.Enumerable.FirstOrDefault%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Func{%60%600,System.Boolean})?displayProperty=fullName>
 
 <!--
 
 #### Affected APIs
 
 - `Overload:System.Linq.Enumerable.OrderBy`
+- `Overload:System.Linq.Enumerable.OrderByDescending`
+- `M:System.Linq.Enumerable.First``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})`
+- `M:System.Linq.Enumerable.FirstOrDefault``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})`
 
 -->

--- a/includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md
+++ b/includes/core-changes/corefx/5.0/orderby-firstordefault-complexity-increase.md
@@ -13,7 +13,7 @@ In .NET 5.0 and later versions, a [change was made](https://github.com/dotnet/ru
 
 #### Reason for change
 
-The cost of potentially invoking the predicate more times is too great, even with the benefit of a lower overall complexity.
+The benefit of invoking the predicate fewer times outweighs a lower overall complexity, so the implementation that was introduced in .NET Core 1.0 was reverted.
 
 #### Version introduced
 


### PR DESCRIPTION
Fixes #19683.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-19949#complexity-of-linq-orderby-increased).