### PR TITLE
Breaking changes for CA2014, CA2015, CA2247

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -128,8 +128,13 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ## Code analysis
 
 - [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer)
+- [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops)
 
 [!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
+
+***
+
+[!INCLUDE [stackalloc-in-loops](../../../includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md)]
 
 ***
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -129,12 +129,17 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 - [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer)
 - [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops)
+- [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert)
 
 [!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
 
 ***
 
 [!INCLUDE [stackalloc-in-loops](../../../includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md)]
+
+***
+
+[!INCLUDE [finalizers-for-memorymanager-types](../../../includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md)]
 
 ***
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -130,6 +130,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer)
 - [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops)
 - [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert)
+- [CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum](#ca2247-argument-passed-to-taskcompletionsource-constructor-should-be-taskcreationoptions-enum-instead-of-taskcontinuationoptions-enum)
 
 [!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
 
@@ -140,6 +141,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ***
 
 [!INCLUDE [finalizers-for-memorymanager-types](../../../includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md)]
+
+***
+
+[!INCLUDE [ctor-arg-should-be-taskcreationoptions](../../../includes/core-changes/codeanalysis/5.0/ctor-arg-should-be-taskcreationoptions.md)]
 
 ***
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -130,7 +130,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer)
 - [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops)
 - [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert)
-- [CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum](#ca2247-argument-passed-to-taskcompletionsource-constructor-should-be-taskcreationoptions-enum-instead-of-taskcontinuationoptions-enum)
+- [CA2247: Argument to TaskCompletionSource constructor should be TaskCreationOptions value](#ca2247-argument-to-taskcompletionsource-constructor-should-be-taskcreationoptions-value)
 
 [!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
 

--- a/docs/core/compatibility/code-analysis.md
+++ b/docs/core/compatibility/code-analysis.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 | - | :-: |
 | [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
 | [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops) | 5.0 |
+| [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert) | 5.0 |
 
 ## .NET 5.0
 
@@ -19,5 +20,9 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE [stackalloc-in-loops](../../../includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md)]
+
+***
+
+[!INCLUDE [finalizers-for-memorymanager-types](../../../includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md)]
 
 ***

--- a/docs/core/compatibility/code-analysis.md
+++ b/docs/core/compatibility/code-analysis.md
@@ -12,6 +12,7 @@ The following breaking changes are documented on this page:
 | [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
 | [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops) | 5.0 |
 | [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert) | 5.0 |
+| [CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum](#ca2247-argument-passed-to-taskcompletionsource-constructor-should-be-taskcreationoptions-enum-instead-of-taskcontinuationoptions-enum) | 5.0 |
 
 ## .NET 5.0
 
@@ -24,5 +25,9 @@ The following breaking changes are documented on this page:
 ***
 
 [!INCLUDE [finalizers-for-memorymanager-types](../../../includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md)]
+
+***
+
+[!INCLUDE [ctor-arg-should-be-taskcreationoptions](../../../includes/core-changes/codeanalysis/5.0/ctor-arg-should-be-taskcreationoptions.md)]
 
 ***

--- a/docs/core/compatibility/code-analysis.md
+++ b/docs/core/compatibility/code-analysis.md
@@ -9,7 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
-| [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
+| [CA1831: Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
 | [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops) | 5.0 |
 | [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert) | 5.0 |
 | [CA2247: Argument to TaskCompletionSource constructor should be TaskCreationOptions value](#ca2247-argument-to-taskcompletionsource-constructor-should-be-taskcreationoptions-value) | 5.0 |

--- a/docs/core/compatibility/code-analysis.md
+++ b/docs/core/compatibility/code-analysis.md
@@ -12,7 +12,7 @@ The following breaking changes are documented on this page:
 | [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
 | [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops) | 5.0 |
 | [CA2015: Do not define finalizers for types derived from MemoryManager\<T>](#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert) | 5.0 |
-| [CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum](#ca2247-argument-passed-to-taskcompletionsource-constructor-should-be-taskcreationoptions-enum-instead-of-taskcontinuationoptions-enum) | 5.0 |
+| [CA2247: Argument to TaskCompletionSource constructor should be TaskCreationOptions value](#ca2247-argument-to-taskcompletionsource-constructor-should-be-taskcreationoptions-value) | 5.0 |
 
 ## .NET 5.0
 

--- a/docs/core/compatibility/code-analysis.md
+++ b/docs/core/compatibility/code-analysis.md
@@ -10,9 +10,14 @@ The following breaking changes are documented on this page:
 | Breaking change | Version introduced |
 | - | :-: |
 | [CA1831 Use AsSpan or AsMemory instead of Range-based indexer](#ca1831-use-asspan-or-asmemory-instead-of-range-based-indexer) | 5.0 |
+| [CA2014: Do not use stackalloc in loops](#ca2014-do-not-use-stackalloc-in-loops) | 5.0 |
 
 ## .NET 5.0
 
 [!INCLUDE [range-based-indexer-on-string](../../../includes/core-changes/codeanalysis/5.0/range-based-indexer-on-string.md)]
+
+***
+
+[!INCLUDE [stackalloc-in-loops](../../../includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md)]
 
 ***

--- a/includes/core-changes/codeanalysis/5.0/ctor-arg-should-be-taskcreationoptions.md
+++ b/includes/core-changes/codeanalysis/5.0/ctor-arg-should-be-taskcreationoptions.md
@@ -1,0 +1,35 @@
+### CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+
+.NET code analyzer rule [CA2247](/visualstudio/code-quality/ca2247) is enabled, by default, starting in .NET 5.0. It produces a build warning for calls to the <xref:System.Threading.Tasks.TaskCompletionSource%601> constructor that pass an argument of type <xref:System.Threading.Tasks.TaskContinuationOptions>.
+
+#### Change description
+
+Starting in .NET 5.0, the .NET SDK includes [.NET source code analyzers](../../../../docs/fundamentals/productivity/code-analysis.md). Several of these rules are enabled, by default, including [CA2247](/visualstudio/code-quality/ca2247). If your project contains code that violates this rule and is configured to treat warnings as errors, this change could break your build.
+
+Rule CA2247 finds calls to the <xref:System.Threading.Tasks.TaskCompletionSource%601> constructor that pass an argument of type <xref:System.Threading.Tasks.TaskContinuationOptions>. The <xref:System.Threading.Tasks.TaskCompletionSource%601> type has a constructor that accepts a <xref:System.Threading.Tasks.TaskCreationOptions> value, and another constructor that accepts an <xref:System.Object>. If you accidentally pass a <xref:System.Threading.Tasks.TaskContinuationOptions> value instead of a <xref:System.Threading.Tasks.TaskCreationOptions> value, the constructor with the <xref:System.Object> parameter is called at run time. Your code will compile and run but won't have the intended behavior.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+- Replace the <xref:System.Threading.Tasks.TaskContinuationOptions> argument with the corresponding <xref:System.Threading.Tasks.TaskCreationOptions> value. Do not suppress this warning, since it almost always highlights a bug in your code. For more information, see [CA2247](/visualstudio/code-quality/ca2247).
+
+- To disable code analysis completely, set `EnableNETAnalyzers` to `false` in your project file. For more information, see [EnableNETAnalyzers](../../../../docs/core/project-sdk/msbuild-props.md#enablenetanalyzers).
+
+#### Category
+
+Code analysis
+
+#### Affected APIs
+
+- <xref:System.Threading.Tasks.TaskCompletionSource%601.%23ctor(System.Object)>
+
+<!--
+
+#### Affected APIs
+
+- ``M:System.Threading.Tasks.TaskCompletionSource`1.#ctor(System.Object)``
+
+-->

--- a/includes/core-changes/codeanalysis/5.0/ctor-arg-should-be-taskcreationoptions.md
+++ b/includes/core-changes/codeanalysis/5.0/ctor-arg-should-be-taskcreationoptions.md
@@ -1,4 +1,4 @@
-### CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+### CA2247: Argument to TaskCompletionSource constructor should be TaskCreationOptions value
 
 .NET code analyzer rule [CA2247](/visualstudio/code-quality/ca2247) is enabled, by default, starting in .NET 5.0. It produces a build warning for calls to the <xref:System.Threading.Tasks.TaskCompletionSource%601> constructor that pass an argument of type <xref:System.Threading.Tasks.TaskContinuationOptions>.
 

--- a/includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md
+++ b/includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md
@@ -1,0 +1,35 @@
+### CA2015: Do not define finalizers for types derived from MemoryManager\<T>
+
+.NET code analyzer rule [CA2015](/visualstudio/code-quality/ca2015) is enabled, by default, starting in .NET 5.0. It produces a build warning for any types that derive from <xref:System.Buffers.MemoryManager%601> that define a finalizer.
+
+#### Change description
+
+Starting in .NET 5.0, the .NET SDK includes [.NET source code analyzers](../../../../docs/fundamentals/productivity/code-analysis.md). Several of these rules are enabled, by default, including [CA2015](/visualstudio/code-quality/ca2015). If your project contains code that violates this rule and is configured to treat warnings as errors, this change could break your build.
+
+Rule CA2015 flags types that derive from <xref:System.Buffers.MemoryManager%601> that define a finalizer. Adding a finalizer to a type that derives from <xref:System.Buffers.MemoryManager%601> is likely an indication of a bug. It suggests that a native resource that could have been obtained in a <xref:System.Span%601> is getting cleaned up, potentially while it's still in use by the <xref:System.Span%601>.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+- Remove the finalizer definition. For more information, see [CA2015](/visualstudio/code-quality/ca2015).
+
+- To disable code analysis completely, set `EnableNETAnalyzers` to `false` in your project file. For more information, see [EnableNETAnalyzers](../../../../docs/core/project-sdk/msbuild-props.md#enablenetanalyzers).
+
+#### Category
+
+Code analysis
+
+#### Affected APIs
+
+Not detectible via API analysis.
+
+<!--
+
+#### Affected APIs
+
+Not detectible via API analysis.
+
+-->

--- a/includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md
+++ b/includes/core-changes/codeanalysis/5.0/finalizers-for-memorymanager-types.md
@@ -24,12 +24,12 @@ Code analysis
 
 #### Affected APIs
 
-Not detectible via API analysis.
+Not detectable via API analysis.
 
 <!--
 
 #### Affected APIs
 
-Not detectible via API analysis.
+Not detectable via API analysis.
 
 -->

--- a/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
+++ b/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
@@ -24,12 +24,12 @@ Code analysis
 
 #### Affected APIs
 
-Not detectible via API analysis.
+Not detectable via API analysis.
 
 <!--
 
 #### Affected APIs
 
-Not detectible via API analysis.
+Not detectable via API analysis.
 
 -->

--- a/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
+++ b/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
@@ -1,0 +1,35 @@
+### CA2014: Do not use stackalloc in loops
+
+.NET code analyzer rule [CA2014](/visualstudio/code-quality/ca2014) is enabled, by default, starting in .NET 5.0. It produces a build warning for any C# code where a [stackalloc](../../../../docs/csharp/language-reference/operators/stackalloc.md) expression is used inside a loop.
+
+#### Change description
+
+Starting in .NET 5.0, the .NET SDK includes [.NET source code analyzers](../../../../docs/fundamentals/productivity/code-analysis.md). Several of these rules are enabled, by default, including [CA2014](/visualstudio/code-quality/ca2014). If your project contains code that violates this rule and is configured to treat warnings as errors, this change could break your build.
+
+Rule CA2014 looks for C# code where a [stackalloc expression](../../../../docs/csharp/language-reference/operators/stackalloc.md) is used inside a loop. [stackalloc](../../../../docs/csharp/language-reference/operators/stackalloc.md) allocates memory from the current stack frame. The memory isn't released until the current method call returns, which can lead to stack overflows. Because you can't catch stack overflow exceptions, the app will terminate in case of stack overflow.
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Recommended action
+
+- Avoid using a [stackalloc expression](../../../../docs/csharp/language-reference/operators/stackalloc.md) inside loops. Allocate the memory block outside the loop and reuse it inside the loop.
+
+- To disable code analysis completely, set `EnableNETAnalyzers` to `false` in your project file. For more information, see [EnableNETAnalyzers](../../../../docs/core/project-sdk/msbuild-props.md#enablenetanalyzers).
+
+#### Category
+
+Code analysis
+
+#### Affected APIs
+
+Not detectible via API analysis.
+
+<!--
+
+#### Affected APIs
+
+Not detectible via API analysis.
+
+-->

--- a/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
+++ b/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
@@ -14,7 +14,7 @@ Rule CA2014 looks for C# code where a [stackalloc expression](../../../../docs/c
 
 #### Recommended action
 
-- Avoid using [stackalloc](../../../../docs/csharp/language-reference/operators/stackalloc.md) inside loops. Allocate the memory block outside the loop and reuse it inside the loop.
+- Avoid using [stackalloc](../../../../docs/csharp/language-reference/operators/stackalloc.md) inside loops. Allocate the memory block outside the loop and reuse it inside the loop. For more information, see [CA2014](/visualstudio/code-quality/ca2014).
 
 - To disable code analysis completely, set `EnableNETAnalyzers` to `false` in your project file. For more information, see [EnableNETAnalyzers](../../../../docs/core/project-sdk/msbuild-props.md#enablenetanalyzers).
 

--- a/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
+++ b/includes/core-changes/codeanalysis/5.0/stackalloc-in-loops.md
@@ -14,7 +14,7 @@ Rule CA2014 looks for C# code where a [stackalloc expression](../../../../docs/c
 
 #### Recommended action
 
-- Avoid using a [stackalloc expression](../../../../docs/csharp/language-reference/operators/stackalloc.md) inside loops. Allocate the memory block outside the loop and reuse it inside the loop.
+- Avoid using [stackalloc](../../../../docs/csharp/language-reference/operators/stackalloc.md) inside loops. Allocate the memory block outside the loop and reuse it inside the loop.
 
 - To disable code analysis completely, set `EnableNETAnalyzers` to `false` in your project file. For more information, see [EnableNETAnalyzers](../../../../docs/core/project-sdk/msbuild-props.md#enablenetanalyzers).
 


### PR DESCRIPTION
Fixes #19807, #19808, #19809.

Preview links:

- [CA2014](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-20428#ca2014-do-not-use-stackalloc-in-loops)
- [CA2015](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-20428#ca2015-do-not-define-finalizers-for-types-derived-from-memorymanagert)
- [CA2247](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-20428#ca2247-argument-passed-to-taskcompletionsource-constructor-should-be-taskcreationoptions-enum-instead-of-taskcontinuationoptions-enum)