### PR TITLE
Respond to feedback

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -521,6 +521,7 @@
         "_csharplang/proposals/csharp-8.0/nested-stackalloc.md": "Nested stackalloc expressions",
         "_csharplang/proposals/csharp-9.0/covariant-returns.md" : "Covariant return types",
         "_csharplang/proposals/csharp-9.0/extending-partial-methods.md" : "Extending partial methods",
+        "_csharplang/proposals/csharp-9.0/extension-getenumerator.md" : "Extension GetEnumerator support in foreach",
         "_csharplang/proposals/csharp-9.0/function-pointers.md" : "Function pointers",
         "_csharplang/proposals/csharp-9.0/init.md" : "Init only setters",
         "_csharplang/proposals/csharp-9.0/lambda-discard-parameters.md" : "Lambda discard parameters", 

--- a/docs/csharp/language-reference/proposals/toc.yml
+++ b/docs/csharp/language-reference/proposals/toc.yml
@@ -104,6 +104,8 @@
       href: ../../../../_csharplang/proposals/csharp-9.0/target-typed-conditional-expression.md
     - name: Covariant return types
       href: ../../../../_csharplang/proposals/csharp-9.0/covariant-returns.md
+    - name: Extension GetEnumerator in foreach loops
+      href: ../../../../_csharplang/proposals/csharp-9.0/extension-getenumerator.md
     - name: Lambda discard parameters
       href: ../../../../_csharplang/proposals/csharp-9.0/lambda-discard-parameters.md
     - name: Attributes on local functions

--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -18,6 +18,7 @@ C# 9.0 adds the following features and enhancements to the C# language:
 - static anonymous functions
 - Target-typed conditional expressions
 - Covariant return types
+- Extension `GetEnumerator` support for `foreach` loops
 - Lambda discard parameters
 - Attributes on local functions
 - Module initializers
@@ -211,7 +212,7 @@ You could call it as follows:
 
 :::code language="csharp" source="snippets/whats-new-csharp9/FitAndFinish.cs" ID="TargetTypeNewArgument":::
 
-Another nice use for this feature is to combine it with init only properties to initialize a new object. The parentheses on `new` are optional:
+Another nice use for this feature is to combine it with init only properties to initialize a new object:
 
 :::code language="csharp" source="snippets/whats-new-csharp9/FitAndFinish.cs" ID="InitWeatherStation":::
 
@@ -222,6 +223,8 @@ A similar feature improves the target type resolution of conditional expressions
 Starting in C# 9.0, you can add the `static` modifier to lambda expressions or anonymous methods. Static lambda expressions are analogous to the `static` local functions: a static lambda or anonymous function can't capture local variables or instance state. The `static` modifier prevents accidentally capturing other variables.
 
 Covariant return types provide flexibility for the return types of overridden functions. An overridden virtual function can return a type derived from the return type declared in the base class method. This can be useful for Records, and for other types that support virtual clone or factory methods.
+
+In addition, the `foreach` loop will recognize and use an extension method `GetEnumerator` that otherwise satisfies the `foreach` pattern. This change means `foreach` is consistent with other pattern-based constructions such as the async pattern, and pattern-based deconstruction. In practice, this change means you can add `foreach` support to any type. You should limit its use to when enumerating an object makes sense in your design.
 
 Next, you can use discards as parameters to lambda expressions. This convenience enables you to avoid naming the argument, and the compiler may avoid using it. You use the `_` for any argument.
 


### PR DESCRIPTION
Two changes here:
1. Fixes #20488  Target type `new` requires parentheses.
1. Add Extension `GetEnumerator` both to the article, and publish the speclet for the feature. See https://github.com/dotnet/docs/pull/20446#pullrequestreview-483029684
