### PR TITLE
Deserialization constructors

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -388,9 +388,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Serialization
 
+- [Non-public, parameterless constructors not used for deserialization](#non-public-parameterless-constructors-not-used-for-deserialization)
 - [JsonSerializer.Serialize throws ArgumentNullException when type parameter is null](#jsonserializerserialize-throws-argumentnullexception-when-type-parameter-is-null)
 - [JsonSerializer.Deserialize requires single-character string](#jsonserializerdeserialize-requires-single-character-string)
 - [BinaryFormatter.Deserialize rewraps some exceptions in SerializationException](#binaryformatterdeserialize-rewraps-some-exceptions-in-serializationexception)
+
+[!INCLUDE [non-public-parameterless-constructors-not-used-for-deserialization](../../../includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md)]
+
+***
 
 [!INCLUDE [jsonserializer-serialize-throws-argumentnullexception-for-null-type](../../../includes/core-changes/serialization/5.0/jsonserializer-serialize-throws-argumentnullexception-for-null-type.md)]
 

--- a/docs/core/compatibility/serialization.md
+++ b/docs/core/compatibility/serialization.md
@@ -9,11 +9,16 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Introduced version |
 | - | - |
+| [Non-public, parameterless constructors not used for deserialization](#non-public-parameterless-constructors-not-used-for-deserialization) | 5.0 |
 | [JsonSerializer.Serialize throws ArgumentNullException when type parameter is null](#jsonserializerserialize-throws-argumentnullexception-when-type-parameter-is-null) | 5.0 |
 | [JsonSerializer.Deserialize requires single-character string](#jsonserializerdeserialize-requires-single-character-string) | 5.0 |
 | [BinaryFormatter.Deserialize rewraps some exceptions in SerializationException](#binaryformatterdeserialize-rewraps-some-exceptions-in-serializationexception) | 5.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [non-public-parameterless-constructors-not-used-for-deserialization](../../../includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md)]
+
+***
 
 [!INCLUDE [jsonserializer-serialize-throws-argumentnullexception-for-null-type](../../../includes/core-changes/serialization/5.0/jsonserializer-serialize-throws-argumentnullexception-for-null-type.md)]
 

--- a/includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md
+++ b/includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md
@@ -20,7 +20,7 @@ If none of these constructors are available, a <xref:System.NotSupportedExceptio
 
 #### Reason for change
 
-- To enforce consistent behavior between all target framework monikers (TFMs) that <xref:System.Text.Json?displayProperty=fullName> builds for (.NET Core 3.0 and later version, and .NET Standard 2.0 and 2.1)
+- To enforce consistent behavior between all target framework monikers (TFMs) that <xref:System.Text.Json?displayProperty=fullName> builds for (.NET Core 3.0 and later versions, and .NET Standard 2.0 and 2.1)
 - Because <xref:System.Text.Json.JsonSerializer> shouldn't call the non-public surface area of a type, whether that's a constructor, a property, or a field.
 
 #### Recommended action

--- a/includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md
+++ b/includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md
@@ -1,0 +1,47 @@
+### Non-public, parameterless constructors not used for deserialization
+
+For consistency across all supported target framework monikers (TFMs), non-public, parameterless constructors are no longer used for deserialization with <xref:System.Text.Json.JsonSerializer>, by default.
+
+#### Change description
+
+On .NET Core 3.0 and 3.1, internal and private constructors can be used for deserialization. On .NET Standard 2.0 and 2.1, internal and private constructors are not allowed, and a <xref:System.MissingMethodException> is thrown if no public, parameterless constructor is defined.
+
+Starting in .NET 5.0, non-public constructors, including parameterless constructors, are ignored by the serializer by default. The serializer uses one of the following constructors for deserialization:
+
+- Public constructor annotated with <xref:System.Text.Json.Serialization.JsonConstructorAttribute>.
+- Public parameterless constructor.
+- Public parameterized constructor (if it's the only public constructor present).
+
+If none of these constructors are available, a <xref:System.NotSupportedException> is thrown if you attempt to deserialize the type.
+
+#### Version introduced
+
+5.0
+
+#### Reason for change
+
+- To enforce consistent behavior between all target framework monikers (TFMs) that <xref:System.Text.Json?displayProperty=fullName> builds for (.NET Core 3.0 and later version, and .NET Standard 2.0 and 2.1)
+- Because <xref:System.Text.Json.JsonSerializer> shouldn't call the non-public surface area of a type, whether that's a constructor, a property, or a field.
+
+#### Recommended action
+
+- If you own the type and it's feasible, make the parameterless constructor public.
+- Otherwise, implement a `JsonConverter<T>` for the type and control the deserialization behavior.
+
+#### Category
+
+Serialization
+
+#### Affected APIs
+
+- <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.DeserializeAsync%2A?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `Overload:System.Text.Json.JsonSerializer.Deserialize`
+- `Overload:System.Text.Json.JsonSerializer.DeserializeAsync`
+
+-->


### PR DESCRIPTION
Fixes #20887.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/serialization?branch=pr-en-us-21025#non-public-parameterless-constructors-not-used-for-deserialization).