### PR TITLE
Update docs for networking Runtime Configuration Options

### DIFF
--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -12,7 +12,7 @@ ms.topic: reference
 
 - Introduced in .NET Core 3.0.
 
-- In .NET Core 3.0: If you omit this setting, support for the HTTP/2 protocol is disabled. This is equivalent to setting the value to `false`.
+- .NET Core 3.0 only: If you omit this setting, support for the HTTP/2 protocol is disabled. This is equivalent to setting the value to `false`.
 
 - .NET Core 3.1 and .NET 5+: If you omit this setting, support for the HTTP/2 protocol is enabled. This is equivalent to setting the value to `true`.
 

--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -16,7 +16,6 @@ ms.topic: reference
 
 - Since .NET Core 3.1: If you omit this setting, support for the HTTP/2 protocol is enabled. This is equivalent to setting the value to `true`.
 
-
 | | Setting name | Values |
 | - | - | - |
 | **runtimeconfig.json** | `System.Net.Http.SocketsHttpHandler.Http2Support` | `false` - disabled<br/>`true` - enabled |
@@ -46,7 +45,6 @@ ms.topic: reference
 - This switch allows relaxing the HTTP header validation, enabling <xref:System.Net.Http.SocketsHttpHandler> to send ISO-8859-1 (Latin-1) encoded characters in headers.
 
 - If you omit this setting, an attempt to send a non-ASCII character will result in <xref:System.Net.Http.HttpRequestException>. This is equivalent to setting the value to `false`.
-
 
 | | Setting name | Values |
 | - | - | - |

--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -14,7 +14,7 @@ ms.topic: reference
 
 - In .NET Core 3.0: If you omit this setting, support for the HTTP/2 protocol is disabled. This is equivalent to setting the value to `false`.
 
-- Since .NET Core 3.1: If you omit this setting, support for the HTTP/2 protocol is enabled. This is equivalent to setting the value to `true`.
+- .NET Core 3.1 and .NET 5+: If you omit this setting, support for the HTTP/2 protocol is enabled. This is equivalent to setting the value to `true`.
 
 | | Setting name | Values |
 | - | - | - |

--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -10,9 +10,12 @@ ms.topic: reference
 
 - Configures whether support for the HTTP/2 protocol is enabled.
 
-- If you omit this setting, support for the HTTP/2 protocol is disabled. This is equivalent to setting the value to `false`.
-
 - Introduced in .NET Core 3.0.
+
+- In .NET Core 3.0: If you omit this setting, support for the HTTP/2 protocol is disabled. This is equivalent to setting the value to `false`.
+
+- Since .NET Core 3.1: If you omit this setting, support for the HTTP/2 protocol is enabled. This is equivalent to setting the value to `true`.
+
 
 | | Setting name | Values |
 | - | - | - |
@@ -37,3 +40,18 @@ ms.topic: reference
 
 > [!NOTE]
 > Starting in .NET 5, the `System.Net.Http.UseSocketsHttpHandler` setting is no longer available.
+
+## Allow sending Latin1 headers in .NET Core 3.1
+
+- This switch allows relaxing the HTTP header validation, enabling <xref:System.Net.Http.SocketsHttpHandler> to send ISO-8859-1 (Latin-1) encoded characters in headers.
+
+- If you omit this setting, an attempt to send a non-ASCII character will result in <xref:System.Net.Http.HttpRequestException>. This is equivalent to setting the value to `false`.
+
+
+| | Setting name | Values |
+| - | - | - |
+| **runtimeconfig.json** | `System.Net.Http.SocketsHttpHandler.AllowLatin1Headers` | `false` - disabled<br/>`true` - enabled |
+| **Environment variable** | `DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS` | `0` - disabled<br/>`1` - enabled |
+
+> [!NOTE]
+> This option is only available in .NET Core 3.1 since version 3.1.9, and not in previous or later versions. In .NET 5 we recommend using <xref:System.Net.Http.SocketsHttpHandler.RequestHeaderEncodingSelector>.

--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -40,7 +40,7 @@ ms.topic: reference
 > [!NOTE]
 > Starting in .NET 5, the `System.Net.Http.UseSocketsHttpHandler` setting is no longer available.
 
-## Allow sending Latin1 headers in .NET Core 3.1
+## Latin1 headers (.NET Core 3.1 only)
 
 - This switch allows relaxing the HTTP header validation, enabling <xref:System.Net.Http.SocketsHttpHandler> to send ISO-8859-1 (Latin-1) encoded characters in headers.
 


### PR DESCRIPTION
## Fixes 2 issues:

1. HTTP/2 is enabled by default since 3.1, the docs did not reflect this change
2. Document the `AllowLatin1Headers` switch introduced in dotnet/corefx#42978