### PR TITLE
replace "dummy" with more inclusive language

### DIFF
--- a/docs/csharp/discards.md
+++ b/docs/csharp/discards.md
@@ -6,7 +6,7 @@ ms.date: 09/22/2020
 ---
 # Discards - C# Guide
 
-Starting with C# 7.0, C# supports discards, which are temporary, dummy variables that are intentionally unused in application code. Discards are equivalent to unassigned variables; they do not have a value. Because there is only a single discard variable, and that variable may not even be allocated storage, discards can reduce memory allocations. Because they make the intent of your code clear, they enhance its readability and maintainability.
+Starting with C# 7.0, C# supports discards, which are temporary, placeholder variables that are intentionally unused in application code. Discards are equivalent to unassigned variables; they do not have a value. Because there is only a single discard variable, and that variable may not even be allocated storage, discards can reduce memory allocations. Because they make the intent of your code clear, they enhance its readability and maintainability.
 
 You indicate that a variable is a discard by assigning it the underscore (`_`) as its name. For example, the following method call returns a 3-tuple in which the first and second values are discards and *area* is a previously declared variable to be set to the corresponding third component returned by *GetCityInformation*:
 

--- a/docs/csharp/discards.md
+++ b/docs/csharp/discards.md
@@ -6,7 +6,7 @@ ms.date: 09/22/2020
 ---
 # Discards - C# Guide
 
-Starting with C# 7.0, C# supports discards, which are temporary, placeholder variables that are intentionally unused in application code. Discards are equivalent to unassigned variables; they do not have a value. Because there is only a single discard variable, and that variable may not even be allocated storage, discards can reduce memory allocations. Because they make the intent of your code clear, they enhance its readability and maintainability.
+Starting with C# 7.0, C# supports discards, which are placeholder variables that are intentionally unused in application code. Discards are equivalent to unassigned variables; they do not have a value. Because there is only a single discard variable, and that variable may not even be allocated storage, discards can reduce memory allocations. Because they make the intent of your code clear, they enhance its readability and maintainability.
 
 You indicate that a variable is a discard by assigning it the underscore (`_`) as its name. For example, the following method call returns a 3-tuple in which the first and second values are discards and *area* is a previously declared variable to be set to the corresponding third component returned by *GetCityInformation*:
 


### PR DESCRIPTION
## Summary

Replace the "dummy" descriptor with a more inclusive "placeholder" for the `_` discard. I think this is an appropriate word because the `_` serve to take up a position in an argument list.

https://developers.google.com/style/inclusive-documentation#ableist-language
