### PR TITLE
Add F# CE custom operation to style guide

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -930,3 +930,48 @@ let MyUrl = "www.mywebsitethatiamworkingwith.com"
 ```
 
 Avoid placing the attribute on the same line as the value.
+
+## Formatting computation expression operations
+
+When creating custom operations for [computation expressions](../language-reference/computation-expressions.md) should use `CONVENTION` naming:
+
+```fsharp
+type MathBuilder () =
+    member _.Yield (_) = 0
+
+    // snake case
+    [<CustomOperation("add_one")>]
+    member _.AddOne (state: int) =
+        state + 1
+
+    // camel case
+    [<CustomOperation("subtractOne")>]
+    member _.SubtractOne (state: int) =
+        state - 1
+
+    // screaming case
+    [<CustomOperation("DIVIDEBY")>]
+    member _.DivideBy (state: int, divisor: int) =
+        state / divisor
+
+    // pascal case
+    [<CustomOperation("MultiplyBy")>]
+    member _.MultiplyBy (state: int, factor: int) =
+        state * factor
+
+let math = MathBuilder()
+
+// 10
+let myNumber =
+    math {
+        add_one
+        add_one
+        add_one
+
+        subtractOne
+
+        DIVIDEBY 2
+
+        MultiplyBy 10
+    }
+```

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -971,3 +971,6 @@ let myNumber =
         multiplyBy 10
     }
 ```
+
+The naming convention used should ultimately be driven by the domain being modeled.
+If it is idiomatic to use a different convention, that convention should be used instead.

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -946,7 +946,7 @@ type MathBuilder () =
     [<CustomOperation("subtractOne")>]
     member _.SubtractOne (state: int) =
         state - 1
-        
+
     [<CustomOperation("divideBy")>]
     member _.DivideBy (state: int, divisor: int) =
         state / divisor

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -933,29 +933,25 @@ Avoid placing the attribute on the same line as the value.
 
 ## Formatting computation expression operations
 
-When creating custom operations for [computation expressions](../language-reference/computation-expressions.md) should use `CONVENTION` naming:
+When creating custom operations for [computation expressions](../language-reference/computation-expressions.md) it is recommended to use camelCase naming:
 
 ```fsharp
 type MathBuilder () =
-    member _.Yield (_) = 0
+    member _.Yield _ = 0
 
-    // snake case
-    [<CustomOperation("add_one")>]
+    [<CustomOperation("addOne")>]
     member _.AddOne (state: int) =
         state + 1
 
-    // camel case
     [<CustomOperation("subtractOne")>]
     member _.SubtractOne (state: int) =
         state - 1
-
-    // screaming case
-    [<CustomOperation("DIVIDEBY")>]
+        
+    [<CustomOperation("divideBy")>]
     member _.DivideBy (state: int, divisor: int) =
         state / divisor
 
-    // pascal case
-    [<CustomOperation("MultiplyBy")>]
+    [<CustomOperation("multiplyBy")>]
     member _.MultiplyBy (state: int, factor: int) =
         state * factor
 
@@ -964,14 +960,14 @@ let math = MathBuilder()
 // 10
 let myNumber =
     math {
-        add_one
-        add_one
-        add_one
+        addOne
+        addOne
+        addOne
 
         subtractOne
 
-        DIVIDEBY 2
+        divideBy 2
 
-        MultiplyBy 10
+        multiplyBy 10
     }
 ```


### PR DESCRIPTION
## Summary

There is currently no recommended naming convention for CE custom operations which causes a non-uniform use in the community.

The most used form is probably snake case (and my preference) such as in [Saturn](https://github.com/SaturnFramework/Saturn), but there are different conventions used in [other libraries](https://github.com/ronaldschlenker/FsHttp/blob/master/src/FsHttp/DslCE.fs).