### PR TITLE
Remove redundant `rec` from function definition in F# tour

### DIFF
--- a/samples/snippets/fsharp/tour.fs
+++ b/samples/snippets/fsharp/tour.fs
@@ -733,7 +733,7 @@ module PatternMatching =
 
     /// Find all managers/executives named "Dave" who do not have any reports.
     /// This uses the 'function' shorthand to as a lambda expression.
-    let rec findDaveWithOpenPosition(emps : List<Employee>) =
+    let findDaveWithOpenPosition(emps : List<Employee>) =
         emps
         |> List.filter(function
                        | Manager({First = "Dave"}, []) -> true // [] matches an empty list.


### PR DESCRIPTION
## Summary

`findDaveWithOpenPosition` does not need `let rec` as its not recursive

