### PR TITLE
MulticastOption.Group doesn't accept null

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -204,6 +204,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ***
 
+## Networking
+
+- [MulticastOption.Group doesn't accept a null value](#multicastoptiongroup-doesnt-accept-a-null-value)
+
+[!INCLUDE [multicastoption-group-doesnt-accept-null](../../../includes/core-changes/networking/5.0/multicastoption-group-doesnt-accept-null.md)]
+
+***
+
 ## Serialization
 
 - [BinaryFormatter.Deserialize rewraps some exceptions in SerializationException](#binaryformatterdeserialize-rewraps-some-exceptions-in-serializationexception)

--- a/docs/core/compatibility/networking.md
+++ b/docs/core/compatibility/networking.md
@@ -9,8 +9,15 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Introduced version |
 | - | - |
+| [MulticastOption.Group doesn't accept a null value](#multicastoptiongroup-doesnt-accept-a-null-value) | 5.0 |
 | [Default value of HttpRequestMessage.Version changed to 1.1](#default-value-of-httprequestmessageversion-changed-to-11) | 3.0 |
 | [WebClient.CancelAsync doesn't always cancel immediately](#webclientcancelasync-doesnt-always-cancel-immediately) | 2.0 |
+
+## .NET 5.0
+
+[!INCLUDE [multicastoption-group-doesnt-accept-null](../../../includes/core-changes/networking/5.0/multicastoption-group-doesnt-accept-null.md)]
+
+***
 
 ## .NET Core 3.0
 

--- a/includes/core-changes/networking/5.0/multicastoption-group-doesnt-accept-null.md
+++ b/includes/core-changes/networking/5.0/multicastoption-group-doesnt-accept-null.md
@@ -1,0 +1,37 @@
+### MulticastOption.Group doesn't accept a null value
+
+<xref:System.Net.Sockets.MulticastOption.Group?displayProperty=nameWithType> no longer accepts a value of `null`. If you set the property to `null`, an <xref:System.ArgumentNullException> is thrown.
+
+#### Version introduced
+
+5.0
+
+#### Change description
+
+In previous versions of .NET, you can set the <xref:System.Net.Sockets.MulticastOption.Group?displayProperty=nameWithType> property to `null`. If the <xref:System.Net.Sockets.MulticastOption> is later passed to <xref:System.Net.Sockets.Socket.SetSocketOption%2A?displayProperty=nameWithType>, the runtime throws a <xref:System.NullReferenceException>.
+
+In .NET 5.0 and later, an <xref:System.ArgumentNullException> is thrown if you set the property to `null`.
+
+#### Reason for change
+
+To be consistent with the Framework Design Guidelines, the property has been updated to throw an <xref:System.ArgumentNullException> if the value is `null`.
+
+#### Recommended action
+
+Make sure that you don't set <xref:System.Net.Sockets.MulticastOption.Group?displayProperty=nameWithType> to `null`.
+
+#### Category
+
+Networking
+
+#### Affected APIs
+
+- <xref:System.Net.Sockets.MulticastOption.Group?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Net.Sockets.MulticastOption.Group`
+
+-->


### PR DESCRIPTION
Fixes #19723.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-20072#multicastoptiongroup-doesnt-accept-a-null-value).