### PR TITLE
Remove statement about TLS 1.3 for .NET Core 3.0

### DIFF
--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -390,7 +390,7 @@ The GPIO packages include APIs for *GPIO*, *SPI*, *I2C*, and *PWM* devices. The 
 When available, .NET Core 3.0 uses **OpenSSL 1.1.1**, **OpenSSL 1.1.0**, or **OpenSSL 1.0.2** on a Linux system. When **OpenSSL 1.1.1** is available, both <xref:System.Net.Security.SslStream?displayProperty=nameWithType> and <xref:System.Net.Http.HttpClient?displayProperty=nameWithType> types will use **TLS 1.3** (assuming both the client and server support **TLS 1.3**).
 
 > [!IMPORTANT]
-> Windows and macOS do not yet support **TLS 1.3**. .NET Core 3.0 will support **TLS 1.3** on these operating systems when support becomes available.
+> Windows and macOS do not yet support **TLS 1.3**.
 
 The following C# 8.0 example demonstrates .NET Core 3.0 on Ubuntu 18.10 connecting to <https://www.cloudflare.com>:
 


### PR DESCRIPTION
I think, TLS 1.3 won't be supported by .NET Core 3.0 since it's out of support and the implementation is coming with .NET 5, as stated in [Transport Layer Security (TLS) best practices with the .NET Framework](https://github.com/dotnet/docs/issues/4675#issuecomment-678421120).

This info should be removed, so we have no misleading information out there... 😉
