### PR TITLE
add link to new .NET learning path

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -34,7 +34,15 @@ highlightedContent:
     # Card
     - title: "Create your first web app."
       itemType: learn
-      url: https://dotnet.microsoft.com/learn/aspnet/hello-world-tutorial/intro
+      url: /learn/aspnet/hello-world-tutorial/intro
+    # Card
+    - title: "Build .NET applications with C#"
+      itemType: learn
+      url: /learn/paths/build-dotnet-applications-csharp/
+    # Card
+    - title: "Browse all .NET Learning paths and modules"
+      itemType: learn
+      url: /learn/dotnet/
     # Card
     - title: "What's new in .NET docs"
       itemType: whats-new


### PR DESCRIPTION
Add link to the new .NET Application learning path.

Add another link to the .NET homepage for all Learn content.

Fix one other learn link to be a relative link
