### PR TITLE
Activity.Tags list order breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -200,7 +200,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
-- [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reserved)
+- [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reversed)
 - [Thread.Abort is obsolete](#threadabort-is-obsolete)
 - [Obsolete properties on ConsoleLoggerOptions](#obsolete-properties-on-consoleloggeroptions)
 - [Hardware intrinsic IsSupported checks may differ for nested types](#hardware-intrinsic-issupported-checks-may-differ-for-nested-types)

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -200,6 +200,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reserved)
 - [Thread.Abort is obsolete](#threadabort-is-obsolete)
 - [Obsolete properties on ConsoleLoggerOptions](#obsolete-properties-on-consoleloggeroptions)
 - [Hardware intrinsic IsSupported checks may differ for nested types](#hardware-intrinsic-issupported-checks-may-differ-for-nested-types)
@@ -218,6 +219,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [reverse-order-of-tags-in-activity-property](../../../includes/core-changes/corefx/5.0/reverse-order-of-tags-in-activity-property.md)]
+
+***
 
 [!INCLUDE [thread-abort-obsolete](../../../includes/core-changes/corefx/5.0/thread-abort-obsolete.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,7 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
-| [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reserved) | 5.0 |
+| [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reversed) | 5.0 |
 | [Parameter names changed in RC1](#parameter-names-changed-in-rc1) | 5.0 |
 | [OSPlatform attributes renamed or removed](#osplatform-attributes-renamed-or-removed) | 5.0 |
 | [Thread.Abort is obsolete](#threadabort-is-obsolete) | 5.0 |

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reserved) | 5.0 |
 | [Parameter names changed in RC1](#parameter-names-changed-in-rc1) | 5.0 |
 | [OSPlatform attributes renamed or removed](#osplatform-attributes-renamed-or-removed) | 5.0 |
 | [Thread.Abort is obsolete](#threadabort-is-obsolete) | 5.0 |
@@ -49,6 +50,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [reverse-order-of-tags-in-activity-property](../../../includes/core-changes/corefx/5.0/reverse-order-of-tags-in-activity-property.md)]
+
+***
 
 [!INCLUDE [reference-assembly-parameter-names-rc1](../../../includes/core-changes/corefx/5.0/reference-assembly-parameter-names-rc1.md)]
 

--- a/includes/core-changes/corefx/5.0/reverse-order-of-tags-in-activity-property.md
+++ b/includes/core-changes/corefx/5.0/reverse-order-of-tags-in-activity-property.md
@@ -1,0 +1,31 @@
+### Order of tags in Activity.Tags is reversed
+
+<xref:System.Diagnostics.Activity.Tags?displayProperty=nameWithType> now stores items in the list according to the order they are added, that is, the first item that's added is first in the list. This change was made to match the [OpenTelemetry Attributes specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/common/common.md#attributes).
+
+#### Change description
+
+In previous .NET versions, <xref:System.Diagnostics.Activity.Tags?displayProperty=nameWithType> stores items in the reverse order from which they're added. That is, the first item added is last in the list. Starting in .NET 5.0, the order of the items is reversed, and the first item added is always first in the list.
+
+#### Version introduced
+
+5.0
+
+#### Recommended action
+
+If your app has a dependency on the <xref:System.Diagnostics.Activity.Tags?displayProperty=nameWithType> list order and you're upgrading to .NET 5.0 or later, you'll need to change this part of your code.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Diagnostics.Activity.Tags?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Diagnostics.Activity.Tags`
+
+-->


### PR DESCRIPTION
Fixes #20776.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-20891#order-of-tags-in-activitytags-is-reversed).