### PR TITLE
Update "parse-tryparse" and  "parse-tryparse2" snippets per published C# conventions

### DIFF
--- a/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse/Program.cs
+++ b/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse/Program.cs
@@ -1,36 +1,40 @@
 ﻿using System;
 
-public class StringConversion
+public static class StringConversion
 {
     public static void Main()
     {
-       string input = String.Empty;
-       try
-       {
-           int result = Int32.Parse(input);
-           Console.WriteLine(result);
-       }
-       catch (FormatException)
-       {
-           Console.WriteLine($"Unable to parse '{input}'");
-       }
-       // Output: Unable to parse ''
+        string input = String.Empty;
+        try
+        {
+            int result = Int32.Parse(input);
+            Console.WriteLine(result);
+        }
+        catch (FormatException)
+        {
+            Console.WriteLine($"Unable to parse '{input}'");
+        }
+        // Output: Unable to parse ''
 
-       try
-       {
+        try
+        {
             int numVal = Int32.Parse("-105");
             Console.WriteLine(numVal);
-       }
-       catch (FormatException e)
-       {
-           Console.WriteLine(e.Message);
-       }
-       // Output: -105
+        }
+        catch (FormatException e)
+        {
+            Console.WriteLine(e.Message);
+        }
+        // Output: -105
 
         if (Int32.TryParse("-105", out int j))
+        {
             Console.WriteLine(j);
+        }
         else
+        {
             Console.WriteLine("String could not be parsed.");
+        }
         // Output: -105
 
         try
@@ -43,11 +47,15 @@ public class StringConversion
         }
         // Output: Input string was not in a correct format.
 
-        string inputString = "abc";
+        const string inputString = "abc";
         if (Int32.TryParse(inputString, out int numValue))
+        {
             Console.WriteLine(inputString);
+        }
         else
+        {
             Console.WriteLine($"Int32.TryParse could not parse '{inputString}' to an int.");
+        }
         // Output: Int32.TryParse could not parse 'abc' to an int.
-     }
+    }
 }

--- a/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse2/Program.cs
+++ b/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse2/Program.cs
@@ -1,40 +1,49 @@
 ﻿using System;
 
-public class StringConversion
+public static class StringConversion
 {
     public static void Main()
     {
         var str = "  10FFxxx";
-        string numericString = String.Empty;
+        string numericString = string.Empty;
         foreach (var c in str)
         {
             // Check for numeric characters (hex in this case) or leading or trailing spaces.
-            if ((c >= '0' && c <= '9') || (Char.ToUpperInvariant(c) >= 'A' && Char.ToUpperInvariant(c) <= 'F') || c == ' ') {
-                numericString = String.Concat(numericString, c.ToString());
+            if ((c >= '0' && c <= '9') || (char.ToUpperInvariant(c) >= 'A' && char.ToUpperInvariant(c) <= 'F') || c == ' ')
+            {
+                numericString = string.Concat(numericString, c.ToString());
             }
             else
             {
                 break;
             }
         }
+
         if (int.TryParse(numericString, System.Globalization.NumberStyles.HexNumber, null, out int i))
+        {
             Console.WriteLine($"'{str}' --> '{numericString}' --> {i}");
-            // Output: '  10FFxxx' --> '  10FF' --> 4351
+        }
+        // Output: '  10FFxxx' --> '  10FF' --> 4351
 
         str = "   -10FFXXX";
         numericString = "";
-        foreach (char c in str) {
+        foreach (char c in str)
+        {
             // Check for numeric characters (0-9), a negative sign, or leading or trailing spaces.
             if ((c >= '0' && c <= '9') || c == ' ' || c == '-')
             {
-                numericString = String.Concat(numericString, c);
-            } else
+                numericString = string.Concat(numericString, c);
+            }
+            else
             {
                 break;
             }
         }
+
         if (int.TryParse(numericString, out int j))
+        {
             Console.WriteLine($"'{str}' --> '{numericString}' --> {j}");
-            // Output: '   -10FFXXX' --> '   -10' --> -10
+        }
+        // Output: '   -10FFXXX' --> '   -10' --> -10
     }
 }


### PR DESCRIPTION
## Summary

Updated the "parse-tryparse" and "parse-tryparse2" snippets used in "[How to convert a string to a number (C# Programming Guide)](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/how-to-convert-a-string-to-a-number)" to adhere to the published [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions) and [Framework Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/).
