### PR TITLE
remove extra org

### DIFF
--- a/.whatsnew.json
+++ b/.whatsnew.json
@@ -6,11 +6,6 @@
         "linkFormat": "relative",
         "relativeLinkPrefix": "/dotnet/"
     },
-    "inclusionCriteria": {
-        "additionalMicrosoftOrgs": [
-            ".NET Platform"
-        ]
-    },
     "areas": [
         {
             "name": "architecture",


### PR DESCRIPTION
Now that the what's new code looks for this org, it's not needed in the configuration
