### PR TITLE
KPI-Q1: Examine bounce rate for C# pattern matching tutorial

### DIFF
--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -22,7 +22,13 @@ For more information about the release, see the [.NET Core 3.0 announcement](htt
 
 ## Language improvements C# 8.0
 
-C# 8.0 is also part of this release, which includes the [nullable reference types](../../csharp/tutorials/nullable-reference-types.md) feature, [async streams](../../csharp/tutorials/generate-consume-asynchronous-stream.md), and [more patterns](../../csharp/tutorials/pattern-matching.md). For more information about C# 8.0 features, see [What's new in C# 8.0](../../csharp/whats-new/csharp-8.md).
+C# 8.0 is also part of this release, which includes the [nullable reference types](../../csharp/language-reference/builtin-types/nullable-reference-types.md) feature, async streams, and more patterns. For more information about C# 8.0 features, see [What's new in C# 8.0](../../csharp/whats-new/csharp-8.md).
+
+Tutorials related to C# 8.0 language features:
+
+- [Tutorial: Express your design intent more clearly with nullable and non-nullable reference types](../../csharp/tutorials/nullable-reference-types.md)
+- [Tutorial: Generate and consume async streams using C# 8.0 and .NET Core 3.0](../../csharp/tutorials/generate-consume-asynchronous-stream.md)
+- [Tutorial: Using pattern matching features to extend data types](../../csharp/tutorials/pattern-matching.md)
 
 Language enhancements were added to support the following API features detailed below:
 

--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -28,7 +28,7 @@ Tutorials related to C# 8.0 language features:
 
 - [Tutorial: Express your design intent more clearly with nullable and non-nullable reference types](../../csharp/tutorials/nullable-reference-types.md)
 - [Tutorial: Generate and consume async streams using C# 8.0 and .NET Core 3.0](../../csharp/tutorials/generate-consume-asynchronous-stream.md)
-- [Tutorial: Using pattern matching features to extend data types](../../csharp/tutorials/pattern-matching.md)
+- [Tutorial: Use pattern matching to build type-driven and data-driven algorithms](../../csharp/tutorials/pattern-matching.md)
 
 Language enhancements were added to support the following API features detailed below:
 

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -265,4 +265,4 @@ storage concerns from the behavior concerns.
 
 ## See also
 
-- [Tutorial: Using pattern matching features to extend data types](tutorials/pattern-matching.md)
+- [Tutorial: Use pattern matching to conditionally return a value](tutorials/pattern-matching.md)

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -265,4 +265,4 @@ storage concerns from the behavior concerns.
 
 ## See also
 
-- [Tutorial: Use pattern matching to conditionally return a value](tutorials/pattern-matching.md)
+- [Tutorial: Use pattern matching to build type-driven and data-driven algorithms](tutorials/pattern-matching.md)

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -56,7 +56,7 @@
     href: tutorials/upgrade-to-nullable-references.md
   - name: Generate and consume asynchronous streams
     href: tutorials/generate-consume-asynchronous-stream.md
-  - name: Extend data capabilities using pattern matching
+  - name: Conditionally return values with pattern matching
     href: tutorials/pattern-matching.md
   - name: Console Application
     href: tutorials/console-teleprompter.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -56,7 +56,7 @@
     href: tutorials/upgrade-to-nullable-references.md
   - name: Generate and consume asynchronous streams
     href: tutorials/generate-consume-asynchronous-stream.md
-  - name: Conditionally return values with pattern matching
+  - name: Build data-driven algorithms with pattern matching
     href: tutorials/pattern-matching.md
   - name: Console Application
     href: tutorials/console-teleprompter.md

--- a/docs/csharp/tutorials/pattern-matching.md
+++ b/docs/csharp/tutorials/pattern-matching.md
@@ -1,9 +1,9 @@
 ---
-title: Use pattern matching features to extend data types
+title: "Tutorial: pattern matching to return a value"
 description: This advanced tutorial demonstrates how to use pattern matching techniques to create functionality using data and algorithms that are created separately.
 ms.date: 03/13/2019
-ms-technology: csharp-whats-new
-ms.custom: mvc
+ms.technology: csharp-whats-new
+ms.custom: contperfq1
 ---
 # Tutorial: Using pattern matching features to extend data types
 

--- a/docs/csharp/tutorials/pattern-matching.md
+++ b/docs/csharp/tutorials/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-title: "Tutorial: pattern matching to return a value"
+title: "Tutorial: Build algorithms with pattern matching"
 description: This advanced tutorial demonstrates how to use pattern matching techniques to create functionality using data and algorithms that are created separately.
 ms.date: 03/13/2019
 ms.technology: csharp-whats-new

--- a/docs/csharp/tutorials/pattern-matching.md
+++ b/docs/csharp/tutorials/pattern-matching.md
@@ -5,7 +5,7 @@ ms.date: 03/13/2019
 ms.technology: csharp-whats-new
 ms.custom: contperfq1
 ---
-# Tutorial: Using pattern matching features to extend data types
+# Tutorial: Use pattern matching to build type-driven and data-driven algorithms.
 
 C# 7 introduced basic pattern matching features. Those features are extended in C# 8 with new expressions and patterns. You can write functionality that behaves as though you extended types that may be in other libraries. Another use for patterns is to create functionality your application requires that isn't a fundamental feature of the type being extended.
 


### PR DESCRIPTION
## Summary

- Added "tutorial" to title per the metadata guidelines.
- Fixed `ms-technology` metadata field.
- Changed title in article to better reflect the goals of the article.
- Changed TOC and inbound link title to reflect the goals of the article.
- Update links in What's new Core 3.0 related to this and other tutorial articles. Instead of inline links (which people won't be ready to perform a tutorial just browsing this content) I explicitly added the links to the tutorials mentioned.

Internal user story 1761038

## Investigation into article

I looked at the last two months of traffic coming into the article to try and figure out a reason for the high bounce and low engagement. The article itself is very well written and I didn't find any issues there. Looking at the sources of the inbound traffic that accounts for the most problems related to bounces is:

- Welcome to C# 9.0 blog post\
devblogs.microsoft.com/dotnet/welcome-to-c-9-0/

- What's new in C# 8.0 doc\
docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8

- What's new in .NET Core 3.0 doc\
docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0

- TOC navigation from dotnet/csharp/ and dotnet/csharp/tutorials

These article link to the language feature about pattern matching, but we don't have a comprehensive article detailing that language feature. We have a few older mentions of the feature but they don't incorperate the new enhancements to the feature that people are looking for. This article is a tutorial on using one of the new aspects of that feature. Since the links coming in are mostly from blog posts and what's new announcements, users aren't ready to step through a tutorial, they just want more information about the feature.

The solution to fixing this bounce rate problem is filling that documentation gap. Github issue #20584 is tracking this new doc request. When that doc is created, the pages mentioned above should link to the new article instead of the tutorial.

It's also noted that the title in the TOC for the article isn't optimally named. I think that changing this title and possible the article title and description may contribute to some better bounce numbers, but I don't think it will significantly impact the bounce problem.

