### PR TITLE
Automatically remove "Not Triaged" label on issue closing

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -178,7 +178,7 @@
     },
     "closed": {
       "processor-default": {
-        "labels-remove": "in-progress"
+        "labels-remove": [ "in-progress", ":watch: Not Triaged" ]
       }
     }
   },


### PR DESCRIPTION
Feel free to close if you don't want that behavior.