### PR TITLE
$rootcert vs $rootCert; Is this intentional, or a mistake?

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
+++ b/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
@@ -47,7 +47,7 @@ Similarly, we save the signed certificate with private key into a PFX file and j
 
 ```powershell
 [String]$testCertPath = Join-Path -Path 'cert:\LocalMachine\My\' -ChildPath "$($testCert.Thumbprint)"
-Export-PfxCertificate -Cert $testCertPath -FilePath testcert.pfx -Password $rootcertPassword
+Export-PfxCertificate -Cert $testCertPath -FilePath testcert.pfx -Password $rootCertPassword
 Export-Certificate -Cert $testCertPath -FilePath testcert.crt
 ```
 

--- a/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
+++ b/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
@@ -23,15 +23,15 @@ When developing a secure service or client using Windows Communication Foundatio
 The following command creates a self-signed certificate with a subject name of "RootCA" in the Current User Personal store.
 
 ```powershell
-$rootcert = New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -DnsName "RootCA" -TextExtension @("2.5.29.19={text}CA=true") -KeyUsage CertSign,CrlSign,DigitalSignature
+$rootCert = New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -DnsName "RootCA" -TextExtension @("2.5.29.19={text}CA=true") -KeyUsage CertSign,CrlSign,DigitalSignature
 ```
 
 We need to export the certificate to a PFX file so that it can be imported to where it's needed in a later step. When exporting a certificate with the private key, a password is needed to protect it. We save the password in a `SecureString` and use the [Export-PfxCertificate](/powershell/module/pkiclient/export-pfxcertificate) cmdlet to export the certificate with the associated private key to a PFX file. We also save just the public certificate into a CRT file using the [Export-Certificate](/powershell/module/pkiclient/export-certificate) cmdlet.
 
 ```powershell
-[System.Security.SecureString]$rootcertPassword = ConvertTo-SecureString -String "password" -Force -AsPlainText
-[String]$rootCertPath = Join-Path -Path 'cert:\CurrentUser\My\' -ChildPath "$($rootcert.Thumbprint)"
-Export-PfxCertificate -Cert $rootCertPath -FilePath 'RootCA.pfx' -Password $rootcertPassword
+[System.Security.SecureString]$rootCertPassword = ConvertTo-SecureString -String "password" -Force -AsPlainText
+[String]$rootCertPath = Join-Path -Path 'cert:\CurrentUser\My\' -ChildPath "$($rootCert.Thumbprint)"
+Export-PfxCertificate -Cert $rootCertPath -FilePath 'RootCA.pfx' -Password $rootCertPassword
 Export-Certificate -Cert $rootCertPath -FilePath 'RootCA.crt'
 ```
 


### PR DESCRIPTION
I was trying to follow the instruction to generate Root CA and Intermediate CA and I noticed the variable name was different ($rootcert and $rootCert). Is it supposed to be different?

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
