### PR TITLE
dotnet nuget verify doc

### DIFF
--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -1,0 +1,72 @@
+---
+title: dotnet nuget verify command
+description: The dotnet nuget verify command verifies a signed package.
+author: kartheekp-ms
+ms.date: 10/08/2020
+---
+# dotnet nuget verify
+
+**This article applies to:** ✔️ .NET 5.0.100-rc.2.x SDK and later versions
+
+## Name
+
+`dotnet nuget verify` - Verifies a signed NuGet package.
+
+## Synopsis
+
+```dotnetcli
+dotnet nuget verify [<package-path(s)>]
+    [--all]
+    [--certificate-fingerprint <FINGERPRINT>]
+    [-v|--verbosity <LEVEL>]
+
+dotnet nuget verify -h|--help
+```
+
+## Description
+
+The `dotnet nuget verify` command verifies a signed NuGet package.
+
+## Arguments
+
+- **`package-path(s)`**
+
+  Specifies the file path to the package(s) to be verified. Multiple position arguments can be passed in to verify multiple packages.
+
+## Options
+
+- **`--all`**
+
+  Specifies that all verifications possible should be performed on the package(s). By default, only `signatures` are verified.
+
+- **`--certificate-fingerprint <FINGERPRINT>`**
+
+  Verify that the signer certificate matches with one of the specified `SHA256` fingerprints. This option can be supplied multiple times to provide multiple fingerprints.
+
+* **`-v|--verbosity <LEVEL>`**
+
+  Sets the MSBuild verbosity level. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `normal`.
+
+* **`-h|--help`**
+
+  Prints out a short help for the command.
+
+## Examples
+
+- Verifies *foo.nupkg*:
+
+  ```dotnetcli
+  dotnet nuget verify foo.nupkg
+  ```
+
+- Verifies multiple NuGet packages *foo.nupkg* and *all .nupkg files in the directory specified*:
+
+  ```dotnetcli
+  dotnet nuget verify foo.nupkg c:\mydir\*.nupkg
+  ```
+
+- Verifies *foo.nupkg* signature matches with the specified certificate fingerprint:
+
+  ```dotnetcli
+  dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039
+  ```

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -40,7 +40,7 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
   Specifies that all verifications possible should be performed on the package(s). By default, only `signatures` are verified.
 
 > [!NOTE]
-> This command currently supports only `signature` verification. Additional quality checks shall be added in the future.
+> This command currently supports only `signature` verification.
 
 - **`--certificate-fingerprint <FINGERPRINT>`**
 

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -73,3 +73,9 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
   ```dotnetcli
   dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039
   ```
+
+- Verifies *foo.nupkg* signature matches with one of the specified certificate fingerprints:
+
+  ```dotnetcli
+  dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 --certificate-fingerprint EC10992GG5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E027
+  ```

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -62,7 +62,7 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
   dotnet nuget verify foo.nupkg
   ```
 
-- Verifies multiple NuGet packages *foo.nupkg* and *all .nupkg files in the directory specified*:
+- Verify multiple NuGet packages - *foo.nupkg* and *all .nupkg files in the directory specified*:
 
   ```dotnetcli
   dotnet nuget verify foo.nupkg c:\mydir\*.nupkg

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -39,6 +39,9 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
 
   Specifies that all verifications possible should be performed on the package(s). By default, only `signatures` are verified.
 
+> [!NOTE]
+> This command currently supports only `signature` verification. Additional quality checks shall be added in the future.
+
 - **`--certificate-fingerprint <FINGERPRINT>`**
 
   Verify that the signer certificate matches with one of the specified `SHA256` fingerprints. This option can be supplied multiple times to provide multiple fingerprints.

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -68,7 +68,7 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
   dotnet nuget verify foo.nupkg c:\mydir\*.nupkg
   ```
 
-- Verifies *foo.nupkg* signature matches with the specified certificate fingerprint:
+- Verify *foo.nupkg* signature matches with the specified certificate fingerprint:
 
   ```dotnetcli
   dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -56,7 +56,7 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
 
 ## Examples
 
-- Verifies *foo.nupkg*:
+- Verify *foo.nupkg*:
 
   ```dotnetcli
   dotnet nuget verify foo.nupkg

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -74,7 +74,7 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
   dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039
   ```
 
-- Verifies *foo.nupkg* signature matches with one of the specified certificate fingerprints:
+- Verify *foo.nupkg* signature matches with one of the specified certificate fingerprints:
 
   ```dotnetcli
   dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 --certificate-fingerprint EC10992GG5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E027

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -199,6 +199,8 @@ items:
           href: ../core/tools/dotnet-nuget-remove-source.md
         - name: dotnet nuget update source
           href: ../core/tools/dotnet-nuget-update-source.md
+        - name: dotnet nuget verify
+          href: ../core/tools/dotnet-nuget-verify.md
       - name: dotnet pack
         href: ../core/tools/dotnet-pack.md
       - name: dotnet publish


### PR DESCRIPTION
## Summary

`dotnet 5.0.100-rc.2.x` SDK has added `dotnet nuget verify` command.

Happy to iterate to make the doc better based on feedback.

Fixes #20701
