### PR TITLE
.NET Core SDK/CLI --> .NET SDK/CLI

### DIFF
--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -7,7 +7,7 @@ ms.date: 05/20/2020
 
 # Custom templates for dotnet new
 
-The [.NET Core SDK](https://dotnet.microsoft.com/download) comes with many templates already installed and ready for you to use. The [`dotnet new` command](dotnet-new.md) isn't only the way to use a template, but also how to install and uninstall templates. Starting with .NET Core 2.0, you can create your own custom templates for any type of project, such as an app, service, tool, or class library. You can even create a template that outputs one or more independent files, such as a configuration file.
+The [.NET SDK](https://dotnet.microsoft.com/download) comes with many templates already installed and ready for you to use. The [`dotnet new` command](dotnet-new.md) isn't only the way to use a template, but also how to install and uninstall templates. You can create your own custom templates for any type of project, such as an app, service, tool, or class library. You can even create a template that outputs one or more independent files, such as a configuration file.
 
 You can install custom templates from a NuGet package on any NuGet feed, by referencing a NuGet *.nupkg* file directly, or by specifying a file system directory that contains the template. The template engine offers features that allow you to replace values, include and exclude files, and execute custom processing operations when your template is used.
 
@@ -20,7 +20,7 @@ To follow a walkthrough and create a template, see the [Create a custom template
 
 ### .NET default templates
 
-When you install the [.NET Core SDK](https://dotnet.microsoft.com/download), you receive over a dozen built-in templates for creating projects and files, including console apps, class libraries, unit test projects, ASP.NET Core apps (including [Angular](https://angular.io/) and [React](https://reactjs.org/) projects), and configuration files. To list the built-in templates, run the `dotnet new` command with the `-l|--list` option:
+When you install the [.NET SDK](https://dotnet.microsoft.com/download), you receive over a dozen built-in templates for creating projects and files, including console apps, class libraries, unit test projects, ASP.NET Core apps (including [Angular](https://angular.io/) and [React](https://reactjs.org/) projects), and configuration files. To list the built-in templates, run the `dotnet new` command with the `-l|--list` option:
 
 ```dotnetcli
 dotnet new --list
@@ -201,7 +201,7 @@ dotnet new -u
 That command returns something similar to the following output:
 
 ```console
-Template Instantiation Commands for .NET Core CLI
+Template Instantiation Commands for .NET CLI
 
 Currently installed items:
   Microsoft.DotNet.Common.ItemTemplates

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -33,7 +33,7 @@ The `dotnet build` command builds the project and its dependencies into a set of
 - A *.runtimeconfig.json* file, which specifies the shared runtime and its version for an application.
 - Other libraries that the project depends on (via project references or NuGet package references).
 
-For executable projects targeting versions earlier than .NET Core 3.0, library dependencies from NuGet are typically NOT copied to the output folder.  They're resolved from the NuGet global packages folder at run time. With that in mind, the product of `dotnet build` isn't ready to be transferred to another machine to run. To create a version of the application that can be deployed, you need to publish it (for example, with the [dotnet publish](dotnet-publish.md) command). For more information, see [.NET Core Application Deployment](../deploying/index.md).
+For executable projects targeting versions earlier than .NET Core 3.0, library dependencies from NuGet are typically NOT copied to the output folder.  They're resolved from the NuGet global packages folder at run time. With that in mind, the product of `dotnet build` isn't ready to be transferred to another machine to run. To create a version of the application that can be deployed, you need to publish it (for example, with the [dotnet publish](dotnet-publish.md) command). For more information, see [.NET Application Deployment](../deploying/index.md).
 
 For executable projects targeting .NET Core 3.0 and later, library dependencies are copied to the output folder. This means that if there isn't any other publish-specific logic (such as Web projects have), the build output should be deployable.
 
@@ -147,7 +147,7 @@ The project or solution file to build. If a project or solution file isn't speci
   dotnet build --runtime ubuntu.18.04-x64
   ```
 
-- Build the project and use the specified NuGet package source during the restore operation (.NET Core 2.0 SDK and later versions):
+- Build the project and use the specified NuGet package source during the restore operation:
 
   ```dotnetcli
   dotnet build --source c:\packages\mypackages

--- a/docs/core/tools/dotnet-help.md
+++ b/docs/core/tools/dotnet-help.md
@@ -25,7 +25,7 @@ The `dotnet help` command opens up the reference page for more detailed informat
 
 - **`COMMAND_NAME`**
 
-  Name of the .NET Core CLI command. For a list of the valid CLI commands, see [CLI commands](index.md#cli-commands).
+  Name of the .NET CLI command. For a list of the valid CLI commands, see [CLI commands](index.md#cli-commands).
 
 ## Options
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -1,13 +1,13 @@
 ---
 title: dotnet-install scripts
-description: Learn about the dotnet-install scripts to install the .NET Core SDK and the shared runtime.
+description: Learn about the dotnet-install scripts to install the .NET SDK and the shared runtime.
 ms.date: 09/22/2020
 ---
 # dotnet-install scripts reference
 
 ## Name
 
-`dotnet-install.ps1` | `dotnet-install.sh` - Script used to install the .NET Core SDK and the shared runtime.
+`dotnet-install.ps1` | `dotnet-install.sh` - Script used to install the .NET SDK and the shared runtime.
 
 ## Synopsis
 
@@ -42,7 +42,7 @@ The bash script also reads PowerShell switches, so you can use PowerShell switch
 
 ## Description
 
-The `dotnet-install` scripts perform a non-admin installation of the .NET Core SDK, which includes the .NET Core CLI and the shared runtime. There are two scripts:
+The `dotnet-install` scripts perform a non-admin installation of the .NET SDK, which includes the .NET CLI and the shared runtime. There are two scripts:
 
 * A PowerShell script that works on Windows.
 * A bash script that works on Linux/macOS.
@@ -80,13 +80,13 @@ Before running the script, install the required [dependencies](../install/window
 
 You can install a specific version using the `-Version|--version` argument. The version must be specified as a three-part version number, such as `2.1.0`. If the version isn't specified, the script installs the `latest` version.
 
-The install scripts do not update the registry on Windows. They just download the zipped binaries and copy them to a folder. If you want registry key values to be updated, use the .NET Core installers.
+The install scripts do not update the registry on Windows. They just download the zipped binaries and copy them to a folder. If you want registry key values to be updated, use the .NET installers.
 
 ## Options
 
 - **`-Architecture|--architecture <ARCHITECTURE>`**
 
-  Architecture of the .NET Core binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, and `arm`. The default value is `<auto>`, which represents the currently running OS architecture.
+  Architecture of the .NET binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, and `arm`. The default value is `<auto>`, which represents the currently running OS architecture.
 
 - **`-AzureFeed|--azure-feed`**
 
@@ -105,7 +105,7 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`-DryRun|--dry-run`**
 
-  If set, the script won't perform the installation. Instead, it displays what command line to use to consistently install the currently requested version of the .NET Core CLI. For example, if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
+  If set, the script won't perform the installation. Instead, it displays what command line to use to consistently install the currently requested version of the .NET CLI. For example, if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
 
 - **`-FeedCredential|--feed-credential`**
 
@@ -129,7 +129,7 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`-NoPath|--no-path`**
 
-  If set, the installation folder isn't exported to the path for the current session. By default, the script modifies the PATH, which makes the .NET Core CLI available immediately after install.
+  If set, the installation folder isn't exported to the path for the current session. By default, the script modifies the PATH, which makes the .NET CLI available immediately after install.
 
 - **`-ProxyAddress`**
 
@@ -234,7 +234,7 @@ The install scripts do not update the registry on Windows. They just download th
   ./dotnet-install.ps1 -InstallDir '~/.dotnet' -Version '2.1.2' -ProxyAddress $env:HTTP_PROXY -ProxyUseDefaultCredentials;
   ```
 
-- Obtain script and install .NET Core CLI one-liner examples:
+- Obtain script and install .NET CLI one-liner examples:
 
   Windows:
 
@@ -251,5 +251,5 @@ The install scripts do not update the registry on Windows. They just download th
 
 ## See also
 
-- [.NET Core releases](https://github.com/dotnet/core/releases)
-- [.NET Core Runtime and SDK download archive](https://github.com/dotnet/core/blob/master/release-notes/download-archive.md)
+- [.NET releases](https://github.com/dotnet/core/releases)
+- [.NET Runtime and SDK download archive](https://github.com/dotnet/core/blob/master/release-notes/download-archive.md)

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet new command
-description: The dotnet new command creates new .NET Core projects based on the specified template.
+description: The dotnet new command creates new .NET projects based on the specified template.
 no-loc: [Blazor, WebAssembly]
 ms.date: 09/04/2020
 ---
@@ -27,7 +27,7 @@ dotnet new -h|--help
 
 ## Description
 
-The `dotnet new` command creates a .NET Core project or other artifacts based on a template.
+The `dotnet new` command creates a .NET project or other artifacts based on a template.
 
 The command calls the [template engine](https://github.com/dotnet/templating) to create the artifacts on disk based on the specified template and options.
 
@@ -48,7 +48,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
   - If the CLI can't find a template match when invoking `dotnet new`, not even partial.
   - If there's a newer version of the template available. In this case, the project or artifact is created but the CLI warns you about an updated version of the template.
 
-  The following table shows the templates that come pre-installed with the .NET Core SDK. The default language for the template is shown inside the brackets. Click on the short name link to see the specific template options.
+  The following table shows the templates that come pre-installed with the .NET SDK. The default language for the template is shown inside the brackets. Click on the short name link to see the specific template options.
 
 | Templates                                    | Short name                      | Language     | Tags                                  | Introduced |
 |----------------------------------------------|---------------------------------|--------------|---------------------------------------|------------|
@@ -127,7 +127,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
 - **`--nuget-source <SOURCE>`**
 
-  Specifies a NuGet source to use during install. Available since .NET Core 2.1 SDK.
+  Specifies a NuGet source to use during install.
 
 - **`-o|--output <OUTPUT_DIRECTORY>`**
 
@@ -169,6 +169,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
 
@@ -188,7 +189,7 @@ Each project template may have additional options available. The core templates 
 
 - **`-f|--framework <FRAMEWORK>`**
 
-  Specifies the [framework](../../standard/frameworks.md) to target. Values: `netcoreapp<version>` to create a .NET Core Class Library or `netstandard<version>` to create a .NET Standard Class Library. The default value is `netstandard2.0`.
+  Specifies the [framework](../../standard/frameworks.md) to target. Values: `net5.0` or `netcoreapp<version>` to create a .NET Class Library or `netstandard<version>` to create a .NET Standard Class Library. The default value for .NET 5.0 SDK is `net5.0`.
 
 - **`--langVersion <VERSION_NUMBER>`**
 
@@ -206,7 +207,7 @@ Each project template may have additional options available. The core templates 
 
 - **`-f|--framework <FRAMEWORK>`**
 
-  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK.
+  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `net5.0`. Available since .NET Core 3.1 SDK.
 
 - **`--langVersion <VERSION_NUMBER>`**
 
@@ -765,7 +766,7 @@ Each project template may have additional options available. The core templates 
 
 - **`--sdk-version <VERSION_NUMBER>`**
 
-  Specifies the version of the .NET Core SDK to use in the *global.json* file.
+  Specifies the version of the .NET SDK to use in the *global.json* file.
 
 ***
 

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -261,6 +261,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
 
@@ -284,6 +285,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
   | 2.2         | `netcoreapp2.2` |
@@ -508,6 +510,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
   | 2.1         | `netcoreapp2.1` |
@@ -595,6 +598,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
 
@@ -647,6 +651,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
   | 2.1         | `netcoreapp2.0` |
@@ -667,6 +672,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
   | 2.1         | `netcoreapp2.0` |
@@ -752,6 +758,7 @@ Each project template may have additional options available. The core templates 
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |
   | 3.0         | `netcoreapp3.0` |
   | 2.1         | `netcoreapp2.1` |

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -182,4 +182,4 @@ Web projects aren't packable by default. To override the default behavior, add t
   
   - [Packing using a .nuspec](/nuget/reference/msbuild-targets#packing-using-a-nuspec)
   - [Advanced extension points to create customized package](/nuget/reference/msbuild-targets#advanced-extension-points-to-create-customized-package)
-  - [Global properties](/visualstudio/msbuild/msbuild-properties?view=vs-2019#global-properties)
+  - [Global properties](/visualstudio/msbuild/msbuild-properties#global-properties)

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet pack command
-description: The dotnet pack command creates NuGet packages for your .NET Core project.
+description: The dotnet pack command creates NuGet packages for your .NET project.
 ms.date: 04/28/2020
 ---
 # dotnet pack

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet publish command
-description: The dotnet publish command publishes a .NET Core project or solution to a directory.
-ms.date: 02/24/2020
+description: The dotnet publish command publishes a .NET project or solution to a directory.
+ms.date: 11/11/2020
 ---
 # dotnet publish
 
@@ -35,7 +35,7 @@ dotnet publish -h|--help
 - A *.runtimeconfig.json* file that specifies the shared runtime that the application expects, as well as other configuration options for the runtime (for example, garbage collection type).
 - The application's dependencies, which are copied from the NuGet cache into the output folder.
 
-The `dotnet publish` command's output is ready for deployment to a hosting system (for example, a server, PC, Mac, laptop) for execution. It's the only officially supported way to prepare the application for deployment. Depending on the type of deployment that the project specifies, the hosting system may or may not have the .NET Core shared runtime installed on it. For more information, see [Publish .NET Core apps with the .NET Core CLI](../deploying/deploy-with-cli.md).
+The `dotnet publish` command's output is ready for deployment to a hosting system (for example, a server, PC, Mac, laptop) for execution. It's the only officially supported way to prepare the application for deployment. Depending on the type of deployment that the project specifies, the hosting system may or may not have the .NET shared runtime installed on it. For more information, see [Publish .NET apps with the .NET CLI](../deploying/deploy-with-cli.md).
 
 ### Implicit restore
 
@@ -159,7 +159,7 @@ For more information, see the following resources:
 
 - **`--self-contained [true|false]`**
 
-  Publishes the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine. Default is `true` if a runtime identifier is specified and the project is an executable project (not a library project). For more information, see [.NET Core application publishing](../deploying/index.md) and [Publish .NET Core apps with the .NET Core CLI](../deploying/deploy-with-cli.md).
+  Publishes the .NET runtime with your application so the runtime doesn't need to be installed on the target machine. Default is `true` if a runtime identifier is specified and the project is an executable project (not a library project). For more information, see [.NET application publishing](../deploying/index.md) and [Publish .NET apps with the .NET CLI](../deploying/deploy-with-cli.md).
 
   If this option is used without specifying `true` or `false`, the default is `true`. In that case, don't put the solution or project argument immediately after `--self-contained`, because `true` or `false` is expected in that position.
 
@@ -169,7 +169,7 @@ For more information, see the following resources:
 
 - **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 
-  Publishes the application for a given runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). For more information, see [.NET Core application publishing](../deploying/index.md) and [Publish .NET Core apps with the .NET Core CLI](../deploying/deploy-with-cli.md).
+  Publishes the application for a given runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). For more information, see [.NET application publishing](../deploying/index.md) and [Publish .NET apps with the .NET CLI](../deploying/deploy-with-cli.md).
 
 - **`-v|--verbosity <LEVEL>`**
 
@@ -225,8 +225,8 @@ For more information, see the following resources:
 
 ## See also
 
-- [.NET Core application publishing overview](../deploying/index.md)
-- [Publish .NET Core apps with the .NET Core CLI](../deploying/deploy-with-cli.md)
+- [.NET application publishing overview](../deploying/index.md)
+- [Publish .NET apps with the .NET CLI](../deploying/deploy-with-cli.md)
 - [Target frameworks](../../standard/frameworks.md)
 - [Runtime Identifier (RID) catalog](../rid-catalog.md)
 - [Working with macOS Catalina Notarization](../install/macos-notarization-issues.md)

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -40,7 +40,7 @@ Sometimes, it might be inconvenient to run the implicit NuGet restore with these
 
 ### Specify feeds
 
-To restore the dependencies, NuGet needs the feeds where the packages are located. Feeds are usually provided via the *nuget.config* configuration file. A default configuration file is provided when the .NET Core SDK is installed. To specify additional feeds, do one of the following:
+To restore the dependencies, NuGet needs the feeds where the packages are located. Feeds are usually provided via the *nuget.config* configuration file. A default configuration file is provided when the .NET SDK is installed. To specify additional feeds, do one of the following:
 
 - Create your own *nuget.config* file in the project directory. For more information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior) and [nuget.config differences](#nugetconfig-differences) later in this article.
 - Use `dotnet nuget` commands such as [`dotnet nuget add source`](dotnet-nuget-add-source.md).
@@ -65,11 +65,11 @@ There are three specific settings that `dotnet restore` ignores:
 
 - [bindingRedirects](/nuget/schema/nuget-config-file#bindingredirects-section)
 
-  Binding redirects don't work with `<PackageReference>` elements and .NET Core only supports `<PackageReference>` elements for NuGet packages.
+  Binding redirects don't work with `<PackageReference>` elements and .NET only supports `<PackageReference>` elements for NuGet packages.
 
 - [solution](/nuget/schema/nuget-config-file#solution-section)
 
-  This setting is Visual Studio specific and doesn't apply to .NET Core. .NET Core doesn't use a `packages.config` file and instead uses `<PackageReference>` elements for NuGet packages.
+  This setting is Visual Studio specific and doesn't apply to .NET. .NET doesn't use a `packages.config` file and instead uses `<PackageReference>` elements for NuGet packages.
 
 - [trustedSigners](/nuget/schema/nuget-config-file#trustedsigners-section)
 

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -37,7 +37,7 @@ The `dotnet run` command is used in the context of projects, not built assemblie
 dotnet myapp.dll
 ```
 
-For more information on the `dotnet` driver, see the [.NET Core Command Line Tools (CLI)](index.md) topic.
+For more information on the `dotnet` driver, see the [.NET Command Line Tools (CLI)](index.md) topic.
 
 To run the application, the `dotnet run` command resolves the dependencies of the application that are outside of the shared runtime from the NuGet cache. Because it uses cached dependencies, it's not recommended to use `dotnet run` to run applications in production. Instead, [create a deployment](../deploying/index.md) using the [`dotnet publish`](dotnet-publish.md) command and deploy the published output.
 
@@ -124,7 +124,6 @@ To run the application, the `dotnet run` command resolves the dependencies of th
   ```
 
 - Restore dependencies and tools for the project in the current directory only showing minimal output and then run the project:
- (.NET Core SDK 2.0 and later versions):
 
   ```dotnetcli
   dotnet run --verbosity m

--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -9,7 +9,7 @@ ms.date: 02/14/2020
 
 ## Name
 
-`dotnet sln` - Lists or modifies the projects in a .NET Core solution file.
+`dotnet sln` - Lists or modifies the projects in a .NET solution file.
 
 ## Synopsis
 

--- a/docs/core/tools/dotnet-store.md
+++ b/docs/core/tools/dotnet-store.md
@@ -45,7 +45,7 @@ dotnet store -h|--help
 
 - **`--framework-version <FRAMEWORK_VERSION>`**
 
-  Specifies the .NET Core SDK version. This option enables you to select a specific framework version beyond the framework specified by the `-f|--framework` option.
+  Specifies the .NET SDK version. This option enables you to select a specific framework version beyond the framework specified by the `-f|--framework` option.
 
 - **`-h|--help`**
 
@@ -53,7 +53,7 @@ dotnet store -h|--help
 
 - **`-o|--output <OUTPUT_DIRECTORY>`**
 
-  Specifies the path to the runtime package store. If not specified, it defaults to the *store* subdirectory of the user profile .NET Core installation directory.
+  Specifies the path to the runtime package store. If not specified, it defaults to the *store* subdirectory of the user profile .NET installation directory.
 
 - **`--skip-optimization`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -274,5 +274,5 @@ For more information and examples on how to use selective unit test filtering, s
 ## See also
 
 - [Frameworks and Targets](../../standard/frameworks.md)
-- [.NET Core Runtime Identifier (RID) catalog](../rid-catalog.md)
+- [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
 - [Passing runsettings arguments through commandline](https://github.com/Microsoft/vstest-docs/blob/master/docs/RunSettingsArguments.md)

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet tool install command
-description: The dotnet tool install command installs the specified .NET Core tool on your machine.
+description: The dotnet tool install command installs the specified .NET tool on your machine.
 ms.date: 02/14/2020
 ---
 # dotnet tool install
@@ -9,7 +9,7 @@ ms.date: 02/14/2020
 
 ## Name
 
-`dotnet tool install` - Installs the specified [.NET Core tool](global-tools.md) on your machine.
+`dotnet tool install` - Installs the specified [.NET tool](global-tools.md) on your machine.
 
 ## Synopsis
 
@@ -34,7 +34,7 @@ dotnet tool install -h|--help
 
 ## Description
 
-The `dotnet tool install` command provides a way for you to install .NET Core tools on your machine. To use the command, you specify one of the following installation options:
+The `dotnet tool install` command provides a way for you to install .NET tools on your machine. To use the command, you specify one of the following installation options:
 
 * To install a global tool in the default location, use the `--global` option.
 * To install a global tool in a custom location,  use the `--tool-path` option.
@@ -61,7 +61,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`PACKAGE_NAME`**
 
-  Name/ID of the NuGet package that contains the .NET Core tool to install.
+  Name/ID of the NuGet package that contains the .NET tool to install.
 
 ## Options
 
@@ -75,7 +75,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`framework <FRAMEWORK>`**
 
-  Specifies the [target framework](../../standard/frameworks.md) to install the tool for. By default, the .NET Core SDK tries to choose the most appropriate target framework.
+  Specifies the [target framework](../../standard/frameworks.md) to install the tool for. By default, the .NET SDK tries to choose the most appropriate target framework.
 
 - **`-g|--global`**
 
@@ -121,6 +121,6 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
-- [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI](global-tools-how-to-use.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [.NET tools](global-tools.md)
+- [Tutorial: Install and use a .NET global tool using the .NET CLI](global-tools-how-to-use.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-list.md
+++ b/docs/core/tools/dotnet-tool-list.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet tool list command
-description: The dotnet tool list command lists the .NET Core tools that are installed on your machine.
+description: The dotnet tool list command lists the .NET tools that are installed on your machine.
 ms.date: 02/14/2020
 ---
 # dotnet tool list
@@ -9,7 +9,7 @@ ms.date: 02/14/2020
 
 ## Name
 
-`dotnet tool list` - Lists all [.NET Core tools](global-tools.md) of the specified type currently installed on your machine.
+`dotnet tool list` - Lists all [.NET tools](global-tools.md) of the specified type currently installed on your machine.
 
 ## Synopsis
 
@@ -27,7 +27,7 @@ dotnet tool list -h|--help
 
 ## Description
 
-The `dotnet tool list` command provides a way for you to list all .NET Core global, tool-path, or local tools installed on your machine. The command lists the package name, version installed, and the tool command.  To use the command, you specify one of the following:
+The `dotnet tool list` command provides a way for you to list all .NET global, tool-path, or local tools installed on your machine. The command lists the package name, version installed, and the tool command.  To use the command, you specify one of the following:
 
 * To list global tools installed in the default location, use the `--global` option
 * To list global tools installed in a custom location, use the `--tool-path` option.
@@ -73,6 +73,6 @@ The `dotnet tool list` command provides a way for you to list all .NET Core glob
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
-- [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI](global-tools-how-to-use.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [.NET tools](global-tools.md)
+- [Tutorial: Install and use a .NET global tool using the .NET CLI](global-tools-how-to-use.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-restore.md
+++ b/docs/core/tools/dotnet-tool-restore.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet tool restore command
-description: The dotnet tool restore command installs on your machine the .NET Core local tools that are in scope for the current directory.
+description: The dotnet tool restore command installs on your machine the .NET local tools that are in scope for the current directory.
 ms.date: 02/14/2020
 ---
 # dotnet tool restore
@@ -9,7 +9,7 @@ ms.date: 02/14/2020
 
 ## Name
 
-`dotnet tool restore` - Installs on your machine the .NET Core local tools that are in scope for the current directory.
+`dotnet tool restore` - Installs on your machine the .NET local tools that are in scope for the current directory.
 
 ## Synopsis
 
@@ -73,5 +73,5 @@ The `dotnet tool restore` command finds the tool manifest file that is in scope 
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [.NET tools](global-tools.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-run.md
+++ b/docs/core/tools/dotnet-tool-run.md
@@ -43,5 +43,5 @@ The `dotnet tool run` command searches tool manifest files that are in scope for
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [.NET tools](global-tools.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-search.md
+++ b/docs/core/tools/dotnet-tool-search.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet tool search command
-description: The dotnet tool search command searches the .NET Core tools that are published to NuGet.org.
+description: The dotnet tool search command searches the .NET tools that are published to NuGet.org.
 ms.date: 11/11/2020
 ---
 # dotnet tool search
@@ -9,7 +9,7 @@ ms.date: 11/11/2020
 
 ## Name
 
-`dotnet tool search` - Searches all [.NET Core tools](global-tools.md) that are published to NuGet.
+`dotnet tool search` - Searches all [.NET tools](global-tools.md) that are published to NuGet.
 
 ## Synopsis
 
@@ -94,6 +94,6 @@ The command uses the [NuGet Search API](/nuget/api/search-query-service-resource
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
-- [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI](global-tools-how-to-use.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [.NET tools](global-tools.md)
+- [Tutorial: Install and use a .NET global tool using the .NET CLI](global-tools-how-to-use.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-uninstall.md
+++ b/docs/core/tools/dotnet-tool-uninstall.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet tool uninstall command
-description: The dotnet tool uninstall command uninstalls the specified .NET Core tool from your machine.
+description: The dotnet tool uninstall command uninstalls the specified .NET tool from your machine.
 ms.date: 02/14/2020
 ---
 # dotnet tool uninstall
@@ -9,7 +9,7 @@ ms.date: 02/14/2020
 
 ## Name
 
-`dotnet tool uninstall` - Uninstalls the specified [.NET Core tool](global-tools.md) from your machine.
+`dotnet tool uninstall` - Uninstalls the specified [.NET tool](global-tools.md) from your machine.
 
 ## Synopsis
 
@@ -25,7 +25,7 @@ dotnet tool uninstall -h|--help
 
 ## Description
 
-The `dotnet tool uninstall` command provides a way for you to uninstall .NET Core tools from your machine. To use the command, you specify one of the following options:
+The `dotnet tool uninstall` command provides a way for you to uninstall .NET tools from your machine. To use the command, you specify one of the following options:
 
 * To uninstall a global tool that was installed in the default location, use the `--global` option.
 * To uninstall a global tool that was installed in a custom location,  use the `--tool-path` option.
@@ -37,7 +37,7 @@ The `dotnet tool uninstall` command provides a way for you to uninstall .NET Cor
 
 - **`PACKAGE_NAME`**
 
-  Name/ID of the NuGet package that contains the .NET Core tool to uninstall. You can find the package name using the [dotnet tool list](dotnet-tool-list.md) command.
+  Name/ID of the NuGet package that contains the .NET tool to uninstall. You can find the package name using the [dotnet tool list](dotnet-tool-list.md) command.
 
 ## Options
 
@@ -73,6 +73,6 @@ The `dotnet tool uninstall` command provides a way for you to uninstall .NET Cor
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
-- [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI](global-tools-how-to-use.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [.NET tools](global-tools.md)
+- [Tutorial: Install and use a .NET global tool using the .NET CLI](global-tools-how-to-use.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet tool update command
-description: The dotnet tool update command updates the specified .NET Core tool on your machine.
+description: The dotnet tool update command updates the specified .NET tool on your machine.
 ms.date: 07/08/2020
 ---
 # dotnet tool update
@@ -9,7 +9,7 @@ ms.date: 07/08/2020
 
 ## Name
 
-`dotnet tool update` - Updates the specified [.NET Core tool](global-tools.md) on your machine.
+`dotnet tool update` - Updates the specified [.NET tool](global-tools.md) on your machine.
 
 ## Synopsis
 
@@ -38,7 +38,7 @@ dotnet tool update -h|--help
 
 ## Description
 
-The `dotnet tool update` command provides a way for you to update .NET Core tools on your machine to the latest stable version of the package. The command uninstalls and reinstalls a tool, effectively updating it. To use the command, you specify one of the following options:
+The `dotnet tool update` command provides a way for you to update .NET tools on your machine to the latest stable version of the package. The command uninstalls and reinstalls a tool, effectively updating it. To use the command, you specify one of the following options:
 
 * To update a global tool that was installed in the default location, use the `--global` option
 * To update a global tool that was installed in a custom location, use the `--tool-path` option.
@@ -50,7 +50,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 - **`PACKAGE_ID`**
 
-  Name/ID of the NuGet package that contains the .NET Core global tool to update. You can find the package name using the [dotnet tool list](dotnet-tool-list.md) command.
+  Name/ID of the NuGet package that contains the .NET global tool to update. You can find the package name using the [dotnet tool list](dotnet-tool-list.md) command.
 
 ## Options
 
@@ -138,7 +138,7 @@ The `dotnet tool update` command provides a way for you to update .NET Core tool
 
 ## See also
 
-- [.NET Core tools](global-tools.md)
+- [.NET tools](global-tools.md)
 - [Semantic versioning](https://semver.org)
-- [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI](global-tools-how-to-use.md)
-- [Tutorial: Install and use a .NET Core local tool using the .NET Core CLI](local-tools-how-to-use.md)
+- [Tutorial: Install and use a .NET global tool using the .NET CLI](global-tools-how-to-use.md)
+- [Tutorial: Install and use a .NET local tool using the .NET CLI](local-tools-how-to-use.md)

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -233,7 +233,7 @@ For more information about each tool, type `dotnet <tool-name> --help`.
 
 ## Examples
 
-Create a new .NET Core console application:
+Create a new .NET console application:
 
 ```dotnetcli
 dotnet new console

--- a/docs/core/tools/elevated-access.md
+++ b/docs/core/tools/elevated-access.md
@@ -16,11 +16,11 @@ The following commands can be run elevated:
 
 We don't recommend running other commands elevated. In particular, we don't recommend elevation with commands that use MSBuild, such as [dotnet restore](dotnet-restore.md), [dotnet build](dotnet-build.md), and [dotnet run](dotnet-run.md). The primary issue is permission management problems when a user transitions back and forth between root and a restricted account after issuing dotnet commands. You may find as a restricted user that you don't have access to the file built by a root user. There are ways to resolve this situation, but they're unnecessary to get into in the first place.
 
-You can run commands as root as long as you don’t transition back and forth between root and a restricted account. For example, Docker containers run as root by default, so they have this characteristic.
+You can run commands as root as long as you don't transition back and forth between root and a restricted account. For example, Docker containers run as root by default, so they have this characteristic.
 
 ## Global tool installation
 
-The following instructions demonstrate the recommended way to install, run, and uninstall .NET Core tools that require elevated permissions to execute.
+The following instructions demonstrate the recommended way to install, run, and uninstall .NET tools that require elevated permissions to execute.
 
 <!-- markdownlint-disable MD025 -->
 
@@ -31,7 +31,7 @@ The following instructions demonstrate the recommended way to install, run, and 
 If the folder `%ProgramFiles%\dotnet-tools` already exists, do the following to check whether the "Users" group has permission to write or modify that directory:
 
 - Right-click the `%ProgramFiles%\dotnet-tools` folder and select **Properties**. The **Common Properties** dialog box opens.
-- Select the **Security** tab. Under **Group or user names**, check whether the “Users” group has permission to write or modify the directory.
+- Select the **Security** tab. Under **Group or user names**, check whether the "Users" group has permission to write or modify the directory.
 - If the "Users" group can write or modify the directory, use a different directory name when installing the tools rather than *dotnet-tools*.
 
 To install tools, run the following command in elevated prompt. It will create the *dotnet-tools* folder during the installation.
@@ -102,4 +102,4 @@ During development, you may need elevated access to test your application. This 
 
 ## See also
 
-- [.NET Core Global Tools overview](global-tools.md)
+- [.NET tools overview](global-tools.md)

--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -1,19 +1,19 @@
 ---
 title: Enable tab completion
-description: This article teaches you how to enable tab completion for the .NET Core CLI for PowerShell, Bash, and zsh.
+description: This article teaches you how to enable tab completion for the .NET CLI for PowerShell, Bash, and zsh.
 author: adegeo
 ms.author: adegeo
 ms.topic: how-to
 ms.date: 11/03/2019
 ---
 
-# How to enable TAB completion for the .NET Core CLI
+# How to enable TAB completion for the .NET CLI
 
 **This article applies to:** ✔️ .NET Core 2.1 SDK and later versions
 
 This article describes how to configure tab completion for three shells, PowerShell, Bash, and zsh. For other shells, refer to their documentation on how to configure tab completion.
 
-Once set up, tab completion for the .NET Core CLI is triggered by typing a `dotnet` command in the shell, and then pressing the TAB key. The current command line is sent to the `dotnet complete` command, and the results are processed by your shell. You can test the results without enabling tab completion by sending something directly to the `dotnet complete` command. For example:
+Once set up, tab completion for the .NET CLI is triggered by typing a `dotnet` command in the shell, and then pressing the TAB key. The current command line is sent to the `dotnet complete` command, and the results are processed by your shell. You can test the results without enabling tab completion by sending something directly to the `dotnet complete` command. For example:
 
 ```console
 > dotnet complete "dotnet a"
@@ -24,7 +24,7 @@ migrate
 pack
 ```
 
-If that command doesn't work, make sure that .NET Core 2.0 SDK or above is installed. If it's installed, but that command still doesn't work, make sure that the `dotnet` command resolves to a version of .NET Core 2.0 SDK and above. Use the `dotnet --version` command to see what version of `dotnet` your current path is resolving to. For more information, see [Select the .NET Core version to use](../versions/selection.md).
+If that command doesn't work, make sure that .NET Core 2.0 SDK or above is installed. If it's installed, but that command still doesn't work, make sure that the `dotnet` command resolves to a version of .NET Core 2.0 SDK and above. Use the `dotnet --version` command to see what version of `dotnet` your current path is resolving to. For more information, see [Select the .NET version to use](../versions/selection.md).
 
 ### Examples
 
@@ -40,7 +40,7 @@ Input                                | becomes                                  
 
 ## PowerShell
 
-To add tab completion to **PowerShell** for the .NET Core CLI, create or edit the profile stored in the variable `$PROFILE`. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
+To add tab completion to **PowerShell** for the .NET CLI, create or edit the profile stored in the variable `$PROFILE`. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
 
 Add the following code to your profile:
 
@@ -56,7 +56,7 @@ Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
 
 ## bash
 
-To add tab completion to your **bash** shell for the .NET Core CLI, add the following code to your `.bashrc` file:
+To add tab completion to your **bash** shell for the .NET CLI, add the following code to your `.bashrc` file:
 
 ```bash
 # bash parameter completion for the dotnet CLI
@@ -79,7 +79,7 @@ complete -f -F _dotnet_bash_complete dotnet
 
 ## zsh
 
-To add tab completion to your **zsh** shell for the .NET Core CLI, add the following code to your `.zshrc` file:
+To add tab completion to your **zsh** shell for the .NET CLI, add the following code to your `.zshrc` file:
 
 ```zsh
 # zsh parameter completion for the dotnet CLI

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -1,6 +1,6 @@
 ---
 title: global.json overview
-description: Learn how to use the global.json file to set the .NET Core SDK version when running .NET Core CLI commands.
+description: Learn how to use the global.json file to set the .NET SDK version when running .NET CLI commands.
 ms.topic: how-to
 ms.date: 05/01/2020
 ms.custom: "updateeachrelease"
@@ -9,13 +9,13 @@ ms.custom: "updateeachrelease"
 
 **This article applies to:** ✔️ .NET Core 2.0 SDK and later versions
 
-The *global.json* file allows you to define which .NET Core SDK version is used when you run .NET Core CLI commands. Selecting the .NET Core SDK is independent from specifying the runtime your project targets. The .NET Core SDK version indicates which versions of the .NET Core CLI is used.
+The *global.json* file allows you to define which .NET SDK version is used when you run .NET CLI commands. Selecting the .NET SDK is independent from specifying the runtime your project targets. The .NET SDK version indicates which versions of the .NET CLI is used.
 
 In general, you want to use the latest version of the SDK tools, so no *global.json* file is needed. In some advanced scenarios, you might want to control the version of the SDK tools, and this article explains how to do this.
 
 For more information about specifying the runtime instead, see [Target frameworks](../../standard/frameworks.md).
 
-.NET Core SDK looks for a *global.json* file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
+The .NET SDK looks for a *global.json* file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
 
 ## global.json schema
 
@@ -23,7 +23,7 @@ For more information about specifying the runtime instead, see [Target framework
 
 Type: `object`
 
-Specifies information about the .NET Core SDK to select.
+Specifies information about the .NET SDK to select.
 
 #### version
 
@@ -31,7 +31,7 @@ Specifies information about the .NET Core SDK to select.
 
 - Available since: .NET Core 1.0 SDK.
 
-The version of the .NET Core SDK to use.
+The version of the .NET SDK to use.
 
 This field:
 
@@ -78,7 +78,7 @@ The following table shows the possible values for the `rollForward` key:
 | `latestPatch` | Uses the latest installed patch level that matches the requested major, minor, and feature band with a patch level and that is greater or equal than the specified value. <br> If not found, fails. |
 | `latestFeature` | Uses the highest installed feature band and patch level that matches the requested major and minor with a feature band and patch level that is greater or equal than the specified value. <br> If not found, fails. |
 | `latestMinor` | Uses the highest installed minor, feature band, and patch level that matches the requested major with a minor, feature band, and patch level that is greater or equal than the specified value. <br> If not found, fails. |
-| `latestMajor` | Uses the highest installed .NET Core SDK with a version that is greater or equal than the specified value. <br> If not found, fail. |
+| `latestMajor` | Uses the highest installed .NET SDK with a version that is greater or equal than the specified value. <br> If not found, fail. |
 | `disable`     | Doesn't roll forward. Exact match required. |
 
 ### msbuild-sdks
@@ -143,11 +143,11 @@ The following example shows how to use the highest patch version installed of a 
 }
 ```
 
-## global.json and the .NET Core CLI
+## global.json and the .NET CLI
 
-It's helpful to know which SDK versions are installed on your machine to set one in the *global.json* file. For more information on how to do that, see [How to check that .NET Core is already installed](../install/how-to-detect-installed-versions.md#check-sdk-versions).
+It's helpful to know which SDK versions are installed on your machine to set one in the *global.json* file. For more information on how to do that, see [How to check that .NET is already installed](../install/how-to-detect-installed-versions.md#check-sdk-versions).
 
-To install additional .NET Core SDK versions on your machine, visit the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page.
+To install additional .NET SDK versions on your machine, visit the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page.
 
 You can create a new the *global.json* file in the current directory by executing the [dotnet new](dotnet-new.md) command, similar to the following example:
 
@@ -158,7 +158,7 @@ dotnet new globaljson --sdk-version 3.0.100
 ## Matching rules
 
 > [!NOTE]
-> The matching rules are governed by the `dotnet.exe` entry point, which is common across all installed .NET Core installed runtimes. The matching rules for the latest installed version of the .NET Core Runtime are used when you have multiple runtimes installed side-by-side or if or you're using a *global.json* file.
+> The matching rules are governed by the `dotnet.exe` entry point, which is common across all installed .NET installed runtimes. The matching rules for the latest installed version of the .NET Runtime are used when you have multiple runtimes installed side-by-side or if or you're using a *global.json* file.
 
 ## [.NET Core 3.x](#tab/netcore3x)
 

--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -1,15 +1,15 @@
 ---
-title: "Tutorial: Create a .NET Core tool"
-description: Learn how to create a .NET Core tool. A tool is a console application that is installed by using the .NET Core CLI.
+title: "Tutorial: Create a .NET tool"
+description: Learn how to create a .NET tool. A tool is a console application that is installed by using the .NET CLI.
 ms.topic: tutorial
 ms.date: 02/12/2020
 ---
 
-# Tutorial: Create a .NET Core tool using the .NET Core CLI
+# Tutorial: Create a .NET tool using the .NET CLI
 
 **This article applies to:** ✔️ .NET Core 2.1 SDK and later versions
 
-This tutorial teaches you how to create and package a .NET Core tool. The .NET Core CLI lets you create a console application as a tool, which others can install and run. .NET Core tools are NuGet packages that are installed from the .NET Core CLI. For more information about tools, see [.NET Core tools overview](global-tools.md).
+This tutorial teaches you how to create and package a .NET tool. The .NET CLI lets you create a console application as a tool, which others can install and run. .NET tools are NuGet packages that are installed from the .NET CLI. For more information about tools, see [.NET tools overview](global-tools.md).
 
 The tool that you'll create is a console application that takes a message as input and displays the message along with lines of text that create the image of a robot.
 
@@ -186,7 +186,7 @@ Before you can pack and distribute the application as a tool, you need to modify
 
 ## Troubleshoot
 
-If you get an error message while following the tutorial, see [Troubleshoot .NET Core tool usage issues](troubleshoot-usage-issues.md).
+If you get an error message while following the tutorial, see [Troubleshoot .NET tool usage issues](troubleshoot-usage-issues.md).
 
 ## Next steps
 

--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -1,11 +1,11 @@
 ---
-title: "Tutorial: Install and use a .NET Core global tool"
+title: "Tutorial: Install and use a .NET global tool"
 description: Learn how to install and use a .NET tool as a global tool.
 ms.topic: tutorial
 ms.date: 02/12/2020
 ---
 
-# Tutorial: Install and use a .NET Core global tool using the .NET Core CLI
+# Tutorial: Install and use a .NET global tool using the .NET CLI
 
 **This article applies to:** ✔️ .NET Core 2.1 SDK and later versions
 
@@ -23,9 +23,9 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    dotnet tool install --global --add-source ./nupkg microsoft.botsay
    ```
 
-   The `--global` parameter tells the .NET Core CLI to install the tool binaries in a default location that is automatically added to the PATH environment variable.
+   The `--global` parameter tells the .NET CLI to install the tool binaries in a default location that is automatically added to the PATH environment variable.
 
-   The `--add-source` parameter tells the .NET Core CLI to temporarily use the *./nupkg* directory as an additional source feed for NuGet packages. You gave your package a unique name to make sure that it will only be found in the *./nupkg* directory, not on the Nuget.org site.
+   The `--add-source` parameter tells the .NET CLI to temporarily use the *./nupkg* directory as an additional source feed for NuGet packages. You gave your package a unique name to make sure that it will only be found in the *./nupkg* directory, not on the Nuget.org site.
 
    The output shows the command used to call the tool and the version installed:
 
@@ -65,7 +65,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    dotnet tool install --tool-path ~/bin --add-source ./nupkg microsoft.botsay
    ```
 
-   The `--tool-path` parameter tells the .NET Core CLI to install the tool binaries in the specified location. If the directory doesn't exist, it is created. This directory is not automatically added to the PATH environment variable.
+   The `--tool-path` parameter tells the .NET CLI to install the tool binaries in the specified location. If the directory doesn't exist, it is created. This directory is not automatically added to the PATH environment variable.
 
    The output shows the command used to call the tool and the version installed:
 
@@ -104,7 +104,7 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
 ## Troubleshoot
 
-If you get an error message while following the tutorial, see [Troubleshoot .NET Core tool usage issues](troubleshoot-usage-issues.md).
+If you get an error message while following the tutorial, see [Troubleshoot .NET tool usage issues](troubleshoot-usage-issues.md).
 
 ## Next steps
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -1,17 +1,17 @@
 ---
-title: .NET Core CLI
+title: .NET CLI
 titleSuffix: ""
-description: An overview of the .NET Core CLI and its features.
+description: An overview of the .NET CLI and its features.
 ms.topic: overview
 ms.date: 02/13/2020
 ---
-# .NET Core CLI overview
+# .NET CLI overview
 
 **This article applies to:** ✔️ .NET Core 2.1 SDK and later versions
 
-The .NET Core command-line interface (CLI) is a cross-platform toolchain for developing, building, running, and publishing .NET Core applications.
+The .NET command-line interface (CLI) is a cross-platform toolchain for developing, building, running, and publishing .NET applications.
 
-The .NET Core CLI is included with the [.NET Core SDK](../sdk.md). To learn how to install the .NET Core SDK, see [Install .NET Core](../install/windows.md).
+The .NET CLI is included with the [.NET SDK](../sdk.md). To learn how to install the .NET SDK, see [Install .NET Core](../install/windows.md).
 
 ## CLI commands
 
@@ -58,7 +58,7 @@ The following commands are installed by default:
 - [`tool run`](global-tools.md#invoke-a-local-tool) Available since .NET Core SDK 3.0.
 - [`tool uninstall`](dotnet-tool-uninstall.md)
 
-Tools are console applications that are installed from NuGet packages and are invoked from the command prompt. You can write tools yourself or install tools written by third parties. Tools are also known as global tools, tool-path tools, and local tools. For more information, see [.NET Core tools overview](global-tools.md).
+Tools are console applications that are installed from NuGet packages and are invoked from the command prompt. You can write tools yourself or install tools written by third parties. Tools are also known as global tools, tool-path tools, and local tools. For more information, see [.NET tools overview](global-tools.md).
 
 ## Command structure
 
@@ -74,7 +74,7 @@ dotnet /build_output/my_app.dll
 
 The driver is named [dotnet](dotnet.md) and has two responsibilities, either running a [framework-dependent app](../deploying/index.md) or executing a command.
 
-To run a framework-dependent app, specify the app after the driver, for example, `dotnet /path/to/my_app.dll`. When executing the command from the folder where the app's DLL resides, simply execute `dotnet my_app.dll`. If you want to use a specific version of the .NET Core Runtime, use the `--fx-version <VERSION>` option (see the [dotnet command](dotnet.md) reference).
+To run a framework-dependent app, specify the app after the driver, for example, `dotnet /path/to/my_app.dll`. When executing the command from the folder where the app's DLL resides, simply execute `dotnet my_app.dll`. If you want to use a specific version of the .NET Runtime, use the `--fx-version <VERSION>` option (see the [dotnet command](dotnet.md) reference).
 
 When you supply a command to the driver, `dotnet.exe` starts the CLI command execution process. For example:
 
@@ -99,4 +99,4 @@ The options you pass on the command line are the options to the command invoked.
 ## See also
 
 - [dotnet/sdk GitHub repository](https://github.com/dotnet/sdk/)
-- [.NET Core installation guide](../install/windows.md)
+- [.NET installation guide](../install/windows.md)

--- a/docs/core/tools/local-tools-how-to-use.md
+++ b/docs/core/tools/local-tools-how-to-use.md
@@ -1,11 +1,11 @@
 ---
-title: "Tutorial: Install and use .NET Core local tools"
+title: "Tutorial: Install and use .NET local tools"
 description: Learn how to install and use a .NET tool as a local tool.
 ms.topic: tutorial
 ms.date: 02/12/2020
 ---
 
-# Tutorial: Install and use a .NET Core local tool using the .NET Core CLI
+# Tutorial: Install and use a .NET local tool using the .NET CLI
 
 **This article applies to:** ✔️ .NET Core 3.0 SDK and later versions
 
@@ -196,7 +196,7 @@ dotnet tool uninstall dotnetsay
 
 ## Troubleshoot
 
-If you get an error message while following the tutorial, see [Troubleshoot .NET Core tool usage issues](troubleshoot-usage-issues.md).
+If you get an error message while following the tutorial, see [Troubleshoot .NET tool usage issues](troubleshoot-usage-issues.md).
 
 ## See also
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -68,7 +68,7 @@ The telemetry feature collects the following data:
 | >=2.1.300     | Kernel version. |
 | >=2.1.300     | Libc release/version. |
 | >=3.0.100     | Whether the output was redirected (true or false). |
-| >=3.0.100     | On a CLI/SDK crash, the exception type and its stack trace (only CLI/SDK code is included in the stack trace sent). For more information, see [.NET CLI/SDK crash exception telemetry collected](#net-core-clisdk-crash-exception-telemetry-collected). |
+| >=3.0.100     | On a CLI/SDK crash, the exception type and its stack trace (only CLI/SDK code is included in the stack trace sent). For more information, see [.NET CLI/SDK crash exception telemetry collected](#net-clisdk-crash-exception-telemetry-collected). |
 
 ### Collected options
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -1,12 +1,12 @@
 ---
-title: .NET Core SDK telemetry
-description: Discover the .NET Core SDK telemetry features that collect usage information for analysis, which data is collected, and how to disable it.
+title: .NET SDK telemetry
+description: Discover the .NET SDK telemetry features that collect usage information for analysis, which data is collected, and how to disable it.
 author: KathleenDollard
 ms.date: 08/27/2019
 ---
-# .NET Core SDK telemetry
+# .NET SDK telemetry
 
-The [.NET Core SDK](index.md) includes a telemetry feature that collects usage data and exception information when the .NET Core CLI crashes. The .NET Core CLI comes with the .NET Core SDK and is the set of verbs that enable you to build, test, and publish your .NET Core apps. It's important that the .NET team understands how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
+The [.NET SDK](index.md) includes a telemetry feature that collects usage data and exception information when the .NET CLI crashes. The .NET CLI comes with the .NET SDK and is the set of verbs that enable you to build, test, and publish your .NET apps. It's important that the .NET team understands how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
 
 The collected data is published in aggregate under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
@@ -16,7 +16,7 @@ The collected data is published in aggregate under the [Creative Commons Attribu
 
 - `dotnet [path-to-app].dll`
 
-Telemetry *is collected* when using any of the [.NET Core CLI commands](index.md), such as:
+Telemetry *is collected* when using any of the [.NET CLI commands](index.md), such as:
 
 - `dotnet build`
 - `dotnet pack`
@@ -24,23 +24,23 @@ Telemetry *is collected* when using any of the [.NET Core CLI commands](index.md
 
 ## How to opt out
 
-The .NET Core SDK telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
+The .NET SDK telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
 
-A single telemetry entry is also sent by the .NET Core SDK installer when a successful installation happens. To opt out, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable before you install the .NET Core SDK.
+A single telemetry entry is also sent by the .NET SDK installer when a successful installation happens. To opt out, set the `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable before you install the .NET SDK.
 
 ## Disclosure
 
-The .NET Core SDK displays text similar to the following when you first run one of the [.NET Core CLI commands](index.md) (for example, `dotnet build`). Text may vary slightly depending on the version of the SDK you're running. This "first run" experience is how Microsoft notifies you about data collection.
+The .NET SDK displays text similar to the following when you first run one of the [.NET CLI commands](index.md) (for example, `dotnet build`). Text may vary slightly depending on the version of the SDK you're running. This "first run" experience is how Microsoft notifies you about data collection.
 
 ```console
 Telemetry
 ---------
-The .NET Core tools collect usage data in order to help us improve your experience. The data is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The .NET tools collect usage data in order to help us improve your experience. The data is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
 
-Read more about .NET Core CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
+Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
 ```
 
-To disable this message and the .NET Core welcome message, set the `DOTNET_NOLOGO` environment variable to `true`. Note that this variable has no effect on telemetry opt out.
+To disable this message and the .NET welcome message, set the `DOTNET_NOLOGO` environment variable to `true`. Note that this variable has no effect on telemetry opt out.
 
 ## Data points
 
@@ -57,7 +57,7 @@ The telemetry feature collects the following data:
 | All          | Three octet IP address used to determine the geographical location. |
 | All          | Operating system and version. |
 | All          | Runtime ID (RID) the SDK is running on. |
-| All          | .NET Core SDK version. |
+| All          | .NET SDK version. |
 | All          | Telemetry profile: an optional value only used with explicit user opt-in and used internally at Microsoft. |
 | >=2.0        | Command arguments and options: several arguments and options are collected (not arbitrary strings). See [collected options](#collected-options). Hashed after 2.1.300. |
 | >=2.0         | Whether the SDK is running in a container. |
@@ -68,7 +68,7 @@ The telemetry feature collects the following data:
 | >=2.1.300     | Kernel version. |
 | >=2.1.300     | Libc release/version. |
 | >=3.0.100     | Whether the output was redirected (true or false). |
-| >=3.0.100     | On a CLI/SDK crash, the exception type and its stack trace (only CLI/SDK code is included in the stack trace sent). For more information, see [.NET Core CLI/SDK crash exception telemetry collected](#net-core-clisdk-crash-exception-telemetry-collected). |
+| >=3.0.100     | On a CLI/SDK crash, the exception type and its stack trace (only CLI/SDK code is included in the stack trace sent). For more information, see [.NET CLI/SDK crash exception telemetry collected](#net-core-clisdk-crash-exception-telemetry-collected). |
 
 ### Collected options
 
@@ -99,13 +99,13 @@ A subset of commands sends selected options if they're used, along with their va
 
 Except for `--verbosity` and `--sdk-package-version`, all the other values are hashed starting with .NET Core 2.1.100 SDK.
 
-## .NET Core CLI/SDK crash exception telemetry collected
+## .NET CLI/SDK crash exception telemetry collected
 
-If the .NET Core CLI/SDK crashes, it collects the name of the exception and stack trace of the CLI/SDK code. This information is collected to assess problems and improve the quality of the .NET Core SDK and CLI. This article provides information about the data we collect. It also provides tips on how users building their own version of the .NET Core SDK can avoid inadvertent disclosure of personal or sensitive information.
+If the .NET CLI/SDK crashes, it collects the name of the exception and stack trace of the CLI/SDK code. This information is collected to assess problems and improve the quality of the .NET SDK and CLI. This article provides information about the data we collect. It also provides tips on how users building their own version of the .NET SDK can avoid inadvertent disclosure of personal or sensitive information.
 
 ### Types of collected data
 
-.NET Core CLI collects information for CLI/SDK exceptions only, not exceptions in your application. The collected data contains the name of the exception and the stack trace. This stack trace is of CLI/SDK code.
+.NET CLI collects information for CLI/SDK exceptions only, not exceptions in your application. The collected data contains the name of the exception and the stack trace. This stack trace is of CLI/SDK code.
 
 The following example shows the kind of data that is collected:
 
@@ -126,11 +126,11 @@ at Microsoft.DotNet.Cli.Program.Main(String[] args)
 
 ### Avoid inadvertent disclosure of information
 
-.NET Core contributors and anyone else running a version of the .NET Core SDK that they built themselves should consider the path to their SDK source code. If a crash occurs while using a .NET Core SDK that is a custom debug build or configured with custom build symbol files, the SDK source file path from the build machine is collected as part of the stack trace and isn't hashed.
+.NET contributors and anyone else running a version of the .NET SDK that they built themselves should consider the path to their SDK source code. If a crash occurs while using a .NET SDK that is a custom debug build or configured with custom build symbol files, the SDK source file path from the build machine is collected as part of the stack trace and isn't hashed.
 
-Because of this, custom builds of the .NET Core SDK shouldn't be located in directories whose path names expose personal or sensitive information.
+Because of this, custom builds of the .NET SDK shouldn't be located in directories whose path names expose personal or sensitive information.
 
 ## See also
 
-- [.NET Core CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry)
+- [.NET CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry)
 - [Telemetry reference source (dotnet/sdk repository)](https://github.com/dotnet/sdk/tree/master/src/Cli/dotnet/Telemetry)

--- a/docs/core/tools/troubleshoot-usage-issues.md
+++ b/docs/core/tools/troubleshoot-usage-issues.md
@@ -1,21 +1,21 @@
 ---
-title: Troubleshoot .NET Core tool usage issues
-description: Discover the common issues when running .NET Core tools and possible solutions.
+title: Troubleshoot .NET tool usage issues
+description: Discover the common issues when running .NET tools and possible solutions.
 author: kdollard
 ms.topic: troubleshooting
 ms.date: 02/14/2020
 ---
 
-# Troubleshoot .NET Core tool usage issues
+# Troubleshoot .NET tool usage issues
 
-You might come across issues when trying to install or run a .NET Core tool, which can be a global tool or a local tool. This article describes the common root causes and some possible solutions.
+You might come across issues when trying to install or run a .NET tool, which can be a global tool or a local tool. This article describes the common root causes and some possible solutions.
 
-## Installed .NET Core tool fails to run
+## Installed .NET tool fails to run
 
-When a .NET Core tool fails to run, most likely you ran into one of the following issues:
+When a .NET tool fails to run, most likely you ran into one of the following issues:
 
 * The executable file for the tool wasn't found.
-* The correct version of the .NET Core runtime wasn't found.
+* The correct version of the .NET runtime wasn't found.
 
 ### Executable file not found
 
@@ -25,7 +25,7 @@ If the executable file isn't found, you'll see a message similar to the followin
 Could not execute because the specified command or file was not found.
 Possible reasons for this include:
   * You misspelled a built-in dotnet command.
-  * You intended to execute a .NET Core program, but dotnet-xyz does not exist.
+  * You intended to execute a .NET program, but dotnet-xyz does not exist.
   * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
 ```
 
@@ -47,21 +47,21 @@ The name of the executable determines how you invoke the tool. The following tab
 
   If you're trying to run a global tool, check that the `PATH` environment variable on your machine contains the path where you installed the global tool and that the executable is in that path.
 
-  The .NET Core CLI tries to add the default location to the PATH environment variable on its first usage. However, there are some scenarios where the location might not be added to PATH automatically:
+  The .NET CLI tries to add the default location to the PATH environment variable on its first usage. However, there are some scenarios where the location might not be added to PATH automatically:
 
-  * If you're using Linux and you've installed the .NET Core SDK using *.tar.gz* files and not apt-get or rpm.
+  * If you're using Linux and you've installed the .NET SDK using *.tar.gz* files and not apt-get or rpm.
   * If you're using macOS 10.15 "Catalina" or later versions.
-  * If you're using macOS 10.14 "Mojave" or earlier versions, and you've installed the .NET Core SDK using *.tar.gz* files and not *.pkg*.
+  * If you're using macOS 10.14 "Mojave" or earlier versions, and you've installed the .NET SDK using *.tar.gz* files and not *.pkg*.
   * If you've installed the .NET Core 3.0 SDK and you've set the `DOTNET_ADD_GLOBAL_TOOLS_TO_PATH` environment variable to `false`.
   * If you've installed .NET Core 2.2 SDK or earlier versions, and you've set the `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` environment variable to `true`.
 
-  In these scenarios or if you specified the `--tool-path` option, the `PATH` environment variable on your machine doesn't automatically contain the path where you installed the global tool. In that case, append the tool location (for example, `$HOME/.dotnet/tools`) to the `PATH` environment variable by using whatever method your shell provides for updating environment variables. For more information, see [.NET Core tools](global-tools.md).
+  In these scenarios or if you specified the `--tool-path` option, the `PATH` environment variable on your machine doesn't automatically contain the path where you installed the global tool. In that case, append the tool location (for example, `$HOME/.dotnet/tools`) to the `PATH` environment variable by using whatever method your shell provides for updating environment variables. For more information, see [.NET tools](global-tools.md).
 
 * Local tools
 
   If you're trying to run a local tool, verify that there's a manifest file called *dotnet-tools.json* in the current directory or any of its parent directories. This file can also live under a folder named *.config* anywhere in the project folder hierarchy, instead of the root folder. If *dotnet-tools.json* exists, open it and check for the tool you're trying to run. If the file doesn't contain an entry for `"isRoot": true`, then also check further up the file hierarchy for additional tool manifest files.
 
-  If you're trying to run a .NET Core tool that was installed with a specified path, you need to include that path when using the tool. An example of using a tool-path installed tool is:
+  If you're trying to run a .NET tool that was installed with a specified path, you need to include that path when using the tool. An example of using a tool-path installed tool is:
 
   ```console
   ..\<toolDirectory>\dotnet-<toolName>
@@ -69,11 +69,11 @@ The name of the executable determines how you invoke the tool. The following tab
 
 ### Runtime not found
 
-.NET Core tools are [framework-dependent applications](../deploying/index.md#publish-framework-dependent), which means they rely on a .NET Core runtime installed on your machine. If the expected runtime isn't found, they follow normal .NET Core runtime roll-forward rules such as:
+.NET tools are [framework-dependent applications](../deploying/index.md#publish-framework-dependent), which means they rely on a .NET runtime installed on your machine. If the expected runtime isn't found, they follow normal .NET runtime roll-forward rules such as:
 
 * An application rolls forward to the highest patch release of the specified major and minor version.
 * If there's no matching runtime with a matching major and minor version number, the next higher minor version is used.
-* Roll forward doesn't occur between preview versions of the runtime or between preview versions and release versions. So, .NET Core tools created using preview versions must be rebuilt and republished by the author and reinstalled.
+* Roll forward doesn't occur between preview versions of the runtime or between preview versions and release versions. So, .NET tools created using preview versions must be rebuilt and republished by the author and reinstalled.
 
 Roll-forward won't occur by default in two common scenarios:
 
@@ -82,26 +82,26 @@ Roll-forward won't occur by default in two common scenarios:
 
 If an application can't find an appropriate runtime, it fails to run and reports an error.
 
-You can find out which .NET Core runtimes are installed on your machine using one of the following commands:
+You can find out which .NET runtimes are installed on your machine using one of the following commands:
 
 ```dotnetcli
 dotnet --list-runtimes
 dotnet --info
 ```
 
-If you think the tool should support the runtime version you currently have installed, you can contact the tool author and see if they can update the version number or multi-target. Once they've recompiled and republished their tool package to NuGet with an updated version number, you can update your copy. While that doesn't happen, the quickest solution for you is to install a version of the runtime that would work with the tool you're trying to run. To download a specific .NET Core runtime version, visit the [.NET Core download page](https://dotnet.microsoft.com/download/dotnet-core).
+If you think the tool should support the runtime version you currently have installed, you can contact the tool author and see if they can update the version number or multi-target. Once they've recompiled and republished their tool package to NuGet with an updated version number, you can update your copy. While that doesn't happen, the quickest solution for you is to install a version of the runtime that would work with the tool you're trying to run. To download a specific .NET runtime version, visit the [.NET download page](https://dotnet.microsoft.com/download/dotnet-core).
 
-If you install the .NET Core SDK to a non-default location, you need to set the environment variable `DOTNET_ROOT` to the directory that contains the `dotnet` executable.
+If you install the .NET SDK to a non-default location, you need to set the environment variable `DOTNET_ROOT` to the directory that contains the `dotnet` executable.
 
-## .NET Core tool installation fails
+## .NET tool installation fails
 
-There are a number of reasons the installation of a .NET Core global or local tool may fail. When the tool installation fails, you'll see a message similar to the following one:
+There are a number of reasons the installation of a .NET global or local tool may fail. When the tool installation fails, you'll see a message similar to the following one:
 
 ```console
 Tool '{0}' failed to install. This failure may have been caused by:
 
 * You are attempting to install a preview release and did not use the --version option to specify the version.
-* A package by this name was found, but it was not a .NET Core tool.
+* A package by this name was found, but it was not a .NET tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
 * You mistyped the name of the tool.
 
@@ -127,17 +127,17 @@ As package IDs are updated, you'll need to change to the new package ID to get t
 
 * You're attempting to install a preview release and didn't use the `--version` option to specify the version.
 
-.NET Core tools that are in preview must be specified with a portion of the name to indicate that they are in preview. You don't need to include the entire preview. Assuming the version numbers are in the expected format, you can use something like the following example:
+.NET tools that are in preview must be specified with a portion of the name to indicate that they are in preview. You don't need to include the entire preview. Assuming the version numbers are in the expected format, you can use something like the following example:
 
 ```dotnetcli
 dotnet tool install -g --version 1.1.0-pre <toolName>
 ```
 
-### Package isn't a .NET Core tool
+### Package isn't a .NET tool
 
-* A NuGet package by this name was found, but it wasn't a .NET Core tool.
+* A NuGet package by this name was found, but it wasn't a .NET tool.
 
-If you try to install a NuGet package that is a regular NuGet package and not a .NET Core tool, you'll see an error similar to the following:
+If you try to install a NuGet package that is a regular NuGet package and not a .NET tool, you'll see an error similar to the following:
 
 > NU1212: Invalid project-package combination for `<ToolName>`. DotnetToolReference project style can only contain references of the DotnetTool type.
 
@@ -155,4 +155,4 @@ A common reason for failure is that the tool name isn't correct. This can happen
 
 ## See also
 
-* [.NET Core tools](global-tools.md)
+* [.NET tools](global-tools.md)

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -1,11 +1,11 @@
 ---
-title: Continuous Integration (CI) with .NET Core SDK and tools
-description: Learn how to use the .NET Core SDK and its tools on the build server with continuous integration.
+title: Continuous Integration (CI) with .NET SDK and tools
+description: Learn how to use the .NET SDK and its tools on the build server with continuous integration.
 ms.date: 05/18/2017
 ---
-# Using .NET Core SDK and tools in Continuous Integration (CI)
+# Using the .NET SDK and tools in Continuous Integration (CI)
 
-This document outlines using the .NET Core SDK and its tools on a build server. The .NET Core toolset works both interactively, where a developer types commands at a command prompt, and automatically, where a Continuous Integration (CI) server runs a build script. The commands, options, inputs, and outputs are the same, and the only things you supply are a way to acquire the tooling and a system to build your app. This document focuses on scenarios of tool acquisition for CI with recommendations on how to design and structure your build scripts.
+This document outlines using the .NET SDK and its tools on a build server. The .NET toolset works both interactively, where a developer types commands at a command prompt, and automatically, where a Continuous Integration (CI) server runs a build script. The commands, options, inputs, and outputs are the same, and the only things you supply are a way to acquire the tooling and a system to build your app. This document focuses on scenarios of tool acquisition for CI with recommendations on how to design and structure your build scripts.
 
 ## Installation options for CI build servers
 
@@ -26,7 +26,7 @@ The installer script is automated to run at the start of the build to fetch and 
 > [!NOTE]
 > **Azure DevOps Services**
 >
-> When using the installer script, native dependencies aren't installed automatically. You must install the native dependencies if the operating system doesn't have them. For more information, see [.NET Core dependencies and requirements](../install/windows.md#dependencies).
+> When using the installer script, native dependencies aren't installed automatically. You must install the native dependencies if the operating system doesn't have them. For more information, see [.NET dependencies and requirements](../install/windows.md#dependencies).
 
 ## CI setup examples
 
@@ -36,9 +36,9 @@ This section describes a manual setup using a PowerShell or bash script, along w
 
 Each SaaS service has its own methods for creating and configuring a build process. If you use different SaaS solution than those listed or require customization beyond the pre-packaged support, you must perform at least some manual configuration.
 
-In general, a manual setup requires you to acquire a version of the tools (or the latest nightly builds of the tools) and run your build script. You can use a PowerShell or bash script to orchestrate the .NET Core commands or use a project file that outlines the build process. The [orchestration section](#orchestrating-the-build) provides more detail on these options.
+In general, a manual setup requires you to acquire a version of the tools (or the latest nightly builds of the tools) and run your build script. You can use a PowerShell or bash script to orchestrate the .NET commands or use a project file that outlines the build process. The [orchestration section](#orchestrating-the-build) provides more detail on these options.
 
-After you create a script that performs a manual CI build server setup, use it on your dev machine to build your code locally for testing purposes. Once you confirm that the script is running well locally, deploy it to your CI build server. A relatively simple PowerShell script demonstrates how to obtain the .NET Core SDK and install it on a Windows build server:
+After you create a script that performs a manual CI build server setup, use it on your dev machine to build your code locally for testing purposes. Once you confirm that the script is running well locally, deploy it to your CI build server. A relatively simple PowerShell script demonstrates how to obtain the .NET SDK and install it on a Windows build server:
 
 ```powershell
 $ErrorActionPreference="Stop"
@@ -114,15 +114,15 @@ LOCALDOTNET="$INSTALLDIR/dotnet"
 
 ### Travis CI
 
-You can configure [Travis CI](https://travis-ci.org/) to install the .NET Core SDK using the `csharp` language and the `dotnet` key. For more information, see the official Travis CI docs on [Building a C#, F#, or Visual Basic Project](https://docs.travis-ci.com/user/languages/csharp/). Note as you access the Travis CI information that the community-maintained `language: csharp` language identifier works for all .NET languages, including F#, and Mono.
+You can configure [Travis CI](https://travis-ci.org/) to install the .NET SDK using the `csharp` language and the `dotnet` key. For more information, see the official Travis CI docs on [Building a C#, F#, or Visual Basic Project](https://docs.travis-ci.com/user/languages/csharp/). Note as you access the Travis CI information that the community-maintained `language: csharp` language identifier works for all .NET languages, including F#, and Mono.
 
 Travis CI runs both macOS and Linux jobs in a *build matrix*, where you specify a combination of runtime, environment, and exclusions/inclusions to cover your build combinations for your app. For more information, see the [Customizing the Build](https://docs.travis-ci.com/user/customizing-the-build) article in the Travis CI documentation. The MSBuild-based tools include the LTS (1.0.x) and Current (1.1.x) runtimes in the package; so by installing the SDK, you receive everything you need to build.
 
 ### AppVeyor
 
-[AppVeyor](https://www.appveyor.com/) installs the .NET Core 1.0.1 SDK with the `Visual Studio 2017` build worker image. Other build images with different versions of the .NET Core SDK are available. For more information, see the [appveyor.yml example](https://github.com/dotnet/docs/blob/master/appveyor.yml) and the [Build worker images](https://www.appveyor.com/docs/build-environment/#build-worker-images) article in the AppVeyor docs.
+[AppVeyor](https://www.appveyor.com/) installs the .NET Core 1.0.1 SDK with the `Visual Studio 2017` build worker image. Other build images with different versions of the .NET SDK are available. For more information, see the [appveyor.yml example](https://github.com/dotnet/docs/blob/master/appveyor.yml) and the [Build worker images](https://www.appveyor.com/docs/build-environment/#build-worker-images) article in the AppVeyor docs.
 
-The .NET Core SDK binaries are downloaded and unzipped in a subdirectory using the install script, and then they're added to the `PATH` environment variable. Add a build matrix to run integration tests with multiple versions of the .NET Core SDK:
+The .NET SDK binaries are downloaded and unzipped in a subdirectory using the install script, and then they're added to the `PATH` environment variable. Add a build matrix to run integration tests with multiple versions of the .NET SDK:
 
 ```yaml
 environment:
@@ -136,10 +136,10 @@ install:
 
 ### Azure DevOps Services
 
-Configure Azure DevOps Services to build .NET Core projects using one of these approaches:
+Configure Azure DevOps Services to build .NET projects using one of these approaches:
 
 1. Run the script from the [manual setup step](#manual-setup) using your commands.
-1. Create a build composed of several Azure DevOps Services built-in build tasks that are configured to use .NET Core tools.
+1. Create a build composed of several Azure DevOps Services built-in build tasks that are configured to use .NET tools.
 
 Both solutions are valid. Using a manual setup script, you control the version of the tools that you receive, since you download them as part of the build. The build is run from a script that you must create. This article only covers the manual option. For more information on composing a build with Azure DevOps Services build tasks, see the [Azure Pipelines](/azure/devops/pipelines/index) documentation.
 
@@ -163,9 +163,9 @@ To use a manual setup script in Azure DevOps Services, create a new build defini
 
 ## Orchestrating the build
 
-Most of this document describes how to acquire the .NET Core tools and configure various CI services without providing information on how to orchestrate, or *actually build*, your code with .NET Core. The choices on how to structure the build process depend on many factors that can't be covered in a general way here. For more information on orchestrating your builds with each technology, explore the resources and samples provided in the documentation sets of [Travis CI](https://travis-ci.org/), [AppVeyor](https://www.appveyor.com/), and [Azure Pipelines](/azure/devops/pipelines/index).
+Most of this document describes how to acquire the .NET tools and configure various CI services without providing information on how to orchestrate, or *actually build*, your code with .NET Core. The choices on how to structure the build process depend on many factors that can't be covered in a general way here. For more information on orchestrating your builds with each technology, explore the resources and samples provided in the documentation sets of [Travis CI](https://travis-ci.org/), [AppVeyor](https://www.appveyor.com/), and [Azure Pipelines](/azure/devops/pipelines/index).
 
-Two general approaches that you take in structuring the build process for .NET Core code using the .NET Core tools are using MSBuild directly or using the .NET Core command-line commands. Which approach you should take is determined by your comfort level with the approaches and trade-offs in complexity. MSBuild provides you the ability to express your build process as tasks and targets, but it comes with the added complexity of learning MSBuild project file syntax. Using the .NET Core command-line tools is perhaps simpler, but it requires you to write orchestration logic in a scripting language like `bash` or PowerShell.
+Two general approaches that you take in structuring the build process for .NET code using the .NET tools are using MSBuild directly or using the .NET command-line commands. Which approach you should take is determined by your comfort level with the approaches and trade-offs in complexity. MSBuild provides you the ability to express your build process as tasks and targets, but it comes with the added complexity of learning MSBuild project file syntax. Using the .NET command-line tools is perhaps simpler, but it requires you to write orchestration logic in a scripting language like `bash` or PowerShell.
 
 ## See also
 


### PR DESCRIPTION
Fixes #21507 

Updates the docs in the core/tools folder for .NET 5 naming and TFM.