### PR TITLE
Be more specific about the overloads of Process.Start that fail on non-Windows platforms

### DIFF
--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -84,7 +84,8 @@ This article organizes the affected APIs by namespace.
 | <xref:System.Diagnostics.Process.MinWorkingSet?displayProperty=nameWithType> (set only) | Linux |
 | <xref:System.Diagnostics.Process.ProcessorAffinity?displayProperty=nameWithType> | macOS |
 | <xref:System.Diagnostics.Process.MainWindowHandle?displayProperty=nameWithType> | Linux and macOS |
-| <xref:System.Diagnostics.Process.Start%2A?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Diagnostics.Process.Start(System.String,System.String,System.String,System.Security.SecureString,System.String)?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Diagnostics.Process.Start(System.String,System.String,System.Security.SecureString,System.String)?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Diagnostics.ProcessStartInfo.UserName?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Diagnostics.ProcessStartInfo.PasswordInClearText?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Diagnostics.ProcessStartInfo.Domain?displayProperty=nameWithType> | Linux and macOS |


### PR DESCRIPTION
## Summary

The ["Unsupported APIs on .NET Core" page](https://docs.microsoft.com/en-us/dotnet/core/compatibility/unsupported-apis#systemdiagnosticsprocess) simply states that `Process.Start` throws on non-Windows platforms.

Obviously not all overloads of `Process.Start` are unsupported; only those that take a username and a password. This PR makes the documentation more specific.