### PR TITLE
Adding .NET SDK error pages for 1005, 1047, and 1059

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1005.md
+++ b/docs/core/tools/sdk-errors/netsdk1005.md
@@ -1,0 +1,18 @@
+---
+title: "NETSDK1005 and NETSDK1047: Asset file is missing target"
+description: How to resolve the issue of an asset file missing a target
+author: sfoslund
+ms.topic: error-reference
+ms.date: 10/09/2020
+f1_keywords:
+- NETSDK1005
+- NETSDK1047
+---
+# NETSDK1005 and NETSDK1047: Asset file is missing target
+
+**This article applies to:** ✔️ .NET 2.1.100 SDK and later versions
+
+When the .NET SDK issues error NETSDK1005 or NETSDK1047, the project's assets file is missing information on one of your target frameworks. This can usually be fixed by ensuring that restore is run and that the missing target value is included in the `TargetFrameworks` property of your project.
+
+> [!NOTE]
+> There was a known issue with early builds of .NET 5 preview 8 when used with versions of Visual Studio 16.8 previews which resulted in this error. Specifically, if the missing target is `net5.0-windows7.0` or `net5.0`, please ensure that you have updated to the latest versions of Visual Studio and the .NET 5 SDK.

--- a/docs/core/tools/sdk-errors/netsdk1005.md
+++ b/docs/core/tools/sdk-errors/netsdk1005.md
@@ -1,6 +1,6 @@
 ---
 title: "NETSDK1005 and NETSDK1047: Asset file is missing target"
-description: How to resolve the issue of an asset file missing a target
+description: How to resolve the issue of an asset file missing a target.
 author: sfoslund
 ms.topic: error-reference
 ms.date: 10/09/2020
@@ -15,4 +15,4 @@ f1_keywords:
 When the .NET SDK issues error NETSDK1005 or NETSDK1047, the project's assets file is missing information on one of your target frameworks. This can usually be fixed by ensuring that restore is run and that the missing target value is included in the `TargetFrameworks` property of your project.
 
 > [!NOTE]
-> There was a known issue with early builds of .NET 5 preview 8 when used with versions of Visual Studio 16.8 previews which resulted in this error. Specifically, if the missing target is `net5.0-windows7.0` or `net5.0`, please ensure that you have updated to the latest versions of Visual Studio and the .NET 5 SDK.
+> There was a known issue with early builds of .NET 5 preview 8 when used with versions of Visual Studio 16.8 previews which resulted in this error. Specifically, if the missing target is `net5.0-windows7.0` or `net5.0`, ensure that you have updated to the latest versions of Visual Studio and the .NET 5 SDK.

--- a/docs/core/tools/sdk-errors/netsdk1059.md
+++ b/docs/core/tools/sdk-errors/netsdk1059.md
@@ -1,0 +1,14 @@
+---
+title: "NETSDK1059: Project contains obsolete .NET CLI tool"
+description: How to resolve the issue of a project containing an obsolete .NET CLI tool
+author: sfoslund
+ms.topic: error-reference
+ms.date: 10/09/2020
+f1_keywords:
+- NETSDK1059
+---
+# NETSDK1059: Project contains obsolete .NET CLI tool
+
+**This article applies to:** ✔️ .NET 2.1.100 SDK and later versions
+
+When the .NET SDK issues warning NETSDK1059, your project contains an obsolete .NET CLI tool. As of .NET 2.1, these tools are included in the .NET SDK and do not need to be explicitly referenced by the project. More information for migrating to .NET 2.1 can be found [here](https://aka.ms/dotnetclitools-in-box).

--- a/docs/core/tools/sdk-errors/netsdk1059.md
+++ b/docs/core/tools/sdk-errors/netsdk1059.md
@@ -1,6 +1,6 @@
 ---
 title: "NETSDK1059: Project contains obsolete .NET CLI tool"
-description: How to resolve the issue of a project containing an obsolete .NET CLI tool
+description: How to resolve the issue of a project containing an obsolete .NET CLI tool.
 author: sfoslund
 ms.topic: error-reference
 ms.date: 10/09/2020


### PR DESCRIPTION
## Summary

Adding .NET SDK error pages for netsdk1005 and netsdk1047 (which are duplicates) and netsdk1059.