### PR TITLE
fix typo in link

### DIFF
--- a/docs/csharp/tutorials/exploration/top-level-statements.md
+++ b/docs/csharp/tutorials/exploration/top-level-statements.md
@@ -204,7 +204,7 @@ Top-level statements can only be in one file, and that file cannot contain names
 
 Finally, you can clean the animation code to remove some duplication:
 
-:::code language="csharp" source="snippets/top-level-statements/Utiliities.cs" ID="Animation":::
+:::code language="csharp" source="snippets/top-level-statements/Utilities.cs" ID="Animation":::
 
 Now you have a complete application, and you've refactored the reusable parts for later use.
 


### PR DESCRIPTION
This fixes the build warning for the missing snippet file.

See https://github.com/dotnet/docs/pull/21259#issuecomment-720675321