### PR TITLE
Fix typo to be consistent with example

### DIFF
--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -54,7 +54,7 @@ C# [***string interpolation***](../language-reference/tokens/interpolated.md) en
 
 :::code language="csharp" source="./snippets/shared/Features.cs" ID="StringInterpolation":::
 
-An interpolated string is declared using the `$` token. String interpolation evaluates the expressions between `{` and `}`, then converts the result to a `string`, and replaces the text between the brackets with the string result of the expression. The `:` in the first expression, `{weatherData.Data:MM-DD-YYYY}` specifies the *format string*. In the preceding example, it specifies that the date should be printed in "MM-DD-YYYY" format.
+An interpolated string is declared using the `$` token. String interpolation evaluates the expressions between `{` and `}`, then converts the result to a `string`, and replaces the text between the brackets with the string result of the expression. The `:` in the first expression, `{weatherData.Date:MM-DD-YYYY}` specifies the *format string*. In the preceding example, it specifies that the date should be printed in "MM-DD-YYYY" format.
 
 ## Pattern matching
 


### PR DESCRIPTION
The reference to the expression was inconsistent with the corresponding example above it.  The member referenced in the interpolation expression should be Date, not Data.

## Summary

I modified the text to the correct vowel 'e' instead of the erroneous vowel 'a', making the text of the expression consistent with the example code and improving the value of the encapsulating text by decreasing the probability of confusion or higher orders of cognitive processing that have the potential to diminish the learning experience via the phenomenology of frustration that could negate the benefit of the intended clarification.
Fixes #Issue_Number (if available)
