### PR TITLE
Fix PowerShell minimum version test

### DIFF
--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -92,7 +92,7 @@ Use PowerShell commands to check the value of the **Release** entry of the **HKE
 The following examples check the value of the **Release** entry to determine whether .NET Framework 4.6.2 or later is installed. This code returns `True` if it's installed and `False` otherwise.
 
 ```powershell
-(Get-ItemProperty "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release -ge 394802
+(Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release -ge 394802
 ```
 
 ### Query the registry using code


### PR DESCRIPTION
Updated the PowerShell minimum version test to include the necessary `\` between HKLM: and SOFTWARE paths. Without, the test will fail regardless if the key is present or not due to path being incorrect

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
