### PR TITLE
TextFormatFlags.ModifyStrings is obsolete

### DIFF
--- a/docs/core/compatibility/3.1-5.0.md
+++ b/docs/core/compatibility/3.1-5.0.md
@@ -481,6 +481,7 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 
 ## Windows Forms
 
+- [TextFormatFlags.ModifyString is obsolete](#textformatflagsmodifystring-is-obsolete)
 - [DataGridView no longer resets fonts for customized cell styles](#datagridview-no-longer-resets-fonts-for-customized-cell-styles)
 - [OutputType set to WinExe for WPF and WinForms apps](#outputtype-set-to-winexe-for-wpf-and-winforms-apps)
 - [DataGridView-related APIs now throw InvalidOperationException](#datagridview-related-apis-now-throw-invalidoperationexception)
@@ -489,6 +490,10 @@ If you're migrating from version 3.1 of .NET Core, ASP.NET Core, or EF Core to v
 - [WinForms methods now throw ArgumentException](#winforms-methods-now-throw-argumentexception)
 - [WinForms methods now throw ArgumentNullException](#winforms-methods-now-throw-argumentnullexception)
 - [WinForms properties now throw ArgumentOutOfRangeException](#winforms-properties-now-throw-argumentoutofrangeexception)
+
+[!INCLUDE [modifystring-field-of-textformatflags-obsolete](../../../includes/core-changes/windowsforms/5.0/modifystring-field-of-textformatflags-obsolete.md)]
+
+***
 
 [!INCLUDE [datagridview-doesnt-reset-custom-font-settings](../../../includes/core-changes/windowsforms/5.0/datagridview-doesnt-reset-custom-font-settings.md)]
 

--- a/docs/core/compatibility/winforms.md
+++ b/docs/core/compatibility/winforms.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [TextFormatFlags.ModifyString is obsolete](#textformatflagsmodifystring-is-obsolete) | 5.0 |
 | [DataGridView no longer resets fonts for customized cell styles](#datagridview-no-longer-resets-fonts-for-customized-cell-styles) | 5.0 |
 | [OutputType set to WinExe for WPF and WinForms apps](#outputtype-set-to-winexe-for-wpf-and-winforms-apps) | 5.0 |
 | [DataGridView-related APIs now throw InvalidOperationException](#datagridview-related-apis-now-throw-invalidoperationexception) | 5.0 |
@@ -34,6 +35,10 @@ The following breaking changes are documented on this page:
 | [UseLegacyImages compatibility switch not supported](#uselegacyimages-compatibility-switch-not-supported) | 3.0 |
 
 ## .NET 5.0
+
+[!INCLUDE [modifystring-field-of-textformatflags-obsolete](../../../includes/core-changes/windowsforms/5.0/modifystring-field-of-textformatflags-obsolete.md)]
+
+***
 
 [!INCLUDE [datagridview-doesnt-reset-custom-font-settings](../../../includes/core-changes/windowsforms/5.0/datagridview-doesnt-reset-custom-font-settings.md)]
 

--- a/includes/core-changes/windowsforms/5.0/modifystring-field-of-textformatflags-obsolete.md
+++ b/includes/core-changes/windowsforms/5.0/modifystring-field-of-textformatflags-obsolete.md
@@ -1,6 +1,6 @@
 ### TextFormatFlags.ModifyString is obsolete
 
-The <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=nameWithType> field is obsolete, as warning, and may be removed in a future .NET version.
+The <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=nameWithType> field is obsolete, as a warning, and may be removed in a future .NET version.
 
 #### Change description
 

--- a/includes/core-changes/windowsforms/5.0/modifystring-field-of-textformatflags-obsolete.md
+++ b/includes/core-changes/windowsforms/5.0/modifystring-field-of-textformatflags-obsolete.md
@@ -1,0 +1,35 @@
+### TextFormatFlags.ModifyString is obsolete
+
+The <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=nameWithType> field is obsolete, as warning, and may be removed in a future .NET version.
+
+#### Change description
+
+In previous .NET versions, the <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=nameWithType> enumeration field is not marked obsolete. In .NET 5.0 and later versions, it is marked obsolete as a warning. This field may be removed in a future .NET version.
+
+#### Reason for change
+
+Passing a string to <xref:System.Windows.Forms.TextRenderer.MeasureText%2A?displayProperty=nameWithType> with <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=nameWithType> alters the string in some situations. This behavior breaks the string immutability promise and may lead to a fatal .NET runtime state corruption.
+
+#### Version introduced
+
+.NET 5.0 RC1
+
+#### Recommended action
+
+Update any code that relies on <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=nameWithType>.
+
+#### Category
+
+Windows Forms
+
+#### Affected APIs
+
+- <xref:System.Windows.Forms.TextFormatFlags.ModifyString?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `F:System.Windows.Forms.TextFormatFlags.ModifyString`
+
+-->


### PR DESCRIPTION
Fixes #20804.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/winforms?branch=pr-en-us-21346#textformatflagsmodifystring-is-obsolete).