### PR TITLE
Add printfn "%A" to `Script.fsx`

### DIFF
--- a/docs/fsharp/tutorials/fsharp-interactive/index.md
+++ b/docs/fsharp/tutorials/fsharp-interactive/index.md
@@ -70,7 +70,7 @@ let getOddSquares xs =
     |> List.filter (fun x -> x % 2 <> 0)
     |> List.map (fun x -> x * x)
 
-getOddSquares [1..10]
+printfn "%A" (getOddSquares [1..10])
 ```
 
 When this file is created in your machine, you can run it with `dotnet fsi` and see the output directly in your terminal window:


### PR DESCRIPTION
Without printfn, `dotnet fsi Script.fsx` would not output anything in the terminal.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
