### PR TITLE
Add using-statement F1 keyword

### DIFF
--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -2,6 +2,8 @@
 description: "using directive - C# Reference"
 title: "using directive - C# Reference"
 ms.date: 07/20/2015
+f1_keywords: 
+  - "using_CSharpKeyword"
 helpviewer_keywords:
   - "using directive [C#]"
 ms.assetid: b42b8e61-5e7e-439c-bb71-370094b44ae8

--- a/docs/csharp/language-reference/keywords/using-statement.md
+++ b/docs/csharp/language-reference/keywords/using-statement.md
@@ -2,6 +2,8 @@
 description: "using statement - C# Reference"
 title: "using statement - C# Reference"
 ms.date: 05/29/2020
+f1_keywords:
+  - "using-statement_CSharpKeyword"
 helpviewer_keywords:
   - "using statement [C#]"
 ms.assetid: afc355e6-f0b9-4240-94dd-0d93f17d9fc3

--- a/docs/csharp/language-reference/keywords/using.md
+++ b/docs/csharp/language-reference/keywords/using.md
@@ -3,7 +3,6 @@ description: "using keyword - C# Reference"
 title: "using keyword - C# Reference"
 ms.date: 04/05/2019
 f1_keywords: 
-  - "using_CSharpKeyword"
   - "using"
 helpviewer_keywords: 
   - "using keyword [C#]"


### PR DESCRIPTION
## Summary

This PR adds an f1_keyword for the using-statement context of the `using` keyword and moves the default `using` keyword to the `using-directive` page.  This allows the F1 help to route this keyword to pages more specific to the context in which it is being used.

Fixes part of #20799, Roslyn changes under dotnet/roslyn#48898.