### PR TITLE
Document --name option for dotnet-counters and dotnet-dump

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -66,11 +66,11 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--refresh-int
 
 - **`-p|--process-id <PID>`**
 
-  The ID of the process to be monitored.
+  The ID of the process to be collect counter data from.
 
 - **`-n|--name <name>`**
 
-  The name of the process to be monitored. This can be specified instead of the `--process-id` option. If there are multiple processes with the specified name, the command will fail and process-id must be specified instead.
+  The name of the process to be collect counter data from.
 
 - **`--refresh-interval <SECONDS>`**
 
@@ -179,7 +179,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--refresh-int
 
 - **`-n|--name <name>`**
 
-  The name of the process to be monitored. This can be specified instead of the `--process-id` option. If there are multiple processes with the specified name, the command will fail and process-id must be specified instead.
+  The name of the process to be monitored.
 
 - **`--refresh-interval <SECONDS>`**
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -59,7 +59,7 @@ Periodically collect selected counter values and export them into a specified fi
 ### Synopsis
 
 ```console
-dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--counters <COUNTERS>] [--format] [-o|--output] [-- <command>]
+dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--refresh-interval] [--counters <COUNTERS>] [--format] [-o|--output] [-- <command>]
 ```
 
 ### Options
@@ -67,6 +67,10 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [--refreshInterval] [--cou
 - **`-p|--process-id <PID>`**
 
   The ID of the process to be monitored.
+
+- **`-n|--name <name>`**
+
+  The name of the process to be monitored. This can be specified instead of the `--process-id` option. If there are multiple processes with the specified name, the command will fail and process-id must be specified instead.
 
 - **`--refresh-interval <SECONDS>`**
 
@@ -164,7 +168,7 @@ Displays periodically refreshing values of selected counters.
 ### Synopsis
 
 ```console
-dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [--counters] [-- <command>]
+dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--refresh-interval] [--counters] [-- <command>]
 ```
 
 ### Options
@@ -172,6 +176,10 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [--refreshInterval] [--cou
 - **`-p|--process-id <PID>`**
 
   The ID of the process to be monitored.
+
+- **`-n|--name <name>`**
+
+  The name of the process to be monitored. This can be specified instead of the `--process-id` option. If there are multiple processes with the specified name, the command will fail and process-id must be specified instead.
 
 - **`--refresh-interval <SECONDS>`**
 

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -60,7 +60,7 @@ Captures a dump from a process.
 ### Synopsis
 
 ```console
-dotnet-dump collect [-h|--help] [-p|--process-id] [--type] [-o|--output] [--diag]
+dotnet-dump collect [-h|--help] [-p|--process-id] [-n|--name] [--type] [-o|--output] [--diag]
 ```
 
 ### Options
@@ -71,7 +71,11 @@ dotnet-dump collect [-h|--help] [-p|--process-id] [--type] [-o|--output] [--diag
 
 - **`-p|--process-id <PID>`**
 
-  Specifies the process ID number to collect a memory dump from.
+  Specifies the process ID number to collect a dump from.
+
+- **`-n|--name <name>`**
+
+  Specifies the name of the process to collect a dump from.
 
 - **`--type <Full|Heap|Mini>`**
 


### PR DESCRIPTION
## Summary

This documents the `--name` option for `dotnet-counters` and `dotnet-dump`. For some reason `dotnet-trace` and `dotnet-gcdump` already has them documented but these two tools don't. 


