### PR TITLE
Cache markdownlint-cli npm installation in GH action

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,7 +23,15 @@ jobs:
     - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v1
+      env:
+        cache_name: cache-node-modules
       with:
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
         node-version: 12.x
     - name: Run Markdownlint
       run: |

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -21,17 +21,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v1
+    - name: Cache node modules
+      uses: actions/cache@v2
       env:
-        cache_name: cache-node-modules
+        cache-name: cache-node-modules
       with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
         path: ~/.npm
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-
           ${{ runner.os }}-
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
         node-version: 12.x
     - name: Run Markdownlint
       run: |


### PR DESCRIPTION
This is taken from [GitHub docs](https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#using-the-cache-action).

@adegeo, Do you know how to confirm that this actually works?

I wouldn't expect a huge time difference, the only npm dependency is markdownlint, which has small size. So, feel free to close this if you think it doesn't worth caching the dependency.