### PR TITLE
Standardize sample projects, Part 22

### DIFF
--- a/docs/architecture/modernize-desktop/example-migration-core.md
+++ b/docs/architecture/modernize-desktop/example-migration-core.md
@@ -229,7 +229,7 @@ In this case, delete all the content of the *.csproj* file and replace it with t
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <UseWPF>true</UseWPF>
+        <UseWpf>true</UseWpf>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 </Project>

--- a/docs/standard/io/snippets/how-to-read-text-from-a-file/csharp/async-wpf/TextFiles.csproj
+++ b/docs/standard/io/snippets/how-to-read-text-from-a-file/csharp/async-wpf/TextFiles.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/io/snippets/how-to-read-text-from-a-file/vb/async-wpf/TextFiles.vbproj
+++ b/docs/standard/io/snippets/how-to-read-text-from-a-file/vb/async-wpf/TextFiles.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/desktop-guide/wpf/data-binding-overview/csharp/bindings.csproj
+++ b/samples/snippets/desktop-guide/wpf/data-binding-overview/csharp/bindings.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/desktop-guide/wpf/data-binding-overview/vb/bindings.vbproj
+++ b/samples/snippets/desktop-guide/wpf/data-binding-overview/vb/bindings.vbproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>bindings</RootNamespace>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/desktop-guide/wpf/styles-and-templates-intro/csharp/CSharpExample.csproj
+++ b/samples/snippets/desktop-guide/wpf/styles-and-templates-intro/csharp/CSharpExample.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>IntroToStylingAndTemplating</RootNamespace>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
     <AssemblyName>IntroToStylingAndTemplating</AssemblyName>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/samples/snippets/desktop-guide/wpf/styles-and-templates-intro/vb/VBExample.vbproj
+++ b/samples/snippets/desktop-guide/wpf/styles-and-templates-intro/vb/VBExample.vbproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>IntroToStylingAndTemplating</RootNamespace>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
     <AssemblyName>IntroToStylingAndTemplating</AssemblyName>
   </PropertyGroup>
 

--- a/samples/snippets/desktop-guide/wpf/styles-templates-create-apply-template/csharp/CSharpExample.csproj
+++ b/samples/snippets/desktop-guide/wpf/styles-templates-create-apply-template/csharp/CSharpExample.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>IntroToStylingAndTemplating</RootNamespace>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
     <AssemblyName>IntroToStylingAndTemplating</AssemblyName>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/samples/snippets/desktop-guide/wpf/styles-templates-create-apply-template/vb/VBExample.vbproj
+++ b/samples/snippets/desktop-guide/wpf/styles-templates-create-apply-template/vb/VBExample.vbproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>IntroToStylingAndTemplating</RootNamespace>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
     <AssemblyName>IntroToStylingAndTemplating</AssemblyName>
   </PropertyGroup>
 

--- a/samples/snippets/standard/async/async-and-await/cs/AsyncFirstExampleCS.csproj
+++ b/samples/snippets/standard/async/async-and-await/cs/AsyncFirstExampleCS.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/standard/async/async-and-await/vb/AsyncFirstExampleVB.vbproj
+++ b/samples/snippets/standard/async/async-and-await/vb/AsyncFirstExampleVB.vbproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>AsyncFirstExampleVB</RootNamespace>
-    <UseWPF>true</UseWPF>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Standardize to use `<UseWpf>` as per the SDK error messages:

```
NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'
```
```
NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.
```