### PR TITLE
Clarify CAS support

### DIFF
--- a/docs/framework/misc/code-access-security.md
+++ b/docs/framework/misc/code-access-security.md
@@ -22,7 +22,7 @@ ms.assetid: 859af632-c80d-4736-8d6f-1e01b09ce127
 [!INCLUDE[net_security_note](../../../includes/net-security-note-md.md)]  
 
 > [!NOTE]
-> Because Code Access Security is deprecated, most modern code within the .NET ecosystem is not designed to operate within a partial trust environment. Applications which rely on CAS should not expect modern libraries to behave correctly within these environments unless the library developer has taken explicit steps to ensure compatibility within the CAS sandbox.  
+> Because Code Access Security is deprecated, most modern code within the .NET ecosystem is not designed to operate within a partial trust environment. Applications that rely on CAS should not expect modern libraries to behave correctly within these environments, unless the library developer has taken explicit steps to ensure compatibility within the CAS sandbox.  
 
  Today's highly connected computer systems are frequently exposed to code originating from various, possibly unknown sources. Code can be attached to email, contained in documents, or downloaded over the Internet. Unfortunately, many computer users have experienced firsthand the effects of malicious mobile code, including viruses and worms, which can damage or destroy data and cost time and money.  
   

--- a/docs/framework/misc/code-access-security.md
+++ b/docs/framework/misc/code-access-security.md
@@ -20,7 +20,10 @@ ms.assetid: 859af632-c80d-4736-8d6f-1e01b09ce127
 # Code Access Security
 
 [!INCLUDE[net_security_note](../../../includes/net-security-note-md.md)]  
-  
+
+> [!NOTE]
+> Because Code Access Security is deprecated, most modern code within the .NET ecosystem is not designed to operate within a partial trust environment. Applications which rely on CAS should not expect modern libraries to behave correctly within these environments unless the library developer has taken explicit steps to ensure compatibility within the CAS sandbox.  
+
  Today's highly connected computer systems are frequently exposed to code originating from various, possibly unknown sources. Code can be attached to email, contained in documents, or downloaded over the Internet. Unfortunately, many computer users have experienced firsthand the effects of malicious mobile code, including viruses and worms, which can damage or destroy data and cost time and money.  
   
  Most common security mechanisms give rights to users based on their credentials (usually a password) and restrict resources (often directories and files) that the user is allowed to access. However, this approach fails to address several issues: users obtain code from many sources, some of which might be unreliable; code can contain bugs or vulnerabilities that enable it to be exploited by malicious code; and code sometimes does things that the user does not know it will do. As a result, computer systems can be damaged and private data can be leaked when cautious and trustworthy users run malicious or error-filled software. Most operating system security mechanisms require that every piece of code must be trusted in order to run, except perhaps for scripts on a Web page. Therefore, there is still a need for a widely applicable security mechanism that allows code originating from one computer system to execute with protection on another system, even when there is no trust relationship between the systems.  

--- a/includes/net-security-note-md.md
+++ b/includes/net-security-note-md.md
@@ -5,6 +5,6 @@
 >
 > **CAS is not supported in .NET Core, .NET 5, or later versions. CAS is not supported by versions of C# later than 7.0.**
 >
-> CAS in .NET Framework should not be used as a mechanism for enforcing security boundaries based on code origination or other identity aspects. CAS and Security-Transparent Code are not supported as a security boundary with partially trusted code, especially code of unknown origin. We advise against loading and executing code of unknown origins without putting alternative security measures in place. .NET Framework will not issue security patches for any elevation of privilege exploits which might be discovered against the CAS sandbox.
+> CAS in .NET Framework should not be used as a mechanism for enforcing security boundaries based on code origination or other identity aspects. CAS and Security-Transparent Code are not supported as a security boundary with partially trusted code, especially code of unknown origin. We advise against loading and executing code of unknown origins without putting alternative security measures in place. .NET Framework will not issue security patches for any elevation-of-privilege exploits that might be discovered against the CAS sandbox.
 >
 > This policy applies to all versions of .NET Framework, but does not apply to the .NET Framework included in Silverlight.

--- a/includes/net-security-note-md.md
+++ b/includes/net-security-note-md.md
@@ -5,6 +5,6 @@
 >
 > **CAS is not supported in .NET Core, .NET 5, or later versions. CAS is not supported by versions of C# later than 7.0.**
 >
-> CAS in .NET Framework should not be used as a mechanism for enforcing security boundaries based on code origination or other identity aspects. CAS and Security-Transparent Code are not supported as a security boundary with partially trusted code, especially code of unknown origin. We advise against loading and executing code of unknown origins without putting alternative security measures in place.
+> CAS in .NET Framework should not be used as a mechanism for enforcing security boundaries based on code origination or other identity aspects. CAS and Security-Transparent Code are not supported as a security boundary with partially trusted code, especially code of unknown origin. We advise against loading and executing code of unknown origins without putting alternative security measures in place. .NET Framework will not issue security patches for any elevation of privilege exploits which might be discovered against the CAS sandbox.
 >
 > This policy applies to all versions of .NET Framework, but does not apply to the .NET Framework included in Silverlight.


### PR DESCRIPTION
## Summary

Clarify CAS support within the .NET ecosystem. With these modifications, the CAS overview document is intended to convey three concrete points:

- In .NET Framework, we do not support CAS as a security enforcement mechanism. We will not service any reported security vulnerabilities.
- In .NET Core / .NET 5, the CAS infrastructure doesn't even exist. (The docs already stated this.)
- The .NET ecosystem at large has moved on and no longer tests against partial trust environments. If an app relies on CAS, the default assumption should be that the app _cannot_ pull in new code or new libraries unless the code / library author has gone out of their way to develop for a partial trust environment.

Fixes https://github.com/dotnet/dotnet-api-docs/issues/3957
