### PR TITLE
Update naming-rules.md

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -66,7 +66,7 @@ dotnet_naming_symbols.types.applicable_accessibilities = public, internal, priva
 
 ## Naming rule properties
 
-All naming rule properties are required.
+All naming rule properties are required for a rule to take effect.
 
 | Property | Description |
 | -- | -- |

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -145,7 +145,7 @@ dotnet_naming_symbols.public_symbols.applicable_kinds           = property,metho
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
 dotnet_naming_symbols.public_symbols.required_modifiers         = readonly
 
-# Defining the `first_word_upper_case_style` naming style 
+# Defining the `first_word_upper_case_style` naming style
 dotnet_naming_style.first_word_upper_case_style.capitalization = first_word_upper
 
 # Defining the `public_members_must_be_capitalized` naming rule, by setting the symbol group to the 'public symbols' symbol group,

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -74,7 +74,7 @@ All naming rule properties are required for a rule to take effect.
 | -- | -- |
 | `symbols` | The title of the symbol group, defining the symbols to which this rule should be applied |
 | `style` | The title of the naming style which should be associated with this rule |
-| `severity` |  Any of the available [severity levels](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#severity-level)<sup>1</sup> |
+| `severity` |  Sets the severity with which to enforce the naming rule. Set the associated value to one of the available [severity levels](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#severity-level).<sup>1</sup> |
 
 **Notes:**
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -105,7 +105,7 @@ You can set the following properties for symbol groups, to limit which symbols a
 
 ## Naming style properties
 
-A naming style defines the conventions we want to enforce with a naming rule. For example:
+A naming style defines the conventions you want to enforce with the rule. For example:
 
 * Capitalize with `PascalCase`
 * Starts with `m_`

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -24,7 +24,7 @@ Naming rules concern the naming of .NET programming language code elements, such
 A naming rule has three parts:
 
 * The group of symbols it applies to.
-* what naming style to associate with the rule, and
+* The naming style to associate with the rule.
 * the severity for enforcing the convention.
 
 ## General syntax

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -102,7 +102,7 @@ You can set the following properties for symbol groups, to limit which symbols a
 
 1. Tuple members aren't currently supported in `applicable_kinds`.
 2. The symbol group matches _all_ the modifiers in the `required_modifiers` property.  If you omit this property, no specific modifiers are required for a match. This means a symbol's modifiers have no effect on whether or not this rule is applied.
-3. If your group has `static` or `shared` in the `required_modifiers` property, the group will also include `const` symbols because they are implicitly `static`/`Shared`. However, you can create a new naming rule with its' own symbol group of `const` symbols.
+3. If your group has `static` or `shared` in the `required_modifiers` property, the group will also include `const` symbols because they are implicitly `static`/`Shared`. However, If you don't want the `static` naming rule to apply to `const` symbols, you can create a new naming rule with a symbol group of `const`.
 
 ## Naming style properties
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -31,7 +31,7 @@ You define naming rules in an EditorConfig file.
 
 ## General syntax
 
-To define a naming rule, symbol group, or naming style, write one or more property settings using the following syntax:
+To define a naming rule, symbol group, or naming style, set one or more properties using the following syntax:
 
 ```none
 <prefix>.<title>.<propertyName> = <propertyValue>
@@ -55,7 +55,7 @@ Each type of definition&mdash;[naming rule](#naming-rule-properties), [symbol gr
 
 ### \<title>
 
-**\<title>** is a descriptive name that you choose that associates multiple property settings into a single definition. For example, the following properties produce two symbol group definitions, `interface` and `types`, each of which has two properties set on it.
+**\<title>** is a descriptive name you choose that associates multiple property settings into a single definition. For example, the following properties produce two symbol group definitions, `interface` and `types`, each of which has two properties set on it.
 
 ```ini
 dotnet_naming_symbols.interface.applicable_kinds = interface

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -63,7 +63,6 @@ dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum, d
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 ```
 
-produces two symbol group definitions -- `interface` and `types` -- each of which has two properties set on it.
 
 ## Naming rule properties
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -27,6 +27,8 @@ A naming rule has three parts:
 * The naming style to associate with the rule.
 * The severity for enforcing the convention.
 
+You define naming rules in an EditorConfig file.
+
 ## General syntax
 
 To define a naming rule, symbol group, or naming style, write one or more property settings with the following syntax:

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -159,7 +159,7 @@ All naming options have rule ID `IDE1006` and title `Naming rule violation`. You
 dotnet_diagnostic.IDE1006.severity = <severity value>
 ```
 
-The value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
+The severity value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -49,7 +49,7 @@ The order of the properties is not important.
 | Naming style | `dotnet_naming_style` | `dotnet_naming_style.pascal_case.capitalization = pascal_case` |
 | Naming rule | `dotnet_naming_rule` | `dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion`
 
-Each type of definition -- [naming rule](#naming-rule-properties), [symbol group](#symbol-group-properties), or [naming style](#style-properties)  -- has its own supported properties, as described below.
+Each type of definition&mdash;[naming rule](#naming-rule-properties), [symbol group](#symbol-group-properties), or [naming style](#naming-style-properties)&mdash;has its own supported properties, as described in the following sections.
 
 ### \<title>
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -37,7 +37,7 @@ To define a naming rule, symbol group, or naming style, write one or more proper
 <prefix>.<title>.<propertyName> = <propertyValue>
 ```
 
-Each property should only be set once, but some settings allow multiple comma-separated values.
+Each property should only be set once, but some settings allow multiple, comma-separated values.
 
 The order of the properties is not important.
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -23,7 +23,7 @@ Naming rules concern the naming of .NET programming language code elements, such
 
 A naming rule has three parts:
 
-* the symbol group -- to which symbols does the rule apply?
+* The group of symbols it applies to.
 * what naming style to associate with the rule, and
 * the severity for enforcing the convention.
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -53,7 +53,7 @@ Each type of definition&mdash;[naming rule](#naming-rule-properties), [symbol gr
 
 ### \<title>
 
-**\<title>** is a descriptive name that you choose, which associates multiple property settings into a single definition. For example, the following:
+**\<title>** is a descriptive name that you choose that associates multiple property settings into a single definition. For example, the following properties produce two naming rule definitions, `interface` and `types`, each of which has two properties set on it.
 
 ```ini
 dotnet_naming_symbols.interface.applicable_kinds = interface

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -25,7 +25,7 @@ A naming rule has three parts:
 
 * The group of symbols it applies to.
 * The naming style to associate with the rule.
-* the severity for enforcing the convention.
+* The severity for enforcing the convention.
 
 ## General syntax
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -43,7 +43,7 @@ The order of the properties is not important.
 
 ### \<prefix>
 
-**\<prefix>** specifies which kind of element is being defined -- naming rule, symbol group, or naming style -- and must be one of the following:
+**\<prefix>** specifies which kind of element is being defined&mdash;naming rule, symbol group, or naming style&mdash;and must be one of the following:
 
 | To set a property for | Use the prefix | Example |
 | --- | --- | -- |

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -31,7 +31,7 @@ You define naming rules in an EditorConfig file.
 
 ## General syntax
 
-To define a naming rule, symbol group, or naming style, write one or more property settings with the following syntax:
+To define a naming rule, symbol group, or naming style, write one or more property settings using the following syntax:
 
 ```none
 <prefix>.<title>.<propertyName> = <propertyValue>
@@ -47,15 +47,15 @@ The order of the properties is not important.
 
 | To set a property for | Use the prefix | Example |
 | --- | --- | -- |
+| Naming rule | `dotnet_naming_rule` | `dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion` |
 | Symbol group | `dotnet_naming_symbols` | `dotnet_naming_symbols.interface.applicable_kinds = interface` |
 | Naming style | `dotnet_naming_style` | `dotnet_naming_style.pascal_case.capitalization = pascal_case` |
-| Naming rule | `dotnet_naming_rule` | `dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion`
 
 Each type of definition&mdash;[naming rule](#naming-rule-properties), [symbol group](#symbol-group-properties), or [naming style](#naming-style-properties)&mdash;has its own supported properties, as described in the following sections.
 
 ### \<title>
 
-**\<title>** is a descriptive name that you choose that associates multiple property settings into a single definition. For example, the following properties produce two naming rule definitions, `interface` and `types`, each of which has two properties set on it.
+**\<title>** is a descriptive name that you choose that associates multiple property settings into a single definition. For example, the following properties produce two symbol group definitions, `interface` and `types`, each of which has two properties set on it.
 
 ```ini
 dotnet_naming_symbols.interface.applicable_kinds = interface
@@ -64,7 +64,6 @@ dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, p
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum, delegate
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 ```
-
 
 ## Naming rule properties
 
@@ -139,16 +138,21 @@ If you don't specify any custom naming rules, the following default styles are u
 The following *.editorconfig* file contains a naming convention that specifies that public properties, methods, fields, events, and delegates must be capitalized. Notice that this naming convention specifies multiple kinds of symbol to apply the rule to, using a comma to separate the values.
 
 ```ini
-# Public members must be capitalized (public_members_must_be_capitalized)
 [*.{cs,vb}]
-dotnet_naming_rule.public_members_must_be_capitalized.symbols   = public_symbols
+
+# Defining the 'public_symbols' symbol group
 dotnet_naming_symbols.public_symbols.applicable_kinds           = property,method,field,event,delegate
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
 dotnet_naming_symbols.public_symbols.required_modifiers         = readonly
 
-dotnet_naming_rule.public_members_must_be_capitalized.style    = first_word_upper_case_style
+# Defining the `first_word_upper_case_style` naming style 
 dotnet_naming_style.first_word_upper_case_style.capitalization = first_word_upper
 
+# Defining the `public_members_must_be_capitalized` naming rule, by setting the symbol group to the 'public symbols' symbol group,
+dotnet_naming_rule.public_members_must_be_capitalized.symbols   = public_symbols
+# setting the naming style to the `first_word_upper_case_style` naming style,
+dotnet_naming_rule.public_members_must_be_capitalized.style    = first_word_upper_case_style
+# and setting the severity.
 dotnet_naming_rule.public_members_must_be_capitalized.severity = suggestion
 ```
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -153,7 +153,7 @@ dotnet_naming_rule.public_members_must_be_capitalized.severity = suggestion
 
 ## <a name="rule-id-ide1006-naming-rule-violation"></a>Rule ID: "IDE1006" (Naming rule violation)
 
-All naming options have rule ID `IDE1006` and title `Naming rule violation`. Severity of naming violations can be configured globally in an EditorConfig file with the following syntax:
+All naming options have rule ID `IDE1006` and title `Naming rule violation`. You can configure the severity of naming violations globally in an EditorConfig file with the following syntax:
 
 ```ini
 dotnet_diagnostic.IDE1006.severity = <severity value>

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -35,7 +35,7 @@ To define a naming rule, symbol group, or naming style, write one or more proper
 <prefix>.<title>.<propertyName> = <propertyValue>
 ```
 
-Each property should only be set once, but some settings allow multiple comma-separated values. 
+Each property should only be set once, but some settings allow multiple comma-separated values.
 
 The order of the properties is not important.
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -21,160 +21,63 @@ helpviewer_keywords:
 
 Naming rules concern the naming of .NET programming language code elements, such as classes, properties, and methods. For example, you can specify that public members must be capitalized or that private fields must begin with `_`.
 
-For each naming rule, you must specify the symbols it applies to, a naming style, and a severity for enforcing the convention, using the properties that follow. The order of the properties is not important.
+A naming rule has three parts:
 
-To begin, choose a title for your naming rule that you will use in each of the properties that are needed to fully describe the rule. For example, `public_members_must_be_capitalized` is a good, descriptive name for a naming rule. This page will refer to the title you choose as **<namingRuleTitle\>** in the sections that follow.
+* the symbol group -- to which symbols does the rule apply?
+* what naming style to associate with the rule, and
+* the severity for enforcing the convention.
 
-## <a name="rule-id-ide1006-naming-rule-violation"></a>Rule ID: "IDE1006" (Naming rule violation)
+## General syntax
 
-All naming options have rule ID `IDE1006` and title `Naming rule violation`. Severity of naming violations can be configured in an EditorConfig file with the following syntax:
+To define a naming rule, symbol group, or naming style, write one or more property settings with the following syntax:
 
-```ini
-dotnet_diagnostic.IDE1006.severity = <severity value>
+```none
+<prefix>.<title>.<propertyName> = <propertyValue>
 ```
 
-The value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
+Each property should only be set once, but some settings allow multiple comma-separated values. 
 
-## Symbols
+The order of the properties is not important.
 
-First, identify a group of symbols to apply the naming rule to. This property has the following format:
+### \<prefix>
 
-`dotnet_naming_rule.<namingRuleTitle>.symbols = <symbolTitle>`
+**\<prefix>** specifies which kind of element is being defined -- naming rule, symbol group, or naming style -- and must be one of the following:
 
-Give a name to the group of symbols by replacing the **<symbolTitle\>** value with a descriptive title, for example `public_symbols`. You'll use the **<symbolTitle\>** value in the three property names that describe which symbols the rule is applied to (kinds of symbol, accessibility levels, and modifiers).
+| To set a property for | Use the prefix | Example |
+| --- | --- | -- |
+| Symbol group | `dotnet_naming_symbols` | `dotnet_naming_symbols.interface.applicable_kinds = interface` |
+| Naming style | `dotnet_naming_style` | `dotnet_naming_style.pascal_case.capitalization = pascal_case` |
+| Naming rule | `dotnet_naming_rule` | `dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion`
 
-### Kinds of symbols
+Each type of definition -- [naming rule](#naming-rule-properties), [symbol group](#symbol-group-properties), or [naming style](#style-properties)  -- has its own supported properties, as described below.
 
-To describe the kind of symbols to apply the naming rule to, specify a property in the following format:
+### \<title>
 
-`dotnet_naming_symbols.<symbolTitle>.applicable_kinds = <values>`
+**\<title>** is a descriptive name that you choose, which associates multiple property settings into a single definition. For example, the following:
 
-The following list shows the allowable values, and you can specify multiple values by separating them with a comma.
+```ini
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 
-- \* (use this value to specify all symbols)
-- namespace
-- class
-- struct
-- interface
-- enum
-- property
-- method
-- field
-- event
-- delegate
-- parameter
-- type_parameter
-- local
-- local_function
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum, delegate
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+```
 
-> [!NOTE]
-> Tuple members aren't currently supported.
+produces two symbol group definitions -- `interface` and `types` -- each of which has two properties set on it.
 
-### Accessibility levels of symbols
+## Naming rule properties
 
-To describe the accessibility levels of the symbols you want the naming rule to apply to, specify a property name in the following format:
+All naming rule properties are required.
 
-`dotnet_naming_symbols.<symbolTitle>.applicable_accessibilities = <values>`
+| Property | Description |
+| -- | -- |
+| `symbols` | The title of the symbol group, defining the symbols to which this rule should be applied |
+| `style` | The title of the naming style which should be associated with this rule |
+| `severity` |  Any of the available [severity levels](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#severity-level)<sup>1</sup> |
 
-The following list shows the allowable values, and you can specify multiple values by separating them with a comma.
+**Notes:**
 
-- \* (use this value to specify all accessibility levels)
-- public
-- internal or friend
-- private
-- protected
-- protected\_internal or protected_friend
-- private\_protected
-- local
-
-   The `local` accessibility level applies to symbols defined within a method. It's useful for defining naming rules for symbols whose accessibility can't be specified in code. For example, if you specify `applicable_accessibilities = local` on a naming convention for constants (`required_modifiers = const`), the rule applies only to constants defined within a method and not those defined in a type.
-
-   ```csharp
-   class TypeName
-   {
-     // Constant defined in a type.
-     const int X = 3;
-
-     void Method()
-     {
-       // Constant defined in a method with "local" accessibility.
-       const int Y = 4;
-     }
-   }
-   ```
-
-### Symbol modifiers (optional)
-
-To describe the modifiers of the symbols you want the naming rule to apply to, specify a property name in the following format:
-
-`dotnet_naming_symbols.<symbolTitle>.required_modifiers = <values>`
-
-The following list shows the allowable values (separate multiple values with a comma):
-
-- `abstract` or `must_inherit`
-- `async`
-- `const`
-- `readonly`
-- `static` or `shared`
-
-   > [!NOTE]
-   > If you have a naming rule for `static` or `shared` symbols, it is also applied to `const` symbols because they are implicitly static. If you don't want the `static` naming rule to apply to `const` symbols, create a separate naming rule for `const` symbols.
-
-A naming rule matches signatures that have *all* the modifiers specified in `required_modifiers`. If you omit this property, the default value of an empty list is used, that is, no specific modifiers are required for a match. This means a symbol's modifiers have no effect on whether or not this rule is applied.
-
-> [!TIP]
-> Do not specify a value of `*` for `required_modifiers`. Instead, just omit the `required_modifiers` property altogether and your naming rule will apply to any kind of modifier.
-
-## Style
-
-Now that you've identified the group of symbols to apply the naming rule to, you can describe the naming style. A style can be that the name has a certain prefix or a certain suffix, or that individual words in the name are separated with a certain character. You can also specify a capitalization style. The style property has the following format:
-
-`dotnet_naming_rule.<namingRuleTitle>.style = <styleTitle>`
-
-Give the style a name by replacing the **<styleTitle\>** value with a descriptive title, for example `first_word_upper_case_style`. You'll use the **<styleTitle\>** value in the property names that describe the naming style (prefix, suffix, word separator character, and capitalization). Use one or more of these properties to describe your style.
-
-### Require a prefix
-
-To specify that symbol names must begin with certain characters, use this property:
-
-`dotnet_naming_style.<styleTitle>.required_prefix = <prefix>`
-
-### Require a suffix
-
-To specify that symbol names must end with certain characters, use this property:
-
-`dotnet_naming_style.<styleTitle>.required_suffix = <suffix>`
-
-### Require a certain word separator
-
-To specify that individual words in symbol names must be separated with a certain character, use this property:
-
-`dotnet_naming_style.<styleTitle>.word_separator = <separator character>`
-
-### Require a capitalization style
-
-To specify a particular capitalization style for symbol names, use this property:
-
-`dotnet_naming_style.<styleTitle>.capitalization = <value>`
-
-The allowable values for this property are:
-
-- pascal_case
-- camel_case
-- first\_word_upper
-- all\_upper
-- all_lower
-
-> [!NOTE]
-> You must specify a capitalization style as part of your naming style, otherwise your naming style might be ignored.
-
-## Severity
-
-To describe the severity of a violation of your naming rule, specify a property in the following format:
-
-`dotnet_naming_rule.<namingRuleTitle>.severity = <value>`
-
-Severity specification with the above syntax is only respected inside development IDEs, such as Visual Studio. This setting is not understood by the C# or VB compilers, hence not respected during build. Instead, to enforce naming style rules on build, you should set the severity by using the rule ID-based severity configuration as explained in [this section](#rule-id-ide1006-naming-rule-violation). For more information, see this [GitHub issue](https://github.com/dotnet/roslyn/issues/44201).
+1. Severity specification within a naming rule is only respected inside development IDEs, such as Visual Studio. This setting is not understood by the C# or VB compilers, hence not respected during build. Instead, to enforce naming style rules on build, you should set the severity by using the rule ID-based severity configuration as explained in [this section](#rule-id-ide1006-naming-rule-violation). For more information, see this [GitHub issue](https://github.com/dotnet/roslyn/issues/44201).
 
 ## Rule order
 
@@ -183,6 +86,44 @@ The order in which naming rules are defined in an EditorConfig file doesn't matt
 > [!NOTE]
 >
 > If you're using a version of Visual Studio earlier than Visual Studio 2019 version 16.2, naming rules should be ordered from most-specific to least-specific in the EditorConfig file. The first rule encountered that can be applied is the only rule that is applied. However, if there are multiple rule *properties* with the same name, the most recently found property with that name takes precedence. For more information, see [File hierarchy and precedence](/visualstudio/ide/create-portable-custom-editor-options#file-hierarchy-and-precedence).
+
+## Symbol group properties
+
+You can set the following properties for symbol groups, to limit which symbols are included in the group. To specify multiple values in a single property setting, separate them with a comma.
+
+| Property | Description | Allowed values | Required |
+| -- | -- | -- | -- |
+| `applicable_kinds` | Kinds of symbols in the group <sup>1</sup> | `*` (use this value to specify all symbols)<br/>`namespace`<br/>`class`<br/>`struct`<br/>`interface`<br/>`enum`<br/>`property`<br/>`method`<br/>`field`<br/>`event`<br/>`delegate`<br/>`parameter`<br/>`type_parameter`<br/>`local`<br/>`local_function` | Yes |
+| `applicable_accessibilities` | Accessibility levels of the symbols in the group | `*` (use this value to specify all accessibility levels)<br/>`public`<br/>`internal` or `friend`<br/>`private`<br/>`protected`<br/>`protected_internal` or `protected_friend`<br/>`private_protected`<br/>`local` (for symbols defined within a method) | Yes |
+| `required_modifiers` | Only match symbols with _all_ the specified modifiers <sup>2</sup> | `abstract` or `must_inherit`<br/>`async`<br/>`const`<br/>`readonly`<br/>`static` or `shared` <sup>3</sup> | No |
+
+**Notes:**
+
+1. Tuple members aren't currently supported in `applicable_kinds`.
+2. The symbol group matches _all_ the modifiers in the `required_modifiers` property.  If you omit this property, no specific modifiers are required for a match. This means a symbol's modifiers have no effect on whether or not this rule is applied.
+3. If your group has `static` or `shared` in the `required_modifiers` property, the group will also include `const` symbols because they are implicitly `static`/`Shared`. However, you can create a new naming rule with its' own symbol group of `const` symbols.
+
+## Naming style properties
+
+A naming style defines the conventions we want to enforce with a naming rule. For example:
+
+* Capitalize with `PascalCase`
+* Starts with `m_`
+* Ends with `_g`
+* Separate words with `__`
+
+You can set the following properties for a naming style:
+
+| Property | Description | Allowed values | Required |
+| -- | -- | -- | -- |
+| `capitalization` | Capitalization style for words within the symbol | `pascal_case`<br/>`camel_case`<br/>`first_word_upper`<br/>`all_upper`<br/>`all_lower` | Yes<sup>1</sup> |
+| `required_prefix` | Must begin with these characters | | No |
+| `required_suffix` | Must end with these characters | | No |
+| `word_separator` | Words within the symbol need to be separated with this character | | No |
+
+**Notes:**
+
+1. You must specify a capitalization style as part of your naming style, otherwise your naming style might be ignored.
 
 ## Default naming styles
 
@@ -209,6 +150,16 @@ dotnet_naming_style.first_word_upper_case_style.capitalization = first_word_uppe
 
 dotnet_naming_rule.public_members_must_be_capitalized.severity = suggestion
 ```
+
+## <a name="rule-id-ide1006-naming-rule-violation"></a>Rule ID: "IDE1006" (Naming rule violation)
+
+All naming options have rule ID `IDE1006` and title `Naming rule violation`. Severity of naming violations can be configured globally in an EditorConfig file with the following syntax:
+
+```ini
+dotnet_diagnostic.IDE1006.severity = <severity value>
+```
+
+The value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -101,7 +101,7 @@ You can set the following properties for symbol groups, to limit which symbols a
 
 1. Tuple members aren't currently supported in `applicable_kinds`.
 2. The symbol group matches _all_ the modifiers in the `required_modifiers` property.  If you omit this property, no specific modifiers are required for a match. This means a symbol's modifiers have no effect on whether or not this rule is applied.
-3. If your group has `static` or `shared` in the `required_modifiers` property, the group will also include `const` symbols because they are implicitly `static`/`Shared`. However, If you don't want the `static` naming rule to apply to `const` symbols, you can create a new naming rule with a symbol group of `const`.
+3. If your group has `static` or `shared` in the `required_modifiers` property, the group will also include `const` symbols because they are implicitly `static`/`Shared`. However, if you don't want the `static` naming rule to apply to `const` symbols, you can create a new naming rule with a symbol group of `const`.
 
 ## Naming style properties
 


### PR DESCRIPTION
After two days of fruitless effort in trying to parse and understand what this document is trying to say, I've given up and rewritten it.

1. The excess verbiage obscures the underlying syntax of _prefix_._title_._propertyName_ `=` _value_.
2. The difference between "setting a property on a symbol group / naming style" and "setting the symbol group / naming style on the naming rule" is not sufficiently clear. (At least, I missed it even after I'd gone over the page multiple times.)
3. This isn't a straightforward How To document, so having a separate heading + paragraph of verbiage for each property doesn't make sense.

## Summary

1. Properties are now in tables, one table for each element type -- naming rule, symbol group, or naming style.
2. Added a "General syntax" section, describing the underlying syntax of setting properties on elements related to naming rules.
3. Folds some of the smaller headers into other sections. 