### PR TITLE
Array initializer can be used in more places

### DIFF
--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -34,7 +34,7 @@ The `new` operator permits the initial values of the array elements to be specif
 
 :::code language="csharp" source="./snippets/shared/Features.cs" ID="InitializeArray":::
 
-The length of the array is inferred from the number of expressions between `{` and `}`. Local variable and field declarations can be shortened further such that the array type doesn't have to be restated.
+The length of the array is inferred from the number of expressions between `{` and `}`. Array initialization can be shortened further such that the array type doesn't have to be restated.
 
 :::code language="csharp" source="./snippets/shared/Features.cs" ID="InitializeShortened":::
 


### PR DESCRIPTION
Array initializer can be used to initialize "auto properties" as well. Specifying that it can be used with "Local variable and field declarations" might not be accurate. Also future versions of C# might add more possibilities(perhaps for method parameter array default value). So I think that saying "Array initialization" covers all current possible use cases and is also future-proof.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
