### PR TITLE
Format headers of threat classes in  wcf security considerations for data doc

### DIFF
--- a/docs/framework/wcf/feature-details/security-considerations-for-data.md
+++ b/docs/framework/wcf/feature-details/security-considerations-for-data.md
@@ -9,19 +9,19 @@ ms.assetid: a7eb98da-4a93-4692-8b59-9d670c79ffb2
 
 # Security Considerations for Data
 
-When dealing with data in Windows Communication Foundation (WCF), you must consider a number of threat categories. The following table lists the most important threat classes that relate to data processing. WCF provides tools to mitigate these threats.
+When dealing with data in Windows Communication Foundation (WCF), you must consider a number of threat categories. The following list shows the most important threat classes that relate to data processing. WCF provides tools to mitigate these threats.
 
-**Denial of service**
+* Denial of service
 
-When receiving untrusted data, the data may cause the receiving side to access a disproportionate amount of various resources, such as memory, threads, available connections, or processor cycles by causing lengthy computations. A denial-of-service attack against a server may cause it to crash and be unable to process messages from other, legitimate clients.
+  When receiving untrusted data, the data may cause the receiving side to access a disproportionate amount of various resources, such as memory, threads, available connections, or processor cycles by causing lengthy computations. A denial-of-service attack against a server may cause it to crash and be unable to process messages from other, legitimate clients.
 
-**Malicious code execution**
+* Malicious code execution
 
-Incoming untrusted data causes the receiving side to run code it did not intend to.
+  Incoming untrusted data causes the receiving side to run code it did not intend to.
 
-**Information disclosure**
+* Information disclosure
 
-The remote attacker forces the receiving party to respond to its requests in such a way as to disclose more information than it intends to.
+  The remote attacker forces the receiving party to respond to its requests in such a way as to disclose more information than it intends to.
 
 ## User-Provided Code and Code Access Security
 

--- a/docs/framework/wcf/feature-details/security-considerations-for-data.md
+++ b/docs/framework/wcf/feature-details/security-considerations-for-data.md
@@ -11,13 +11,16 @@ ms.assetid: a7eb98da-4a93-4692-8b59-9d670c79ffb2
 
 When dealing with data in Windows Communication Foundation (WCF), you must consider a number of threat categories. The following table lists the most important threat classes that relate to data processing. WCF provides tools to mitigate these threats.
 
-Denial of service
+**Denial of service**
+
 When receiving untrusted data, the data may cause the receiving side to access a disproportionate amount of various resources, such as memory, threads, available connections, or processor cycles by causing lengthy computations. A denial-of-service attack against a server may cause it to crash and be unable to process messages from other, legitimate clients.
 
-Malicious code execution
+**Malicious code execution**
+
 Incoming untrusted data causes the receiving side to run code it did not intend to.
 
-Information disclosure
+**Information disclosure**
+
 The remote attacker forces the receiving party to respond to its requests in such a way as to disclose more information than it intends to.
 
 ## User-Provided Code and Code Access Security


### PR DESCRIPTION
This section previously looked like this:

![security_considerations_data](https://user-images.githubusercontent.com/9868994/97196409-ad370080-1769-11eb-9bcb-9ebb29f7d6fa.PNG)
