### PR TITLE
Fix parameter array explanation

### DIFF
--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -116,13 +116,14 @@ Passing a reference-type parameter allows you to change the value of the referen
 
 Sometimes, the requirement that you specify the exact number of arguments to your method is restrictive. By using the `params` keyword to indicate that a parameter is a parameter array, you allow your method to be called with a variable number of arguments. The parameter tagged with the `params` keyword must be an array type, and it must be the last parameter in the method's parameter list.
 
-A caller can then invoke the method in either of three ways:
+A caller can then invoke the method in either of four ways:
 
 - By passing an array of the appropriate type that contains the desired number of elements.
 - By passing a comma-separated list of individual arguments of the appropriate type to the method.
+- By passing `null`.
 - By not providing an argument to the parameter array.
 
-The following example defines a method named `GetVowels` that returns all the vowels from a parameter array. The `Main` method illustrates all three ways of invoking the method. Callers are not required to supply any arguments for parameters that include the `params` modifier. In that case, the parameter is an empty array.
+The following example defines a method named `GetVowels` that returns all the vowels from a parameter array. The `Main` method illustrates all four ways of invoking the method. Callers are not required to supply any arguments for parameters that include the `params` modifier. In that case, the parameter is an empty array.
 
 [!code-csharp[csSnippets.Methods#75](~/samples/snippets/csharp/concepts/methods/params75.cs#75)]
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -122,7 +122,7 @@ A caller can then invoke the method in either of three ways:
 - By passing a comma-separated list of individual arguments of the appropriate type to the method.
 - By not providing an argument to the parameter array.
 
-The following example defines a method named `GetVowels` that returns all the vowels from a parameter array. The `Main` method illustrates all three ways of invoking the method. Callers are not required to supply any arguments for parameters that include the `params` modifier. In that case, the parameter is `null`.
+The following example defines a method named `GetVowels` that returns all the vowels from a parameter array. The `Main` method illustrates all three ways of invoking the method. Callers are not required to supply any arguments for parameters that include the `params` modifier. In that case, the parameter is an empty array.
 
 [!code-csharp[csSnippets.Methods#75](~/samples/snippets/csharp/concepts/methods/params75.cs#75)]
 

--- a/samples/snippets/csharp/concepts/methods/params75.cs
+++ b/samples/snippets/csharp/concepts/methods/params75.cs
@@ -11,6 +11,9 @@ class Example
 
         string fromMultipleArguments = GetVowels("apple", "banana", "pear");
         Console.WriteLine($"Vowels from multiple arguments: '{fromMultipleArguments}'");
+        
+        string fromNull = GetVowels(null);
+        Console.WriteLine($"Vowels from null: '{fromNull}'");
 
         string fromNoValue = GetVowels();
         Console.WriteLine($"Vowels from no value: '{fromNoValue}'");
@@ -33,6 +36,7 @@ class Example
 // The example displays the following output:
 //     Vowels from array: 'aeaaaea'
 //     Vowels from multiple arguments: 'aeaaaea'
+//     Vowels from null: ''
 //     Vowels from no value: ''
 
 //</Snippet75>


### PR DESCRIPTION
When called with no arguments, the parameter array is an empty array of the specified type, not null.
