### PR TITLE
Removed redundant Directory.Exists

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.Directory_Copy/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.Directory_Copy/cs/program.cs
@@ -23,11 +23,9 @@ class DirectoryCopyExample
         }
 
         DirectoryInfo[] dirs = dir.GetDirectories();
-        // If the destination directory doesn't exist, create it.
-        if (!Directory.Exists(destDirName))
-        {
-            Directory.CreateDirectory(destDirName);
-        }
+        
+        // If the destination directory doesn't exist, create it.       
+        Directory.CreateDirectory(destDirName);        
 
         // Get the files in the directory and copy them to the new location.
         FileInfo[] files = dir.GetFiles();


### PR DESCRIPTION
Directory.CreateDirectory documentation states that it already checks for directory existence before creating it.

Fixes #20350 
