### PR TITLE
Update official-net-docker-images.md

### DIFF
--- a/docs/architecture/microservices/net-core-net-framework-containers/official-net-docker-images.md
+++ b/docs/architecture/microservices/net-core-net-framework-containers/official-net-docker-images.md
@@ -26,13 +26,13 @@ Why multiple images? When developing, building, and running containerized applic
 
 ### During development and build
 
-During development, what is important is how fast you can iterate changes, and the ability to debug the changes. The size of the image isn't as important as the ability to make changes to your code and see the changes quickly. Some tools and "build-agent containers", use the development .NET Core image (*mcr.microsoft.com/dotnet/core/sdk:3.1*) during development and build process. When building inside a Docker container, the important aspects are the elements that are needed to compile your app. This includes the compiler and any other .NET dependencies.
+During development, what is important is how fast you can iterate changes, and the ability to debug the changes. The size of the image isn't as important as the ability to make changes to your code and see the changes quickly. Some tools and "build-agent containers", use the development .NET Core image (*mcr.microsoft.com/dotnet/sdk:5.0*) during development and build process. When building inside a Docker container, the important aspects are the elements that are needed to compile your app. This includes the compiler and any other .NET dependencies.
 
 Why is this type of build image important? You don't deploy this image to production. Instead, it's an image that you use to build the content you place into a production image. This image would be used in your continuous integration (CI) environment or build environment when using Docker multi-stage builds.
 
 ### In production
 
-What is important in production is how fast you can deploy and start your containers based on a production .NET Core image. Therefore, the runtime-only image based on *mcr.microsoft.com/dotnet/core/aspnet:3.1* is small so that it can travel quickly across the network from your Docker registry to your Docker hosts. The contents are ready to run, enabling the fastest time from starting the container to processing results. In the Docker model, there is no need for compilation from C\# code, as there is when you run dotnet build or dotnet publish when using the build container.
+What is important in production is how fast you can deploy and start your containers based on a production .NET Core image. Therefore, the runtime-only image based on *mcr.microsoft.com/dotnet/aspnet:5.0* is small so that it can travel quickly across the network from your Docker registry to your Docker hosts. The contents are ready to run, enabling the fastest time from starting the container to processing results. In the Docker model, there is no need for compilation from C\# code, as there is when you run dotnet build or dotnet publish when using the build container.
 
 In this optimized image, you put only the binaries and other content needed to run the application. For example, the content created by `dotnet publish` contains only the compiled .NET binaries, images, .js, and .css files. Over time, you will see images that contain pre-jitted (the compilation from IL to native that occurs at runtime) packages.
 
@@ -42,8 +42,8 @@ When you explore the .NET image repositories at Docker Hub, you will find multip
 
 | Image | Comments |
 |-------|----------|
-| mcr.microsoft.com/dotnet/core/aspnet:**3.1** | ASP.NET Core, with runtime only and ASP.NET Core optimizations, on Linux and Windows (multi-arch) |
-| mcr.microsoft.com/dotnet/core/sdk:**3.1** | .NET Core, with SDKs included, on Linux and Windows (multi-arch) |
+| mcr.microsoft.com/dotnet/aspnet:**5.0** | ASP.NET Core, with runtime only and ASP.NET Core optimizations, on Linux and Windows (multi-arch) |
+| mcr.microsoft.com/dotnet/sdk:**5.0** | .NET Core, with SDKs included, on Linux and Windows (multi-arch) |
 
 > [!div class="step-by-step"]
 > [Previous](net-container-os-targets.md)


### PR DESCRIPTION
Updated [Official .NET Docker images](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/net-core-net-framework-containers/official-net-docker-images) to refer to .net 5 images

## Summary
The docs still refer to .net core 3.1 images. This PR updates to latest .net 5.0 images.
For reference: 
- https://hub.docker.com/_/microsoft-dotnet-sdk
- https://hub.docker.com/_/microsoft-dotnet-aspnet/
