### PR TITLE
Directory.Packages.props breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -295,6 +295,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ***
 
+## MSBuild
+
+- [Directory.Packages.props files is imported by default](#directorypackagesprops-files-is-imported-by-default)
+
+[!INCLUDE [directory-packages-props-imported-by-default](../../../includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md)]
+
+***
+
 ## Networking
 
 - [WinHttpHandler removed from .NET runtime](#winhttphandler-removed-from-net-runtime)

--- a/docs/core/compatibility/msbuild.md
+++ b/docs/core/compatibility/msbuild.md
@@ -7,7 +7,14 @@ ms.date: 02/10/2020
 
 The following breaking changes are documented on this page:
 
+- [Directory.Packages.props files is imported by default](#directorypackagesprops-files-is-imported-by-default)
 - [Resource manifest file name change](#resource-manifest-file-name-change)
+
+## .NET 5.0
+
+[!INCLUDE [directory-packages-props-imported-by-default](../../../includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md)]
+
+***
 
 ## .NET Core 3.0
 

--- a/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
+++ b/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
@@ -14,7 +14,7 @@ Starting in .NET 5.0, such a file *is* automatically imported if it exists in th
 
 #### Reason for change
 
-This change was made in order to support central package versioning for NuGet.
+This change was made in order to support [central package versioning](https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions) for NuGet.
 
 #### Recommended action
 

--- a/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
+++ b/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
@@ -1,0 +1,31 @@
+### Directory.Packages.props files is imported by default
+
+
+
+#### Version introduced
+
+5.0 Preview 8
+
+#### Change description
+
+
+
+#### Recommended action
+
+
+
+#### Category
+
+MSBuild
+
+#### Affected APIs
+
+N/A
+
+<!--
+
+#### Affected APIs
+
+Not detectable via API analysis.
+
+-->

--- a/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
+++ b/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
@@ -1,6 +1,6 @@
 ### Directory.Packages.props files is imported by default
 
-
+NuGet's *.props* files automatically import a file named *Directory.Packages.props* if it's found in the project folder or any of its ancestors.
 
 #### Version introduced
 
@@ -8,11 +8,17 @@
 
 #### Change description
 
+In previous .NET versions, you could have a file named *Directory.Packages.props* in your project file and it wouldn't be automatically imported by NuGet's *.props* file at build time.
 
+Starting in .NET 5.0, such a file *is* automatically imported if it exists in the project folder or any of its ancestors. If have a file with this name in your project folder, this automatic import could change behavior of the build. For example, the file will be imported but it wasn't before, or the order of when it's imported could change if you specifically import it.
+
+#### Reason for change
+
+This change was made in order to support central package versioning for NuGet.
 
 #### Recommended action
 
-
+Rename the existing *Directory.Packages.props* file if it should not be imported automatically.
 
 #### Category
 

--- a/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
+++ b/includes/core-changes/msbuild/5.0/directory-packages-props-imported-by-default.md
@@ -10,7 +10,7 @@ NuGet's *.props* files automatically import a file named *Directory.Packages.pro
 
 In previous .NET versions, you could have a file named *Directory.Packages.props* in your project file and it wouldn't be automatically imported by NuGet's *.props* file at build time.
 
-Starting in .NET 5.0, such a file *is* automatically imported if it exists in the project folder or any of its ancestors. If have a file with this name in your project folder, this automatic import could change behavior of the build. For example, the file will be imported but it wasn't before, or the order of when it's imported could change if you specifically import it.
+Starting in .NET 5.0, such a file *is* automatically imported if it exists in the project folder or any of its ancestors. If you have a file with this name in your project folder, this automatic import could change behavior of the build. For example, the file will be imported but it wasn't before, or the order of when it's imported could change if you specifically import it.
 
 #### Reason for change
 


### PR DESCRIPTION
Fixes #20374.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/msbuild?branch=pr-en-us-20603#directorypackagesprops-files-is-imported-by-default).