### PR TITLE
Publish updated nullable reference type spec

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -64,7 +64,8 @@
           "csharp-8.0/notnull-constraint.md",
           "csharp-8.0/obsolete-accessor.md",
           "csharp-8.0/shadowing-in-nested-functions.md",
-          "csharp-8.0/unconstrained-null-coalescing.md"
+          "csharp-8.0/unconstrained-null-coalescing.md",
+          "csharp-8.0/nullable-reference-types-specification.md"
         ]
       },
       {
@@ -509,7 +510,6 @@
         "_csharplang/proposals/csharp-7.3/improved-overload-candidates.md": "Improved overload candidates",
 
         "_csharplang/proposals/csharp-8.0/nullable-reference-types.md": "Null reference types - proposal",
-        "_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md": "Nullable reference types - specification",
         "_csharplang/proposals/csharp-8.0/patterns.md": "Recursive pattern matching",
         "_csharplang/proposals/csharp-8.0/default-interface-methods.md": "Default interface methods",
         "_csharplang/proposals/csharp-8.0/async-streams.md": "Async streams",
@@ -528,6 +528,7 @@
         "_csharplang/proposals/csharp-9.0/local-function-attributes.md" : "Attributes on local functions",
         "_csharplang/proposals/csharp-9.0/module-initializers.md" : "Module initializers",
         "_csharplang/proposals/csharp-9.0/native-integers.md" : "Native sized integers",
+        "_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md": "Nullable reference types - specification",
         "_csharplang/proposals/csharp-9.0/patterns3.md" : "Pattern matching changes",
         "_csharplang/proposals/csharp-9.0/records.md" : "Records",
         "_csharplang/proposals/csharp-9.0/skip-localsinit.md" : "Surpress emitting localsinit flag",

--- a/docs/csharp/language-reference/proposals/toc.yml
+++ b/docs/csharp/language-reference/proposals/toc.yml
@@ -63,7 +63,7 @@
     - name: Nullable reference types - proposal
       href: ../../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
     - name: Nullable reference types - specification
-      href: ../../../../_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md
+      href: ../../../../_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md
     - name: Recursive pattern matching
       href: ../../../../_csharplang/proposals/csharp-8.0/patterns.md
     - name: Default interface methods
@@ -88,6 +88,8 @@
       href: ../../../../_csharplang/proposals/csharp-9.0/records.md
     - name: Top-level statements
       href: ../../../../_csharplang/proposals/csharp-9.0/top-level-statements.md
+    - name: Nullable reference types - specification
+      href: ../../../../_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md
     - name: Pattern matching enhancements
       href: ../../../../_csharplang/proposals/csharp-9.0/patterns3.md
     - name: Init only setters


### PR DESCRIPTION
See dotnet/csharplang#4100

Move the included specification for nullable reference types to the C# 9 folder.

Update the appropriate title metadata.

Because nullable reference types was a C# 8.0 feature, I am publishing this speclet in both C# 8.0 and C# 9.0.
