### PR TITLE
WinHttpHandler removal

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -219,7 +219,12 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Networking
 
+- [WinHttpHandler removed from .NET runtime](#winhttphandler-removed-from-net-runtime)
 - [MulticastOption.Group doesn't accept a null value](#multicastoptiongroup-doesnt-accept-a-null-value)
+
+[!INCLUDE [winhttphandler-removed-from-runtime](../../../includes/core-changes/networking/5.0/winhttphandler-removed-from-runtime.md)]
+
+***
 
 [!INCLUDE [multicastoption-group-doesnt-accept-null](../../../includes/core-changes/networking/5.0/multicastoption-group-doesnt-accept-null.md)]
 

--- a/docs/core/compatibility/networking.md
+++ b/docs/core/compatibility/networking.md
@@ -9,11 +9,16 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Introduced version |
 | - | - |
+| [WinHttpHandler removed from .NET runtime](#winhttphandler-removed-from-net-runtime) | 5.0 |
 | [MulticastOption.Group doesn't accept a null value](#multicastoptiongroup-doesnt-accept-a-null-value) | 5.0 |
 | [Default value of HttpRequestMessage.Version changed to 1.1](#default-value-of-httprequestmessageversion-changed-to-11) | 3.0 |
 | [WebClient.CancelAsync doesn't always cancel immediately](#webclientcancelasync-doesnt-always-cancel-immediately) | 2.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [winhttphandler-removed-from-runtime](../../../includes/core-changes/networking/5.0/winhttphandler-removed-from-runtime.md)]
+
+***
 
 [!INCLUDE [multicastoption-group-doesnt-accept-null](../../../includes/core-changes/networking/5.0/multicastoption-group-doesnt-accept-null.md)]
 

--- a/includes/core-changes/networking/5.0/winhttphandler-removed-from-runtime.md
+++ b/includes/core-changes/networking/5.0/winhttphandler-removed-from-runtime.md
@@ -1,0 +1,31 @@
+### WinHttpHandler removed from .NET runtime
+
+The `WinHttpHandler` class was removed from the *System.Net.Http.dll* assembly. It's now available only as an out-of-band (OOB) [NuGet package](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/).
+
+#### Version introduced
+
+5.0
+
+#### Change description
+
+In previous .NET versions, the <xref:System.Net.Http.WinHttpHandler> class is available as part of the core .NET libraries. Starting in .NET 5.0, the <xref:System.Net.Http.WinHttpHandler> class is only available as a separately installed [NuGet package](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/).
+
+#### Recommended action
+
+Install the [System.Net.Http.WinHttpHandler NuGet package](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/). Or, if you don't require WinHTTP-specific features, use <xref:System.Net.Http.SocketsHttpHandler> instead.
+
+#### Category
+
+Networking
+
+#### Affected APIs
+
+- <xref:System.Net.Http.WinHttpHandler?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Net.Http.WinHttpHandler`
+
+-->


### PR DESCRIPTION
Fixes #19727.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-20140#winhttphandler-removed-from-net-runtime).