### PR TITLE
Removing redundant pipe character

### DIFF
--- a/docs/standard/base-types/character-escapes-in-regular-expressions.md
+++ b/docs/standard/base-types/character-escapes-in-regular-expressions.md
@@ -52,7 +52,7 @@ The backslash (\\) in a regular expression indicates one of the following:
  [!code-csharp[RegularExpressions.Language.Escapes#1](../../../samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.escapes/cs/escape1.cs#1)]
  [!code-vb[RegularExpressions.Language.Escapes#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.escapes/vb/escape1.vb#1)]  
   
- The regular expression `\G(.+)[\t|\u007c](.+)\r?\n` is interpreted as shown in the following table.  
+ The regular expression `\G(.+)[\t\u007c](.+)\r?\n` is interpreted as shown in the following table.  
   
 |Pattern|Description|  
 |-------------|-----------------|  


### PR DESCRIPTION
## Summary

Pipe character is not used in code example nor in Pattern breakout following.
