### PR TITLE
OSPlatform attributes breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -185,6 +185,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [OSPlatform attributes renamed or removed](#osplatform-attributes-renamed-or-removed)
 - [Thread.Abort is obsolete](#threadabort-is-obsolete)
 - [Obsolete properties on ConsoleLoggerOptions](#obsolete-properties-on-consoleloggeroptions)
 - [Hardware intrinsic IsSupported checks may differ for nested types](#hardware-intrinsic-issupported-checks-may-differ-for-nested-types)
@@ -203,6 +204,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [os-platform-attributes-renamed](../../../includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md)]
+
+***
 
 [!INCLUDE [thread-abort-obsolete](../../../includes/core-changes/corefx/5.0/thread-abort-obsolete.md)]
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -185,7 +185,6 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
-- [OSPlatform attributes renamed or removed](#osplatform-attributes-renamed-or-removed)
 - [Thread.Abort is obsolete](#threadabort-is-obsolete)
 - [Obsolete properties on ConsoleLoggerOptions](#obsolete-properties-on-consoleloggeroptions)
 - [Hardware intrinsic IsSupported checks may differ for nested types](#hardware-intrinsic-issupported-checks-may-differ-for-nested-types)
@@ -204,10 +203,6 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
-
-[!INCLUDE [os-platform-attributes-renamed](../../../includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md)]
-
-***
 
 [!INCLUDE [thread-abort-obsolete](../../../includes/core-changes/corefx/5.0/thread-abort-obsolete.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [OSPlatform attributes renamed or removed](#osplatform-attributes-renamed-or-removed) | 5.0 |
 | [Thread.Abort is obsolete](#threadabort-is-obsolete) | 5.0 |
 | [Obsolete properties on ConsoleLoggerOptions](#obsolete-properties-on-consoleloggeroptions) | 5.0 |
 | [Hardware intrinsic IsSupported checks may differ for nested types](#hardware-intrinsic-issupported-checks-may-differ-for-nested-types) | 5.0 |
@@ -47,6 +48,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [os-platform-attributes-renamed](../../../includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md)]
+
+***
 
 [!INCLUDE [thread-abort-obsolete](../../../includes/core-changes/corefx/5.0/thread-abort-obsolete.md)]
 

--- a/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
+++ b/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
@@ -58,9 +58,9 @@ Core .NET libraries
 
 #### Affected APIs
 
-- <xref:System.Runtime.Versioning.MinimumOSPlatformAttribute?displayProperty=fullName>
-- <xref:System.Runtime.Versioning.ObsoletedInOSPlatformAttribute?displayProperty=fullName>
-- <xref:System.Runtime.Versioning.RemovedInOSPlatformAttribute?displayProperty=fullName>
+- `System.Runtime.Versioning.MinimumOSPlatformAttribute`
+- `System.Runtime.Versioning.ObsoletedInOSPlatformAttribute`
+- `System.Runtime.Versioning.RemovedInOSPlatformAttribute`
 
 <!--
 

--- a/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
+++ b/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
@@ -35,7 +35,7 @@ For .NET 5.0 RC1, an additional feature was added to the platform compatibility 
 
 When you retarget your project from .NET 5.0 Preview 8 to .NET 5.0 RC1, you might encounter build or run-time errors due to these changes. For example, the renaming of `MinimumOSPlatformAttribute` is likely to produce errors, because the attribute is applied to platform-specific assemblies at build time, and old build artifacts will still reference the old API name.
 
-Example build-time error:
+Example build-time errors:
 
 - **error CS0246: The type or namespace name 'MinimumOSPlatformAttribute' could not be found (are you missing a using directive or an assembly reference?)**
 - **error CS0246: The type or namespace name 'RemovedInOSPlatformAttribute' could not be found (are you missing a using directive or an assembly reference?)**

--- a/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
+++ b/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
@@ -1,14 +1,31 @@
 ### OSPlatform attributes renamed or removed
 
-
+The following attributes that were introduced in .NET 5.0 Preview 8 have been removed or renamed: `MinimumOSPlatformAttribute`, `RemovedInOSPlatformAttribute`, and `ObsoletedInOSPlatformAttribute`.
 
 #### Change description
 
+.NET 5.0 Preview 8 introduced the following attributes in the <xref:System.Runtime.Versioning> namespace:
 
+- `MinimumOSPlatformAttribute`
+- `RemovedInOSPlatformAttribute`
+- `ObsoletedInOSPlatformAttribute`
+
+In .NET 5.0 Preview 8, when a project targets an OS-specific flavor of .NET 5 by using a [target framework moniker](../../../../docs/standard/frameworks.md) such as `net5.0-windows`, the build adds an assembly-level `System.Runtime.Versioning.MinimumOSPlatformAttribute` attribute.
+
+In .NET 5.0 RC1, the `ObsoletedInOSPlatformAttribute` has been removed, and `MinimumOSPlatformAttribute` and `RemovedInOSPlatformAttribute` have been renamed as follows:
+
+| Preview 8 name | RC1 and later name |
+| - | - |
+| `MinimumOSPlatformAttribute` | <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute> |
+| `RemovedInOSPlatformAttribute` | <xref:System.Runtime.Versioning.UnsupportedOSPlatformAttribute> |
+
+In .NET 5.0 RC1 and later, when a project targets an OS-specific flavor of .NET 5 by using a [target framework moniker](../../../../docs/standard/frameworks.md) such as `net5.0-windows`, the build adds an assembly-level <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute> attribute.
 
 #### Reason for change
 
+.NET 5.0 Preview 8 introduced attributes in <xref:System.Runtime.Versioning> to specify supported platforms for APIs. The attributes are consumed by the [Platform compatibility analyzer](../../../../docs/core/compatibility/code-analysis.md#ca1416-platform-compatibility) to produce build warnings when platform-specific APIs are consumed on platforms that don't supported those APIs.
 
+For .NET 5.0 RC1, an additional feature was added to the platform compatibility analyzer for platform exclusion. The feature allows APIs to be marked as entirely unsupported on OS platforms. That feature prompted changes to the attributes, including using more suitable names. The `ObsoletedInOSPlatformAttribute` was removed because it was no longer needed.
 
 #### Version introduced
 
@@ -16,7 +33,24 @@
 
 #### Recommended action
 
+When you retarget your project from .NET 5.0 Preview 8 to .NET 5.0 RC1, you might encounter build or run-time errors due to these changes. For example, the renaming of `MinimumOSPlatformAttribute` is likely to produce errors, because the attribute is applied to platform-specific assemblies at build time, and old build artifacts will still reference the old API name.
 
+Example build-time error:
+
+- **error CS0246: The type or namespace name 'MinimumOSPlatformAttribute' could not be found (are you missing a using directive or an assembly reference?)**
+- **error CS0246: The type or namespace name 'RemovedInOSPlatformAttribute' could not be found (are you missing a using directive or an assembly reference?)**
+- **error CS0246: The type or namespace name 'ObsoletedInOSPlatformAttribute' could not be found (are you missing a using directive or an assembly reference?)**
+
+Example run-time error:
+
+**Unhandled exception. System.TypeLoadException: Could not load type 'System.Runtime.Versioning.MinimumOSPlatformAttribute' from assembly 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.**
+
+To resolve these errors:
+
+- Update any references of `MinimumOSPlatformAttribute` to <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute>.
+- Update any references of `RemovedInOSPlatformAttribute` to <xref:System.Runtime.Versioning.UnsupportedOSPlatformAttribute>.
+- Remove any references to `ObsoletedInOSPlatformAttribute`.
+- Rebuild your project (or perform clean + build) to delete old build artifacts.
 
 #### Category
 

--- a/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
+++ b/includes/core-changes/corefx/5.0/os-platform-attributes-renamed.md
@@ -1,0 +1,39 @@
+### OSPlatform attributes renamed or removed
+
+
+
+#### Change description
+
+
+
+#### Reason for change
+
+
+
+#### Version introduced
+
+5.0 RC1
+
+#### Recommended action
+
+
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Runtime.Versioning.MinimumOSPlatformAttribute?displayProperty=fullName>
+- <xref:System.Runtime.Versioning.ObsoletedInOSPlatformAttribute?displayProperty=fullName>
+- <xref:System.Runtime.Versioning.RemovedInOSPlatformAttribute?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `T:System.Runtime.Versioning.MinimumOSPlatformAttribute`
+- `T:System.Runtime.Versioning.ObsoletedInOSPlatformAttribute`
+- `T:System.Runtime.Versioning.RemovedInOSPlatformAttribute`
+
+-->


### PR DESCRIPTION
Fixes #20635.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-20659#osplatform-attributes-renamed-or-removed).

(The warnings will go away once we merge the RC1 API doc updates.)