### PR TITLE
TargetFramework breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -367,8 +367,13 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## MSBuild
 
+- [TargetFramework change from netcoreapp to net](#targetframework-change-from-netcoreapp-to-net)
 - [PublishDepsFilePath behavior change](#publishdepsfilepath-behavior-change)
 - [Directory.Packages.props files is imported by default](#directorypackagesprops-files-is-imported-by-default)
+
+[!INCLUDE [targetframework-name-change](../../../includes/core-changes/msbuild/5.0/targetframework-name-change.md)]
+
+***
 
 [!INCLUDE [publishdepsfilepath-behavior-change](../../../includes/core-changes/msbuild/5.0/publishdepsfilepath-behavior-change.md)]
 

--- a/docs/core/compatibility/msbuild.md
+++ b/docs/core/compatibility/msbuild.md
@@ -9,12 +9,17 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | - |
+| [TargetFramework change from netcoreapp to net](#targetframework-change-from-netcoreapp-to-net)
 | [NETCOREAPP3_1 preprocessor symbol is not defined when targeting .NET 5](#netcoreapp3_1-preprocessor-symbol-is-not-defined-when-targeting-net-5) | 5.0 |
 | [PublishDepsFilePath behavior change](#publishdepsfilepath-behavior-change) | 5.0 |
 | [Directory.Packages.props files is imported by default](#directorypackagesprops-files-is-imported-by-default) | 5.0 |
 | [Resource manifest file name change](#resource-manifest-file-name-change) | 3.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [targetframework-name-change](../../../includes/core-changes/msbuild/5.0/targetframework-name-change.md)]
+
+***
 
 [!INCLUDE [netcoreapp3_1-preprocessor-symbol-not-defined](../../../includes/core-changes/msbuild/5.0/netcoreapp3_1-preprocessor-symbol-not-defined.md)]
 

--- a/docs/core/compatibility/msbuild.md
+++ b/docs/core/compatibility/msbuild.md
@@ -9,7 +9,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | - |
-| [TargetFramework change from netcoreapp to net](#targetframework-change-from-netcoreapp-to-net)
+| [TargetFramework change from netcoreapp to net](#targetframework-change-from-netcoreapp-to-net) | 5.0 |
 | [NETCOREAPP3_1 preprocessor symbol is not defined when targeting .NET 5](#netcoreapp3_1-preprocessor-symbol-is-not-defined-when-targeting-net-5) | 5.0 |
 | [PublishDepsFilePath behavior change](#publishdepsfilepath-behavior-change) | 5.0 |
 | [Directory.Packages.props files is imported by default](#directorypackagesprops-files-is-imported-by-default) | 5.0 |

--- a/includes/core-changes/msbuild/5.0/targetframework-name-change.md
+++ b/includes/core-changes/msbuild/5.0/targetframework-name-change.md
@@ -1,0 +1,48 @@
+### TargetFramework change from netcoreapp to net
+
+The value for the MSBuild `TargetFramework` property changed from `netcoreapp3.1` to `net5.0`. This can break code that relies on parsing the value of `TargetFramework`.
+
+#### Version introduced
+
+5.0
+
+#### Change description
+
+In .NET Core 1.0 - 3.1, the value for the MSBuild `TargetFramework` property starts with `netcoreapp`, for example, `netcoreapp3.1` for apps that target .NET Core 3.1. Starting in .NET 5.0, this value is simplified to just start with `net`, for example, `net5.0` for .NET 5.0.
+
+For more information, see [The future of .NET Standard](https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/) and [Target framework names in .NET 5](https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md).
+
+#### Reason for change
+
+- Simplifies the `TargetFramework` value.
+- Enables projects to include a `TargetPlatform` in the `TargetFramework` property.
+
+#### Recommended action
+
+If you have logic that parses the value of `TargetFramework`, you'll need to update it. For example, the following MSBuild condition relies on the value of `TargetFramework`.
+
+```xml
+<PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+```
+
+For this requirement, you can update the code to compare the target framework identifier instead.
+
+```xml
+<PropertyGroup Condition="'$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))' == '.NETCoreApp'">
+```
+
+#### Category
+
+MSBuild
+
+#### Affected APIs
+
+N/A
+
+<!--
+
+#### Affected APIs
+
+Not detectable via API analysis.
+
+-->


### PR DESCRIPTION
Fixes #21024.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/msbuild?branch=pr-en-us-21110#targetframework-change-from-netcoreapp-to-net).