### PR TITLE
Add CopyLocalLockFileAssemblies property

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -75,10 +75,24 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 
 ## Publish properties and items
 
+- [CopyLocalLockFileAssemblies](#copylocallockfileassemblies)
 - [RuntimeIdentifier](#runtimeidentifier)
 - [RuntimeIdentifiers](#runtimeidentifiers)
 - [TrimmerRootAssembly](#trimmerrootassembly)
 - [UseAppHost](#useapphost)
+
+### CopyLocalLockFileAssemblies
+
+The `CopyLocalLockFileAssemblies` property is useful for plugin projects that have dependencies on other libraries. If you set this property to `true`, any NuGet package dependencies are copied to the output directory. That means you can use the output of `dotnet build` to run your plugin on any machine.
+
+> [!TIP]
+> Alternatively, you can use `dotnet publish` to publish the class library. For more information, see [dotnet publish](../tools/dotnet-publish.md).
+
+```xml
+<PropertyGroup>
+  <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+</PropertyGroup>
+```
 
 ### RuntimeIdentifier
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -85,14 +85,14 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 
 The `CopyLocalLockFileAssemblies` property is useful for plugin projects that have dependencies on other libraries. If you set this property to `true`, any NuGet package dependencies are copied to the output directory. That means you can use the output of `dotnet build` to run your plugin on any machine.
 
-> [!TIP]
-> Alternatively, you can use `dotnet publish` to publish the class library. For more information, see [dotnet publish](../tools/dotnet-publish.md).
-
 ```xml
 <PropertyGroup>
   <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 </PropertyGroup>
 ```
+
+> [!TIP]
+> Alternatively, you can use `dotnet publish` to publish the class library. For more information, see [dotnet publish](../tools/dotnet-publish.md).
 
 ### RuntimeIdentifier
 


### PR DESCRIPTION
Fixes #18183.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-21598#copylocallockfileassemblies).