### PR TITLE
Fix misleading wording

### DIFF
--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -39,7 +39,7 @@ That guarantees that no member of a `readonly` struct modifies the state of the 
 
 ## `readonly` instance members
 
-Beginning with C# 8.0, you can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct. If you can't declare the whole structure type as `readonly`, use the `readonly` modifier to mark the instance members that don't modify the state of the struct. In a `readonly` struct, every instance member is considered as `readonly`.
+Beginning with C# 8.0, you can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct. If you can't declare the whole structure type as `readonly`, use the `readonly` modifier to mark the instance members that don't modify the state of the struct.
 
 Within a `readonly` instance member, you can't assign to structure's instance fields. However, a `readonly` member can call a non-`readonly` member. In that case the compiler creates a copy of the structure instance and calls the non-`readonly` member on that copy. As a result, the original structure instance is not modified.
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -32,7 +32,7 @@ All data members of a `readonly` struct must be read-only as follows:
 - Any field declaration must have the [`readonly` modifier](../keywords/readonly.md)
 - Any property, including auto-implemented ones, must be read-only
 
-That guarantees that no member of a `readonly` struct modifies the state of the struct.
+That guarantees that no member of a `readonly` struct modifies the state of the struct. In C# 8.0 and later, that means that other instance members except constructors are implicitly [`readonly`](#readonly-instance-members).
 
 > [!NOTE]
 > In a `readonly` struct, a data member of a mutable reference type still can mutate its own state. For example, you can't replace a <xref:System.Collections.Generic.List%601> instance, but you can add new elements to it.

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -39,7 +39,7 @@ That guarantees that no member of a `readonly` struct modifies the state of the 
 
 ## `readonly` instance members
 
-Beginning with C# 8.0, you can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct. If you can't declare the whole structure type as `readonly`, use the `readonly` modifier to mark the instance members that don't modify the state of the struct. In a `readonly` struct, every instance member is implicitly `readonly`.
+Beginning with C# 8.0, you can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct. If you can't declare the whole structure type as `readonly`, use the `readonly` modifier to mark the instance members that don't modify the state of the struct. In a `readonly` struct, every instance member is considered as `readonly`.
 
 Within a `readonly` instance member, you can't assign to structure's instance fields. However, a `readonly` member can call a non-`readonly` member. In that case the compiler creates a copy of the structure instance and calls the non-`readonly` member on that copy. As a result, the original structure instance is not modified.
 


### PR DESCRIPTION
Fixes #20293

I haven't changed wording into

> ...every instance member is `readonly`

because I'm afraid that such can be interpreted as every instance member (including methods) must be marked with the `readonly` modifier. Unfounded worries?

Another, longer, variant:

>In a `readonly` struct, every instance member, which is not marked as `readonly`, is implicitly `readonly`
