### PR TITLE
Add reference to .NET for Apache Spark open source repository

### DIFF
--- a/includes/spark-preview-note.md
+++ b/includes/spark-preview-note.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> This topic refers to .NET for Apache Spark, which is currently in preview.
+> This topic refers to [.NET for Apache Spark](https://github.com/dotnet/spark), which is currently in preview.


### PR DESCRIPTION
We recently had a customer note how they couldn't find any official documentation linking to the .NET for Apache Spark github project [https://github.com/dotnet/spark](https://github.com/dotnet/spark), so adding this to the preview note to establish the link.
