### PR TITLE
Update F# language reference index to point to FSharp.Core api ref

### DIFF
--- a/docs/fsharp/language-reference/index.md
+++ b/docs/fsharp/language-reference/index.md
@@ -1,11 +1,15 @@
 ---
 title: Language Reference
 description: Find F# language feature information from this reference to language tokens, concepts, types, expressions, and compiler-supported construct topics.
-ms.date: 05/16/2016
+ms.date: 08/13/2020
 ---
 # F# Language Reference
 
 This section is a reference for the F# language, a multi-paradigm programming language targeting .NET. The F# language supports functional, object-oriented, and imperative programming models.
+
+## F# Core Library API reference
+
+[F# Core Library (FSharp.Core) API reference](https://fsharp.github.io/fsharp-core-docs/) is the reference for all F# Core Library namespaces, modules, types, and functions.
 
 ## F# Tokens
 


### PR DESCRIPTION
Link out to here for interested folks: https://fsharp.github.io/fsharp-core-docs/

Since the MSDN stuff is kaput and has been for quite a while

Plus it looks nicer :)