### PR TITLE
Remove .NET Core suffix from project-sdk folder

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -573,7 +573,6 @@
         "docs/core/migration/**.md": ".NET Core",
         "docs/core/porting/**.md": ".NET Core",
         "docs/core/run-time-config/**.md": ".NET Core",
-        "docs/core/project-sdk/**.md": ".NET Core",
         "docs/core/testing/**.md": ".NET Core",
         "docs/core/tools/**.md": ".NET Core CLI",
         "docs/core/tutorials/**.md": ".NET Core",

--- a/docfx.json
+++ b/docfx.json
@@ -573,6 +573,7 @@
         "docs/core/migration/**.md": ".NET Core",
         "docs/core/porting/**.md": ".NET Core",
         "docs/core/run-time-config/**.md": ".NET Core",
+        "docs/core/project-sdk/**.md": ".NET",
         "docs/core/testing/**.md": ".NET Core",
         "docs/core/tools/**.md": ".NET Core CLI",
         "docs/core/tutorials/**.md": ".NET Core",


### PR DESCRIPTION
Addresses https://github.com/dotnet/docs/pull/20693/files#r494460600

@gewarren I addressed only this folder as a follow-up for your PR. But definitely other folders which was updated should be considered too.
