### PR TITLE
Obsolete APIs with custom diagnostics breaking change

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -210,6 +210,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Core .NET libraries
 
+- [API obsoletions with non-default diagnostic IDs](#api-obsoletions-with-non-default-diagnostic-ids)
 - [FrameworkDescription's value is .NET instead of .NET Core](#frameworkdescriptions-value-is-net-instead-of-net-core)
 - [Assembly-related API behavior changes for single-file publishing format](#assembly-related-api-behavior-changes-for-single-file-publishing-format)
 - [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reversed)
@@ -231,6 +232,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs](#sse-and-sse2-comparegreaterthan-methods-properly-handle-nan-inputs)
 - [CounterSet.CreateCounterSetInstance now throws InvalidOperationException if instance already exist](#countersetcreatecountersetinstance-now-throws-invalidoperationexception-if-instance-already-exists)
 - [Microsoft.DotNet.PlatformAbstractions package removed](#microsoftdotnetplatformabstractions-package-removed)
+
+[!INCLUDE [obsolete-apis-with-custom-diagnostics](../../../includes/core-changes/corefx/5.0/obsolete-apis-with-custom-diagnostics.md)]
+
+***
 
 [!INCLUDE [frameworkdescription-returns-net-not-net-core](../../../includes/core-changes/corefx/5.0/frameworkdescription-returns-net-not-net-core.md)]
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [API obsoletions with non-default diagnostic IDs](#api-obsoletions-with-non-default-diagnostic-ids) | 5.0 |
 | [FrameworkDescription's value is .NET instead of .NET Core](#frameworkdescriptions-value-is-net-instead-of-net-core) | 5.0 |
 | [Assembly-related API behavior changes for single-file publishing format](#assembly-related-api-behavior-changes-for-single-file-publishing-format) | 5.0 |
 | [Order of tags in Activity.Tags is reversed](#order-of-tags-in-activitytags-is-reversed) | 5.0 |
@@ -52,6 +53,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [obsolete-apis-with-custom-diagnostics](../../../includes/core-changes/corefx/5.0/obsolete-apis-with-custom-diagnostics.md)]
+
+***
 
 [!INCLUDE [frameworkdescription-returns-net-not-net-core](../../../includes/core-changes/corefx/5.0/frameworkdescription-returns-net-not-net-core.md)]
 

--- a/includes/core-changes/corefx/5.0/obsolete-apis-with-custom-diagnostics.md
+++ b/includes/core-changes/corefx/5.0/obsolete-apis-with-custom-diagnostics.md
@@ -120,7 +120,7 @@ Classes that derive from `CodeAccessSecurityAttribute`:
 - <xref:System.DirectoryServices.DirectoryServicesPermissionAttribute?displayProperty=fullName>
 - <xref:System.Drawing.Printing.PrintingPermissionAttribute?displayProperty=fullName>
 - <xref:System.Net.DnsPermissionAttribute?displayProperty=fullName>
-- <xref:System.Net.SocketPermissionAttribute?displayProperty=fullName
+- <xref:System.Net.SocketPermissionAttribute?displayProperty=fullName>
 - <xref:System.Net.WebPermissionAttribute?displayProperty=fullName>
 - <xref:System.Net.Mail.SmtpPermissionAttribute?displayProperty=fullName>
 - <xref:System.Net.NetworkInformation.NetworkInformationPermissionAttribute?displayProperty=fullName>

--- a/includes/core-changes/corefx/5.0/obsolete-apis-with-custom-diagnostics.md
+++ b/includes/core-changes/corefx/5.0/obsolete-apis-with-custom-diagnostics.md
@@ -1,0 +1,278 @@
+### API obsoletions with non-default diagnostic IDs
+
+Some APIs have been marked as obsolete, starting in .NET 5.0. This breaking change is specific to APIs that have been marked as obsolete *with a custom diagnostic ID*. Suppressing the default obsoletion diagnostic ID, which is [CS0618](../../../../docs/csharp/language-reference/compiler-messages/cs0618.md) for the C# compiler, does not suppress the warnings that the compiler generates when these APIs are used.
+
+#### Change description
+
+In previous .NET versions, these APIs can be used without any build warning. In .NET 5.0 and later versions, use of these APIS produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
+
+The following table lists the custom diagnostic IDs and their corresponding warning messages for obsoleted APIs.
+
+| Diagnostic ID | Description | Severity |
+| - | - |
+| `SYSLIB0001` | The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead. | Warning |
+| `SYSLIB0002` | <xref:System.Security.Permissions.PrincipalPermissionAttribute> is not honored by the runtime and must not be used. | Error |
+| `SYSLIB0003` | Code access security (CAS) is not supported or honored by the runtime. | Warning |
+| `SYSLIB0004` | The constrained execution region (CER) feature is not supported. | Warning |
+| `SYSLIB0005` | The global assembly cache (GAC) is not supported. | Warning |
+| `SYSLIB0006` | <xref:System.Threading.Thread.Abort?displayProperty=nameWithType> is not supported and throws <xref:System.PlatformNotSupportedException>. | Warning |
+| `SYSLIB0007` | The default implementation of this cryptography algorithm is not supported. | Warning |
+| `SYSLIB0008` | The <xref:System.Runtime.CompilerServices.DebugInfoGenerator.CreatePdbGenerator> API is not supported and throws <xref:System.PlatformNotSupportedException>. | Warning |
+| `SYSLIB0009` | The <xref:System.Net.AuthenticationManager.Authenticate%2A?displayProperty=nameWithType> and <xref:System.Net.AuthenticationManager.PreAuthenticate%2A?displayProperty=nameWithType> methods are not supported and throw <xref:System.PlatformNotSupportedException>. | Warning |
+| `SYSLIB0010`| Some remoting APIs are not supported and throw <xref:System.PlatformNotSupportedException>. | Warning |
+| `SYSLIB0011` | <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> serialization is obsolete and should not be used. | Warning |
+| `SYSLIB0012` | <xref:System.Reflection.Assembly.CodeBase?displayProperty=nameWithType> and <xref:System.Reflection.Assembly.EscapedCodeBase?displayProperty=nameWithType> are only included for .NET Framework compatibility. Use <xref:System.Reflection.Assembly.Location?displayProperty=nameWithType> instead. | Warning |
+
+#### Version introduced
+
+.NET 5.0
+
+#### Recommended action
+
+- Follow the specific guidance provided for the each diagnostic ID using the URL link provided on the warning.
+
+- Warnings or errors for these obsoletions can't be suppressed using the standard diagnostic ID for obsolete types or members; use the custom `SYSLIBxxxx` diagnostic ID value instead.
+
+#### Category
+
+- Core .NET libraries
+
+#### Affected APIs
+
+##### SYSLIB0001
+
+- <xref:System.Text.Encoding.UTF7?displayProperty=nameWithType>
+- <xref:System.Text.UTF7Encoding.%23ctor%2A>
+
+##### SYSLIB0002
+
+- <xref:System.Security.Permissions.PrincipalPermissionAttribute.%23ctor(System.Security.Permissions.SecurityAction)>
+
+##### SYSLIB0003
+
+Classes in the `System.Security.Permissions` namespace:
+
+- <xref:System.Security.Permissions.CodeAccessSecurityAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.DataProtectionPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.DataProtectionPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.EnvironmentPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.EnvironmentPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.FileDialogPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.FileDialogPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.FileIOPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.FileIOPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.GacIdentityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.GacIdentityPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.HostProtectionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.IsolatedStorageFilePermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.IsolatedStorageFilePermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.IsolatedStoragePermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.IsolatedStoragePermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.KeyContainerPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry?displayProperty=fullName>
+- <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection?displayProperty=fullName>
+- <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator?displayProperty=fullName>
+- <xref:System.Security.Permissions.KeyContainerPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.MediaPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.MediaPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.PermissionSetAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.PrincipalPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.PrincipalPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.PublisherIdentityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.ReflectionPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.ReflectionPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.RegistryPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.RegistryPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.ResourcePermissionBase?displayProperty=fullName>
+- <xref:System.Security.Permissions.ResourcePermissionBaseEntry?displayProperty=fullName>
+- <xref:System.Security.Permissions.SecurityAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.SecurityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.SecurityPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.SiteIdentityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.SiteIdentityPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.StorePermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.StorePermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.StrongNameIdentityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.StrongNameIdentityPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.StrongNamePublicKeyBlob?displayProperty=fullName>
+- <xref:System.Security.Permissions.TypeDescriptorPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.TypeDescriptorPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.UIPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.UIPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.UrlIdentityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.UrlIdentityPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.WebBrowserPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.WebBrowserPermissionAttribute?displayProperty=fullName>
+- <xref:System.Security.Permissions.ZoneIdentityPermission?displayProperty=fullName>
+- <xref:System.Security.Permissions.ZoneIdentityPermissionAttribute?displayProperty=fullName>
+
+Classes that derive from `CodeAccessSecurityAttribute`:
+
+- <xref:System.Configuration.ConfigurationPermissionAttribute?displayProperty=fullName>
+- <xref:System.Data.Common.DBDataPermissionAttribute?displayProperty=fullName>
+- <xref:System.Data.Odbc.OdbcPermissionAttribute?displayProperty=fullName>
+- <xref:System.Data.OleDb.OleDbPermissionAttribute?displayProperty=fullName>
+- <xref:System.Data.OracleClient.OraclePermissionAttribute?displayProperty=fullName>
+- <xref:System.Data.SqlClient.SqlClientPermissionAttribute?displayProperty=fullName>
+- <xref:System.Diagnostics.EventLogPermissionAttribute?displayProperty=fullName>
+- <xref:System.Diagnostics.PerformanceCounterPermissionAttribute?displayProperty=fullName>
+- <xref:System.DirectoryServices.DirectoryServicesPermissionAttribute?displayProperty=fullName>
+- <xref:System.Drawing.Printing.PrintingPermissionAttribute?displayProperty=fullName>
+- <xref:System.Net.DnsPermissionAttribute?displayProperty=fullName>
+- <xref:System.Net.SocketPermissionAttribute?displayProperty=fullName
+- <xref:System.Net.WebPermissionAttribute?displayProperty=fullName>
+- <xref:System.Net.Mail.SmtpPermissionAttribute?displayProperty=fullName>
+- <xref:System.Net.NetworkInformation.NetworkInformationPermissionAttribute?displayProperty=fullName>
+- <xref:System.Net.PeerToPeer.PnrpPermissionAttribute?displayProperty=fullName>
+- <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute?displayProperty=fullName>
+- <xref:System.ServiceProcess.ServiceControllerPermissionAttribute?displayProperty=fullName>
+- <xref:System.Transactions.DistributedTransactionPermissionAttribute?displayProperty=fullName>
+- <xref:System.Web.AspNetHostingPermissionAttribute?displayProperty=fullName>
+
+Interfaces:
+
+- <xref:System.Security.Permissions.IUnrestrictedPermission?displayProperty=fullName>
+- <xref:System.Security.IPermission?displayProperty=fullName>
+- <xref:System.Security.IStackWalk?displayProperty=fullName>
+- <xref:System.Security.Policy.IIdentityPermissionFactory?displayProperty=fullName>
+
+Classes that implement `IStackWalk`:
+
+- <xref:System.Security.NamedPermissionSet?displayProperty=fullName>
+- <xref:System.Security.PermissionSet?displayProperty=fullName>
+
+Classes that implement `IPermission`:
+
+- <xref:System.Security.CodeAccessPermission?displayProperty=fullName>
+
+Classes that derive from `CodeAccessPermission`:
+
+- <xref:System.Configuration.ConfigurationPermission?displayProperty=fullName>
+- <xref:System.Data.Common.DBDataPermission?displayProperty=fullName>
+- <xref:System.Data.Odbc.OdbcPermission?displayProperty=fullName>
+- <xref:System.Data.OleDb.OleDbPermission?displayProperty=fullName>
+- <xref:System.Data.SqlClient.SqlClientPermission?displayProperty=fullName>
+- <xref:System.Data.OracleClient.OraclePermission?displayProperty=fullName>
+- <xref:System.Drawing.Printing.PrintingPermission?displayProperty=fullName>
+- <xref:System.Net.DnsPermission?displayProperty=fullName>
+- <xref:System.Net.SocketPermission?displayProperty=fullName>
+- <xref:System.Net.WebPermission?displayProperty=fullName>
+- <xref:System.Net.Mail.SmtpPermission?displayProperty=fullName>
+- <xref:System.Net.NetworkInformation.NetworkInformationPermission?displayProperty=fullName>
+- <xref:System.Net.PeerToPeer.PnrpPermission?displayProperty=fullName>
+- <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission?displayProperty=fullName>
+- <xref:System.Transactions.DistributedTransactionPermission?displayProperty=fullName>
+- <xref:System.Web.AspNetHostingPermission?displayProperty=fullName>
+- <xref:System.Xaml.Permissions.XamlLoadPermission?displayProperty=fullName>
+
+Classes that derive from `ResourcePermissionBase`:
+
+- <xref:System.Diagnostics.EventLogPermission?displayProperty=fullName>
+- <xref:System.Diagnostics.PerformanceCounterPermission?displayProperty=fullName>
+- <xref:System.DirectoryServices.DirectoryServicesPermission?displayProperty=fullName>
+- <xref:System.ServiceProcess.ServiceControllerPermission?displayProperty=fullName>
+
+Enums in the `System.Security.Permissions` namespace:
+
+- <xref:System.Security.Permissions.DataProtectionPermissionFlags?displayProperty=fullName>
+- <xref:System.Security.Permissions.EnvironmentPermissionAccess?displayProperty=fullName>
+- <xref:System.Security.Permissions.FileDialogPermissionAccess?displayProperty=fullName>
+- <xref:System.Security.Permissions.FileIOPermissionAccess?displayProperty=fullName>
+- <xref:System.Security.Permissions.HostProtectionResource?displayProperty=fullName>
+- <xref:System.Security.Permissions.IsolatedStorageContainment?displayProperty=fullName>
+- <xref:System.Security.Permissions.KeyContainerPermissionFlags?displayProperty=fullName>
+- <xref:System.Security.Permissions.MediaPermissionAudio?displayProperty=fullName>
+- <xref:System.Security.Permissions.MediaPermissionImage?displayProperty=fullName>
+- <xref:System.Security.Permissions.MediaPermissionVideo?displayProperty=fullName>
+- <xref:System.Security.Permissions.PermissionState?displayProperty=fullName>
+- <xref:System.Security.Permissions.ReflectionPermissionFlag?displayProperty=fullName>
+- <xref:System.Security.Permissions.RegistryPermissionAccess?displayProperty=fullName>
+- <xref:System.Security.Permissions.SecurityAction?displayProperty=fullName>
+- <xref:System.Security.Permissions.SecurityPermissionFlag?displayProperty=fullName>
+- <xref:System.Security.Permissions.StorePermissionFlags?displayProperty=fullName>
+- <xref:System.Security.Permissions.TypeDescriptorPermissionFlags?displayProperty=fullName>
+- <xref:System.Security.Permissions.UIPermissionClipboard?displayProperty=fullName>
+- <xref:System.Security.Permissions.UIPermissionWindow?displayProperty=fullName>
+- <xref:System.Security.Permissions.WebBrowserPermissionLevel?displayProperty=fullName>
+
+Classes and members that depend on code access security types:
+
+- <xref:System.AppDomain.PermissionSet?displayProperty=fullName>
+- <xref:System.Runtime.InteropServices.AllowReversePInvokeCallsAttribute?displayProperty=fullName>
+- <xref:System.Security.HostProtectionException?displayProperty=fullName>
+- <xref:System.Security.Policy.FileCodeGroup?displayProperty=fullName>
+- <xref:System.Security.Policy.StrongName?displayProperty=fullName>
+- <xref:System.Security.Policy.StrongNameMembershipCondition?displayProperty=fullName>
+- [System.Security.Policy.ApplicationTrust.ApplicationTrust(PermissionSet, IEnumerable\<StrongName>)](/dotnet/api/system.security.policy.applicationtrust.-ctor#System_Security_Policy_ApplicationTrust__ctor_System_Security_PermissionSet_System_Collections_Generic_IEnumerable_System_Security_Policy_StrongName__)
+- <xref:System.Security.Policy.ApplicationTrust.FullTrustAssemblies?displayProperty=fullName>
+- <xref:System.Security.Policy.GacInstalled?displayProperty=fullName>
+- <xref:System.Security.Policy.PolicyStatement.%23ctor%2A?displayProperty=fullName>
+- <xref:System.Security.Policy.PolicyLevel.AddNamedPermissionSet(System.Security.NamedPermissionSet)?displayProperty=fullName>
+- <xref:System.Security.Policy.PolicyLevel.ChangeNamedPermissionSet(System.String,System.Security.PermissionSet)?displayProperty=fullName>
+- <xref:System.Security.Policy.PolicyLevel.GetNamedPermissionSet(System.String)?displayProperty=fullName>
+- <xref:System.Security.Policy.PolicyLevel.RemoveNamedPermissionSet(System.String)?displayProperty=fullName>
+- <xref:System.Security.Policy.PolicyLevel.RemoveNamedPermissionSet(System.Security.NamedPermissionSet)?displayProperty=nameWithType>
+- <xref:System.Security.Policy.PolicyStatement.PermissionSet?displayProperty=fullName>
+- <xref:System.Security.Policy.Publisher?displayProperty=fullName>
+- <xref:System.Security.Policy.Site?displayProperty=fullName>
+- <xref:System.Security.Policy.Url?displayProperty=fullName>
+- <xref:System.Security.Policy.Zone?displayProperty=fullName>
+- <xref:System.Security.SecurityManager?displayProperty=fullName>
+
+##### SYSLIB0004
+
+- <xref:System.Runtime.CompilerServices.RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup(System.Runtime.CompilerServices.RuntimeHelpers.TryCode,System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode,System.Object)?displayProperty=nameWithType>
+- <xref:System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegions?displayProperty=nameWithType>
+- <xref:System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegionsNoOP?displayProperty=nameWithType>
+- <xref:System.Runtime.CompilerServices.RuntimeHelpers.PrepareContractedDelegate(System.Delegate)?displayProperty=nameWithType>
+- <xref:System.Runtime.CompilerServices.RuntimeHelpers.ProbeForSufficientStack?displayProperty=nameWithType>
+- <xref:System.Runtime.ConstrainedExecution.Cer?displayProperty=nameWithType>
+- <xref:System.Runtime.ConstrainedExecution.Consistency?displayProperty=nameWithType>
+- <xref:System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute?displayProperty=nameWithType>
+- <xref:System.Runtime.ConstrainedExecution.ReliabilityContractAttribute?displayProperty=nameWithType>
+
+##### SYSLIB0005
+
+- <xref:System.Reflection.Assembly.GlobalAssemblyCache?displayProperty=nameWithType>
+
+##### SYSLIB0006
+
+- <xref:System.Threading.Thread.Abort?displayProperty=nameWithType>
+- <xref:System.Threading.Thread.Abort(System.Object)?displayProperty=nameWithType>
+
+##### SYSLIB0007
+
+- <xref:System.Security.Cryptography.AsymmetricAlgorithm.Create?displayProperty=fullName>
+- <xref:System.Security.Cryptography.HashAlgorithm.Create?displayProperty=fullName>
+- <xref:System.Security.Cryptography.HMAC.Create?displayProperty=fullName>
+- <xref:System.Security.Cryptography.KeyedHashAlgorithm.Create?displayProperty=fullName>
+- <xref:System.Security.Cryptography.SymmetricAlgorithm.Create?displayProperty=fullName>
+
+##### SYSLIB0008
+
+- <xref:System.Runtime.CompilerServices.DebugInfoGenerator.CreatePdbGenerator?displayProperty=nameWithType>
+
+##### SYSLIB0009
+
+- <xref:System.Net.AuthenticationManager.Authenticate%2A?displayProperty=nameWithType>
+- <xref:System.Net.AuthenticationManager.PreAuthenticate%2A?displayProperty=nameWithType>
+
+##### SYSLIB0010
+
+- <xref:System.MarshalByRefObject.GetLifetimeService?displayProperty=nameWithType>
+- <xref:System.MarshalByRefObject.InitializeLifetimeService?displayProperty=nameWithType>
+
+##### SYSLIB0011
+
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize%2A?displayProperty=nameWithType>
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize%2A?displayProperty=nameWithType>
+- <xref:System.Runtime.Serialization.Formatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType>
+- <xref:System.Runtime.Serialization.Formatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType>
+- <xref:System.Runtime.Serialization.IFormatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType>
+- <xref:System.Runtime.Serialization.IFormatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType>
+
+##### SYSLIB0012
+
+- <xref:System.Reflection.Assembly.CodeBase?displayProperty=nameWithType>
+- <xref:System.Reflection.Assembly.EscapedCodeBase?displayProperty=nameWithType>


### PR DESCRIPTION
Fixes #20894.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/corefx?branch=pr-en-us-21169#api-obsoletions-with-non-default-diagnostic-ids).