### PR TITLE
Update interpolated-strings.md

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md
+++ b/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md
@@ -37,7 +37,7 @@ You can use an interpolated string anywhere you can use a string literal.  The i
 
 To include a curly brace ("{" or "}") in an interpolated string, use two curly braces, "{{" or "}}".  See the Implicit Conversions section for more details.
 
-If the interpolated string contains other characters with special meaning in an interpolated string, such as the quotation mark ("), colon (:), or comma (,), they should be escaped if they occur in literal text, or they should be included in an expression delimited by parentheses if they are language elements included in an interpolated expression. The following example escapes quotation marks to include them in the result string, and it uses parentheses to delimit the expression `(age == 1 ? "" : "s")` so that the colon is not interpreted as beginning a format string.
+If the interpolated string contains other characters with special meaning in an interpolated string, such as the quotation mark ("), colon (:), or comma (,), they should be escaped if they occur in literal text, or they should be included in an expression delimited by parentheses if they are language elements included in an interpolated expression. The following example escapes quotation marks to include them in the result string:
 
 [!code-vb[interpolated-strings](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings4.vb)]
 


### PR DESCRIPTION
Remove reference to C# conditional expression `(age == 1 ? "" : "s"` which can't be used in VB as written (the VB version has no colon so the problem of needing to escape it via parentheses goes away).