### PR TITLE
Add F1 keywords for default token semantics

### DIFF
--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -4,7 +4,6 @@ title: "default - C# Reference"
 ms.date: 08/04/2017
 f1_keywords: 
   - "default"
-  - "default_CSharpKeyword"
 helpviewer_keywords: 
   - "default keyword [C#]"
 ms.assetid: 14c48aaa-7d35-4058-a1a4-f53353050579

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -8,7 +8,6 @@ f1_keywords:
   - "case"
   - "case_CSharpKeyword"
   - "defaultcase_CSharpKeyword"
-  - "defaultcase"
 helpviewer_keywords:
   - "switch statement [C#]"
   - "switch keyword [C#]"

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -7,6 +7,8 @@ f1_keywords:
   - "switch"
   - "case"
   - "case_CSharpKeyword"
+  - "defaultcase_CSharpKeyword"
+  - "defaultcase"
 helpviewer_keywords:
   - "switch statement [C#]"
   - "switch keyword [C#]"

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -6,7 +6,6 @@ f1_keywords:
   - "default_CSharpKeyword"
   - "default"
   - "defaultvalue_CSharpKeyword"
-  - "defaultvalue"
 helpviewer_keywords: 
   - "default keyword [C#]"
 ---

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -5,6 +5,8 @@ ms.date: 03/13/2020
 f1_keywords:
   - "default_CSharpKeyword"
   - "default"
+  - "defaultvalue_CSharpKeyword"
+  - "defaultvalue"
 helpviewer_keywords: 
   - "default keyword [C#]"
 ---

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -3,8 +3,6 @@ title: "default value expressions - C# reference"
 description: "Use the default value expressions to obtain the default value of a type"
 ms.date: 03/13/2020
 f1_keywords:
-  - "default_CSharpKeyword"
-  - "default"
   - "defaultvalue_CSharpKeyword"
 helpviewer_keywords: 
   - "default keyword [C#]"

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -3,7 +3,7 @@ title: "default value expressions - C# reference"
 description: "Use the default value expressions to obtain the default value of a type"
 ms.date: 03/13/2020
 f1_keywords:
-  - "defaultvalue_CSharpKeyword"
+  - "default_CSharpKeyword"
 helpviewer_keywords: 
   - "default keyword [C#]"
 ---


### PR DESCRIPTION
## Summary

This PR adds two separate f1_keywords for different semantics of the `default` keyword.  This allows the F1 help to route to the appropriate page based on the context, rather than having to route to a generic `default` page.

Fixes part of #20799, Roslyn changes under dotnet/roslyn#48392.