### PR TITLE
Updated C#/VB to match proposed changes. Update article

### DIFF
--- a/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
+++ b/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
@@ -1,7 +1,6 @@
 ---
 title: Register callbacks for cancellation requests
 ms.date: 08/14/2020
-ms.topic: how-to
 ms.technology: dotnet-standard
 dev_langs: 
   - "csharp"

--- a/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
+++ b/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
@@ -1,5 +1,5 @@
 ---
-title: "How to: Register callbacks for cancellation requests"
+title: "Register callbacks for cancellation requests"
 ms.date: 08/14/2020
 ms.topic: how-to
 ms.technology: dotnet-standard
@@ -11,7 +11,7 @@ helpviewer_keywords:
 ms.assetid: 8838dd75-18ed-4b8b-b322-cd4531faac64
 ---
 
-# How to: Register callbacks for cancellation requests
+# Register callbacks for cancellation requests
 
 Learn how to register a delegate that will be invoked when a <xref:System.Threading.CancellationToken.IsCancellationRequested%2A> property becomes true. The value changes from false to true when a call to <xref:System.Threading.CancellationTokenSource.Cancel%2A> on the object that created the token is made. Use this technique for canceling asynchronous operations that do not natively support the unified cancellation framework, and for unblocking methods that might be waiting for an asynchronous operation to finish.
 

--- a/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
+++ b/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
@@ -1,5 +1,5 @@
 ---
-title: "Register callbacks for cancellation requests"
+title: Register callbacks for cancellation requests
 ms.date: 08/14/2020
 ms.topic: how-to
 ms.technology: dotnet-standard

--- a/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
+++ b/docs/standard/threading/how-to-register-callbacks-for-cancellation-requests.md
@@ -1,28 +1,33 @@
 ---
-title: "How to: Register Callbacks for Cancellation Requests"
-ms.date: "03/30/2017"
+title: "How to: Register callbacks for cancellation requests"
+ms.date: 08/14/2020
+ms.topic: how-to
 ms.technology: dotnet-standard
 dev_langs: 
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "cancellation, how to register callbacks"
 ms.assetid: 8838dd75-18ed-4b8b-b322-cd4531faac64
 ---
-# How to: Register Callbacks for Cancellation Requests
-The following example shows how to register a delegate that will be invoked when a <xref:System.Threading.CancellationToken.IsCancellationRequested%2A> property becomes true due to a call to <xref:System.Threading.CancellationTokenSource.Cancel%2A> on the object that created the token. Use this technique for cancelling asynchronous operations that do not natively support the unified cancellation framework, and for unblocking methods that might be waiting for an asynchronous operation to finish.  
-  
+
+# How to: Register callbacks for cancellation requests
+
+Learn how to register a delegate that will be invoked when a <xref:System.Threading.CancellationToken.IsCancellationRequested%2A> property becomes true. The value changes from false to true when a call to <xref:System.Threading.CancellationTokenSource.Cancel%2A> on the object that created the token is made. Use this technique for canceling asynchronous operations that do not natively support the unified cancellation framework, and for unblocking methods that might be waiting for an asynchronous operation to finish.
+
 > [!NOTE]
-> When "Just My Code" is enabled, Visual Studio in some cases will break on the line that throws the exception and display an error message that says "exception not handled by user code." This error is benign. You can press F5 to continue from it, and see the exception-handling behavior that is demonstrated in the examples below. To prevent Visual Studio from breaking on the first error, just uncheck the "Just My Code" checkbox under **Tools, Options, Debugging, General**.  
-  
-## Example  
- In the following example, the <xref:System.Net.WebClient.CancelAsync%2A> method is registered as the method to be invoked when cancellation is requested through the cancellation token.  
-  
- [!code-csharp[Conceptual.Cancellation.Callback#1](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.cancellation.callback/cs/howtoexample1.cs#1)]
- [!code-vb[Conceptual.Cancellation.Callback#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/howtoexample1.vb#1)]  
-  
- If cancellation has already been requested when the callback is registered, the callback is still guaranteed to be called. In this particular case, the <xref:System.Net.WebClient.CancelAsync%2A> method will do nothing if no asynchronous operation is in progress, so it is always safe to call the method.  
-  
+> When "Just My Code" is enabled, Visual Studio in some cases will break on the line that throws the exception and display an error message that says "exception not handled by user code." This error is benign. You can press <kbd>F5</kbd> to continue from it, and see the exception-handling behavior that is demonstrated in the examples below. To prevent Visual Studio from breaking on the first error, just uncheck the "Just My Code" checkbox under **Tools, Options, Debugging, General**.
+
+## Example
+
+In the following example, the <xref:System.Net.WebClient.CancelAsync%2A> method is registered as the method to be invoked when cancellation is requested through the cancellation token.
+
+:::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.cancellation.callback/cs/howtoexample1.cs":::
+:::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/howtoexample1.vb":::
+
+If cancellation has already been requested when the callback is registered, the callback is still guaranteed to be called. In this particular case, the <xref:System.Net.WebClient.CancelAsync%2A> method will do nothing if no asynchronous operation is in progress, so it is always safe to call the method.
+
 ## See also
 
-- [Cancellation in Managed Threads](cancellation-in-managed-threads.md)
+- [Cancellation in managed threads](cancellation-in-managed-threads.md)
+- <xref:System.Net.WebClient.DownloadStringTaskAsync(System.String)?displayProperty=nameWithType>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.cancellation.callback/cs/cs.csproj
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.cancellation.callback/cs/cs.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.cancellation.callback/cs/howtoexample1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.cancellation.callback/cs/howtoexample1.cs
@@ -1,53 +1,48 @@
-﻿// <Snippet1>
-using System;
+﻿using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
 class CancelWithCallback
 {
-   static void Main()
-   {
-      var cts = new CancellationTokenSource();
-      var token = cts.Token;
+    static void Main()
+    {
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
 
-      // Start cancelable task.
-      Task t = Task.Run( () => {
-                    WebClient wc = new WebClient();
+        _ = Task.Run(async () =>
+        {
+            using var client = new WebClient();
 
-                    // Create an event handler to receive the result.
-                    wc.DownloadStringCompleted += (obj, e) => {
-                               // Check status of WebClient, not external token.
-                               if (!e.Cancelled) {
-                                  Console.WriteLine("The download has completed:\n");
-                                  Console.WriteLine(e.Result + "\n\nPress any key.");
-                               }
-                               else {
-                                  Console.WriteLine("The download was canceled.");
-                               }
-                    };
+            client.DownloadStringCompleted += (_, args) =>
+            {
+                if (args.Cancelled)
+                {
+                    Console.WriteLine("The download was canceled.");
+                }
+                else
+                {
+                    Console.WriteLine("The download has completed:\n");
+                    Console.WriteLine($"{args.Result}\n\nPress any key to continue.");
+                }
+            };
 
-                    // Do not initiate download if the external token
-                    // has already been canceled.
-                    if (!token.IsCancellationRequested) {
-                       // Register the callback to a method that can unblock.
-                       using (CancellationTokenRegistration ctr = token.Register(() => wc.CancelAsync()))
-                       {
-                          Console.WriteLine("Starting request\n");
-                          wc.DownloadStringAsync(new Uri("http://www.contoso.com"));
-                       }
-                    }
-               }, token);
+            if (!token.IsCancellationRequested)
+            {
+                using CancellationTokenRegistration ctr = token.Register(() => client.CancelAsync());
 
-      Console.WriteLine("Press 'c' to cancel.\n");
-      char ch = Console.ReadKey().KeyChar;
-      Console.WriteLine();
-      if (ch == 'c')
-         cts.Cancel();
+                Console.WriteLine("Starting request\n");
+                await client.DownloadStringTaskAsync(new Uri("http://www.contoso.com"));
+            }
+        }, token);
 
-      Console.WriteLine("Press any key to exit.");
-      Console.ReadKey();
-      cts.Dispose();
-   }
+        Console.WriteLine("Press 'c' to cancel.\n\n");
+        if (Console.ReadKey().KeyChar == 'c')
+        {
+            cts.Cancel();
+        }
+
+        Console.WriteLine("\nPress any key to exit.");
+        Console.ReadKey();
+    }
 }
-// </Snippet1>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/howtoexample1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/howtoexample1.vb
@@ -1,47 +1,41 @@
-﻿' Visual Basic .NET Document
-
-' <Snippet1>
+﻿Imports System.Net
 Imports System.Threading
-Imports System.Threading.Tasks
-Imports System.Net
 
-Class CancelWithCallback
-    Shared Sub Main()
-        Dim cts As New CancellationTokenSource()
-        Dim token As CancellationToken = cts.Token
+Friend Class CancelWithCallback
+    Private Shared Sub Main()
+        Using cts = New CancellationTokenSource()
+            Dim token = cts.Token
+            Task.Run(
+                Async Function()
+                    Using client As WebClient = New WebClient()
+                        AddHandler client.DownloadDataCompleted,
+                        Sub(__, args)
+                            If args.Cancelled Then
+                                Console.WriteLine("The download was canceled.")
+                            Else
+                                Console.WriteLine($"The download has completed:{vbLf}")
+                                Console.WriteLine($"{args.Result}{vbLf}{vbLf}Press any key to continue.")
+                            End If
+                        End Sub
 
-        ' Start cancelable task.
-        Dim t As Task = Task.Run(
-           Sub()
-               Dim wc As New WebClient()
+                        If Not token.IsCancellationRequested Then
+                            Dim ctr As CancellationTokenRegistration = token.Register(Sub() client.CancelAsync())
+                            Console.WriteLine($"Starting request{vbLf}")
+                            Await client.DownloadStringTaskAsync(New Uri("http://www.contoso.com"))
+                        End If
+                    End Using
 
-               ' Create an event handler to receive the result.
-               AddHandler wc.DownloadStringCompleted,
-                          Sub(obj, e)
-                             ' Check status of WebClient, not external token.
-                             If Not e.Cancelled Then
-                                  Console.WriteLine("The download has completed:" + vbCrLf)
-                                  Console.WriteLine(e.Result + vbCrLf + vbCrLf + "Press any key.")
-                              Else
-                                  Console.WriteLine("Download was canceled.")
-                              End If
-                          End Sub
-               Using ctr As CancellationTokenRegistration = token.Register(Sub() wc.CancelAsync())
-                   Console.WriteLine("Starting request..." + vbCrLf)
-                   wc.DownloadStringAsync(New Uri("http://www.contoso.com"))
-               End Using
-           End Sub, token)
+                End Function, token)
 
-        Console.WriteLine("Press 'c' to cancel." + vbCrLf)
-        Dim ch As Char = Console.ReadKey().KeyChar
-        Console.WriteLine()
+            Console.WriteLine($"Press 'c' to cancel.{vbLf}{vbLf}")
 
-        If ch = "c"c Then
-            cts.Cancel()
-        End If
-        Console.WriteLine("Press any key to exit.")
-        Console.ReadKey()
-        cts.Dispose()
+            If Console.ReadKey().KeyChar = "c"c Then
+                cts.Cancel()
+            End If
+
+            Console.WriteLine($"{vbLf}Press any key to exit.")
+            Console.ReadKey()
+
+        End Using
     End Sub
 End Class
-' </Snippet1>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/howtoexample1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/howtoexample1.vb
@@ -7,7 +7,7 @@ Friend Class CancelWithCallback
             Dim token = cts.Token
             Task.Run(
                 Async Function()
-                    Using client As WebClient = New WebClient()
+                    Using client As New WebClient()
                         AddHandler client.DownloadDataCompleted,
                         Sub(__, args)
                             If args.Cancelled Then

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/vb.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.cancellation.callback/vb/vb.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>vb</RootNamespace>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Use `DownloadStringTaskAsync`, thanks @pkulikov 👍🏼 
- Discard `Task t`
- Apply `using` to `CancellationTokenSource` and `WebClient` as both are `IDisposable`
- Make use of the `Task.Run(Func<Task>, CancelationToken)` overload, exposing `async` lambda
- Invert `if` logic to avoid negation flow
- Rename `e` to `args`
- Place opening `{` occurrences on newline
- Use string interpolation
- Simplified console prompts/interaction logic
- Remove code comments as they are not localized

Fixes #6050
