### PR TITLE
Update link: aspnet/websdk to dotnet/sdk

### DIFF
--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -16,7 +16,7 @@ The following SDKs are available for .NET Core:
 | ID | Description | Repo|
 | - | - | - |
 | `Microsoft.NET.Sdk` | The .NET Core SDK | <https://github.com/dotnet/sdk> |
-| `Microsoft.NET.Sdk.Web` | The .NET Core [Web SDK](/aspnet/core/razor-pages/web-sdk) | <https://github.com/aspnet/websdk> |
+| `Microsoft.NET.Sdk.Web` | The .NET Core [Web SDK](/aspnet/core/razor-pages/web-sdk) | <https://github.com/dotnet/sdk> |
 | `Microsoft.NET.Sdk.Razor` | The .NET Core [Razor SDK](/aspnet/core/razor-pages/sdk) |
 | `Microsoft.NET.Sdk.Worker` | The .NET Core Worker Service SDK |
 | `Microsoft.NET.Sdk.WindowsDesktop` | The .NET Core WinForms and WPF SDK |


### PR DESCRIPTION
aspnet/websdk has been merged with dotnet/sdk, so I updated the link.

Source: https://github.com/aspnet/websdk readme

## Summary

Updated a link