### PR TITLE
Fix out of date explanation of named arguments

### DIFF
--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -56,7 +56,7 @@ You can also used *named arguments* instead of positional arguments when invokin
 
 [!code-csharp[csSnippets.Methods#45](../../samples/snippets/csharp/concepts/methods/named1.cs#45)]
 
-You can invoke a method using both positional arguments and named arguments. However, a positional argument cannot follow a named argument. The following example invokes the `TestMotorcycle.Drive` method from the previous example using one positional argument and one named argument.
+You can invoke a method using both positional arguments and named arguments. However, positional arguments can only follow named arguments when the named arguments are in the correct positions. The following example invokes the `TestMotorcycle.Drive` method from the previous example using one positional argument and one named argument.
 
 [!code-csharp[csSnippets.Methods#46](../../samples/snippets/csharp/concepts/methods/named2.cs#46)]
 


### PR DESCRIPTION
the old sentence: "However, a positional argument cannot follow a named argument" is wrong as of C# 7.2

https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-2#non-trailing-named-arguments
states: "Method calls may now use named arguments that precede positional arguments when those named arguments are in the correct positions."