### PR TITLE
Add breaking change for casting RCW to IsIInspectable interface

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -319,8 +319,13 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Interop
 
+- [Casting RCW to an `InterfaceIsIInspectable` interface throws PlatformNotSupportedException](#casting-rcw-to-an-interfaceisiinspectable-interface-throws-platformnotsupportedexception)
 - [No A/W suffix probing on non-Windows platforms](#no-aw-suffix-probing-on-non-windows-platforms)
 - [Built-in support for WinRT is removed from .NET](#built-in-support-for-winrt-is-removed-from-net)
+
+[!INCLUDE [casting-rcw-to-inspectable-interface-throws-exception](../../../includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md)]
+
+***
 
 [!INCLUDE [function-suffix-pinvoke](../../../includes/core-changes/interop/5.0/function-suffix-pinvoke.md)]
 

--- a/docs/core/compatibility/interop.md
+++ b/docs/core/compatibility/interop.md
@@ -9,10 +9,15 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Casting RCW to an `InterfaceIsIInspectable` interface throws PlatformNotSupportedException](#casting-rcw-to-an-interfaceisiinspectable-interface-throws-platformnotsupportedexception) | 5.0 |
 | [No A/W suffix probing on non-Windows platforms](#no-aw-suffix-probing-on-non-windows-platforms) | 5.0 |
 | [Built-in support for WinRT is removed from .NET](#built-in-support-for-winrt-is-removed-from-net) | 5.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [casting-rcw-to-inspectable-interface-throws-exception](../../../includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md)]
+
+***
 
 [!INCLUDE [function-suffix-pinvoke](../../../includes/core-changes/interop/5.0/function-suffix-pinvoke.md)]
 

--- a/includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
+++ b/includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
@@ -1,6 +1,6 @@
 ### Casting RCW to an `InterfaceIsIInspectable` interface throws PlatformNotSupportedException
 
-Casting a runtime callable wrapper (RCW) to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> now throws a <xref:System.PlatformNotSupportedException>.
+Casting a runtime callable wrapper (RCW) to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> now throws a <xref:System.PlatformNotSupportedException>. This change is a follow up to the [removal of WinRT support from .NET](../../../../docs/core/compatibility/interop.md#built-in-support-for-winrt-is-removed-from-net).
 
 #### Version introduced
 
@@ -8,9 +8,9 @@ Casting a runtime callable wrapper (RCW) to an interface marked as <xref:System.
 
 #### Change description
 
-In .NET versions prior to .NET 5.0 preview 6, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> interface works as expected. In .NET 5.0 previews 6-8 and RC1, you can successfully cast an RCW to an <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> interface. However, you might get access violations when you execute methods on the interface, because the underlying support in the runtime doesn't exist.
+In .NET versions prior to .NET 5.0 preview 6, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> works as expected. In .NET 5.0 previews 6-8 and RC1, you can successfully cast an RCW to an <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> interface. However, you might get access violations when you execute methods on the interface, because the underlying support in the runtime [was removed in .NET 5.0 preview 6](../../../../docs/core/compatibility/interop.md#built-in-support-for-winrt-is-removed-from-net).
 
-In .NET 5.0 and later versions, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> throws a <xref:System.PlatformNotSupportedException> at cast time. This change is a follow up to the [removal of WinRT support from .NET](../../../../docs/core/compatibility/interop.md#built-in-support-for-winrt-is-removed-from-net).
+In .NET 5.0 RC2 and later versions, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> throws a <xref:System.PlatformNotSupportedException> at cast time.
 
 #### Reason for change
 

--- a/includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
+++ b/includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
@@ -8,7 +8,7 @@ Casting a runtime callable wrapper (RCW) to an interface marked as <xref:System.
 
 #### Change description
 
-In previous .NET versions, you can succesfully case an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable>. However, you might get access violations when you execute methods on the interface.
+In .NET versions prior to .NET 5.0 preview 6, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> interface works as expected. In .NET 5.0 previews 6-8 and RC1, you can successfully cast an RCW to an <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> interface. However, you might get access violations when you execute methods on the interface, because the underlying support in the runtime doesn't exist.
 
 In .NET 5.0 and later versions, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> throws a <xref:System.PlatformNotSupportedException> at cast time. This change is a follow up to the [removal of WinRT support from .NET](../../../../docs/core/compatibility/interop.md#built-in-support-for-winrt-is-removed-from-net).
 
@@ -32,6 +32,7 @@ The support for <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceI
       void GetRuntimeClassNameSlot();
       void GetTrustLevelSlot();
 
+      // The original members of the IMine interface go here.
       ...
   }
   ```

--- a/includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
+++ b/includes/core-changes/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
@@ -1,0 +1,53 @@
+### Casting RCW to an `InterfaceIsIInspectable` interface throws PlatformNotSupportedException
+
+Casting a runtime callable wrapper (RCW) to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> now throws a <xref:System.PlatformNotSupportedException>.
+
+#### Version introduced
+
+5.0 RC2
+
+#### Change description
+
+In previous .NET versions, you can succesfully case an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable>. However, you might get access violations when you execute methods on the interface.
+
+In .NET 5.0 and later versions, casting an RCW to an interface marked as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> throws a <xref:System.PlatformNotSupportedException> at cast time. This change is a follow up to the [removal of WinRT support from .NET](../../../../docs/core/compatibility/interop.md#built-in-support-for-winrt-is-removed-from-net).
+
+#### Reason for change
+
+The support for <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> was [removed in a previous .NET 5.0 preview](../../../../docs/core/compatibility/interop.md#built-in-support-for-winrt-is-removed-from-net). However, casting to an <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> interface was accidentally overlooked. Since the underlying support in the runtime no longer exists, throwing a <xref:System.PlatformNotSupportedException> enables a graceful failure path. Throwing an exception also makes it more discoverable that this feature is no longer supported.
+
+#### Recommended action
+
+- If you can define the interface in a Windows runtime metadata (WinMD) file, use the C#/WinRT tool instead.
+
+- Otherwise, mark the interface as <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown> instead of <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable>, and add three dummy entries to the start of the interface for the <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable> methods. The following code snippet shows an example.
+
+  ```csharp
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  interface IMine
+  {
+      // Do not call these three methods.
+      // They're exclusively to fill in the slots in the vtable.
+      void GetIIdsSlot();
+      void GetRuntimeClassNameSlot();
+      void GetTrustLevelSlot();
+
+      ...
+  }
+  ```
+
+#### Category
+
+Interop
+
+#### Affected APIs
+
+- <xref:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `F:System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIInspectable`
+
+-->


### PR DESCRIPTION
Fixes #20439.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/interop?branch=pr-en-us-20790#casting-rcw-to-an-interfaceisiinspectable-interface-throws-platformnotsupportedexception).