### PR TITLE
Fix br tags that are not well-formed

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -21,7 +21,7 @@ dev_langs:
 |-|-|
 | **Rule ID** |CA1001|
 | **Category** |Microsoft.Design|
-| **Fix is breaking or non-breaking** |Non-breaking - If the type is not visible outside the assembly.<br/></br/>Breaking - If the type is visible outside the assembly.|
+| **Fix is breaking or non-breaking** |Non-breaking - If the type is not visible outside the assembly.<br/><br/>Breaking - If the type is visible outside the assembly.|
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 |-|-|
 | **Rule ID** |CA1707|
 | **Category** |Microsoft.Naming|
-| **Fix is breaking or non-breaking** |Breaking - when raised on assemblies<br/></br/>Non-breaking - when raised on type parameters|
+| **Fix is breaking or non-breaking** |Breaking - when raised on assemblies<br/><br/>Non-breaking - when raised on type parameters|
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -35,8 +35,8 @@ The following table lists the reserved suffixes and the base types and interface
 |Suffix|Base type/Interface|
 |------------|--------------------------|
 |Attribute|<xref:System.Attribute?displayProperty=fullName>|
-|Collection|<xref:System.Collections.ICollection?displayProperty=fullName><br/></br/><xref:System.Collections.IEnumerable?displayProperty=fullName><br/></br/><xref:System.Collections.Queue?displayProperty=fullName><br/></br/><xref:System.Collections.Stack?displayProperty=fullName><br/></br/><xref:System.Collections.Generic.ICollection%601?displayProperty=fullName><br/></br/><xref:System.Data.DataSet?displayProperty=fullName><br/></br/><xref:System.Data.DataTable?displayProperty=fullName>|
-|Dictionary|<xref:System.Collections.IDictionary?displayProperty=fullName><br/></br/><xref:System.Collections.Generic.IDictionary%602?displayProperty=fullName>|
+|Collection|<xref:System.Collections.ICollection?displayProperty=fullName><br/><br/><xref:System.Collections.IEnumerable?displayProperty=fullName><br/><br/><xref:System.Collections.Queue?displayProperty=fullName><br/><br/><xref:System.Collections.Stack?displayProperty=fullName><br/><br/><xref:System.Collections.Generic.ICollection%601?displayProperty=fullName><br/><br/><xref:System.Data.DataSet?displayProperty=fullName><br/><br/><xref:System.Data.DataTable?displayProperty=fullName>|
+|Dictionary|<xref:System.Collections.IDictionary?displayProperty=fullName><br/><br/><xref:System.Collections.Generic.IDictionary%602?displayProperty=fullName>|
 |EventArgs|<xref:System.EventArgs?displayProperty=fullName>|
 |EventHandler|An event-handler delegate|
 |Exception|<xref:System.Exception?displayProperty=fullName>|

--- a/docs/fundamentals/code-analysis/quality-rules/ca1715.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1715.md
@@ -21,7 +21,7 @@ dev_langs:
 |-|-|
 | **Rule ID** |CA1715|
 | **Category** |Microsoft.Naming|
-| **Fix is breaking or non-breaking** |Breaking - when fired on interfaces.<br/></br/>Non-breaking - when raised on generic type parameters.|
+| **Fix is breaking or non-breaking** |Breaking - when fired on interfaces.<br/><br/>Non-breaking - when raised on generic type parameters.|
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 |-|-|
 | **Rule ID** |CA1801|
 | **Category** |Microsoft.Usage|
-| **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br/></br/>Non-breaking - If you change the member to use the parameter within its body.<br/></br/>Breaking - If you remove the parameter and it is visible outside the assembly.|
+| **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br/><br/>Non-breaking - If you change the member to use the parameter within its body.<br/><br/>Breaking - If you remove the parameter and it is visible outside the assembly.|
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 |-|-|
 | **Rule ID** |CA1822|
 | **Category** |Microsoft.Performance|
-| **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br /><br />Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/></br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly.|
+| **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br /><br />Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/><br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly.|
 
 ## Cause
 


### PR DESCRIPTION
## Summary

Fix broken br tags in the code analysis design rules documentation:

![image](https://user-images.githubusercontent.com/1299786/95515569-22f74a00-09be-11eb-94cb-e221cafe4464.png)

See: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001