### PR TITLE
Modify temppath to follow camel case naming convention

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.Directory_Copy/cs/Project.csproj
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.Directory_Copy/cs/Project.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.Directory_Copy/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.Directory_Copy/cs/program.cs
@@ -31,8 +31,8 @@ class DirectoryCopyExample
         FileInfo[] files = dir.GetFiles();
         foreach (FileInfo file in files)
         {
-            string temppath = Path.Combine(destDirName, file.Name);
-            file.CopyTo(temppath, false);
+            string tempPath = Path.Combine(destDirName, file.Name);
+            file.CopyTo(tempPath, false);
         }
 
         // If copying subdirectories, copy them and their contents to new location.
@@ -40,8 +40,8 @@ class DirectoryCopyExample
         {
             foreach (DirectoryInfo subdir in dirs)
             {
-                string temppath = Path.Combine(destDirName, subdir.Name);
-                DirectoryCopy(subdir.FullName, temppath, copySubDirs);
+                string tempPath = Path.Combine(destDirName, subdir.Name);
+                DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
             }
         }
     }


### PR DESCRIPTION
temppath string is not written with camel case naming convention.
