### PR TITLE
Fix broken links

### DIFF
--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -45,7 +45,7 @@ In the preceding example, you don't need to use the null-forgiving operator beca
 
 ## C# language specification
 
-For more information, see [The null-forgiving operator](~/_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md#the-null-forgiving-operator) section of the [draft of the nullable reference types specification](~/_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md).
+For more information, see [The null-forgiving operator](~/_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md#the-null-forgiving-operator) section of the [draft of the nullable reference types specification](~/_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md).
 
 ## See also
 


### PR DESCRIPTION
Fixes #21485

Yes, it's under the 9.0 folder:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/nullable-reference-types-specification#the-null-forgiving-operator
