### PR TITLE
Add dotnet-stack docs

### DIFF
--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -141,5 +141,5 @@ To report managed stacks using `dotnet-stack`:
   
 ## Next Steps
   
-  - [Use dotnet-trace to collect CPU samples of a .NET application](dotnet-trace.md)
-  - [Use dotnet-dump to collect a dump of a .NET application](dotnet-dump.md)
+- [Use dotnet-trace to collect CPU samples of a .NET application](dotnet-trace.md)
+- [Use dotnet-dump to collect a dump of a .NET application](dotnet-dump.md)

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet-stack diagnostic tool - .NET CLI
 description: Learn how to install and use the dotnet-stack CLI tool which captures and prints the managed stacks for all threads in the target .NET process.
-ms.date: 11/17/2020
+ms.date: 04/21/2021
 ---
 # Inspect managed stack traces (dotnet-stack)
 

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -5,7 +5,7 @@ ms.date: 11/17/2020
 ---
 # Inspect managed stack traces (dotnet-stack)
 
-**This article applies to:** ✔️ .NET Core 3.0 SDK and later versions
+**This article applies to:** ✔️ .NET Core 3.0 and later versions
 
 ## Install
 

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -139,7 +139,7 @@ To report managed stacks using `dotnet-stack`:
     Module!Method
   ```
   
-  ## Next Steps
+## Next Steps
   
   - [Use dotnet-trace to collect CPU samples of a .NET application](dotnet-trace.md)
   - [Use dotnet-dump to collect a dump of a .NET application](dotnet-dump.md)

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -55,10 +55,10 @@ The `dotnet-stack` tool:
 
 ## Commands
 
-| Command                                                   |
-|-----------------------------------------------------------|
-| [dotnet-stack report](#dotnet-stack-report)               |
-| [dotnet-stack ps](#dotnet-stack-ps)                       |
+| Command                                     | Description                                                   |
+|---------------------------------------------|---------------------------------------------------------------|
+| [dotnet-stack report](#dotnet-stack-report) | Prints the stack trace for each thread in the target process. |
+| [dotnet-stack ps](#dotnet-stack-ps)         | Lists the dotnet processes that traces can be collected from. |
 
 ## dotnet-stack report
 
@@ -127,7 +127,7 @@ To report managed stacks using `dotnet-stack`:
   - Stack frames follow the form `Module!Method`.
   - Transitions to unmanaged code are represented as `[Native Frames]` in the output.
 
-  ```
+  ```console
   # comment
   Thread (0x1234):
     module!Method
@@ -139,7 +139,7 @@ To report managed stacks using `dotnet-stack`:
     Module!Method
   ```
   
-## Next Steps
+## Next steps
   
 - [Use dotnet-trace to collect CPU samples of a .NET application](dotnet-trace.md)
 - [Use dotnet-dump to collect a dump of a .NET application](dotnet-dump.md)

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -138,3 +138,8 @@ To report managed stacks using `dotnet-stack`:
     Module!Method
     Module!Method
   ```
+  
+  ## Next Steps
+  
+  - [Use dotnet-trace to collect CPU samples of a .NET application](dotnet-trace.md)
+  - [Use dotnet-dump to collect a dump of a .NET application](dotnet-dump.md)

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -1,0 +1,116 @@
+---
+title: dotnet-stack tool - .NET Core
+description: Installing and using the dotnet-stack command-line tool.
+ms.date: 11/21/2019
+---
+# dotnet-stack performance analysis utility
+
+**This article applies to:** ✔️ .NET Core 3.0 SDK and later versions
+
+## Install dotnet-stack
+
+### Option 1 - Install as dotnet global tool:
+
+Install `dotnet-stack` [NuGet package](https://www.nuget.org/packages/dotnet-stack) with the [dotnet tool install](../tools/dotnet-tool-install.md) command:
+
+```dotnetcli
+dotnet tool install --global dotnet-stack
+```
+
+### Option 2 - Direct download:
+
+- Win ([x86](https://aka.ms/dotnet-stack/win-x86) | [x64](https://aka.ms/dotnet-stack/win-x64) | [arm](https://aka.ms/dotnet-stack/win-arm) | [arm-x64](https://aka.ms/dotnet-stack/win-arm64))
+- macOS ([x64](https://aka.ms/dotnet-stack/osx-x64))
+- Linux ([x64](https://aka.ms/dotnet-stack/linux-x64) | [arm](https://aka.ms/dotnet-stack/linux-arm) | [arm64](https://aka.ms/dotnet-stack/linux-arm64) | [musl-x64](https://aka.ms/dotnet-stack/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-stack/linux-musl-arm64))
+
+## Synopsis
+
+```console
+dotnet-stack [-h, --help] [--version] <command>
+```
+
+## Description
+
+The `dotnet-stack` tool:
+
+* Is a cross-platform .NET Core tool.
+* Reports the managed stacks for all threads in .NET process.
+* Is built on [`EventPipe`](./eventpipe.md) of the .NET Core runtime.
+* Delivers the same experience on Windows, Linux, or macOS.
+
+## Options
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+- **`--version`**
+
+  Displays the version of the dotnet-stack utility.
+
+## Commands
+
+| Command                                                   |
+|-----------------------------------------------------------|
+| [dotnet-stack report](#dotnet-stack-report)               |
+| [dotnet-stack ps](#dotnet-stack-ps)                       |
+
+## dotnet-stack report
+
+Collects a diagnostic trace from a running process.
+
+### Synopsis
+
+```console
+dotnet-stack report -p|--process-id <pid>
+                    -n|--name <process-name>
+                    [-h|--help]
+```
+
+### Options
+
+- **`-n, --name <name>`**
+
+  The name of the process to collect the trace from.
+
+- **`-p|--process-id <PID>`**
+
+  The process ID to collect the trace from.
+
+## dotnet-stack ps
+
+ Lists the dotnet processes that traces can be collected from.
+
+### Synopsis
+
+```console
+dotnet-stack ps [-h|--help]
+```
+
+## Report managed stacks with dotnet-stack
+
+To report managed stacks using `dotnet-stack`:
+
+- Get the process identifier (PID) of the .NET Core application to report stacks from.
+
+  - On Windows, you can use Task Manager or the `tasklist` command, for example.
+  - On Linux, for example, the `ps` command.
+  - [dotnet-stack ps](#dotnet-stack-ps)
+
+- Run the following command:
+
+  ```console
+  dotnet-stack report --process-id <PID>
+  ```
+
+  The preceding command generates output similar to the following:
+
+  ```console
+  Thread (0x48839B):
+    [Native Frames]
+    System.Console!System.IO.StdInReader.ReadKey(bool&)
+    System.Console!System.IO.SyncTextReader.ReadKey(bool&)
+    System.Console!System.ConsolePal.ReadKey(bool)
+    System.Console!System.Console.ReadKey()
+    StackTracee!Tracee.Program.Main(class System.String[])
+  ```

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -29,7 +29,6 @@ There are two ways to download and install `dotnet-stack`:
   | macOS   | [x64](https://aka.ms/dotnet-stack/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-stack/linux-x64) \| [arm](https://aka.ms/dotnet-stack/linux-arm) \| [arm64](https://aka.ms/dotnet-stack/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-stack/linux-musl-x64) \| [musl-arm64](https://aka.ms/dotnet-stack/linux-musl-arm64) |
 
-
 ## Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -1,27 +1,34 @@
 ---
 title: dotnet-stack tool - .NET Core
 description: Installing and using the dotnet-stack command-line tool.
-ms.date: 11/21/2019
+ms.date: 11/17/2020
 ---
-# dotnet-stack performance analysis utility
+# Inspect managed stack traces (dotnet-stack)
 
 **This article applies to:** ✔️ .NET Core 3.0 SDK and later versions
 
-## Install dotnet-stack
+## Install
 
-### Option 1 - Install as dotnet global tool:
+There are two ways to download and install `dotnet-stack`:
 
-Install `dotnet-stack` [NuGet package](https://www.nuget.org/packages/dotnet-stack) with the [dotnet tool install](../tools/dotnet-tool-install.md) command:
+- **dotnet global tool:**
 
-```dotnetcli
-dotnet tool install --global dotnet-stack
-```
+  To install the latest release version of the `dotnet-counters` [NuGet package](https://www.nuget.org/packages/dotnet-stack), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
-### Option 2 - Direct download:
+  ```dotnetcli
+  dotnet tool install --global dotnet-stack
+  ```
 
-- Win ([x86](https://aka.ms/dotnet-stack/win-x86) | [x64](https://aka.ms/dotnet-stack/win-x64) | [arm](https://aka.ms/dotnet-stack/win-arm) | [arm-x64](https://aka.ms/dotnet-stack/win-arm64))
-- macOS ([x64](https://aka.ms/dotnet-stack/osx-x64))
-- Linux ([x64](https://aka.ms/dotnet-stack/linux-x64) | [arm](https://aka.ms/dotnet-stack/linux-arm) | [arm64](https://aka.ms/dotnet-stack/linux-arm64) | [musl-x64](https://aka.ms/dotnet-stack/linux-musl-x64) | [musl-arm64](https://aka.ms/dotnet-stack/linux-musl-arm64))
+- **Direct download:**
+
+  Download the tool executable that matches your platform:
+
+  | OS  | Platform |
+  | --- | -------- |
+  | Windows | [x86](https://aka.ms/dotnet-stack/win-x86) \| [x64](https://aka.ms/dotnet-stack/win-x64) \| [arm](https://aka.ms/dotnet-stack/win-arm) \| [arm-x64](https://aka.ms/dotnet-stack/win-arm64) |
+  | macOS   | [x64](https://aka.ms/dotnet-stack/osx-x64) |
+  | Linux   | [x64](https://aka.ms/dotnet-stack/linux-x64) \| [arm](https://aka.ms/dotnet-stack/linux-arm) \| [arm64](https://aka.ms/dotnet-stack/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-stack/linux-musl-x64) \| [musl-arm64](https://aka.ms/dotnet-stack/linux-musl-arm64) |
+
 
 ## Synopsis
 
@@ -34,9 +41,8 @@ dotnet-stack [-h, --help] [--version] <command>
 The `dotnet-stack` tool:
 
 * Is a cross-platform .NET Core tool.
-* Reports the managed stacks for all threads in .NET process.
+* Captures and prints the managed stacks for all threads in the target .NET process.
 * Is built on [`EventPipe`](./eventpipe.md) of the .NET Core runtime.
-* Delivers the same experience on Windows, Linux, or macOS.
 
 ## Options
 

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -119,3 +119,22 @@ To report managed stacks using `dotnet-stack`:
     System.Console!System.Console.ReadKey()
     StackTracee!Tracee.Program.Main(class System.String[])
   ```
+
+  The output of `dotnet-stack` follows the following form:
+
+  - Comments in the output are prefixed with `#`.
+  - Each thread has a header that includes the native thread ID: `Thread (<thread-id>):`.
+  - Stack frames follow the form `Module!Method`.
+  - Transitions to unmanaged code are represented as `[Native Frames]` in the output.
+
+  ```
+  # comment
+  Thread (0x1234):
+    module!Method
+    module!Method
+
+  Thread (0x5678):
+    [Native Frames]
+    Module!Method
+    Module!Method
+  ```

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -1,6 +1,6 @@
 ---
-title: dotnet-stack tool - .NET Core
-description: Installing and using the dotnet-stack command-line tool.
+title: dotnet-stack diagnostic tool - .NET CLI
+description: Learn how to install and use the dotnet-stack CLI tool which captures and prints the managed stacks for all threads in the target .NET process.
 ms.date: 11/17/2020
 ---
 # Inspect managed stack traces (dotnet-stack)
@@ -13,7 +13,7 @@ There are two ways to download and install `dotnet-stack`:
 
 - **dotnet global tool:**
 
-  To install the latest release version of the `dotnet-counters` [NuGet package](https://www.nuget.org/packages/dotnet-stack), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
+  To install the latest release version of the `dotnet-stack` [NuGet package](https://www.nuget.org/packages/dotnet-stack), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
   ```dotnetcli
   dotnet tool install --global dotnet-stack
@@ -41,7 +41,7 @@ The `dotnet-stack` tool:
 
 * Is a cross-platform .NET Core tool.
 * Captures and prints the managed stacks for all threads in the target .NET process.
-* Is built on [`EventPipe`](./eventpipe.md) of the .NET Core runtime.
+* Utilizes [`EventPipe`](./eventpipe.md) tracing provided by the .NET Core runtime.
 
 ## Options
 
@@ -62,7 +62,7 @@ The `dotnet-stack` tool:
 
 ## dotnet-stack report
 
-Collects a diagnostic trace from a running process.
+Prints the stack trace for each thread in the target process.
 
 ### Synopsis
 

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -49,6 +49,10 @@ The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Colle
 
 .NET Core includes what is called the `EventPipe` through which diagnostics data is exposed. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root cause apps running slow.
 
+### dotnet-stack
+
+The [dotnet-stack](dotnet-stack.md) tool allows you quickly print the managed stacks for all threads in a running .NET process.
+
 ### dotnet-symbol
 
 [dotnet-symbol](dotnet-symbol.md) downloads files (symbols, DAC/DBI, host files, etc.) needed to open a core dump or minidump. Use this tool if you need symbols and modules to debug a dump file captured on a different machine.

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -388,6 +388,8 @@ items:
         href: ../core/diagnostics/dotnet-gcdump.md
       - name: dotnet-trace
         href: ../core/diagnostics/dotnet-trace.md
+      - name: dotnet-stack
+        href: ../core/diagnostics/dotnet-stack.md
       - name: dotnet-symbol
         href: ../core/diagnostics/dotnet-symbol.md
       - name: dotnet-sos


### PR DESCRIPTION
## Summary

Adds the documentation for the new `dotnet-stack` tool.

This PR should not be merged until dotnet/diagnostics#1702 is merged and a subsequent release of the tools is uploaded.

CC @dotnet/dotnet-diag 

### Internal preview

✔️ [Inspect managed stack traces (dotnet-stack)](https://review.docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-stack?branch=pr-en-us-21618)