### PR TITLE
C# value types reference: mention struct constraint

### DIFF
--- a/docs/csharp/language-reference/builtin-types/enum.md
+++ b/docs/csharp/language-reference/builtin-types/enum.md
@@ -56,7 +56,7 @@ For more information and examples, see the <xref:System.FlagsAttribute?displayPr
 
 The <xref:System.Enum?displayProperty=nameWithType> type is the abstract base class of all enumeration types. It provides a number of methods to get information about an enumeration type and its values. For more information and examples, see the <xref:System.Enum?displayProperty=nameWithType> API reference page.
 
-Beginning with C# 7.3, you can use `System.Enum` in a base class constraint (that is known as the [enum constraint](../../programming-guide/generics/constraints-on-type-parameters.md#enum-constraints)) to specify that a type parameter is an enumeration type.
+Beginning with C# 7.3, you can use `System.Enum` in a base class constraint (that is known as the [enum constraint](../../programming-guide/generics/constraints-on-type-parameters.md#enum-constraints)) to specify that a type parameter is an enumeration type. Any enumeration type also satisfies the `struct` constraint, which is used to specify that a type parameter is a non-nullable value type.
 
 ## Conversions
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -124,6 +124,10 @@ To declare a `ref` struct as [`readonly`](#readonly-struct), combine the `readon
 
 In .NET, examples of a `ref` struct are <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>.
 
+## struct constraint
+
+You also use the `struct` keyword in the [`struct` constraint](../../programming-guide/generics/constraints-on-type-parameters.md) to specify that a type parameter is a non-nullable value type. Both structure and [enumeration](enum.md) types satisfy the `struct` constraint.
+
 ## Conversions
 
 For any structure type (except [`ref` struct](#ref-struct) types), there exist [boxing and unboxing](../../programming-guide/types/boxing-and-unboxing.md) conversions to and from the <xref:System.ValueType?displayProperty=nameWithType> and <xref:System.Object?displayProperty=nameWithType> types. There exist also boxing and unboxing conversions between a structure type and any interface that it implements.

--- a/docs/csharp/language-reference/builtin-types/value-types.md
+++ b/docs/csharp/language-reference/builtin-types/value-types.md
@@ -25,7 +25,7 @@ If a value type contains a data member of a reference type, only the reference t
 > [!NOTE]
 > To make your code less error-prone and more robust, define and use immutable value types. This article uses mutable value types only for demonstration purposes.
 
-## Kinds of value types
+## Kinds of value types and type constraints
 
 A value type can be one of the two following kinds:
 
@@ -33,6 +33,8 @@ A value type can be one of the two following kinds:
 - an [enumeration type](enum.md), which is defined by a set of named constants and represents a choice or a combination of choices
 
 A [nullable value type](nullable-value-types.md) `T?` represents all values of its underlying value type `T` and an additional [null](../keywords/null.md) value. You cannot assign `null` to a variable of a value type, unless it's a nullable value type.
+
+You can use the [`struct` constraint](../../programming-guide/generics/constraints-on-type-parameters.md) to specify that a type parameter is a non-nullable value type. Both structure and enumeration types satisfy the `struct` constraint. Beginning with C# 7.3, you can use `System.Enum` in a base class constraint (that is known as the [enum constraint](../../programming-guide/generics/constraints-on-type-parameters.md#enum-constraints)) to specify that a type parameter is an enumeration type.
 
 ## Built-in value types
 

--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -14,7 +14,7 @@ Constraints inform the compiler about the capabilities a type argument must have
 
 |Constraint|Description|
 |----------------|-----------------|
-|`where T : struct`|The type argument must be a non-nullable value type. For information about nullable value types, see [Nullable value types](../../language-reference/builtin-types/nullable-value-types.md). Because all value types have an accessible parameterless constructor, the `struct` constraint implies the `new()` constraint and can't be combined with the `new()` constraint. You can't combine the `struct` constraint with the `unmanaged` constraint.|
+|`where T : struct`|The type argument must be a non-nullable [value type](../../language-reference/builtin-types/value-types.md). For information about nullable value types, see [Nullable value types](../../language-reference/builtin-types/nullable-value-types.md). Because all value types have an accessible parameterless constructor, the `struct` constraint implies the `new()` constraint and can't be combined with the `new()` constraint. You can't combine the `struct` constraint with the `unmanaged` constraint.|
 |`where T : class`|The type argument must be a reference type. This constraint applies also to any class, interface, delegate, or array type. In a nullable context in C# 8.0 or later, `T` must be a non-nullable reference type. |
 |`where T : class?`|The type argument must be a reference type, either nullable or non-nullable. This constraint applies also to any class, interface, delegate, or array type.|
 |`where T : notnull`|The type argument must be a non-nullable type. The argument can be a non-nullable reference type in C# 8.0 or later, or a non-nullable value type. |


### PR DESCRIPTION
With enum constraint available, it may be not obvious that the `struct` constraint allows both structure and enum types, but not only structure types. 
