### PR TITLE
Clarify how "x is null" evaluated for reference types

### DIFF
--- a/docs/csharp/language-reference/keywords/is.md
+++ b/docs/csharp/language-reference/keywords/is.md
@@ -94,7 +94,7 @@ The following example shows a comparison of `null` checks:
 
 [!code-csharp[is#11](../../../../samples/snippets/csharp/language-reference/keywords/is/is-const-pattern11.cs#11)]
 
-The expression `x is null` is computed differently for reference types and nullable value types. For nullable value types, it uses <xref:System.Nullable%601.HasValue?displayProperty=nameWithType>. For reference types, it uses `x == null`.
+The expression `x is null` is computed differently for reference types and nullable value types. For nullable value types, it uses <xref:System.Nullable%601.HasValue?displayProperty=nameWithType>. For reference types, it uses `(object)x == null`.
 
 ### var pattern
 


### PR DESCRIPTION
Continuation of #21628 

Cast to `object` is necessary to avoid picking up overloaded `==`. For example, [the snippet on SharpLab](https://sharplab.io/#v2:EYLgtghgzgLgpgJwD4AEBMBGAsAKBQZgAJ1CBhQgb10JuLTUutuaeZoEsAzQgCgHE4MUjwCUhdlEIA7AK4AbOSNZsqONuuIYAnDwBEshbpEBuZcwC+Z2sstrrdmgU0A2MoQFDRhALwA+afJypg6Eyk4oGK7AAPbRcoTRAA6IEDDRCD7ePOQQADRuwGJ+hJwQclBwwczhkYQxcQnJCKnphACEWTn55IU+/qXllbjmQA==)

