### PR TITLE
Typo "Azure functions"→"Azure Functions"

### DIFF
--- a/docs/architecture/serverless/azure-functions.md
+++ b/docs/architecture/serverless/azure-functions.md
@@ -7,7 +7,7 @@ ms.date: 04/06/2020
 ---
 # Azure Functions
 
-Azure functions provide a serverless compute experience. A function is invoked by a *trigger* (such as access to an HTTP endpoint or a timer) and executes a block of code or business logic. Functions also support specialized *bindings* that connect to resources like storage and queues.
+Azure Functions provide a serverless compute experience. A function is invoked by a *trigger* (such as access to an HTTP endpoint or a timer) and executes a block of code or business logic. Functions also support specialized *bindings* that connect to resources like storage and queues.
 
 ![Azure functions logo](./media/azure-functions-logo.png)
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/architecture/serverless/azure-functions

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
