### PR TITLE
Update relative links prefix for what's new pages

### DIFF
--- a/.whatsnew.json
+++ b/.whatsnew.json
@@ -4,7 +4,7 @@
     "rootDirectory": "docs/",
     "docLinkSettings": {
         "linkFormat": "relative",
-        "relativeLinkPrefix": "/dotnet/"
+        "relativeLinkPrefix": "../"
     },
     "areas": [
         {


### PR DESCRIPTION
Update the what's new tool's config file to prefix relative links with "../". Related to PR https://github.com/dotnet/docs/pull/20624, in which relative links were changed to this style. You'll want to use version 0.1.6 of the global tool once this change merges.