### PR TITLE
fix comment in DisposeAsync()

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -43,7 +43,7 @@ public async ValueTask DisposeAsync()
     // Perform async cleanup.
     await DisposeAsyncCore();
 
-    // Dispose of managed resources.
+    // Dispose of unmanaged resources.
     Dispose(false);
     // Suppress finalization.
     GC.SuppressFinalize(this);


### PR DESCRIPTION
`Dispose(false)` disposes of unmanaged resources.

## Summary

Fix a type-o in the docs
