### PR TITLE
Updates github actions to use commits instead of tags

### DIFF
--- a/.github/workflows/bcnotify.yaml
+++ b/.github/workflows/bcnotify.yaml
@@ -7,8 +7,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: timheuer/issue-notifier@v1.0.2
+    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
+    - uses: timheuer/issue-notifier@84b8e0081c0abce88ac2673f1f3ad8529a040586 #@v1.0.2
       env:
         SENDGRID_API_KEY: ${{ secrets.SENDGRID_API }}
       with:

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -35,7 +35,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
 
     # Get the latest preview SDK (or sdk not installed by the runner)
     - name: Setup .NET Core SDK Preview
@@ -61,7 +61,7 @@ jobs:
         
     # Update build output json file
     - name: Upload build results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 #@v1
       with:
         name: build
         path: ./output.json

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d #@v1
       with:
         node-version: 12.x
     - name: Run Markdownlint


### PR DESCRIPTION
It's possible that an action being referenced gets updated and malicious code entered into it. Because we generally reference actions by tags, the owner of a github repository can replace the tag with any commit. Instead of referencing tags, we should reference the commit. This way the codebase cannot change from under us.