### PR TITLE
Enforcing Enum Naming Convention

### DIFF
--- a/docs/csharp/tour-of-csharp/snippets/shared/Types.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/Types.cs
@@ -81,7 +81,7 @@ namespace TourOfCsharp
     // </ImplementInterfaces>
 
     // <EnumDeclaration>
-    public enum SomeRootVegetables
+    public enum SomeRootVegetable
     {
         HorseRadish,
         Radish,


### PR DESCRIPTION
Singular for enum "SomeRootVegetable" and Plural for flags enum "Seasons"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
