### PR TITLE
update .NET Framework to .NET in csharp/languagereferences where applicable

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1685.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1685.md
@@ -12,6 +12,6 @@ ms.assetid: b115dd93-a749-4549-83d3-9cdc92a8ef31
 
 The predefined type 'System.type name' is defined in multiple assemblies in the global alias; using definition from 'File Name'  
   
- This error occurs when a predefined system type such as System.int32 is found in two assemblies. One way this can happen is if you are referencing mscorlib from two different places, such as trying to run the.Net Framework versions 1.0 and 1.1 side-by-side.  
+ This error occurs when a predefined system type such as System.int32 is found in two assemblies. One way this can happen is if you are referencing mscorlib from two different places, such as trying to run the .NET Framework versions 1.0 and 1.1 side-by-side.  
   
  The compiler will use the definition from only one of the assemblies. The compiler searches only global aliases, does not search libraries defined **/reference**. If you have specified **/nostdlib**, the compiler will search for <xref:System.Object>, and in the future start all searches for predefined types in the file where it found <xref:System.Object>.

--- a/docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md
@@ -35,7 +35,7 @@ Specifies that debug information should be placed in a file for later analysis.
   
 - Version information about your compiler, run time, and operating system.  
   
-- Referenced assemblies and modules, saved as hexadecimal digits, except assemblies that ship with the .NET Framework and SDK.  
+- Referenced assemblies and modules, saved as hexadecimal digits, except assemblies that are shipped with the .NET Framework and SDK.  
   
 - Compiler output, if any.  
   

--- a/docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md
@@ -35,7 +35,7 @@ Specifies that debug information should be placed in a file for later analysis.
   
 - Version information about your compiler, run time, and operating system.  
   
-- Referenced assemblies and modules, saved as hexadecimal digits, except assemblies that are shipped with the .NET Framework and SDK.  
+- Referenced assemblies and modules, saved as hexadecimal digits, except assemblies that are shipped with .NET and the .NET SDK.  
   
 - Compiler output, if any.  
   


### PR DESCRIPTION
## Summary

Updating mentions of `.NET Framework` to .`NET` only on csharp/language-reference where applicable. It turns out there are no applicable updates are necessary because many of the doc pages are already mentioning the .NET Framework specifics.

For example, as far as I know existing csharp/language-reference/langversion-compiler-option.md has mentions of .NET Framework but these .NET Framework mentions are correct. Because these mentions are explaining the historical of language features that comes originally from .NET Framework releases.

Also correct minor terms of .Net Framework to .NET and a minor grammar correction.

Fixes #18697 (partially)

@gewarren 
Please review, and if you don't mind could you update the check mark in the issue description of #18697 for csharp/language-reference as completed?
CMIIW, there are no work left on the csharp/language-reference to update from .NET Framework to .NET.
 