### PR TITLE
Add note that msxsl:script is supported only on full framework

### DIFF
--- a/docs/standard/data/xml/script-blocks-using-msxsl-script.md
+++ b/docs/standard/data/xml/script-blocks-using-msxsl-script.md
@@ -8,7 +8,8 @@ ms.assetid: fde6f43f-c594-486f-abcb-2211197fae20
 ---
 # Script Blocks Using msxsl:script
 
-**Script blocks are supported only in .NET Framework (they are not supported on .NET Core or .NET 5 or later).**
+> [!NOTE]
+> Script blocks are supported only in .NET Framework. They are _not_ supported on .NET Core or .NET 5.0 or later.
 
 The <xref:System.Xml.Xsl.XslCompiledTransform> class supports embedded scripts using the `msxsl:script` element. When the style sheet is loaded, any defined functions are compiled to Microsoft intermediate language (MSIL) by the Code Document Object Model (CodeDOM) and are executed during run time. The assembly generated from the embedded script block is separate than the assembly generated for the style sheet.  
   

--- a/docs/standard/data/xml/script-blocks-using-msxsl-script.md
+++ b/docs/standard/data/xml/script-blocks-using-msxsl-script.md
@@ -8,6 +8,8 @@ ms.assetid: fde6f43f-c594-486f-abcb-2211197fae20
 ---
 # Script Blocks Using msxsl:script
 
+**Script blocks are supported only in .NET Framework (they are not supported on .NET Core or .NET 5 or later).**
+
 The <xref:System.Xml.Xsl.XslCompiledTransform> class supports embedded scripts using the `msxsl:script` element. When the style sheet is loaded, any defined functions are compiled to Microsoft intermediate language (MSIL) by the Code Document Object Model (CodeDOM) and are executed during run time. The assembly generated from the embedded script block is separate than the assembly generated for the style sheet.  
   
 ## Enable XSLT Script  


### PR DESCRIPTION
Fixes: https://github.com/dotnet/docs/issues/20182

I'll leave the wording for the doc team.