### PR TITLE
Add docs on profiles to dotnet-trace

### DIFF
--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -109,7 +109,13 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
 - **`--profile <profile-name>`**
 
-  A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.
+  A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly. The table below shows the list of profiles that are available in `dotnet-trace`.
+
+ | Profile | Description |
+ |---------|-------------|
+ |`cpu-sampling`|Useful for tracking CPU usage and general .NET runtime information. This is the default option if no profile or providers are specified.|
+ |`gc-verbose`|Tracks GC collections and samples object allocations.|
+ |`gc-collect`|Tracks GC collections only at very low overhead.|
 
 - **`--providers <list-of-comma-separated-providers>`**
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -109,7 +109,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
 - **`--profile <profile-name>`**
 
-  A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly. The table below shows the list of profiles that are available in `dotnet-trace`.
+  A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly. The following profiles are available:
 
  | Profile | Description |
  |---------|-------------|


### PR DESCRIPTION
`dotnet-trace` does not have much description on the `--profile` option - this PR adds documentation on this option.