### PR TITLE
C# 9 reference update: covariant return types

### DIFF
--- a/docs/csharp/language-reference/keywords/override.md
+++ b/docs/csharp/language-reference/keywords/override.md
@@ -1,7 +1,7 @@
 ---
 description: "override modifier - C# Reference"
 title: "override modifier - C# Reference"
-ms.date: 07/20/2015
+ms.date: 10/22/2020
 f1_keywords: 
   - "override"
   - "override_CSharpKeyword"
@@ -9,17 +9,15 @@ helpviewer_keywords:
   - "override keyword [C#]"
 ms.assetid: dd1907a8-acf8-46d3-80b9-c2ca4febada8
 ---
-# override (C# Reference)
+# override (C# reference)
 
 The `override` modifier is required to extend or modify the abstract or virtual implementation of an inherited method, property, indexer, or event.
 
-## Example
-
-In this example, the `Square` class must provide an overridden implementation of `GetArea` because `GetArea` is inherited from the abstract `Shape` class:
+In the following example, the `Square` class must provide an overridden implementation of `GetArea` because `GetArea` is inherited from the abstract `Shape` class:
 
 [!code-csharp[csrefKeywordsModifiers#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#1)]
 
-An `override` method provides a new implementation of a member that is inherited from a base class. The method that is overridden by an `override` declaration is known as the overridden base method. The overridden base method must have the same signature as the `override` method. For information about inheritance, see [Inheritance](../../programming-guide/classes-and-structs/inheritance.md).
+An `override` method provides a new implementation of the method inherited from a base class. The method that is overridden by an `override` declaration is known as the overridden base method. An `override` method must have the same signature as the overridden base method. Beginning with C# 9.0, `override` methods support covariant return types. In particular, the return type of an `override` method can derive from the return type of the corresponding base method. In C# 8.0 and earlier, the return types of an `override` method and the overridden base method must be the same.
 
 You cannot override a non-virtual or static method. The overridden base method must be `virtual`, `abstract`, or `override`.
 
@@ -27,9 +25,9 @@ An `override` declaration cannot change the accessibility of the `virtual` metho
 
 You cannot use the `new`, `static`, or `virtual` modifiers to modify an `override` method.
 
-An overriding property declaration must specify exactly the same access modifier, type, and name as the inherited property, and the overridden property must be `virtual`, `abstract`, or `override`.
+An overriding property declaration must specify exactly the same access modifier, type, and name as the inherited property. Beginning with C# 9.0, read-only overriding properties support covariant return types. The overridden property must be `virtual`, `abstract`, or `override`.
 
-For more information about how to use the `override` keyword, see [Versioning with the Override and New Keywords](../../programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md) and [Knowing when to use Override and New Keywords](../../programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md).
+For more information about how to use the `override` keyword, see [Versioning with the Override and New Keywords](../../programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md) and [Knowing when to use Override and New Keywords](../../programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md). For information about inheritance, see [Inheritance](../../programming-guide/classes-and-structs/inheritance.md).
 
 ## Example
 
@@ -39,14 +37,15 @@ This example defines a base class named `Employee`, and a derived class named `S
 
 ## C# language specification
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see the [Override methods](~/_csharplang/spec/classes.md#override-methods) section of the [C# language specification](~/_csharplang/spec/introduction.md).
+
+For more information about covariant return types, see the [feature proposal note](~/_csharplang/proposals/csharp-9.0/covariant-returns.md).
 
 ## See also
 
-- [C# Reference](../index.md)
-- [C# Programming Guide](../../programming-guide/index.md)
+- [C# reference](../index.md)
 - [Inheritance](../../programming-guide/classes-and-structs/inheritance.md)
-- [C# Keywords](index.md)
+- [C# keywords](index.md)
 - [Modifiers](index.md)
 - [abstract](abstract.md)
 - [virtual](virtual.md)

--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -220,7 +220,7 @@ A similar feature improves the target type resolution of [conditional expression
 
 Starting in C# 9.0, you can add the `static` modifier to [lambda expressions](../language-reference/operators/lambda-expressions.md) or [anonymous methods](../language-reference/operators/delegate-operator.md). Static lambda expressions are analogous to the `static` local functions: a static lambda or anonymous method can't capture local variables or instance state. The `static` modifier prevents accidentally capturing other variables.
 
-Covariant return types provide flexibility for the return types of overridden functions. An overridden virtual function can return a type derived from the return type declared in the base class method. This can be useful for Records, and for other types that support virtual clone or factory methods.
+Covariant return types provide flexibility for the return types of [override](../language-reference/keywords/override.md) methods. An override method can return a type derived from the return type of the overridden base method. This can be useful for records and for other types that support virtual clone or factory methods.
 
 In addition, the [`foreach` loop](../language-reference/keywords/foreach-in.md) will recognize and use an extension method `GetEnumerator` that otherwise satisfies the `foreach` pattern. This change means `foreach` is consistent with other pattern-based constructions such as the async pattern, and pattern-based deconstruction. In practice, this change means you can add `foreach` support to any type. You should limit its use to when enumerating an object makes sense in your design.
 


### PR DESCRIPTION
Fixes #20577 

Related, typo fixes in the proposal note: dotnet/csharplang#4045 (@BillWagner could you please review and merge that as well)
