### PR TITLE
Add links to one-file binaries for diagnostics CLI tools

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -18,7 +18,7 @@ dotnet tool install --global dotnet-counters
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
 - Win ([x86](https://aka.ms/dotnet-counters/win-x86) | [x64](https://aka.ms/dotnet-counters/win-x64) | [arm](https://aka.ms/dotnet-counters/win-arm) | [arm-x64](https://aka.ms/dotnet-counters/win-arm64))
-- OSX ([x64](https://aka.ms/dotnet-counters/osx-x64))
+- macOS ([x64](https://aka.ms/dotnet-counters/osx-x64))
 - Linux ([x64](https://aka.ms/dotnet-counters/linux-x64) | [arm](https://aka.ms/dotnet-counters/linux-arm) | [arm64](https://aka.ms/dotnet-counters/linux-arm64) | [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-counters/linux-musl-arm64))
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -9,13 +9,15 @@ ms.date: 02/26/2020
 
 ## Install dotnet-counters
 
+### Option 1 - Install as dotnet global tool:
+
 To install the latest release version of the `dotnet-counters` [NuGet package](https://www.nuget.org/packages/dotnet-counters), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
 ```dotnetcli
 dotnet tool install --global dotnet-counters
 ```
 
-Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+### Option 2 - Direct download:
 
 - Win ([x86](https://aka.ms/dotnet-counters/win-x86) | [x64](https://aka.ms/dotnet-counters/win-x64) | [arm](https://aka.ms/dotnet-counters/win-arm) | [arm-x64](https://aka.ms/dotnet-counters/win-arm64))
 - macOS ([x64](https://aka.ms/dotnet-counters/osx-x64))

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -17,9 +17,9 @@ dotnet tool install --global dotnet-counters
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
- - Win ([x86](https://aka.ms/dotnet-counters/win-x86) | [x64](https://aka.ms/dotnet-counters/win-x64) | [arm](https://aka.ms/dotnet-counters/win-arm) | [arm-x64](https://aka.ms/dotnet-counters/win-arm64))
- - OSX ([x64](https://aka.ms/dotnet-counters/osx-x64))
- - Linux ([x64](https://aka.ms/dotnet-counters/linux-x64) | [arm](https://aka.ms/dotnet-counters/linux-arm) | [arm64](https://aka.ms/dotnet-counters/linux-arm64) | [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-counters/linux-musl-arm64))
+- Win ([x86](https://aka.ms/dotnet-counters/win-x86) | [x64](https://aka.ms/dotnet-counters/win-x64) | [arm](https://aka.ms/dotnet-counters/win-arm) | [arm-x64](https://aka.ms/dotnet-counters/win-arm64))
+- OSX ([x64](https://aka.ms/dotnet-counters/osx-x64))
+- Linux ([x64](https://aka.ms/dotnet-counters/linux-x64) | [arm](https://aka.ms/dotnet-counters/linux-arm) | [arm64](https://aka.ms/dotnet-counters/linux-arm64) | [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-counters/linux-musl-arm64))
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -16,10 +16,10 @@ dotnet tool install --global dotnet-counters
 ```
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+
  - Win ([x86](https://aka.ms/dotnet-counters/win-x86) | [x64](https://aka.ms/dotnet-counters/win-x64) | [arm](https://aka.ms/dotnet-counters/win-arm) | [arm-x64](https://aka.ms/dotnet-counters/win-arm64))
  - OSX ([x64](https://aka.ms/dotnet-counters/osx-x64))
  - Linux ([x64](https://aka.ms/dotnet-counters/linux-x64) | [arm](https://aka.ms/dotnet-counters/linux-arm) | [arm64](https://aka.ms/dotnet-counters/linux-arm64) | [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-counters/linux-musl-arm64))
-
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -15,6 +15,12 @@ To install the latest release version of the `dotnet-counters` [NuGet package](h
 dotnet tool install --global dotnet-counters
 ```
 
+Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+ - Win ([x86](https://aka.ms/dotnet-counters/win-x86) | [x64](https://aka.ms/dotnet-counters/win-x64) | [arm](https://aka.ms/dotnet-counters/win-arm) | [arm-x64](https://aka.ms/dotnet-counters/win-arm64))
+ - OSX ([x64](https://aka.ms/dotnet-counters/osx-x64))
+ - Linux ([x64](https://aka.ms/dotnet-counters/linux-x64) | [arm](https://aka.ms/dotnet-counters/linux-arm) | [arm64](https://aka.ms/dotnet-counters/linux-arm64) | [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-counters/linux-musl-arm64))
+
+
 ## Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -21,7 +21,7 @@ dotnet tool install -g dotnet-dump
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
 - Win ([x86](https://aka.ms/dotnet-dump/win-x86) | [x64](https://aka.ms/dotnet-dump/win-x64) | [arm](https://aka.ms/dotnet-dump/win-arm) | [arm-x64](https://aka.ms/dotnet-dump/win-arm64))
-- OSX ([x64](https://aka.ms/dotnet-dump/osx-x64))
+- macOS ([x64](https://aka.ms/dotnet-dump/osx-x64))
 - Linux ([x64](https://aka.ms/dotnet-dump/linux-x64) | [arm](https://aka.ms/dotnet-dump/linux-arm) | [arm64](https://aka.ms/dotnet-dump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-dump/linux-musl-arm64))
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -19,10 +19,10 @@ dotnet tool install -g dotnet-dump
 ```
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+
  - Win ([x86](https://aka.ms/dotnet-dump/win-x86) | [x64](https://aka.ms/dotnet-dump/win-x64) | [arm](https://aka.ms/dotnet-dump/win-arm) | [arm-x64](https://aka.ms/dotnet-dump/win-arm64))
  - OSX ([x64](https://aka.ms/dotnet-dump/osx-x64))
  - Linux ([x64](https://aka.ms/dotnet-dump/linux-x64) | [arm](https://aka.ms/dotnet-dump/linux-arm) | [arm64](https://aka.ms/dotnet-dump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-dump/linux-musl-arm64))
-
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -18,6 +18,12 @@ To install the latest release version of the `dotnet-dump` [NuGet package](https
 dotnet tool install -g dotnet-dump
 ```
 
+Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+ - Win ([x86](https://aka.ms/dotnet-dump/win-x86) | [x64](https://aka.ms/dotnet-dump/win-x64) | [arm](https://aka.ms/dotnet-dump/win-arm) | [arm-x64](https://aka.ms/dotnet-dump/win-arm64))
+ - OSX ([x64](https://aka.ms/dotnet-dump/osx-x64))
+ - Linux ([x64](https://aka.ms/dotnet-dump/linux-x64) | [arm](https://aka.ms/dotnet-dump/linux-arm) | [arm64](https://aka.ms/dotnet-dump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-dump/linux-musl-arm64))
+
+
 ## Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -8,9 +8,11 @@ ms.date: 10/14/2019
 **This article applies to:** ✔️ .NET Core 3.0 SDK and later versions
 
 > [!NOTE]
-> `dotnet-dump` isn't supported on macOS.
+> `dotnet-dump` is supported on macOS with .NET Core 5.0+.
 
 ## Install dotnet-dump
+
+### Option 1 - Install as dotnet global tool:
 
 To install the latest release version of the `dotnet-dump` [NuGet package](https://www.nuget.org/packages/dotnet-dump), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
@@ -18,7 +20,7 @@ To install the latest release version of the `dotnet-dump` [NuGet package](https
 dotnet tool install -g dotnet-dump
 ```
 
-Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+### Option 2 - Direct download:
 
 - Win ([x86](https://aka.ms/dotnet-dump/win-x86) | [x64](https://aka.ms/dotnet-dump/win-x64) | [arm](https://aka.ms/dotnet-dump/win-arm) | [arm-x64](https://aka.ms/dotnet-dump/win-arm64))
 - macOS ([x64](https://aka.ms/dotnet-dump/osx-x64))

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -20,9 +20,9 @@ dotnet tool install -g dotnet-dump
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
- - Win ([x86](https://aka.ms/dotnet-dump/win-x86) | [x64](https://aka.ms/dotnet-dump/win-x64) | [arm](https://aka.ms/dotnet-dump/win-arm) | [arm-x64](https://aka.ms/dotnet-dump/win-arm64))
- - OSX ([x64](https://aka.ms/dotnet-dump/osx-x64))
- - Linux ([x64](https://aka.ms/dotnet-dump/linux-x64) | [arm](https://aka.ms/dotnet-dump/linux-arm) | [arm64](https://aka.ms/dotnet-dump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-dump/linux-musl-arm64))
+- Win ([x86](https://aka.ms/dotnet-dump/win-x86) | [x64](https://aka.ms/dotnet-dump/win-x64) | [arm](https://aka.ms/dotnet-dump/win-arm) | [arm-x64](https://aka.ms/dotnet-dump/win-arm64))
+- OSX ([x64](https://aka.ms/dotnet-dump/osx-x64))
+- Linux ([x64](https://aka.ms/dotnet-dump/linux-x64) | [arm](https://aka.ms/dotnet-dump/linux-arm) | [arm64](https://aka.ms/dotnet-dump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-dump/linux-musl-arm64))
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -18,7 +18,7 @@ dotnet tool install -g dotnet-gcdump
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
 - Win ([x86](https://aka.ms/dotnet-gcdump/win-x86) | [x64](https://aka.ms/dotnet-gcdump/win-x64) | [arm](https://aka.ms/dotnet-gcdump/win-arm) | [arm-x64](https://aka.ms/dotnet-gcdump/win-arm64))
-- OSX ([x64](https://aka.ms/dotnet-gcdump/osx-x64))
+- macOS ([x64](https://aka.ms/dotnet-gcdump/osx-x64))
 - Linux ([x64](https://aka.ms/dotnet-gcdump/linux-x64) | [arm](https://aka.ms/dotnet-gcdump/linux-arm) | [arm64](https://aka.ms/dotnet-gcdump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64))
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -9,13 +9,15 @@ ms.date: 07/26/2020
 
 ## Install dotnet-gcdump
 
+### Option 1 - Install as dotnet global tool:
+
 To install the latest release version of the `dotnet-gcdump` [NuGet package](https://www.nuget.org/packages/dotnet-gcdump), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
 ```dotnetcli
 dotnet tool install -g dotnet-gcdump
 ```
 
-Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+### Option 2 - Direct download:
 
 - Win ([x86](https://aka.ms/dotnet-gcdump/win-x86) | [x64](https://aka.ms/dotnet-gcdump/win-x64) | [arm](https://aka.ms/dotnet-gcdump/win-arm) | [arm-x64](https://aka.ms/dotnet-gcdump/win-arm64))
 - macOS ([x64](https://aka.ms/dotnet-gcdump/osx-x64))

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -15,6 +15,12 @@ To install the latest release version of the `dotnet-gcdump` [NuGet package](htt
 dotnet tool install -g dotnet-gcdump
 ```
 
+Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+ - Win ([x86](https://aka.ms/dotnet-gcdump/win-x86) | [x64](https://aka.ms/dotnet-gcdump/win-x64) | [arm](https://aka.ms/dotnet-gcdump/win-arm) | [arm-x64](https://aka.ms/dotnet-gcdump/win-arm64))
+ - OSX ([x64](https://aka.ms/dotnet-gcdump/osx-x64))
+ - Linux ([x64](https://aka.ms/dotnet-gcdump/linux-x64) | [arm](https://aka.ms/dotnet-gcdump/linux-arm) | [arm64](https://aka.ms/dotnet-gcdump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64))
+
+
 ## Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -17,9 +17,9 @@ dotnet tool install -g dotnet-gcdump
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
- - Win ([x86](https://aka.ms/dotnet-gcdump/win-x86) | [x64](https://aka.ms/dotnet-gcdump/win-x64) | [arm](https://aka.ms/dotnet-gcdump/win-arm) | [arm-x64](https://aka.ms/dotnet-gcdump/win-arm64))
- - OSX ([x64](https://aka.ms/dotnet-gcdump/osx-x64))
- - Linux ([x64](https://aka.ms/dotnet-gcdump/linux-x64) | [arm](https://aka.ms/dotnet-gcdump/linux-arm) | [arm64](https://aka.ms/dotnet-gcdump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64))
+- Win ([x86](https://aka.ms/dotnet-gcdump/win-x86) | [x64](https://aka.ms/dotnet-gcdump/win-x64) | [arm](https://aka.ms/dotnet-gcdump/win-arm) | [arm-x64](https://aka.ms/dotnet-gcdump/win-arm64))
+- OSX ([x64](https://aka.ms/dotnet-gcdump/osx-x64))
+- Linux ([x64](https://aka.ms/dotnet-gcdump/linux-x64) | [arm](https://aka.ms/dotnet-gcdump/linux-arm) | [arm64](https://aka.ms/dotnet-gcdump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64))
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -16,10 +16,10 @@ dotnet tool install -g dotnet-gcdump
 ```
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+
  - Win ([x86](https://aka.ms/dotnet-gcdump/win-x86) | [x64](https://aka.ms/dotnet-gcdump/win-x64) | [arm](https://aka.ms/dotnet-gcdump/win-arm) | [arm-x64](https://aka.ms/dotnet-gcdump/win-arm64))
  - OSX ([x64](https://aka.ms/dotnet-gcdump/osx-x64))
  - Linux ([x64](https://aka.ms/dotnet-gcdump/linux-x64) | [arm](https://aka.ms/dotnet-gcdump/linux-arm) | [arm64](https://aka.ms/dotnet-gcdump/linux-arm64) | [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64))
-
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-sos.md
+++ b/docs/core/diagnostics/dotnet-sos.md
@@ -15,6 +15,12 @@ To install the latest release version of the `dotnet-sos` [NuGet package](https:
 dotnet tool install -g dotnet-sos
 ```
 
+Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+ - Win ([x86](https://aka.ms/dotnet-sos/win-x86) | [x64](https://aka.ms/dotnet-sos/win-x64) | [arm](https://aka.ms/dotnet-sos/win-arm) | [arm-x64](https://aka.ms/dotnet-sos/win-arm64))
+ - OSX ([x64](https://aka.ms/dotnet-sos/osx-x64))
+ - Linux ([x64](https://aka.ms/dotnet-sos/linux-x64) | [arm](https://aka.ms/dotnet-sos/linux-arm) | [arm64](https://aka.ms/dotnet-sos/linux-arm64) | [musl-x64](https://aka.ms/dotnet-sos/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-sos/linux-musl-arm64))
+
+
 ## Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-sos.md
+++ b/docs/core/diagnostics/dotnet-sos.md
@@ -18,7 +18,7 @@ dotnet tool install -g dotnet-sos
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
 - Win ([x86](https://aka.ms/dotnet-sos/win-x86) | [x64](https://aka.ms/dotnet-sos/win-x64) | [arm](https://aka.ms/dotnet-sos/win-arm) | [arm-x64](https://aka.ms/dotnet-sos/win-arm64))
-- OSX ([x64](https://aka.ms/dotnet-sos/osx-x64))
+- macOS ([x64](https://aka.ms/dotnet-sos/osx-x64))
 - Linux ([x64](https://aka.ms/dotnet-sos/linux-x64) | [arm](https://aka.ms/dotnet-sos/linux-arm) | [arm64](https://aka.ms/dotnet-sos/linux-arm64) | [musl-x64](https://aka.ms/dotnet-sos/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-sos/linux-musl-arm64))
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-sos.md
+++ b/docs/core/diagnostics/dotnet-sos.md
@@ -16,10 +16,10 @@ dotnet tool install -g dotnet-sos
 ```
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+
  - Win ([x86](https://aka.ms/dotnet-sos/win-x86) | [x64](https://aka.ms/dotnet-sos/win-x64) | [arm](https://aka.ms/dotnet-sos/win-arm) | [arm-x64](https://aka.ms/dotnet-sos/win-arm64))
  - OSX ([x64](https://aka.ms/dotnet-sos/osx-x64))
  - Linux ([x64](https://aka.ms/dotnet-sos/linux-x64) | [arm](https://aka.ms/dotnet-sos/linux-arm) | [arm64](https://aka.ms/dotnet-sos/linux-arm64) | [musl-x64](https://aka.ms/dotnet-sos/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-sos/linux-musl-arm64))
-
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-sos.md
+++ b/docs/core/diagnostics/dotnet-sos.md
@@ -17,9 +17,9 @@ dotnet tool install -g dotnet-sos
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
- - Win ([x86](https://aka.ms/dotnet-sos/win-x86) | [x64](https://aka.ms/dotnet-sos/win-x64) | [arm](https://aka.ms/dotnet-sos/win-arm) | [arm-x64](https://aka.ms/dotnet-sos/win-arm64))
- - OSX ([x64](https://aka.ms/dotnet-sos/osx-x64))
- - Linux ([x64](https://aka.ms/dotnet-sos/linux-x64) | [arm](https://aka.ms/dotnet-sos/linux-arm) | [arm64](https://aka.ms/dotnet-sos/linux-arm64) | [musl-x64](https://aka.ms/dotnet-sos/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-sos/linux-musl-arm64))
+- Win ([x86](https://aka.ms/dotnet-sos/win-x86) | [x64](https://aka.ms/dotnet-sos/win-x64) | [arm](https://aka.ms/dotnet-sos/win-arm) | [arm-x64](https://aka.ms/dotnet-sos/win-arm64))
+- OSX ([x64](https://aka.ms/dotnet-sos/osx-x64))
+- Linux ([x64](https://aka.ms/dotnet-sos/linux-x64) | [arm](https://aka.ms/dotnet-sos/linux-arm) | [arm64](https://aka.ms/dotnet-sos/linux-arm64) | [musl-x64](https://aka.ms/dotnet-sos/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-sos/linux-musl-arm64))
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-sos.md
+++ b/docs/core/diagnostics/dotnet-sos.md
@@ -9,13 +9,15 @@ ms.date: 08/26/2020
 
 ## Install dotnet-sos
 
+### Option 1 - Install as dotnet global tool:
+
 To install the latest release version of the `dotnet-sos` [NuGet package](https://www.nuget.org/packages/dotnet-sos), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
 ```dotnetcli
 dotnet tool install -g dotnet-sos
 ```
 
-Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+### Option 2 - Direct download:
 
 - Win ([x86](https://aka.ms/dotnet-sos/win-x86) | [x64](https://aka.ms/dotnet-sos/win-x64) | [arm](https://aka.ms/dotnet-sos/win-arm) | [arm-x64](https://aka.ms/dotnet-sos/win-arm64))
 - macOS ([x64](https://aka.ms/dotnet-sos/osx-x64))

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -18,7 +18,7 @@ dotnet tool install --global dotnet-trace
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
 - Win ([x86](https://aka.ms/dotnet-trace/win-x86) | [x64](https://aka.ms/dotnet-trace/win-x64) | [arm](https://aka.ms/dotnet-trace/win-arm) | [arm-x64](https://aka.ms/dotnet-trace/win-arm64))
-- OSX ([x64](https://aka.ms/dotnet-trace/osx-x64))
+- macOS ([x64](https://aka.ms/dotnet-trace/osx-x64))
 - Linux ([x64](https://aka.ms/dotnet-trace/linux-x64) | [arm](https://aka.ms/dotnet-trace/linux-arm) | [arm64](https://aka.ms/dotnet-trace/linux-arm64) | [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-trace/linux-musl-arm64))
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -9,13 +9,15 @@ ms.date: 11/21/2019
 
 ## Install dotnet-trace
 
+### Option 1 - Install as dotnet global tool:
+
 Install `dotnet-trace` [NuGet package](https://www.nuget.org/packages/dotnet-trace) with the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
 ```dotnetcli
 dotnet tool install --global dotnet-trace
 ```
 
-Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+### Option 2 - Direct download:
 
 - Win ([x86](https://aka.ms/dotnet-trace/win-x86) | [x64](https://aka.ms/dotnet-trace/win-x64) | [arm](https://aka.ms/dotnet-trace/win-arm) | [arm-x64](https://aka.ms/dotnet-trace/win-arm64))
 - macOS ([x64](https://aka.ms/dotnet-trace/osx-x64))

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -17,9 +17,9 @@ dotnet tool install --global dotnet-trace
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
 
- - Win ([x86](https://aka.ms/dotnet-trace/win-x86) | [x64](https://aka.ms/dotnet-trace/win-x64) | [arm](https://aka.ms/dotnet-trace/win-arm) | [arm-x64](https://aka.ms/dotnet-trace/win-arm64))
- - OSX ([x64](https://aka.ms/dotnet-trace/osx-x64))
- - Linux ([x64](https://aka.ms/dotnet-trace/linux-x64) | [arm](https://aka.ms/dotnet-trace/linux-arm) | [arm64](https://aka.ms/dotnet-trace/linux-arm64) | [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-trace/linux-musl-arm64))
+- Win ([x86](https://aka.ms/dotnet-trace/win-x86) | [x64](https://aka.ms/dotnet-trace/win-x64) | [arm](https://aka.ms/dotnet-trace/win-arm) | [arm-x64](https://aka.ms/dotnet-trace/win-arm64))
+- OSX ([x64](https://aka.ms/dotnet-trace/osx-x64))
+- Linux ([x64](https://aka.ms/dotnet-trace/linux-x64) | [arm](https://aka.ms/dotnet-trace/linux-arm) | [arm64](https://aka.ms/dotnet-trace/linux-arm64) | [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-trace/linux-musl-arm64))
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -16,10 +16,10 @@ dotnet tool install --global dotnet-trace
 ```
 
 Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+
  - Win ([x86](https://aka.ms/dotnet-trace/win-x86) | [x64](https://aka.ms/dotnet-trace/win-x64) | [arm](https://aka.ms/dotnet-trace/win-arm) | [arm-x64](https://aka.ms/dotnet-trace/win-arm64))
  - OSX ([x64](https://aka.ms/dotnet-trace/osx-x64))
  - Linux ([x64](https://aka.ms/dotnet-trace/linux-x64) | [arm](https://aka.ms/dotnet-trace/linux-arm) | [arm64](https://aka.ms/dotnet-trace/linux-arm64) | [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-trace/linux-musl-arm64))
-
 
 ## Synopsis
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -15,6 +15,12 @@ Install `dotnet-trace` [NuGet package](https://www.nuget.org/packages/dotnet-tra
 dotnet tool install --global dotnet-trace
 ```
 
+Starting from .NET 5, it is now possible to directly download a one-file executable for your operating system:
+ - Win ([x86](https://aka.ms/dotnet-trace/win-x86) | [x64](https://aka.ms/dotnet-trace/win-x64) | [arm](https://aka.ms/dotnet-trace/win-arm) | [arm-x64](https://aka.ms/dotnet-trace/win-arm64))
+ - OSX ([x64](https://aka.ms/dotnet-trace/osx-x64))
+ - Linux ([x64](https://aka.ms/dotnet-trace/linux-x64) | [arm](https://aka.ms/dotnet-trace/linux-arm) | [arm64](https://aka.ms/dotnet-trace/linux-arm64) | [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-trace/linux-musl-arm64))
+
+
 ## Synopsis
 
 ```console


### PR DESCRIPTION
## Summary

The direct download links are available in each tool documentation page

Fixes https://github.com/dotnet/diagnostics/issues/344
