### PR TITLE
Mention alternative name of the null-forgiving operator

### DIFF
--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # ! (null-forgiving) operator (C# reference)
 
-Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiving operator. In an enabled [nullable annotation context](../../nullable-references.md#nullable-annotation-context), you use the null-forgiving operator to declare that expression `x` of a reference type isn't `null`: `x!`. The unary prefix `!` operator is the [logical negation operator](boolean-logical-operators.md#logical-negation-operator-).
+Available in C# 8.0 and later, the unary postfix `!` operator is the null-forgiving, or null-suppression, operator. In an enabled [nullable annotation context](../../nullable-references.md#nullable-annotation-context), you use the null-forgiving operator to declare that expression `x` of a reference type isn't `null`: `x!`. The unary prefix `!` operator is the [logical negation operator](boolean-logical-operators.md#logical-negation-operator-).
 
 The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1256,7 +1256,7 @@
       displayName: conditional, ternary, ref
     - name: "! (null-forgiving) operator"
       href: language-reference/operators/null-forgiving.md
-      displayName: nullable reference, null-forgiveness
+      displayName: nullable reference, null-forgiveness, null suppression
     - name: "?? and ??= operators"
       href: language-reference/operators/null-coalescing-operator.md
       displayName: null-coalescing, assignment


### PR DESCRIPTION
"null suppression" term is used at the compiler messages. For example:
https://sharplab.io/#v2:EYLgtghgzgLgpgJwDQxAgrgOwD4AEBMAzAAQDeAsAFDE3EH5lW3N0CMADMVMQLzGboANoICEIgNxNaAXyrSgA===
