### PR TITLE
Add documentation for EnforceCodeStyleInBuild and AnalysisMode proper…

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -202,7 +202,7 @@ The following table shows the available options.
 
 ### CodeAnalysisTreatWarningsAsErrors
 
-The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code quality analysis warnings (CAxxxx) should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code quality analysis](../../fundamentals/productivity/code-analysis.md#code-quality-analysis) warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
+The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code quality analysis warnings (CAxxxx) should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code quality analysis](../../fundamentals/productivity/code-analysis.md#code-quality-analysis) warnings are also treated as errors. If you do not want code quality analysis warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -184,7 +184,7 @@ The following table shows the available options.
 
 ### AnalysisMode
 
-Starting with .NET 5.0 RC2, the .NET SDK ships with [all "CA" code quality rules](/visualstudio/code-quality/code-analysis-for-managed-code-warnings). By default, only [some rules are enabled by default](../../fundamentals/productivity/code-analysis.md#enabled-rules) as build warnings. The `AnalysisMode` property lets you customize the set of enabled by default rules. You can either switch to a more aggressive (opt-out) analysis mode or a more conservative (opt-in) analysis mode. For example, if you want to enable all rules by default as build warnings, you can set the value to `AllEnabledByDefault`.
+Starting with .NET 5.0 RC2, the .NET SDK ships with all of the ["CA" code quality rules](/visualstudio/code-quality/code-analysis-for-managed-code-warnings). By default, only [some rules are enabled](../../fundamentals/productivity/code-analysis.md#enabled-rules) as build warnings. The `AnalysisMode` property lets you customize the set of rules that are enabled by default. You can either switch to a more aggressive (opt-out) analysis mode or a more conservative (opt-in) analysis mode. For example, if you want to enable all rules by default as build warnings, set the value to `AllEnabledByDefault`.
 
 ```xml
 <PropertyGroup>
@@ -196,9 +196,9 @@ The following table shows the available options.
 
 | Value | Meaning |
 |-|-|
-| `Default` | Default mode, where certain rules are enabled as build warnings, certain rules are enabled as Visual Studio IDE suggestions, and remainder are disabled. |
-| `AllEnabledByDefault` | Aggressive or Opt-out mode, where all rules are enabled by default as build warnings. You can selectively [opt out](../../fundamentals/productivity/configure-code-analysis-rules.md) of individual rules to disable them. |
-| `AllDisabledByDefault` | Conservative or Opt-in mode, where all rules are disabled by default. You can selectively [opt into](../../fundamentals/productivity/configure-code-analysis-rules.md) individual rules to enable them. |
+| `Default` | Default mode, where certain rules are enabled as build warnings, certain rules are enabled as Visual Studio IDE suggestions, and the remainder are disabled. |
+| `AllEnabledByDefault` | Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively [opt out](../../fundamentals/productivity/configure-code-analysis-rules.md) of individual rules to disable them. |
+| `AllDisabledByDefault` | Conservative or opt-in mode, where all rules are disabled by default. You can selectively [opt into](../../fundamentals/productivity/configure-code-analysis-rules.md) individual rules to enable them. |
 
 ### CodeAnalysisTreatWarningsAsErrors
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -202,7 +202,7 @@ The following table shows the available options.
 
 ### CodeAnalysisTreatWarningsAsErrors
 
-The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code analysis warnings should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code analysis](../../fundamentals/productivity/code-analysis.md) warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
+The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code quality analysis warnings should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code quality analysis](../../fundamentals/productivity/code-analysis.md#code-quality-analysis) warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
 
 ```xml
 <PropertyGroup>
@@ -212,7 +212,7 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 
 ### EnableNETAnalyzers
 
-[.NET code quality analysis](../../fundamentals/productivity/code-analysis.md) is enabled, by default, for projects that target .NET 5.0 or later. You can enable .NET code analysis for projects that target earlier versions of .NET by setting the `EnableNETAnalyzers` property to `true`. To disable code analysis in any project, set this property to `false`.
+[.NET code quality analysis](../../fundamentals/productivity/code-analysis.md#code-quality-analysis) is enabled, by default, for projects that target .NET 5.0 or later. You can enable .NET code analysis for projects that target earlier versions of .NET by setting the `EnableNETAnalyzers` property to `true`. To disable code analysis in any project, set this property to `false`.
 
 ```xml
 <PropertyGroup>
@@ -225,7 +225,7 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 
 ### EnforceCodeStyleInBuild
 
-[.NET code style analysis](../../fundamentals/productivity/code-analysis.md) is disabled, by default, on build for all .NET projects. You can enable code style analysis for .NET projects by setting the `EnforceCodeStyleInBuild` property to `true`.
+[.NET code style analysis](../../fundamentals/productivity/code-analysis.md#code-style-analysis) is disabled, by default, on build for all .NET projects. You can enable code style analysis for .NET projects by setting the `EnforceCodeStyleInBuild` property to `true`.
 
 ```xml
 <PropertyGroup>
@@ -233,7 +233,7 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 </PropertyGroup>
 ```
 
-All code style rules that are [configured](../../fundamentals/productivity/code-analysis.md#enable-code-style-analysis-in-build) to be warnings or errors will execute on build and report violations.
+All code style rules that are [configured](../../fundamentals/productivity/code-analysis.md#code-style-analysis) to be warnings or errors will execute on build and report violations.
 
 ## Run-time configuration properties
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -202,7 +202,7 @@ The following table shows the available options.
 
 ### CodeAnalysisTreatWarningsAsErrors
 
-The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code quality analysis warnings should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code quality analysis](../../fundamentals/productivity/code-analysis.md#code-quality-analysis) warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
+The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code quality analysis warnings (CAxxxx) should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code quality analysis](../../fundamentals/productivity/code-analysis.md#code-quality-analysis) warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -182,6 +182,24 @@ The following table shows the available options.
 | `5.0` | The set of rules that was enabled for the .NET 5.0 release is used, even if newer rules are available. |
 | `5` | The set of rules that was enabled for the .NET 5.0 release is used, even if newer rules are available. |
 
+### AnalysisMode
+
+Starting with .NET 5.0 RC2, the .NET SDK ships with [all "CA" code quality rules](/visualstudio/code-quality/code-analysis-for-managed-code-warnings). By default, only [some rules are enabled by default](../../fundamentals/productivity/code-analysis.md#enabled-rules) as build warnings. The `AnalysisMode` property lets you customize the set of enabled by default rules. You can either switch to a more aggressive (opt-out) analysis mode or a more conservative (opt-in) analysis mode. For example, if you want to enable all rules by default as build warnings, you can set the value to `AllEnabledByDefault`.
+
+```xml
+<PropertyGroup>
+  <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+</PropertyGroup>
+```
+
+The following table shows the available options.
+
+| Value | Meaning |
+|-|-|
+| `Default` | Default mode, where certain rules are enabled as build warnings, certain rules are enabled as Visual Studio IDE suggestions, and remainder are disabled. |
+| `AllEnabledByDefault` | Aggressive or Opt-out mode, where all rules are enabled by default as build warnings. You can selectively [opt out](../../fundamentals/productivity/configure-code-analysis-rules.md) of individual rules to disable them. |
+| `AllDisabledByDefault` | Conservative or Opt-in mode, where all rules are disabled by default. You can selectively [opt into](../../fundamentals/productivity/configure-code-analysis-rules.md) individual rules to enable them. |
+
 ### CodeAnalysisTreatWarningsAsErrors
 
 The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code analysis warnings should be treated as warnings and break the build. If you use the `-warnaserror` flag when you build your projects, [.NET code analysis](../../fundamentals/productivity/code-analysis.md) warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
@@ -194,7 +212,7 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 
 ### EnableNETAnalyzers
 
-[.NET Code analysis](../../fundamentals/productivity/code-analysis.md) is enabled, by default, for projects that target .NET 5.0 or later. You can enable .NET code analysis for projects that target earlier versions of .NET by setting the `EnableNETAnalyzers` property to true. To disable code analysis in any project, set this property to `false`.
+[.NET code quality analysis](../../fundamentals/productivity/code-analysis.md) is enabled, by default, for projects that target .NET 5.0 or later. You can enable .NET code analysis for projects that target earlier versions of .NET by setting the `EnableNETAnalyzers` property to `true`. To disable code analysis in any project, set this property to `false`.
 
 ```xml
 <PropertyGroup>
@@ -204,6 +222,18 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 
 > [!TIP]
 > Another way to enable .NET code analysis on projects that target .NET versions prior to .NET 5.0 is to set the [AnalysisLevel](#analysislevel) property to `latest`.
+
+### EnforceCodeStyleInBuild
+
+[.NET code style analysis](../../fundamentals/productivity/code-analysis.md) is disabled, by default, on build for all .NET projects. You can enable code style analysis for .NET projects by setting the `EnforceCodeStyleInBuild` property to `true`.
+
+```xml
+<PropertyGroup>
+  <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+</PropertyGroup>
+```
+
+All code style rules that are [configured](../../fundamentals/productivity/code-analysis.md#enable-code-style-analysis-in-build) to be warnings or errors will execute on build and report violations.
 
 ## Run-time configuration properties
 

--- a/docs/fundamentals/productivity/code-analysis.md
+++ b/docs/fundamentals/productivity/code-analysis.md
@@ -11,10 +11,10 @@ helpviewer_keywords:
 ---
 # Overview of .NET source code analysis
 
-.NET compiler platform (Roslyn) analyzers inspect your C# or Visual Basic code for code quality and code style issues. Starting in .NET 5.0, these analyzers are included with the .NET SDK. (Previously, you installed these analyzers as a [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers).)
+.NET compiler platform (Roslyn) analyzers inspect your C# or Visual Basic code for code quality and code style issues. Starting in .NET 5.0, these analyzers are included with the .NET SDK. (Previously, you installed code quality analyzers as a [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers), and code style analyzers were installed with Visual Studio.)
 
-- [Code quality analysis ("CA" rules)](#code-quality-analysis)
-- [Code style analysis ("IDE" rules)](#code-style-analysis)
+- [Code quality analysis ("CAxxxx" rules)](#code-quality-analysis)
+- [Code style analysis ("IDExxxx" rules)](#code-style-analysis)
 
 If rule violations are found by an analyzer, they're reported as a suggestion, warning, or error, depending on how each rule is [configured](configure-code-analysis-rules.md). Code analysis violations appear with the prefix "CA" or "IDE" to differentiate them from compiler errors.
 
@@ -25,7 +25,7 @@ If rule violations are found by an analyzer, they're reported as a suggestion, w
 
 ## Code quality analysis
 
-_Code quality analysis ("CA" rules)_ inspect your C# or Visual Basic code for security, performance, design and other issues. It is enabled, by default, for projects that target .NET 5.0 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`. You can also disable code analysis for your project by setting `EnableNETAnalyzers` to `false`.
+_Code quality analysis ("CA") rules_ inspect your C# or Visual Basic code for security, performance, design and other issues. Analysis is enabled, by default, for projects that target .NET 5.0 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`. You can also disable code analysis for your project by setting `EnableNETAnalyzers` to `false`.
 
 ### Enabled rules
 
@@ -42,20 +42,20 @@ The following rules are enabled, by default, in .NET 5.0 Preview 8.
 
 You can change the severity of these rules to disable them or elevate them to errors.
 
-### Enabling additional rules
+### Enable additional rules
 
-Starting with .NET 5.0 RC2, the .NET SDK ships with [all "CA" code quality rules](/visualstudio/code-quality/code-analysis-for-managed-code-warnings). For a full list of rules that are included with each .NET SDK version, see [analyzer releases](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md).
+Starting with .NET 5.0 RC2, the .NET SDK ships with all of the ["CA" code quality rules](/visualstudio/code-quality/code-analysis-for-managed-code-warnings). For a full list of rules that are included with each .NET SDK version, see [analyzer releases](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md).
 
 #### Default analysis mode
 
-In the default analysis mode, some rules are [enabled by default](#enabled-rules) as build warnings. Some other rules are enabled by default only as Visual Studio IDE suggestions with corresponding code fixes. Rest of the rules are disabled by default. Full list of rules specified at [analyzer releases](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md) includes each rule's default severity and whether or not the rule is enabled by default in the default analysis mode.
+In the default analysis mode, some rules are [enabled by default](#enabled-rules) as build warnings. Some other rules are enabled by default only as Visual Studio IDE suggestions with corresponding code fixes. The remaining rules are disabled by default. The [full list of rules](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md) includes each rule's default severity and whether or not the rule is enabled by default in the default analysis mode.
 
 #### Custom analysis mode
 
-You can [configure code analysis rules](configure-code-analysis-rules.md) to enable or disable individual rule or a category of rules. Additionally, you can configure the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) to switch to below custom analysis modes:
+You can [configure code analysis rules](configure-code-analysis-rules.md) to enable or disable an individual rule or a category of rules. Additionally, you can use the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) property to switch to one of the following custom analysis modes:
 
 - _Aggressive_ or _Opt-out_ mode: All rules are enabled by default as build warnings. You can selectively [opt out](configure-code-analysis-rules.md) of individual rules to disable them.
-- _Conservative_ or _Opt-in_ mode, where all rules are disabled by default. You can selectively [opt into](configure-code-analysis-rules.md) individual rules to enable them.
+- _Conservative_ or _Opt-in_ mode: All rules are disabled by default. You can selectively [opt into](configure-code-analysis-rules.md) individual rules to enable them.
 
 ### Treat warnings as errors
 
@@ -90,16 +90,16 @@ By default, you'll get the latest code analysis rules and default rule severitie
 
 ## Code style analysis
 
-_[Code style analysis](/visualstudio/ide/editorconfig-code-style-settings-reference) ("IDE" rules)_ enables you to define and maintain consistent code style in your codebase. Following are the default settings:
+_[Code style analysis](/visualstudio/ide/editorconfig-code-style-settings-reference) ("IDExxxx" rules)_ enables you to define and maintain consistent code style in your codebase. Following are the default settings:
 
-- Command line build: Code style analysis is disabled, by default, for all .NET projects on command line builds.
+- Command line build: Code style analysis is disabled, by default, for all .NET projects on command-line builds.
 - Visual Studio: Code style analysis is enabled, by default, for all .NET projects inside Visual Studio as [code refactoring quick actions](/visualstudio/ide/code-generation-in-visual-studio).
 
-Starting .NET 5.0 RC2, you can enable code style analysis on build, both on command line and inside Visual Studio. Code style violations will appear as warnings or errors on build with an "IDE" prefix. This enables you to strictly enforce consistent code styles at build time.
+Starting .NET 5.0 RC2, you can enable code style analysis on build, both at the command line and inside Visual Studio. Code style violations appear as warnings or errors with an "IDE" prefix. This enables you to enforce consistent code styles at build time.
 
 Steps to enable code style analysis on build:
 
-1. Set MSBuild property [EnforceCodeStyleInBuild](../../core/project-sdk/msbuild-props.md#enforcecodestyleinbuild) property to `true`.
+1. Set the MSBuild property [EnforceCodeStyleInBuild](../../core/project-sdk/msbuild-props.md#enforcecodestyleinbuild) to `true`.
 2. [Configure](configure-code-analysis-rules.md) each "IDE" code style rule that you wish to run on build as a warning or an error. For example:
 
    ```ini
@@ -108,7 +108,7 @@ Steps to enable code style analysis on build:
    dotnet_diagnostic.IDE0005.severity = warning
    ```
 
-   Alternatively, you can [configure the entire "Style" category](configure-code-analysis-rules.md#configure-multiple-rules) to be a warning or an error by default and selectively turn off rules that you do not wish to run on build. For example:
+   Alternatively, you can [configure the entire "Style" category](configure-code-analysis-rules.md#configure-multiple-rules) to be a warning or error, by default, and then selectively turn off rules that you don't want to run on build. For example:
 
    ```ini
    [*.{cs,vb}]

--- a/docs/fundamentals/productivity/code-analysis.md
+++ b/docs/fundamentals/productivity/code-analysis.md
@@ -53,6 +53,7 @@ In the default analysis mode, some rules are [enabled by default](#enabled-rules
 #### Custom analysis mode
 
 You can [configure code analysis rules](configure-code-analysis-rules.md) to enable or disable individual rule or a category of rules. Additionally, you can configure the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) to switch to below custom analysis modes:
+
 - _Aggressive_ or _Opt-out_ mode: All rules are enabled by default as build warnings. You can selectively [opt out](configure-code-analysis-rules.md) of individual rules to disable them.
 - _Conservative_ or _Opt-in_ mode, where all rules are disabled by default. You can selectively [opt into](configure-code-analysis-rules.md) individual rules to enable them.
 

--- a/docs/fundamentals/productivity/code-analysis.md
+++ b/docs/fundamentals/productivity/code-analysis.md
@@ -59,7 +59,7 @@ You can [configure code analysis rules](configure-code-analysis-rules.md) to ena
 
 ### Treat warnings as errors
 
-If you use the `-warnaserror` flag when you build your projects, .NET code analysis warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
+If you use the `-warnaserror` flag when you build your projects, all code analysis warnings are also treated as errors. If you do not want code quality warnings (CAxxxx) to be treated as errors in presence of `-warnaserror`, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
 
 ```xml
 <PropertyGroup>

--- a/docs/fundamentals/productivity/code-analysis.md
+++ b/docs/fundamentals/productivity/code-analysis.md
@@ -53,8 +53,8 @@ In the default analysis mode, some rules are [enabled by default](#enabled-rules
 #### Custom analysis mode
 
 You can [configure code analysis rules](configure-code-analysis-rules.md) to enable or disable individual rule or a category of rules. Additionally, you can configure the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) to switch to below custom analysis modes:
-  - _Aggressive_ or _Opt-out_ mode: All rules are enabled by default as build warnings. You can selectively [opt out](configure-code-analysis-rules.md) of individual rules to disable them.
-  - _Conservative_ or _Opt-in_ mode, where all rules are disabled by default. You can selectively [opt into](configure-code-analysis-rules.md) individual rules to enable them.
+- _Aggressive_ or _Opt-out_ mode: All rules are enabled by default as build warnings. You can selectively [opt out](configure-code-analysis-rules.md) of individual rules to disable them.
+- _Conservative_ or _Opt-in_ mode, where all rules are disabled by default. You can selectively [opt into](configure-code-analysis-rules.md) individual rules to enable them.
 
 ### Treat warnings as errors
 
@@ -100,12 +100,15 @@ Steps to enable code style analysis on build:
 
 1. Set MSBuild property [EnforceCodeStyleInBuild](../../core/project-sdk/msbuild-props.md#enforcecodestyleinbuild) property to `true`.
 2. [Configure](configure-code-analysis-rules.md) each "IDE" code style rule that you wish to run on build as a warning or an error. For example:
+
    ```ini
    [*.{cs,vb}]
    # IDE0005: Using directive is unnecessary (escalated to a build warning)
    dotnet_diagnostic.IDE0005.severity = warning
    ```
+
    Alternatively, you can [configure the entire "Style" category](configure-code-analysis-rules.md#configure-multiple-rules) to be a warning or an error by default and selectively turn off rules that you do not wish to run on build. For example:
+
    ```ini
    [*.{cs,vb}]
   

--- a/docs/fundamentals/productivity/code-analysis.md
+++ b/docs/fundamentals/productivity/code-analysis.md
@@ -11,9 +11,10 @@ helpviewer_keywords:
 ---
 # Overview of .NET source code analysis
 
-.NET compiler platform (Roslyn) analyzers inspect your C# or Visual Basic code for security, performance, design, and other issues. Starting in .NET 5.0, these analyzers are included with the .NET SDK. (Previously, you installed these analyzers as a [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers).)
+.NET compiler platform (Roslyn) analyzers inspect your C# or Visual Basic code for code quality and code style issues. Starting in .NET 5.0, these analyzers are included with the .NET SDK. (Previously, you installed these analyzers as a [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers).)
 
-Code analysis is enabled, by default, for projects that target .NET 5.0 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`. You can also disable code analysis for your project by setting `EnableNETAnalyzers` to `false`.
+- [Code quality analysis ("CA" rules)](#code-quality-analysis)
+- [Code style analysis ("IDE" rules)](#code-style-analysis)
 
 If rule violations are found by an analyzer, they're reported as a suggestion, warning, or error, depending on how each rule is [configured](configure-code-analysis-rules.md). Code analysis violations appear with the prefix "CA" or "IDE" to differentiate them from compiler errors.
 
@@ -22,7 +23,11 @@ If rule violations are found by an analyzer, they're reported as a suggestion, w
 > - You can also install third party analyzers, such as [StyleCop](https://www.nuget.org/packages/StyleCop.Analyzers/), [Roslynator](https://www.nuget.org/packages/Roslynator.Analyzers/), [XUnit Analyzers](https://www.nuget.org/packages/xunit.analyzers/), and [Sonar Analyzer](https://www.nuget.org/packages/SonarAnalyzer.CSharp/).
 > - If you're using Visual Studio, many analyzer rules have associated *code fixes* that you can apply to correct the problem. Code fixes are shown in the light bulb icon menu.
 
-## Enabled rules
+## Code quality analysis
+
+_Code quality analysis ("CA" rules)_ inspect your C# or Visual Basic code for security, performance, design and other issues. It is enabled, by default, for projects that target .NET 5.0 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`. You can also disable code analysis for your project by setting `EnableNETAnalyzers` to `false`.
+
+### Enabled rules
 
 The following rules are enabled, by default, in .NET 5.0 Preview 8.
 
@@ -35,11 +40,23 @@ The following rules are enabled, by default, in .NET 5.0 Preview 8.
 | [CA2015](/visualstudio/code-quality/ca2015) | Reliability | Warning | Do not define finalizers for types derived from <xref:System.Buffers.MemoryManager%601> |
 | [CA2247](/visualstudio/code-quality/ca2247) | Usage | Warning | Argument passed to TaskCompletionSource constructor should be <xref:System.Threading.Tasks.TaskCreationOptions> enum instead of <xref:System.Threading.Tasks.TaskContinuationOptions> |
 
-You can change the severity of these rules to disable them or elevate them to errors. In addition, you may want to enable additional rules that are included in this release but are disabled by default. For more information, see [Configure code analysis rules](configure-code-analysis-rules.md).
+You can change the severity of these rules to disable them or elevate them to errors.
 
-For a full list of rules that are included with each .NET SDK version, see [analyzer releases](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). This list also includes each rule's default severity. Some rules are enabled only as IDE suggestions with corresponding code fixes.
+### Enabling additional rules
 
-## Treat warnings as errors
+Starting with .NET 5.0 RC2, the .NET SDK ships with [all "CA" code quality rules](/visualstudio/code-quality/code-analysis-for-managed-code-warnings). For a full list of rules that are included with each .NET SDK version, see [analyzer releases](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md).
+
+#### Default analysis mode
+
+In the default analysis mode, some rules are [enabled by default](#enabled-rules) as build warnings. Some other rules are enabled by default only as Visual Studio IDE suggestions with corresponding code fixes. Rest of the rules are disabled by default. Full list of rules specified at [analyzer releases](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md) includes each rule's default severity and whether or not the rule is enabled by default in the default analysis mode.
+
+#### Custom analysis mode
+
+You can [configure code analysis rules](configure-code-analysis-rules.md) to enable or disable individual rule or a category of rules. Additionally, you can configure the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) to switch to below custom analysis modes:
+  - _Aggressive_ or _Opt-out_ mode: All rules are enabled by default as build warnings. You can selectively [opt out](configure-code-analysis-rules.md) of individual rules to disable them.
+  - _Conservative_ or _Opt-in_ mode, where all rules are disabled by default. You can selectively [opt into](configure-code-analysis-rules.md) individual rules to enable them.
+
+### Treat warnings as errors
 
 If you use the `-warnaserror` flag when you build your projects, .NET code analysis warnings are also treated as errors. If you only want compiler warnings to be treated as errors, you can set the `CodeAnalysisTreatWarningsAsErrors` MSBuild property to `false` in your project file.
 
@@ -51,7 +68,7 @@ If you use the `-warnaserror` flag when you build your projects, .NET code analy
 
 You'll still see any code analysis warnings, but they won't break your build.
 
-## Latest updates
+### Latest updates
 
 By default, you'll get the latest code analysis rules and default rule severities as you upgrade to newer versions of the .NET SDK. If you don't want this behavior, for example, if you want to ensure that no new rules are enabled or disabled, you can override it in one of the following ways:
 
@@ -70,9 +87,39 @@ By default, you'll get the latest code analysis rules and default rule severitie
 
 - Install the [Microsoft.CodeAnalysis.NetAnalyzers NuGet package](https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisnetanalyzers) to decouple rule updates from .NET SDK updates. Installing the package turns off the built-in SDK analyzers and generates a build warning if the SDK contains a newer analyzer assembly version than that of the NuGet package.
 
+## Code style analysis
+
+_[Code style analysis](/visualstudio/ide/editorconfig-code-style-settings-reference) ("IDE" rules)_ enables you to define and maintain consistent code style in your codebase. Following are the default settings:
+
+- Command line build: Code style analysis is disabled, by default, for all .NET projects on command line builds.
+- Visual Studio: Code style analysis is enabled, by default, for all .NET projects inside Visual Studio as [code refactoring quick actions](/visualstudio/ide/code-generation-in-visual-studio).
+
+Starting .NET 5.0 RC2, you can enable code style analysis on build, both on command line and inside Visual Studio. Code style violations will appear as warnings or errors on build with an "IDE" prefix. This enables you to strictly enforce consistent code styles at build time.
+
+Steps to enable code style analysis on build:
+
+1. Set MSBuild property [EnforceCodeStyleInBuild](../../core/project-sdk/msbuild-props.md#enforcecodestyleinbuild) property to `true`.
+2. [Configure](configure-code-analysis-rules.md) each "IDE" code style rule that you wish to run on build as a warning or an error. For example:
+   ```ini
+   [*.{cs,vb}]
+   # IDE0005: Using directive is unnecessary (escalated to a build warning)
+   dotnet_diagnostic.IDE0005.severity = warning
+   ```
+   Alternatively, you can [configure the entire "Style" category](configure-code-analysis-rules.md#configure-multiple-rules) to be a warning or an error by default and selectively turn off rules that you do not wish to run on build. For example:
+   ```ini
+   [*.{cs,vb}]
+  
+   # Default severity for analyzer diagnostics with category 'Style' (escalated to build warnings)
+   dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+   # IDE0005: Using directive is unnecessary (disabled on build)
+   dotnet_diagnostic.IDE0005.severity = silent
+   ```
+
 ## See also
 
 - [Code analysis in Visual Studio](/visualstudio/code-quality/roslyn-analyzers-overview)
-- [Code analysis rule reference](/visualstudio/code-quality/code-analysis-for-managed-code-warnings)
+- [Code quality analysis rule reference](/visualstudio/code-quality/code-analysis-for-managed-code-warnings)
+- [Code style analysis rule reference](/visualstudio/ide/editorconfig-code-style-settings-reference)
 - [.NET Compiler Platform SDK](../../csharp/roslyn-sdk/index.md)
 - [Tutorial: Write your first analyzer and code fix](../../csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md)


### PR DESCRIPTION
…ties

I have also split the top level doc into separate sections for Code quality analysis and Code style analysis. We may want to split into separate pages if each section gets bigger?

[Added by gewarren]
[Preview link](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/productivity/code-analysis?branch=pr-en-us-20537).