### PR TITLE
What's new in .NET 5: rephrase entry about records

### DIFF
--- a/docs/core/dotnet-five.md
+++ b/docs/core/dotnet-five.md
@@ -57,7 +57,7 @@ For .NET 5.0 apps and libraries, the `net5.0` Target Framework Moniker (TFM) com
 
 Developers writing .NET 5 apps will have access to the latest C# version and features. .NET 5 is paired with C# 9, which brings many new features to the language. Here are a few highlights:
 
-- Records: Immutable reference types that behave like value types, and introduce the new `with` keyword into the language.
+- Records: reference types with value-based equality semantics and non-destructive mutation supported by a new `with` expression.
 - Relational pattern matching: Extends pattern matching capabilities to relational operators for comparative evaluations and expressions, including logical patterns - new keywords `and`, `or`, and `not`.
 - Top-level statements: As a means for accelerating adoption and learning of C#, the `Main` method can be omitted and application as simple as the following is valid:
 


### PR DESCRIPTION
- Records make it easy to create immutable types, but they are not forced to be immutable. Users still can define public fields and mutable properties or methods that mutate the record's state
- "...behave like value types" - this is too broad. What is the behaviour of value types exactly? One may say that "a variable of a value type contains the instance of the type, not a reference to it", for example.