### PR TITLE
CA1831 breaking change.

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -120,6 +120,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ***
 
+## Code analysis
+
+- [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer)
+
+[!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
+
+***
+
 ## Core .NET libraries
 
 - [Parameter names changed in reference assemblies](#parameter-names-changed-in-reference-assemblies)

--- a/docs/core/compatibility/breaking-changes.md
+++ b/docs/core/compatibility/breaking-changes.md
@@ -27,6 +27,7 @@ Select the .NET Core technology area that you're interested in. Individual chang
 > [!div class="op_single_selector"]
 >
 > - [ASP.NET Core](aspnetcore.md)
+> - [Code analysis](code-analysis.md)
 > - [Core .NET libraries](corefx.md)
 > - [Cryptography](cryptography.md)
 > - [EF Core](/ef/core/what-is-new/ef-core-3.0/breaking-changes)

--- a/docs/core/compatibility/code-analysis.md
+++ b/docs/core/compatibility/code-analysis.md
@@ -1,0 +1,18 @@
+---
+title: Code analysis breaking changes
+description: Lists the breaking changes in .NET source code analyzers.
+ms.date: 08/22/2020
+---
+# Code analysis breaking changes
+
+The following breaking changes are documented on this page:
+
+| Breaking change | Version introduced |
+| - | :-: |
+| [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
+
+## .NET 5.0
+
+[!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
+
+***

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -194,7 +194,7 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 
 ### EnableNETAnalyzers
 
-[.NET Code analysis](../../fundamentals/productivity/code-analysis.md) is enabled, by default, for projects that target .NET 5.0 or later. You can enable .NET code analysis for projects that target earlier versions of .NET by setting the `EnableNETAnalyzers` property to true.
+[.NET Code analysis](../../fundamentals/productivity/code-analysis.md) is enabled, by default, for projects that target .NET 5.0 or later. You can enable .NET code analysis for projects that target earlier versions of .NET by setting the `EnableNETAnalyzers` property to true. To disable code analysis in any project, set this property to `false`.
 
 ```xml
 <PropertyGroup>

--- a/docs/fundamentals/productivity/code-analysis.md
+++ b/docs/fundamentals/productivity/code-analysis.md
@@ -13,7 +13,7 @@ helpviewer_keywords:
 
 .NET code analyzers inspect your C# or Visual Basic code for security, performance, design, and other issues. Starting in .NET 5.0, these analyzers are included with the .NET SDK. (Previously, you installed these analyzers as a [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers).)
 
-Code analysis is enabled, by default, for projects that target .NET 5.0 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`.
+Code analysis is enabled, by default, for projects that target .NET 5.0 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`. You can also disable code analysis for your project by setting `EnableNETAnalyzers` to `false`.
 
 If rule violations are found by an analyzer, they're reported as a suggestion, warning, or error, depending on how each rule is [configured](configure-code-analysis-rules.md). Code analysis violations appear with the prefix "CA" or "IDE" to differentiate them from compiler errors.
 

--- a/includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md
+++ b/includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md
@@ -6,7 +6,17 @@
 
 Starting in .NET 5.0, the .NET SDK includes [.NET source code analyzers](../../../../docs/fundamentals/productivity/code-analysis.md). Several of these rules are enabled, by default, including [CA1831](/visualstudio/code-quality/ca1831). If your project contains code that violates this rule and is configured to treat warnings as errors, this change could break your build.
 
-Rule CA1831 finds instances where a <xref:System.Range>-based indexer is used on a string, but no copy was intended. If the <xref:System.Range>-based indexer is used directly on a string to produce an implicit cast, then an unnecessary copy of the requested portion of the string is created. CA1831 suggests using the <xref:System.Range>-based indexer on a *span* of the string, instead.
+Rule CA1831 finds instances where a <xref:System.Range>-based indexer is used on a string, but no copy was intended. If the <xref:System.Range>-based indexer is used directly on a string to produce an implicit cast, then an unnecessary copy of the requested portion of the string is created. For example:
+
+```csharp
+ReadOnlySpan<char> slice = str[1..3];
+```
+
+CA1831 suggests using the <xref:System.Range>-based indexer on a *span* of the string, instead. For example:
+
+```csharp
+ReadOnlySpan<char> slice = str.AsSpan()[1..3];
+```
 
 #### Version introduced
 
@@ -14,7 +24,11 @@ Rule CA1831 finds instances where a <xref:System.Range>-based indexer is used on
 
 #### Recommended action
 
-- To correct your code and avoid unnecessary allocations, call <xref:System.MemoryExtensions.AsSpan(System.String)> or <xref:System.MemoryExtensions.AsMemory(System.String)> before using the <xref:System.Range>-based indexer.
+- To correct your code and avoid unnecessary allocations, call <xref:System.MemoryExtensions.AsSpan(System.String)> or <xref:System.MemoryExtensions.AsMemory(System.String)> before using the <xref:System.Range>-based indexer. For example:
+
+  ```csharp
+  ReadOnlySpan<char> slice = str.AsSpan()[1..3];
+  ```
 
 - If you don't want to change your code, you can disable the rule by setting its severity to `suggestion` or `none`. For more information, see [Configure code analysis rules](../../../../docs/fundamentals/productivity/configure-code-analysis-rules.md).
 

--- a/includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md
+++ b/includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md
@@ -1,0 +1,37 @@
+### CA1831 Use AsSpan or AsMemory instead of Range-based indexer
+
+.NET code analyzer rule [CA1831](/visualstudio/code-quality/ca1831) is enabled, by default, starting in .NET 5.0. It produces a build warning for any code where a <xref:System.Range>-based indexer is used on a string, but no copy was intended.
+
+#### Change description
+
+Starting in .NET 5.0, the .NET SDK includes [.NET source code analyzers](../../../../docs/fundamentals/productivity/code-analysis.md). Several of these rules are enabled, by default, including [CA1831](/visualstudio/code-quality/ca1831). If your project contains code that violates this rule and is configured to treat warnings as errors, this change could break your build.
+
+Rule CA1831 finds instances where a <xref:System.Range>-based indexer is used on a string, but no copy was intended. If the <xref:System.Range>-based indexer is used directly on a string to produce an implicit cast, then an unnecessary copy of the requested portion of the string is created. CA1831 suggests using the <xref:System.Range>-based indexer on a *span* of the string, instead.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+- To correct your code and avoid unnecessary allocations, call <xref:System.MemoryExtensions.AsSpan(System.String)> or <xref:System.MemoryExtensions.AsMemory(System.String)> before using the <xref:System.Range>-based indexer.
+
+- If you don't want to change your code, you can disable the rule by setting its severity to `suggestion` or `none`. For more information, see [Configure code analysis rules](../../../../docs/fundamentals/productivity/configure-code-analysis-rules.md).
+
+- To disable code analysis completely, set `EnableNETAnalyzers` to `false` in your project file. For more information, see [EnableNETAnalyzers](../../../../docs/core/project-sdk/msbuild-props.md#enablenetanalyzers).
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Range?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Range`
+
+-->


### PR DESCRIPTION
- Fixes #19805.
- Adds new "code analysis" category of breaking changes.
- [Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/code-analysis?branch=pr-en-us-20243#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer).