### PR TITLE
Fix build warning for proposals/csharp-7.0/task-types.md

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -486,6 +486,7 @@
         "_csharplang/proposals/csharp-7.0/throw-expression.md": "Throw expressions",
         "_csharplang/proposals/csharp-7.0/binary-literals.md": "Binary literals",
         "_csharplang/proposals/csharp-7.0/digit-separators.md": "Digit separators",
+        "_csharplang/proposals/csharp-7.0/task-types.md": "Async task types",
 
         "_csharplang/proposals/csharp-7.1/async-main.md": "Async main method",
         "_csharplang/proposals/csharp-7.1/target-typed-default.md": "Default expressions",

--- a/docs/csharp/language-reference/proposals/toc.yml
+++ b/docs/csharp/language-reference/proposals/toc.yml
@@ -14,6 +14,8 @@
       href: ../../../../_csharplang/proposals/csharp-7.0/binary-literals.md
     - name: Digit separators
       href: ../../../../_csharplang/proposals/csharp-7.0/digit-separators.md
+    - name: Async task types
+      href: ../../../../_csharplang/proposals/csharp-7.0/task-types.md
   - name: C# 7.1 specification proposals
     items:
     - name: Async main method


### PR DESCRIPTION
This PR fixes a build warning for not having a title for this file.

The other fix to the warning is to exclude this file in docfx.json.

I'm not sure which fix is the correct/preferred one.

The file was recently added in https://github.com/dotnet/csharplang/pull/4107.