### PR TITLE
add extensions to link destinations

### DIFF
--- a/docs/whats-new/2020-10.md
+++ b/docs/whats-new/2020-10.md
@@ -18,7 +18,7 @@ You can download the latest .NET SDK from the [.NET downloads page](https://dotn
 - [SYSLIB0001: The UTF-7 encoding is insecure](../core/compatibility/syslib0001.md) - SYSLIB reference
 - [SYSLIB0002: PrincipalPermissionAttribute is obsolete](../core/compatibility/syslib0002.md) - SYSLIB reference
 - [SYSLIB0003: Code access security is not supported](../core/compatibility/syslib0003.md) - SYSLIB reference
-- [SYSLIB0004: The constrained execution region (CER) feature is not supported](../core/compatibility/syslib0004)
+- [SYSLIB0004: The constrained execution region (CER) feature is not supported](../core/compatibility/syslib0004.md)
   - Update syslib0004 docs with workarounds
   - SYSLIB reference
 - [SYSLIB0005: The global assembly cache (GAC) is not supported](../core/compatibility/syslib0005.md) - SYSLIB reference
@@ -65,11 +65,11 @@ You can download the latest .NET SDK from the [.NET downloads page](https://dotn
 
 ### New articles
 
-- [What's new in F# 5.0](../fsharp/whats-new/fsharp-50.md.md) - What's new in F# 5.0
+- [What's new in F# 5.0](../fsharp/whats-new/fsharp-50.md) - What's new in F# 5.0
 
 ### Updated articles
 
-- [Interactive programming with F\#](../fsharp/tutorials/fsharp-interactive/index.md.md) - Update F# Interactive reference for F# 5
+- [Interactive programming with F\#](../fsharp/tutorials/fsharp-interactive/index.md) - Update F# Interactive reference for F# 5
 
 ## .NET fundamentals
 
@@ -83,7 +83,7 @@ You can download the latest .NET SDK from the [.NET downloads page](https://dotn
 - [Simplify name (IDE0001)](../fundamentals/code-analysis/style-rules/ide0001.md) - Document remaining IDExxxx rules
 - [Simplify member access (IDE0002)](../fundamentals/code-analysis/style-rules/ide0002.md) - Document remaining IDExxxx rules
 - [this and Me preferences (IDE0003 and IDE0009)](../fundamentals/code-analysis/style-rules/ide0003-ide0009.md) - Refactor few code style rules to separate docs
-- [Remove unnecessary cast (IDE0004)](../fundamentals/code-analysis/style-rules/ide0004) - Document remaining IDExxxx rules
+- [Remove unnecessary cast (IDE0004)](../fundamentals/code-analysis/style-rules/ide0004.md) - Document remaining IDExxxx rules
 - [Remove unnecessary import (IDE0005)](../fundamentals/code-analysis/style-rules/ide0005.md) - Document remaining IDExxxx rules
 - ['var' preferences (IDE0007 and IDE0008)](../fundamentals/code-analysis/style-rules/ide0007-ide0008.md) - Port remaining documented C# code style rules to new format
 - [Add missing cases to switch statement (IDE0010)](../fundamentals/code-analysis/style-rules/ide0010.md) - Document remaining IDExxxx rules
@@ -153,10 +153,8 @@ You can download the latest .NET SDK from the [.NET downloads page](https://dotn
 - [Use conditional delegate call (IDE1005)](../fundamentals/code-analysis/style-rules/ide1005.md) - Port remaining documented C# code style rules to new format
 - [Modifier preferences](../fundamentals/code-analysis/style-rules/modifier-preferences.md) - Refactor few code style rules to separate docs
 - [Null-checking preferences](../fundamentals/code-analysis/style-rules/null-checking-preferences.md) - Refactor few code style rules to separate docs
-- [Parameter preferences](../fundamentals/code-analysis/style-rules/parameter-preferences.md) - Refactor few code style rules to separate docs
 - [Pattern matching preferences](../fundamentals/code-analysis/style-rules/pattern-matching-preferences.md) - Port remaining documented C# code style rules to new format
 - [Unnecessary code rules](../fundamentals/code-analysis/style-rules/unnecessary-code-rules.md) - Document remaining IDExxxx rules
-- ['using' directive preferences](../fundamentals/code-analysis/style-rules/using-directive-preferences.md) - Port remaining documented C# code style rules to new format
 - [Tools and diagnostics in .NET](../fundamentals/tools-and-productivity.md) - Tools and diagnostics
 
 ### Updated articles
@@ -180,7 +178,6 @@ You can download the latest .NET SDK from the [.NET downloads page](https://dotn
 ### New articles
 
 - [Best practices for displaying and persisting formatted data](../standard/base-types/best-practices-display-data.md) - Behavior changes due to NLS -> ICU switch on Windows
-- [Extract elements from a string](../standard/base-types/parse-strings.md) - Move alternatives out of String.Split ref
 - [Behavior changes when comparing strings on .NET 5+](../standard/base-types/string-comparison-net-5-plus.md) - Behavior changes due to NLS -> ICU switch on Windows
 - [Runtime libraries overview](../standard/runtime-libraries-overview.md) - Reorg Fundamentals TOC
 

--- a/docs/whats-new/2020-10.md
+++ b/docs/whats-new/2020-10.md
@@ -14,184 +14,184 @@ You can download the latest .NET SDK from the [.NET downloads page](https://dotn
 
 ### New articles
 
-- [Obsolete features in .NET 5](../core/compatibility/syslib-obsoletions) - SYSLIB reference
-- [SYSLIB0001: The UTF-7 encoding is insecure](../core/compatibility/syslib0001) - SYSLIB reference
-- [SYSLIB0002: PrincipalPermissionAttribute is obsolete](../core/compatibility/syslib0002) - SYSLIB reference
-- [SYSLIB0003: Code access security is not supported](../core/compatibility/syslib0003) - SYSLIB reference
+- [Obsolete features in .NET 5](../core/compatibility/syslib-obsoletions.md) - SYSLIB reference
+- [SYSLIB0001: The UTF-7 encoding is insecure](../core/compatibility/syslib0001.md) - SYSLIB reference
+- [SYSLIB0002: PrincipalPermissionAttribute is obsolete](../core/compatibility/syslib0002.md) - SYSLIB reference
+- [SYSLIB0003: Code access security is not supported](../core/compatibility/syslib0003.md) - SYSLIB reference
 - [SYSLIB0004: The constrained execution region (CER) feature is not supported](../core/compatibility/syslib0004)
   - Update syslib0004 docs with workarounds
   - SYSLIB reference
-- [SYSLIB0005: The global assembly cache (GAC) is not supported](../core/compatibility/syslib0005) - SYSLIB reference
-- [SYSLIB0006: Thread.Abort is not supported](../core/compatibility/syslib0006) - SYSLIB reference
-- [SYSLIB0007: Default implementations of cryptography algorithms not supported](../core/compatibility/syslib0007) - SYSLIB reference
-- [SYSLIB0008: CreatePdbGenerator is not supported](../core/compatibility/syslib0008) - SYSLIB reference
-- [SYSLIB0009: The AuthenticationManager Authenticate and PreAuthenticate methods are not supported](../core/compatibility/syslib0009) - SYSLIB reference
-- [SYSLIB0010: Unsupported remoting APIs](../core/compatibility/syslib0010) - SYSLIB reference
-- [SYSLIB0011: BinaryFormatter serialization is obsolete](../core/compatibility/syslib0011) - SYSLIB reference
-- [SYSLIB0012: Assembly.CodeBase and Assembly.EscapedCodeBase are obsolete](../core/compatibility/syslib0012) - SYSLIB reference
-- [ReadyToRun Compilation](../core/deploying/ready-to-run) - Document PublishReadyToRun
-- [Tracing .NET applications with PerfCollect](../core/diagnostics/trace-perfcollect-lttng) - Add tutorial on collecting traces with PerfCollect
-- [Console log formatting](../core/extensions/console-log-formatter) - Adding console log formatting article
-- [Releases and support for .NET Core and .NET 5](../core/releases-and-support) - Releases and support doc
-- [dotnet nuget verify](../core/tools/dotnet-nuget-verify) - dotnet nuget verify doc
+- [SYSLIB0005: The global assembly cache (GAC) is not supported](../core/compatibility/syslib0005.md) - SYSLIB reference
+- [SYSLIB0006: Thread.Abort is not supported](../core/compatibility/syslib0006.md) - SYSLIB reference
+- [SYSLIB0007: Default implementations of cryptography algorithms not supported](../core/compatibility/syslib0007.md) - SYSLIB reference
+- [SYSLIB0008: CreatePdbGenerator is not supported](../core/compatibility/syslib0008.md) - SYSLIB reference
+- [SYSLIB0009: The AuthenticationManager Authenticate and PreAuthenticate methods are not supported](../core/compatibility/syslib0009.md) - SYSLIB reference
+- [SYSLIB0010: Unsupported remoting APIs](../core/compatibility/syslib0010.md) - SYSLIB reference
+- [SYSLIB0011: BinaryFormatter serialization is obsolete](../core/compatibility/syslib0011.md) - SYSLIB reference
+- [SYSLIB0012: Assembly.CodeBase and Assembly.EscapedCodeBase are obsolete](../core/compatibility/syslib0012.md) - SYSLIB reference
+- [ReadyToRun Compilation](../core/deploying/ready-to-run.md) - Document PublishReadyToRun
+- [Tracing .NET applications with PerfCollect](../core/diagnostics/trace-perfcollect-lttng.md) - Add tutorial on collecting traces with PerfCollect
+- [Console log formatting](../core/extensions/console-log-formatter.md) - Adding console log formatting article
+- [Releases and support for .NET Core and .NET 5](../core/releases-and-support.md) - Releases and support doc
+- [dotnet nuget verify](../core/tools/dotnet-nuget-verify.md) - dotnet nuget verify doc
 
 ### Updated articles
 
-- [Introduction to .NET](../core/introduction) - Update .NET intro
-- [dotnet new](../core/tools/dotnet-new) - Add missing blazorwasm options
+- [Introduction to .NET](../core/introduction.md) - Update .NET intro
+- [dotnet new](../core/tools/dotnet-new.md) - Add missing blazorwasm options
 
 ## C# language
 
 ### New articles
 
-- [with expression (C# reference)](../csharp/language-reference/operators/with-expression) - C# 9 reference update: a with expression
-- [Use pattern matching to build your class behavior for better code](../csharp/tutorials/exploration/patterns-objects) - Pattern tutorial
-- [Tutorial: Explore ideas using top-level statements to build code as you learn](../csharp/tutorials/exploration/top-level-statements) - Top level statements tutorial
-- [Object-Oriented programming (C#)](../csharp/tutorials/intro-to-csharp/object-oriented-programming) - move OO tutorial to get-started
+- [with expression (C# reference)](../csharp/language-reference/operators/with-expression.md) - C# 9 reference update: a with expression
+- [Use pattern matching to build your class behavior for better code](../csharp/tutorials/exploration/patterns-objects.md) - Pattern tutorial
+- [Tutorial: Explore ideas using top-level statements to build code as you learn](../csharp/tutorials/exploration/top-level-statements.md) - Top level statements tutorial
+- [Object-Oriented programming (C#)](../csharp/tutorials/intro-to-csharp/object-oriented-programming.md) - move OO tutorial to get-started
 
 ### Updated articles
 
-- [Nullable reference types](../csharp/nullable-references) - Add known pitfalls to nullable reference types
-- [What's new in C# 7.0 through C# 7.3](../csharp/whats-new/csharp-7) - Consolidate C# 7 what's new
+- [Nullable reference types](../csharp/nullable-references.md) - Add known pitfalls to nullable reference types
+- [What's new in C# 7.0 through C# 7.3](../csharp/whats-new/csharp-7.md) - Consolidate C# 7 what's new
 
 ## .NET Framework
 
 ### New articles
 
-- [Code analysis](../framework/code-analyzers) - Update .NET Framework -> .NET
-- [wfc.exe (Workflow Command-line Compiler Tool)](../framework/windows-workflow-foundation/wfc-exe-workflow-compiler-tool) - adding documentations for wfc.exe
+- [Code analysis](../framework/code-analyzers.md) - Update .NET Framework -> .NET
+- [wfc.exe (Workflow Command-line Compiler Tool)](../framework/windows-workflow-foundation/wfc-exe-workflow-compiler-tool.md) - adding documentations for wfc.exe
 
 ## F# language
 
 ### New articles
 
-- [What's new in F# 5.0](../fsharp/whats-new/fsharp-50) - What's new in F# 5.0
+- [What's new in F# 5.0](../fsharp/whats-new/fsharp-50.md.md) - What's new in F# 5.0
 
 ### Updated articles
 
-- [Interactive programming with F\#](../fsharp/tutorials/fsharp-interactive/index) - Update F# Interactive reference for F# 5
+- [Interactive programming with F\#](../fsharp/tutorials/fsharp-interactive/index.md.md) - Update F# Interactive reference for F# 5
 
 ## .NET fundamentals
 
 ### New articles
 
-- [CA2218: Override GetHashCode on overriding Equals](../fundamentals/code-analysis/quality-rules/ca2218) - Add two missing CA rules
-- [CA2224: Override Equals on overloading operator equals](../fundamentals/code-analysis/quality-rules/ca2224) - Add two missing CA rules
-- [Code block preferences](../fundamentals/code-analysis/style-rules/code-block-preferences) - Port remaining documented C# code style rules to new format
-- [Expression-bodied-members](../fundamentals/code-analysis/style-rules/expression-bodied-members) - Port remaining documented C# code style rules to new format
-- [Expression-level preferences](../fundamentals/code-analysis/style-rules/expression-level-preferences) - Refactor few code style rules to separate docs
-- [Simplify name (IDE0001)](../fundamentals/code-analysis/style-rules/ide0001) - Document remaining IDExxxx rules
-- [Simplify member access (IDE0002)](../fundamentals/code-analysis/style-rules/ide0002) - Document remaining IDExxxx rules
-- [this and Me preferences (IDE0003 and IDE0009)](../fundamentals/code-analysis/style-rules/ide0003-ide0009) - Refactor few code style rules to separate docs
+- [CA2218: Override GetHashCode on overriding Equals](../fundamentals/code-analysis/quality-rules/ca2218.md) - Add two missing CA rules
+- [CA2224: Override Equals on overloading operator equals](../fundamentals/code-analysis/quality-rules/ca2224.md) - Add two missing CA rules
+- [Code block preferences](../fundamentals/code-analysis/style-rules/code-block-preferences.md) - Port remaining documented C# code style rules to new format
+- [Expression-bodied-members](../fundamentals/code-analysis/style-rules/expression-bodied-members.md) - Port remaining documented C# code style rules to new format
+- [Expression-level preferences](../fundamentals/code-analysis/style-rules/expression-level-preferences.md) - Refactor few code style rules to separate docs
+- [Simplify name (IDE0001)](../fundamentals/code-analysis/style-rules/ide0001.md) - Document remaining IDExxxx rules
+- [Simplify member access (IDE0002)](../fundamentals/code-analysis/style-rules/ide0002.md) - Document remaining IDExxxx rules
+- [this and Me preferences (IDE0003 and IDE0009)](../fundamentals/code-analysis/style-rules/ide0003-ide0009.md) - Refactor few code style rules to separate docs
 - [Remove unnecessary cast (IDE0004)](../fundamentals/code-analysis/style-rules/ide0004) - Document remaining IDExxxx rules
-- [Remove unnecessary import (IDE0005)](../fundamentals/code-analysis/style-rules/ide0005) - Document remaining IDExxxx rules
-- ['var' preferences (IDE0007 and IDE0008)](../fundamentals/code-analysis/style-rules/ide0007-ide0008) - Port remaining documented C# code style rules to new format
-- [Add missing cases to switch statement (IDE0010)](../fundamentals/code-analysis/style-rules/ide0010) - Document remaining IDExxxx rules
-- [Add braces (IDE0011)](../fundamentals/code-analysis/style-rules/ide0011) - Port remaining documented C# code style rules to new format
-- [Use throw expression (IDE0016)](../fundamentals/code-analysis/style-rules/ide0016) - Port remaining documented C# code style rules to new format
-- [Use object initializers (IDE0017)](../fundamentals/code-analysis/style-rules/ide0017) - Refactor few code style rules to separate docs
-- [Inline variable declaration (IDE0018)](../fundamentals/code-analysis/style-rules/ide0018) - Port remaining documented C# code style rules to new format
-- [Use pattern matching to avoid 'as' followed by a 'null' check (IDE0019)](../fundamentals/code-analysis/style-rules/ide0019) - Port remaining documented C# code style rules to new format
-- [Use pattern matching to avoid 'is' check followed by a cast (IDE0020)](../fundamentals/code-analysis/style-rules/ide0020) - Port remaining documented C# code style rules to new format
-- [Use expression body for constructors (IDE0021)](../fundamentals/code-analysis/style-rules/ide0021) - Port remaining documented C# code style rules to new format
-- [Use expression body for methods (IDE0022)](../fundamentals/code-analysis/style-rules/ide0022) - Port remaining documented C# code style rules to new format
-- [Use expression body for operators (IDE0023 and IDE0024)](../fundamentals/code-analysis/style-rules/ide0023-ide0024) - Port remaining documented C# code style rules to new format
-- [Use expression body for properties (IDE0025)](../fundamentals/code-analysis/style-rules/ide0025) - Port remaining documented C# code style rules to new format
-- [Use expression body for indexers (IDE0026)](../fundamentals/code-analysis/style-rules/ide0026) - Port remaining documented C# code style rules to new format
-- [Use expression body for accessors (IDE0027)](../fundamentals/code-analysis/style-rules/ide0027) - Port remaining documented C# code style rules to new format
-- [Use collection initializers (IDE0028)](../fundamentals/code-analysis/style-rules/ide0028) - Refactor few code style rules to separate docs
-- [Use coalesce expression (IDE0029)](../fundamentals/code-analysis/style-rules/ide0029) - Refactor few code style rules to separate docs
-- [Use null propagation (IDE0031)](../fundamentals/code-analysis/style-rules/ide0031) - Refactor few code style rules to separate docs
-- [Use auto property (IDE0032)](../fundamentals/code-analysis/style-rules/ide0032) - Refactor few code style rules to separate docs
-- [Use explicitly provided tuple name (IDE0033)](../fundamentals/code-analysis/style-rules/ide0033) - Refactor few code style rules to separate docs
-- [Simplify 'default' expression (IDE0034)](../fundamentals/code-analysis/style-rules/ide0034) - Port remaining documented C# code style rules to new format
-- [Remove unreachable code (IDE0035)](../fundamentals/code-analysis/style-rules/ide0035) - Document remaining IDExxxx rules
-- [Order modifiers (IDE0036)](../fundamentals/code-analysis/style-rules/ide0036) - Refactor few code style rules to separate docs
-- [Use inferred member name (IDE0037)](../fundamentals/code-analysis/style-rules/ide0037) - Refactor few code style rules to separate docs
-- [Use local function instead of lambda (IDE0039)](../fundamentals/code-analysis/style-rules/ide0039) - Port remaining documented C# code style rules to new format
-- [Add accessibility modifiers (IDE0040)](../fundamentals/code-analysis/style-rules/ide0040) - Refactor few code style rules to separate docs
-- [Use is null check (IDE0041)](../fundamentals/code-analysis/style-rules/ide0041) - Refactor few code style rules to separate docs
-- [Deconstruct variable declaration (IDE0042)](../fundamentals/code-analysis/style-rules/ide0042) - Port remaining documented C# code style rules to new format
-- [Add readonly modifier (IDE0044)](../fundamentals/code-analysis/style-rules/ide0044) - Refactor few code style rules to separate docs
-- [Use conditional expression for assignment (IDE0045)](../fundamentals/code-analysis/style-rules/ide0045) - Refactor few code style rules to separate docs
-- [Use conditional expression for return (IDE0046)](../fundamentals/code-analysis/style-rules/ide0046) - Refactor few code style rules to separate docs
-- [Parentheses preferences (IDE0047 and IDE0048)](../fundamentals/code-analysis/style-rules/ide0047-ide0048) - Refactor few code style rules to separate docs
-- [Use language keywords instead of framework type names for type references (IDE0049)](../fundamentals/code-analysis/style-rules/ide0049) - Refactor few code style rules to separate docs
-- [Convert anonymous type to tuple (IDE0050)](../fundamentals/code-analysis/style-rules/ide0050) - Document remaining IDExxxx rules
-- [Remove unused private member (IDE0051)](../fundamentals/code-analysis/style-rules/ide0051) - Document remaining IDExxxx rules
-- [Remove unread private member (IDE0052)](../fundamentals/code-analysis/style-rules/ide0052) - Document remaining IDExxxx rules
-- [Use expression body for lambdas (IDE0053)](../fundamentals/code-analysis/style-rules/ide0053) - Port remaining documented C# code style rules to new format
-- [Use compound assignment (IDE0054)](../fundamentals/code-analysis/style-rules/ide0054) - Refactor few code style rules to separate docs
-- [Use index operator (IDE0056)](../fundamentals/code-analysis/style-rules/ide0056) - Port remaining documented C# code style rules to new format
-- [Use range operator (IDE0057)](../fundamentals/code-analysis/style-rules/ide0057) - Port remaining documented C# code style rules to new format
-- [Unused expression value (IDE0058)](../fundamentals/code-analysis/style-rules/ide0058) - Refactor few code style rules to separate docs
-- [Unnecessary value assignment (IDE0059)](../fundamentals/code-analysis/style-rules/ide0059) - Refactor few code style rules to separate docs
-- [Remove unused parameter (IDE0060)](../fundamentals/code-analysis/style-rules/ide0060) - Refactor few code style rules to separate docs
-- [Use expression body for local functions (IDE0061)](../fundamentals/code-analysis/style-rules/ide0061) - Port remaining documented C# code style rules to new format
-- [Make local function static (IDE0062)](../fundamentals/code-analysis/style-rules/ide0062) - Port remaining documented C# code style rules to new format
-- [Use simple 'using' statement (IDE0063)](../fundamentals/code-analysis/style-rules/ide0063) - Port remaining documented C# code style rules to new format
-- [Make struct fields writable (IDE0064)](../fundamentals/code-analysis/style-rules/ide0064) - Document remaining IDExxxx rules
-- ['using' directive placement (IDE0065)](../fundamentals/code-analysis/style-rules/ide0065) - Port remaining documented C# code style rules to new format
-- [Use switch expression (IDE0066)](../fundamentals/code-analysis/style-rules/ide0066) - Port remaining documented C# code style rules to new format
-- [Use 'System.HashCode.Combine' (IDE0070)](../fundamentals/code-analysis/style-rules/ide0070) - Document remaining IDExxxx rules
-- [Simplify interpolation (IDE0071)](../fundamentals/code-analysis/style-rules/ide0071) - Document remaining IDExxxx rules
-- [Add missing cases to switch expression (IDE0072)](../fundamentals/code-analysis/style-rules/ide0072) - Document remaining IDExxxx rules
-- [Require file header (IDE0073)](../fundamentals/code-analysis/style-rules/ide0073) - Document remaining IDExxxx rules
-- [Simplify conditional expression (IDE0075)](../fundamentals/code-analysis/style-rules/ide0075) - Document remaining IDExxxx rules
-- [Remove invalid global 'SuppressMessageAttribute' (IDE0076)](../fundamentals/code-analysis/style-rules/ide0076) - Document remaining IDExxxx rules
-- [Avoid legacy format target in global 'SuppressMessageAttribute' (IDE0077)](../fundamentals/code-analysis/style-rules/ide0077) - Document remaining IDExxxx rules
-- [Use pattern matching (IDE0078)](../fundamentals/code-analysis/style-rules/ide0078) - Document remaining IDExxxx rules
-- [Remove unnecessary suppression (IDE0079)](../fundamentals/code-analysis/style-rules/ide0079) - Document remaining IDExxxx rules
-- [Remove unnecessary suppression operator (IDE0080)](../fundamentals/code-analysis/style-rules/ide0080) - Document remaining IDExxxx rules
-- [Remove `ByVal` (IDE0081)](../fundamentals/code-analysis/style-rules/ide0081) - Document remaining IDExxxx rules
-- [Convert `typeof` to `nameof` (IDE0082)](../fundamentals/code-analysis/style-rules/ide0082) - Document remaining IDExxxx rules
-- [Use pattern matching (`not` operator) (IDE0083)](../fundamentals/code-analysis/style-rules/ide0083) - Document remaining IDExxxx rules
-- [Use pattern matching (`IsNot` operator) (IDE0084)](../fundamentals/code-analysis/style-rules/ide0084) - Document remaining IDExxxx rules
-- [Simplify `new` expression (IDE0090)](../fundamentals/code-analysis/style-rules/ide0090) - Document remaining IDExxxx rules
-- [Remove unnecessary equality operator (IDE0100)](../fundamentals/code-analysis/style-rules/ide0100) - Document remaining IDExxxx rules
-- [Remove unnecessary discard (IDE0110)](../fundamentals/code-analysis/style-rules/ide0110) - Add docs for IDE0110.
-- [Use conditional delegate call (IDE1005)](../fundamentals/code-analysis/style-rules/ide1005) - Port remaining documented C# code style rules to new format
-- [Modifier preferences](../fundamentals/code-analysis/style-rules/modifier-preferences) - Refactor few code style rules to separate docs
-- [Null-checking preferences](../fundamentals/code-analysis/style-rules/null-checking-preferences) - Refactor few code style rules to separate docs
-- [Parameter preferences](../fundamentals/code-analysis/style-rules/parameter-preferences) - Refactor few code style rules to separate docs
-- [Pattern matching preferences](../fundamentals/code-analysis/style-rules/pattern-matching-preferences) - Port remaining documented C# code style rules to new format
-- [Unnecessary code rules](../fundamentals/code-analysis/style-rules/unnecessary-code-rules) - Document remaining IDExxxx rules
-- ['using' directive preferences](../fundamentals/code-analysis/style-rules/using-directive-preferences) - Port remaining documented C# code style rules to new format
-- [Tools and diagnostics in .NET](../fundamentals/tools-and-productivity) - Tools and diagnostics
+- [Remove unnecessary import (IDE0005)](../fundamentals/code-analysis/style-rules/ide0005.md) - Document remaining IDExxxx rules
+- ['var' preferences (IDE0007 and IDE0008)](../fundamentals/code-analysis/style-rules/ide0007-ide0008.md) - Port remaining documented C# code style rules to new format
+- [Add missing cases to switch statement (IDE0010)](../fundamentals/code-analysis/style-rules/ide0010.md) - Document remaining IDExxxx rules
+- [Add braces (IDE0011)](../fundamentals/code-analysis/style-rules/ide0011.md) - Port remaining documented C# code style rules to new format
+- [Use throw expression (IDE0016)](../fundamentals/code-analysis/style-rules/ide0016.md) - Port remaining documented C# code style rules to new format
+- [Use object initializers (IDE0017)](../fundamentals/code-analysis/style-rules/ide0017.md) - Refactor few code style rules to separate docs
+- [Inline variable declaration (IDE0018)](../fundamentals/code-analysis/style-rules/ide0018.md) - Port remaining documented C# code style rules to new format
+- [Use pattern matching to avoid 'as' followed by a 'null' check (IDE0019)](../fundamentals/code-analysis/style-rules/ide0019.md) - Port remaining documented C# code style rules to new format
+- [Use pattern matching to avoid 'is' check followed by a cast (IDE0020)](../fundamentals/code-analysis/style-rules/ide0020.md) - Port remaining documented C# code style rules to new format
+- [Use expression body for constructors (IDE0021)](../fundamentals/code-analysis/style-rules/ide0021.md) - Port remaining documented C# code style rules to new format
+- [Use expression body for methods (IDE0022)](../fundamentals/code-analysis/style-rules/ide0022.md) - Port remaining documented C# code style rules to new format
+- [Use expression body for operators (IDE0023 and IDE0024)](../fundamentals/code-analysis/style-rules/ide0023-ide0024.md) - Port remaining documented C# code style rules to new format
+- [Use expression body for properties (IDE0025)](../fundamentals/code-analysis/style-rules/ide0025.md) - Port remaining documented C# code style rules to new format
+- [Use expression body for indexers (IDE0026)](../fundamentals/code-analysis/style-rules/ide0026.md) - Port remaining documented C# code style rules to new format
+- [Use expression body for accessors (IDE0027)](../fundamentals/code-analysis/style-rules/ide0027.md) - Port remaining documented C# code style rules to new format
+- [Use collection initializers (IDE0028)](../fundamentals/code-analysis/style-rules/ide0028.md) - Refactor few code style rules to separate docs
+- [Use coalesce expression (IDE0029)](../fundamentals/code-analysis/style-rules/ide0029.md) - Refactor few code style rules to separate docs
+- [Use null propagation (IDE0031)](../fundamentals/code-analysis/style-rules/ide0031.md) - Refactor few code style rules to separate docs
+- [Use auto property (IDE0032)](../fundamentals/code-analysis/style-rules/ide0032.md) - Refactor few code style rules to separate docs
+- [Use explicitly provided tuple name (IDE0033)](../fundamentals/code-analysis/style-rules/ide0033.md) - Refactor few code style rules to separate docs
+- [Simplify 'default' expression (IDE0034)](../fundamentals/code-analysis/style-rules/ide0034.md) - Port remaining documented C# code style rules to new format
+- [Remove unreachable code (IDE0035)](../fundamentals/code-analysis/style-rules/ide0035.md) - Document remaining IDExxxx rules
+- [Order modifiers (IDE0036)](../fundamentals/code-analysis/style-rules/ide0036.md) - Refactor few code style rules to separate docs
+- [Use inferred member name (IDE0037)](../fundamentals/code-analysis/style-rules/ide0037.md) - Refactor few code style rules to separate docs
+- [Use local function instead of lambda (IDE0039)](../fundamentals/code-analysis/style-rules/ide0039.md) - Port remaining documented C# code style rules to new format
+- [Add accessibility modifiers (IDE0040)](../fundamentals/code-analysis/style-rules/ide0040.md) - Refactor few code style rules to separate docs
+- [Use is null check (IDE0041)](../fundamentals/code-analysis/style-rules/ide0041.md) - Refactor few code style rules to separate docs
+- [Deconstruct variable declaration (IDE0042)](../fundamentals/code-analysis/style-rules/ide0042.md) - Port remaining documented C# code style rules to new format
+- [Add readonly modifier (IDE0044)](../fundamentals/code-analysis/style-rules/ide0044.md) - Refactor few code style rules to separate docs
+- [Use conditional expression for assignment (IDE0045)](../fundamentals/code-analysis/style-rules/ide0045.md) - Refactor few code style rules to separate docs
+- [Use conditional expression for return (IDE0046)](../fundamentals/code-analysis/style-rules/ide0046.md) - Refactor few code style rules to separate docs
+- [Parentheses preferences (IDE0047 and IDE0048)](../fundamentals/code-analysis/style-rules/ide0047-ide0048.md) - Refactor few code style rules to separate docs
+- [Use language keywords instead of framework type names for type references (IDE0049)](../fundamentals/code-analysis/style-rules/ide0049.md) - Refactor few code style rules to separate docs
+- [Convert anonymous type to tuple (IDE0050)](../fundamentals/code-analysis/style-rules/ide0050.md) - Document remaining IDExxxx rules
+- [Remove unused private member (IDE0051)](../fundamentals/code-analysis/style-rules/ide0051.md) - Document remaining IDExxxx rules
+- [Remove unread private member (IDE0052)](../fundamentals/code-analysis/style-rules/ide0052.md) - Document remaining IDExxxx rules
+- [Use expression body for lambdas (IDE0053)](../fundamentals/code-analysis/style-rules/ide0053.md) - Port remaining documented C# code style rules to new format
+- [Use compound assignment (IDE0054)](../fundamentals/code-analysis/style-rules/ide0054.md) - Refactor few code style rules to separate docs
+- [Use index operator (IDE0056)](../fundamentals/code-analysis/style-rules/ide0056.md) - Port remaining documented C# code style rules to new format
+- [Use range operator (IDE0057)](../fundamentals/code-analysis/style-rules/ide0057.md) - Port remaining documented C# code style rules to new format
+- [Unused expression value (IDE0058)](../fundamentals/code-analysis/style-rules/ide0058.md) - Refactor few code style rules to separate docs
+- [Unnecessary value assignment (IDE0059)](../fundamentals/code-analysis/style-rules/ide0059.md) - Refactor few code style rules to separate docs
+- [Remove unused parameter (IDE0060)](../fundamentals/code-analysis/style-rules/ide0060.md) - Refactor few code style rules to separate docs
+- [Use expression body for local functions (IDE0061)](../fundamentals/code-analysis/style-rules/ide0061.md) - Port remaining documented C# code style rules to new format
+- [Make local function static (IDE0062)](../fundamentals/code-analysis/style-rules/ide0062.md) - Port remaining documented C# code style rules to new format
+- [Use simple 'using' statement (IDE0063)](../fundamentals/code-analysis/style-rules/ide0063.md) - Port remaining documented C# code style rules to new format
+- [Make struct fields writable (IDE0064)](../fundamentals/code-analysis/style-rules/ide0064.md) - Document remaining IDExxxx rules
+- ['using' directive placement (IDE0065)](../fundamentals/code-analysis/style-rules/ide0065.md) - Port remaining documented C# code style rules to new format
+- [Use switch expression (IDE0066)](../fundamentals/code-analysis/style-rules/ide0066.md) - Port remaining documented C# code style rules to new format
+- [Use 'System.HashCode.Combine' (IDE0070)](../fundamentals/code-analysis/style-rules/ide0070.md) - Document remaining IDExxxx rules
+- [Simplify interpolation (IDE0071)](../fundamentals/code-analysis/style-rules/ide0071.md) - Document remaining IDExxxx rules
+- [Add missing cases to switch expression (IDE0072)](../fundamentals/code-analysis/style-rules/ide0072.md) - Document remaining IDExxxx rules
+- [Require file header (IDE0073)](../fundamentals/code-analysis/style-rules/ide0073.md) - Document remaining IDExxxx rules
+- [Simplify conditional expression (IDE0075)](../fundamentals/code-analysis/style-rules/ide0075.md) - Document remaining IDExxxx rules
+- [Remove invalid global 'SuppressMessageAttribute' (IDE0076)](../fundamentals/code-analysis/style-rules/ide0076.md) - Document remaining IDExxxx rules
+- [Avoid legacy format target in global 'SuppressMessageAttribute' (IDE0077)](../fundamentals/code-analysis/style-rules/ide0077.md) - Document remaining IDExxxx rules
+- [Use pattern matching (IDE0078)](../fundamentals/code-analysis/style-rules/ide0078.md) - Document remaining IDExxxx rules
+- [Remove unnecessary suppression (IDE0079)](../fundamentals/code-analysis/style-rules/ide0079.md) - Document remaining IDExxxx rules
+- [Remove unnecessary suppression operator (IDE0080)](../fundamentals/code-analysis/style-rules/ide0080.md) - Document remaining IDExxxx rules
+- [Remove `ByVal` (IDE0081)](../fundamentals/code-analysis/style-rules/ide0081.md) - Document remaining IDExxxx rules
+- [Convert `typeof` to `nameof` (IDE0082)](../fundamentals/code-analysis/style-rules/ide0082.md) - Document remaining IDExxxx rules
+- [Use pattern matching (`not` operator) (IDE0083)](../fundamentals/code-analysis/style-rules/ide0083.md) - Document remaining IDExxxx rules
+- [Use pattern matching (`IsNot` operator) (IDE0084)](../fundamentals/code-analysis/style-rules/ide0084.md) - Document remaining IDExxxx rules
+- [Simplify `new` expression (IDE0090)](../fundamentals/code-analysis/style-rules/ide0090.md) - Document remaining IDExxxx rules
+- [Remove unnecessary equality operator (IDE0100)](../fundamentals/code-analysis/style-rules/ide0100.md) - Document remaining IDExxxx rules
+- [Remove unnecessary discard (IDE0110)](../fundamentals/code-analysis/style-rules/ide0110.md) - Add docs for IDE0110.
+- [Use conditional delegate call (IDE1005)](../fundamentals/code-analysis/style-rules/ide1005.md) - Port remaining documented C# code style rules to new format
+- [Modifier preferences](../fundamentals/code-analysis/style-rules/modifier-preferences.md) - Refactor few code style rules to separate docs
+- [Null-checking preferences](../fundamentals/code-analysis/style-rules/null-checking-preferences.md) - Refactor few code style rules to separate docs
+- [Parameter preferences](../fundamentals/code-analysis/style-rules/parameter-preferences.md) - Refactor few code style rules to separate docs
+- [Pattern matching preferences](../fundamentals/code-analysis/style-rules/pattern-matching-preferences.md) - Port remaining documented C# code style rules to new format
+- [Unnecessary code rules](../fundamentals/code-analysis/style-rules/unnecessary-code-rules.md) - Document remaining IDExxxx rules
+- ['using' directive preferences](../fundamentals/code-analysis/style-rules/using-directive-preferences.md) - Port remaining documented C# code style rules to new format
+- [Tools and diagnostics in .NET](../fundamentals/tools-and-productivity.md) - Tools and diagnostics
 
 ### Updated articles
 
-- [Language rules](../fundamentals/code-analysis/style-rules/language-rules) - Refactor few code style rules to separate docs
+- [Language rules](../fundamentals/code-analysis/style-rules/language-rules.md) - Refactor few code style rules to separate docs
 
 ## .NET for Apache Spark
 
 ### New articles
 
-- [Connect to Azure Data Lake Storage Gen 2 or WASB account](../spark/how-to-guides/connect-to-azure-storage) - Adding How To Guides for .NET for Apache Spark
-- [Connect .NET for Apache Spark to Azure Event Hubs](../spark/how-to-guides/connect-to-event-hub) - Adding How To Guides for .NET for Apache Spark
-- [Connect .NET for Apache Spark to MongoDB](../spark/how-to-guides/connect-to-mongo-db) - Adding How To Guides for .NET for Apache Spark
-- [Connect .NET for Apache Spark to SQL Server](../spark/how-to-guides/connect-to-sql-server) - Adding How To Guides for .NET for Apache Spark
-- [Write and call UDFs in .NET for Apache Spark interactive environments](../spark/how-to-guides/dotnet-interactive-udf-issue) - Adding How To Guides for .NET for Apache Spark
-- [Use .NET for Apache Spark in Jupyter notebooks](../spark/how-to-guides/dotnet-spark-jupyter-notebooks) - How-To: .NET Interactive + .NET for Apache Spark
-- [Call a Java UDF from your .NET for Apache Spark application](../spark/how-to-guides/java-udf-from-dotnet) - Adding How To Guides for .NET for Apache Spark
+- [Connect to Azure Data Lake Storage Gen 2 or WASB account](../spark/how-to-guides/connect-to-azure-storage.md) - Adding How To Guides for .NET for Apache Spark
+- [Connect .NET for Apache Spark to Azure Event Hubs](../spark/how-to-guides/connect-to-event-hub.md) - Adding How To Guides for .NET for Apache Spark
+- [Connect .NET for Apache Spark to MongoDB](../spark/how-to-guides/connect-to-mongo-db.md) - Adding How To Guides for .NET for Apache Spark
+- [Connect .NET for Apache Spark to SQL Server](../spark/how-to-guides/connect-to-sql-server.md) - Adding How To Guides for .NET for Apache Spark
+- [Write and call UDFs in .NET for Apache Spark interactive environments](../spark/how-to-guides/dotnet-interactive-udf-issue.md) - Adding How To Guides for .NET for Apache Spark
+- [Use .NET for Apache Spark in Jupyter notebooks](../spark/how-to-guides/dotnet-spark-jupyter-notebooks.md) - How-To: .NET Interactive + .NET for Apache Spark
+- [Call a Java UDF from your .NET for Apache Spark application](../spark/how-to-guides/java-udf-from-dotnet.md) - Adding How To Guides for .NET for Apache Spark
 
 ## .NET
 
 ### New articles
 
-- [Best practices for displaying and persisting formatted data](../standard/base-types/best-practices-display-data) - Behavior changes due to NLS -> ICU switch on Windows
-- [Extract elements from a string](../standard/base-types/parse-strings) - Move alternatives out of String.Split ref
-- [Behavior changes when comparing strings on .NET 5+](../standard/base-types/string-comparison-net-5-plus) - Behavior changes due to NLS -> ICU switch on Windows
-- [Runtime libraries overview](../standard/runtime-libraries-overview) - Reorg Fundamentals TOC
+- [Best practices for displaying and persisting formatted data](../standard/base-types/best-practices-display-data.md) - Behavior changes due to NLS -> ICU switch on Windows
+- [Extract elements from a string](../standard/base-types/parse-strings.md) - Move alternatives out of String.Split ref
+- [Behavior changes when comparing strings on .NET 5+](../standard/base-types/string-comparison-net-5-plus.md) - Behavior changes due to NLS -> ICU switch on Windows
+- [Runtime libraries overview](../standard/runtime-libraries-overview.md) - Reorg Fundamentals TOC
 
 ### Updated articles
 
-- [Compare strings in .NET](../standard/base-types/comparing) - Behavior changes due to NLS -> ICU switch on Windows
-- [Standard date and time format strings](../standard/base-types/standard-date-and-time-format-strings) - Q2 Content performance updates
-- [Managed Execution Process](../standard/managed-execution-process) - .NET Framework -> .NET
-- [Serialization guidelines](../standard/serialization/serialization-guidelines) - .NET Framework -> .NET
-- [How to serialize and deserialize (marshal and unmarshal) JSON in .NET](../standard/serialization/system-text-json-how-to) - 5.0 updates to System.Text.Json docs
-- [How to migrate from Newtonsoft.Json to System.Text.Json](../standard/serialization/system-text-json-migrate-from-newtonsoft-how-to) - 5.0 updates to System.Text.Json docs
+- [Compare strings in .NET](../standard/base-types/comparing.md) - Behavior changes due to NLS -> ICU switch on Windows
+- [Standard date and time format strings](../standard/base-types/standard-date-and-time-format-strings.md) - Q2 Content performance updates
+- [Managed Execution Process](../standard/managed-execution-process.md) - .NET Framework -> .NET
+- [Serialization guidelines](../standard/serialization/serialization-guidelines.md) - .NET Framework -> .NET
+- [How to serialize and deserialize (marshal and unmarshal) JSON in .NET](../standard/serialization/system-text-json-how-to.md) - 5.0 updates to System.Text.Json docs
+- [How to migrate from Newtonsoft.Json to System.Text.Json](../standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md) - 5.0 updates to System.Text.Json docs
 
 ## Community contributors
 


### PR DESCRIPTION
For some reason, this month, the tool did not include the `.md` extention on the links in the articles.

see https://github.com/dotnet/docs/pull/21469#issuecomment-726336346

/cc @scottaddie 