### PR TITLE
Fix broken link to HTTP2 spec

### DIFF
--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -1426,7 +1426,7 @@ With Ngen PDBs, NGen can create a PDB that contains the IL-to-native mapping wit
 
     HTTP/2 is also supported and on by default for Windows 10 Universal Windows Platform (UWP) apps that use the <xref:System.Net.Http.HttpClient?displayProperty=nameWithType> API.
 
-    In order to provide a way to use the [PUSH_PROMISE](https://http2.github.io/http2-spec/#PUSH_PROMISE) feature in ASP.NET applications, a new method with two overloads, <xref:System.Web.HttpResponse.PushPromise%28System.String%29> and <xref:System.Web.HttpResponse.PushPromise%28System.String%2CSystem.String%2CSystem.Collections.Specialized.NameValueCollection%29>, has been added to the <xref:System.Web.HttpResponse> class.
+    In order to provide a way to use the [PUSH_PROMISE](https://httpwg.github.io/http2-spec/#PUSH_PROMISE) feature in ASP.NET applications, a new method with two overloads, <xref:System.Web.HttpResponse.PushPromise%28System.String%29> and <xref:System.Web.HttpResponse.PushPromise%28System.String%2CSystem.String%2CSystem.Collections.Specialized.NameValueCollection%29>, has been added to the <xref:System.Web.HttpResponse> class.
 
     > [!NOTE]
     > While ASP.NET Core supports HTTP/2, support for the PUSH PROMISE feature has not yet been added.


### PR DESCRIPTION
The repository for the HTTP2 spec has moved, or the org owning the repo has changed their name resulting in a broken link.
Before: https://http2.github.io/http2-spec/#PUSH_PROMISE
After: https://httpwg.github.io/http2-spec/#PUSH_PROMISE