### PR TITLE
Document ObjectModelValidator overload breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 3.1 to 5.0
 description: Lists the breaking changes from version 3.1 to version 5.0 of .NET, ASP.NET Core, and EF Core.
-ms.date: 09/18/2020
+ms.date: 09/29/2020
 ---
 # Breaking changes for migration from version 3.1 to 5.0
 
@@ -31,6 +31,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [Localization: ResourceManagerWithCultureStringLocalizer class and WithCulture interface member removed](#localization-resourcemanagerwithculturestringlocalizer-class-and-withculture-interface-member-removed)
 - [Middleware: Database error page marked as obsolete](#middleware-database-error-page-marked-as-obsolete)
 - [Middleware: Exception Handler Middleware throws original exception if handler not found](#middleware-exception-handler-middleware-throws-original-exception-if-handler-not-found)
+- [MVC: ObjectModelValidator calls a new overload of ValidationVisitor.Validate](#mvc-objectmodelvalidator-calls-a-new-overload-of-validationvisitorvalidate)
 - [Security: Cookie name encoding removed](#security-cookie-name-encoding-removed)
 - [Security: IdentityModel NuGet package versions updated](#security-identitymodel-nuget-package-versions-updated)
 - [SignalR: MessagePack Hub Protocol moved to MessagePack 2.x package](#signalr-messagepack-hub-protocol-moved-to-messagepack-2x-package)
@@ -123,6 +124,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 ***
 
 [!INCLUDE[Middleware: Exception Handler Middleware throws original exception if handler not found](~/includes/core-changes/aspnetcore/5.0/middleware-exception-handler-throws-original-exception.md)]
+
+***
+
+[!INCLUDE[MVC: ObjectModelValidator calls a new overload of ValidationVisitor.Validate](~/includes/core-changes/aspnetcore/5.0/mvc-objectmodelvalidator-calls-new-overload.md)]
 
 ***
 

--- a/docs/core/compatibility/aspnetcore.md
+++ b/docs/core/compatibility/aspnetcore.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core breaking changes
 titleSuffix: ""
 description: Lists the breaking changes in ASP.NET Core.
-ms.date: 09/18/2020
+ms.date: 09/29/2020
 author: scottaddie
 ms.author: scaddie
 ---
@@ -77,6 +77,7 @@ The following breaking changes in ASP.NET Core 3.0, 3.1, and 5.0 are documented 
 - [Middleware: Exception Handler Middleware throws original exception if handler not found](#middleware-exception-handler-middleware-throws-original-exception-if-handler-not-found)
 - [MVC: Controller action Async suffix removed](#mvc-async-suffix-trimmed-from-controller-action-names)
 - [MVC: JsonResult moved to Microsoft.AspNetCore.Mvc.Core](#mvc-jsonresult-moved-to-microsoftaspnetcoremvccore)
+- [MVC: ObjectModelValidator calls a new overload of ValidationVisitor.Validate](#mvc-objectmodelvalidator-calls-a-new-overload-of-validationvisitorvalidate)
 - [MVC: Precompilation tool deprecated](#mvc-precompilation-tool-deprecated)
 - [MVC: Types changed to internal](#mvc-pubternal-types-changed-to-internal)
 - [MVC: Web API compatibility shim removed](#mvc-web-api-compatibility-shim-removed)
@@ -191,6 +192,10 @@ The following breaking changes in ASP.NET Core 3.0, 3.1, and 5.0 are documented 
 ***
 
 [!INCLUDE[Middleware: Exception Handler Middleware throws original exception if handler not found](~/includes/core-changes/aspnetcore/5.0/middleware-exception-handler-throws-original-exception.md)]
+
+***
+
+[!INCLUDE[MVC: ObjectModelValidator calls a new overload of ValidationVisitor.Validate](~/includes/core-changes/aspnetcore/5.0/mvc-objectmodelvalidator-calls-new-overload.md)]
 
 ***
 

--- a/includes/core-changes/aspnetcore/5.0/mvc-objectmodelvalidator-calls-new-overload.md
+++ b/includes/core-changes/aspnetcore/5.0/mvc-objectmodelvalidator-calls-new-overload.md
@@ -1,0 +1,65 @@
+### MVC: ObjectModelValidator calls a new overload of ValidationVisitor.Validate
+
+In ASP.NET Core 5.0, an overload was added to the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor> class. The overload accepts the top-level model instance that contains properties:
+
+```diff
+  bool Validate(ModelMetadata metadata, string key, object model, bool alwaysValidateAtTopLevel);
++ bool Validate(ModelMetadata metadata, string key, object model, bool alwaysValidateAtTopLevel, object container);
+```
+
+<xref:Microsoft.AspNetCore.Mvc.ModelBinding.ObjectModelValidator> invokes this new overload of `ValidationVisitor` to perform validation. This new overload is pertinent if your validation library integrates with ASP.NET Core MVC's model validation system.
+
+For discussion, see GitHub issue [dotnet/aspnetcore#26020](https://github.com/dotnet/aspnetcore/issues/26020).
+
+#### Version introduced
+
+5.0
+
+#### Old behavior
+
+`ObjectModelValidator` invokes the following overload during model validation:
+
+```csharp
+ValidationVisitor.Validate(ModelMetadata metadata, string key, object model, bool alwaysValidateAtTopLevel)
+```
+
+#### New behavior
+
+`ObjectModelValidator` invokes the following overload during model validation:
+
+```csharp
+ValidationVisitor.Validate(ModelMetadata metadata, string key, object model, bool alwaysValidateAtTopLevel, object container)
+```
+
+#### Reason for change
+
+This change was introduced to support validators, such as <xref:System.ComponentModel.DataAnnotations.CompareAttribute>, that rely on inspection of other properties.
+
+#### Recommended action
+
+Validation frameworks that rely on `ObjectModelValidator` to invoke the existing overload of `ValidationVisitor` must override the new method when targeting .NET 5:
+
+```csharp
+public class MyCustomValidationVisitor : ValidationVisitor
+{
++  public override bool Validate(ModelMetadata metadata, string key, object model, bool alwaysValidateAtTopLevel, object container)
++  {
++    ...
+}
+```
+
+#### Category
+
+ASP.NET Core
+
+#### Affected APIs
+
+<xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.Validate%2A?displayProperty=nameWithType>
+
+<!--
+
+#### Affected APIs
+
+`Overload:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.Validate`
+
+-->

--- a/includes/core-changes/aspnetcore/5.0/mvc-objectmodelvalidator-calls-new-overload.md
+++ b/includes/core-changes/aspnetcore/5.0/mvc-objectmodelvalidator-calls-new-overload.md
@@ -1,6 +1,6 @@
 ### MVC: ObjectModelValidator calls a new overload of ValidationVisitor.Validate
 
-In ASP.NET Core 5.0, an overload was added to the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor> class. The overload accepts the top-level model instance that contains properties:
+In ASP.NET Core 5.0, an overload of the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.Validate%2A?displayProperty=nameWithType> was added. The new overload accepts the top-level model instance that contains properties:
 
 ```diff
   bool Validate(ModelMetadata metadata, string key, object model, bool alwaysValidateAtTopLevel);
@@ -37,7 +37,7 @@ This change was introduced to support validators, such as <xref:System.Component
 
 #### Recommended action
 
-Validation frameworks that rely on `ObjectModelValidator` to invoke the existing overload of `ValidationVisitor` must override the new method when targeting .NET 5:
+Validation frameworks that rely on `ObjectModelValidator` to invoke the existing overload of `ValidationVisitor` must override the new method when targeting .NET 5.0 or later:
 
 ```csharp
 public class MyCustomValidationVisitor : ValidationVisitor


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/440
