### PR TITLE
Fix a bug with the recommended remove code

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes, version 3.1 to 5.0
 description: Lists the breaking changes from version 3.1 to version 5.0 of .NET, ASP.NET Core, and EF Core.
-ms.date: 10/06/2020
+ms.date: 10/14/2020
 ---
 # Breaking changes for migration from version 3.1 to 5.0
 

--- a/includes/core-changes/aspnetcore/5.0/http-httpclient-instances-log-integer-status-codes.md
+++ b/includes/core-changes/aspnetcore/5.0/http-httpclient-instances-log-integer-status-codes.md
@@ -55,12 +55,7 @@ If you need to force compatibility with the old behavior and use textual status 
         // Other service registrations go first. Code omitted for brevity.
 
         // Place the following after all AddHttpClient registrations.
-        var descriptors = services.Where(
-            s => s.ServiceType == typeof(IHttpMessageHandlerBuilderFilter));
-        foreach (var descriptor in descriptors)
-        {
-            services.Remove(descriptor);
-        }
+        services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
 
         services.AddSingleton<IHttpMessageHandlerBuilderFilter,
                               MyLoggingHttpMessageHandlerBuilderFilter>();


### PR DESCRIPTION
## Summary

Use the [`services.RemoveAll<T>()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.extensions.servicecollectiondescriptorextensions.removeall?view=dotnet-plat-ext-3.1#Microsoft_Extensions_DependencyInjection_Extensions_ServiceCollectionDescriptorExtensions_RemoveAll__1_Microsoft_Extensions_DependencyInjection_IServiceCollection_) function instead. This avoids the following error:

`System.InvalidOperationException: 'Collection was modified; enumeration operation may not execute.'`

Fixes #21097

## Preview

✔️ [HttpClient instances created by IHttpClientFactory log integer status codes](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0?branch=pr-en-us-21098#http-httpclient-instances-created-by-ihttpclientfactory-log-integer-status-codes)
