### PR TITLE
Removed confusing sentence

### DIFF
--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -102,7 +102,7 @@ The above line creates a new `Person` record where the `LastName` property is a 
 
 ***Init only setters*** provide consistent syntax to initialize members of an object. Property initializers make it clear which value is setting which property. The downside is that those properties must be settable. Starting with C# 9.0, you can create `init` accessors instead of `set` accessors for properties and indexers. Callers can use property initializer syntax to set these values in creation expressions, but those properties are readonly once construction has completed. Init only setters provide a window to change state. That window closes when the construction phase ends. The construction phase effectively ends after all initialization, including property initializers and with-expressions have completed.
 
-You can declare init only setters in any type you write. For example, the following struct defines a weather observation structure:
+You can declare `init` only setters in any type you write. For example, the following struct defines a weather observation structure:
 
 :::code language="csharp" source="snippets/whats-new-csharp9/WeatherObservation.cs" ID="DeclareWeatherObservation":::
 

--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -102,7 +102,7 @@ The above line creates a new `Person` record where the `LastName` property is a 
 
 ***Init only setters*** provide consistent syntax to initialize members of an object. Property initializers make it clear which value is setting which property. The downside is that those properties must be settable. Starting with C# 9.0, you can create `init` accessors instead of `set` accessors for properties and indexers. Callers can use property initializer syntax to set these values in creation expressions, but those properties are readonly once construction has completed. Init only setters provide a window to change state. That window closes when the construction phase ends. The construction phase effectively ends after all initialization, including property initializers and with-expressions have completed.
 
-The preceding example for positional records demonstrates using an init-only setter to set a property using a with expression. You can declare init only setters in any type you write. For example, the following struct defines a weather observation structure:
+You can declare init only setters in any type you write. For example, the following struct defines a weather observation structure:
 
 :::code language="csharp" source="snippets/whats-new-csharp9/WeatherObservation.cs" ID="DeclareWeatherObservation":::
 


### PR DESCRIPTION
The removed sentence is confusing:
- The preceding example is in the preceding section, which seems to be very far away and out of context of the current section. First, I've thought that the mentioned example hasn't been included into the article.
- Moreover, the example with records *doesn't demonstrate* how to use an `init` accessor (it's an implementation detail of a `with` expression). So, it's useless as an example. 
