### PR TITLE
Document breaking change in crypto introduced in 3.0

### DIFF
--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -324,7 +324,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 - [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption)
 - [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased)
 - [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x)
-- [CryptoStream.Dispose transforms final block only when writing](#cryptoStreamdispose-transforms-final-block-only-when-writing)
+- [CryptoStream.Dispose transforms final block only when writing](#cryptostreamdispose-transforms-final-block-only-when-writing)
 
 [!INCLUDE [begin-trusted-cert-linux](~/includes/core-changes/cryptography/3.0/begin-trusted-cert-linux.md)]
 

--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -324,6 +324,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 - [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption)
 - [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased)
 - [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x)
+- [System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing](#systemsecuritycryptographycryptostreamdispose-is-transforming-final-block-only-when-writing)
 
 [!INCLUDE [begin-trusted-cert-linux](~/includes/core-changes/cryptography/3.0/begin-trusted-cert-linux.md)]
 
@@ -338,6 +339,10 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 ***
 
 [!INCLUDE[.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](~/includes/core-changes/cryptography/3.0/net-core-3-0-prefers-openssl-1-1-x.md)]
+
+***
+
+[!INCLUDE [cryptography-cryptostream-dispose-final-block-write](../../../includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.0.md
+++ b/docs/core/compatibility/2.2-3.0.md
@@ -324,7 +324,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 - [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption)
 - [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased)
 - [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x)
-- [System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing](#systemsecuritycryptographycryptostreamdispose-is-transforming-final-block-only-when-writing)
+- [CryptoStream.Dispose transforms final block only when writing](#cryptoStreamdispose-transforms-final-block-only-when-writing)
 
 [!INCLUDE [begin-trusted-cert-linux](~/includes/core-changes/cryptography/3.0/begin-trusted-cert-linux.md)]
 
@@ -342,7 +342,7 @@ If you're migrating from version 2.2 to version 3.0 of .NET Core, ASP.NET Core, 
 
 ***
 
-[!INCLUDE [cryptography-cryptostream-dispose-final-block-write](../../../includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
+[!INCLUDE [CryptoStream.Dispose transforms final block only when writing](~/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -322,7 +322,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 - [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption)
 - [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased)
 - [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x)
-- [CryptoStream.Dispose transforms final block only when writing](#cryptoStreamdispose-transforms-final-block-only-when-writing)
+- [CryptoStream.Dispose transforms final block only when writing](#cryptostreamdispose-transforms-final-block-only-when-writing)
 
 [!INCLUDE [begin-trusted-cert-linux](~/includes/core-changes/cryptography/3.0/begin-trusted-cert-linux.md)]
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -322,6 +322,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 - [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption)
 - [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased)
 - [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x)
+- [System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing](#systemsecuritycryptographycryptostreamdispose-is-transforming-final-block-only-when-writing)
 
 [!INCLUDE [begin-trusted-cert-linux](~/includes/core-changes/cryptography/3.0/begin-trusted-cert-linux.md)]
 
@@ -336,6 +337,10 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 ***
 
 [!INCLUDE[.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](~/includes/core-changes/cryptography/3.0/net-core-3-0-prefers-openssl-1-1-x.md)]
+
+***
+
+[!INCLUDE [cryptography-cryptostream-dispose-final-block-write](../../../includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
 
 ***
 

--- a/docs/core/compatibility/2.2-3.1.md
+++ b/docs/core/compatibility/2.2-3.1.md
@@ -322,7 +322,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 - [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption)
 - [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased)
 - [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x)
-- [System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing](#systemsecuritycryptographycryptostreamdispose-is-transforming-final-block-only-when-writing)
+- [CryptoStream.Dispose transforms final block only when writing](#cryptoStreamdispose-transforms-final-block-only-when-writing)
 
 [!INCLUDE [begin-trusted-cert-linux](~/includes/core-changes/cryptography/3.0/begin-trusted-cert-linux.md)]
 
@@ -340,7 +340,7 @@ If you're migrating from version 2.2 to version 3.1 of .NET Core, ASP.NET Core, 
 
 ***
 
-[!INCLUDE [cryptography-cryptostream-dispose-final-block-write](../../../includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
+[!INCLUDE [CryptoStream.Dispose transforms final block only when writing](~/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
 
 ***
 

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -14,7 +14,7 @@ The following breaking changes are documented on this page:
 | [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption) | 3.0 |
 | [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased) | 3.0 |
 | [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x) | 3.0 |
-| [System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing](#systemsecuritycryptographycryptostreamdispose-is-transforming-final-block-only-when-writing) | 3.0 |
+| [CryptoStream.Dispose transforms final block only when writing](#cryptoStreamdispose-transforms-final-block-only-when-writing) | 3.0 |
 | [Boolean parameter of SignedCms.ComputeSignature is respected](#boolean-parameter-of-signedcmscomputesignature-is-respected) | 2.1 |
 
 ## .NET 5.0
@@ -41,7 +41,7 @@ The following breaking changes are documented on this page:
 
 ***
 
-[!INCLUDE [cryptography-cryptostream-dispose-final-block-write](../../../includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
+[!INCLUDE [CryptoStream.Dispose transforms final block only when writing](~/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
 
 ***
 

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -14,7 +14,7 @@ The following breaking changes are documented on this page:
 | [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption) | 3.0 |
 | [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased) | 3.0 |
 | [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x) | 3.0 |
-| [CryptoStream.Dispose transforms final block only when writing](#cryptoStreamdispose-transforms-final-block-only-when-writing) | 3.0 |
+| [CryptoStream.Dispose transforms final block only when writing](#cryptostreamdispose-transforms-final-block-only-when-writing) | 3.0 |
 | [Boolean parameter of SignedCms.ComputeSignature is respected](#boolean-parameter-of-signedcmscomputesignature-is-respected) | 2.1 |
 
 ## .NET 5.0

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -14,6 +14,7 @@ The following breaking changes are documented on this page:
 | [EnvelopedCms defaults to AES-256 encryption](#envelopedcms-defaults-to-aes-256-encryption) | 3.0 |
 | [Minimum size for RSAOpenSsl key generation has increased](#minimum-size-for-rsaopenssl-key-generation-has-increased) | 3.0 |
 | [.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](#net-core-30-prefers-openssl-11x-to-openssl-10x) | 3.0 |
+| [System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing](#systemsecuritycryptographycryptostreamdispose-is-transforming-final-block-only-when-writing) | 3.0 |
 | [Boolean parameter of SignedCms.ComputeSignature is respected](#boolean-parameter-of-signedcmscomputesignature-is-respected) | 2.1 |
 
 ## .NET 5.0
@@ -37,6 +38,10 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE[.NET Core 3.0 prefers OpenSSL 1.1.x to OpenSSL 1.0.x](~/includes/core-changes/cryptography/3.0/net-core-3-0-prefers-openssl-1-1-x.md)]
+
+***
+
+[!INCLUDE [cryptography-cryptostream-dispose-final-block-write](../../../includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md)]
 
 ***
 

--- a/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
+++ b/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
@@ -1,16 +1,16 @@
-### System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing
+### CryptoStream.Dispose transforms final block only when writing
 
-The <xref:System.Security.Cryptography.CryptoStream.Dispose?displayProperty=fullName> which is used to finish crypto stream operations was previously throwing an exception when used with some crypto transforms (i.e. AES with padding) and reading was not complete. This scenario can occur i.e. in network scenarios when operation is cancelled and causing users to have to catch the exception.
+The <xref:System.Security.Cryptography.CryptoStream.Dispose%2A?displayProperty=nameWithType> method, which is used to finish `CryptoStream` operations, no longer attempts to transform the final block when reading.
 
 #### Change description
 
-In previous versions, when using <xref:System.Security.Cryptography.CryptoStream> in <xref:System.Security.Cryptography.CryptoStreamMode.Read> mode and user performed incomplete read the <xref:System.Security.Cryptography.CryptoStream.Dispose> could throw an exception (i.e. when using AES with padding) as final block was attempted to be transformed but data was incomplete.
+In previous .NET versions, if a user performed an incomplete read when using <xref:System.Security.Cryptography.CryptoStream> in <xref:System.Security.Cryptography.CryptoStreamMode.Read> mode, the <xref:System.Security.Cryptography.CryptoStream.Dispose%2A> method could throw an exception (for example, when using AES with padding). The exception was thrown because the final block was attempted to be transformed but the data was incomplete.
 
-In .NET 3.0 and later versions, the <xref:System.Security.Cryptography.CryptoStream.Dispose> will no longer try to transform the final block when reading which will allow for incomplete reads.
+In .NET 3.0 and later versions, <xref:System.Security.Cryptography.CryptoStream.Dispose%2A> no longer tries to transform the final block when reading, which allow sfor incomplete reads.
 
 #### Reason for change
 
-This change enables incomplete reads from the crypto stream (i.e. when cancelling network operations) without need to catch an exception.
+This change enables incomplete reads from the crypto stream when a network operation is cancelled, without the need to catch an exception.
 
 #### Version introduced
 
@@ -18,8 +18,10 @@ This change enables incomplete reads from the crypto stream (i.e. when cancellin
 
 #### Recommended action
 
-Most apps should not be affected by this change. If application previously caught an exception in order to suppress exception caused by the incomplete read it will no longer be needed.
-If app used transforming of the final block in hashing scenarios it might now need to ensure the entire stream is read before stream is disposed.
+Most apps should not be affected by this change.
+
+If your application previously caught an exception in case of an incomplete read, you can delete that `catch` block.
+If your app used transforming of the final block in hashing scenarios, you might need to ensure that the entire stream is read before it's disposed.
 
 #### Category
 
@@ -33,6 +35,6 @@ Cryptography
 
 #### Affected APIs
 
-- `P:System.Security.Cryptography.CryptoStream.Dispose`
+- `M:System.Security.Cryptography.CryptoStream.Dispose`
 
 -->

--- a/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
+++ b/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
@@ -29,7 +29,7 @@ Cryptography
 
 #### Affected APIs
 
-- <xref:System.Security.Cryptography.CryptoStream.Dispose?displayProperty=fullName>
+- <xref:System.Security.Cryptography.CryptoStream.Dispose%2A?displayProperty=fullName>
 
 <!--
 

--- a/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
+++ b/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
@@ -1,0 +1,38 @@
+### System.Security.Cryptography.CryptoStream.Dispose is transforming final block only when writing
+
+The <xref:System.Security.Cryptography.CryptoStream.Dispose?displayProperty=fullName> which is used to finish crypto stream operations was previously throwing an exception when used with some crypto transforms (i.e. AES with padding) and reading was not complete. This scenario can occur i.e. in network scenarios when operation is cancelled and causing users to have to catch the exception.
+
+#### Change description
+
+In previous versions, when using <xref:System.Security.Cryptography.CryptoStream> in <xref:System.Security.Cryptography.CryptoStreamMode.Read> mode and user performed incomplete read the <xref:System.Security.Cryptography.CryptoStream.Dispose> could throw an exception (i.e. when using AES with padding) as final block was attempted to be transformed but data was incomplete.
+
+In .NET 3.0 and later versions, the <xref:System.Security.Cryptography.CryptoStream.Dispose> will no longer try to transform the final block when reading which will allow for incomplete reads.
+
+#### Reason for change
+
+This change enables incomplete reads from the crypto stream (i.e. when cancelling network operations) without need to catch an exception.
+
+#### Version introduced
+
+3.0
+
+#### Recommended action
+
+Most apps should not be affected by this change. If application previously caught an exception in order to suppress exception caused by the incomplete read it will no longer be needed.
+If app used transforming of the final block in hashing scenarios it might now need to ensure the entire stream is read before stream is disposed.
+
+#### Category
+
+Cryptography
+
+#### Affected APIs
+
+- <xref:System.Security.Cryptography.CryptoStream.Dispose?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Security.Cryptography.CryptoStream.Dispose`
+
+-->

--- a/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
+++ b/includes/core-changes/cryptography/3.0/cryptography-cryptostream-dispose-final-block-write.md
@@ -6,7 +6,7 @@ The <xref:System.Security.Cryptography.CryptoStream.Dispose%2A?displayProperty=n
 
 In previous .NET versions, if a user performed an incomplete read when using <xref:System.Security.Cryptography.CryptoStream> in <xref:System.Security.Cryptography.CryptoStreamMode.Read> mode, the <xref:System.Security.Cryptography.CryptoStream.Dispose%2A> method could throw an exception (for example, when using AES with padding). The exception was thrown because the final block was attempted to be transformed but the data was incomplete.
 
-In .NET 3.0 and later versions, <xref:System.Security.Cryptography.CryptoStream.Dispose%2A> no longer tries to transform the final block when reading, which allow sfor incomplete reads.
+In .NET Core 3.0 and later versions, <xref:System.Security.Cryptography.CryptoStream.Dispose%2A> no longer tries to transform the final block when reading, which allows for incomplete reads.
 
 #### Reason for change
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/2042
Fixes: https://github.com/dotnet/runtime/issues/33283

## Summary

Document breaking change in crypto introduced in 3.0.

cc: @jcdickinson
