### PR TITLE
Spark | Update getting started tutorial

### DIFF
--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -71,11 +71,11 @@ To extract the Apache Spark files:
 
 ![Install Spark](https://dotnet.microsoft.com/static/images/spark-extract-with-7-zip.png?v=YvjUv54LIxI9FbALPC3h8zSQdyMtK2-NKbFOliG-f8M)
 
-Run the following commands to set the environment variables used to locate Apache Spark. For Windows, make sure to run the command prompt in administrator mode.
+Run the following commands to set the environment variables used to locate Apache Spark. On Windows, make sure to run the command prompt in administrator mode.
 
 # [Windows](#tab/windows)
 
-```console
+```text
 setx /M HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%\bin"
@@ -124,15 +124,15 @@ To extract the Microsoft.Spark.Worker:
 
 ### 7. Set DOTNET_WORKER_DIR and check dependencies
 
-Run one of the following commands to set the `DOTNET_WORKER_DIR` environment variable, which is used by .NET apps to locate .NET for Apache Spark. Make sure to replace `<PATH-DOTNET_WORKER_DIR>` with the directory where you downloaded and extracted the Microsoft.Spark.Worker
+Run one of the following commands to set the `DOTNET_WORKER_DIR` environment variable, which is used by .NET apps to locate .NET for Apache Spark. Make sure to replace `<PATH-DOTNET_WORKER_DIR>` with the directory where you downloaded and extracted the `Microsoft.Spark.Worker`. On Windows, make sure to run the command prompt in administrator mode.
 
-# [Windows](tab/windows)
+#### [Windows](#tab/windows)
 
 ```console
 setx /M DOTNET_WORKER_DIR <PATH-DOTNET_WORKER_DIR>
 ```
 
-# [Mac/Linux](tab/linux)
+#### [Mac/Linux](#tab/linux)
 
 ```bash
 export DOTNET_WORKER_DIR=<your_path>

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -73,7 +73,7 @@ To extract the Apache Spark files:
 
 Run the following commands to set the environment variables used to locate Apache Spark. On Windows, make sure to run the command prompt in administrator mode.
 
-# [Windows](#tab/windows)
+#### [Windows](#tab/windows)
 
 ```text
 setx /M HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
@@ -81,7 +81,7 @@ setx /M SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%\bin"
 ```
 
-# [Mac/Linux](#tab/linux)
+#### [Mac/Linux](#tab/linux)
 
 ```bash
 export SPARK_HOME=~/bin/spark-2.4.1-bin-hadoop2.7/
@@ -129,13 +129,13 @@ Run one of the following commands to set the `DOTNET_WORKER_DIR` environment var
 #### [Windows](#tab/windows)
 
 ```console
-setx /M DOTNET_WORKER_DIR <PATH-DOTNET_WORKER_DIR>
+setx /M DOTNET_WORKER_DIR <PATH-DOTNET-WORKER-DIR>
 ```
 
 #### [Mac/Linux](#tab/linux)
 
 ```bash
-export DOTNET_WORKER_DIR=<your_path>
+export DOTNET_WORKER_DIR=<PATH-DOTNET-WORKER-DIR>
 ```
 
 ---
@@ -166,7 +166,7 @@ dotnet add package Microsoft.Spark
 > [!NOTE]
 > This tutorial uses the latest version of the `Microsoft.Spark` NuGet package unless otherwise specified.
 
-### 3. Code your app
+### 3. Write your app
 
 Open *Program.cs* in Visual Studio Code, or any text editor, and replace all of the code with the following:
 
@@ -234,7 +234,7 @@ dotnet build
 
 1. Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
 
-# [Windows](#tab/windows)
+### [Windows](#tab/windows)
 
 ```console
 spark-submit ^
@@ -244,7 +244,7 @@ microsoft-spark-2.4.x-<version>.jar ^
 dotnet MySparkApp.dll <path-of-input.txt>
 ```
 
-# [Mac/Linux](#tab/linux)
+### [Mac/Linux](#tab/linux)
 
 ```bash
 spark-submit \

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -75,7 +75,7 @@ Run the following commands to set the environment variables used to locate Apach
 
 #### [Windows](#tab/windows)
 
-```text
+```console
 setx /M HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%\bin"
@@ -93,7 +93,7 @@ source ~/.bashrc
 
 Once you've installed everything and set your environment variables, open a **new** command prompt or terminal and run the following command:
 
-```console
+```text
 spark-submit --version
 ```
 

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -71,17 +71,17 @@ To extract the Apache Spark files:
 
 ![Install Spark](https://dotnet.microsoft.com/static/images/spark-extract-with-7-zip.png?v=YvjUv54LIxI9FbALPC3h8zSQdyMtK2-NKbFOliG-f8M)
 
-Run the following commands to set the environment variables used to locate Apache Spark.
+Run the following commands to set the environment variables used to locate Apache Spark. For Windows, make sure to run the command prompt in administrator mode.
 
 # [Windows](#tab/windows)
 
 ```console
 setx /M HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
-setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%"
+setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%\bin"
 ```
 
-# [Mac/Linux](#tab/unix)
+# [Mac/Linux](#tab/linux)
 
 ```bash
 export SPARK_HOME=~/bin/spark-2.4.1-bin-hadoop2.7/
@@ -93,7 +93,9 @@ source ~/.bashrc
 
 Once you've installed everything and set your environment variables, open a **new** command prompt or terminal and run the following command:
 
-`%SPARK_HOME%\bin\spark-submit --version`
+```console
+spark-submit --version
+```
 
 If the command runs and prints version information, you can move to the next step.
 
@@ -124,13 +126,13 @@ To extract the Microsoft.Spark.Worker:
 
 Run one of the following commands to set the `DOTNET_WORKER_DIR` environment variable, which is used by .NET apps to locate .NET for Apache Spark. Make sure to replace `<PATH-DOTNET_WORKER_DIR>` with the directory where you downloaded and extracted the Microsoft.Spark.Worker
 
-#### [Windows](tab/windows)
+# [Windows](tab/windows)
 
 ```console
 setx /M DOTNET_WORKER_DIR <PATH-DOTNET_WORKER_DIR>
 ```
 
-#### [Mac/Linux](tab/unix)
+# [Mac/Linux](tab/linux)
 
 ```bash
 export DOTNET_WORKER_DIR=<your_path>
@@ -242,7 +244,7 @@ microsoft-spark-2.4.x-<version>.jar ^
 dotnet MySparkApp.dll <path-of-input.txt>
 ```
 
-# [Mac/Linux](#tab/unix)
+# [Mac/Linux](#tab/linux)
 
 ```bash
 spark-submit \

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -1,9 +1,11 @@
 ---
 title: Get started with .NET for Apache Spark
-description: Discover how to run a .NET for Apache Spark app using .NET Core on Windows, macOS, and Ubuntu.
-ms.date: 06/25/2020
+description: Discover how to run a .NET for Apache Spark app using .NET Core on Windows, MacOS, and Ubuntu.
+ms.date: 08/24/2020
 ms.topic: tutorial
 ms.custom: mvc
+ms.author: luquinta
+author: luisquintanilla
 # Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark.
 ---
 
@@ -142,7 +144,10 @@ The `dotnet` command creates a `new` application of type `console` for you. The 
 
 To use .NET for Apache Spark in an app, install the Microsoft.Spark package. In your command prompt or terminal, run the following command:
 
-`dotnet add package Microsoft.Spark --version 0.8.0`
+`dotnet add package Microsoft.Spark`
+
+> [!NOTE]
+> This tutorial uses the latest version of the `Microsoft.Spark` NuGet package unless otherwise specified.
 
 ### 3. Code your app
 
@@ -150,35 +155,38 @@ Open *Program.cs* in Visual Studio Code, or any text editor, and replace all of 
 
 ```csharp
 using Microsoft.Spark.Sql;
+using static Microsoft.Spark.Sql.Functions;
 
-namespace MySparkApp
+namespace mySparkApp
 {
     class Program
     {
         static void Main(string[] args)
         {
-            // Create a Spark session.
-            SparkSession spark = SparkSession
-                .Builder()
-                .AppName("word_count_sample")
-                .GetOrCreate();
+            // Create spark session
+            SparkSession spark = 
+                SparkSession
+                    .Builder()
+                    .AppName("word_count_sample")
+                    .GetOrCreate();
 
-            // Create initial DataFrame.
+            // Create initial DataFrame
             DataFrame dataFrame = spark.Read().Text("input.txt");
 
-            // Count words.
-            DataFrame words = dataFrame
-                .Select(Functions.Split(Functions.Col("value"), " ").Alias("words"))
-                .Select(Functions.Explode(Functions.Col("words"))
-                .Alias("word"))
-                .GroupBy("word")
-                .Count()
-                .OrderBy(Functions.Col("count").Desc());
+            // Count words
+            DataFrame words = 
+                dataFrame
+                    .Select(Split(Col("value")," ").Alias("words"))
+                    .Select(Explode(Col("words")))
+                    .Alias("word")
+                    .GroupBy("word")
+                    .Count()
+                    .OrderBy(Col("count").Desc());
 
-            // Show results.
+            // Show results
             words.Show();
 
-            // Stop Spark session.
+            // Stop spark session
             spark.Stop();
         }
     }
@@ -201,6 +209,18 @@ This .NET app uses .NET for Apache Spark
 This .NET app counts words with Apache Spark
 ```
 
+  Save the changes.
+
+Open the *mySparkApp.csproj* file. Copy the newly created *input.txt* file to your build output directory by adding the following contents inside the `Project` tags:
+
+ ```xml
+<ItemGroup>
+    <Content Include="input.txt">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+ </ItemGroup>
+ ```
+
 ## Run your .NET for Apache Spark app
 
 1. Run the following command to build your application:
@@ -209,14 +229,14 @@ This .NET app counts words with Apache Spark
    dotnet build
    ```
 
-2. Run the following command to submit your application to run on Apache Spark:
+2. Navigate to your build output directory and enter the following command to submit your application to run on Apache Spark:
 
    ```console
    spark-submit \
    --class org.apache.spark.deploy.dotnet.DotnetRunner \
    --master local \
    microsoft-spark-2.4.x-<version>.jar \
-   dotnet HelloSpark.dll
+   dotnet mySparkApp.dll
    ```
 
    > [!NOTE]

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -287,9 +287,9 @@ Congratulations! You successfully authored and ran a .NET for Apache Spark app.
 In this tutorial, you learned how to:
 > [!div class="checklist"]
 >
-> * Prepare your Windows environment for .NET for Apache Spark
+> * Prepare your environment for .NET for Apache Spark
 > * Write your first .NET for Apache Spark application
-> * Build and run your simple .NET for Apache Spark application
+> * Build and run your .NET for Apache Spark application
 
 To see a video explaining the steps above, check out the [.NET for Apache Spark 101 video series](https://channel9.msdn.com/Series/NET-for-Apache-Spark-101/Run-Your-First-NET-for-Apache-Spark-App).
 

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with .NET for Apache Spark
-description: Discover how to run a .NET for Apache Spark app using .NET Core on Windows, MacOS, and Ubuntu.
+description: Discover how to run a .NET for Apache Spark app using .NET Core on Windows, macOS, and Ubuntu.
 ms.date: 09/17/2020
 ms.topic: tutorial
 ms.custom: mvc
@@ -63,7 +63,7 @@ To extract the nested **.tar** file:
 
 To extract the Apache Spark files:
 
-* Right click on **spark-2.4.1-bin-hadoop2.7.tar** and select **7-Zip -> Extract files...**
+* Right-click on **spark-2.4.1-bin-hadoop2.7.tar** and select **7-Zip -> Extract files...**
 * Enter **C:\bin** in the **Extract to** field.
 * Uncheck the checkbox below the **Extract to** field.
 * Select **OK**.
@@ -108,7 +108,7 @@ Download the [Microsoft.Spark.Worker](https://github.com/dotnet/spark/releases) 
 To extract the Microsoft.Spark.Worker:
 
 * Locate the **Microsoft.Spark.Worker.netcoreapp3.1.win-x64-0.8.0.zip** file that you downloaded.
-* Right click and select **7-Zip -> Extract files...**.
+* Right-click and select **7-Zip -> Extract files...**.
 * Enter **C:\bin** in the **Extract to** field.
 * Uncheck the checkbox below the **Extract to** field.
 * Select **OK**.
@@ -153,7 +153,7 @@ dotnet new console -o MySparkApp
 cd MySparkApp
 ```
 
-The `dotnet` command creates a `new` application of type `console` for you. The `-o` parameter creates a directory named *MySparkApp* where your app is stored and populates it with the required files. The `cd MySparkApp` command changes the directory to the app directory you just created.
+The `dotnet` command creates a `new` application of type `console` for you. The `-o` parameter creates a directory named *MySparkApp* where your app is stored and populates it with the required files. The `cd MySparkApp` command changes the directory to the app directory you created.
 
 ### 2. Install NuGet package
 
@@ -210,7 +210,7 @@ namespace MySparkApp
 }
 ```
 
-[SparkSession](xref:Microsoft.Spark.Sql.SparkSession) is the entrypoint of Apache Spark applications which manages the context and information of your application. Using the [Text](xref:Microsoft.Spark.Sql.DataFrameReader.Text%2A) method, the text data from the file specified by the `filePath` is read into a [DataFrame](xref:Microsoft.Spark.Sql.DataFrame). A DataFrame is a way of organizing data into a set of named columns. Then, a series of transformations are applied to split the sentences in the file, group each of the words, count them and order them in descending order. The result of these operations are stored in another DataFrame. Note that at this point, no operations have taken place because .NET for Apache Spark lazily evaluates the data. It's not until the [Show](xref:Microsoft.Spark.Sql.DataFrame.Show%2A) method is called to display the contents of the `words` transformed DataFrame to the console that the operations defined in the lines above execute. Once you no longer need the Spark session, use the [Stop](xref:Microsoft.Spark.Sql.SparkSession.Stop%2A) method to stop your session.
+[SparkSession](xref:Microsoft.Spark.Sql.SparkSession) is the entrypoint of Apache Spark applications, which manages the context and information of your application. Using the [Text](xref:Microsoft.Spark.Sql.DataFrameReader.Text%2A) method, the text data from the file specified by the `filePath` is read into a [DataFrame](xref:Microsoft.Spark.Sql.DataFrame). A DataFrame is a way of organizing data into a set of named columns. Then, a series of transformations is applied to split the sentences in the file, group each of the words, count them and order them in descending order. The result of these operations is stored in another DataFrame. Note that at this point, no operations have taken place because .NET for Apache Spark lazily evaluates the data. It's not until the [Show](xref:Microsoft.Spark.Sql.DataFrame.Show%2A) method is called to display the contents of the `words` transformed DataFrame to the console that the operations defined in the lines above execute. Once you no longer need the Spark session, use the [Stop](xref:Microsoft.Spark.Sql.SparkSession.Stop%2A) method to stop your session.
 
 ### 4. Create data file
 
@@ -232,7 +232,7 @@ Run the following command to build your application:
 dotnet build
 ```
 
-Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
+Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark. Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
 
 ### [Windows](#tab/windows)
 
@@ -291,7 +291,7 @@ In this tutorial, you learned how to:
 > * Write your first .NET for Apache Spark application
 > * Build and run your simple .NET for Apache Spark application
 
-To see a video explaining the steps above, checkout the [.NET for Apache Spark 101 video series](https://channel9.msdn.com/Series/NET-for-Apache-Spark-101/Run-Your-First-NET-for-Apache-Spark-App).
+To see a video explaining the steps above, check out the [.NET for Apache Spark 101 video series](https://channel9.msdn.com/Series/NET-for-Apache-Spark-101/Run-Your-First-NET-for-Apache-Spark-App).
 
 Check out the resources page to learn more.
 > [!div class="nextstepaction"]

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -76,8 +76,8 @@ Run the following commands to set the environment variables used to locate Apach
 # [Windows](#tab/windows)
 
 ```console
-setx HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
-setx SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
+setx /M HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
+setx /M SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%"
 ```
 
@@ -127,13 +127,13 @@ Run one of the following commands to set the `DOTNET_WORKER_DIR` environment var
 # [Windows](tab/windows)
 
 ```console
-setx DOTNET_WORKER_DIR=<PATH-DOTNET_WORKER_DIR>
+setx /M DOTNET_WORKER_DIR <PATH-DOTNET_WORKER_DIR>
 ```
 
 # [Mac/Linux](tab/unix)
 
 ```bash
-export DOTNET_WORKER_DIR <your_path>
+export DOTNET_WORKER_DIR=<your_path>
 ```
 
 ---

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -124,13 +124,13 @@ To extract the Microsoft.Spark.Worker:
 
 Run one of the following commands to set the `DOTNET_WORKER_DIR` environment variable, which is used by .NET apps to locate .NET for Apache Spark. Make sure to replace `<PATH-DOTNET_WORKER_DIR>` with the directory where you downloaded and extracted the Microsoft.Spark.Worker
 
-# [Windows](tab/windows)
+#### [Windows](tab/windows)
 
 ```console
 setx /M DOTNET_WORKER_DIR <PATH-DOTNET_WORKER_DIR>
 ```
 
-# [Mac/Linux](tab/unix)
+#### [Mac/Linux](tab/unix)
 
 ```bash
 export DOTNET_WORKER_DIR=<your_path>

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -226,13 +226,13 @@ Save the changes and close the file.
 
 ## Run your .NET for Apache Spark app
 
-1. Run the following command to build your application:
+Run the following command to build your application:
 
 ```dotnetcli
 dotnet build
 ```
 
-1. Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
+Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
 
 ### [Windows](#tab/windows)
 
@@ -259,7 +259,7 @@ dotnet MySparkApp.dll <path-of-input.txt>
 > [!NOTE]
 > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`. Otherwise, you'd have to use the full path (for example, *C:\bin\apache-spark\bin\spark-submit* or *~/spark/bin/spark-submit*).
 
-1. When your app runs, the word count data of the *input.txt* file is written to the console.
+When your app runs, the word count data of the *input.txt* file is written to the console.
 
 ```console
 +------+-----+

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -222,7 +222,7 @@ This .NET app counts words with Apache Spark
 
 Save the changes and close the file.
 
-## 5. Run your .NET for Apache Spark app
+## Run your .NET for Apache Spark app
 
 1. Run the following command to build your application:
 
@@ -230,7 +230,7 @@ Save the changes and close the file.
 dotnet build
 ```
 
-2. Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
+1. Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
 
 # [Windows](#tab/windows)
 
@@ -257,7 +257,7 @@ dotnet MySparkApp.dll <path-of-input.txt>
 > [!NOTE]
 > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`. Otherwise, you'd have to use the full path (for example, *C:\bin\apache-spark\bin\spark-submit* or *~/spark/bin/spark-submit*).
 
-3. When your app runs, the word count data of the *input.txt* file is written to the console.
+1. When your app runs, the word count data of the *input.txt* file is written to the console.
 
 ```console
 +------+-----+

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -19,7 +19,7 @@ In this tutorial, you learn how to:
 >
 > * Prepare your environment for .NET for Apache Spark
 > * Write your first .NET for Apache Spark application
-> * Build and run your simple .NET for Apache Spark application
+> * Build and run your .NET for Apache Spark application
 
 [!INCLUDE [spark-preview-note](../../../includes/spark-preview-note.md)]
 
@@ -71,20 +71,25 @@ To extract the Apache Spark files:
 
 ![Install Spark](https://dotnet.microsoft.com/static/images/spark-extract-with-7-zip.png?v=YvjUv54LIxI9FbALPC3h8zSQdyMtK2-NKbFOliG-f8M)
 
-Run the following commands to set the environment variables used to locate Apache Spark on **Windows**:
+Run the following commands to set the environment variables used to locate Apache Spark.
+
+# [Windows](#tab/windows)
 
 ```console
 setx HADOOP_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
 setx SPARK_HOME C:\bin\spark-2.4.1-bin-hadoop2.7\
+setx /M PATH "%PATH%;%HADOOP_HOME%;%SPARK_HOME%"
 ```
 
-Run the following commands to set the environment variables used to locate Apache Spark on **macOS** and **Ubuntu**:
+# [Mac/Linux](#tab/unix)
 
 ```bash
 export SPARK_HOME=~/bin/spark-2.4.1-bin-hadoop2.7/
 export PATH="$SPARK_HOME/bin:$PATH"
 source ~/.bashrc
 ```
+
+---
 
 Once you've installed everything and set your environment variables, open a **new** command prompt or terminal and run the following command:
 
@@ -117,13 +122,21 @@ To extract the Microsoft.Spark.Worker:
 
 ### 7. Set DOTNET_WORKER_DIR and check dependencies
 
-Run one of the following commands to set the `DOTNET_WORKER_DIR` Environment Variable, which is used by .NET apps to locate .NET for Apache Spark.
+Run one of the following commands to set the `DOTNET_WORKER_DIR` environment variable, which is used by .NET apps to locate .NET for Apache Spark. Make sure to replace `<PATH-DOTNET_WORKER_DIR>` with the directory where you downloaded and extracted the Microsoft.Spark.Worker
 
-On **Windows**, create a [new environment variable](https://www.java.com/en/download/help/path.xml) `DOTNET_WORKER_DIR` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, `C:\bin\Microsoft.Spark.Worker\`).
+# [Windows](tab/windows)
 
-On **macOS**, create a new environment variable using `export DOTNET_WORKER_DIR <your_path>` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, *~/bin/Microsoft.Spark.Worker/*).
+```console
+setx DOTNET_WORKER_DIR=<PATH-DOTNET_WORKER_DIR>
+```
 
-On **Ubuntu**, create a [new environment variable](https://help.ubuntu.com/community/EnvironmentVariables) `DOTNET_WORKER_DIR` and set it to the directory where you downloaded and extracted the Microsoft.Spark.Worker (for example, *~/bin/Microsoft.Spark.Worker*).
+# [Mac/Linux](tab/unix)
+
+```bash
+export DOTNET_WORKER_DIR <your_path>
+```
+
+---
 
 Finally, double-check that you can run `dotnet`, `java`, `spark-shell` from your command line before you move to the next section.
 
@@ -209,38 +222,40 @@ This .NET app counts words with Apache Spark
 
 Save the changes and close the file.
 
-## Run your .NET for Apache Spark app
+## 5. Run your .NET for Apache Spark app
 
 1. Run the following command to build your application:
 
-   ```dotnetcli
-   dotnet build
-   ```
+```dotnetcli
+dotnet build
+```
 
 2. Navigate to your build output directory and use the `spark-submit` command to submit your application to run on Apache Spark, Make sure to replace  `<version>` with the version of your .NET worker and `<path-of-input.txt>` with the path of your *input.txt* file is stored.
 
-    # [Windows](#tab/windows)
+# [Windows](#tab/windows)
 
-    ```console
-    spark-submit ^
-    --class org.apache.spark.deploy.dotnet.DotnetRunner ^
-    --master local ^
-    microsoft-spark-2.4.x-<version>.jar ^
-    dotnet MySparkApp.dll <path-of-input.txt>
-    ```
+```console
+spark-submit ^
+--class org.apache.spark.deploy.dotnet.DotnetRunner ^
+--master local ^
+microsoft-spark-2.4.x-<version>.jar ^
+dotnet MySparkApp.dll <path-of-input.txt>
+```
 
-    # [Mac/Linux](#tab/unix)
+# [Mac/Linux](#tab/unix)
 
-    ```bash
-    spark-submit \
-    --class org.apache.spark.deploy.dotnet.DotnetRunner \
-    --master local \
-    microsoft-spark-2.4.x-<version>.jar \
-    dotnet MySparkApp.dll <path-of-input.txt>
-    ```
+```bash
+spark-submit \
+--class org.apache.spark.deploy.dotnet.DotnetRunner \
+--master local \
+microsoft-spark-2.4.x-<version>.jar \
+dotnet MySparkApp.dll <path-of-input.txt>
+```
 
-   > [!NOTE]
-   > This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`. Otherwise, you'd have to use the full path (for example, *C:\bin\apache-spark\bin\spark-submit* or *~/spark/bin/spark-submit*).
+---
+
+> [!NOTE]
+> This command assumes you have downloaded Apache Spark and added it to your PATH environment variable to be able to use `spark-submit`. Otherwise, you'd have to use the full path (for example, *C:\bin\apache-spark\bin\spark-submit* or *~/spark/bin/spark-submit*).
 
 3. When your app runs, the word count data of the *input.txt* file is written to the console.
 


### PR DESCRIPTION
## Summary

- Updates to get started tutorial code and version used
- Clarify where files created at build time reside.

Fixes #19668 

[Preview Link](https://review.docs.microsoft.com/en-us/dotnet/spark/tutorials/get-started?branch=pr-en-us-20264&tabs=windows#write-a-net-for-apache-spark-app)