### PR TITLE
Remove unnecessary bit

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -3,7 +3,7 @@ title: Implement a DisposeAsync method
 description: Learn how to implement DisposeAsync and DisposeAsyncCore methods to perform asynchronous resource cleanup.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/10/2020
+ms.date: 09/16/2020
 ms.technology: dotnet-standard
 dev_langs:
   - "csharp"
@@ -72,7 +72,7 @@ You may need to implement both the <xref:System.IDisposable> and <xref:System.IA
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.asyncdisposable/dispose-and-disposeasync.cs":::
 
-The <xref:System.IDisposable.Dispose?displayProperty=nameWithType> and <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementations are both simple boilerplate code. The `Dispose(bool)` and `DisposeAsyncCore()` methods start by checking if `_disposed` is `true`, and will only run when it's `false`.
+The <xref:System.IDisposable.Dispose?displayProperty=nameWithType> and <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementations are both simple boilerplate code.
 
 In the `Dispose(bool)` overload method, the <xref:System.IDisposable> instance is conditionally disposed of if it is not `null`. The <xref:System.IAsyncDisposable> instance is casted as <xref:System.IDisposable>, and if it is also not `null` it is disposed of as well. Both instances are then assigned to `null`.
 

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.asyncdisposable/dispose-and-disposeasync.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.asyncdisposable/dispose-and-disposeasync.cs
@@ -6,8 +6,6 @@ namespace Samples
 {
     public class CustomDisposable : IDisposable, IAsyncDisposable
     {
-        bool _disposed;
-
         IDisposable _disposableResource = new MemoryStream();
         IAsyncDisposable _asyncDisposableResource = new MemoryStream();
 
@@ -27,44 +25,34 @@ namespace Samples
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
+            if (disposing)
             {
-                _disposed = true;
-
-                if (disposing)
-                {
-                    _disposableResource?.Dispose();
-                    (_asyncDisposableResource as IDisposable)?.Dispose();
-                }
-
-                _disposableResource = null;
-                _asyncDisposableResource = null;
+                _disposableResource?.Dispose();
+                (_asyncDisposableResource as IDisposable)?.Dispose();
             }
+
+            _disposableResource = null;
+            _asyncDisposableResource = null;
         }
 
         protected virtual async ValueTask DisposeAsyncCore()
         {
-            if (!_disposed)
+            if (_asyncDisposableResource is not null)
             {
-                _disposed = true;
-
-                if (_asyncDisposableResource is not null)
-                {
-                    await _asyncDisposableResource.DisposeAsync().ConfigureAwait(false);
-                }
-
-                if (_disposableResource is IAsyncDisposable disposable)
-                {
-                    await disposable.DisposeAsync().ConfigureAwait(false);
-                }
-                else
-                {
-                    _disposableResource.Dispose();
-                }
-
-                _asyncDisposableResource = null;
-                _disposableResource = null;
+                await _asyncDisposableResource.DisposeAsync().ConfigureAwait(false);
             }
+
+            if (_disposableResource is IAsyncDisposable disposable)
+            {
+                await disposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                _disposableResource.Dispose();
+            }
+
+            _asyncDisposableResource = null;
+            _disposableResource = null;
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.asyncdisposable/disposeasync.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.asyncdisposable/disposeasync.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
 {
-    private bool _disposed;
     private Utf8JsonWriter _jsonWriter = new Utf8JsonWriter(new MemoryStream());
 
     public void Dispose()
@@ -24,13 +23,6 @@ public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-
         if (disposing)
         {
             _jsonWriter?.Dispose();
@@ -41,16 +33,11 @@ public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
 
     protected virtual async ValueTask DisposeAsyncCore()
     {
-        if (!_disposed)
+        if (_jsonWriter is not null)
         {
-            _disposed = true;
-
-            if (_jsonWriter is not null)
-            {
-                await _jsonWriter.DisposeAsync();
-            }
-
-            _jsonWriter = null;
+            await _jsonWriter.DisposeAsync();
         }
+
+        _jsonWriter = null;
     }
 }


### PR DESCRIPTION
## Summary

Remove unnecessary `_disposed` bit from examples as it was causing confusion.

Fixes https://github.com/dotnet/docs/issues/20629

## Preview

✔️ [Implement a DisposeAsync method](https://review.docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync?branch=pr-en-us-20666)