### PR TITLE
Deconstruct is for positional records only

### DIFF
--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -42,7 +42,6 @@ The record definition creates a `Person` type that contains two readonly propert
 - Override for <xref:System.Object.GetHashCode>
 - Copy and Clone members
 - `PrintMembers` and <xref:System.Object.ToString>
-- `Deconstruct` method
 
 Records support inheritance. You can declare a new record derived from `Person` as follows:
 
@@ -58,7 +57,6 @@ The compiler synthesizes different versions of the methods above. The method sig
 - Records have a consistent string representation generated for you.
 - Records support copy construction. Correct copy construction must include inheritance hierarchies, and properties added by developers.
 - Records can be copied with modification. These copy and modify operations supports non-destructive mutation.
-- All records support deconstruction.
 
 In addition to the familiar `Equals` overloads, `operator ==`, and `operator !=`, the compiler synthesizes a new `EqualityContract` property. The property returns a `Type` object that matches the type of the record. If the base type is `object`, the property is `virtual`. If the base type is another record type, the property is an `override`. If the record type is `sealed`, the property is `sealed`. The synthesized `GetHashCode` uses the `GetHashCode` from all properties and fields declared in the base type and the record type. These synthesized methods enforce value-based equality throughout an inheritance hierarchy. That means a `Student` will never be considered equal to a `Person` with the same name. The types of the two records must match as well as all properties shared among the record types being equal.
 


### PR DESCRIPTION
The `Deconstruct` method is only synthesized for positional records.
