### PR TITLE
Fix title suffix

### DIFF
--- a/docs/visual-basic/getting-started/whats-new.md
+++ b/docs/visual-basic/getting-started/whats-new.md
@@ -1,5 +1,5 @@
 ---
-title: "What's new for Visual Basic"
+title: What's new
 ms.date: 10/24/2018
 f1_keywords:
   - "VB.StartPage.WhatsNew"


### PR DESCRIPTION
A title suffix is applied globally and affects this file. So, the current title is "What's new for Visual Basic - Visual Basic".

After this fix, it will be "What's new - Visual Basic".

If you would like it to be "What's new for Visual Basic", let me know to override the titleSuffix.