### PR TITLE
Breaking change for key-value pair serialization

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -388,10 +388,15 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Serialization
 
+- [PropertyNamingPolicy is honored when serializing and deserializing key-value pairs](#propertynamingpolicy-is-honored-when-serializing-and-deserializing-key-value-pairs)
 - [Non-public, parameterless constructors not used for deserialization](#non-public-parameterless-constructors-not-used-for-deserialization)
 - [JsonSerializer.Serialize throws ArgumentNullException when type parameter is null](#jsonserializerserialize-throws-argumentnullexception-when-type-parameter-is-null)
 - [JsonSerializer.Deserialize requires single-character string](#jsonserializerdeserialize-requires-single-character-string)
 - [BinaryFormatter.Deserialize rewraps some exceptions in SerializationException](#binaryformatterdeserialize-rewraps-some-exceptions-in-serializationexception)
+
+[!INCLUDE [options-honored-when-serializing-key-value-pairs](../../../includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md)]
+
+***
 
 [!INCLUDE [non-public-parameterless-constructors-not-used-for-deserialization](../../../includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md)]
 

--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -388,7 +388,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Serialization
 
-- [PropertyNamingPolicy is honored when serializing and deserializing key-value pairs](#propertynamingpolicy-is-honored-when-serializing-and-deserializing-key-value-pairs)
+- [PropertyNamingPolicy, PropertyNameCaseInsensitive, and Encoder options are honored when serializing and deserializing key-value pairs](#propertynamingpolicy-propertynamecaseinsensitive-and-encoder-options-are-honored-when-serializing-and-deserializing-key-value-pairs)
 - [Non-public, parameterless constructors not used for deserialization](#non-public-parameterless-constructors-not-used-for-deserialization)
 - [JsonSerializer.Serialize throws ArgumentNullException when type parameter is null](#jsonserializerserialize-throws-argumentnullexception-when-type-parameter-is-null)
 - [JsonSerializer.Deserialize requires single-character string](#jsonserializerdeserialize-requires-single-character-string)

--- a/docs/core/compatibility/serialization.md
+++ b/docs/core/compatibility/serialization.md
@@ -9,12 +9,17 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Introduced version |
 | - | - |
+| [PropertyNamingPolicy is honored when serializing and deserializing key-value pairs](#propertynamingpolicy-is-honored-when-serializing-and-deserializing-key-value-pairs) | 5.0 |
 | [Non-public, parameterless constructors not used for deserialization](#non-public-parameterless-constructors-not-used-for-deserialization) | 5.0 |
 | [JsonSerializer.Serialize throws ArgumentNullException when type parameter is null](#jsonserializerserialize-throws-argumentnullexception-when-type-parameter-is-null) | 5.0 |
 | [JsonSerializer.Deserialize requires single-character string](#jsonserializerdeserialize-requires-single-character-string) | 5.0 |
 | [BinaryFormatter.Deserialize rewraps some exceptions in SerializationException](#binaryformatterdeserialize-rewraps-some-exceptions-in-serializationexception) | 5.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [options-honored-when-serializing-key-value-pairs](../../../includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md)]
+
+***
 
 [!INCLUDE [non-public-parameterless-constructors-not-used-for-deserialization](../../../includes/core-changes/serialization/5.0/non-public-parameterless-constructors-not-used-for-deserialization.md)]
 

--- a/docs/core/compatibility/serialization.md
+++ b/docs/core/compatibility/serialization.md
@@ -9,7 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Introduced version |
 | - | - |
-| [PropertyNamingPolicy is honored when serializing and deserializing key-value pairs](#propertynamingpolicy-is-honored-when-serializing-and-deserializing-key-value-pairs) | 5.0 |
+| [PropertyNamingPolicy, PropertyNameCaseInsensitive, and Encoder options are honored when serializing and deserializing key-value pairs](#propertynamingpolicy-propertynamecaseinsensitive-and-encoder-options-are-honored-when-serializing-and-deserializing-key-value-pairs) | 5.0 |
 | [Non-public, parameterless constructors not used for deserialization](#non-public-parameterless-constructors-not-used-for-deserialization) | 5.0 |
 | [JsonSerializer.Serialize throws ArgumentNullException when type parameter is null](#jsonserializerserialize-throws-argumentnullexception-when-type-parameter-is-null) | 5.0 |
 | [JsonSerializer.Deserialize requires single-character string](#jsonserializerdeserialize-requires-single-character-string) | 5.0 |

--- a/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
+++ b/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
@@ -1,6 +1,6 @@
 ### PropertyNamingPolicy is honored when serializing and deserializing key-value pairs
 
-<xref:System.Text.Json.JsonSerializer> now honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options when serializing the `Key` and `Value` property names of a <xref:System.Collections.Generic.KeyValuePair%602> instance. Additionally, <xref:System.Text.Json.JsonSerializer> honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive?displayProperty=nameWithType> options when deserializing <xref:System.Collections.Generic.KeyValuePair%602> instances.
+<xref:System.Text.Json.JsonSerializer> now honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.Encoder> options when serializing the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> property names of a <xref:System.Collections.Generic.KeyValuePair%602> instance. Additionally, <xref:System.Text.Json.JsonSerializer> honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> options when deserializing <xref:System.Collections.Generic.KeyValuePair%602> instances.
 
 #### Change description
 

--- a/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
+++ b/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
@@ -1,4 +1,4 @@
-### PropertyNamingPolicy is honored when serializing and deserializing key-value pairs
+### PropertyNamingPolicy, PropertyNameCaseInsensitive, and Encoder options are honored when serializing and deserializing key-value pairs
 
 <xref:System.Text.Json.JsonSerializer> now honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.Encoder> options when serializing the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> property names of a <xref:System.Collections.Generic.KeyValuePair%602> instance. Additionally, <xref:System.Text.Json.JsonSerializer> honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> options when deserializing <xref:System.Collections.Generic.KeyValuePair%602> instances.
 
@@ -6,7 +6,7 @@
 
 ##### Serialization
 
-In .NET Core 3.x versions and in the 4.7.x versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), the properties of <xref:System.Collections.Generic.KeyValuePair%602> instances are always serialized as "Key" and "Value" exactly, regardless of any <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are *not* camel-cased after serialization.
+In .NET Core 3.x versions and in the 4.6.0-4.7.2 versions versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), the properties of <xref:System.Collections.Generic.KeyValuePair%602> instances are always serialized as "Key" and "Value" exactly, regardless of any <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are *not* camel-cased after serialization, even though the specified property-naming policy dictates so.
 
 ```csharp
 var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -16,7 +16,7 @@ Console.WriteLine(JsonSerializer.Serialize(kvp, options));
 // Actual: {"Key":1,"Value":1}
 ```
 
-Starting in .NET 5.0, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.Encoder> options are honored when serializing <xref:System.Collections.Generic.KeyValuePair%602> instances. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are camel-cased after serialization.
+Starting in .NET 5.0, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.Encoder> options are honored when serializing <xref:System.Collections.Generic.KeyValuePair%602> instances. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are camel-cased after serialization, in accordance with the specified property-naming policy.
 
 ```csharp
 var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -27,7 +27,7 @@ Console.WriteLine(JsonSerializer.Serialize(kvp, options));
 
 ##### Deserialization
 
-In .NET Core 3.x versions and in the 4.7.x versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), a <xref:System.Text.Json.JsonException> is thrown when the JSON property names are not precisely `Key` and `Value`, for example, if they don't start with an uppercase letter.
+In .NET Core 3.x versions and in the 4.7.x versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), a <xref:System.Text.Json.JsonException> is thrown when the JSON property names are not precisely `Key` and `Value`, for example, if they don't start with an uppercase letter. The exception is thrown even if a specified property-naming policy expressly permits it.
 
 ```csharp
 var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -36,7 +36,7 @@ string json = @"{""key"":1,""value"":1}";
 JsonSerializer.Deserialize<KeyValuePair<int, int>>(json, options);
 ```
 
-Starting in .NET 5.0, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> options are honored when deserializing using <xref:System.Text.Json.JsonSerializer>. For example, the following code snippet shows successful deserialization of lowercased <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> property names.
+Starting in .NET 5.0, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> options are honored when deserializing using <xref:System.Text.Json.JsonSerializer>. For example, the following code snippet shows successful deserialization of lowercased <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> property names because the specified property-naming policy permits it.
 
 ```csharp
 var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -76,14 +76,20 @@ Serialization
 
 #### Affected APIs
 
-- <xref:System.Text.Json.JsonSerializer.Serialize(System.Object,System.Type,System.Text.Json.JsonSerializerOptions)?displayProperty=fullName>
-- <xref:System.Text.Json.JsonSerializer.Deserialize%60%601(System.String,System.Text.Json.JsonSerializerOptions)?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.SerializeToUtf8Bytes%2A?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.SerializeAsync%2A?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.DeserializeAsync%2A?displayProperty=fullName>
 
 <!--
 
 #### Affected APIs
 
-- `M:System.Text.Json.JsonSerializer.Serialize(System.Object,System.Type,System.Text.Json.JsonSerializerOptions)`
-- `M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)`
+- `Overload:System.Text.Json.JsonSerializer.Serialize`
+- `Overload:System.Text.Json.JsonSerializer.SerializeAsync`
+- `Overload:System.Text.Json.JsonSerializer.SerializeToUtf8Bytes`
+- `Overload:System.Text.Json.JsonSerializer.Deserialize`
+- `Overload:System.Text.Json.JsonSerializer.DeserializeAsync`
 
 -->

--- a/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
+++ b/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
@@ -6,7 +6,7 @@
 
 ##### Serialization
 
-In .NET Core 3.x versions and in the 4.6.0-4.7.2 versions versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), the properties of <xref:System.Collections.Generic.KeyValuePair%602> instances are always serialized as "Key" and "Value" exactly, regardless of any <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are *not* camel-cased after serialization, even though the specified property-naming policy dictates so.
+In .NET Core 3.x versions and in the 4.6.0-4.7.2 versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), the properties of <xref:System.Collections.Generic.KeyValuePair%602> instances are always serialized as "Key" and "Value" exactly, regardless of any <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are *not* camel-cased after serialization, even though the specified property-naming policy dictates so.
 
 ```csharp
 var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
+++ b/includes/core-changes/serialization/5.0/options-honored-when-serializing-key-value-pairs.md
@@ -1,0 +1,89 @@
+### PropertyNamingPolicy is honored when serializing and deserializing key-value pairs
+
+<xref:System.Text.Json.JsonSerializer> now honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options when serializing the `Key` and `Value` property names of a <xref:System.Collections.Generic.KeyValuePair%602> instance. Additionally, <xref:System.Text.Json.JsonSerializer> honors the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive?displayProperty=nameWithType> options when deserializing <xref:System.Collections.Generic.KeyValuePair%602> instances.
+
+#### Change description
+
+##### Serialization
+
+In .NET Core 3.x versions and in the 4.7.x versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), the properties of <xref:System.Collections.Generic.KeyValuePair%602> instances are always serialized as "Key" and "Value" exactly, regardless of any <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.Encoder?displayProperty=nameWithType> options. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are *not* camel-cased after serialization.
+
+```csharp
+var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+KeyValuePair<int, int> kvp = KeyValuePair.Create(1, 1);
+Console.WriteLine(JsonSerializer.Serialize(kvp, options));
+// Expected: {"key":1,"value":1}
+// Actual: {"Key":1,"Value":1}
+```
+
+Starting in .NET 5.0, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.Encoder> options are honored when serializing <xref:System.Collections.Generic.KeyValuePair%602> instances. The following code example shows how the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> properties are camel-cased after serialization.
+
+```csharp
+var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+KeyValuePair<int, int> kvp = KeyValuePair.Create(1, 1);
+Console.WriteLine(JsonSerializer.Serialize(kvp, options));
+// {"key":1,"value":1}
+```
+
+##### Deserialization
+
+In .NET Core 3.x versions and in the 4.7.x versions of the [System.Text.Json NuGet package](https://www.nuget.org/packages/System.Text.Json), a <xref:System.Text.Json.JsonException> is thrown when the JSON property names are not precisely `Key` and `Value`, for example, if they don't start with an uppercase letter.
+
+```csharp
+var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+string json = @"{""key"":1,""value"":1}";
+// Throws JsonException.
+JsonSerializer.Deserialize<KeyValuePair<int, int>>(json, options);
+```
+
+Starting in .NET 5.0, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> and <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> options are honored when deserializing using <xref:System.Text.Json.JsonSerializer>. For example, the following code snippet shows successful deserialization of lowercased <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> property names.
+
+```csharp
+var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+string json = @"{""key"":1,""value"":1}";
+
+KeyValuePair<int, int> kvp = JsonSerializer.Deserialize<KeyValuePair<int, int>>(json);
+Console.WriteLine(kvp.Key); // 1
+Console.WriteLine(kvp.Value); // 1
+```
+
+To accommodate payloads that were serialized with previous versions, "Key" and "Value" are special-cased to match when deserializing. Even though the <xref:System.Collections.Generic.KeyValuePair%602.Key> and <xref:System.Collections.Generic.KeyValuePair%602.Value> property names aren't camel-cased according to the in <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> option in the following code example, they deserialize successfully.
+
+```csharp
+var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+string json = @"{""Key"":1,""Value"":1}";
+
+KeyValuePair<int, int> kvp = JsonSerializer.Deserialize<KeyValuePair<int, int>>(json);
+Console.WriteLine(kvp.Key); // 1
+Console.WriteLine(kvp.Value); // 1
+```
+
+#### Version introduced
+
+5.0
+
+#### Reason for change
+
+Substantial customer feedback indicated that the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> should be honored. For completeness, the <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> and <xref:System.Text.Json.JsonSerializerOptions.Encoder> options are also honored, so that <xref:System.Collections.Generic.KeyValuePair%602> instances are treated the same as any other plain old CLR object (POCO).
+
+#### Recommended action
+
+If this change is disruptive to you, you can use a [custom converter](../../../../docs/standard/serialization/system-text-json-converters-how-to.md) that implements the desired semantics.
+
+#### Category
+
+Serialization
+
+#### Affected APIs
+
+- <xref:System.Text.Json.JsonSerializer.Serialize(System.Object,System.Type,System.Text.Json.JsonSerializerOptions)?displayProperty=fullName>
+- <xref:System.Text.Json.JsonSerializer.Deserialize%60%601(System.String,System.Text.Json.JsonSerializerOptions)?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `M:System.Text.Json.JsonSerializer.Serialize(System.Object,System.Type,System.Text.Json.JsonSerializerOptions)`
+- `M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)`
+
+-->


### PR DESCRIPTION
Fixes #20898.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/serialization?branch=pr-en-us-21050#propertynamingpolicy-is-honored-when-serializing-and-deserializing-key-value-pairs).