### PR TITLE
Fix typo

### DIFF
--- a/docs/azure/authentication.md
+++ b/docs/azure/authentication.md
@@ -9,7 +9,7 @@ ms.custom: azure-sdk-dotnet
 
 ## Recommended: Azure.Identity
 
-The latest packages in the Azure SDK for .NET use a common authentication package to authenticate, `Azure.Identity`. Using `Azure.Identity` is recommended over other authentication mechanisms described later in this document. Packages supporting the credentials provided by `Azure.Identity` are built on top of `Azure.Core` and have package identifiers starting with *Azure.* [See the package list](packages.md) for an inventory of packages that use `Azure.Core`.
+The latest packages in the Azure SDK for .NET use a common authentication package to authenticate, `Azure.Identity`. Using `Azure.Identity` is recommended over other authentication mechanisms described later in this document. Packages supporting the credentials provided by `Azure.Identity` are built on top of `Azure.Core` and have package identifiers starting with *Azure*. [See the package list](packages.md) for an inventory of packages that use `Azure.Core`.
 
 For complete instructions on using `Azure.Identity` in your project, see the documentation for [Azure Identity client for .NET](/dotnet/api/overview/azure/identity-readme).
 


### PR DESCRIPTION
## Summary

Fixing what appears to be typo where period is within the bold font. This was pointed out by translator who was not sure if the period was meant to be part of the identifier "Azure".