### PR TITLE
Add info about FrameworkDescription API

### DIFF
--- a/docs/core/install/how-to-detect-installed-versions.md
+++ b/docs/core/install/how-to-detect-installed-versions.md
@@ -10,7 +10,7 @@ zone_pivot_groups: operating-systems-set-one
 
 # How to check that .NET is already installed
 
-This article teaches you how to check which versions of the .NET runtime and SDK are installed on your computer. .NET may have already been installed if you have an integrated development environment, such as Visual Studio or Visual Studio for Mac.
+This article teaches you how to check which versions of the .NET runtime and SDK are installed on your computer. If you have an integrated development environment, such as Visual Studio or Visual Studio for Mac, .NET may have already been installed.
 
 Installing an SDK installs the corresponding runtime.
 
@@ -134,7 +134,7 @@ Microsoft.NETCore.App 5.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
 
 ## Check for install folders
 
-It's possible that .NET is installed but not added to the `PATH` variable for your operating system or user profile. Running the commands from the previous sections may not work. As an alternative, you can check that the .NET install folders exist.
+It's possible that .NET is installed but not added to the `PATH` variable for your operating system or user profile. In this case, the commands from the previous sections may not work. As an alternative, you can check that the .NET install folders exist.
 
 When you install .NET from an installer or script, it's installed to a standard folder. Much of the time the installer or script you're using to install .NET gives you an option to install to a different folder. If you choose to install to a different folder, adjust the start of the folder path.
 
@@ -186,3 +186,7 @@ You can see both the SDK versions and runtime versions with the command `dotnet 
 - [Install the .NET Runtime and SDK for Windows](windows.md).
 - [Install the .NET Runtime and SDK for macOS](macos.md).
 - [Install the .NET Runtime and SDK for Linux](linux.md).
+
+## See also
+
+- [Determine which .NET Framework versions are installed](../../framework/migration-guide/how-to-determine-which-versions-are-installed.md)

--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -35,6 +35,14 @@ Community-maintained tools are available to help detect which .NET Framework ver
 
 For information about detecting the installed updates for each version of .NET Framework, see [How to: Determine which .NET Framework updates are installed](how-to-determine-which-net-framework-updates-are-installed.md).
 
+## Determine which .NET version an app is running on
+
+You can use the <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> property to query for which .NET implementation your app is running on. If the app is running on .NET Framework, the output will be similar to:
+
+```output
+.NET Framework 4.8.4250.0
+```
+
 ## Detect .NET Framework 4.5 and later versions
 
 The version of .NET Framework (4.5 and later) installed on a machine is listed in the registry at **HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full**. If the **Full** subkey is missing, then .NET Framework 4.5 or above isn't installed.
@@ -231,14 +239,6 @@ The .NET Framework CLR installed with .NET Framework is versioned separately. Th
   ```output
   Version: 4.0.30319.18010
   ```
-
-## Determine which .NET version an app is running on
-
-You can use the <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> property to query for which .NET implementation your app is running on. If the app is running on .NET Framework, the output will be similar to:
-
-```output
-.NET Framework 4.8.4250.0
-```
 
 ## See also
 

--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -35,12 +35,19 @@ Community-maintained tools are available to help detect which .NET Framework ver
 
 For information about detecting the installed updates for each version of .NET Framework, see [How to: Determine which .NET Framework updates are installed](how-to-determine-which-net-framework-updates-are-installed.md).
 
-## Determine which .NET version an app is running on
+## Determine which .NET implementation and version an app is running on
 
-You can use the <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> property to query for which .NET implementation your app is running on. If the app is running on .NET Framework, the output will be similar to:
+You can use the <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> property to query for which .NET implementation and version your app is running on. If the app is running on .NET Framework, the output will be similar to:
 
 ```output
 .NET Framework 4.8.4250.0
+```
+
+By comparison, if the app is running on .NET Core or .NET 5+, the output will be similar to:
+
+```output
+.NET Core 3.1.9
+.NET 5.0.0
 ```
 
 ## Detect .NET Framework 4.5 and later versions

--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -1,18 +1,21 @@
 ---
 title: Determine which .NET Framework versions are installed
 description: Use code, regedit.exe, or PowerShell to detect which versions of .NET Framework are installed on a machine by querying the Windows registry.
-ms.date: "02/03/2020"
+ms.date: 12/04/2020
 dev_langs:
   - "csharp"
   - "vb"
 helpviewer_keywords:
   - "versions, determining for .NET Framework"
-  - ".NET Framework, determining version"
+  - ".NET Framework, determining installed versions"
 ms.assetid: 40a67826-e4df-4f59-a651-d9eb0fdc755d
 ---
 # How to: Determine which .NET Framework versions are installed
 
 Users can [install](../install/index.md) and run multiple versions of .NET Framework on their computers. When you develop or deploy your app, you might need to know which .NET Framework versions are installed on the user's computer. The registry contains a list of the versions of .NET Framework installed on the computer.
+
+> [!NOTE]
+> This article is specific to .NET Framework. To determine which .NET Core and .NET 5+ SDKs and runtimes are installed, see [How to check that .NET is already installed](../../core/install/how-to-detect-installed-versions.md).
 
 .NET Framework consists of two main components, which are versioned separately:
 
@@ -75,13 +78,13 @@ To determine whether a *minimum* version of .NET Framework is present, check for
 
 ### Use Registry Editor
 
-01. From the **Start** menu, choose **Run**, enter *regedit*, and then select **OK**.
+1. From the **Start** menu, choose **Run**, enter *regedit*, and then select **OK**.
 
    (You must have administrative credentials to run regedit.)
 
-01. In the Registry Editor, open the following subkey: **HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full**. If the **Full** subkey isn't present, then you don't have .NET Framework 4.5 or later installed.
+1. In the Registry Editor, open the following subkey: **HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full**. If the **Full** subkey isn't present, then you don't have .NET Framework 4.5 or later installed.
 
-01. Check for a REG_DWORD entry named **Release**. If it exists, then you have .NET Framework 4.5 or later installed. Its value corresponds to a particular version of .NET Framework. In the following figure, for example, the value of the **Release** entry is 528040, which is the release key for .NET Framework 4.8.
+1. Check for a REG_DWORD entry named **Release**. If it exists, then you have .NET Framework 4.5 or later installed. Its value corresponds to a particular version of .NET Framework. In the following figure, for example, the value of the **Release** entry is 528040, which is the release key for .NET Framework 4.8.
 
    ![Registry entry for .NET Framework 4.5](./media/clr-installdir.png )
 
@@ -228,6 +231,14 @@ The .NET Framework CLR installed with .NET Framework is versioned separately. Th
   ```output
   Version: 4.0.30319.18010
   ```
+
+## Determine which .NET version an app is running on
+
+You can use the <xref:System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription?displayProperty=nameWithType> property to query for which .NET implementation your app is running on. If the app is running on .NET Framework, the output will be similar to:
+
+```output
+.NET Framework 4.8.4250.0
+```
 
 ## See also
 


### PR DESCRIPTION
Fixes #21674.

Also adds note about applying to .NET Framework only, and provides link to .NET Core article.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed?branch=pr-en-us-21836#determine-which-net-version-an-app-is-running-on).