### PR TITLE
Fix build warning

### DIFF
--- a/docs/framework/resources/creating-satellite-assemblies-for-desktop-apps.md
+++ b/docs/framework/resources/creating-satellite-assemblies-for-desktop-apps.md
@@ -89,8 +89,13 @@ The following is a simple "Hello world" example that displays a message box cont
 
 2. To indicate that English (en) is the application's default culture, add the following <xref:System.Resources.NeutralResourcesLanguageAttribute?displayProperty=nameWithType> attribute to the application's AssemblyInfo file or to the main source code file that will be compiled into the application's main assembly.
 
-    [!code-csharp[Conceptual.Resources.Locating#2](~/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.locating/cs/assemblyinfo.cs#2)]
-    [!code-vb[Conceptual.Resources.Locating#2](~/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb#2)]  
+    ```csharp
+    [assembly: NeutralResourcesLanguageAttribute("en")]
+    ```
+
+    ```vb
+    <Assembly: NeutralResourcesLanguageAttribute("en")>
+    ```
   
 3. Add support for additional cultures (en-US, fr-FR, and ru-RU) to the application as follows:  
   

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
@@ -34,8 +34,4 @@ Imports System.Runtime.InteropServices
 
 <Assembly: AssemblyVersion("1.0.0.0")>
 <Assembly: AssemblyFileVersion("1.0.0.0")>
-
-' <Snippet2>
 <Assembly: NeutralResourcesLanguageAttribute("en")>
-' </Snippet2>
-


### PR DESCRIPTION
@gewarren, The deleted AssemblyInfo was only referencing one line. So I referenced that line directly instead of adding the whole file again.

If you want to add the file back, please tell me.