### PR TITLE
Move alternatives out of String.Split ref

### DIFF
--- a/docs/csharp/how-to/parse-strings-using-split.md
+++ b/docs/csharp/how-to/parse-strings-using-split.md
@@ -2,7 +2,7 @@
 title: "Parse strings using String.Split (C# Guide)"
 description: The Split method returns an array of strings split from a set of delimiters. It's an easy way to parse strings.
 ms.date: 01/03/2018
-helpviewer_keywords: 
+helpviewer_keywords:
   - "splitting strings [C#]"
   - "Split method [C#]"
   - "strings [C#], splitting"
@@ -53,6 +53,7 @@ Consecutive instances of any separator produce the empty string in the output ar
 
 ## See also
 
+- [Extract elements from a string](../../standard/base-types/parse-strings.md)
 - [C# programming guide](../programming-guide/index.md)
 - [Strings](../programming-guide/strings/index.md)
 - [.NET regular expressions](../../standard/base-types/regular-expressions.md)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1442,7 +1442,7 @@ items:
         href: ../standard/base-types/comparing.md
       - name: Change case
         href: ../standard/base-types/changing-case.md
-      - name: Break strings up
+      - name: Extract elements from a string
         href: ../standard/base-types/parse-strings.md
       - name: Use the StringBuilder class
         href: ../standard/base-types/stringbuilder.md

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1442,6 +1442,8 @@ items:
         href: ../standard/base-types/comparing.md
       - name: Change case
         href: ../standard/base-types/changing-case.md
+      - name: Break strings up
+        href: ../standard/base-types/parse-strings.md
       - name: Use the StringBuilder class
         href: ../standard/base-types/stringbuilder.md
       - name: "How to: Perform basic string manipulations"

--- a/docs/standard/base-types/basic-manipulations.md
+++ b/docs/standard/base-types/basic-manipulations.md
@@ -3,26 +3,26 @@ title: Basic String Manipulations in .NET
 description: See an example that calls many string methods.
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "strings [.NET], examples"
 ms.assetid: 121d1eae-251b-44c0-8818-57da04b8215e
 ---
 # How to: Perform Basic String Manipulations in .NET
 
-The following example uses some of the methods discussed in the [Basic String Operations](basic-string-operations.md) topics to construct a class that performs string manipulations in a manner that might be found in a real-world application. The `MailToData` class stores the name and address of an individual in separate properties and provides a way to combine the `City`, `State`, and `Zip` fields into a single string for display to the user. Furthermore, the class allows the user to enter the city, state, and ZIP Code information as a single string; the application automatically parses the single string and enters the proper information into the corresponding property.  
-  
-For simplicity, this example uses a console application with a command-line interface.  
-  
-## Example  
+The following example uses some of the methods discussed in the [Basic String Operations](basic-string-operations.md) topics to construct a class that performs string manipulations in a manner that might be found in a real-world application. The `MailToData` class stores the name and address of an individual in separate properties and provides a way to combine the `City`, `State`, and `Zip` fields into a single string for display to the user. Furthermore, the class allows the user to enter the city, state, and zip code information as a single string. The application automatically parses the single string and enters the proper information into the corresponding property.
+
+For simplicity, this example uses a console application with a command-line interface.
+
+## Example
 
 [!code-csharp[Conceptual.String.BasicOps#1](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.string.basicops/cs/basicops.cs#1)]
-[!code-vb[Conceptual.String.BasicOps#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.string.basicops/vb/basicops.vb#1)]  
-  
-When the preceding code is executed, the user is asked to enter their name and address. The application places the information in the appropriate properties and displays the information back to the user, creating a single string that displays the city, state, and ZIP Code information.  
-  
+[!code-vb[Conceptual.String.BasicOps#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.string.basicops/vb/basicops.vb#1)]
+
+When the preceding code is executed, the user is asked to enter their name and address. The application places the information in the appropriate properties and displays the information back to the user, creating a single string that displays the city, state, and zip code information.
+
 ## See also
 
 - [Basic String Operations](basic-string-operations.md)

--- a/docs/standard/base-types/basic-string-operations.md
+++ b/docs/standard/base-types/basic-string-operations.md
@@ -3,7 +3,7 @@ title: Basic String Operations in .NET
 description: Learn about the basic operations that you can perform on strings.
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
-helpviewer_keywords: 
+helpviewer_keywords:
   - "strings [.NET], basic string operations"
   - "custom strings"
 ms.assetid: 8133d357-90b5-4b62-9927-43323d99b6b6
@@ -18,7 +18,7 @@ Several methods in the <xref:System.String?displayProperty=nameWithType> and <xr
 ## Related sections
 
 [Type Conversion in .NET](type-conversion.md)\
-Describes how to convert one type into another type.  
+Describes how to convert one type into another type.
 
 [Formatting Types](formatting-types.md)\
 Describes how to format strings using format specifiers.

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -36,7 +36,7 @@ The periods are gone from the substrings, but now two extra empty substrings hav
 
 ## Regular expressions
 
-If your string conforms to a fixed pattern, you can use a regular expression to extract and handle its elements. For example, if strings take the form "*number* *operand* *number*", you can use a [regular expression](/dotnet/standard/base-types/regular-expressions) to extract and handle the string's elements. Here's an example:
+If your string conforms to a fixed pattern, you can use a regular expression to extract and handle its elements. For example, if strings take the form "*number* *operand* *number*", you can use a [regular expression](regular-expressions.md) to extract and handle the string's elements. Here's an example:
 
 :::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="1" interactive="try-dotnet":::
 :::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="1":::

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -17,19 +17,22 @@ This article covers some different techniques for extracting parts of a string.
 
 <xref:System.String.Split%2A?displayProperty=nameWithType> provides a handful of overloads to help you break up a string into a group of substrings based on one or more delimiting characters that you specify. You can choose to limit the total number of substrings in the final result, trim white-space characters from substrings, or exclude empty substrings.
 
-The following examples show three different overloads of `String.Split()`. The first example calls the <xref:System.String.Split(System.Char[])> overload and passes in a single delimiting character.
+The following examples show three different overloads of `String.Split()`. The first example calls the <xref:System.String.Split(System.Char[])> overload without passing any separator characters. When you don't specify any delimiting characters, `String.Split()` uses default delimiters, which are white-space characters, to split up the string.
 
 [!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#1)]
+:::code language="vb" source="snippets/parse-strings/vb/intro.vb" id="1":::
 
 As you can see, the period characters (`.`) are included in two of the substrings. If you want to exclude the period characters, you can add the period character as an additional delimiting character. The next example shows how to do this.
 
 [!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#2)]
+:::code language="vb" source="snippets/parse-strings/vb/intro.vb" id="2":::
 
 The periods are gone from the substrings, but now two extra empty substrings have been included. These empty substring represent the substring between the word and the period that follows it. To omit empty substrings from the resulting array, you can call the
 <xref:System.String.Split(System.Char[],System.StringSplitOptions)> overload and specify
 <xref:System.StringSplitOptions.RemoveEmptyEntries?displayProperty=nameWithType> for the `options` parameter.
 
 [!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#3)]
+:::code language="vb" source="snippets/parse-strings/vb/intro.vb" id="3":::
 
 ## Regular expressions
 
@@ -105,3 +108,11 @@ The following example uses the <xref:System.String.IndexOf%2A> method to find th
 
 :::code language="csharp" source="snippets/parse-strings/csharp/indexof.cs" id="1" interactive="try-dotnet":::
 :::code language="vb" source="snippets/parse-strings/vb/indexof.vb" id="1":::
+
+## See also
+
+- [Basic string operations in .NET](basic-string-operations.md)
+- [.NET regular expressions](regular-expressions.md)
+- <xref:System.String.Split%2A?displayProperty=nameWithType>
+- <xref:System.String.IndexOf%2A?displayProperty=nameWithType>
+- <xref:System.String.Substring%2A?displayProperty=nameWithType>

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -113,6 +113,4 @@ The following example uses the <xref:System.String.IndexOf%2A> method to find th
 
 - [Basic string operations in .NET](basic-string-operations.md)
 - [.NET regular expressions](regular-expressions.md)
-- <xref:System.String.Split%2A?displayProperty=nameWithType>
-- <xref:System.String.IndexOf%2A?displayProperty=nameWithType>
-- <xref:System.String.Substring%2A?displayProperty=nameWithType>
+- [How to parse strings using String.Split in C#](../../csharp/how-to/parse-strings-using-split.md)

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -17,7 +17,7 @@ This article covers some different techniques for extracting parts of a string.
 
 <xref:System.String.Split%2A?displayProperty=nameWithType> provides a handful of overloads to help you break up a string into a group of substrings based on one or more delimiting characters that you specify. You can choose to limit the total number of substrings in the final result, trim white-space characters from substrings, or exclude empty substrings.
 
-The following examples show three different overloads of `String.Split()`. The first example calls the <xref:System.String.Split(System.Char[])> overload and passes in a single delimiter.
+The following examples show three different overloads of `String.Split()`. The first example calls the <xref:System.String.Split(System.Char[])> overload and passes in a single delimiting character.
 
 [!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#1)]
 
@@ -25,7 +25,7 @@ As you can see, the period characters (`.`) are included in two of the substring
 
 [!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#2)]
 
-The periods are gone from the substrings, but now two extra empty substrings have been included. These empty substring represent the substring between a word and the period that follows it. To omit empty substrings from the resulting array, you can call the
+The periods are gone from the substrings, but now two extra empty substrings have been included. These empty substring represent the substring between the word and the period that follows it. To omit empty substrings from the resulting array, you can call the
 <xref:System.String.Split(System.Char[],System.StringSplitOptions)> overload and specify
 <xref:System.StringSplitOptions.RemoveEmptyEntries?displayProperty=nameWithType> for the `options` parameter.
 
@@ -33,10 +33,10 @@ The periods are gone from the substrings, but now two extra empty substrings hav
 
 ## Regular expressions
 
-If your strings conform to a fixed pattern, you can use a regular expression to extract and handle their elements. For example, if strings take the form "*number* *operand* *number*" you can use a [regular expression](/dotnet/standard/base-types/regular-expressions) to extract and handle the string's elements. Here's an example:
+If your string conforms to a fixed pattern, you can use a regular expression to extract and handle its elements. For example, if strings take the form "*number* *operand* *number*", you can use a [regular expression](/dotnet/standard/base-types/regular-expressions) to extract and handle the string's elements. Here's an example:
 
-:::code language="csharp" source="snippets/parse-strings/regex.cs" id="1" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/regex.vb" id="1":::
+:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="1" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/vb/regex.vb" id="1":::
 
 The regular expression pattern `(\d+)\s+([-+*/])\s+(\d+)` is defined like this:
 
@@ -50,11 +50,11 @@ The regular expression pattern `(\d+)\s+([-+*/])\s+(\d+)` is defined like this:
 
 You can also use a regular expression to extract substrings from a string based on a pattern rather than a fixed set of characters. This is a common scenario when either of these conditions occurs:
 
-- One or more of the delimiter characters does not always serve as a delimiter in the <xref:System.String> instance.
+- One or more of the delimiter characters does not *always* serve as a delimiter in the <xref:System.String> instance.
 
 - The sequence and number of delimiter characters is variable or unknown.
 
-For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (in C#) or `vbCrLf` (in Visual Basic) characters is variable, and they don't always serve as delimiters.
+For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (newline) characters is variable, and they don't always serve as delimiters.
 
 ```text
 [This is captured\ntext.]\n\n[\n[This is more captured text.]\n]
@@ -63,8 +63,8 @@ For example, the <xref:System.String.Split%2A> method cannot be used to split th
 
 A regular expression can split this string easily, as the following example shows.
 
-:::code language="csharp" source="snippets/parse-strings/regex.cs" id="2" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/regex.vb" id="2":::
+:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="2" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/vb/regex.vb" id="2":::
 
 The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
 
@@ -76,8 +76,8 @@ The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
 
 The <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method is almost identical to <xref:System.String.Split%2A?displayProperty=nameWithType>, except that it splits a string based on a regular expression pattern instead of a fixed character set. For example, the following example uses the <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method to split a string that contains substrings delimited by various combinations of hyphens and other characters.
 
-:::code language="csharp" source="snippets/parse-strings/regex.cs" id="3" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/regex.vb" id="3":::
+:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="3" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/vb/regex.vb" id="3":::
 
 The regular expression pattern `\s-\s?[+*]?\s?-\s` is defined like this:
 
@@ -89,7 +89,7 @@ The regular expression pattern `\s-\s?[+*]?\s?-\s` is defined like this:
 |`\s?`|Match zero or one white-space character.|
 |`-\s`|Match a hyphen followed by a white-space character.|
 
-## Search methods and the Substring method
+## String.IndexOf and String.Substring methods
 
 If you aren't interested in all of the substrings in a string, you might prefer to work with one of the string comparison methods that returns the index at which the match begins. You can then call the <xref:System.String.Substring%2A> method to extract the substring that you want. The string comparison methods include:
 
@@ -103,5 +103,5 @@ If you aren't interested in all of the substrings in a string, you might prefer 
 
 The following example uses the <xref:System.String.IndexOf%2A> method to find the periods in a string. It then uses the <xref:System.String.Substring%2A> method to return full sentences.
 
-:::code language="csharp" source="snippets/parse-strings/indexof.cs" id="1" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/indexof.vb" id="1":::
+:::code language="csharp" source="snippets/parse-strings/csharp/indexof.cs" id="1" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/vb/indexof.vb" id="1":::

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -13,6 +13,10 @@ helpviewer_keywords:
 
 This article covers some different techniques for extracting parts of a string.
 
+- Use the [Split method](#stringsplit-method) when the substrings you want are separated by a known delimiting character (or characters).
+- [Regular expressions](#regular-expressions) are useful when the string conforms to a fixed pattern.
+- Use the [IndexOf and Substring methods](#stringindexof-and-stringsubstring-methods) in conjunction when you don't want to extract *all* of the substrings in a string.
+
 ## String.Split method
 
 <xref:System.String.Split%2A?displayProperty=nameWithType> provides a handful of overloads to help you break up a string into a group of substrings based on one or more delimiting characters that you specify. You can choose to limit the total number of substrings in the final result, trim white-space characters from substrings, or exclude empty substrings.

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -1,0 +1,107 @@
+---
+title: String parsing techniques in .NET
+description: Learn about different techniques to extract parts of a string, including String.Split, regular expressions, and String.Substring.
+ms.date: 10/30/2020
+ms.technology: dotnet-standard
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "strings [.NET], breaking up"
+---
+# Extract elements from a string
+
+This article covers some different techniques for extracting parts of a string.
+
+## String.Split method
+
+<xref:System.String.Split%2A?displayProperty=nameWithType> provides a handful of overloads to help you break up a string into a group of substrings based on one or more delimiting characters that you specify. You can choose to limit the total number of substrings in the final result, trim white-space characters from substrings, or exclude empty substrings.
+
+The following examples show three different overloads of `String.Split()`. The first example calls the <xref:System.String.Split(System.Char[])> overload and passes in a single delimiter.
+
+[!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#1)]
+
+As you can see, the period characters (`.`) are included in two of the substrings. If you want to exclude the period characters, you can add the period character as an additional delimiting character. The next example shows how to do this.
+
+[!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#2)]
+
+The periods are gone from the substrings, but now two extra empty substrings have been included. These empty substring represent the substring between a word and the period that follows it. To omit empty substrings from the resulting array, you can call the
+<xref:System.String.Split(System.Char[],System.StringSplitOptions)> overload and specify
+<xref:System.StringSplitOptions.RemoveEmptyEntries?displayProperty=nameWithType> for the `options` parameter.
+
+[!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#3)]
+
+## Regular expressions
+
+If your strings conform to a fixed pattern, you can use a regular expression to extract and handle their elements. For example, if strings take the form "*number* *operand* *number*" you can use a [regular expression](/dotnet/standard/base-types/regular-expressions) to extract and handle the string's elements. Here's an example:
+
+:::code language="csharp" source="snippets/parse-strings/regex.cs" id="1" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/regex.vb" id="1":::
+
+The regular expression pattern `(\d+)\s+([-+*/])\s+(\d+)` is defined like this:
+
+|Pattern|Description|
+|-------------|-----------------|
+|`(\d+)`|Match one or more decimal digits. This is the first capturing group.|
+|`\s+`|Match one or more white-space characters.|
+|`([-+*/])`|Match an arithmetic operator sign (+, -, *, or /). This is the second capturing group.|
+|`\s+`|Match one or more white-space characters.|
+|`(\d+)`|Match one or more decimal digits. This is the third capturing group.|
+
+You can also use a regular expression to extract substrings from a string based on a pattern rather than a fixed set of characters. This is a common scenario when either of these conditions occurs:
+
+- One or more of the delimiter characters does not always serve as a delimiter in the <xref:System.String> instance.
+
+- The sequence and number of delimiter characters is variable or unknown.
+
+For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (in C#) or `vbCrLf` (in Visual Basic) characters is variable, and they don't always serve as delimiters.
+
+```text
+[This is captured\ntext.]\n\n[\n[This is more captured text.]\n]
+\n[Some more captured text:\n   Option1\n   Option2][Terse text.]
+```
+
+A regular expression can split this string easily, as the following example shows.
+
+:::code language="csharp" source="snippets/parse-strings/regex.cs" id="2" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/regex.vb" id="2":::
+
+The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
+
+|Pattern|Description|
+|-------------|-----------------|
+|`\[`|Match an opening bracket.|
+|`([^\[\]]+)`|Match any character that is not an opening or a closing bracket one or more times. This is the first capturing group.|
+|`\]`|Match a closing bracket.|
+
+The <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method is almost identical to <xref:System.String.Split%2A?displayProperty=nameWithType>, except that it splits a string based on a regular expression pattern instead of a fixed character set. For example, the following example uses the <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method to split a string that contains substrings delimited by various combinations of hyphens and other characters.
+
+:::code language="csharp" source="snippets/parse-strings/regex.cs" id="3" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/regex.vb" id="3":::
+
+The regular expression pattern `\s-\s?[+*]?\s?-\s` is defined like this:
+
+|Pattern|Description|
+|-------------|-----------------|
+|`\s-`|Match a white-space character followed by a hyphen.|
+|`\s?`|Match zero or one white-space character.|
+|`[+*]?`|Match zero or one occurrence of either the + or * character.|
+|`\s?`|Match zero or one white-space character.|
+|`-\s`|Match a hyphen followed by a white-space character.|
+
+## Search methods and the Substring method
+
+If you aren't interested in all of the substrings in a string, you might prefer to work with one of the string comparison methods that returns the index at which the match begins. You can then call the <xref:System.String.Substring%2A> method to extract the substring that you want. The string comparison methods include:
+
+- <xref:System.String.IndexOf%2A>, which returns the zero-based index of the first occurrence of a character or string in a string instance.
+
+- <xref:System.String.IndexOfAny%2A>, which returns the zero-based index in the current string instance of the first occurrence of any character in a character array.
+
+- <xref:System.String.LastIndexOf%2A>, which returns the zero-based index of the last occurrence of a character or string in a string instance.
+
+- <xref:System.String.LastIndexOfAny%2A>, which returns a zero-based index in the current string instance of the last occurrence of any character in a character array.
+
+The following example uses the <xref:System.String.IndexOf%2A> method to find the periods in a string. It then uses the <xref:System.String.Substring%2A> method to return full sentences.
+
+:::code language="csharp" source="snippets/parse-strings/indexof.cs" id="1" interactive="try-dotnet":::
+:::code language="visual-basic" source="snippets/parse-strings/indexof.vb" id="1":::

--- a/docs/standard/base-types/parse-strings.md
+++ b/docs/standard/base-types/parse-strings.md
@@ -36,7 +36,7 @@ The periods are gone from the substrings, but now two extra empty substrings hav
 If your string conforms to a fixed pattern, you can use a regular expression to extract and handle its elements. For example, if strings take the form "*number* *operand* *number*", you can use a [regular expression](/dotnet/standard/base-types/regular-expressions) to extract and handle the string's elements. Here's an example:
 
 :::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="1" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/vb/regex.vb" id="1":::
+:::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="1":::
 
 The regular expression pattern `(\d+)\s+([-+*/])\s+(\d+)` is defined like this:
 
@@ -64,7 +64,7 @@ For example, the <xref:System.String.Split%2A> method cannot be used to split th
 A regular expression can split this string easily, as the following example shows.
 
 :::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="2" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/vb/regex.vb" id="2":::
+:::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="2":::
 
 The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
 
@@ -77,7 +77,7 @@ The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
 The <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method is almost identical to <xref:System.String.Split%2A?displayProperty=nameWithType>, except that it splits a string based on a regular expression pattern instead of a fixed character set. For example, the following example uses the <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method to split a string that contains substrings delimited by various combinations of hyphens and other characters.
 
 :::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="3" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/vb/regex.vb" id="3":::
+:::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="3":::
 
 The regular expression pattern `\s-\s?[+*]?\s?-\s` is defined like this:
 
@@ -104,4 +104,4 @@ If you aren't interested in all of the substrings in a string, you might prefer 
 The following example uses the <xref:System.String.IndexOf%2A> method to find the periods in a string. It then uses the <xref:System.String.Substring%2A> method to return full sentences.
 
 :::code language="csharp" source="snippets/parse-strings/csharp/indexof.cs" id="1" interactive="try-dotnet":::
-:::code language="visual-basic" source="snippets/parse-strings/vb/indexof.vb" id="1":::
+:::code language="vb" source="snippets/parse-strings/vb/indexof.vb" id="1":::

--- a/docs/standard/base-types/snippets/parse-strings/csharp/Program.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/Program.cs
@@ -4,9 +4,9 @@ namespace parse_strings
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
-            Console.WriteLine("Hello World!");
+            Intro.Intro1();
         }
     }
 }

--- a/docs/standard/base-types/snippets/parse-strings/csharp/Program.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace parse_strings
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/docs/standard/base-types/snippets/parse-strings/csharp/indexof.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/indexof.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+public class IndexOfExample
+{
+    public static void Example1()
+    {
+        // <Snippet1>
+        String s = "This is the first sentence in a string. " +
+                       "More sentences will follow. For example, " +
+                       "this is the third sentence. This is the " +
+                       "fourth. And this is the fifth and final " +
+                       "sentence.";
+        var sentences = new List<String>();
+        int start = 0;
+        int position;
+
+        // Extract sentences from the string.
+        do
+        {
+            position = s.IndexOf('.', start);
+            if (position >= 0)
+            {
+                sentences.Add(s.Substring(start, position - start + 1).Trim());
+                start = position + 1;
+            }
+        } while (position > 0);
+
+        // Display the sentences.
+        foreach (var sentence in sentences)
+            Console.WriteLine(sentence);
+
+        // The example displays the following output:
+        //       This is the first sentence in a string.
+        //       More sentences will follow.
+        //       For example, this is the third sentence.
+        //       This is the fourth.
+        //       And this is the fifth and final sentence.
+        // </Snippet1>
+    }
+}

--- a/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
@@ -68,11 +68,11 @@ namespace Split
             // This example produces the following output:
             //
             // Substring: You
-// Substring: win
-// Substring: some
-// Substring: You
-// Substring: lose
-// Substring: some
+            // Substring: win
+            // Substring: some
+            // Substring: You
+            // Substring: lose
+            // Substring: some
             //</snippet3>
         }
     }

--- a/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
@@ -64,6 +64,15 @@ namespace Split
             {
                 Console.WriteLine($"Substring: {sub}");
             }
+
+            // This example produces the following output:
+            //
+            // Substring: You
+// Substring: win
+// Substring: some
+// Substring: You
+// Substring: lose
+// Substring: some
             //</snippet3>
         }
     }

--- a/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
@@ -1,0 +1,70 @@
+﻿using System;
+
+namespace Split
+{
+    class Intro
+    {
+        public static void Intro1()
+        {
+            //<snippet1>
+            string s = "You win some. You lose some.";
+
+            string[] subs = s.Split(' ');
+
+            foreach (var sub in subs)
+            {
+                Console.WriteLine($"Substring: {sub}");
+            }
+
+            // This example produces the following output:
+            //
+            // Substring: You
+            // Substring: win
+            // Substring: some.
+            // Substring: You
+            // Substring: lose
+            // Substring: some.
+            //</snippet1>
+        }
+
+        public static void Intro2()
+        {
+            //<snippet2>
+            string s = "You win some. You lose some.";
+
+            string[] subs = s.Split(' ', '.');
+
+            foreach (var sub in subs)
+            {
+                Console.WriteLine($"Substring: {sub}");
+            }
+
+            // This example produces the following output:
+            //
+            // Substring: You
+            // Substring: win
+            // Substring: some
+            // Substring:
+            // Substring: You
+            // Substring: lose
+            // Substring: some
+            // Substring:
+            //</snippet2>
+        }
+
+        public static void Intro3()
+        {
+            //<snippet3>
+            string s = "You win some. You lose some.";
+            char[] separators = new char[] { ' ', '.' };
+
+            string[] subs = s.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var sub in subs)
+            {
+                Console.WriteLine($"Substring: {sub}");
+            }
+            //</snippet3>
+        }
+    }
+}

--- a/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/intro.cs
@@ -1,79 +1,76 @@
 ﻿using System;
 
-namespace Split
+class Intro
 {
-    class Intro
+    public static void Intro1()
     {
-        public static void Intro1()
+        //<snippet1>
+        string s = "You win some. You lose some.";
+
+        string[] subs = s.Split();
+
+        foreach (string sub in subs)
         {
-            //<snippet1>
-            string s = "You win some. You lose some.";
-
-            string[] subs = s.Split(' ');
-
-            foreach (var sub in subs)
-            {
-                Console.WriteLine($"Substring: {sub}");
-            }
-
-            // This example produces the following output:
-            //
-            // Substring: You
-            // Substring: win
-            // Substring: some.
-            // Substring: You
-            // Substring: lose
-            // Substring: some.
-            //</snippet1>
+            Console.WriteLine($"Substring: {sub}");
         }
 
-        public static void Intro2()
+        // This example produces the following output:
+        //
+        // Substring: You
+        // Substring: win
+        // Substring: some.
+        // Substring: You
+        // Substring: lose
+        // Substring: some.
+        //</snippet1>
+    }
+
+    public static void Intro2()
+    {
+        //<snippet2>
+        string s = "You win some. You lose some.";
+
+        string[] subs = s.Split(' ', '.');
+
+        foreach (string sub in subs)
         {
-            //<snippet2>
-            string s = "You win some. You lose some.";
-
-            string[] subs = s.Split(' ', '.');
-
-            foreach (var sub in subs)
-            {
-                Console.WriteLine($"Substring: {sub}");
-            }
-
-            // This example produces the following output:
-            //
-            // Substring: You
-            // Substring: win
-            // Substring: some
-            // Substring:
-            // Substring: You
-            // Substring: lose
-            // Substring: some
-            // Substring:
-            //</snippet2>
+            Console.WriteLine($"Substring: {sub}");
         }
 
-        public static void Intro3()
+        // This example produces the following output:
+        //
+        // Substring: You
+        // Substring: win
+        // Substring: some
+        // Substring:
+        // Substring: You
+        // Substring: lose
+        // Substring: some
+        // Substring:
+        //</snippet2>
+    }
+
+    public static void Intro3()
+    {
+        //<snippet3>
+        string s = "You win some. You lose some.";
+        char[] separators = new char[] { ' ', '.' };
+
+        string[] subs = s.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (string sub in subs)
         {
-            //<snippet3>
-            string s = "You win some. You lose some.";
-            char[] separators = new char[] { ' ', '.' };
-
-            string[] subs = s.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-
-            foreach (var sub in subs)
-            {
-                Console.WriteLine($"Substring: {sub}");
-            }
-
-            // This example produces the following output:
-            //
-            // Substring: You
-            // Substring: win
-            // Substring: some
-            // Substring: You
-            // Substring: lose
-            // Substring: some
-            //</snippet3>
+            Console.WriteLine($"Substring: {sub}");
         }
+
+        // This example produces the following output:
+        //
+        // Substring: You
+        // Substring: win
+        // Substring: some
+        // Substring: You
+        // Substring: lose
+        // Substring: some
+        //</snippet3>
     }
 }

--- a/docs/standard/base-types/snippets/parse-strings/csharp/parse-strings.csproj
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/parse-strings.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>parse_strings</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/base-types/snippets/parse-strings/csharp/regex.cs
+++ b/docs/standard/base-types/snippets/parse-strings/csharp/regex.cs
@@ -1,0 +1,95 @@
+﻿using System;
+
+public class RegExExamples
+{
+    public static void Example1()
+    {
+        // <Snippet1>
+        String[] expressions = { "16 + 21", "31 * 3", "28 / 3",
+                               "42 - 18", "12 * 7",
+                               "2, 4, 6, 8" };
+        String pattern = @"(\d+)\s+([-+*/])\s+(\d+)";
+
+        foreach (string expression in expressions)
+        {
+            foreach (System.Text.RegularExpressions.Match m in
+            System.Text.RegularExpressions.Regex.Matches(expression, pattern))
+            {
+                int value1 = Int32.Parse(m.Groups[1].Value);
+                int value2 = Int32.Parse(m.Groups[3].Value);
+                switch (m.Groups[2].Value)
+                {
+                    case "+":
+                        Console.WriteLine("{0} = {1}", m.Value, value1 + value2);
+                        break;
+                    case "-":
+                        Console.WriteLine("{0} = {1}", m.Value, value1 - value2);
+                        break;
+                    case "*":
+                        Console.WriteLine("{0} = {1}", m.Value, value1 * value2);
+                        break;
+                    case "/":
+                        Console.WriteLine("{0} = {1:N2}", m.Value, value1 / value2);
+                        break;
+                }
+            }
+        }
+
+        // The example displays the following output:
+        //       16 + 21 = 37
+        //       31 * 3 = 93
+        //       28 / 3 = 9.33
+        //       42 - 18 = 24
+        //       12 * 7 = 84
+        // </Snippet1>
+    }
+
+    public static void Example2()
+    {
+        // <Snippet2>
+        String input = "[This is captured\ntext.]\n\n[\n" +
+                       "[This is more captured text.]\n]\n" +
+                       "[Some more captured text:\n   Option1" +
+                       "\n   Option2][Terse text.]";
+        String pattern = @"\[([^\[\]]+)\]";
+        int ctr = 0;
+
+        foreach (System.Text.RegularExpressions.Match m in
+           System.Text.RegularExpressions.Regex.Matches(input, pattern))
+        {
+            Console.WriteLine("{0}: {1}", ++ctr, m.Groups[1].Value);
+        }
+
+        // The example displays the following output:
+        //       1: This is captured
+        //       text.
+        //       2: This is more captured text.
+        //       3: Some more captured text:
+        //          Option1
+        //          Option2
+        //       4: Terse text.
+        // </Snippet2>
+    }
+
+    public static void Example3()
+    {
+        // <Snippet3>
+        String input = "abacus -- alabaster - * - atrium -+- " +
+                       "any -*- actual - + - armoire - - alarm";
+        String pattern = @"\s-\s?[+*]?\s?-\s";
+        String[] elements = System.Text.RegularExpressions.Regex.Split(input, pattern);
+
+        foreach (string element in elements)
+            Console.WriteLine(element);
+
+        // The example displays the following output:
+        //       abacus
+        //       alabaster
+        //       atrium
+        //       any
+        //       actual
+        //       armoire
+        //       alarm
+        // </Snippet3>
+    }
+}

--- a/docs/standard/base-types/snippets/parse-strings/vb/Program.vb
+++ b/docs/standard/base-types/snippets/parse-strings/vb/Program.vb
@@ -1,0 +1,7 @@
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Console.WriteLine("Hello World!")
+    End Sub
+End Module

--- a/docs/standard/base-types/snippets/parse-strings/vb/Program.vb
+++ b/docs/standard/base-types/snippets/parse-strings/vb/Program.vb
@@ -1,7 +1,9 @@
-Imports System
+﻿Imports System
 
 Module Program
-    Sub Main(args As String())
-        Console.WriteLine("Hello World!")
+    Sub Main()
+        'Intro1()
+        'Intro2()
+        Intro3()
     End Sub
 End Module

--- a/docs/standard/base-types/snippets/parse-strings/vb/indexof.vb
+++ b/docs/standard/base-types/snippets/parse-strings/vb/indexof.vb
@@ -1,0 +1,38 @@
+﻿' Visual Basic .NET Document
+Option Strict On
+
+Module Example
+    Public Sub Example1()
+        ' <Snippet1>
+        Dim input As String = "This is the first sentence in a string. " +
+                            "More sentences will follow. For example, " +
+                            "this is the third sentence. This is the " +
+                            "fourth. And this is the fifth and final " +
+                            "sentence."
+        Dim sentences As New List(Of String)
+        Dim start As Integer = 0
+        Dim position As Integer
+
+        ' Extract sentences from the string.
+        Do
+            position = input.IndexOf("."c, start)
+            If position >= 0 Then
+                sentences.Add(input.Substring(start, position - start + 1).Trim())
+                start = position + 1
+            End If
+        Loop While position > 0
+
+        ' Display the sentences.
+        For Each sentence In sentences
+            Console.WriteLine(sentence)
+        Next
+    End Sub
+
+    ' The example displays the following output:
+    '       This is the first sentence in a string.
+    '       More sentences will follow.
+    '       For example, this is the third sentence.
+    '       This is the fourth.
+    '       And this is the fifth and final sentence.
+    ' </Snippet1>
+End Module

--- a/docs/standard/base-types/snippets/parse-strings/vb/intro.vb
+++ b/docs/standard/base-types/snippets/parse-strings/vb/intro.vb
@@ -1,0 +1,65 @@
+﻿Module IntroExamples
+
+    Sub Intro1()
+        '<snippet1>
+        Dim s As String = "You win some. You lose some."
+        Dim subs As String() = s.Split()
+
+        For Each substring As String In subs
+            Console.WriteLine("Substring: {0}", substring)
+        Next
+
+        ' This example produces the following output:
+        '
+        ' Substring: You
+        ' Substring: win
+        ' Substring: some.
+        ' Substring: You
+        ' Substring: lose
+        ' Substring: some.
+        '</snippet1>
+    End Sub
+
+    Sub Intro2()
+        '<snippet2>
+        Dim s As String = "You win some. You lose some."
+        Dim subs As String() = s.Split(" "c, "."c)
+
+        For Each substring As String In subs
+            Console.WriteLine("Substring: {0}", substring)
+        Next
+
+        ' This example produces the following output:
+        '
+        ' Substring: You
+        ' Substring: win
+        ' Substring: some
+        ' Substring:
+        ' Substring: You
+        ' Substring: lose
+        ' Substring: some
+        ' Substring:
+        '</snippet2>
+    End Sub
+
+    Sub Intro3()
+        '<snippet3>
+        Dim s As String = "You win some. You lose some."
+        Dim separators As Char() = New Char() {" "c, "."c}
+        Dim subs As String() = s.Split(separators, StringSplitOptions.RemoveEmptyEntries)
+
+        For Each substring As String In subs
+            Console.WriteLine("Substring: {0}", substring)
+        Next
+
+        ' This example produces the following output:
+        '
+        ' Substring: You
+        ' Substring: win
+        ' Substring: some
+        ' Substring: You
+        ' Substring: lose
+        ' Substring: some
+        '</snippet3>
+    End Sub
+End Module

--- a/docs/standard/base-types/snippets/parse-strings/vb/parse-strings.vbproj
+++ b/docs/standard/base-types/snippets/parse-strings/vb/parse-strings.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>parse_strings</RootNamespace>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/base-types/snippets/parse-strings/vb/regex.vb
+++ b/docs/standard/base-types/snippets/parse-strings/vb/regex.vb
@@ -1,0 +1,89 @@
+﻿' Visual Basic .NET Document
+Option Strict On
+
+Imports System.Text.RegularExpressions
+
+Module RegExExamples
+    Public Sub Example1()
+        ' <Snippet1>
+        Dim expressions() As String = {"16 + 21", "31 * 3", "28 / 3",
+                                      "42 - 18", "12 * 7",
+                                      "2, 4, 6, 8"}
+
+        Dim pattern As String = "(\d+)\s+([-+*/])\s+(\d+)"
+        For Each expression In expressions
+            For Each m As Match In Regex.Matches(expression, pattern)
+                Dim value1 As Integer = Int32.Parse(m.Groups(1).Value)
+                Dim value2 As Integer = Int32.Parse(m.Groups(3).Value)
+                Select Case m.Groups(2).Value
+                    Case "+"
+                        Console.WriteLine("{0} = {1}", m.Value, value1 + value2)
+                    Case "-"
+                        Console.WriteLine("{0} = {1}", m.Value, value1 - value2)
+                    Case "*"
+                        Console.WriteLine("{0} = {1}", m.Value, value1 * value2)
+                    Case "/"
+                        Console.WriteLine("{0} = {1:N2}", m.Value, value1 / value2)
+                End Select
+            Next
+        Next
+
+        ' The example displays the following output:
+        '       16 + 21 = 37
+        '       31 * 3 = 93
+        '       28 / 3 = 9.33
+        '       42 - 18 = 24
+        '       12 * 7 = 84
+        ' </Snippet1>
+    End Sub
+
+    Public Sub Example2()
+        ' <Snippet2>
+        Dim input As String = String.Format("[This is captured{0}text.]" +
+                                          "{0}{0}[{0}[This is more " +
+                                          "captured text.]{0}{0}" +
+                                          "[Some more captured text:" +
+                                          "{0}   Option1" +
+                                          "{0}   Option2][Terse text.]",
+                                          vbCrLf)
+        Dim pattern As String = "\[([^\[\]]+)\]"
+        Dim ctr As Integer = 0
+        For Each m As Match In Regex.Matches(input, pattern)
+            ctr += 1
+            Console.WriteLine("{0}: {1}", ctr, m.Groups(1).Value)
+        Next
+
+        ' The example displays the following output:
+        '       1: This is captured
+        '       text.
+        '       2: This is more captured text.
+        '       3: Some more captured text:
+        '          Option1
+        '          Option2
+        '       4: Terse text.
+        ' </Snippet2>
+    End Sub
+
+
+    Public Sub Example3()
+        ' <Snippet3>
+        Dim input As String = "abacus -- alabaster - * - atrium -+- " +
+                            "any -*- actual - + - armoir - - alarm"
+        Dim pattern As String = "\s-\s?[+*]?\s?-\s"
+        Dim elements() As String = Regex.Split(input, pattern)
+        For Each element In elements
+            Console.WriteLine(element)
+        Next
+
+        ' The example displays the following output:
+        '       abacus
+        '       alabaster
+        '       atrium
+        '       any
+        '       actual
+        '       armoir
+        '       alarm
+        ' </Snippet3>
+    End Sub
+End Module
+


### PR DESCRIPTION
Contributes to dotnet/dotnet-api-docs#4309.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/standard/base-types/parse-strings?branch=pr-en-us-21288).