### PR TITLE
Document launching child proc using dotnet-trace and dotnet-counters

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -175,7 +175,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
  **`-- <command>` (for target applications running .NET 5.0 or later only)**
 
-  Prefixing the `collect` command with `--` followed by a command executes the given command as a child process and starts collecting metric from the target process. This is useful for getting metrics from runtime startup (before `Main` runs) and can be used to diagnose or monitor issues that happen early in the application startup.
+  After the collection configuration parameters, the user can append `--` followed by a command to start a .NET application with at least a 5.0 runtime. `dotnet-counters` will launch a process with the provided command and monitor the requested metrics. This is often useful to collect metrics for the application's startup path and can be used to diagnose or monitor issues that happen early before or shortly after the main entrypoint.
 
   > [!NOTE]
   > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -80,6 +80,9 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--cou
 
   After the collection configuration parameters, the user can append `--` followed by a command to start a .NET application with at least a 5.0 runtime. `dotnet-counters` will launch a process with the provided command and collect the requested metrics. This is often useful to collect metrics for the application's startup path and can be used to diagnose or monitor issues that happen early before or shortly after the main entrypoint.
 
+> [!NOTE]
+> Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.
+
 ### Examples
 
 - Collect all counters at a refresh interval of 3 seconds and generate a csv as output:
@@ -174,6 +177,9 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
   Prefixing the `collect` command with `--` followed by a command executes the given command as a child process and starts collecting metric from the target process. This is useful for getting metrics from runtime startup (before `Main` runs) and can be used to diagnose or monitor issues that happen early in the application startup.
 
+  > [!NOTE]
+  > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.
+
 ### Examples
 
 - Monitor all counters from `System.Runtime` at a refresh interval of 3 seconds:
@@ -233,6 +239,8 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
 - Launch `my-aspnet-server.exe` and monitor the # of assemblies loaded from its startup (.NET 5.0 or later only):
 
+  NOTE: This works for apps running .NET 5.0 or later only.
+
   ```console
   > dotnet-counters monitor --counters System.Runtime[assembly-count] -- my-aspnet-server.exe
 
@@ -244,6 +252,8 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
   ```
   
 - Launch `my-aspnet-server.exe` with `arg1` and `arg2` as command-line arguments and monitor its working set and GC heap size from its startup (.NET 5.0 or later only):
+
+  NOTE: This works for apps running .NET 5.0 or later only.
 
   ```console
   > dotnet-counters monitor --counters System.Runtime[working-set,gc-heap-size] -- my-aspnet-server.exe arg1 arg2

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -78,7 +78,7 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--cou
 
 - **`-- <command>` (for target applications running .NET 5.0 or later only)**
 
-  Putting `--` followed by a command to start a .NET 5.0 (or later) application after the `collect` command launches the given command as a child process and starts collecting metric from the target process. This is useful for getting metrics from runtime startup (before `Main` runs) and can be used to diagnose or monitor issues that happen early in the application startup.
+  After the collection configuration parameters, the user can append `--` followed by a command to start a .NET application with at least a 5.0 runtime. `dotnet-counters` will launch a process with the provided command and collect the requested metrics. This is often useful to collect metrics for the application's startup path and can be used to diagnose or monitor issues that happen early before or shortly after the main entrypoint.
 
 ### Examples
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -51,7 +51,7 @@ Periodically collect selected counter values and export them into a specified fi
 ### Synopsis
 
 ```console
-dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [counter_list] [--format] [-o|--output]
+dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--counters] [counter_list] [--format] [-o|--output] [-- <command>]
 ```
 
 ### Options
@@ -64,9 +64,9 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
   The number of seconds to delay between updating the displayed counters
 
-- **`counter_list <COUNTERS>`**
+- **`--counters`**
 
-  A space separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying `counter_name`, then all counters are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command.
+  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command.
 
 - **`--format <csv|json>`**
 
@@ -75,6 +75,10 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [count
 - **`-o|--output <output>`**
 
   The name of the output file.
+
+- **`-- <command>` (for target applications running .NET 5.0 or later only)**
+
+  Putting `--` followed by a command to start a .NET 5.0 (or later) application after the `collect` command launches the given command as a child process and starts collecting metric from the target process. This is useful for getting metrics from runtime startup (before `Main` runs) and can be used to diagnose or monitor issues that happen early in the application startup.
 
 ### Examples
 
@@ -85,6 +89,14 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
   counter_list is unspecified. Monitoring all counters by default.
   Starting a counter session. Press Q to quit.
+  ```
+
+- Start `dotnet mvc.dll` as a child process and start collecting runtime counters and ASP.NET Core Hosting counters from startup and save it as a JSON output:
+
+  ```console
+  > dotnet-counters collect --format json --counters System.Runtime,Microsoft.AspNetCore.Hosting -- dotnet mvc.dll
+  Starting a counter session. Press Q to quit.
+  File saved to counter.json
   ```
 
 ## dotnet-counters list
@@ -141,7 +153,7 @@ Displays periodically refreshing values of selected counters.
 ### Synopsis
 
 ```console
-dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [counter_list]
+dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [counter_list] [-- <command>]
 ```
 
 ### Options
@@ -154,9 +166,13 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
   The number of seconds to delay between updating the displayed counters
 
-- **`counter_list <COUNTERS>`**
+- **`--counters`**
 
-  A space separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying `counter_name`, then all counters are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command.
+  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command.
+
+ **`-- <command>` (for target applications running .NET 5.0 or later only)**
+
+  Prefixing the `collect` command with `--` followed by a command executes the given command as a child process and starts collecting metric from the target process. This is useful for getting metrics from runtime startup (before `Main` runs) and can be used to diagnose or monitor issues that happen early in the application startup.
 
 ### Examples
 
@@ -164,25 +180,44 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
   ```console
   > dotnet-counters monitor --process-id 1902  --refresh-interval 3 System.Runtime
-
   Press p to pause, r to resume, q to quit.
-    System.Runtime:
-      CPU Usage (%)                                 24
-      Working Set (MB)                            1982
-      GC Heap Size (MB)                            811
-      Gen 0 GC / second                             20
-      Gen 1 GC / second                              4
-      Gen 2 GC / second                              1
-      Number of Exceptions / sec                     4
+      Status: Running
+
+  [System.Runtime]
+      % Time in GC since last GC (%)                                 0
+      Allocation Rate (B / 1 sec)                                5,376
+      CPU Usage (%)                                                  0
+      Exception Count (Count / 1 sec)                                0
+      GC Fragmentation (%)                                          48.467
+      GC Heap Size (MB)                                              0
+      Gen 0 GC Count (Count / 1 sec)                                 1
+      Gen 0 Size (B)                                                24
+      Gen 1 GC Count (Count / 1 sec)                                 1
+      Gen 1 Size (B)                                                24
+      Gen 2 GC Count (Count / 1 sec)                                 1
+      Gen 2 Size (B)                                           272,000
+      IL Bytes Jitted (B)                                       19,449
+      LOH Size (B)                                              19,640
+      Monitor Lock Contention Count (Count / 1 sec)                  0
+      Number of Active Timers                                        0
+      Number of Assemblies Loaded                                    7
+      Number of Methods Jitted                                     166
+      POH (Pinned Object Heap) Size (B)                             24
+      ThreadPool Completed Work Item Count (Count / 1 sec)           0
+      ThreadPool Queue Length                                        0
+      ThreadPool Thread Count                                        2
+      Working Set (MB)                                              19
   ```
 
 - Monitor just CPU usage and GC heap size from `System.Runtime`:
 
   ```console
-  > dotnet-counters monitor --process-id 1902 System.Runtime[cpu-usage,gc-heap-size]
+  > dotnet-counters monitor --process-id 1902 --counters System.Runtime[cpu-usage,gc-heap-size]
 
   Press p to pause, r to resume, q to quit.
-    System.Runtime:
+    Status: Running
+
+  [System.Runtime]
       CPU Usage (%)                                 24
       GC Heap Size (MB)                            811
   ```
@@ -190,12 +225,39 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 - Monitor `EventCounter` values from user-defined `EventSource`. For more information, see [Tutorial: Measure performance using EventCounters in .NET Core](event-counter-perf.md).
 
   ```console
-  > dotnet-counters monitor --process-id 1902 Samples-EventCounterDemos-Minimal
+  > dotnet-counters monitor --process-id 1902 --counters Samples-EventCounterDemos-Minimal
 
   Press p to pause, r to resume, q to quit.
       request                                      100
   ```
+
+- Launch `my-aspnet-server.exe` and monitor the # of assemblies loaded from its startup (.NET 5.0 or later only):
+
+  ```console
+  > dotnet-counters monitor --counters System.Runtime[assembly-count] -- my-aspnet-server.exe
+
+  Press p to pause, r to resume, q to quit.
+    Status: Running
+
+  [System.Runtime]
+      Number of Assemblies Loaded                   24
+  ```
   
+- Launch `my-aspnet-server.exe` with `arg1` and `arg2` as command-line arguments and monitor its working set and GC heap size from its startup (.NET 5.0 or later only):
+
+  ```console
+  > dotnet-counters monitor --counters System.Runtime[working-set,gc-heap-size]
+  ```
+
+  ```console
+  Press p to pause, r to resume, q to quit.
+    Status: Running
+
+  [System.Runtime]
+      GC Heap Size (MB)                                 39
+      Working Set (MB)                                  59
+  ```
+
 ## dotnet-counters ps
 
 Display a list of dotnet processes that can be monitored.

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -51,7 +51,7 @@ Periodically collect selected counter values and export them into a specified fi
 ### Synopsis
 
 ```console
-dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--counters] [counter_list] [--format] [-o|--output] [-- <command>]
+dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--counters <COUNTERS>] [--format] [-o|--output] [-- <command>]
 ```
 
 ### Options
@@ -64,7 +64,7 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--cou
 
   The number of seconds to delay between updating the displayed counters
 
-- **`--counters`**
+- **`--counters <COUNTERS>`**
 
   A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command.
 
@@ -156,7 +156,7 @@ Displays periodically refreshing values of selected counters.
 ### Synopsis
 
 ```console
-dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [counter_list] [-- <command>]
+dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [--counters] [-- <command>]
 ```
 
 ### Options
@@ -169,7 +169,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 
   The number of seconds to delay between updating the displayed counters
 
-- **`--counters`**
+- **`--counters <COUNTERS>`**
 
   A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command.
 
@@ -185,7 +185,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 - Monitor all counters from `System.Runtime` at a refresh interval of 3 seconds:
 
   ```console
-  > dotnet-counters monitor --process-id 1902  --refresh-interval 3 System.Runtime
+  > dotnet-counters monitor --process-id 1902  --refresh-interval 3 --counters System.Runtime
   Press p to pause, r to resume, q to quit.
       Status: Running
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -246,7 +246,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [count
 - Launch `my-aspnet-server.exe` with `arg1` and `arg2` as command-line arguments and monitor its working set and GC heap size from its startup (.NET 5.0 or later only):
 
   ```console
-  > dotnet-counters monitor --counters System.Runtime[working-set,gc-heap-size]
+  > dotnet-counters monitor --counters System.Runtime[working-set,gc-heap-size] -- my-aspnet-server.exe arg1 arg2
   ```
 
   ```console

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -109,7 +109,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
 - **`-- <command>` (for target applications running .NET 5.0 only)**
 
-  After the collection configuration parameters, the user can append `--` followed by a command to start a .NET application with at least a 5.0 runtime. This may be helpful when diagnosing issues that happen early in the process, such as startup performance issue or assembly loader and binder errors. Note that the target application being traced must be running .NET 5.0 or later to be able to use this feature.
+  After the collection configuration parameters, the user can append `--` followed by a command to start a .NET application with at least a 5.0 runtime. This may be helpful when diagnosing issues that happen early in the process, such as startup performance issue or assembly loader and binder errors.
 
   > [!NOTE]
   > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -189,7 +189,7 @@ To collect traces using `dotnet-trace`:
 
 NOTE: This works for apps running .NET 5.0 or later only.
 
-Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace. 
+Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace.
 
 Suppose there is a .NET 5.0 application named `hello.exe` that you want to collect a trace from its startup.
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -111,6 +111,9 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
   Putting `--` followed by a command to start a .NET 5.0 (or later) application after the `collect` command launches the given command as a child process and tries to collect a trace from it at startup. This may be helpful when diagnosing issues that happen early in the process, such as startup performance issue or assembly loader and binder errors. Note that the target application being traced must be running .NET 5.0 or later to be able to use this feature.
 
+  > [!NOTE]
+  > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.
+
 ## dotnet-trace convert
 
 Converts `nettrace` traces to alternate formats for use with alternate trace analysis tools.

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -194,15 +194,13 @@ NOTE: This works for apps running .NET 5.0 or later only.
 
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace.
 
-Suppose there is a .NET 5.0 application named `hello.exe` with `arg1` and `arg2` that you want to collect a trace from its startup.
-
-To do this, run the following command:
+This will launch `hello.exe` with `arg1` and `arg2` as its command line arguments and collect a trace from its runtime startup:
 
 ```console
 dotnet-trace collect -- hello.exe arg1 arg2
 ```
 
-This will launch `hello.exe` with `arg1` and `arg2` as its command line arguments and collect a trace from its runtime startup:
+The preceding command generates output similar to the following:
 
 ```console
 No profile or providers specified, defaulting to trace profile 'cpu-sampling'
@@ -223,6 +221,8 @@ You can stop collecting the trace by pressing `<Enter>` or `<Ctrl + C>` key. Doi
 
 > [!NOTE]
 > Launching `hello.exe` via dotnet-trace will make its input/output to be redirected and you won't be able to interact with its stdin/stdout.
+> Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process.
+> If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable.
 
 ## View the trace captured from dotnet-trace
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -109,7 +109,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
 - **`-- <command>` (for target applications running .NET 5.0 only)**
 
-  Putting `--` followed by a command to start a .NET 5.0 (or later) application after the `collect` command launches the given command as a child process and tries to collect a trace from it at startup. This may be helpful when diagnosing issues that happen early in the process, such as startup performance issue or assembly loader and binder errors. Note that the target application being traced must be running .NET 5.0 or later to be able to use this feature.
+  After the collection configuration parameters, the user can append `--` followed by a command to start a .NET application with at least a 5.0 runtime. This may be helpful when diagnosing issues that happen early in the process, such as startup performance issue or assembly loader and binder errors. Note that the target application being traced must be running .NET 5.0 or later to be able to use this feature.
 
   > [!NOTE]
   > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -216,7 +216,7 @@ Output File    : E:\temp\gcperfsim\trace.nettrace
 Press <Enter> or <Ctrl+C> to exit...
 ```
 
-You can stop the collecting by pressing `<Enter>` or `<Ctrl + C>` key. Doing this will also exit `hello.exe`.
+You can stop collecting the trace by pressing `<Enter>` or `<Ctrl + C>` key. Doing this will also exit `hello.exe`.
 
 > [!NOTE]
 > Launching `hello.exe` via dotnet-trace will make its input/output to be redirected and you won't be able to interact with its stdin/stdout.

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -60,6 +60,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
     [--format <Chromium|NetTrace|Speedscope>] [-h|--help]
     [-n, --name <name>]  [-o|--output <trace-file-path>] [-p|--process-id <pid>]
     [--profile <profile-name>] [--providers <list-of-comma-separated-providers>]
+    [-- <command>] (for target applications running .NET 5.0 or later)
 ```
 
 ### Options
@@ -105,6 +106,10 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
   - `Provider[,Provider]`
   - `Provider` is in the form: `KnownProviderName[:Flags[:Level][:KeyValueArgs]]`.
   - `KeyValueArgs` is in the form: `[key1=value1][;key2=value2]`.
+
+- **`-- <command>` (for target applications running .NET 5.0 only)**
+
+  Putting `--` followed by a command to start a .NET 5.0 (or later) application after the `collect` command launches the given command as a child process and tries to collect a trace from it at startup. This may be helpful when diagnosing issues that happen early in the process, such as startup performance issue or assembly loader and binder errors. Note that the target application being traced must be running .NET 5.0 or later to be able to use this feature.
 
 ## dotnet-trace convert
 
@@ -179,6 +184,42 @@ To collect traces using `dotnet-trace`:
   ```
 
 - Stop collection by pressing the `<Enter>` key. `dotnet-trace` will finish logging events to the *trace.nettrace* file.
+
+## Launch a child application and collect a trace from its startup using dotnet-trace
+
+NOTE: This works for apps running .NET 5.0 or later only.
+
+Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace. 
+
+Suppose there is a .NET 5.0 application named `hello.exe` that you want to collect a trace from its startup.
+
+To do this, run the following command:
+
+```console
+dotnet-trace collect -- hello.exe
+```
+
+This will launch `hello.exe` and collect a trace from its runtime startup:
+
+```console
+No profile or providers specified, defaulting to trace profile 'cpu-sampling'
+
+Provider Name                           Keywords            Level               Enabled By
+Microsoft-DotNETCore-SampleProfiler     0x0000F00000000000  Informational(4)    --profile
+Microsoft-Windows-DotNETRuntime         0x00000014C14FCCBD  Informational(4)    --profile
+
+Process        : E:\temp\gcperfsim\bin\Debug\net5.0\gcperfsim.exe
+Output File    : E:\temp\gcperfsim\trace.nettrace
+
+
+[00:00:00:05]   Recording trace 122.244  (KB)
+Press <Enter> or <Ctrl+C> to exit...
+```
+
+You can stop the collecting by pressing `<Enter>` or `<Ctrl + C>` key. Doing this will also exit `hello.exe`.
+
+> [!NOTE]
+> Launching `hello.exe` via dotnet-trace will make its input/output to be redirected and you won't be able to interact with its stdin/stdout.
 
 ## View the trace captured from dotnet-trace
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -194,15 +194,15 @@ NOTE: This works for apps running .NET 5.0 or later only.
 
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace.
 
-Suppose there is a .NET 5.0 application named `hello.exe` that you want to collect a trace from its startup.
+Suppose there is a .NET 5.0 application named `hello.exe` with `arg1` and `arg2` that you want to collect a trace from its startup.
 
 To do this, run the following command:
 
 ```console
-dotnet-trace collect -- hello.exe
+dotnet-trace collect -- hello.exe arg1 arg2
 ```
 
-This will launch `hello.exe` and collect a trace from its runtime startup:
+This will launch `hello.exe` with `arg1` and `arg2` as its command line arguments and collect a trace from its runtime startup:
 
 ```console
 No profile or providers specified, defaulting to trace profile 'cpu-sampling'


### PR DESCRIPTION
## Summary

This documents a new dotnet-trace and dotnet-counters feature where an application can be launched and monitored/traced from its startup, introduced by https://github.com/dotnet/diagnostics/pull/1635. 

This PR can be merged once we officially ship the new versions of the diagnostics CLI tools (which is scheduled to be some time next week or so).

cc @tommcdon 