### PR TITLE
Add links to perfcollect tutorial 

### DIFF
--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -44,7 +44,7 @@ If you would like to use .NET Core global CLI diagnostic tools to diagnose proce
 
 **This tool applies to: ✔️** .NET Core 2.1 and later versions
 
-The [`PerfCollect`](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md) script is useful for collecting performance traces and is the recommended tool for collecting traces prior to .NET Core 3.0. If using `PerfCollect` in a container, keep the following requirements in mind:
+The [`PerfCollect`](./trace-perfcollect-lttng.md) script is useful for collecting performance traces and is the recommended tool for collecting traces prior to .NET Core 3.0. If using `PerfCollect` in a container, keep the following requirements in mind:
 
 1. `PerfCollect` requires the [`SYS_ADMIN` capability](https://man7.org/linux/man-pages/man7/capabilities.7.html) (in order to run the `perf` tool), so be sure the container is [started with that capability](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
 2. `PerfCollect` requires some environment variables be set prior to the app it is profiling starting. These can be set either in a [Dockerfile](https://docs.docker.com/engine/reference/builder/#env) or when [starting the container](https://docs.docker.com/engine/reference/run/#env-environment-variables). Because these variables shouldn't be set in normal production environments, it's common to just add them when starting a container that will be profiled. The two variables which PerfCollect requires are:

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -414,6 +414,8 @@ items:
         href: ../core/diagnostics/dotnet-sos.md
     - name: .NET Core diagnostics tutorials
       items:
+      - name: Collect performance trace in Linux with PerfCollect
+        href: ../core/diagnostics/trace-perfcollect-lttng.md
       - name: Get perf metrics with EventCounters
         href: ../core/diagnostics/event-counter-perf.md
       - name: Debug a memory leak


### PR DESCRIPTION
Add perfcollect tutorial link to toc as well as from containers diagnostics doc.