### PR TITLE
Fix incorrect/oudated documentation for supported platforms

### DIFF
--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -260,9 +260,9 @@ This article organizes the affected API members by namespace.
 
 | Member | Platforms that throw |
 | - | - |
-| <xref:System.Security.Cryptography.Pkcs.CmsSigner.%23ctor(System.Security.Cryptography.CspParameters)> | All |
-| <xref:System.Security.Cryptography.Pkcs.SignedCms.ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner,System.Boolean)?displayProperty=nameWithType> | All |
-| <xref:System.Security.Cryptography.Pkcs.SignerInfo.ComputeCounterSignature?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.Pkcs.CmsSigner.%23ctor(System.Security.Cryptography.CspParameters)> | Linux and macOS |
+| <xref:System.Security.Cryptography.Pkcs.SignedCms.ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner,System.Boolean)?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.Pkcs.SignerInfo.ComputeCounterSignature?displayProperty=nameWithType> | Linux and macOS |
 
 ## System.Security.Cryptography.X509Certificates
 


### PR DESCRIPTION
This is based on what I see in:

https://github.com/dotnet/runtime/blob/77b752b7cec435943668df438ab9cb33d5ece253/src/libraries/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs#L47-L48

However, this PR still needs a product team review.

I also think this file should be somehow auto generated from runtime source code based on this new attribute.