### PR TITLE
Update cancel-an-async-task-or-a-list-of-tasks.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks.md
+++ b/docs/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks.md
@@ -154,7 +154,7 @@ Add the following `ProcessUrlAsync` method below the `SumPageSizesAsync` method:
 static async Task<int> ProcessUrlAsync(string url, HttpClient client, CancellationToken token)
 {
     HttpResponseMessage response = await client.GetAsync(url, token);
-    byte[] content = await response.Content.ReadAsByteArrayAsync(token);
+    byte[] content = await response.Content.ReadAsByteArrayAsync();
     Console.WriteLine($"{url,-60} {content.Length,10:#,#}");
 
     return content.Length;

--- a/docs/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks.md
+++ b/docs/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks.md
@@ -161,7 +161,7 @@ static async Task<int> ProcessUrlAsync(string url, HttpClient client, Cancellati
 }
 ```
 
-For any given URL, the method will use the `client` instance provided to get the response as a `byte[]`. The <xref:System.Threading.CancellationToken> instance is passed into the <xref:System.Net.Http.HttpClient.GetAsync(System.String,System.Threading.CancellationToken)?displayProperty=nameWithType> and <xref:System.Net.Http.HttpContent.ReadAsByteArrayAsync(System.Threading.CancellationToken)?displayProperty=nameWithType> methods. The `token` is used to register for requested cancellation. The length is returned after the URL and length is written to the console.
+For any given URL, the method will use the `client` instance provided to get the response as a `byte[]`. The <xref:System.Threading.CancellationToken> instance is passed into the <xref:System.Net.Http.HttpClient.GetAsync(System.String,System.Threading.CancellationToken)?displayProperty=nameWithType> and <xref:System.Net.Http.HttpContent.ReadAsByteArrayAsync?displayProperty=nameWithType> methods. The `token` is used to register for requested cancellation. The length is returned after the URL and length is written to the console.
 
 ### Example application output
 

--- a/docs/csharp/programming-guide/concepts/async/snippets/cancel-tasks/cancel-tasks/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/cancel-tasks/cancel-tasks/Program.cs
@@ -80,7 +80,7 @@ class Program
     static async Task<int> ProcessUrlAsync(string url, HttpClient client, CancellationToken token)
     {
         HttpResponseMessage response = await client.GetAsync(url, token);
-        byte[] content = await response.Content.ReadAsByteArrayAsync(token);
+        byte[] content = await response.Content.ReadAsByteArrayAsync();
         Console.WriteLine($"{url,-60} {content.Length,10:#,#}");
 
         return content.Length;


### PR DESCRIPTION
Simply remove .NET 5 overload for now. Not really too important with the example.

Fixes #20841

✔️ [Cancel a list of tasks (C#)](https://review.docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks?branch=pr-en-us-20851)