### PR TITLE
.NET on Linux default cipher suites

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -303,8 +303,13 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Cryptography
 
+- [New default TLS CipherSuites for .NET on Linux](#new-defaultl-tls-ciphersuites-for-net-on-linux)
 - [System.Security.Cryptography APIs not supported on Blazor WebAssembly](#systemsecuritycryptography-apis-not-supported-on-blazor-webassembly)
 - [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only)
+
+[!INCLUDE [new-default-cipher-suites-for-tls-on-linux](../../../includes/core-changes/cryptography/5.0/new-default-cipher-suites-for-tls-on-linux.md)]
+
+***
 
 [!INCLUDE[Cryptography APIs not supported on Blazor WebAssembly](~/includes/core-changes/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly.md)]
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -303,7 +303,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Cryptography
 
-- [Default TLS cipher suites for .NET on Linux](#defaultl-tls-cipher-suites-for-net-on-linux)
+- [Default TLS cipher suites for .NET on Linux](#default-tls-cipher-suites-for-net-on-linux)
 - [System.Security.Cryptography APIs not supported on Blazor WebAssembly](#systemsecuritycryptography-apis-not-supported-on-blazor-webassembly)
 - [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only)
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -303,11 +303,11 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Cryptography
 
-- [New default TLS CipherSuites for .NET on Linux](#new-defaultl-tls-ciphersuites-for-net-on-linux)
+- [Default TLS cipher suites for .NET on Linux](#defaultl-tls-cipher-suites-for-net-on-linux)
 - [System.Security.Cryptography APIs not supported on Blazor WebAssembly](#systemsecuritycryptography-apis-not-supported-on-blazor-webassembly)
 - [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only)
 
-[!INCLUDE [new-default-cipher-suites-for-tls-on-linux](../../../includes/core-changes/cryptography/5.0/new-default-cipher-suites-for-tls-on-linux.md)]
+[!INCLUDE [default-cipher-suites-for-tls-on-linux](../../../includes/core-changes/cryptography/5.0/default-cipher-suites-for-tls-on-linux.md)]
 
 ***
 

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -9,6 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [New default TLS CipherSuites for .NET on Linux](#new-defaultl-tls-ciphersuites-for-net-on-linux) | 5.0 |
 | [System.Security.Cryptography APIs not supported on Blazor WebAssembly](#systemsecuritycryptography-apis-not-supported-on-blazor-webassembly) | 5.0 |
 | [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only) | 5.0 |
 | [BEGIN TRUSTED CERTIFICATE syntax no longer supported on Linux](#begin-trusted-certificate-syntax-no-longer-supported-for-root-certificates-on-linux) | 3.0 |
@@ -19,6 +20,10 @@ The following breaking changes are documented on this page:
 | [Boolean parameter of SignedCms.ComputeSignature is respected](#boolean-parameter-of-signedcmscomputesignature-is-respected) | 2.1 |
 
 ## .NET 5.0
+
+[!INCLUDE [new-default-cipher-suites-for-tls-on-linux](../../../includes/core-changes/cryptography/5.0/new-default-cipher-suites-for-tls-on-linux.md)]
+
+***
 
 [!INCLUDE[Cryptography APIs not supported on Blazor WebAssembly](~/includes/core-changes/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly.md)]
 

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -9,7 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
-| [New default TLS CipherSuites for .NET on Linux](#new-defaultl-tls-ciphersuites-for-net-on-linux) | 5.0 |
+| [Default TLS cipher suites for .NET on Linux](#defaultl-tls-cipher-suites-for-net-on-linux) | 5.0 |
 | [System.Security.Cryptography APIs not supported on Blazor WebAssembly](#systemsecuritycryptography-apis-not-supported-on-blazor-webassembly) | 5.0 |
 | [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only) | 5.0 |
 | [BEGIN TRUSTED CERTIFICATE syntax no longer supported on Linux](#begin-trusted-certificate-syntax-no-longer-supported-for-root-certificates-on-linux) | 3.0 |
@@ -21,7 +21,7 @@ The following breaking changes are documented on this page:
 
 ## .NET 5.0
 
-[!INCLUDE [new-default-cipher-suites-for-tls-on-linux](../../../includes/core-changes/cryptography/5.0/new-default-cipher-suites-for-tls-on-linux.md)]
+[!INCLUDE [default-cipher-suites-for-tls-on-linux](../../../includes/core-changes/cryptography/5.0/default-cipher-suites-for-tls-on-linux.md)]
 
 ***
 

--- a/docs/core/compatibility/cryptography.md
+++ b/docs/core/compatibility/cryptography.md
@@ -9,7 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
-| [Default TLS cipher suites for .NET on Linux](#defaultl-tls-cipher-suites-for-net-on-linux) | 5.0 |
+| [Default TLS cipher suites for .NET on Linux](#default-tls-cipher-suites-for-net-on-linux) | 5.0 |
 | [System.Security.Cryptography APIs not supported on Blazor WebAssembly](#systemsecuritycryptography-apis-not-supported-on-blazor-webassembly) | 5.0 |
 | [System.Security.Cryptography.Oid is functionally init-only](#systemsecuritycryptographyoid-is-functionally-init-only) | 5.0 |
 | [BEGIN TRUSTED CERTIFICATE syntax no longer supported on Linux](#begin-trusted-certificate-syntax-no-longer-supported-for-root-certificates-on-linux) | 3.0 |

--- a/includes/core-changes/cryptography/5.0/default-cipher-suites-for-tls-on-linux.md
+++ b/includes/core-changes/cryptography/5.0/default-cipher-suites-for-tls-on-linux.md
@@ -1,4 +1,4 @@
-### New default TLS CipherSuites for .NET on Linux
+### Default TLS cipher suites for .NET on Linux
 
 .NET, on Linux, now respects the OpenSSL configuration for default cipher suites when doing TLS/SSL via the <xref:System.Net.Security.SslStream> class or higher-level operations, such as HTTPS via the <xref:System.Net.Http.HttpClient> class. When default cipher suites aren't explicitly configured, .NET on Linux uses a tightly restricted list of permitted cipher suites.
 

--- a/includes/core-changes/cryptography/5.0/new-default-cipher-suites-for-tls-on-linux.md
+++ b/includes/core-changes/cryptography/5.0/new-default-cipher-suites-for-tls-on-linux.md
@@ -1,0 +1,69 @@
+### New default TLS CipherSuites for .NET on Linux
+
+.NET, on Linux, now respects the OpenSSL configuration for default cipher suites when doing TLS/SSL via the <xref:System.Net.Security.SslStream> class or higher-level operations, such as HTTPS via the <xref:System.Net.Http.HttpClient> class. When default cipher suites aren't explicitly configured, .NET on Linux uses a tightly restricted list of permitted cipher suites.
+
+#### Change description
+
+In previous .NET versions, .NET does not respect system configuration for default cipher suites. The default cipher suite list for .NET on Linux is very permissive.
+
+Starting in .NET 5.0, .NET on Linux respects the OpenSSL configuration for default cipher suites when it's specified in *openssl.cnf*. When cipher suites aren't explicitly configured, the only permitted cipher suites are as follows:
+
+- TLS 1.3 cipher suites
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+
+Since this fallback default doesn't include any cipher suites that are compatible with TLS 1.0 or TLS 1.1, these older protocol versions are effectively disabled by default.
+
+Supplying a CipherSuitePolicy value to SslStream for a specific session will still replace the configuration file content and/or .NET fallback default.
+
+#### Reason for change
+
+Users running .NET on Linux requested that the default configuration for <xref:System.Net.Security.SslStream> be changed to one that provided a high security rating from third-party assessment tools.
+
+#### Version introduced
+
+5.0 RC1
+
+#### Recommended action
+
+The new defaults are likely to work when communicating with modern clients or servers. If you need to expand the default cipher suite list to accept legacy clients (or to contact legacy servers), either specify a `CipherSuitePolicy` value or change the OpenSSL configuration file. On many Linux distributions, the OpenSSL configuration file is at */etc/ssl/openssl.cnf*.
+
+This sample *openssl.cnf* file is a minimal file that's equivalent to the default cipher suites policy for .NET 5.0 and later on Linux. Instead of replacing the system file, merge these concepts with the file that's present on your system.
+
+```ini
+openssl_conf = default_conf
+
+[default_conf]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+CipherString = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256
+```
+
+On the Red Hat Enterprise Linux, CentOS, and Fedora distributions, .NET applications default to the cipher suites permitted by the system-wide cryptographic policies. On these distributions, use the crypto-policies configuration instead of *openssl.cnf*.
+
+#### Category
+
+- Cryptography
+- Security
+
+#### Affected APIs
+
+Not detectible via API analysis.
+
+<!--
+
+#### Affected APIs
+
+- Not detectible via API analysis.
+
+-->


### PR DESCRIPTION
Fixes #20842.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/cryptography?branch=pr-en-us-20976#default-tls-cipher-suites-for-net-on-linux).