### PR TITLE
Fix syntactic error in recursion article

### DIFF
--- a/docs/fsharp/language-reference/functions/recursive-functions-the-rec-keyword.md
+++ b/docs/fsharp/language-reference/functions/recursive-functions-the-rec-keyword.md
@@ -30,7 +30,7 @@ Recursive functions - functions that call themselves - are identified explicitly
 The following example shows a recursive function that computes the *n*<sup>th</sup> Fibonacci number using the mathematical definition.
 
 ```fsharp
-let fib n =
+let rec fib n =
     match n with
     | 0 | 1 -> 1
     | n -> fib (n-1) + fib (n-2)


### PR DESCRIPTION
The example `fib` function in recursive-functions-the-rec-keyword.md, is not valid F# code as it lacks the `rec` keyword.

## Summary
The first fibonacci example does not compile
``` fsharp
let fib n =
    match n with
    | 0 | 1 -> 1
    | n -> fib (n-1) + fib (n-2)
```
I tested it on my machine and a simple addition of the `rec` keyword is enough to make the example compile.

