### PR TITLE
Change https to http for jsnlog.com, https does not resolve to the correct website.

### DIFF
--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -207,7 +207,7 @@ Here are some third-party logging frameworks that work with various .NET workloa
 
 - [elmah.io](https://elmah.io) ([GitHub repo](https://github.com/elmahio/Elmah.Io.Extensions.Logging))
 - [Gelf](https://docs.graylog.org/en/2.3/pages/gelf.html) ([GitHub repo](https://github.com/mattwcole/gelf-extensions-logging))
-- [JSNLog](https://jsnlog.com) ([GitHub repo](https://github.com/mperdeck/jsnlog))
+- [JSNLog](http://jsnlog.com) ([GitHub repo](https://github.com/mperdeck/jsnlog))
 - [KissLog.net](https://kisslog.net) ([GitHub repo](https://github.com/catalingavan/KissLog-net))
 - [Log4Net](https://logging.apache.org/log4net) ([GitHub repo](https://github.com/apache/logging-log4net))
 - [Loggr](https://loggr.net) ([GitHub repo](https://github.com/imobile3/Loggr.Extensions.Logging))


### PR DESCRIPTION
Unfortunately, the https version of jsnlog.com doesn't resolve to the correct website while the http version does.
If it is not allowed to have http-links (non-https-links) on docs, we should probably refer directly to the GitHub repository.

HTTPS:
![image](https://user-images.githubusercontent.com/3382717/95004685-8fd4a380-05bc-11eb-92b3-f3a1b24fe372.png)

HTTP: 
![image](https://user-images.githubusercontent.com/3382717/95004692-9e22bf80-05bc-11eb-9c2e-f4287bb6d767.png)
