### PR TITLE
Add missing ms.technology

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -461,7 +461,8 @@
         "docs/framework/xaml-services/**/**.md": "dotnet-wpf",
         "docs/standard/data/**/**.md": "dotnet-data",
         "docs/standard/security/**/**.md": "dotnet-security",
-        "docs/visual-basic/language-reference/error-messages/**/**.md": "vb-diagnostics"
+        "docs/visual-basic/language-reference/error-messages/**/**.md": "vb-diagnostics",
+        "docs/visual-basic/misc/**/**.md": "vb-diagnostics"
       },
       "title": {
         "_csharplang/spec/introduction.md": "Introduction",


### PR DESCRIPTION
The label "Technology - C# / VB diagnostics" wasn't applied in a test PR #20166 due to the missing ms.technology for that folder.