### PR TITLE
UNC paths on Unix

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -122,6 +122,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [Uri recognition of UNC paths on Unix](#uri-recognition-of-unc-paths-on-unix)
 - [Environment.OSVersion returns the correct operating system version](#environmentosversion-returns-the-correct-operating-system-version)
 - [Complexity of LINQ OrderBy.First{OrDefault} increased](#complexity-of-linq-orderbyfirstordefault-increased)
 - [IntPtr and UIntPtr implement IFormattable](#intptr-and-uintptr-implement-iformattable)
@@ -134,6 +135,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [unc-path-recognition-unix](../../../includes/core-changes/corefx/5.0/unc-path-recognition-unix.md)]
+
+***
 
 [!INCLUDE [environment-osversion-returns-correct-version](../../../includes/core-changes/corefx/5.0/environment-osversion-returns-correct-version.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Uri recognition of UNC paths on Unix](#uri-recognition-of-unc-paths-on-unix) | 5.0 |
 | [Environment.OSVersion returns the correct operating system version](#environmentosversion-returns-the-correct-operating-system-version) | 5.0 |
 | [Complexity of LINQ OrderBy.First{OrDefault} increased](#complexity-of-linq-orderbyfirstordefault-increased) | 5.0 |
 | [IntPtr and UIntPtr implement IFormattable](#intptr-and-uintptr-implement-iformattable) | 5.0 |
@@ -41,6 +42,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [unc-path-recognition-unix](../../../includes/core-changes/corefx/5.0/unc-path-recognition-unix.md)]
+
+***
 
 [!INCLUDE [environment-osversion-returns-correct-version](../../../includes/core-changes/corefx/5.0/environment-osversion-returns-correct-version.md)]
 

--- a/includes/core-changes/corefx/5.0/unc-path-recognition-unix.md
+++ b/includes/core-changes/corefx/5.0/unc-path-recognition-unix.md
@@ -1,0 +1,37 @@
+### Uri recognition of UNC paths on Unix
+
+The <xref:System.Uri> class now recognizes strings that start with two forward slashes (`//`) as universal naming convention (UNC) paths on Unix operating systems. This change makes the behavior for such strings consistent across all platforms.
+
+#### Change description
+
+In previous versions of .NET, the <xref:System.Uri> class recognizes strings that start with with two forward slashes, for example, `//contoso`, as absolute file paths on Unix operating systems. However, on Windows, such strings are recognized as UNC paths.
+
+Starting in .NET 5.0,  the <xref:System.Uri> class recognizesstrings that start with with two forward slashes as UNC paths on all platforms, including Unix. In addition, properties behave according to UNC semantics:
+
+- <xref:System.Uri.IsUnc?displayProperty=nameWithType> returns `true`.
+- Backslashes in the path are replaced with forward slashes. For example, `//first\second` becomes `//first/second`.
+- <xref:System.Uri.LocalPath?displayProperty=nameWithType> doesn't percent-encode characters. For example, `//first/\uFFF0` is *not* converted to `//first/%EF%BF%B0`.
+
+#### Version introduced
+
+5.0
+
+#### Recommended action
+
+No action is required on the part of the developer.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Uri?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Uri`
+
+-->

--- a/includes/core-changes/corefx/5.0/unc-path-recognition-unix.md
+++ b/includes/core-changes/corefx/5.0/unc-path-recognition-unix.md
@@ -6,7 +6,7 @@ The <xref:System.Uri> class now recognizes strings that start with two forward s
 
 In previous versions of .NET, the <xref:System.Uri> class recognizes strings that start with with two forward slashes, for example, `//contoso`, as absolute file paths on Unix operating systems. However, on Windows, such strings are recognized as UNC paths.
 
-Starting in .NET 5.0,  the <xref:System.Uri> class recognizesstrings that start with with two forward slashes as UNC paths on all platforms, including Unix. In addition, properties behave according to UNC semantics:
+Starting in .NET 5.0,  the <xref:System.Uri> class recognizes strings that start with with two forward slashes as UNC paths on all platforms, including Unix. In addition, properties behave according to UNC semantics:
 
 - <xref:System.Uri.IsUnc?displayProperty=nameWithType> returns `true`.
 - Backslashes in the path are replaced with forward slashes. For example, `//first\second` becomes `//first/second`.


### PR DESCRIPTION
Fixes #19966.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-20176#uri-recognition-of-unc-paths-on-unix).