### PR TITLE
Enable markdownlint for samples directory

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -29,4 +29,4 @@ jobs:
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
         npm i -g markdownlint-cli
-        markdownlint "**/*.md" -i "samples/**/*.md"
+        markdownlint "**/*.md"


### PR DESCRIPTION
I'm not sure why it was ignored in the first place. But the build seem to pass.

cc: @adegeo