### PR TITLE
Correct the window of when a module initializer runs

### DIFF
--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -238,7 +238,7 @@ A code generator reads attributes or other code elements using the Roslyn analys
 
 The two features added for code generators are extensions to ***partial method syntax***, and ***module initializers***. First, the changes to partial methods. Before C# 9.0, partial methods are `private` but can't specify an access modifier, have a `void` return, and can't have `out` parameters. These restrictions meant that if no method implementation is provided, the compiler removes all calls to the partial method. C# 9.0 removes these restrictions, but requires that partial method declarations have an implementation. Code generators can provide that implementation. To avoid introducing a breaking change, the compiler considers any partial method without an access modifier to follow the old rules. If the partial method includes the `private` access modifier, the new rules govern that partial method.
 
-The second new feature for code generators is ***module initializers***. Module initializers are methods that have the <xref:System.Runtime.CompilerServices.ModuleInitializerAttribute> attribute attached to them. These methods will be called by the runtime when the assembly loads. A module initializer method:
+The second new feature for code generators is ***module initializers***. Module initializers are methods that have the <xref:System.Runtime.CompilerServices.ModuleInitializerAttribute> attribute attached to them. These methods will be called by the runtime before any other field access or method invocation within the entire module. A module initializer method:
 
 - Must be static
 - Must be parameterless


### PR DESCRIPTION
The description of "when an assembly loads" was misleading. The guarantee is similar to a static constructor, but must run before any static constructors in that module.

Fixes #21164
