### PR TITLE
reclassify how to articles, Content OKR

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
@@ -6,6 +6,8 @@ helpviewer_keywords:
   - "enumerations [C#]"
   - "extension methods [C#], for enums"
   - "enum extensibility [C#]"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 100106f9-1e54-462c-8ebe-3892fe23b6eb
 ---
 # How to create a new method for an enumeration (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-declare-and-use-read-write-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-declare-and-use-read-write-properties.md
@@ -8,6 +8,8 @@ helpviewer_keywords:
   - "properties [C#], declaring"
   - "read/write properties [C#]"
   - "accessors [C#], declaring properties with"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: a4962fef-af7e-4c4b-a929-4ae4d646ab8a
 ---
 # How to declare and use read write properties (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-define-abstract-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-define-abstract-properties.md
@@ -5,6 +5,8 @@ ms.date: 07/20/2015
 helpviewer_keywords: 
   - "properties [C#], abstract"
   - "abstract properties [C#]"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 672a90eb-47b9-4ae0-9914-af53852fddcb
 ---
 # How to define abstract properties (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-define-constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-define-constants.md
@@ -5,6 +5,8 @@ ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, constants"
   - "constants [C#]"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 43f511be-346c-4b8a-995e-aded94542ece
 ---
 # How to define constants in C\#

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-implement-a-lightweight-class-with-auto-implemented-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-implement-a-lightweight-class-with-auto-implemented-properties.md
@@ -5,6 +5,8 @@ ms.date: 07/20/2015
 helpviewer_keywords:
   - "auto-implemented properties [C#]"
   - "properties [C#], auto-implemented"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 1dc5a8ad-a4f7-4f32-8506-3fc6d8c8bfed
 ---
 # How to implement a lightweight class with auto-implemented properties (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-implement-and-call-a-custom-extension-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-implement-and-call-a-custom-extension-method.md
@@ -4,6 +4,8 @@ description: Learn how to implement extension methods for any .NET type. Client 
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "extension methods [C#], implementing and calling"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 7dab2a56-cf8e-4a47-a444-fe610a02772a
 ---
 # How to implement and call a custom extension method (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -4,6 +4,8 @@ description: Learn how to initialize a dictionary in C#, using either the Add me
 ms.date: 12/20/2018
 helpviewer_keywords: 
   - "collection initializers [C#], with Dictionary"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 25283922-f8ee-40dc-a639-fac30804ec71
 ---
 # How to initialize a dictionary with a collection initializer (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
@@ -5,6 +5,8 @@ ms.date: 12/20/2018
 helpviewer_keywords: 
   - "object initializers [C#], how to use"
   - "objects [C#], initializing"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 4b75ebb2-2e29-43de-929c-d736a8f27ce6
 ---
 # How to initialize objects by using an object initializer (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-know-the-difference-passing-a-struct-and-passing-a-class-to-a-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-know-the-difference-passing-a-struct-and-passing-a-class-to-a-method.md
@@ -6,6 +6,8 @@ helpviewer_keywords:
   - "structs [C#], passing as method parameter"
   - "passing parameters [C#], structs vs. classes"
   - "methods [C#], passing classes vs. structs"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 9c1313a6-32a8-4ea7-a59f-450f66af628b
 ---
 # How to know the difference between passing a struct and passing a class reference to a method (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-override-the-tostring-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-override-the-tostring-method.md
@@ -5,6 +5,8 @@ ms.date: 07/20/2015
 helpviewer_keywords: 
   - "ToString method, overriding in C#"
   - "inheritance [C#], overriding OnPaint and ToString"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 8016db69-1f19-420c-8e17-98e8bebb7749
 ---
 # How to override the ToString method (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-return-subsets-of-element-properties-in-a-query.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-return-subsets-of-element-properties-in-a-query.md
@@ -4,6 +4,8 @@ description: Learn how to use an anonymous type in a query expression in C# to r
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "anonymous types [C#], for subsets of element properties"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: fabdf349-f443-4e3f-8368-6c471be1dd7b
 ---
 # How to return subsets of element properties in a query (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-use-implicitly-typed-local-variables-and-arrays-in-a-query-expression.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-use-implicitly-typed-local-variables-and-arrays-in-a-query-expression.md
@@ -4,6 +4,8 @@ description: Use implicitly typed local variables in C# to have the compiler det
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "implicitly-typed local variables [C#], how to use"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 6b7354d2-af79-427a-b6a8-f74eb8fd0b91
 ---
 # How to use implicitly typed local variables and arrays in a query expression (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-use-named-and-optional-arguments-in-office-programming.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-use-named-and-optional-arguments-in-office-programming.md
@@ -6,6 +6,8 @@ helpviewer_keywords:
   - "named and optional arguments [C#], Office programming"
   - "optional arguments [C#], Office programming"
   - "named arguments [C#], Office programming"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 65b8a222-bcd8-454c-845f-84adff5a356f
 ---
 # How to use named and optional arguments in Office programming (C# Programming Guide)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md
@@ -5,6 +5,8 @@ ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# Language, copy constructor"
   - "copy constructor [C#]"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: fba899b5-fc41-428e-a745-3ebdbf37990a
 ---
 # How to write a copy constructor (C# Programming Guide)

--- a/docs/csharp/programming-guide/types/how-to-convert-a-byte-array-to-an-int.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-a-byte-array-to-an-int.md
@@ -5,6 +5,8 @@ ms.date: 07/20/2015
 helpviewer_keywords:
   - "conversions [C#], byte array to int"
   - "byte arrays [C#], converting to int"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: d6ac20e2-448e-4aea-99b9-faf04c6f1e79
 ---
 # How to convert a byte array to an int (C# Programming Guide)

--- a/docs/csharp/programming-guide/types/how-to-convert-a-string-to-a-number.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-a-string-to-a-number.md
@@ -1,31 +1,33 @@
 ---
 title: "How to convert a string to a number - C# Programming Guide"
 description: Learn how to convert a string to a number in C# by calling the Parse, TryParse, or Convert class methods.
-ms.date: 02/11/2019
+ms.date: 11/20/2020
 helpviewer_keywords: 
   - "conversions [C#]"
   - "conversions [C#], string to int"
   - "converting strings to int [C#]"
   - "strings [C#], converting to int"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 467b9979-86ee-4afd-b734-30299cda91e3
 ---
 # How to convert a string to a number (C# Programming Guide)
 
-You can convert a [string](../../language-reference/builtin-types/reference-types.md) to a number by calling the `Parse` or `TryParse` method found on the various numeric types (`int`, `long`, `double`, etc.), or by using methods in the <xref:System.Convert?displayProperty=nameWithType> class.  
+You can convert a [string](../../language-reference/builtin-types/reference-types.md) to a number by calling the `Parse` or `TryParse` method found on the various numeric types (`int`, `long`, `double`, and so on), or by using methods in the <xref:System.Convert?displayProperty=nameWithType> class.  
   
- If you have a string, it is slightly more efficient and straightforward to call a `TryParse` method (for example, [`int.TryParse("11", out number)`](xref:System.Int32.TryParse%2A)) or `Parse` method (for example, [`var number = int.Parse("11")`](xref:System.Int32.Parse%2A)).  Using a <xref:System.Convert> method is more useful for general objects that implement <xref:System.IConvertible>.  
+ It's slightly more efficient and straightforward to call a `TryParse` method (for example, [`int.TryParse("11", out number)`](xref:System.Int32.TryParse%2A)) or `Parse` method (for example, [`var number = int.Parse("11")`](xref:System.Int32.Parse%2A)).  Using a <xref:System.Convert> method is more useful for general objects that implement <xref:System.IConvertible>.  
   
- You can use `Parse` or `TryParse` methods on the numeric type you expect the string contains, such as the <xref:System.Int32?displayProperty=nameWithType> type.  The <xref:System.Convert.ToInt32%2A?displayProperty=nameWithType> method uses <xref:System.Int32.Parse%2A> internally.  The `Parse` method returns the converted number; the `TryParse` method returns a <xref:System.Boolean> value that indicates whether the conversion succeeded, and returns the converted number in an [`out` parameter](../../language-reference/keywords/out.md). If the string is not in a valid format, `Parse` throws an exception, whereas `TryParse` returns `false`. When calling a `Parse` method, you should always use exception handling to catch a <xref:System.FormatException> in the event that the parse operation fails.  
+ You use `Parse` or `TryParse` methods on the numeric type you expect the string contains, such as the <xref:System.Int32?displayProperty=nameWithType> type.  The <xref:System.Convert.ToInt32%2A?displayProperty=nameWithType> method uses <xref:System.Int32.Parse%2A> internally.  The `Parse` method returns the converted number; the `TryParse` method returns a <xref:System.Boolean> value that indicates whether the conversion succeeded, and returns the converted number in an [`out` parameter](../../language-reference/keywords/out.md). If the string isn't in a valid format, `Parse` throws an exception, but `TryParse` returns `false`. When calling a `Parse` method, you should always use exception handling to catch a <xref:System.FormatException> in the event that the parse operation fails.  
   
 ## Calling the Parse and TryParse methods
 
-The `Parse` and `TryParse` methods ignore white space at the beginning and at the end of the string, but all other characters must be characters that form the appropriate numeric type (`int`, `long`, `ulong`, `float`, `decimal`, etc.).  Any white space within the string that forms the number causes an error.  For example, you can use `decimal.TryParse` to parse "10", "10.3", or "  10  ", but you cannot use this method to parse 10 from "10X", "1 0" (note the embedded space), "10 .3" (note the embedded space), "10e1" (`float.TryParse` works here), and so on. In addition, a string whose value is `null` or <xref:System.String.Empty?displayProperty=nameWithType> fails to parse successfully. You can check for a null or empty string before attempting to parse it by calling the <xref:System.String.IsNullOrEmpty%2A?displayProperty=nameWithType> method.
+The `Parse` and `TryParse` methods ignore white space at the beginning and at the end of the string, but all other characters must be characters that form the appropriate numeric type (`int`, `long`, `ulong`, `float`, `decimal`, and so on).  Any white space within the string that forms the number causes an error.  For example, you can use `decimal.TryParse` to parse "10", "10.3", or "  10  ", but you can't use this method to parse 10 from "10X", "1 0" (note the embedded space), "10 .3" (note the embedded space), "10e1" (`float.TryParse` works here), and so on. A string whose value is `null` or <xref:System.String.Empty?displayProperty=nameWithType> fails to parse successfully. You can check for a null or empty string before attempting to parse it by calling the <xref:System.String.IsNullOrEmpty%2A?displayProperty=nameWithType> method.
 
 The following example demonstrates both successful and unsuccessful calls to `Parse` and `TryParse`.  
   
 [!code-csharp[Parse and TryParse](~/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse/program.cs)]  
 
-The following example illustrates one a approach to parsing a string that is expected to include leading numeric characters (including hexadecimal characters) and trailing non-numeric characters. It assigns valid characters from the beginning of a string to a new string before calling the <xref:System.Int32.TryParse%2A> method. Because the strings to be parsed contain a small number of characters, the example calls the <xref:System.String.Concat%2A?displayProperty=nameWithType> method to assign valid characters to a new string. For a larger string, the <xref:System.Text.StringBuilder> class can be used instead.
+The following example illustrates one an approach to parsing a string expected to include leading numeric characters (including hexadecimal characters) and trailing non-numeric characters. It assigns valid characters from the beginning of a string to a new string before calling the <xref:System.Int32.TryParse%2A> method. Because the strings to be parsed contain a small number of characters, the example calls the <xref:System.String.Concat%2A?displayProperty=nameWithType> method to assign valid characters to a new string. For a larger string, the <xref:System.Text.StringBuilder> class can be used instead.
   
 [!code-csharp[Removing invalid characters](~/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse2/program.cs)]  
 

--- a/docs/csharp/programming-guide/types/how-to-convert-a-string-to-a-number.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-a-string-to-a-number.md
@@ -27,7 +27,7 @@ The following example demonstrates both successful and unsuccessful calls to `Pa
   
 [!code-csharp[Parse and TryParse](~/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse/program.cs)]  
 
-The following example illustrates one an approach to parsing a string expected to include leading numeric characters (including hexadecimal characters) and trailing non-numeric characters. It assigns valid characters from the beginning of a string to a new string before calling the <xref:System.Int32.TryParse%2A> method. Because the strings to be parsed contain a small number of characters, the example calls the <xref:System.String.Concat%2A?displayProperty=nameWithType> method to assign valid characters to a new string. For a larger string, the <xref:System.Text.StringBuilder> class can be used instead.
+The following example illustrates one approach to parsing a string expected to include leading numeric characters (including hexadecimal characters) and trailing non-numeric characters. It assigns valid characters from the beginning of a string to a new string before calling the <xref:System.Int32.TryParse%2A> method. Because the strings to be parsed contain a small number of characters, the example calls the <xref:System.String.Concat%2A?displayProperty=nameWithType> method to assign valid characters to a new string. For a larger string, the <xref:System.Text.StringBuilder> class can be used instead.
   
 [!code-csharp[Removing invalid characters](~/samples/snippets/csharp/programming-guide/string-to-number/parse-tryparse2/program.cs)]  
 

--- a/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
@@ -7,6 +7,8 @@ helpviewer_keywords:
   - "conversions [C#], hexidecimal strings"
   - "strings [C#], converting hexadecimal strings"
   - "hexadecimal strings [C#]"
+ms.topic: how-to
+ms.custom: contperfq2
 ms.assetid: 7115c49f-7d1d-40c3-8bd9-aae0cc1d46b6
 ---
 # How to convert between hexadecimal strings and numeric types (C# Programming Guide)


### PR DESCRIPTION
Improve content performance for how-to article on converting a string to a number.

It ws incorrectly classified as "conceptual" instead of "how to". The change in formula to the correct classification will fix much of the issues.

In addition, do an edit pass for grammar and style.

Also, note that many other "how to" articles in the C# programming guide were mis-classified as "conceptual". Make those changes as well.

Fixes [AB#1795383](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1795383)
