### PR TITLE
Fix formatting in WPF breaking change

### DIFF
--- a/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md
+++ b/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md
@@ -2,15 +2,17 @@
 
 #### Details
 
-In .NET Framework 4.6.2, a number of changes were made to support previously unsupported paths (both in length and format). Checks for proper drive separator (colon) syntax were made more correct, which had the side effect of blocking some URI paths in a few select Path APIs where they used to be tolerated.
+In .NET Framework 4.6.2, a number of changes were made to support previously unsupported paths (both in length and format). Checks for proper drive separator (colon) syntax were made more correct, which had the side effect of blocking some URI paths in a few select Path APIs where they were previously tolerated.
 
 #### Suggestion
 
-If passing a URI to affected APIs, modify the string to be a legal path first.<ul><li>Remove the scheme from URLs manually (e.g. remove `file://` from URLs)
+If passing a URI to affected APIs, modify the string to be a legal path first.
 
-- Pass the URI to the <xref:System.Uri> class and use <xref:System.Uri.LocalPath>
+- Remove the scheme from URLs manually (for example, remove `file://` from URLs).
 
-Alternatively, you can opt out of the new path normalization by setting the `Switch.System.IO.UseLegacyPathHandling` AppContext switch to true.
+- Pass the URI to the <xref:System.Uri> class and use <xref:System.Uri.LocalPath>.
+
+Alternatively, you can opt out of the new path normalization by setting the `Switch.System.IO.UseLegacyPathHandling` AppContext switch to `true`.
 
 | Name    | Value       |
 |:--------|:------------|

--- a/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md
+++ b/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md
@@ -12,7 +12,7 @@ A deadlock may result in a Reentrant service, which restricts instances of the s
 
 To address this issue, you can do the following:
 
-- Set the service's concurrency mode to <xref:System.ServiceModel.ConcurrencyMode.Single?displayProperty=nameWithType> or &lt;System.ServiceModel.ConcurrencyMode.Multiple?displayProperty=nameWithType&gt;. For example:
+- Set the service's concurrency mode to <xref:System.ServiceModel.ConcurrencyMode.Single?displayProperty=nameWithType> or <System.ServiceModel.ConcurrencyMode.Multiple?displayProperty=nameWithType>. For example:
 
 ```csharp
 [ServiceBehavior(ConcurrencyMode = ConcurrencyMode.Reentrant)]

--- a/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md
+++ b/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md
@@ -12,7 +12,7 @@ A deadlock may result in a Reentrant service, which restricts instances of the s
 
 To address this issue, you can do the following:
 
-- Set the service's concurrency mode to <xref:System.ServiceModel.ConcurrencyMode.Single?displayProperty=nameWithType> or <System.ServiceModel.ConcurrencyMode.Multiple?displayProperty=nameWithType>. For example:
+- Set the service's concurrency mode to <xref:System.ServiceModel.ConcurrencyMode.Single?displayProperty=nameWithType> or <xref:System.ServiceModel.ConcurrencyMode.Multiple?displayProperty=nameWithType>. For example:
 
 ```csharp
 [ServiceBehavior(ConcurrencyMode = ConcurrencyMode.Reentrant)]

--- a/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md
+++ b/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md
@@ -20,7 +20,7 @@
 - <xref:System.Windows.Controls.Expander> controls are now correctly announced as groups (expand/collapse) by screen readers.
 - <xref:System.Windows.Controls.DataGridCell> controls are now correctly announced as data grid cell (localized) by screen readers.
 - Screen readers will now announce the name of an editable <xref:System.Windows.Controls.ComboBox>.
-- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as &quot;no item in view&quot; by screen readers.
+- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as "no item in view" by screen readers.
 
 **LiveRegion support**
 
@@ -35,10 +35,21 @@ In order for the application to benefit from these changes, it must run on .NET 
 - Target .NET Framework 4.7.1. This is the recommended approach. These accessibility changes are enabled by default on WPF applications that target .NET Framework 4.7.1 or later.
 - It opts out of the legacy accessibility behaviors by adding the following [AppContext Switch](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) in the `<runtime>` section of the app config file and setting it to `false`, as the following example shows.
 
-<pre><code class="lang-xml">&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#13;&#10;&lt;configuration&gt;&#13;&#10;&lt;startup&gt;&#13;&#10;&lt;supportedRuntime version=&quot;v4.0&quot; sku=&quot;.NETFramework,Version=v4.7&quot;/&gt;&#13;&#10;&lt;/startup&gt;&#13;&#10;&lt;runtime&gt;&#13;&#10;&lt;!-- AppContextSwitchOverrides value attribute is in the form of &#39;key1=true/false;key2=true/false  --&gt;&#13;&#10;&lt;AppContextSwitchOverrides value=&quot;Switch.UseLegacyAccessibilityFeatures=false&quot; /&gt;&#13;&#10;&lt;/runtime&gt;&#13;&#10;&lt;/configuration&gt;&#13;&#10;</code></pre>
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+    <startup>
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+    </startup>
+    <runtime>
+      <!-- AppContextSwitchOverrides value attribute is in the form of 'key1=true/false;key2=true/false'  -->
+      <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false" />
+    </runtime>
+  </configuration>
+  ```
 
 Applications that target .NET Framework 4.7.1 or later and want to preserve the legacy accessibility behavior can opt in to the use of legacy accessibility features by explicitly setting this AppContext switch to `true`.
-For an overview of UI automation, see the [UI Automation Overview](~/docs/framework/ui-automation/ui-automation-overview.md).
+For an overview of UI automation, see [UI Automation Overview](~/docs/framework/ui-automation/ui-automation-overview.md).
 
 | Name    | Value       |
 |:--------|:------------|

--- a/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md
+++ b/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md
@@ -3,35 +3,41 @@
 #### Details
 
 **High Contrast improvements**
-<ul><li>The focus for the <xref:System.Windows.Controls.Expander> control is now visible. In previous versions of the .NET Framework, it was not.
+
+- The focus for the <xref:System.Windows.Controls.Expander> control is now visible. In previous versions of .NET Framework, it was not.
 - The text in <xref:System.Windows.Controls.CheckBox> and <xref:System.Windows.Controls.RadioButton> controls when they are selected is now easier to see than in previous .NET Framework versions.
-- The border of a disabled <xref:System.Windows.Controls.ComboBox> is now the same color as the disabled text. In previous versions of the .NET Framework, it was not.
-- Disabled and focused buttons now use the correct theme color. In previous versions of the .NET Framework, they did not.
-- The dropdown button is now visible when a <xref:System.Windows.Controls.ComboBox> control's style is set to <xref:System.Windows.Controls.ToolBar.ComboBoxStyleKey?displayProperty=nameWithType>, In previous versions of the .NET Framework, it was not.
-- The sort indicator arrow in a <xref:System.Windows.Controls.DataGrid> control now uses theme colors. In previous versions of the .NET Framework, it did not.
-- The default hyperlink style now changes to the correct theme color on mouse over. In previous versions of the .NET Framework, it did not.
-- The Keyboard focus on radio buttons is now visible. In previous versions of the .NET Framework, it was not.
-- The <xref:System.Windows.Controls.DataGrid> control's checkbox column now uses the expected colors for keyboard focus feedback. In previous versions of the .NET Framework, it did not.
-- the Keyboard focus visuals are now visible on <xref:System.Windows.Controls.ComboBox> and <xref:System.Windows.Controls.ListBox> controls. In previous versions of the .NET Framework, it was not.</p>
+- The border of a disabled <xref:System.Windows.Controls.ComboBox> is now the same color as the disabled text. In previous versions of .NET Framework, it was not.
+- Disabled and focused buttons now use the correct theme color. In previous versions of .NET Framework, they did not.
+- The dropdown button is now visible when a <xref:System.Windows.Controls.ComboBox> control's style is set to <xref:System.Windows.Controls.ToolBar.ComboBoxStyleKey?displayProperty=nameWithType>. In previous versions of .NET Framework, it was not.
+- The sort indicator arrow in a <xref:System.Windows.Controls.DataGrid> control now uses theme colors. In previous versions of .NET Framework, it did not.
+- The default hyperlink style now changes to the correct theme color on mouse over. In previous versions of .NET Framework, it did not.
+- The Keyboard focus on radio buttons is now visible. In previous versions of .NET Framework, it was not.
+- The <xref:System.Windows.Controls.DataGrid> control's checkbox column now uses the expected colors for keyboard focus feedback. In previous versions of .NET Framework, it did not.
+- the Keyboard focus visuals are now visible on <xref:System.Windows.Controls.ComboBox> and <xref:System.Windows.Controls.ListBox> controls. In previous versions of .NET Framework, it was not.
+
 **Screen reader interaction improvements**
-<ul><li><xref:System.Windows.Controls.Expander> controls are now correctly announced as groups (expand/collapse) by screen readers.
+
+- <xref:System.Windows.Controls.Expander> controls are now correctly announced as groups (expand/collapse) by screen readers.
 - <xref:System.Windows.Controls.DataGridCell> controls are now correctly announced as data grid cell (localized) by screen readers.
 - Screen readers will now announce the name of an editable <xref:System.Windows.Controls.ComboBox>.
-- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as &quot;no item in view&quot; by screen readers.</p>
+- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as &quot;no item in view&quot; by screen readers.
+
 **LiveRegion support**
-Screen readers such as Narrator help people know the UI contents of an application, usually by describing something about the UI that's currently focused, because that is probably the element of most interest to the user. However, if a UI element changes somewhere in the screen and it does not have the focus, the user may not be informed and miss important information. LiveRegions are meant to solve this problem. A developer can use them to inform the screen reader or any other [UI Automation](~/docs/framework/ui-automation/ui-automation-overview.md) client that an important change has been made to a UI element. The screen reader can then decide how and when to inform the user of this change. The LiveSetting property also lets the screen reader know how important it is to inform the user of the change made to the UI.
+
+Screen readers, such as Narrator, help people understand the user interface (UI) of an application, usually by describing the UI element that currently has focus. However, if a UI element changes somewhere in the screen and it does not have the focus, the user may not be informed and miss important information. LiveRegions are meant to solve this problem. A developer can use them to inform the screen reader or any other [UI Automation](~/docs/framework/ui-automation/ui-automation-overview.md) client that an important change has been made to a UI element. The screen reader can then decide how and when to inform the user of this change. The LiveSetting property also lets the screen reader know how important it is to inform the user of the change made to the UI.
 
 #### Suggestion
 
 **How to opt in or out of these changes**
-In order for the application to benefit from these changes, it must run on the .NET Framework 4.7.1 or later. The application can benefit from these changes in either of the following ways:
 
-- Target the .NET Framework 4.7.1. This is the recommended approach. These accessibility changes are enabled by default on WPF applications that target the .NET Framework 4.7.1 or later.
+In order for the application to benefit from these changes, it must run on .NET Framework 4.7.1 or later. The application can benefit from these changes in either of the following ways:
+
+- Target .NET Framework 4.7.1. This is the recommended approach. These accessibility changes are enabled by default on WPF applications that target .NET Framework 4.7.1 or later.
 - It opts out of the legacy accessibility behaviors by adding the following [AppContext Switch](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) in the `<runtime>` section of the app config file and setting it to `false`, as the following example shows.
 
 <pre><code class="lang-xml">&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#13;&#10;&lt;configuration&gt;&#13;&#10;&lt;startup&gt;&#13;&#10;&lt;supportedRuntime version=&quot;v4.0&quot; sku=&quot;.NETFramework,Version=v4.7&quot;/&gt;&#13;&#10;&lt;/startup&gt;&#13;&#10;&lt;runtime&gt;&#13;&#10;&lt;!-- AppContextSwitchOverrides value attribute is in the form of &#39;key1=true/false;key2=true/false  --&gt;&#13;&#10;&lt;AppContextSwitchOverrides value=&quot;Switch.UseLegacyAccessibilityFeatures=false&quot; /&gt;&#13;&#10;&lt;/runtime&gt;&#13;&#10;&lt;/configuration&gt;&#13;&#10;</code></pre>
 
-Applications that target the .NET Framework 4.7.1 or later and want to preserve the legacy accessibility behavior can opt in to the use of legacy accessibility features by explicitly setting this AppContext switch to `true`.
+Applications that target .NET Framework 4.7.1 or later and want to preserve the legacy accessibility behavior can opt in to the use of legacy accessibility features by explicitly setting this AppContext switch to `true`.
 For an overview of UI automation, see the [UI Automation Overview](~/docs/framework/ui-automation/ui-automation-overview.md).
 
 | Name    | Value       |


### PR DESCRIPTION
Asterisks intended for boldfacing were showing on the rendered page.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.0-4.7.1?branch=pr-en-us-20461#windows-presentation-foundation-wpf).