### PR TITLE
Add explanation and details for why DisposeAsyncCore is the guidance

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -33,7 +33,7 @@ protected virtual ValueTask DisposeAsyncCore()
 
 ### The DisposeAsync() method
 
-The `public` parameterless `DisposeAsync()` method is called implicitly in an `await using` statement, and its purpose is to free unmanaged resources, perform general cleanup, and to indicate that the finalizer, if one is present, needn't run. Freeing the memory associated with a managed object is always the domain of the [garbage collector](index.md). Because of this, it has a standard implementation:
+The `public` parameterless `DisposeAsync()` method is called implicitly in an `await using` statement, and its purpose is to free unmanaged resources, perform general cleanup, and to indicate that the finalizer, if one is present, need not run. Freeing the memory associated with a managed object is always the domain of the [garbage collector](index.md). Because of this, it has a standard implementation:
 
 ```csharp
 public async ValueTask DisposeAsync()
@@ -53,7 +53,10 @@ public async ValueTask DisposeAsync()
 
 ### The DisposeAsyncCore() method
 
-The `DisposeAsyncCore()` method is intended to perform the asynchronous cleanup of managed resources or for cascading calls to `DisposeAsync()`. It encapsulates the common asynchronous clean up operations when a subclass inherits a base classes that is an implementation of <xref:System.IAsyncDisposable>. The `DisposeAsyncCore()` method is `virtual` so that derived classes can define additional cleanup in their overrides.
+The `DisposeAsyncCore()` method is intended to perform the asynchronous cleanup of managed resources or for cascading calls to `DisposeAsync()`. It encapsulates the common asynchronous cleanup operations when a subclass inherits a base class that is an implementation of <xref:System.IAsyncDisposable>. The `DisposeAsyncCore()` method is `virtual` so that derived classes can define additional cleanup in their overrides.
+
+> [!TIP]
+> If an implementation of <xref:System.IAsyncDisposable> is `sealed` the `DisposeAsyncCore()` method is not needed, and the asynchronous cleanup can be performed directly in the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method.
 
 ## Implement the async dispose pattern
 

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -1,6 +1,6 @@
 ---
 title: Implement a DisposeAsync method
-description:
+description: Learn how to implement DisposeAsync and DisposeAsyncCore methods to perform asynchronous resource cleanup.
 author: IEvangelist
 ms.author: dapine
 ms.date: 08/25/2020

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -3,7 +3,7 @@ title: Implement a DisposeAsync method
 description:
 author: IEvangelist
 ms.author: dapine
-ms.date: 06/02/2020
+ms.date: 08/25/2020
 ms.technology: dotnet-standard
 dev_langs:
   - "csharp"
@@ -16,7 +16,7 @@ helpviewer_keywords:
 
 The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> that represents the asynchronous dispose operation.
 
-It is typical that when implementing the <xref:System.IAsyncDisposable> interface, classes will also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous, or asynchronous dispose. All of the guidance for implementing the dispose pattern applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
+It is typical when implementing the <xref:System.IAsyncDisposable> interface that classes will also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous, or asynchronous dispose. All of the guidance for implementing the dispose pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
 
 ## DisposeAsync() and DisposeAsyncCore()
 
@@ -30,8 +30,6 @@ protected virtual ValueTask DisposeAsyncCore()
 {
 }
 ```
-
-The `DisposeAsyncCore()` method is `virtual` so that derived classes can define additional cleanup in their overrides.
 
 ### The DisposeAsync() method
 
@@ -52,6 +50,10 @@ public async ValueTask DisposeAsync()
 
 > [!NOTE]
 > One primary difference in the async dispose pattern compared to the dispose pattern, is that the call from <xref:System.IAsyncDisposable.DisposeAsync> to the `Dispose(bool)` overload method is given `false` as an argument. When implementing the <xref:System.IDisposable.Dispose?displayProperty=nameWithType> method, however; `true` is passed instead. This helps ensure functional equivalence with the synchronous dispose pattern, and further ensures that finalizer code paths still get invoked. In other words, the `DisposeAsyncCore()` method will dispose of managed resources asynchronously, so you don't want to dispose of them synchronously as well. Therefore, call `Dispose(false)` instead of `Dispose(true)`.
+
+### The DisposeAsyncCore() method
+
+The `DisposeAsyncCore()` method is intended to perform the asynchronous cleanup of managed resources or for cascading calls to `DisposeAsync()`. It encapsulates the common asynchronous clean up operations when a subclass inherits a base classes that is an implementation of <xref:System.IAsyncDisposable>. The `DisposeAsyncCore()` method is `virtual` so that derived classes can define additional cleanup in their overrides.
 
 ## Implement the async dispose pattern
 

--- a/docs/standard/index.yml
+++ b/docs/standard/index.yml
@@ -154,6 +154,8 @@ landingContent:
             url: garbage-collection/fundamentals.md
           - text: Implement a Dispose method
             url: garbage-collection/implementing-dispose.md
+          - text: Implement a DisposeAsync method
+            url: garbage-collection/implementing-disposeasync.md
 
   # Card
   - title: Learn about parallel programming


### PR DESCRIPTION
## Summary

Add explanation and details for why `DisposeAsyncCore()` is the official guidance.

Fixes #19304
