### PR TITLE
Add links to Q&A

### DIFF
--- a/docs/core/install/index.yml
+++ b/docs/core/install/index.yml
@@ -66,3 +66,19 @@ landingContent:
             url: linux-sles.md
           - text: Ubuntu
             url: linux-ubuntu.md
+
+# Card
+  - title: "Q&A"
+    linkLists:
+      - linkListType: get-started
+        links:
+          - text: standalone installers
+            url: /answers/topics/dotnet-ad-installer.html
+          - text: Visual Studio installers
+            url: /answers/topics/dotnet-ad-vs.html
+          - text: Linux feeds
+            url: /answers/topics/dotnet-ad-linux.html
+          - text: Docker
+            url: /answers/topics/dotnet-ad-docker.html
+          - text: Enterprise deployment
+            url: /answers/topics/dotnet-ad-enterprise.html

--- a/docs/core/install/index.yml
+++ b/docs/core/install/index.yml
@@ -72,7 +72,7 @@ landingContent:
     linkLists:
       - linkListType: get-started
         links:
-          - text: standalone installers
+          - text: Standalone installers
             url: /answers/topics/dotnet-ad-installer.html
           - text: Visual Studio installers
             url: /answers/topics/dotnet-ad-vs.html

--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -22,6 +22,8 @@ landingContent:
             url: tutorials/intro-to-csharp/index.md
           - text: "Create C# apps with Visual Studio"
             url: /visualstudio/get-started/csharp/tutorial-console
+          - text: C# on Q&A
+            url: /answers/topics/dotnet-csharp.html
       - linkListType: video
         links:
           - text: "What is C#?"

--- a/docs/framework/index.yml
+++ b/docs/framework/index.yml
@@ -28,6 +28,10 @@ landingContent:
             url: get-started/overview.md
           - text: System requirements
             url: get-started/system-requirements.md
+      - linkListType: get-started
+        links:
+          - text: .NET Framework on Q&A
+            url: /answers/topics/dotnet-runtime-framework.html
       - linkListType: concept
         links:
           - text: Older versions of .NET Framework

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -28,7 +28,10 @@ landingContent:
         links:
           - text: Download the .NET Core SDK
             url: https://dotnet.microsoft.com/download
-
+      - linkListType: get-started
+        links:
+          - text: F# on Q&A
+            url: /answers/topics/dotnet-fsharp.html
   - title: "F# fundamentals"
     linkLists:
       - linkListType: overview

--- a/docs/fundamentals/index.yml
+++ b/docs/fundamentals/index.yml
@@ -38,6 +38,8 @@ landingContent:
             url: ../core/get-started.md
           - text: Get started with ASP.NET Core
             url: /aspnet/core/
+          - text: .NET on Q&A
+            url: /answers/products/dotnet
       - linkListType: concept
         links:
           - text: .NET Standard

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -93,6 +93,9 @@ conceptualContent:
         - url: https://channel9.msdn.com/Series/NET-Core-101/What-is-NET
           itemType: video
           text: What is .NET?
+        - url: /answers/products/dotnet
+          itemType: get-started
+          text: .NET on Q&A
         - url: ./core/introduction.md
           itemType: overview
           text: Overview of .NET

--- a/docs/iot/index.yml
+++ b/docs/iot/index.yml
@@ -30,6 +30,10 @@ landingContent:
         links:
           - text: .NET IoT Libraries overview  
             url: intro.md               
+      - linkListType: get-started
+        links:
+          - text: .NET IoT on Q&A
+            url: /answers/topics/dotnet-iot.html
       - linkListType: deploy
         links:
           - text: Deploy .NET apps to Raspberry Pi  

--- a/docs/machine-learning/index.yml
+++ b/docs/machine-learning/index.yml
@@ -35,6 +35,10 @@ landingContent:
             url: resources/tasks.md
           - text: How to choose an algorithm
             url: how-to-choose-an-ml-net-algorithm.md
+      - linkListType: get-started
+        links:
+          - text: ML.NET on Q&A
+            url: /answers/topics/dotnet-mlnet.html
 
   # Get started
   - title: Get started in 10 minutes

--- a/docs/spark/index.yml
+++ b/docs/spark/index.yml
@@ -27,6 +27,10 @@ landingContent:
         links:
           - text: What is .NET for Apache Spark?
             url: what-is-apache-spark-dotnet.md
+      - linkListType: get-started
+        links:
+          - text: .NET for Apache Spark on Q&A
+            url: /answers/topics/dotnet-apache-spark.html
       - linkListType: reference
         links:
           - text: API Reference

--- a/docs/visual-basic/index.yml
+++ b/docs/visual-basic/index.yml
@@ -53,6 +53,10 @@ landingContent:
             url: developing-apps/index.md
           - text: Windows Forms apps
             url: developing-apps/windows-forms/index.md
+      - linkListType: get-started
+        links:
+          - text: Visual Basic on Q&A
+            url: /answers/topics/dotnet-visual-basic.html
 
   - title: Language reference
     linkLists:

--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -64,6 +64,10 @@ landingContent:
     links:
     - text: .NET samples browser
       url: /samples/browse/?products=dotnet
+  - linkListType: get-started
+    links:
+    - text: .NET on Q&A
+      url: /answers/products/dotnet
   - linkListType: whats-new
     links:
     - text: Community


### PR DESCRIPTION
Each landing page where there was a relevant tag is linked to the relevant locations on Q&A. Exceptions are:

- dotnet-azure doesn't have a tag.
- installers have different tags for different installers, so multiple links have been added.
