### PR TITLE
Update unsupported-apis for CMS

### DIFF
--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -261,8 +261,7 @@ This article organizes the affected API members by namespace.
 | Member | Platforms that throw |
 | - | - |
 | <xref:System.Security.Cryptography.Pkcs.CmsSigner.%23ctor(System.Security.Cryptography.CspParameters)> | All |
-| <xref:System.Security.Cryptography.Pkcs.SignedCms.ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner,System.Boolean)?displayProperty=nameWithType> | All |
-| <xref:System.Security.Cryptography.Pkcs.SignerInfo.ComputeCounterSignature?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.Pkcs.SignerInfo.ComputeCounterSignature()?displayProperty=nameWithType> | All |
 
 ## System.Security.Cryptography.X509Certificates
 

--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -261,7 +261,7 @@ This article organizes the affected API members by namespace.
 | Member | Platforms that throw |
 | - | - |
 | <xref:System.Security.Cryptography.Pkcs.CmsSigner.%23ctor(System.Security.Cryptography.CspParameters)> | All |
-| <xref:System.Security.Cryptography.Pkcs.SignerInfo.ComputeCounterSignature()?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.Pkcs.SignerInfo.ComputeCounterSignature?displayProperty=nameWithType> | All |
 
 ## System.Security.Cryptography.X509Certificates
 


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/41596

## Summary

List of unsupported APIs is inaccurate for CMS. This makes it up to date.
