### PR TITLE
Add enumconstraint_CSharpKeyword

### DIFF
--- a/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
+++ b/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
@@ -8,6 +8,7 @@ f1_keywords:
   - "whereconstraint_CSharpKeyword"
   - "classconstraint_CSharpKeyword"
   - "structconstraint_CSharpKeyword"
+  - "enumconstraint_CSharpKeyword"
 helpviewer_keywords:
   - "where (generic type constraint) [C#]"
 ---


### PR DESCRIPTION
## Summary

This PR adds an f1_keyword for the generic where clause context of the `enum` keyword.  This allows the F1 help to route to this usage of the keyword, rather than always routing to the class declaration page.

Fixes part of #20799, Roslyn changes under dotnet/roslyn#TBD.

