### PR TITLE
Fix Dockerfile, COPY command

### DIFF
--- a/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md
+++ b/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md
@@ -284,7 +284,7 @@ The resulting file is then:
 11
 12  FROM base AS final
 13  WORKDIR /app
-14  COPY --from=publish /app
+14  COPY --from=publish /app .
 15  ENTRYPOINT ["dotnet", "Catalog.API.dll"]
 ```
 


### PR DESCRIPTION
## Summary

COPY should recieve two parameters. https://docs.docker.com/engine/reference/builder/#copy
Without it, Docker throws a build error saying: 'Dockerfile parse error line 14: COPY requires at least two arguments, but only one was provided. Destination could not be determined.'