### PR TITLE
Note for torn-reads in EventCounters

### DIFF
--- a/docs/core/diagnostics/event-counters.md
+++ b/docs/core/diagnostics/event-counters.md
@@ -141,6 +141,16 @@ The `AddRequest()` method can be called from a request handler, and the `Request
 public void AddRequest() => Interlocked.Increment(ref _requestCount);
 ```
 
+To prevent torn reads (on 32-bit architectures) of the `long`-field `_requestCount` use <xref:System.Threading.Volatile.Read%2A?displayProperty=nameWithType>.
+
+```csharp
+_requestRateCounter = new IncrementingPollingCounter("request-rate", this, () => Volatile.Read(ref _requestCount))
+{
+	DisplayName = "Request Rate",
+	DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+};
+```
+
 ## Consume EventCounters
 
 There are two primary ways of consuming EventCounters, either in-proc, or out-of-proc. The consumption of EventCounters can be distinguished into three layers of various consuming technologies.

--- a/docs/core/diagnostics/event-counters.md
+++ b/docs/core/diagnostics/event-counters.md
@@ -141,10 +141,10 @@ The `AddRequest()` method can be called from a request handler, and the `Request
 public void AddRequest() => Interlocked.Increment(ref _requestCount);
 ```
 
-To prevent torn reads (on 32-bit architectures) of the `long`-field `_requestCount` use <xref:System.Threading.Volatile.Read%2A?displayProperty=nameWithType>.
+To prevent torn reads (on 32-bit architectures) of the `long`-field `_requestCount` use <xref:System.Threading.Interlocked.Read%2A?displayProperty=nameWithType>.
 
 ```csharp
-_requestRateCounter = new IncrementingPollingCounter("request-rate", this, () => Volatile.Read(ref _requestCount))
+_requestRateCounter = new IncrementingPollingCounter("request-rate", this, () => Interlocked.Read(ref _requestCount))
 {
     DisplayName = "Request Rate",
     DisplayRateTimeScale = TimeSpan.FromSeconds(1)

--- a/docs/core/diagnostics/event-counters.md
+++ b/docs/core/diagnostics/event-counters.md
@@ -146,8 +146,8 @@ To prevent torn reads (on 32-bit architectures) of the `long`-field `_requestCou
 ```csharp
 _requestRateCounter = new IncrementingPollingCounter("request-rate", this, () => Volatile.Read(ref _requestCount))
 {
-	DisplayName = "Request Rate",
-	DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+    DisplayName = "Request Rate",
+    DisplayRateTimeScale = TimeSpan.FromSeconds(1)
 };
 ```
 

--- a/docs/core/diagnostics/snippets/EventCounters/RequestEventSource.cs
+++ b/docs/core/diagnostics/snippets/EventCounters/RequestEventSource.cs
@@ -6,7 +6,7 @@ public class RequestEventSource : EventSource
     public static readonly RequestEventSource Log = new RequestEventSource();
 
     private IncrementingPollingCounter _requestRateCounter;
-    private int _requestCount = 0;
+    private long _requestCount = 0;
 
     private RequestEventSource() =>
         _requestRateCounter = new IncrementingPollingCounter("request-rate", this, () => _requestCount)


### PR DESCRIPTION
* updated the sample code to use `long` for `_requestCount` which is more realisitc than using `int`
* for `int` a torn read can happen on 32-bit architectures, so added a note therefore

For background see e.g. https://github.com/dotnet/aspnetcore/pull/26630