### PR TITLE
FrameworkDescription breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -205,6 +205,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [FrameworkDescription's value is .NET instead of .NET Core](#frameworkdescriptions-value-is-net-instead-of-net-core)
 - [Assembly-related API behavior changes for single-file publishing format](#assembly-related-api-behavior-changes-for-single-file-publishing-format)
 - [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reversed)
 - [Thread.Abort is obsolete](#threadabort-is-obsolete)
@@ -225,6 +226,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [frameworkdescription-returns-net-not-net-core](../../../includes/core-changes/corefx/5.0/frameworkdescription-returns-net-not-net-core.md)]
+
+***
 
 [!INCLUDE [assembly-api-behavior-changes-for-single-file-publish](../../../includes/core-changes/corefx/5.0/assembly-api-behavior-changes-for-single-file-publish.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [FrameworkDescription's value is .NET instead of .NET Core](#frameworkdescriptions-value-is-net-instead-of-net-core) | 5.0 |
 | [Assembly-related API behavior changes for single-file publishing format](#assembly-related-api-behavior-changes-for-single-file-publishing-format) | 5.0 |
 | [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reversed) | 5.0 |
 | [Parameter names changed in RC1](#parameter-names-changed-in-rc1) | 5.0 |
@@ -51,6 +52,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [frameworkdescription-returns-net-not-net-core](../../../includes/core-changes/corefx/5.0/frameworkdescription-returns-net-not-net-core.md)]
+
+***
 
 [!INCLUDE [assembly-api-behavior-changes-for-single-file-publish](../../../includes/core-changes/corefx/5.0/assembly-api-behavior-changes-for-single-file-publish.md)]
 

--- a/includes/core-changes/corefx/5.0/frameworkdescription-returns-net-not-net-core.md
+++ b/includes/core-changes/corefx/5.0/frameworkdescription-returns-net-not-net-core.md
@@ -1,0 +1,37 @@
+### FrameworkDescription's value is .NET instead of .NET Core
+
+<xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> now returns ".NET" instead of ".NET Core".
+
+#### Change description
+
+In previous .NET versions, <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> returns ".NET Core" as part of the description string, for example, `.NET Core 3.1.1`.
+
+Starting in .NET 5.0, <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> returns ".NET" as part of the description string, for example, `.NET 5.0.0`.
+
+#### Reason for change
+
+With .NET 5, `netcoreapp` is replaced by `net` as the short target-framework moniker. For consistency, the framework's description has also been updated. The change is cosmetic, as the `FrameworkName` isn't encoded anywhere else than in the <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> property.
+
+#### Version introduced
+
+5.0
+
+#### Recommended action
+
+Update any code that searches for ".NET Core" in the string returned by <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription>.
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+- <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`
+
+-->


### PR DESCRIPTION
Fixes #20958.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-21054#frameworkdescriptions-value-is-net-instead-of-net-core).