### PR TITLE
fix the source path for retired C# 7.x content

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2615,15 +2615,15 @@
             "redirect_url": "/dotnet/csharp/programming-guide/types/index"
         },
         {
-            "source_path": "docs/csharp/csharp-7-1.md",
+            "source_path": "docs/csharp/whats-new/csharp-7-1.md",
             "redirect_url": "/dotnet/csharp/whats-new/csharp-7"
         },
         {
-            "source_path": "docs/csharp/csharp-7-2.md",
+            "source_path": "docs/csharp/whats-new/csharp-7-2.md",
             "redirect_url": "/dotnet/csharp/whats-new/csharp-7"
         },
         {
-            "source_path": "docs/csharp/csharp-7-3.md",
+            "source_path": "docs/csharp/whats-new/csharp-7-3.md",
             "redirect_url": "/dotnet/csharp/whats-new/csharp-7"
         },
         {


### PR DESCRIPTION
The "whats-new" folder was missing.

Fixes #21057 

