### PR TITLE
Update WinRT breaking change guidance

### DIFF
--- a/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md
+++ b/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md
@@ -21,9 +21,13 @@ This breaking change was made for the following reasons:
 
 #### Recommended action
 
-- Remove references to the [Microsoft.Windows.SDK.Contracts package](https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts) and replace them with references to the [Microsoft.Windows.SDK.NET package](https://www.nuget.org/packages/microsoft.windows.sdk.net).
+- Remove references to the [Microsoft.Windows.SDK.Contracts package](https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts).  Instead, specify the version of the Windows APIs that you want to access via the `TargetFramework` property of the project.  For example:
 
-- Use the [C#/WinRT](/windows/uwp/csharp-winrt/) tool chain to generate or customize WinRT APIs and types in .NET 5.0 and later versions.
+```xml
+<TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+```
+
+- Use the [C#/WinRT](/windows/uwp/csharp-winrt/) tool chain to generate or customize WinRT APIs and types for .NET 5.0 and later versions.
 
 #### Category
 

--- a/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md
+++ b/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md
@@ -25,7 +25,7 @@ This breaking change was made for the following reasons:
 
   ```xml
   <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
-  \```
+  ```
 
 - Use the [C#/WinRT](/windows/uwp/csharp-winrt/) tool chain to generate or customize WinRT APIs and types for .NET 5.0 and later versions.
 

--- a/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md
+++ b/includes/core-changes/interop/5.0/built-in-support-for-winrt-removed.md
@@ -23,9 +23,9 @@ This breaking change was made for the following reasons:
 
 - Remove references to the [Microsoft.Windows.SDK.Contracts package](https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts).  Instead, specify the version of the Windows APIs that you want to access via the `TargetFramework` property of the project.  For example:
 
-```xml
-<TargetFramework>net5.0-windows10.0.19041</TargetFramework>
-```
+  ```xml
+  <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+  \```
 
 - Use the [C#/WinRT](/windows/uwp/csharp-winrt/) tool chain to generate or customize WinRT APIs and types for .NET 5.0 and later versions.
 


### PR DESCRIPTION
The primary way to use Windows WinRT APIs should be by targeting Windows in the `TargetFramework`.