### PR TITLE
Update section: Formatting if expressions.

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -638,6 +638,7 @@ In some cases, `do...yield` may aid in readability. These cases, though subjecti
 
 Indentation of conditionals depends on the size and complexity of the expressions that make them up.
 Simply write them on one line when:
+
 - `cond`, `e1` and `e2` are short
 - `e1` and `e2` are not `if/then/else` expressions themselves.
 
@@ -666,13 +667,13 @@ else e4
 If any of the conditions or expressions is multi-line, the entire `if/then/else` expression is multi-line:
 
 ```fsharp
-if cond1 then 
+if cond1 then
     e1
-elif cond2 then 
+elif cond2 then
     e2
-elif cond3 then 
+elif cond3 then
     e3
-else 
+else
     e4
 ```
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -636,21 +636,16 @@ In some cases, `do...yield` may aid in readability. These cases, though subjecti
 
 ## Formatting if expressions
 
-Indentation of conditionals depends on the sizes of the expressions that make them up. If `cond`, `e1` and `e2` are short, simply write them on one line:
+Indentation of conditionals depends on the size and complexity of the expressions that make them up.
+Simply write them on one line when:
+- `cond`, `e1` and `e2` are short
+- `e1` and `e2` are not `if/then/else` expressions themselves.
 
 ```fsharp
 if cond then e1 else e2
 ```
 
-If either `cond`, `e1` or `e2` are longer, but not multi-line:
-
-```fsharp
-if cond
-then e1
-else e2
-```
-
-If any of the expressions are multi-line:
+If any of the expressions are multi-line or `if/then/else` expressions.
 
 ```fsharp
 if cond then
@@ -659,13 +654,26 @@ else
     e2
 ```
 
-Multiple conditionals with `elif` and `else` are indented at the same scope as the `if`:
+Multiple conditionals with `elif` and `else` are indented at the same scope as the `if` when they follow the rules of the one line `if/then/else` expressions.
 
 ```fsharp
 if cond1 then e1
 elif cond2 then e2
 elif cond3 then e3
 else e4
+```
+
+If any of the conditions or expressions is multi-line, the entire `if/then/else` expression is multi-line:
+
+```fsharp
+if cond1 then 
+    e1
+elif cond2 then 
+    e2
+elif cond3 then 
+    e3
+else 
+    e4
 ```
 
 ### Pattern matching constructs


### PR DESCRIPTION
## Summary

Updated the section `Formatting if expressions` in the F# style guide.

Fixes #21530.