### PR TITLE
Fix labeling Roslyn issues

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -77,7 +77,7 @@
           "(?i)csharp-null-safety$": {
             "labels-add": ":card_file_box: Technology - C# Null safety"
           },
-          "(?i)csharp-csharp-roslyn$": {
+          "(?i)csharp-roslyn$": {
             "labels-add": ":card_file_box: Technology - Roslyn APIs"
           },
           "(?i)csharp-whats-new$": {


### PR DESCRIPTION
Discovered in #20403 

The value for technology is set as "csharp-roslyn" not "csharp-csharp-roslyn":

https://github.com/dotnet/docs/blob/a0980c8fea1fe7ba30538d63e8fa5486af168a95/docfx.json#L438