### PR TITLE
Add section on constructors, static members and member invocations.

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -886,6 +886,16 @@ let makeStreamReader x = new System.IO.StreamReader(path = x)
 
 ### Formatting constructors, static members and member invocations
 
+If the expression is short, separate arguments with spaces and keep it in one line.
+
+```fsharp
+let person = new Person(a1, a2)
+
+let myRegexMatch = Regex.Match(input, regex)
+
+let untypedRes = checker.ParseFile(file, source, opts)
+```
+
 If the expression is long, use newlines and indent one scope, rather than indenting to the bracket.
 
 ```fsharp
@@ -894,8 +904,6 @@ let person =
         argument1,
         argument2
     )
-
-let p = new Person(a, b) // keep in one line if short
 
 let myRegexMatch =
     Regex.Match(

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -884,6 +884,33 @@ let makeStreamReader x = new System.IO.StreamReader(path=x)
 let makeStreamReader x = new System.IO.StreamReader(path = x)
 ```
 
+### Formatting constructors, static members and member invocations
+
+If the expression is long, use newlines and indent one scope, rather than indenting to the bracket.
+
+```fsharp
+let person =
+    new Person(
+        argument1,
+        argument2
+    )
+
+let p = new Person(a, b) // keep in one line if short
+
+let myRegexMatch =
+    Regex.Match(
+        "my longer input string with some interesting content in it",
+        "myRegexPattern"
+    )
+
+let untypedRes =
+    checker.ParseFile(
+        fileName,
+        sourceText,
+        parsingOptionsWithDefines
+    )
+```
+
 ## Formatting attributes
 
 [Attributes](../language-reference/attributes.md) are placed above a construct:


### PR DESCRIPTION
## Summary

Add a new section to the F# style guide on constructors, static members and member invocations.

Fixes #21362
