### PR TITLE
Fix typo

### DIFF
--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -93,7 +93,7 @@ Here is a more complete ref return example, showing both the method signature an
 
 [!code-csharp[FindReturningRef](~/samples/snippets/csharp/new-in-7/MatrixSearch.cs#FindReturningRef "Find returning by reference")]
 
-The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [ref readonly](#ref-readonly-locals) variable.
+The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned value by storing the value in a local [ref readonly](#ref-readonly-locals) variable.
 
 For an example, see [A ref returns and ref locals example](#a-ref-returns-and-ref-locals-example).
 


### PR DESCRIPTION
## Summary

Fix typo: "returned valued"  -> "returned value"

Fixes #20960
