### PR TITLE
Clarify suppressing multiple warnings

### DIFF
--- a/docs/core/compatibility/syslib-obsoletions.md
+++ b/docs/core/compatibility/syslib-obsoletions.md
@@ -59,5 +59,21 @@ Project file:
 </Project>
 ```
 
+If you must suppress several warnings in the project file, you can use a single semicolon-delimited _\<NoWarn\>_ element, or you can include several _\<NoWarn\>_ elements:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   <TargetFramework>net5.0</TargetFramework>
+   <!-- Use a semicolon-delimited list to suppress multiple warnings project-wide -->
+   <NoWarn>$(NoWarn);SYSLIB0001;SYSLIB0002;SYSLIB0003</NoWarn>
+   <!-- Alternatively, use multiple NoWarn elements, each suppressing an individual warning -->
+   <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
+   <NoWarn>$(NoWarn);SYSLIB0002</NoWarn>
+   <NoWarn>$(NoWarn);SYSLIB0003</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
 > [!NOTE]
 > Suppressing a warning in this way only disables that specific obsoletion warning. It doesn't disable any other warnings, including other obsoletion warnings.

--- a/docs/core/compatibility/syslib-obsoletions.md
+++ b/docs/core/compatibility/syslib-obsoletions.md
@@ -55,25 +55,14 @@ Project file:
    <TargetFramework>net5.0</TargetFramework>
    <!-- NoWarn below suppresses SYSLIB0001 project-wide -->
    <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
-  </PropertyGroup>
-</Project>
-```
-
-If you must suppress several warnings in the project file, you can use a single semicolon-delimited _\<NoWarn\>_ element, or you can include several _\<NoWarn\>_ elements:
-
-```xml
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-   <TargetFramework>net5.0</TargetFramework>
-   <!-- Use a semicolon-delimited list to suppress multiple warnings project-wide -->
-   <NoWarn>$(NoWarn);SYSLIB0001;SYSLIB0002;SYSLIB0003</NoWarn>
-   <!-- Alternatively, use multiple NoWarn elements, each suppressing an individual warning -->
-   <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
+   <!-- To suppress multiple warnings, you can use multiple NoWarn elements -->
    <NoWarn>$(NoWarn);SYSLIB0002</NoWarn>
    <NoWarn>$(NoWarn);SYSLIB0003</NoWarn>
+   <!-- Alternatively, you can suppress multiple warnings by using a semicolon-delimited list -->
+   <NoWarn>$(NoWarn);SYSLIB0001;SYSLIB0002;SYSLIB0003</NoWarn>
   </PropertyGroup>
 </Project>
 ```
 
 > [!NOTE]
-> Suppressing a warning in this way only disables that specific obsoletion warning. It doesn't disable any other warnings, including other obsoletion warnings.
+> Suppressing warnings in this way only disables the obsoletion warnings you specify. It doesn't disable any other warnings, including obsoletion warnings with different diagnostic IDs.


### PR DESCRIPTION
## Summary

This clarifies the "suppressing SYSLIBxxxx" section a little bit, showing how to suppress multiple warnings at a time. I anticipate people migrating code may have to suppress multiple warnings as they begin migration, so it'd be useful for them to have an easy example to follow.
