### PR TITLE
Update broken source code link to new location

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
+++ b/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
@@ -204,7 +204,7 @@ Run your program to see the results.
 
 ## Next steps
 
-If you got stuck, you can see the source for this tutorial [in our GitHub repo](https://github.com/dotnet/docs/tree/master/samples/snippets/csharp/classes-quickstart/).
+If you got stuck, you can see the source for this tutorial [in our GitHub repo](https://github.com/dotnet/docs/tree/master/docs/csharp/tutorials/intro-to-csharp/snippets/introduction-to-classes).
 
 You can continue with the [object oriented programming](object-oriented-programming.md) tutorial.
 


### PR DESCRIPTION
The source for this tutorial seems to have moved. I think I tracked down the correct new location of the source code.
Old: https://github.com/dotnet/docs/tree/master/samples/snippets/csharp/classes-quickstart/
New: https://github.com/dotnet/docs/tree/master/docs/csharp/tutorials/intro-to-csharp/snippets/introduction-to-classes