### PR TITLE
Add f1-keyword for `class` used as generic type constraint

### DIFF
--- a/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
+++ b/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
@@ -7,6 +7,7 @@ f1_keywords:
   - "whereconstraint"
   - "whereconstraint_CSharpKeyword"
   - "classconstraint_CSharpKeyword"
+  - "structconstraint_CSharpKeyword"
 helpviewer_keywords:
   - "where (generic type constraint) [C#]"
 ---

--- a/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
+++ b/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
@@ -6,6 +6,7 @@ ms.date: 04/15/2020
 f1_keywords:
   - "whereconstraint"
   - "whereconstraint_CSharpKeyword"
+  - "classconstraint_CSharpKeyword"
 helpviewer_keywords:
   - "where (generic type constraint) [C#]"
 ---


### PR DESCRIPTION
## Summary

This PR adds an f1_keyword for the generic where clause context of the `class` keyword.  This allows the F1 help to route to this usage of the keyword, rather than always routing to the class declaration page.

Fixes part of #20799, Roslyn changes under dotnet/roslyn#48506.

## Alternative Solution

This PR is unnecessary if the existing `whereconstraint_CSharpKeyword` keyword can be used by Roslyn for this context.
