### PR TITLE
Added missing `protected` keyword

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/object-oriented-programming.md
+++ b/docs/csharp/tutorials/intro-to-csharp/object-oriented-programming.md
@@ -156,7 +156,7 @@ Replace it with the following code:
 
 :::code language="csharp" source="./snippets/object-oriented-programming/BankAccount.cs" ID="RefactoredMakeWithdrawal":::
 
-The added method is  , which means that it can be called only from derived classes. That declaration prevents other clients from calling the method. It's also `virtual` so that derived classes can change the behavior. The return type is a `Transaction?`. The `?` annotation indicates that the method may return `null`. Add the following implementation in the `LineOfCreditAccount` to charge a fee when the withdrawal limit is exceeded:
+The added method is `protected`, which means that it can be called only from derived classes. That declaration prevents other clients from calling the method. It's also `virtual` so that derived classes can change the behavior. The return type is a `Transaction?`. The `?` annotation indicates that the method may return `null`. Add the following implementation in the `LineOfCreditAccount` to charge a fee when the withdrawal limit is exceeded:
 
 :::code language="csharp" source="./snippets/object-oriented-programming/LineOfCreditAccount.cs" ID="AddOverdraftFee":::
 


### PR DESCRIPTION
Added missing `protected` keyword to the code description

## Summary

The 'protected' keyword was missing from the code description. This was added back to avoid confusing the reader.

