### PR TITLE
Update docker-compose with new mssql location

### DIFF
--- a/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md
+++ b/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md
@@ -377,7 +377,7 @@ services:
       - sqldata
 
   sqldata:
-    image: mssql-server-linux:latest
+    image: mcr.microsoft.com/mssql/server:latest
     environment:
       - SA_PASSWORD=Pass@word
       - ACCEPT_EULA=Y


### PR DESCRIPTION
## Summary

This PR slightly improves quality of docs for readers that like to follow along.

The previous sqldata image `mssql-server-linux:latest` does not work anymore.
Equivalent image is `mcr.microsoft.com/mssql/server`.

Fixes #20353 