### PR TITLE
Fix language identifiers for CAxxxx rules

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -45,7 +45,7 @@ In general, do not suppress a warning from this rule. It is OK to suppress the w
 
 The following example shows a class that violates the rule and a class that satisfies the rule by implementing <xref:System.IDisposable>. The class does not implement a finalizer because the class does not directly own any unmanaged resources.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1001-types-that-own-disposable-fields-should-be-disposable_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1001-types-that-own-disposable-fields-should-be-disposable_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1001.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1003.md
@@ -57,7 +57,7 @@ You can configure this option for just this rule, for all rules, or for all rule
 
 The following example shows a delegate that violates the rule. In the Visual Basic example, comments describe how to modify the example to satisfy the rule. For the C# example, an example follows that shows the modified code.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1003-use-generic-event-handler-instances_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1003-use-generic-event-handler-instances_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1003.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -59,7 +59,7 @@ The following example shows two enumerations that satisfy the rule and an enumer
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1008.cs":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1008-enums-should-have-zero-value_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1008-enums-should-have-zero-value_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -54,7 +54,7 @@ You can configure this option for just this rule, for all rules, or for all rule
 
 The following code snippet contains an abstract type that violates this rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1012-abstract-types-should-not-have-constructors_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1012-abstract-types-should-not-have-constructors_1.vb" id="snippet1":::
 
 ```csharp
 // Violates this rule
@@ -78,4 +78,4 @@ public abstract class Book
 }
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1012-abstract-types-should-not-have-constructors_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1012-abstract-types-should-not-have-constructors_1.vb" id="snippet2":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1018.md
@@ -47,7 +47,7 @@ The following example defines two attributes. `BadCodeMaintainerAttribute` incor
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1018.cs":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1018-mark-attributes-with-attributeusageattribute_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1018-mark-attributes-with-attributeusageattribute_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1019.md
@@ -49,7 +49,7 @@ The following example shows two attributes that define a mandatory (positional) 
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1019.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1019-define-accessors-for-attribute-arguments_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1019-define-accessors-for-attribute-arguments_1.vb":::
 
 ## Positional and Named Arguments
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -57,7 +57,7 @@ The following example shows two enumerations that don't use the recommended unde
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1028.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1028-enum-storage-should-be-int32_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1028-enum-storage-should-be-int32_1.vb" id="snippet1":::
 
 ## Example of how to fix
 
@@ -65,7 +65,7 @@ The following example fixes the previous violation by changing the underlying da
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1028.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1028-enum-storage-should-be-int32_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1028-enum-storage-should-be-int32_1.vb" id="snippet2":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1031.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1031.md
@@ -76,7 +76,7 @@ You can configure these options for just this rule, for all rules, or for all ru
 
 The following example shows a type that violates this rule and a type that correctly implements the `catch` block.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1031-do-not-catch-general-exception-types_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1031-do-not-catch-general-exception-types_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1031.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1034.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1034.md
@@ -66,4 +66,4 @@ internal class ParentType
 }
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1034-nested-types-should-not-be-visible_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1034-nested-types-should-not-be-visible_1.vb":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1041.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1041.md
@@ -67,7 +67,7 @@ public string Name
 }
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1041-provide-obsoleteattribute-message_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1041-provide-obsoleteattribute-message_1.vb":::
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -67,7 +67,7 @@ public string this[int index]
 }
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1043-use-integral-or-string-argument-for-indexers_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1043-use-integral-or-string-argument-for-indexers_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1044.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1044.md
@@ -55,6 +55,6 @@ You can configure this option for just this rule, for all rules, or for all rule
 
 In the following example, `BadClassWithWriteOnlyProperty` is a type with a write-only property. `GoodClassWithReadWriteProperty` contains the corrected code.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1044-properties-should-not-be-write-only_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1044-properties-should-not-be-write-only_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1044.cs" id="snippet1":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1050.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1050.md
@@ -45,7 +45,7 @@ The following example shows a library that has a type incorrectly declared outsi
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1050.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1050-declare-types-in-namespaces_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1050-declare-types-in-namespaces_1.vb" id="snippet1":::
 
 ## Example 2
 
@@ -53,4 +53,4 @@ The following application uses the library that was defined previously. The type
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1050.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1050-declare-types-in-namespaces_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1050-declare-types-in-namespaces_1.vb" id="snippet2":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1052.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1052.md
@@ -71,7 +71,7 @@ public class StaticMembers
 }
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1052-static-holder-types-should-be-sealed_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1052-static-holder-types-should-be-sealed_1.vb":::
 
 ## Fix with the static modifier
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1054.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1054.md
@@ -57,7 +57,7 @@ The following example shows a type, `ErrorProne`, that violates this rule, and a
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1054.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1054-uri-parameters-should-not-be-strings_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1054-uri-parameters-should-not-be-strings_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -57,7 +57,7 @@ The following example shows a type, `ErrorProne`, that violates this rule, and a
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1055.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1055-uri-return-values-should-not-be-strings_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1055-uri-return-values-should-not-be-strings_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1056.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1056.md
@@ -57,7 +57,7 @@ The following example shows a type, `ErrorProne`, that violates this rule, and a
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1056.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1056-uri-properties-should-not-be-strings_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1056-uri-properties-should-not-be-strings_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1060.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1060.md
@@ -57,7 +57,7 @@ Do not suppress a warning from this rule.
 
 The following example declares a method that violates this rule. To correct the violation, the **RemoveDirectory** P/Invoke should be moved to an appropriate class that is designed to hold only P/Invokes.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet1":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1060.cs" id="snippet1":::
 
@@ -67,7 +67,7 @@ Because the **NativeMethods** class should not be marked by using **SuppressUnma
 
 The following example shows an **Interaction.Beep** method that wraps the **MessageBeep** function from user32.dll. The **MessageBeep** P/Invoke is put in the **NativeMethods** class.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet2":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1060.cs" id="snippet2":::
 
@@ -77,7 +77,7 @@ P/Invoke methods that can be safely exposed to any application and that do not h
 
 The following example shows an **Environment.TickCount** property that wraps the **GetTickCount** function from kernel32.dll.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet3":::
+:::code language="vb" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet3":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1060.cs" id="snippet3":::
 
@@ -87,7 +87,7 @@ P/Invoke methods that cannot be safely called and that could cause side effects 
 
 The following example shows a **Cursor.Hide** method that wraps the **ShowCursor** function from user32.dll.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet4":::
+:::code language="vb" source="snippets/vb/all-rules/ca1060-move-p-invokes-to-nativemethods-class_1.vb" id="snippet4":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1060.cs" id="snippet4":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1303.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1303.md
@@ -92,7 +92,7 @@ dotnet_code_quality.CA1303.use_naming_heuristic = true
 
 The following example shows a method that writes to the console when either of its two arguments are out of range. For the `hour` argument check, a literal string is passed to `Console.WriteLine`, which violates this rule. For the `minute` argument check, a string that's retrieved through a <xref:System.Resources.ResourceManager> is passed to `Console.WriteLine`, which satisfies the rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1303-do-not-pass-literals-as-localized-parameters_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1303-do-not-pass-literals-as-localized-parameters_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1303.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1401.md
@@ -45,4 +45,4 @@ The following example declares a method that violates this rule.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1401.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1401-p-invokes-should-not-be-visible_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1401-p-invokes-should-not-be-visible_1.vb":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -73,4 +73,4 @@ class FourthDerivedClass : ThirdDerivedClass {}
 class FifthDerivedClass : FourthDerivedClass {}
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1501-avoid-excessive-inheritance_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1501-avoid-excessive-inheritance_1.vb":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1712.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1712.md
@@ -63,7 +63,7 @@ public enum DigitalImageMode2
 }
 ```
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1712-do-not-prefix-enum-values-with-type-name_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1712-do-not-prefix-enum-values-with-type-name_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1715.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1715.md
@@ -84,7 +84,7 @@ Do not suppress a warning from this rule.
 
 The following code snippet shows an incorrectly named interface:
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet1":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1715.cs" id="snippet1":::
 
@@ -92,13 +92,13 @@ The following code snippet fixes the previous violation by prefixing the interfa
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1715.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet2":::
 
 ## Type parameter naming example
 
 The following code snippet shows an incorrectly named generic type parameter:
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet3":::
+:::code language="vb" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet3":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1715.cs" id="snippet3":::
 
@@ -106,4 +106,4 @@ The following code snippet fixes the previous violation by prefixing the generic
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1715.cs" id="snippet4":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet4":::
+:::code language="vb" source="snippets/vb/all-rules/ca1715-identifiers-should-have-correct-prefix_1.vb" id="snippet4":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1721.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1721.md
@@ -63,7 +63,7 @@ The following example contains a method and property that violate this rule.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1721.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1721-property-names-should-not-match-get-methods_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1721-property-names-should-not-match-get-methods_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -83,6 +83,6 @@ dotnet_code_quality.CA1802.required_modifiers = none
 
 The following example shows a type, `UseReadOnly`, that violates the rule and a type, `UseConstant`, that satisfies the rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1802-use-literals-where-appropriate_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1802-use-literals-where-appropriate_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1802.cs" id="snippet1":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -71,7 +71,7 @@ The following example shows a class that ignores the result of calling String.Tr
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1806.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1806-do-not-ignore-method-results_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1806-do-not-ignore-method-results_1.vb" id="snippet1":::
 
 ## Example 2
 
@@ -79,7 +79,7 @@ The following example fixes the previous violation by assigning the result of St
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1806.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1806-do-not-ignore-method-results_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1806-do-not-ignore-method-results_1.vb" id="snippet2":::
 
 ## Example 3
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1810.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1810.md
@@ -53,7 +53,7 @@ The following example shows a type, `StaticConstructor`, that violates the rule 
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1810.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1810-initialize-reference-type-static-fields-inline_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1810-initialize-reference-type-static-fields-inline_1.vb":::
 
 Note the addition of the `beforefieldinit` flag on the MSIL definition for the `NoStaticConstructor` class.
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1813.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1813.md
@@ -45,7 +45,7 @@ The following example shows a custom attribute that satisfies this rule.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1813.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1813-avoid-unsealed-attributes_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1813-avoid-unsealed-attributes_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1814.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1814.md
@@ -43,6 +43,6 @@ Suppress a warning from this rule if the multidimensional array does not waste s
 
 The following example shows declarations for jagged and multidimensional arrays.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1814-prefer-jagged-arrays-over-multidimensional_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca1814-prefer-jagged-arrays-over-multidimensional_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1814.cs" id="snippet1":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca1816.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1816.md
@@ -57,7 +57,7 @@ Only suppress a warning from this rule if you are deliberately using <xref:Syste
 
 This code shows a method that calls <xref:System.GC.SuppressFinalize%2A?displayProperty=nameWithType>, but doesn't pass [this (C#)](../../../csharp/language-reference/keywords/this.md) or [Me (Visual Basic)](../../../visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md#me). As a result, this code violates rule CA1816.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1816-call-gc-suppressfinalize-correctly_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1816-call-gc-suppressfinalize-correctly_1.vb" id="snippet1":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1816.cs" id="snippet1":::
 
@@ -65,7 +65,7 @@ This code shows a method that calls <xref:System.GC.SuppressFinalize%2A?displayP
 
 This example shows a method that correctly calls <xref:System.GC.SuppressFinalize%2A?displayProperty=nameWithType> by passing [this (C#)](../../../csharp/language-reference/keywords/this.md) or [Me (Visual Basic)](../../../visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md#me).
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1816-call-gc-suppressfinalize-correctly_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1816-call-gc-suppressfinalize-correctly_1.vb" id="snippet2":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1816.cs" id="snippet2":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1819.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1819.md
@@ -61,7 +61,7 @@ The following example shows a property that violates this rule:
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1819.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet1":::
 
 To fix a violation of this rule, either make the property a method or change the property to return a collection instead of an array.
 
@@ -69,7 +69,7 @@ To fix a violation of this rule, either make the property a method or change the
 
 The following example fixes the violation by changing the property to a method:
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet2":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1819.cs" id="snippet2":::
 
@@ -79,7 +79,7 @@ The following example fixes the violation by changing the property to return a <
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1819.cs" id="snippet3":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet3":::
+:::code language="vb" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet3":::
 
 ## Allow users to modify a property
 
@@ -87,11 +87,11 @@ You might want to allow the consumer of the class to modify a property. The foll
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1819.cs" id="snippet4":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet4":::
+:::code language="vb" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet4":::
 
 The following example fixes the violation by changing the property to return a <xref:System.Collections.ObjectModel.Collection%601?displayProperty=fullName>:
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet5":::
+:::code language="vb" source="snippets/vb/all-rules/ca1819-properties-should-not-return-arrays_1.vb" id="snippet5":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1819.cs" id="snippet5":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -199,7 +199,7 @@ To fix this, you can disable the emitting of overflow checks by the Visual Basic
 
 To disable the emitting of overflow checks, right-click the project name in Solution Explorer and then click **Properties**. Click **Compile**, click **Advanced Compile Options**, and then check **Remove integer overflow checks**.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2000-dispose-objects-before-losing-scope-vboverflow_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2000-dispose-objects-before-losing-scope-vboverflow_1.vb":::
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2002.md
@@ -71,7 +71,7 @@ Otherwise, do not suppress a warning from this rule.
 
 The following example shows some object locks that violate the rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2002-do-not-lock-on-objects-with-weak-identity_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2002-do-not-lock-on-objects-with-weak-identity_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2002.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2100.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2100.md
@@ -105,7 +105,7 @@ You can configure all of these options for just this rule, for all rules, or for
 
 The following example shows a method, `UnsafeQuery`, that violates the rule and a method, `SaferQuery`, that satisfies the rule by using a parameterized command string.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2100-review-sql-queries-for-security-vulnerabilities_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2100-review-sql-queries-for-security-vulnerabilities_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2100.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2119.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2119.md
@@ -55,7 +55,7 @@ The following example shows a type, `BaseImplementation`, that violates this rul
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2119.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2119-seal-methods-that-satisfy-private-interfaces_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca2119-seal-methods-that-satisfy-private-interfaces_1.vb" id="snippet1":::
 
 ## Example 2
 
@@ -63,7 +63,7 @@ The following example exploits the virtual method implementation of the previous
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2119.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2119-seal-methods-that-satisfy-private-interfaces_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca2119-seal-methods-that-satisfy-private-interfaces_1.vb" id="snippet2":::
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2200.md
@@ -45,4 +45,4 @@ The following example shows a method, `CatchAndRethrowExplicitly`, which violate
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2200.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2200-rethrow-to-preserve-stack-details_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2200-rethrow-to-preserve-stack-details_1.vb":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -81,13 +81,13 @@ The following code shows a constructor that incorrectly instantiates an instance
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2208.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2208-instantiate-argument-exceptions-correctly_1.vb" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca2208-instantiate-argument-exceptions-correctly_1.vb" id="snippet1":::
 
 The following code fixes the previous violation by switching the constructor arguments.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2208.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2208-instantiate-argument-exceptions-correctly_1.vb" id="snippet2":::
+:::code language="vb" source="snippets/vb/all-rules/ca2208-instantiate-argument-exceptions-correctly_1.vb" id="snippet2":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2211.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2211.md
@@ -43,6 +43,6 @@ It is safe to suppress a warning from this rule if you are developing an applica
 
 The following example shows a type that violates this rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2211-non-constant-fields-should-not-be-visible_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2211-non-constant-fields-should-not-be-visible_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2211.cs" id="snippet1":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca2214.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2214.md
@@ -45,7 +45,7 @@ The following example demonstrates the effect of violating this rule. The test a
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2214.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2214-do-not-call-overridable-methods-in-constructors_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2214-do-not-call-overridable-methods-in-constructors_1.vb":::
 
 This example produces the following output:
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2217.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2217.md
@@ -57,13 +57,13 @@ The following code shows an enumeration, `Color`, that contains the value 3. 3 i
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2217.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2217-do-not-mark-enums-with-flagsattribute_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2217-do-not-mark-enums-with-flagsattribute_1.vb":::
 
 The following code shows an enumeration, `Days`, that meets the requirements for being marked with <xref:System.FlagsAttribute>:
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2217.cs" id="snippet2":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2217-do-not-mark-enums-with-flagsattribute_2.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2217-do-not-mark-enums-with-flagsattribute_2.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2218.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2218.md
@@ -53,11 +53,11 @@ Do not suppress a warning from this rule.
 
 The following example shows a class (reference type) that violates this rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2218.vb" id="1":::
+:::code language="vb" source="snippets/vb/all-rules/ca2218.vb" id="1":::
 
 The following example fixes the violation by overriding <xref:System.Object.GetHashCode>.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2218.vb" id="2":::
+:::code language="vb" source="snippets/vb/all-rules/ca2218.vb" id="2":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -42,11 +42,11 @@ It is safe to suppress a warning from this rule if the equality operator returns
 
 The following example shows a class (reference type) that violates this rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2224.vb" id="1":::
+:::code language="vb" source="snippets/vb/all-rules/ca2224.vb" id="1":::
 
 The following example fixes the violation by overriding <xref:System.Object.Equals%2A?displayProperty=fullName>.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2224.vb" id="2":::
+:::code language="vb" source="snippets/vb/all-rules/ca2224.vb" id="2":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2227.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2227.md
@@ -49,7 +49,7 @@ The following example shows a type with a writable collection property and shows
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2227.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2227-collection-properties-should-be-read-only_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2227-collection-properties-should-be-read-only_1.vb":::
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2234.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2234.md
@@ -55,7 +55,7 @@ You can configure this option for just this rule, for all rules, or for all rule
 
 The following example shows a method, `ErrorProne`, that violates the rule and a method, `SaferWay`, that correctly calls the <xref:System.Uri> overload:
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2234-pass-system-uri-objects-instead-of-strings_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2234-pass-system-uri-objects-instead-of-strings_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2234.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2235.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2235.md
@@ -48,7 +48,7 @@ The following example shows two types: one that violates the rule and one that s
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2235.cs" id="snippet1":::
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2235-mark-all-non-serializable-fields_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2235-mark-all-non-serializable-fields_1.vb":::
 
 ## Remarks
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2237.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2237.md
@@ -43,7 +43,7 @@ Do not suppress a warning from this rule for exception classes because they must
 
 The following example shows a type that violates the rule. Uncomment the <xref:System.SerializableAttribute> attribute line to satisfy the rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2237-mark-iserializable-types-with-serializableattribute_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2237-mark-iserializable-types-with-serializableattribute_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2237.cs" id="snippet1":::
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2241.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2241.md
@@ -80,6 +80,6 @@ dotnet_code_quality.CA2241.try_determine_additional_string_formatting_methods_au
 
 The following example shows two violations of the rule.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2241-provide-correct-arguments-to-formatting-methods_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2241-provide-correct-arguments-to-formatting-methods_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2241.cs" id="snippet1":::

--- a/docs/fundamentals/code-analysis/quality-rules/ca2242.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2242.md
@@ -42,6 +42,6 @@ Do not suppress a warning from this rule.
 
 The following example shows two expressions that incorrectly test a value against <xref:System.Double.NaN?displayProperty=fullName> and an expression that correctly uses <xref:System.Double.IsNaN%2A?displayProperty=fullName> to test the value.
 
-:::code language="vbnet" source="snippets/vb/all-rules/ca2242-test-for-nan-correctly_1.vb":::
+:::code language="vb" source="snippets/vb/all-rules/ca2242-test-for-nan-correctly_1.vb":::
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca2242.cs" id="snippet1":::


### PR DESCRIPTION
Currently, both languages are displayed regardless of the chosen one in the drop down at the top of the page.
This should fix that. But needs to be confirmed in staging first.

This is a "Search & Replace" PR. No manual changes are made. (Replaces `language="vbnet"` with `language="vb"`