### PR TITLE
CA1710: additional_required_suffixes configurability

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -107,7 +107,7 @@ dotnet_code_quality.CA1710.exclude_indirect_base_types = false
 You can provide additional required suffixes or override the behavior of some hardcoded suffixes by adding the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
-dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class
+dotnet_code_quality.CA1710.additional_required_suffixes = [type]->[suffix]
 ```
 
 For `[types]`, separate multiple types with a `|` character. Types can be specified in either of the following formats:

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -113,7 +113,7 @@ dotnet_code_quality.CA1710.additional_required_suffixes = [type]->[suffix]
 Separate multiple values with a `|` character. Types can be specified in either of the following formats:
 
 - Type name only (includes all types with the name, regardless of the containing type or namespace).
-- Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format) with an optional `T:` prefix.
+- Fully qualified names in the symbol's [documentation ID format](../../../csharp/programming-guide/xmldoc/processing-the-xml-file.md#id-strings) with an optional `T:` prefix.
 
 Examples:
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -102,6 +102,28 @@ You can configure whether to exclude indirect base types from the rule. By defau
 dotnet_code_quality.CA1710.exclude_indirect_base_types = false
 ```
 
+### Additional required suffixes
+
+You can provide additional required suffixes or override the behavior of some hardcoded suffixes by adding the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class
+```
+
+Allowed format: List (separated by '|') of type names with their required suffix (separated by '->').
+Allowed type name formats:
+
+  1. Type name only (includes all types with the name, regardless of the containing type or namespace)
+  2. Fully qualified names in the [symbol's documentation ID format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format) with an optional "T:" prefix.
+
+Examples:
+
+| Option Value | Summary |
+| --- | --- |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class` | All types inheriting from 'MyClass' are expected to have the 'Class' suffix |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class|MyNamespace.IPath->Path` | All types inheriting from 'MyClass' are expected to have the 'Class' suffix AND all types implementing 'MyNamespace.IPath' are expected to have the 'Path' suffix. |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = T:System.Data.IDataReader->{}` | Allows to override built-in suffixes, in this case, all types implementing 'IDataReader' are no longer expected to end in 'Collection' |
+
 ## Related rules
 
 [CA1711: Identifiers should not have incorrect suffix](ca1711.md)

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -110,19 +110,18 @@ You can provide additional required suffixes or override the behavior of some ha
 dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class
 ```
 
-Allowed format: List (separated by '|') of type names with their required suffix (separated by '->').
-Allowed type name formats:
+For `[types]`, separate multiple types with a `|` character. Types can be specified in either of the following formats:
 
-  1. Type name only (includes all types with the name, regardless of the containing type or namespace)
-  2. Fully qualified names in the [symbol's documentation ID format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format) with an optional "T:" prefix.
+- Type name only (includes all types with the name, regardless of the containing type or namespace).
+- Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format) with an optional `T:` prefix.
 
 Examples:
 
 | Option Value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class` | All types inheriting from 'MyClass' are expected to have the 'Class' suffix |
-|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class|MyNamespace.IPath->Path` | All types inheriting from 'MyClass' are expected to have the 'Class' suffix AND all types implementing 'MyNamespace.IPath' are expected to have the 'Path' suffix. |
-|`dotnet_code_quality.CA1710.additional_required_suffixes = T:System.Data.IDataReader->{}` | Allows to override built-in suffixes, in this case, all types implementing 'IDataReader' are no longer expected to end in 'Collection' |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class|MyNamespace.IPath->Path` | All types that inherit from 'MyClass' are required to have the 'Class' suffix AND all types that implement 'MyNamespace.IPath' are required to have the 'Path' suffix. |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = T:System.Data.IDataReader->{}` | Overrides built-in suffixes. In this case, all types that implement 'IDataReader' are no longer required to end in 'Collection'. |
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -110,7 +110,7 @@ You can provide additional required suffixes or override the behavior of some ha
 dotnet_code_quality.CA1710.additional_required_suffixes = [type]->[suffix]
 ```
 
-For `[types]`, separate multiple types with a `|` character. Types can be specified in either of the following formats:
+Separate multiple values with a `|` character. Types can be specified in either of the following formats:
 
 - Type name only (includes all types with the name, regardless of the containing type or namespace).
 - Fully qualified names in the symbol's [documentation ID format](../../../csharp/language-reference/language-specification/documentation-comments.md#id-string-format) with an optional `T:` prefix.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -119,7 +119,7 @@ Examples:
 
 | Option Value | Summary |
 | --- | --- |
-|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class` | All types inheriting from 'MyClass' are expected to have the 'Class' suffix |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class` | All types that inherit from 'MyClass' are required to have the 'Class' suffix. |
 |`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class|MyNamespace.IPath->Path` | All types that inherit from 'MyClass' are required to have the 'Class' suffix AND all types that implement 'MyNamespace.IPath' are required to have the 'Path' suffix. |
 |`dotnet_code_quality.CA1710.additional_required_suffixes = T:System.Data.IDataReader->{}` | Overrides built-in suffixes. In this case, all types that implement 'IDataReader' are no longer required to end in 'Collection'. |
 


### PR DESCRIPTION
## Summary

Update doc for rule CA1710 to mention already existing configurability behavior.

Relates to https://github.com/dotnet/roslyn-analyzers/pull/3148 and https://github.com/dotnet/roslyn-analyzers/pull/3237