### PR TITLE
Clarify distinction between "assembly reference" and "version referenced by an assembly"

### DIFF
--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -7,7 +7,7 @@ ms.date: 10/16/2018
 
 Strong naming refers to signing an assembly with a key, producing a [strong-named assembly](../assembly/strong-named.md). When an assembly is strong-named, it creates a unique identity based on the name and assembly version number, and it can help prevent assembly conflicts.
 
-The downside to strong naming is that the .NET Framework on Windows enables strict loading of assemblies once an assembly is strong named. A strong-named assembly reference must exactly match the version referenced by an assembly, forcing developers to [configure binding redirects](../../framework/configure-apps/redirect-assembly-versions.md) when using the assembly:
+The downside to strong naming is that the .NET Framework on Windows enables strict loading of assemblies once an assembly is strong named. A strong-named assembly reference must exactly match the version of the loaded assembly, forcing developers to [configure binding redirects](../../framework/configure-apps/redirect-assembly-versions.md) when using the assembly:
 
 ```xml
 <configuration>


### PR DESCRIPTION
## Summary

Reading the phrase "A strong-named assembly reference must exactly match the version referenced by an assembly", I am confused as to what "version referenced by an assembly" refers to, it seems to refer to the same thing as "assembly reference" in the first part of the phrase. So I was trying to find the expression that would clarify what is meant by the second part, which I think refer to the "the candidate assembly to be bound", which depends on the context (nuget, GAC...). I chose loaded assembly here, but I'm not sure it's accurate.
