### PR TITLE
Replace default constructor with parameterless

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
@@ -11,7 +11,7 @@ ms.assetid: 4b75ebb2-2e29-43de-929c-d736a8f27ce6
 
 You can use object initializers to initialize type objects in a declarative manner without explicitly invoking a constructor for the type.  
   
-The following examples show how to use object initializers with named objects. The compiler processes object initializers by first accessing the default instance constructor and then processing the member initializations. Therefore, if the parameterless constructor is declared as `private` in the class, object initializers that require public access will fail.
+The following examples show how to use object initializers with named objects. The compiler processes object initializers by first accessing the parameterless instance constructor and then processing the member initializations. Therefore, if the parameterless constructor is declared as `private` in the class, object initializers that require public access will fail.
   
 You must use an object initializer if you're defining an anonymous type. For more information, see [How to return subsets of element properties in a query](how-to-return-subsets-of-element-properties-in-a-query.md).  
   

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToObjectInitializers.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToObjectInitializers.cs
@@ -13,7 +13,7 @@ namespace object_collection_initializers
             StudentName student1 = new StudentName("Craig", "Playstead");
 
             // Make the same declaration by using an object initializer and sending
-            // arguments for the first and last names. The default constructor is
+            // arguments for the first and last names. The parameterless constructor is
             // invoked in processing this declaration, not the constructor that has
             // two parameters.
             StudentName student2 = new StudentName
@@ -24,7 +24,7 @@ namespace object_collection_initializers
 
             // Declare a StudentName by using an object initializer and sending
             // an argument for only the ID property. No corresponding constructor is
-            // necessary. Only the default constructor is used to process object
+            // necessary. Only the parameterless constructor is used to process object
             // initializers.
             StudentName student3 = new StudentName
             {
@@ -54,7 +54,7 @@ namespace object_collection_initializers
 
         public class StudentName
         {
-            // The default constructor has no parameters. The default constructor
+            // This constructor has no parameters. The parameterless constructor
             // is invoked in the processing of object initializers.
             // You can test this by changing the access modifier from public to
             // private. The declarations in Main that use object initializers will


### PR DESCRIPTION
## Summary

Updated the article "How to initialize objects by using an object
initializer". Replaced "default" constructor with "parameterless"
in the article itself and corresponding code snippets file.

Contributes to the issue #11957
