### PR TITLE
Replaces "indexer" word with the "accessor"

### DIFF
--- a/docs/csharp/programming-guide/indexers/index.md
+++ b/docs/csharp/programming-guide/indexers/index.md
@@ -40,7 +40,7 @@ Starting with C# 7.0, both the get and set accessor can be an implemented as exp
   
 - The [this](../../language-reference/keywords/this.md) keyword is used to define the indexer.  
   
-- The [value](../../language-reference/keywords/value.md) keyword is used to define the value being assigned by the `set` indexer.  
+- The [value](../../language-reference/keywords/value.md) keyword is used to define the value being assigned by the `set` accessor.  
   
 - Indexers do not have to be indexed by an integer value; it is up to you how to define the specific look-up mechanism.  
   


### PR DESCRIPTION
`set` is an accessor, not an indexer
