### PR TITLE
Added C# version alert, include it in concerning article

### DIFF
--- a/docs/csharp/includes/csharp-version-alert.md
+++ b/docs/csharp/includes/csharp-version-alert.md
@@ -1,0 +1,9 @@
+---
+author: IEvangelist
+ms.author: dapine
+ms.topic: include
+ms.date: 09/08/2020
+---
+
+> [!IMPORTANT]
+> C# is versioned. Depending on the version of C# you're using, various features may or may not be available. C# versions are *defaulted* based on the target framework. For more information, see [C# language versioning defaults](../language-reference/configure-language-version.md#defaults).

--- a/docs/csharp/includes/csharp-version-alert.md
+++ b/docs/csharp/includes/csharp-version-alert.md
@@ -6,4 +6,4 @@ ms.date: 09/08/2020
 ---
 
 > [!IMPORTANT]
-> C# is versioned. Depending on the version of C# you're using, various features may or may not be available. C# versions are *defaulted* based on the target framework. For more information, see [C# language versioning defaults](../language-reference/configure-language-version.md#defaults).
+> The official documentation tracks the latest C# version. We are currently writing for C# 9.0. Depending on the version of C# you're using, various features may not be available. The *default* C# version for your project is based on the target framework. For more information, see [C# language versioning defaults](../language-reference/configure-language-version.md#defaults).


### PR DESCRIPTION
## Summary

Added C# version alert, include it in concerning article. We could either identify additional articles now to include this in, or include this where needed as we make updates to articles.

Fixes #18237
