### PR TITLE
Update configurability for CA1068

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -83,7 +83,7 @@ dotnet_code_quality.CA1068.api_surface = private, internal
 
 #### Exclude specific symbols
 
-You can exclude specific symbols, for example, types methods, from analysis. For example, to specify that the rule should not run on any code within types named `MyType`, add the following key-value pair to an *.editorconfig* file in your project:
+You can exclude specific symbols, such as types and methods, from analysis. For example, to specify that the rule should not run on any code within types named `MyType`, add the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
 dotnet_code_quality.CA1068.excluded_symbol_names = MyType
@@ -106,7 +106,7 @@ Examples:
 
 #### Exclude specific types and their derived types
 
-You can configure specific types, including their derived types, to exclude from analysis. For example, to specify that the rule should not run on any methods within types named `MyType` and its derived types, add the following key-value pair to an *.editorconfig* file in your project:
+You can exclude specific types and their derived types from analysis. For example, to specify that the rule should not run on any methods within types named `MyType` and their derived types, add the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
 dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -69,7 +69,7 @@ This rule has the following configurable options that can be configured for just
 
 Use the following options to configure which parts of your codebase to run this rule on.
 
-- [Include specific API surfaces](#api-surface)
+- [Include specific API surfaces](#include-specific-api-surfaces)
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
@@ -92,7 +92,7 @@ dotnet_code_quality.CA1068.excluded_symbol_names = MyType
 Allowed symbol name formats in the option value (separated by `|`):
 
 - Symbol name only (includes all symbols with the name, regardless of the containing type or namespace).
-- Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format). Each symbol name requires a symbol-kind prefix, such as `M:` for methods, `T:` for types, and `N:` for namespaces.
+- Fully qualified names in the symbol's [documentation ID format](../../../csharp/programming-guide/xmldoc/processing-the-xml-file.md#id-strings). Each symbol name requires a symbol-kind prefix, such as `M:` for methods, `T:` for types, and `N:` for namespaces.
 - `.ctor` for constructors and `.cctor` for static constructors.
 
 Examples:
@@ -115,7 +115,7 @@ dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType
 Allowed symbol name formats in the option value (separated by `|`):
 
 - Type name only (includes all types with the name, regardless of the containing type or namespace).
-- Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format), with an optional `T:` prefix.
+- Fully qualified names in the symbol's [documentation ID format](../../../csharp/programming-guide/xmldoc/processing-the-xml-file.md#id-strings), with an optional `T:` prefix.
 
 Examples:
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -63,7 +63,7 @@ If the method is an externally visible public API that is already part of a ship
 
 ## Configurability
 
-This rule has the following configurable options that can be configured for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+This rule has the following configurable options that can be configured for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Excluded symbols
 
@@ -77,22 +77,22 @@ dotnet_code_quality.CA1068.excluded_symbol_names = MyType
 
 Allowed symbol name formats in the option value (separated by `|`):
 
-- Symbol name only (includes all symbols with the name, regardless of the containing type or namespace)
-- Fully qualified names in the symbol's [documentation ID format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format). Each symbol name requires a symbol kind prefix, such as "M:" prefix for methods, `T:` prefix for types, "N:" prefix for namespaces, etc.
-- `.ctor` for constructors and `.cctor` for static constructors
+- Symbol name only (includes all symbols with the name, regardless of the containing type or namespace).
+- Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format). Each symbol name requires a symbol-kind prefix, such as `M:` for methods, `T:` for types, and `N:` for namespaces.
+- `.ctor` for constructors and `.cctor` for static constructors.
 
 Examples:
 
 | Option Value | Summary |
 | --- | --- |
-|`dotnet_code_quality.CA1068.excluded_symbol_names = MyType` | Matches all symbols named 'MyType' in the compilation
-|`dotnet_code_quality.CA1068.excluded_symbol_names = MyType1|MyType2` | Matches all symbols named either 'MyType1' or 'MyType2' in the compilation
-|`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS.MyType.MyMethod(ParamType)` | Matches specific method 'MyMethod' with given fully qualified signature
-|`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)|M:NS2.MyType2.MyMethod2(ParamType)` | Matches specific methods 'MyMethod1' and 'MyMethod2' with respective fully qualified signature
+|`dotnet_code_quality.CA1068.excluded_symbol_names = MyType` | Matches all symbols named 'MyType'. |
+|`dotnet_code_quality.CA1068.excluded_symbol_names = MyType1|MyType2` | Matches all symbols named either 'MyType1' or 'MyType2'. |
+|`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS.MyType.MyMethod(ParamType)` | Matches specific method `MyMethod` with the specified fully qualified signature. |
+|`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)|M:NS2.MyType2.MyMethod2(ParamType)` | Matches specific methods 'MyMethod1' and 'MyMethod2' with the respective fully qualified signatures. |
 
 #### Excluded type names with derived types
 
-You can configure which types, including its derived types, to exclude from analysis. For example, to specify that the rule should not run on any methods within types named `MyType` and its derived types, add the following key-value pair to an *.editorconfig* file in your project:
+You can configure specific types, including their derived types, to exclude from analysis. For example, to specify that the rule should not run on any methods within types named `MyType` and its derived types, add the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
 dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType
@@ -100,17 +100,17 @@ dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType
 
 Allowed symbol name formats in the option value (separated by `|`):
 
-- Type name only (includes all types with the name, regardless of the containing type or namespace)
-- Fully qualified names in the symbol's [documentation ID format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format), with an optional `T:` prefix.
+- Type name only (includes all types with the name, regardless of the containing type or namespace).
+- Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format), with an optional `T:` prefix.
 
 Examples:
 
 | Option Value | Summary |
 | --- | --- |
-|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType` | Matches all types named 'MyType' and all of its derived types in the compilation
-|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType1|MyType2` | Matches all types named either 'MyType1' or 'MyType2' and all of their derived types in the compilation
-|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS.MyType` | Matches specific type 'MyType' with given fully qualified name and all of its derived types
-|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS1.MyType1|M:NS2.MyType2` | Matches specific types 'MyType1' and 'MyType2' with respective fully qualified names and all of their derived types
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType` | Matches all types named 'MyType' and all of their derived types. |
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType1|MyType2` | Matches all types named either 'MyType1' or 'MyType2' and all of their derived types. |
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS.MyType` | Matches specific type 'MyType' with given fully qualified name and all of its derived types. |
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS1.MyType1|M:NS2.MyType2` | Matches specific types 'MyType1' and 'MyType2' with the respective fully qualified names, and all of their derived types. |
 
 ### API surface
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -24,7 +24,7 @@ ms.author: mavasani
 
 A method has a <xref:System.Threading.CancellationToken> parameter that is not the last parameter.
 
-By default, this rule analyzes the entire codebase, but this is [configurable](#excluded-symbols).
+By default, this rule analyzes the entire codebase, but this is [configurable](#include-or-exclude-selected-apis).
 
 ## Rule description
 
@@ -65,11 +65,25 @@ If the method is an externally visible public API that is already part of a ship
 
 This rule has the following configurable options that can be configured for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
-### Excluded symbols
+### Include or exclude selected APIs
 
-#### Excluded symbol names
+Use the following options to configure which parts of your codebase to run this rule on.
 
-You can configure which parts of your codebase to exclude from analysis. For example, to specify that the rule should not run on any code within types named `MyType`, add the following key-value pair to an *.editorconfig* file in your project:
+- [Include specific API surfaces](#api-surface)
+- [Exclude specific symbols](#exclude-specific-symbols)
+- [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
+
+#### Include specific API surfaces
+
+You can include or exclude APIs from analysis based on their accessibility. For example, to specify that the rule should run only against the non-public API surface, add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1068.api_surface = private, internal
+```
+
+#### Exclude specific symbols
+
+You can exclude specific symbols, for example, types methods, from analysis. For example, to specify that the rule should not run on any code within types named `MyType`, add the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
 dotnet_code_quality.CA1068.excluded_symbol_names = MyType
@@ -90,7 +104,7 @@ Examples:
 |`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS.MyType.MyMethod(ParamType)` | Matches specific method `MyMethod` with the specified fully qualified signature. |
 |`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)|M:NS2.MyType2.MyMethod2(ParamType)` | Matches specific methods 'MyMethod1' and 'MyMethod2' with the respective fully qualified signatures. |
 
-#### Excluded type names with derived types
+#### Exclude specific types and their derived types
 
 You can configure specific types, including their derived types, to exclude from analysis. For example, to specify that the rule should not run on any methods within types named `MyType` and its derived types, add the following key-value pair to an *.editorconfig* file in your project:
 
@@ -111,14 +125,6 @@ Examples:
 |`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType1|MyType2` | Matches all types named either 'MyType1' or 'MyType2' and all of their derived types. |
 |`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS.MyType` | Matches specific type 'MyType' with given fully qualified name and all of its derived types. |
 |`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS1.MyType1|M:NS2.MyType2` | Matches specific types 'MyType1' and 'MyType2' with the respective fully qualified names, and all of their derived types. |
-
-### API surface
-
-You can configure which parts of your codebase to run this rule on, based on their accessibility. For example, to specify that the rule should run only against the non-public API surface, add the following key-value pair to an *.editorconfig* file in your project:
-
-```ini
-dotnet_code_quality.CA1068.api_surface = private, internal
-```
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -24,6 +24,8 @@ ms.author: mavasani
 
 A method has a <xref:System.Threading.CancellationToken> parameter that is not the last parameter.
 
+By default, this rule analyzes the entire codebase, but this is [configurable](#configurability).
+
 ## Rule description
 
 Methods that perform long running operations or asynchronous operations and are cancelable normally take a cancellation token parameter. Each cancellation token has a <xref:System.Threading.CancellationTokenSource> that creates the token and uses it for cancelable computations. It is common practice to have a long chain of method calls that pass around the cancellation token from the callers to the callees. Hence, a large number of methods that take part in a cancelable computation end up having a cancellation token parameter. However, the cancellation token itself is not usually relevant to the core functionality of a majority of these methods. It's considered a good API design practice to have such parameters be the last parameter in the list.
@@ -61,7 +63,36 @@ If the method is an externally visible public API that is already part of a ship
 
 ## Configurability
 
-[Roslyn analyzers issue 2851](https://github.com/dotnet/roslyn-analyzers/issues/2851) tracks making the rule configurable. Once it's implemented, you can configure the API surface on which rule executes to avoid having to use source suppressions.
+You can configure which parts of your codebase to run this rule on, based on their accessibility. For example, to specify that the rule should run only against the non-public API surface, add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1068.api_surface = private, internal
+```
+
+### Excluded symbol names
+
+You can configure which parts of your codebase to exclude from analysis. For example, to specify that the rule should not run on any code within types named `MyType`, add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1068.excluded_symbol_names = .ctor
+```
+
+Allowed symbol name formats in the option value (separated by `|`):
+
+- Symbol name only (includes all symbols with the name, regardless of the containing type or namespace)
+- Fully qualified names in the symbol's [documentation ID format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format). Each symbol name requires a symbol kind prefix, such as "M:" prefix for methods, `T:` prefix for types, "N:" prefix for namespaces, etc.
+- `.ctor` for constructors and `.cctor` for static constructors
+
+Examples:
+
+| Option Value | Summary |
+| --- | --- |
+|`dotnet_code_quality.CA1068.excluded_symbol_names = MyType` | Matches all symbols named 'MyType' in the compilation
+|`dotnet_code_quality.CA1068.excluded_symbol_names = MyType1|MyType2` | Matches all symbols named either 'MyType1' or 'MyType2' in the compilation
+|`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS.MyType.MyMethod(ParamType)` | Matches specific method 'MyMethod' with given fully qualified signature
+|`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)|M:NS2.MyType2.MyMethod2(ParamType)` | Matches specific methods 'MyMethod1' and 'MyMethod2' with respective fully qualified signature
+
+You can configure all of these options for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -24,7 +24,7 @@ ms.author: mavasani
 
 A method has a <xref:System.Threading.CancellationToken> parameter that is not the last parameter.
 
-By default, this rule analyzes the entire codebase, but this is [configurable](#configurability).
+By default, this rule analyzes the entire codebase, but this is [configurable](#excluded-symbols).
 
 ## Rule description
 
@@ -63,18 +63,16 @@ If the method is an externally visible public API that is already part of a ship
 
 ## Configurability
 
-You can configure which parts of your codebase to run this rule on, based on their accessibility. For example, to specify that the rule should run only against the non-public API surface, add the following key-value pair to an *.editorconfig* file in your project:
+This rule has the following configurable options that can be configured for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
-```ini
-dotnet_code_quality.CA1068.api_surface = private, internal
-```
+### Excluded symbols
 
-### Excluded symbol names
+#### Excluded symbol names
 
 You can configure which parts of your codebase to exclude from analysis. For example, to specify that the rule should not run on any code within types named `MyType`, add the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
-dotnet_code_quality.CA1068.excluded_symbol_names = .ctor
+dotnet_code_quality.CA1068.excluded_symbol_names = MyType
 ```
 
 Allowed symbol name formats in the option value (separated by `|`):
@@ -92,7 +90,35 @@ Examples:
 |`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS.MyType.MyMethod(ParamType)` | Matches specific method 'MyMethod' with given fully qualified signature
 |`dotnet_code_quality.CA1068.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)|M:NS2.MyType2.MyMethod2(ParamType)` | Matches specific methods 'MyMethod1' and 'MyMethod2' with respective fully qualified signature
 
-You can configure all of these options for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+#### Excluded type names with derived types
+
+You can configure which types, including its derived types, to exclude from analysis. For example, to specify that the rule should not run on any methods within types named `MyType` and its derived types, add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType
+```
+
+Allowed symbol name formats in the option value (separated by `|`):
+
+- Type name only (includes all types with the name, regardless of the containing type or namespace)
+- Fully qualified names in the symbol's [documentation ID format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format), with an optional `T:` prefix.
+
+Examples:
+
+| Option Value | Summary |
+| --- | --- |
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType` | Matches all types named 'MyType' and all of its derived types in the compilation
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = MyType1|MyType2` | Matches all types named either 'MyType1' or 'MyType2' and all of their derived types in the compilation
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS.MyType` | Matches specific type 'MyType' with given fully qualified name and all of its derived types
+|`dotnet_code_quality.CA1068.excluded_type_names_with_derived_types = M:NS1.MyType1|M:NS2.MyType2` | Matches specific types 'MyType1' and 'MyType2' with respective fully qualified names and all of their derived types
+
+### API surface
+
+You can configure which parts of your codebase to run this rule on, based on their accessibility. For example, to specify that the rule should run only against the non-public API surface, add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1068.api_surface = private, internal
+```
 
 ## Related rules
 


### PR DESCRIPTION
## Summary

Update documentation for rule CA1068 to mention the 2 new configurability options.

Relates to https://github.com/dotnet/roslyn-analyzers/pull/4474 and https://github.com/dotnet/roslyn-analyzers/pull/4500
