### PR TITLE
Improve minor syntax

### DIFF
--- a/docs/core/tutorials/snippets/library-with-visual-studio/csharp/ShowCase/Program.cs
+++ b/docs/core/tutorials/snippets/library-with-visual-studio/csharp/ShowCase/Program.cs
@@ -13,7 +13,7 @@ class Program
                 ResetConsole();
 
             string input = Console.ReadLine();
-            if (string.IsNullOrEmpty(input)) break;
+            if (String.IsNullOrEmpty(input)) break;
             Console.WriteLine($"Input: {input} {"Begins with uppercase? ",30}: " +
                               $"{(input.StartsWithUpper() ? "Yes" : "No")}\n");
             row += 3;

--- a/docs/core/tutorials/snippets/library-with-visual-studio/csharp/StringLibrary/Class1.cs
+++ b/docs/core/tutorials/snippets/library-with-visual-studio/csharp/StringLibrary/Class1.cs
@@ -6,11 +6,11 @@ namespace UtilityLibraries
     {
         public static bool StartsWithUpper(this string str)
         {
-            if (string.IsNullOrWhiteSpace(str))
+            if (String.IsNullOrWhiteSpace(str))
                 return false;
 
             char ch = str[0];
-            return char.IsUpper(ch);
+            return Char.IsUpper(ch);
         }
     }
 }

--- a/docs/core/tutorials/snippets/library-with-visual-studio/csharp/StringLibraryTest/UnitTest1.cs
+++ b/docs/core/tutorials/snippets/library-with-visual-studio/csharp/StringLibraryTest/UnitTest1.cs
@@ -40,7 +40,7 @@ namespace StringLibraryTest
         public void DirectCallWithNullOrEmpty()
         {
             // Tests that we expect to return false.
-            string[] words = { string.Empty, null };
+            string[] words = { String.Empty, null };
             foreach (var word in words)
             {
                 bool result = StringLibrary.StartsWithUpper(word);


### PR DESCRIPTION
## Summary

After #20357, reading testing-library-with-visual-studio, and some C# docs,
I realized that I made a mistake in my previous pull request.
Now I know that most people and also docs prefer starting with a lower case for variables and with an upper case for classes.

So I fixed it again including UnitTest1.cs.
Sorry to confuse.