### PR TITLE
redirect proposals to C# 9

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1052,7 +1052,7 @@
     },
     {
       "source_path": "docs/csharp/language-reference/proposals/index.md",
-      "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-8.0/nullable-reference-types"
+      "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-9.0/records"
     },
     {
       "source_path": "docs/csharp/language-reference/operators/addition-assignment-operator.md",


### PR DESCRIPTION
Missed this when I published the 9.0 proposals.

See https://github.com/dotnet/docs/issues/20352#issuecomment-684007953