### PR TITLE
Standardize sample projects, Part 20

### DIFF
--- a/docs/framework/resources/creating-satellite-assemblies-for-desktop-apps.md
+++ b/docs/framework/resources/creating-satellite-assemblies-for-desktop-apps.md
@@ -89,13 +89,8 @@ The following is a simple "Hello world" example that displays a message box cont
 
 2. To indicate that English (en) is the application's default culture, add the following <xref:System.Resources.NeutralResourcesLanguageAttribute?displayProperty=nameWithType> attribute to the application's AssemblyInfo file or to the main source code file that will be compiled into the application's main assembly.
 
-    ```csharp
-    [assembly: NeutralResourcesLanguageAttribute("en")]
-    ```
-
-    ```vb
-    <Assembly: NeutralResourcesLanguageAttribute("en")>
-    ```
+    [!code-csharp[Conceptual.Resources.Locating#2](~/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.locating/cs/assemblyinfo.cs#2)]
+    [!code-vb[Conceptual.Resources.Locating#2](~/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb#2)]  
   
 3. Add support for additional cultures (en-US, fr-FR, and ru-RU) to the application as follows:  
   

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.locating/cs/assemblyinfo.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.locating/cs/assemblyinfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Resources;
+
+// <Snippet2>
+[assembly: NeutralResourcesLanguage("en")]
+// </Snippet2>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
@@ -1,40 +1,5 @@
 ﻿Imports System.Resources
 
-Imports System.Reflection
-Imports System.Runtime.InteropServices
-
-' General Information about an assembly is controlled through the following 
-' set of attributes. Change these attribute values to modify the information
-' associated with an assembly.
-
-' Review the values of the assembly attributes
-
-<Assembly: AssemblyTitle("LocatingVB1")>
-<Assembly: AssemblyDescription("")>
-<Assembly: AssemblyCompany("Microsoft")>
-<Assembly: AssemblyProduct("LocatingVB1")>
-<Assembly: AssemblyCopyright("Copyright © Microsoft 2010")>
-<Assembly: AssemblyTrademark("")>
-
-<Assembly: ComVisible(False)>
-
-'The following GUID is for the ID of the typelib if this project is exposed to COM
-<Assembly: Guid("d502b151-335c-499c-9aff-79ed093c8ac5")>
-
-' Version information for an assembly consists of the following four values:
-'
-'      Major Version
-'      Minor Version 
-'      Build Number
-'      Revision
-'
-' You can specify all the values or you can default the Build and Revision Numbers 
-' by using the '*' as shown below:
-' <Assembly: AssemblyVersion("1.0.*")> 
-
-<Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("1.0.0.0")>
-
 ' <Snippet2>
 <Assembly: NeutralResourcesLanguage("en")>
 ' </Snippet2>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
@@ -34,4 +34,8 @@ Imports System.Runtime.InteropServices
 
 <Assembly: AssemblyVersion("1.0.0.0")>
 <Assembly: AssemblyFileVersion("1.0.0.0")>
+
+' <Snippet2>
 <Assembly: NeutralResourcesLanguageAttribute("en")>
+' </Snippet2>
+

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/assemblyinfo.vb
@@ -36,6 +36,5 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyFileVersion("1.0.0.0")>
 
 ' <Snippet2>
-<Assembly: NeutralResourcesLanguageAttribute("en")>
+<Assembly: NeutralResourcesLanguage("en")>
 ' </Snippet2>
-

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/locatingvb1.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/locatingvb1.vbproj
@@ -1,98 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>
-    </ProductVersion>
-    <SchemaVersion>
-    </SchemaVersion>
-    <ProjectGuid>{04C61C9C-B1AB-469D-8A41-89A1E9971A1A}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <StartupObject>LocatingVB1.Module1</StartupObject>
+    <TargetFramework>net48</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>LocatingVB1</RootNamespace>
     <AssemblyName>LocatingVB1</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <MyType>Console</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>none</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>LocatingVB1.xml</DocumentationFile>
-    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionExplicit>On</OptionExplicit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionCompare>Binary</OptionCompare>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionStrict>On</OptionStrict>
-  </PropertyGroup>
-  <PropertyGroup>
-    <OptionInfer>On</OptionInfer>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Import Include="Microsoft.VisualBasic" />
-    <Import Include="System" />
-    <Import Include="System.Diagnostics" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Greetings.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Greetings.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Module1.vb" />
-    <Compile Include="AssemblyInfo.vb" />
-<!--    <Compile Include="Greetings.en-US.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Greetings.en-US.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Greetings.fr-FR.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Greetings.fr-FR.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Greetings.ru-RU.Designer.vb">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Greetings.ru-RU.resx</DependentUpon>
-    </Compile> -->
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Greetings.resx">
-      <CustomToolNamespace>My.</CustomToolNamespace>
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Greetings.en-US.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Greetings.fr-FR.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Greetings.ru-RU.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/snippets.5000.json
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/snippets.5000.json
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.resources.locating/vb/snippets.5000.json
@@ -1,3 +1,0 @@
-{
-    "host": "visualstudio"
-}


### PR DESCRIPTION
Follow-up to #20076 /cc @gewarren 

See dotnet/sdk#12951 for why it's necessary to build the .vbproj with Visual Studio.