### PR TITLE
Issue 18496

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -84,4 +84,6 @@ public class CardType : Enumeration
 - **SmartEnum**. Ardalis - Classes to help produce strongly typed smarter enums in .NET. \
   <https://www.nuget.org/packages/Ardalis.SmartEnum/>
 
-> [!div class="step-by-step"] >[Previous](implement-value-objects.md) >[Next](domain-model-layer-validations.md)
+>[!div class="step-by-step"]
+>[Previous](implement-value-objects.md)
+>[Next](domain-model-layer-validations.md)

--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -1,7 +1,7 @@
 ---
 title: Using Enumeration classes instead of enum types
 description: .NET Microservices Architecture for Containerized .NET Applications | Lear how you can use enumeration classes, instead of enums, as a way to solve some limitations of the latter.
-ms.date: 10/08/2018
+ms.date: 11/20/2020
 ---
 # Use enumeration classes instead of enum types
 
@@ -9,7 +9,7 @@ ms.date: 10/08/2018
 
 Instead, you can create Enumeration classes that enable all the rich features of an object-oriented language.
 
-However, this isn't a critical topic and in many cases, for simplicity, you can still use regular [enum types](../../../csharp/language-reference/builtin-types/enum.md) if that's your preference. Anyway, the use of enumeration classes is more related to business-related concepts.
+However, this isn't a critical topic and in many cases, for simplicity, you can still use regular [enum types](../../../csharp/language-reference/builtin-types/enum.md) if that's your preference. The use of enumeration classes is more related to business-related concepts.
 
 ## Implement an Enumeration base class
 

--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -3,6 +3,7 @@ title: Using Enumeration classes instead of enum types
 description: .NET Microservices Architecture for Containerized .NET Applications | Lear how you can use enumeration classes, instead of enums, as a way to solve some limitations of the latter.
 ms.date: 11/20/2020
 ---
+
 # Use enumeration classes instead of enum types
 
 [Enumerations](../../../csharp/language-reference/builtin-types/enum.md) (or *enum types* for short) are a thin language wrapper around an integral type. You might want to limit their use to when you are storing one value from a closed set of values. Classification based on sizes (small, medium, large) is a good example. Using enums for control flow or more robust abstractions can be a [code smell](https://deviq.com/code-smells/). This type of usage leads to fragile code with many control flow statements checking values of the enum.
@@ -22,29 +23,22 @@ public abstract class Enumeration : IComparable
 
     public int Id { get; private set; }
 
-    protected Enumeration(int id, string name)
-    {
-        Id = id;
-        Name = name;
-    }
+    protected Enumeration(int id, string name) => (Id, Name) = (id, name);
 
     public override string ToString() => Name;
 
-    public static IEnumerable<T> GetAll<T>() where T : Enumeration
-    {
-        var fields = typeof(T).GetFields(BindingFlags.Public |
-                                         BindingFlags.Static |
-                                         BindingFlags.DeclaredOnly);
-
-        return fields.Select(f => f.GetValue(null)).Cast<T>();
-    }
+    public static IEnumerable<T> GetAll<T>() where T : Enumeration =>
+            typeof(T).GetFields(BindingFlags.Public |
+                                BindingFlags.Static |
+                                BindingFlags.DeclaredOnly)
+                      .Select(f => f.GetValue(null)).Cast<T>();
 
     public override bool Equals(object obj)
     {
-        var otherValue = obj as Enumeration;
-
-        if (otherValue == null)
+        if (!(obj is Enumeration otherValue))
+        {
             return false;
+        }
 
         var typeMatches = GetType().Equals(obj.GetType());
         var valueMatches = Id.Equals(otherValue.Id);
@@ -63,12 +57,11 @@ You can use this class as a type in any entity or value object, as for the follo
 ```csharp
 public class CardType : Enumeration
 {
-    public static readonly CardType Amex = new CardType(1, "Amex");
-    public static readonly CardType Visa = new CardType(2, "Visa");
-    public static readonly CardType MasterCard = new CardType(3, "MasterCard");
+    public static readonly CardType Amex = new CardType(1, nameof(Amex));
+    public static readonly CardType Visa = new CardType(2, nameof(Visa));
+    public static readonly CardType MasterCard = new CardType(3, nameof(MasterCard));
 
-    public CardType(int id, string name)
-        : base(id, name)
+    public CardType(int id, string name) : base(id, name)
     {
     }
 }
@@ -91,6 +84,4 @@ public class CardType : Enumeration
 - **SmartEnum**. Ardalis - Classes to help produce strongly typed smarter enums in .NET. \
   <https://www.nuget.org/packages/Ardalis.SmartEnum/>
 
->[!div class="step-by-step"]
->[Previous](implement-value-objects.md)
->[Next](domain-model-layer-validations.md)
+> [!div class="step-by-step"] >[Previous](implement-value-objects.md) >[Next](domain-model-layer-validations.md)

--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -30,11 +30,12 @@ public abstract class Enumeration : IComparable
         typeof(T).GetFields(BindingFlags.Public |
                             BindingFlags.Static |
                             BindingFlags.DeclaredOnly)
-                 .Select(f => f.GetValue(null)).Cast<T>();
+                 .Select(f => f.GetValue(null))
+                 .Cast<T>();
 
     public override bool Equals(object obj)
     {
-        if (!(obj is Enumeration otherValue))
+        if (obj is not Enumeration otherValue)
         {
             return false;
         }

--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -3,7 +3,6 @@ title: Using Enumeration classes instead of enum types
 description: .NET Microservices Architecture for Containerized .NET Applications | Lear how you can use enumeration classes, instead of enums, as a way to solve some limitations of the latter.
 ms.date: 11/20/2020
 ---
-
 # Use enumeration classes instead of enum types
 
 [Enumerations](../../../csharp/language-reference/builtin-types/enum.md) (or *enum types* for short) are a thin language wrapper around an integral type. You might want to limit their use to when you are storing one value from a closed set of values. Classification based on sizes (small, medium, large) is a good example. Using enums for control flow or more robust abstractions can be a [code smell](https://deviq.com/code-smells/). This type of usage leads to fragile code with many control flow statements checking values of the enum.

--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -1,7 +1,7 @@
 ---
 title: Using Enumeration classes instead of enum types
 description: .NET Microservices Architecture for Containerized .NET Applications | Lear how you can use enumeration classes, instead of enums, as a way to solve some limitations of the latter.
-ms.date: 11/20/2020
+ms.date: 11/25/2020
 ---
 # Use enumeration classes instead of enum types
 
@@ -27,10 +27,10 @@ public abstract class Enumeration : IComparable
     public override string ToString() => Name;
 
     public static IEnumerable<T> GetAll<T>() where T : Enumeration =>
-            typeof(T).GetFields(BindingFlags.Public |
-                                BindingFlags.Static |
-                                BindingFlags.DeclaredOnly)
-                      .Select(f => f.GetValue(null)).Cast<T>();
+        typeof(T).GetFields(BindingFlags.Public |
+                            BindingFlags.Static |
+                            BindingFlags.DeclaredOnly)
+                 .Select(f => f.GetValue(null)).Cast<T>();
 
     public override bool Equals(object obj)
     {
@@ -54,13 +54,15 @@ public abstract class Enumeration : IComparable
 You can use this class as a type in any entity or value object, as for the following `CardType` : `Enumeration` class:
 
 ```csharp
-public class CardType : Enumeration
+public class CardType
+    : Enumeration
 {
-    public static readonly CardType Amex = new CardType(1, nameof(Amex));
-    public static readonly CardType Visa = new CardType(2, nameof(Visa));
-    public static readonly CardType MasterCard = new CardType(3, nameof(MasterCard));
+    public static CardType Amex = new CardType(1, nameof(Amex));
+    public static CardType Visa = new CardType(2, nameof(Visa));
+    public static CardType MasterCard = new CardType(3, nameof(MasterCard));
 
-    public CardType(int id, string name) : base(id, name)
+    public CardType(int id, string name)
+        : base(id, name)
     {
     }
 }


### PR DESCRIPTION
## Summary

Changes per original issue and discussion:

- Use `nameof` expression
- Use expression bodied members
- Use pattern matching
- Grammar (removed casual language)

Fixes #18496
