### PR TITLE
Add breaking change for DataGridView fonts

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -386,6 +386,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Windows Forms
 
+- [DataGridView no longer resets fonts for customized cell styles](#datagridview-no-longer-resets-fonts-for-customized-cell-styles)
 - [OutputType set to WinExe for WPF and WinForms apps](#outputtype-set-to-winexe-for-wpf-and-winforms-apps)
 - [DataGridView-related APIs now throw InvalidOperationException](#datagridview-related-apis-now-throw-invalidoperationexception)
 - [WinForms and WPF apps use Microsoft.NET.Sdk](#winforms-and-wpf-apps-use-microsoftnetsdk)
@@ -393,6 +394,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [WinForms methods now throw ArgumentException](#winforms-methods-now-throw-argumentexception)
 - [WinForms methods now throw ArgumentNullException](#winforms-methods-now-throw-argumentnullexception)
 - [WinForms properties now throw ArgumentOutOfRangeException](#winforms-properties-now-throw-argumentoutofrangeexception)
+
+[!INCLUDE [datagridview-doesnt-reset-custom-font-settings](../../../includes/core-changes/windowsforms/5.0/datagridview-doesnt-reset-custom-font-settings.md)]
+
+***
 
 [!INCLUDE [automatically-infer-winexe-output-type](../../../includes/core-changes/windowsforms/5.0/automatically-infer-winexe-output-type.md)]
 

--- a/docs/core/compatibility/winforms.md
+++ b/docs/core/compatibility/winforms.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [DataGridView no longer resets fonts for customized cell styles](#datagridview-no-longer-resets-fonts-for-customized-cell-styles) | 5.0 |
 | [OutputType set to WinExe for WPF and WinForms apps](#outputtype-set-to-winexe-for-wpf-and-winforms-apps) | 5.0 |
 | [DataGridView-related APIs now throw InvalidOperationException](#datagridview-related-apis-now-throw-invalidoperationexception) | 5.0 |
 | [WinForms and WPF apps use Microsoft.NET.Sdk](#winforms-and-wpf-apps-use-microsoftnetsdk) | 5.0 |
@@ -33,6 +34,10 @@ The following breaking changes are documented on this page:
 | [UseLegacyImages compatibility switch not supported](#uselegacyimages-compatibility-switch-not-supported) | 3.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [datagridview-doesnt-reset-custom-font-settings](../../../includes/core-changes/windowsforms/5.0/datagridview-doesnt-reset-custom-font-settings.md)]
+
+***
 
 [!INCLUDE [automatically-infer-winexe-output-type](../../../includes/core-changes/windowsforms/5.0/automatically-infer-winexe-output-type.md)]
 

--- a/includes/core-changes/windowsforms/5.0/datagridview-doesnt-reset-custom-font-settings.md
+++ b/includes/core-changes/windowsforms/5.0/datagridview-doesnt-reset-custom-font-settings.md
@@ -1,0 +1,41 @@
+### DataGridView no longer resets fonts for customized cell styles
+
+When the ambient font changes, <xref:System.Windows.Forms.DataGridViewElement.DataGridView> no longer resets default cell style fonts to match the ambient font if the cell style font has been customized.
+
+#### Change description
+
+In previous .NET versions, if the ambient font changes, <xref:System.Windows.Forms.DataGridViewElement.DataGridView> resets and overrides user-defined fonts in the <xref:System.Windows.Forms.DataGridView.DefaultCellStyle>, <xref:System.Windows.Forms.DataGridView.ColumnHeadersDefaultCellStyle>, and <xref:System.Windows.Forms.DataGridView.RowHeadersDefaultCellStyle> properties.
+
+Starting in .NET 5.0, if you configure font settings in the <xref:System.Windows.Forms.DataGridView.DefaultCellStyle>, <xref:System.Windows.Forms.DataGridView.ColumnHeadersDefaultCellStyle>, or <xref:System.Windows.Forms.DataGridView.RowHeadersDefaultCellStyle> properties, those settings are retained even when the ambient font changes. For any of these properties that you don't customize the font, the font will change to match the ambient font settings.
+
+#### Reason for change
+
+With the [change of the default font in .NET Core 3.0](../../../../docs/core/compatibility/winforms.md#default-control-font-changed-to-segoe-ui-9-pt), the default font settings for the various cell styles also changed. This behavior is undesirable for apps that rely on custom styling in their <xref:System.Windows.Forms.DataGridViewElement.DataGridView> controls, and impeded the migration of these apps from .NET Framework to .NET 5.0.
+
+#### Version introduced
+
+.NET 5.0 RC2
+
+#### Recommended action
+
+No action is required on your part. However, if you've customized the font in the <xref:System.Windows.Forms.DataGridView.DefaultCellStyle>, <xref:System.Windows.Forms.DataGridView.ColumnHeadersDefaultCellStyle>, or <xref:System.Windows.Forms.DataGridView.RowHeadersDefaultCellStyle> properties and want the font to match the ambient font, set <xref:System.Windows.Forms.DataGridViewCellStyle.Font?displayProperty=nameWithType> to `null` for each property.
+
+#### Category
+
+- Windows Forms
+
+#### Affected APIs
+
+- <xref:System.Windows.Forms.DataGridView.DefaultCellStyle?displayProperty=fullName>
+- <xref:System.Windows.Forms.DataGridView.ColumnHeadersDefaultCellStyle?displayProperty=fullName>
+- <xref:System.Windows.Forms.DataGridView.RowHeadersDefaultCellStyle?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Windows.Forms.DataGridView.DefaultCellStyle`
+- `P:System.Windows.Forms.DataGridView.ColumnHeadersDefaultCellStyle`
+- `P:System.Windows.Forms.DataGridView.RowHeadersDefaultCellStyle`
+
+-->


### PR DESCRIPTION
Fixes #20803.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/winforms?branch=pr-en-us-20953#datagridview-no-longer-resets-fonts-for-customized-cell-styles).