### PR TITLE
Add details for where app code should start in examples

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -3,7 +3,7 @@ title: Configuration providers in .NET
 description: Learn how the Configuration provider API is used to configure .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/16/2020
+ms.date: 12/04/2020
 ---
 
 # Configuration providers in .NET
@@ -35,7 +35,7 @@ Overloads can specify:
 
 Consider the following code:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-33,37-38" highlight="17-23":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-39,43-44" highlight="23-29":::
 
 The preceding code:
 
@@ -60,11 +60,11 @@ For information on record types, see [Record types in C# 9](../../csharp/whats-n
 
 The following code builds the configuration root, binds a section to the `TransientFaultHandlingOptions` record type, and prints the bound values to the console window:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="25-32":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="31-38":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="34-36":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="40-42":::
 
 ### XML configuration provider
 
@@ -72,7 +72,7 @@ The <xref:Microsoft.Extensions.Configuration.Xml.XmlConfigurationProvider> class
 
 The following code demonstrates configuration of XML files using the XML configuration provider.
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-28,46,52-53" highlight="17-28":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-34,52,58-59" highlight="23-34":::
 
 The preceding code:
 
@@ -95,11 +95,11 @@ Repeating elements that use the same element name work if the `name` attribute i
 
 The following code reads the previous configuration file and displays the keys and values:
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="30-45":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="36-51":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="47-51":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="53-57":::
 
 Attributes can be used to supply values:
 
@@ -124,7 +124,7 @@ The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> class
 
 The following code clears all the configuration providers and adds the `IniConfigurationProvider` with two INI files as the source:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-31,38-39" highlight="18-24":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-37,44-45" highlight="24-30":::
 
 An example *appsettings.ini* file with various configuration settings follows:
 
@@ -132,11 +132,11 @@ An example *appsettings.ini* file with various configuration settings follows:
 
 The following code displays the preceding configuration settings by writing them to the console window:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="26-30":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="32-36":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="32-37":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="38-43":::
 
 ## Environment variable configuration provider
 
@@ -179,7 +179,7 @@ To test that the preceding commands override *appsettings.json* and *appsettings
 
 Call <xref:Microsoft.Extensions.Configuration.EnvironmentVariablesExtensions.AddEnvironmentVariables%2A> with a string to specify a prefix for environment variables:
 
-:::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="15-16":::
+:::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="21-22":::
 
 In the preceding code:
 
@@ -302,7 +302,7 @@ The <xref:Microsoft.Extensions.Configuration.Memory.MemoryConfigurationProvider>
 
 The following code adds a memory collection to the configuration system:
 
-:::code language="csharp" source="snippets/configuration/console-memory/Program.cs" highlight="16-23":::
+:::code language="csharp" source="snippets/configuration/console-memory/Program.cs" highlight="22-29":::
 
 In the preceding code, <xref:Microsoft.Extensions.Configuration.MemoryConfigurationBuilderExtensions.AddInMemoryCollection(Microsoft.Extensions.Configuration.IConfigurationBuilder,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}})?displayProperty=nameWithType> adds the memory provider after the default configuration providers. For an example of ordering the configuration providers, see [XML configuration provider](#xml-configuration-provider).
 

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -24,7 +24,7 @@ Configuration in .NET is performed using one or more [configuration providers](#
 
 New .NET console applications created using [dotnet new](../tools/dotnet-new.md) or Visual Studio by default *do not* expose configuration capabilities. To add configuration in a new .NET console application, [add a package reference](../tools/dotnet-add-package.md) to `Microsoft.Extensions.Hosting`. Modify the *Program.cs* file to match the following code:
 
-:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="12":::
+:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="18":::
 
 The <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(System.String[])?displayProperty=nameWithType> method provides default configuration for the app in the following order:
 

--- a/docs/core/extensions/custom-configuration-provider.md
+++ b/docs/core/extensions/custom-configuration-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom configuration provider in .NET
 description: Learn how to implement a custom configuration provider in .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/16/2020
+ms.date: 12/04/2020
 ms.topic: how-to
 ---
 
@@ -53,7 +53,7 @@ An `AddEntityConfiguration` extension method permits adding the configuration so
 
 The following code shows how to use the custom `EntityConfigurationProvider` in *Program.cs*:
 
-:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="21-22":::
+:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="27-28":::
 
 ## See also
 

--- a/docs/core/extensions/generic-host.md
+++ b/docs/core/extensions/generic-host.md
@@ -3,7 +3,7 @@ title: .NET Generic Host
 author: IEvangelist
 description: Learn about the .NET Generic Host, which is responsible for app startup and lifetime management.
 ms.author: dapine
-ms.date: 09/18/2020
+ms.date: 12/04/2020
 ---
 
 # .NET Generic Host
@@ -123,7 +123,7 @@ To add host configuration, call <xref:Microsoft.Extensions.Hosting.HostBuilder.C
 
 The following example creates host configuration:
 
-:::code language="csharp" source="snippets/configuration/console-host/Program.cs" highlight="13-19":::
+:::code language="csharp" source="snippets/configuration/console-host/Program.cs" highlight="19-25":::
 
 ## App configuration
 

--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -3,7 +3,7 @@ title: Logging providers in .NET
 description: Learn how the logging provider API is used in .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/25/2020
+ms.date: 12/04/2020
 ---
 
 # Logging providers in .NET
@@ -19,7 +19,7 @@ The default .NET Worker app templates:
   - [EventSource](#event-source)
   - [EventLog](#windows-eventlog): Windows only
 
-:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="12":::
+:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="18":::
 
 The preceding code shows the `Program` class created with the .NET Worker app templates. The next several sections provide samples based on the .NET Worker app templates, which use the Generic Host.
 
@@ -122,8 +122,14 @@ The following code changes the `SourceName` from the default value of `".NET Run
 ```csharp
 public class Program
 {
-    public static Task Main(string[] args) =>
-        CreateHostBuilder(args).Build().RunAsync();
+    static async Task Main(string[] args)
+    {
+        using IHost host = CreateHostBuilder(args).Build();
+
+        // Application code should start here.
+
+        await host.RunAsync();
+    }
 
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
@@ -144,8 +150,14 @@ To configure provider settings, use <xref:Microsoft.Extensions.Logging.AzureAppS
 ```csharp
 class Program
 {
-    static Task Main(string[] args) =>
-        CreateHostBuilder(args).Build().RunAsync();
+    static async Task Main(string[] args)
+    {
+        using IHost host = CreateHostBuilder(args).Build();
+
+        // Application code should start here.
+
+        await host.RunAsync();
+    }
 
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -3,7 +3,7 @@ title: Options pattern in .NET
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine
-ms.date: 09/30/2020
+ms.date: 12/04/2020
 ---
 
 # Options pattern in .NET
@@ -35,7 +35,7 @@ The following code:
 * Calls [ConfigurationBinder.Bind](xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind%2A) to bind the `TransientFaultHandlingOptions` class to the `"TransientFaultHandlingOptions"` section.
 * Displays the configuration data.
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="25-32":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="31-38":::
 
 In the preceding code, changes to the JSON configuration file after the app has started are read.
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static Task Main(string[] args)
     {
-        IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
         var logger = host.Services.GetRequiredService<ILogger<Program>>();
 

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -9,7 +9,7 @@ namespace ConsoleDisposable.Example
     {
         static Task Main(string[] args)
         {
-            IHost host = CreateHostBuilder(args).Build();
+            using IHost host = CreateHostBuilder(args).Build();
 
             ExemplifyDisposableScoping(host.Services, "Scope 1");
             Console.WriteLine();

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/Program.cs
@@ -9,7 +9,7 @@ namespace ConsoleDI.Example
     {
         static Task Main(string[] args)
         {
-            IHost host = CreateHostBuilder(args).Build();
+            using IHost host = CreateHostBuilder(args).Build();
 
             _ = host.Services.GetService<ExampleService>();
 

--- a/docs/core/extensions/snippets/configuration/console-di/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/Program.cs
@@ -9,7 +9,7 @@ namespace ConsoleDI.Example
     {
         static Task Main(string[] args)
         {
-            IHost host = CreateHostBuilder(args).Build();
+            using IHost host = CreateHostBuilder(args).Build();
 
             ExemplifyScoping(host.Services, "Scope 1");
             ExemplifyScoping(host.Services, "Scope 2");

--- a/docs/core/extensions/snippets/configuration/console-env/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-env/Program.cs
@@ -6,8 +6,14 @@ namespace ConsoleEnvironment.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/console-host/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-host/Program.cs
@@ -5,8 +5,14 @@ using Microsoft.Extensions.Hosting;
 
 class Program
 {
-    static Task Main(string[] args) =>
-        CreateHostBuilder(args).Build().RunAsync();
+    static async Task Main(string[] args)
+    {
+        using IHost host = CreateHostBuilder(args).Build();
+
+        // Application code should start here.
+
+        await host.RunAsync();
+    }
 
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/console-ini/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-ini/Program.cs
@@ -8,8 +8,14 @@ namespace ConsoleIni.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/console-json/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/Program.cs
@@ -7,8 +7,14 @@ namespace ConsoleJson.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/console-memory/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-memory/Program.cs
@@ -7,8 +7,14 @@ namespace ConsoleMemory.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/console-xml/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-xml/Program.cs
@@ -7,8 +7,14 @@ namespace ConsoleXml.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/console/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console/Program.cs
@@ -5,8 +5,14 @@ namespace Console.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args);

--- a/docs/core/extensions/snippets/configuration/custom-provider/Program.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Program.cs
@@ -9,8 +9,14 @@ namespace CustomProvider.Example
 {
     class Program
     {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+        static async Task Main(string[] args)
+        {
+            using IHost host = CreateHostBuilder(args).Build();
+
+            // Application code should start here.
+
+            await host.RunAsync();
+        }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)


### PR DESCRIPTION
## Summary

Adjust code to detail where application code should start. Correct `IHost` with `using`.

Fixes #21540
