### PR TITLE
Update interpolated-strings4.vb

### DIFF
--- a/samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings4.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings4.vb
@@ -5,11 +5,10 @@
       Dim s1 = $"He asked, ""Is your name {name}?"", but didn't wait for a reply."
       Console.WriteLine(s1)
       
-      Dim s2 = $"{name} is {age:D3} year{(If(age = 1, "", "s"))} old."
+      Dim s2 = $"{name} is {age:D3} year{If(age = 1, "", "s")} old."
       Console.WriteLine(s2) 
    End Sub
 End Module
 ' The example displays the following output:
 '       He asked, "Is your name Horace?", but didn't wait for a reply.
 '       Horace is 034 years old.
-' </Snippet1>


### PR DESCRIPTION
Remove the extra brackets around the `If()` expression since they were assumed to escape a colon character that doesn't exist in VB (but does in C#'s conditional operator). This code change is related to the textual changes made in PR #20918.

I have also removed a stray `</Snippet1>` tag that doesn't appear to have a matching opening tag anywhere.