### PR TITLE
Add note for updating existing projects

### DIFF
--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -39,9 +39,6 @@ When your project targets a preview framework that has a corresponding preview l
 > [!IMPORTANT]
 > Visual Studio 2017 added a `<LangVersion>latest</LangVersion>` entry to any project files it created. That meant *C# 7.0* when it was added. However, once you upgrade to Visual Studio 2019, that means the latest released version, regardless of the target framework. These projects now [override the default behavior](#override-a-default). You should edit the project file and remove that node. Then, your project will use the compiler version recommended for your target framework.
 
-> [!TIP]
-> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler produce a diagnostic, CS8304, with a message containing the compiler version being used and the current selected language version.
-
 ## Override a default
 
 If you must specify your C# version explicitly, you can do so in several ways:
@@ -49,6 +46,9 @@ If you must specify your C# version explicitly, you can do so in several ways:
 - Manually edit your [project file](#edit-the-project-file).
 - Set the language version [for multiple projects in a subdirectory](#configure-multiple-projects).
 - Configure the [`-langversion` compiler option](compiler-options/langversion-compiler-option.md).
+
+> [!TIP]
+> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler produce a diagnostic, CS8304, with a message containing the compiler version being used and the current selected language version.
 
 ### Edit the project file
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -36,6 +36,9 @@ The compiler determines a default based on these rules:
 
 When your project targets a preview framework that has a corresponding preview language version, the language version used is the preview language version. You use the latest features with that preview in any environment, without affecting projects that target a released .NET Core version.
 
+> [!IMPORTANT]
+> Visual Studio 2017 added a `<LangVersion>latest</LangVersion>` entry to any project files it created. That meant *C# 7.0* when it was added. However, once you upgrade to Visual Studio 2019, that means the latest released version, regardless of the target framework. These projects now [override the default behavior](#override-a-default). You should edit the project file and remove that node. Then, your project will use the compiler version recommended for your target framework.
+
 > [!TIP]
 > To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler produce a diagnostic, CS8304, with a message containing the compiler version being used and the current selected language version.
 


### PR DESCRIPTION
Fixes #21514

If a project was created with VS 2017, a `LangVersion` node was added. That means your project doesn't get the new behavior.
