### PR TITLE
SendToAsync breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -375,9 +375,14 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Networking
 
+- [Socket.LocalEndPoint is updated after calling SendToAsync](#socketlocalendpoint-is-updated-after-calling-sendtoasync)
 - [WinHttpHandler removed from .NET runtime](#winhttphandler-removed-from-net-runtime)
 - [MulticastOption.Group doesn't accept a null value](#multicastoptiongroup-doesnt-accept-a-null-value)
 - [Cookie Path handling now conforms to RFC 6265](#cookie-path-handling-now-conforms-to-rfc-6265)
+
+[!INCLUDE [localendpoint-updated-on-sendtoasync](../../../includes/core-changes/networking/5.0/localendpoint-updated-on-sendtoasync.md)]
+
+***
 
 [!INCLUDE [winhttphandler-removed-from-runtime](../../../includes/core-changes/networking/5.0/winhttphandler-removed-from-runtime.md)]
 

--- a/docs/core/compatibility/networking.md
+++ b/docs/core/compatibility/networking.md
@@ -9,6 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Introduced version |
 | - | - |
+| [Socket.LocalEndPoint is updated after calling SendToAsync](#socketlocalendpoint-is-updated-after-calling-sendtoasync) | 5.0 |
 | [WinHttpHandler removed from .NET runtime](#winhttphandler-removed-from-net-runtime) | 5.0 |
 | [MulticastOption.Group doesn't accept a null value](#multicastoptiongroup-doesnt-accept-a-null-value) | 5.0 |
 | [Cookie Path handling now conforms to RFC 6265](#cookie-path-handling-now-conforms-to-rfc-6265) | 5.0 |
@@ -16,6 +17,10 @@ The following breaking changes are documented on this page:
 | [WebClient.CancelAsync doesn't always cancel immediately](#webclientcancelasync-doesnt-always-cancel-immediately) | 2.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [localendpoint-updated-on-sendtoasync](../../../includes/core-changes/networking/5.0/localendpoint-updated-on-sendtoasync.md)]
+
+***
 
 [!INCLUDE [winhttphandler-removed-from-runtime](../../../includes/core-changes/networking/5.0/winhttphandler-removed-from-runtime.md)]
 

--- a/includes/core-changes/networking/5.0/localendpoint-updated-on-sendtoasync.md
+++ b/includes/core-changes/networking/5.0/localendpoint-updated-on-sendtoasync.md
@@ -1,0 +1,35 @@
+### Socket.LocalEndPoint is updated after calling SendToAsync
+
+<xref:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)?displayProperty=nameWithType> now updates the value of the <xref:System.Net.Sockets.Socket.LocalEndPoint?displayProperty=nameWithType> property to the socket's local address.
+
+#### Version introduced
+
+5.0 RC1
+
+#### Change description
+
+In previous .NET versions, <xref:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)?displayProperty=nameWithType> does not alter the value of the <xref:System.Net.Sockets.Socket.LocalEndPoint?displayProperty=nameWithType> property on the socket instance. Starting in .NET 5.0, when <xref:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)> successfully completes, the value of <xref:System.Net.Sockets.Socket.LocalEndPoint?displayProperty=nameWithType> is the implicitly bound socket's local address. This new behavior is consistent with the behavior of <xref:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Net.EndPoint)> and <xref:System.Net.Sockets.Socket.BeginSendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint,System.AsyncCallback,System.Object)>/<xref:System.Net.Sockets.Socket.EndSendTo(System.IAsyncResult)>.
+
+#### Reason for change
+
+This change [fixes a bug](https://github.com/dotnet/runtime/issues/915) and makes the behavior consistent across `SendTo` variants.
+
+#### Recommended action
+
+Alter any code that assumes that <xref:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)> won't alter the value of <xref:System.Net.Sockets.Socket.LocalEndPoint?displayProperty=nameWithType>.
+
+#### Category
+
+Networking
+
+#### Affected APIs
+
+- <xref:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `M:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)`
+
+-->


### PR DESCRIPTION
Fixes #20949.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/networking?branch=pr-en-us-21052#socketlocalendpoint-is-updated-after-calling-sendtoasync).