### PR TITLE
Revert "Added version 15.8"

### DIFF
--- a/docs/visual-basic/language-reference/configure-language-version.md
+++ b/docs/visual-basic/language-reference/configure-language-version.md
@@ -39,7 +39,6 @@ The value `latest` uses the latest minor version of the Visual Basic language. V
 |15|The compiler accepts only syntax that is included in Visual Basic 15.0 or lower.|
 |15.3|The compiler accepts only syntax that is included in Visual Basic 15.3 or lower.|
 |15.5|The compiler accepts only syntax that is included in Visual Basic 15.5 or lower.|
-|15.8|The compiler accepts only syntax that is included in Visual Basic 15.8 or lower.|
 |latest|The compiler accepts all valid language syntax that it can support.|
 
 The special strings `default` and `latest` resolve to the latest major


### PR DESCRIPTION
Reverts dotnet/docs#12884
Contributes to https://github.com/dotnet/docs/issues/20147

Running dotnet build on the following vbproj:

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <LangVersion>15.8</LangVersion>
    <OutputType>Exe</OutputType>
    <RootNamespace>TestLangVersion</RootNamespace>
    <TargetFramework>net5.0</TargetFramework>
  </PropertyGroup>

</Project>
```

outputs:

```powershell
vbc : error BC2014: the value '15.8' is invalid for option 'langversion'
```