### PR TITLE
Delete link

### DIFF
--- a/docs/samples-and-tutorials/index.md
+++ b/docs/samples-and-tutorials/index.md
@@ -94,7 +94,7 @@ This tutorial shows you how to build a simple application on .NET Core that supp
 
 **[Running ASP.NET MVC Applications in Windows Docker Containers](/aspnet/mvc/overview/deployment/docker-aspnetmvc)**
 
-This tutorial demonstrates how to deploy an existing ASP.NET MVC app in a Windows Docker Container. The [completed sample](https://github.com/dotnet/samples/tree/master/framework/docker/MVCRandomAnswerGenerator) is available in the dotnet/samples repository on GitHub.
+This tutorial demonstrates how to deploy an existing ASP.NET MVC app in a Windows Docker Container.
 
 ## View and download samples
 


### PR DESCRIPTION
This link will no longer be valid when [dotnet/AspNetDocs#3745](https://github.com/dotnet/AspNetDocs/pull/3745) is merged. The linked article already includes a link for the sample, so I don't think there is a need to have the link here too.
See https://github.com/dotnet/AspNetDocs/pull/453

Edit by @BillWagner: Fix PR link.