### PR TITLE
Improve deps.json documentation

### DIFF
--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -32,9 +32,11 @@ There are two main scenarios for populating the properties depending on whether 
 
 Additionally, the *\*.deps.json* files for any referenced frameworks are similarly parsed.
 
-Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional dependencies.
+Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an `--additional-deps` optional parameter to set this value on application startup.
 
 The `APP_PATHS` and `APP_NI_PATHS` properties are not populated by default and are omitted for most applications.
+
+To see all *\*.deps.json* files present, you can write a log statement to output `System.AppContext.GetData(“APP_CONTEXT_DEPS_FILES”)`.
 
 ### How do I see the probing properties from managed code?
 

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -36,7 +36,7 @@ Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional
 
 The `APP_PATHS` and `APP_NI_PATHS` properties are not populated by default and are omitted for most applications.
 
-To see all *\*.deps.json* files present, you can write a log statement to output `System.AppContext.GetData(“APP_CONTEXT_DEPS_FILES”)`.
+To see all *\*.deps.json* files present, you can write a log statement to output `System.AppContext.GetData("APP_CONTEXT_DEPS_FILES")`.
 
 ### How do I see the probing properties from managed code?
 

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -36,7 +36,7 @@ Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional
 
 The `APP_PATHS` and `APP_NI_PATHS` properties are not populated by default and are omitted for most applications.
 
-To see all *\*.deps.json* files present, you can write a log statement to output `System.AppContext.GetData("APP_CONTEXT_DEPS_FILES")`.
+The list of all *\*.deps.json* files used by the application can be accessed via `System.AppContext.GetData("APP_CONTEXT_DEPS_FILES")`.
 
 ### How do I see the probing properties from managed code?
 


### PR DESCRIPTION
## Summary

I frequently have to refer back to a comment Nate McMaster made on his blog to me a long time ago to find any reference to `System.AppContext.GetData("APP_CONTEXT_DEPS_FILES")` when debugging assembly loading issues.  It would be very convenient to mention this here, as I frequently ask my customers to dump this value to troubleshoot their problems.  In particular, Azure App Service AI SQL Diagnostics feature causes issues loading System.Threading.AccessControl, and customers somehow think this is my fault, and it would be nice to be able to show them exactly step by step what is going on and that the root cause lies with Azure App Service injecting a random assembly version requirement into their default AssemblyLoadContext.