### PR TITLE
Fix for #21696 for Ubuntu 20.10

### DIFF
--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -53,7 +53,7 @@ The following versions of .NET are no longer supported. The downloads for these 
 [!INCLUDE [linux-prep-intro-apt](includes/linux-prep-intro-apt.md)]
 
 ```bash
-wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+wget https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 ```
 


### PR DESCRIPTION
## Summary

Updated the version for dotnet installation on Ubuntu to 20.10.
Fixes #21696
