### PR TITLE
Notes for including SSL dependencies

### DIFF
--- a/docs/core/deploying/trim-self-contained.md
+++ b/docs/core/deploying/trim-self-contained.md
@@ -32,6 +32,39 @@ When the code is indirectly referencing an assembly through reflection, you can 
 </ItemGroup>
 ```
 
+### Support for SSL Certificates
+
+Suppose one of the scenarios is to load SSL certificates within an ASP.Net Core app.  We want to ensure that when trimming we also prevent trimming assemblies that will help with loading SSL certificates.
+
+We can update our project file to include the following for ASP.Net Core 3.1:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>...</PropertyGroup>
+  <!--Include the following for .aspnetcore 3.1-->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="System.Net" />
+    <TrimmerRootAssembly Include="System.Net.Security" />
+    <TrimmerRootAssembly Include="System.Security" />
+  </ItemGroup>
+  ...
+</Project>
+```
+
+If we're using .Net 5.0, we can update our project file to include the following:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+ <PropertyGroup>...</PropertyGroup>
+ <!--Include the following for .net 5.0-->
+ <ItemGroup>
+    <TrimmerRootAssembly Include="System.Net.Security" />
+    <TrimmerRootAssembly Include="System.Security" />
+  </ItemGroup>
+  ...
+</Project>
+```
+
 ## Trim your app - CLI
 
 Trim your application using the [dotnet publish](../tools/dotnet-publish.md) command. When you publish your app, set the following properties:

--- a/docs/core/deploying/trim-self-contained.md
+++ b/docs/core/deploying/trim-self-contained.md
@@ -32,9 +32,9 @@ When the code is indirectly referencing an assembly through reflection, you can 
 </ItemGroup>
 ```
 
-### Support for SSL Certificates
+### Support for SSL certificates
 
-Suppose one of the scenarios is to load SSL certificates within an ASP.NET Core app.  We want to ensure that when trimming we also prevent trimming assemblies that will help with loading SSL certificates.
+If your app loads SSL certificates, such as in an ASP.NET Core app, you'll want to ensure that when trimming you prevent trimming assemblies that will help with loading SSL certificates.
 
 We can update our project file to include the following for ASP.NET Core 3.1:
 

--- a/docs/core/deploying/trim-self-contained.md
+++ b/docs/core/deploying/trim-self-contained.md
@@ -34,9 +34,9 @@ When the code is indirectly referencing an assembly through reflection, you can 
 
 ### Support for SSL Certificates
 
-Suppose one of the scenarios is to load SSL certificates within an ASP.Net Core app.  We want to ensure that when trimming we also prevent trimming assemblies that will help with loading SSL certificates.
+Suppose one of the scenarios is to load SSL certificates within an ASP.NET Core app.  We want to ensure that when trimming we also prevent trimming assemblies that will help with loading SSL certificates.
 
-We can update our project file to include the following for ASP.Net Core 3.1:
+We can update our project file to include the following for ASP.NET Core 3.1:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.Web">


### PR DESCRIPTION
## Summary

These are notes to prevent trimming SSL dependencies with .netcore 3.1 / .net 5.0 apps.

