### PR TITLE
Update character-encoding-introduction.md

### DIFF
--- a/docs/standard/base-types/character-encoding-introduction.md
+++ b/docs/standard/base-types/character-encoding-introduction.md
@@ -229,7 +229,7 @@ For more information about the .NET `Rune` type, see the [`Rune` API reference](
 
 What looks like one character might result from a combination of multiple code points, so a more descriptive term that is often used in place of "character" is [grapheme cluster](https://www.unicode.org/glossary/#grapheme_cluster). The equivalent term in .NET is [text element](xref:System.Globalization.StringInfo.GetTextElementEnumerator%2A).
 
-Consider the `string` instances "a", "á". "á", and "`👩🏽‍🚒`". If your operating system handles them as specified by the Unicode standard, each of these `string` instances appears as a single text element or grapheme cluster. But the last two are represented by more than one scalar value code point.
+Consider the `string` instances "a", "á", "á", and "`👩🏽‍🚒`". If your operating system handles them as specified by the Unicode standard, each of these `string` instances appears as a single text element or grapheme cluster. But the last two are represented by more than one scalar value code point.
 
 * The string "a" is represented by one scalar value and contains one `char` instance.
 


### PR DESCRIPTION
Puts comma (,) between two "á" instead of the dot (.)

Fixes #20152