### PR TITLE
Document --diagnostic-port option on dotnet-counters and dotnet-trace

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -338,31 +338,31 @@ However, when you want to gain a finer control over the lifetime of the app bein
 
 1. The command below makes dotnet-counters create a diagnostics socket named `myport.sock` and wait for a connection.
 
-  ```dotnet-cli
-  dotnet-counters collect --diagnostic-port myport.sock
-  ```
+    > ```dotnet-cli
+    > dotnet-counters collect --diagnostic-port myport.sock
+    > ```
 
-  Output:
+    Output:
 
-  ```bash
-  Waiting for connection on myport.sock
-  Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-  ```
+    > ```bash
+    > Waiting for connection on myport.sock
+    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > ```
 
 2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-counters`.
 
-  ```bash
-  export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-  ./my-dotnet-app arg1 arg2
-  ```
+    > ```bash
+    > export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > ./my-dotnet-app arg1 arg2
+    > ```
 
-  This should then enable `dotnet-counters` to start collecting counters on `my-dotnet-app`:
+    This should then enable `dotnet-counters` to start collecting counters on `my-dotnet-app`:
 
-  ```bash
-  Waiting for connection on myport.sock
-  Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
-  Starting a counter session. Press Q to quit.
-  ```
+    > ```bash
+    > Waiting for connection on myport.sock
+    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
+    > Starting a counter session. Press Q to quit.
+    > ```
 
-  > [!IMPORTANT]
-  > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-counters` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.
+    > [!IMPORTANT]
+    > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-counters` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -338,30 +338,31 @@ However, when you want to gain a finer control over the lifetime of the app bein
 
 1. The command below makes dotnet-counters create a diagnostics socket named `myport.sock` and wait for a connection.
 
-```dotnet-cli
-dotnet-counters collect --diagnostic-port myport.sock
-```
+  ```dotnet-cli
+  dotnet-counters collect --diagnostic-port myport.sock
+  ```
 
-Output:
-```bash
-Waiting for connection on myport.sock
-Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-```
+  Output:
+
+  ```bash
+  Waiting for connection on myport.sock
+  Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+  ```
 
 2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-counters`.
 
-```bash
-export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-./my-dotnet-app arg1 arg2
-```
+  ```bash
+  export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+  ./my-dotnet-app arg1 arg2
+  ```
 
-This should then enable `dotnet-counters` to start collecting counters on `my-dotnet-app`:
+  This should then enable `dotnet-counters` to start collecting counters on `my-dotnet-app`:
 
-```bash
-Waiting for connection on myport.sock
-Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
-Starting a counter session. Press Q to quit.
-```
+  ```bash
+  Waiting for connection on myport.sock
+  Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
+  Starting a counter session. Press Q to quit.
+  ```
 
   > [!IMPORTANT]
   > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-counters` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -365,23 +365,3 @@ Starting a counter session. Press Q to quit.
 
   > [!IMPORTANT]
   > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-counters` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.
-
-## FAQ
-
-1. Can a single process of `dotnet-counters` monitor/collect counters from multiple applications at once using diagnostic ports?
-
-> No. A single process of `dotnet-counters` can only collect or monitor counters from a single application at once.
-
-2. `dotnet-counters` is stuck at "Waiting for connection on ....".
-
-> Make sure your application is running .NET 5 and is launched with the correct environment variable suggested by `dotnet-counters`.
-
-3. My app is stuck with a message similar to one below:
-
-```bash
-The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a Diagnostic Port.
-DOTNET_DiagnosticPorts="myport.sock"
-DOTNET_DefaultDiagnosticPortSuspend=0
-```
-
-> This may happen when some other process has already connected to `dotnet-counters`. Make sure you didn't accidentally launch a child process or are using a wrong socket name that's being used by another instance of active application.

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -321,7 +321,7 @@ dotnet-counters ps [-h|--help]
 ```console
 > dotnet-counters ps
   
-  15683 WebApi     /home/suwhang/repos/WebApi/WebApi
+  15683 WebApi     /home/user/repos/WebApi/WebApi
   16324 dotnet     /usr/local/share/dotnet/dotnet
 ```
 
@@ -346,13 +346,13 @@ However, when you want to gain a finer control over the lifetime of the app bein
 
     > ```bash
     > Waiting for connection on myport.sock
-    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/user/myport.sock
     > ```
 
-2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-counters`.
+2. In a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value in the `dotnet-counters` output.
 
     > ```bash
-    > export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > export DOTNET_DiagnosticPorts=/home/user/myport.sock
     > ./my-dotnet-app arg1 arg2
     > ```
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -264,13 +264,13 @@ However, when you want to gain a finer control over the lifetime of the app bein
 
     > ```bash
     > Waiting for connection on myport.sock
-    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/user/myport.sock
     > ```
 
-2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-trace`.
+2. In a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value in the `dotnet-trace` output.
 
     > ```bash
-    > export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > export DOTNET_DiagnosticPorts=/home/user/myport.sock
     > ./my-dotnet-app arg1 arg2
     > ```
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -260,26 +260,27 @@ However, when you want to gain a finer control over the lifetime of the app bein
 dotnet-trace collect --diagnostic-port myport.sock
 ```
 
-Output:
-```bash
-Waiting for connection on myport.sock
-Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-```
+  Output:
+
+  ```bash
+  Waiting for connection on myport.sock
+  Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+  ```
 
 2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-trace`.
 
-```bash
-export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-./my-dotnet-app arg1 arg2
-```
+  ```bash
+  export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+  ./my-dotnet-app arg1 arg2
+  ```
 
-This should then enable `dotnet-trace` to start tracing `my-dotnet-app`:
+  This should then enable `dotnet-trace` to start tracing `my-dotnet-app`:
 
-```bash
-Waiting for connection on myport.sock
-Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
-Starting a counter session. Press Q to quit.
-```
+  ```bash
+  Waiting for connection on myport.sock
+  Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
+  Starting a counter session. Press Q to quit.
+  ```
 
   > [!IMPORTANT]
   > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-trace` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -72,7 +72,7 @@ Collects a diagnostic trace from a running process.
 ```console
 dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--clrevents <clrevents>]
     [--format <Chromium|NetTrace|Speedscope>] [-h|--help]
-    [-n, --name <name>]  [-o|--output <trace-file-path>] [-p|--process-id <pid>]
+    [-n, --name <name>] [--diagnostic-port] [-o|--output <trace-file-path>] [-p|--process-id <pid>]
     [--profile <profile-name>] [--providers <list-of-comma-separated-providers>]
     [-- <command>] (for target applications running .NET 5.0 or later)
 ```
@@ -98,6 +98,10 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 - **`-n, --name <name>`**
 
   The name of the process to collect the trace from.
+
+- **`--diagnostic-port <path-to-port>`**
+
+  The name of the diagnostic port to create. See [Use diagnostic port to collect a trace from app startup](#use-diagnostic-port-to-collect-a-trace-fromm-app-startup) to learn how to use this option to collect a trace from app startup.
 
 - **`-o|--output <trace-file-path>`**
 
@@ -238,6 +242,47 @@ You can stop collecting the trace by pressing `<Enter>` or `<Ctrl + C>` key. Doi
 > Launching `hello.exe` via dotnet-trace will make its input/output to be redirected and you won't be able to interact with its stdin/stdout.
 > Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process.
 > If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable.
+
+## Use diagnostic port to collect a trace from app startup
+
+  > [!IMPORTANT]
+  > This works for apps running .NET 5.0 or later only.
+
+Diagnostic port is a new runtime feature that was added in .NET 5 that allows you to start tracing from app startup. To do this using `dotnet-trace`, you can either use `dotnet-trace collect -- <command>` as described in the examples above, or use the `--diagnostic-port` option.
+
+Using `dotnet-trace <collect|monitor> -- <command>` to launch the application as a child process is the simplest way to quickly trace it from its startup.
+
+However, when you want to gain a finer control over the lifetime of the app being traced (for example, monitor the app for the first 10 minutes only and continue executing) or if you need to interact with the app using the CLI, using `--diagnostic-port` option allows you to control both the target app being monitored and `dotnet-trace`.
+
+1. The command below makes `dotnet-trace` create a diagnostics socket named `myport.sock` and wait for a connection.
+
+```dotnet-cli
+dotnet-trace collect --diagnostic-port myport.sock
+```
+
+Output:
+```bash
+Waiting for connection on myport.sock
+Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+```
+
+2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-trace`.
+
+```bash
+export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+./my-dotnet-app arg1 arg2
+```
+
+This should then enable `dotnet-trace` to start tracing `my-dotnet-app`:
+
+```bash
+Waiting for connection on myport.sock
+Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
+Starting a counter session. Press Q to quit.
+```
+
+  > [!IMPORTANT]
+  > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-trace` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.
 
 ## View the trace captured from dotnet-trace
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -256,34 +256,34 @@ However, when you want to gain a finer control over the lifetime of the app bein
 
 1. The command below makes `dotnet-trace` create a diagnostics socket named `myport.sock` and wait for a connection.
 
-```dotnet-cli
-dotnet-trace collect --diagnostic-port myport.sock
-```
+    > ```dotnet-cli
+    > dotnet-trace collect --diagnostic-port myport.sock
+    > ```
 
-  Output:
+    Output:
 
-  ```bash
-  Waiting for connection on myport.sock
-  Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-  ```
+    > ```bash
+    > Waiting for connection on myport.sock
+    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > ```
 
 2. On a separate console, launch the target application with the environment variable `DOTNET_DiagnosticPorts` set to the value suggested by `dotnet-trace`.
 
-  ```bash
-  export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
-  ./my-dotnet-app arg1 arg2
-  ```
+    > ```bash
+    > export DOTNET_DiagnosticPorts=/home/suwhang/myport.sock
+    > ./my-dotnet-app arg1 arg2
+    > ```
 
-  This should then enable `dotnet-trace` to start tracing `my-dotnet-app`:
+    This should then enable `dotnet-trace` to start tracing `my-dotnet-app`:
 
-  ```bash
-  Waiting for connection on myport.sock
-  Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
-  Starting a counter session. Press Q to quit.
-  ```
+    > ```bash
+    > Waiting for connection on myport.sock
+    > Start an application with the following environment variable: DOTNET_DiagnosticPorts=myport.sock
+    > Starting a counter session. Press Q to quit.
+    > ```
 
-  > [!IMPORTANT]
-  > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-trace` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.
+    > [!IMPORTANT]
+    > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-trace` before your app, leaving your app to be suspended at runtime. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.
 
 ## View the trace captured from dotnet-trace
 


### PR DESCRIPTION
## Summary

This documents the new --diagnostic-port option on dotnet-counters and dotnet-trace that was added via https://github.com/dotnet/diagnostics/pull/1691 along with some example usage of the feature and potential gotchas.

Not to be merged until the next diagnostics global tool release. 