### PR TITLE
Add recursive flag to PowerShell globbing

### DIFF
--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -174,7 +174,7 @@ dotnet sln [<SOLUTION_FILE>] remove [-h|--help]
 - Add multiple C# projects to a solution using a globbing pattern (Windows PowerShell only):
 
   ```dotnetcli
-  dotnet sln todo.sln add (ls **/*.csproj)
+  dotnet sln todo.sln add (ls -r **/*.csproj)
   ```
 
 - Remove multiple C# projects from a solution using a globbing pattern (Unix/Linux only):
@@ -186,5 +186,5 @@ dotnet sln [<SOLUTION_FILE>] remove [-h|--help]
 - Remove multiple C# projects from a solution using a globbing pattern (Windows PowerShell only):
 
   ```dotnetcli
-  dotnet sln todo.sln remove (ls **/*.csproj)
+  dotnet sln todo.sln remove (ls -r **/*.csproj)
   ```


### PR DESCRIPTION
## Summary

Normally, project files are in sub-folders so it makes sense to use the recursive flag `-r` when adding/removing projects by globbing with PowerShell.

Verified on PowerShell 5.1.18362.752.
Without the flag, it would not include `.csproj` files in sub-folders.

Fixes #20309 