### PR TITLE
Add f1-keyword for `using static` combination

### DIFF
--- a/docs/csharp/language-reference/keywords/using-static.md
+++ b/docs/csharp/language-reference/keywords/using-static.md
@@ -2,6 +2,8 @@
 description: "using static directive - C# Reference"
 title: "using static directive - C# Reference"
 ms.date: 03/10/2017
+f1_keywords: 
+  - "using-static_CSharpKeyword"
 helpviewer_keywords: 
   - "using static directive [C#]"
 ms.assetid: 8b8f9e34-c75e-469b-ba85-6f2eb4090314


### PR DESCRIPTION
## Summary

This PR adds an f1_keyword for the `using static` directive, allowing the `using` and `static` keywords to route here when they are found together as part of that directive.

Fixes part of #20799, Roslyn changes under dotnet/roslyn#48660.

