### PR TITLE
Update dotnet-new.md - allowed values for type parameter are project and item only

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -135,7 +135,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
 - **`--type <TYPE>`**
 
-  Filters templates based on available types. Predefined values are `project`, `item`, and `other`.
+  Filters templates based on available types. Predefined values are `project` and `item`.
 
 - **`-u|--uninstall [PATH|NUGET_ID]`**
 


### PR DESCRIPTION

## Summary
Visual Studio supports only "project" and "item" type, and the field is mandatory. 
We agreed to:
- make type property required and limit allowed values to "project and "item" in template.json schema which is used for template authoring - will be applied both for templates for dotnet new and Visual Studio
- usage of other types is not recommended, therefore suggesting to remove "other" as option suggested in documentation.

Related to: https://github.com/dotnet/templating/issues/2586 
