### PR TITLE
Clarify position of 'not' in overloaded operators for F#

### DIFF
--- a/docs/fsharp/language-reference/operator-overloading.md
+++ b/docs/fsharp/language-reference/operator-overloading.md
@@ -89,7 +89,7 @@ The following table shows the standard operators and their corresponding generat
 |`..`|`op_Range`|
 |`.. ..`|`op_RangeStep`|
 
-Note that the `not` operator in F# does not emit `op_Inequality` because it is not a symbolic operator.
+Note that the `not` operator in F# does not emit `op_Inequality` because it is not a symbolic operator. It is a function that emits IL that negates a boolean expression.
 
 Other combinations of operator characters that are not listed here can be used as operators and have names that are made up by concatenating names for the individual characters from the following table. For example, +! becomes `op_PlusBang`.
 

--- a/docs/fsharp/language-reference/operator-overloading.md
+++ b/docs/fsharp/language-reference/operator-overloading.md
@@ -1,7 +1,7 @@
 ---
 title: Operator Overloading
 description: Learn how to overload arithmetic operators in a class or record type and at the global level in F#.
-ms.date: 05/16/2016
+ms.date: 08/15/2020
 ---
 # Operator Overloading
 
@@ -88,6 +88,8 @@ The following table shows the standard operators and their corresponding generat
 |`/=`|`op_DivisionAssignment`|
 |`..`|`op_Range`|
 |`.. ..`|`op_RangeStep`|
+
+Note that the `not` operator in F# does not emit `op_Inequality` because it is not a symbolic operator.
 
 Other combinations of operator characters that are not listed here can be used as operators and have names that are made up by concatenating names for the individual characters from the following table. For example, +! becomes `op_PlusBang`.
 


### PR DESCRIPTION
fixes https://github.com/dotnet/docs/issues/17855