### PR TITLE
Fix missing space typo

### DIFF
--- a/docs/csharp/properties.md
+++ b/docs/csharp/properties.md
@@ -80,7 +80,7 @@ follows:
 
 [!code-csharp[Validating property setters](../../samples/snippets/csharp/properties/Person.cs#6)]
 
-The preceding example can be simplified by using a`throw` expression as part
+The preceding example can be simplified by using a `throw` expression as part
 of the property setter validation:
 
 [!code-csharp[Validating property setters](../../samples/snippets/csharp/properties/Person.cs#7)]


### PR DESCRIPTION
added a missing space: "athrow expression" should be "a throw expression"