### PR TITLE
Clarify rules and how to enable them

### DIFF
--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -53,8 +53,6 @@ These specific rules aren't enabled by default. To enable them and show any viol
 </PropertyGroup>
 ```
 
-For more information about enabling code analyzers, see [Enable or install first-party .NET analyzers](/visualstudio/code-quality/install-net-analyzers?view=vs-2019&preserve-view=true).
-
 The following snippet shows examples of code that produces the relevant code analyzer warnings or errors.
 
 ```cs
@@ -62,7 +60,7 @@ The following snippet shows examples of code that produces the relevant code ana
 // Potentially incorrect code - answer might vary based on locale.
 //
 string s = GetString();
-// Produces analyzer warning CA1310 for string; CA1310 matches on char ','
+// Produces analyzer warning CA1310 for string; CA1307 matches on char ','
 int idx = s.IndexOf(",");
 Console.WriteLine(idx);
 
@@ -98,11 +96,6 @@ SortedSet<string> mySet = new SortedSet<string>(StringComparer.Ordinal);
 List<string> list = GetListOfStrings();
 list.Sort(StringComparer.Ordinal);
 ```
-
-For more information about these code analyzer rules, including when it might be appropriate to suppress these rules in your own code base, see the following articles:
-
-* [CA1307: Specify StringComparison for clarity](../../fundamentals/code-analysis/quality-rules/ca1307.md)
-* [CA1309: Use ordinal StringComparison](../../fundamentals/code-analysis/quality-rules/ca1309.md)
 
 ### Revert back to NLS behaviors
 

--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -53,7 +53,7 @@ Enable the analyzer through the SDK by setting the following project properties:
 </PropertyGroup>
 ```
 
-For more information about enabling code analyzers, see [Enable or install first-party .NET analyzers](/visualstudio/code-quality/install-net-analyzers?view=vs-2019).
+For more information about enabling code analyzers, see [Enable or install first-party .NET analyzers](/visualstudio/code-quality/install-net-analyzers?view=vs-2019&preserve-view=true).
 
 For example:
 

--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -43,7 +43,7 @@ This section provides two options for dealing with unexpected behavior changes i
 - [CA1309: Use ordinal StringComparison](../../fundamentals/code-analysis/quality-rules/ca1309.md)
 - [CA1310: Specify StringComparison for correctness](../../fundamentals/code-analysis/quality-rules/ca1310.md)
 
-Enable the analyzer through the SDK by setting the following project properties:
+These specific rules aren't enabled by default. To enable them and show any violations as build errors, set the following properties in your project file:
 
 ```xml
 <PropertyGroup>
@@ -55,7 +55,7 @@ Enable the analyzer through the SDK by setting the following project properties:
 
 For more information about enabling code analyzers, see [Enable or install first-party .NET analyzers](/visualstudio/code-quality/install-net-analyzers?view=vs-2019&preserve-view=true).
 
-For example:
+The following snippet shows examples of code that produces the relevant code analyzer warnings or errors.
 
 ```cs
 //

--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -47,7 +47,6 @@ These specific rules aren't enabled by default. To enable them and show any viol
 
 ```xml
 <PropertyGroup>
-  <EnableNETAnalyzers>true</EnableNETAnalyzers>
   <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   <WarningsAsErrors>$(WarningsAsErrors);CA1307;CA1309;CA1310</WarningsAsErrors>
 </PropertyGroup>

--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -37,9 +37,7 @@ This section provides two options for dealing with unexpected behavior changes i
 
 ### Enable code analyzers
 
-[Code analyzers](../../fundamentals/code-analysis/overview.md) can detect possibly buggy call sites. To help guard against any surprising behaviors, we recommend enabling .NET compiler platform (Roslyn) analyzers in your project. The analyzers help flag code that might inadvertently be using a linguistic comparer when an ordinal comparer was likely intended.
-
-Enable the following rules:
+[Code analyzers](../../fundamentals/code-analysis/overview.md) can detect possibly buggy call sites. To help guard against any surprising behaviors, we recommend enabling .NET compiler platform (Roslyn) analyzers in your project. The analyzers help flag code that might inadvertently be using a linguistic comparer when an ordinal comparer was likely intended. The following rules should help flag these issues:
 
 - [CA1307: Specify StringComparison for clarity](../../fundamentals/code-analysis/quality-rules/ca1307.md)
 - [CA1309: Use ordinal StringComparison](../../fundamentals/code-analysis/quality-rules/ca1309.md)

--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -1,7 +1,7 @@
 ---
 title: Behavior changes when comparing strings on .NET 5+
 description: Learn about string-comparison behavior changes in .NET 5 and later versions on Windows.
-ms.date: 11/04/2020
+ms.date: 12/07/2020
 ---
 # Behavior changes when comparing strings on .NET 5+
 
@@ -37,7 +37,25 @@ This section provides two options for dealing with unexpected behavior changes i
 
 ### Enable code analyzers
 
-[Code analyzers](../../fundamentals/code-analysis/overview.md) can detect possibly buggy call sites. To help guard against any surprising behaviors, we recommend installing [the __Microsoft.CodeAnalysis.FxCopAnalyzers__ NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/) into your project. This package includes the code analysis rules [CA1307](../../fundamentals/code-analysis/quality-rules/ca1307.md) and [CA1309](../../fundamentals/code-analysis/quality-rules/ca1309.md), which help flag code that might inadvertently be using a linguistic comparer when an ordinal comparer was likely intended.
+[Code analyzers](../../fundamentals/code-analysis/overview.md) can detect possibly buggy call sites. To help guard against any surprising behaviors, we recommend enabling .NET compiler platform (Roslyn) analyzers in your project. The analyzers help flag code that might inadvertently be using a linguistic comparer when an ordinal comparer was likely intended.
+
+Enable the following rules:
+
+- [CA1307: Specify StringComparison for clarity](../../fundamentals/code-analysis/quality-rules/ca1307.md)
+- [CA1309: Use ordinal StringComparison](../../fundamentals/code-analysis/quality-rules/ca1309.md)
+- [CA1310: Specify StringComparison for correctness](../../fundamentals/code-analysis/quality-rules/ca1310.md)
+
+Enable the analyzer through the SDK by setting the following project properties:
+
+```xml
+<PropertyGroup>
+  <EnableNETAnalyzers>true</EnableNETAnalyzers>
+  <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  <WarningsAsErrors>$(WarningsAsErrors);CA1307;CA1309;CA1310</WarningsAsErrors>
+</PropertyGroup>
+```
+
+For more information about enabling code analyzers, see [Enable or install first-party .NET analyzers](/visualstudio/code-quality/install-net-analyzers?view=vs-2019).
 
 For example:
 
@@ -46,7 +64,7 @@ For example:
 // Potentially incorrect code - answer might vary based on locale.
 //
 string s = GetString();
-// Produces analyzer warning CA1307.
+// Produces analyzer warning CA1310 for string; CA1310 matches on char ','
 int idx = s.IndexOf(",");
 Console.WriteLine(idx);
 
@@ -93,7 +111,7 @@ For more information about these code analyzer rules, including when it might be
 To revert .NET 5 applications back to older NLS behaviors when running on Windows, follow the steps in [.NET Globalization and ICU](../globalization-localization/globalization-icu.md). This application-wide compatibility switch must be set at the application level. Individual libraries cannot opt-in or opt-out of this behavior.
 
 > [!TIP]
-> We strongly recommend you enable the [CA1307](../../fundamentals/code-analysis/quality-rules/ca1307.md) and [CA1309](../../fundamentals/code-analysis/quality-rules/ca1309.md) code analysis rules to help improve code hygiene and discover any existing latent bugs. For more information, see [Enable code analyzers](#enable-code-analyzers).
+> We strongly recommend you enable the [CA1307](../../fundamentals/code-analysis/quality-rules/ca1307.md), [CA1309](../../fundamentals/code-analysis/quality-rules/ca1309.md), and [CA1310](../../fundamentals/code-analysis/quality-rules/ca1310.md) code analysis rules to help improve code hygiene and discover any existing latent bugs. For more information, see [Enable code analyzers](#enable-code-analyzers).
 
 ## Affected APIs
 


### PR DESCRIPTION
## Summary

- Rewrote section on enabling the rules. Removed the NuGet package reference and described how to enable them in the SDK.
- Added rule CA1310 as it works on "string" variations instead of just CA1307 which works on 'char' variations.

Fixes #21848

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus?branch=pr-en-us-21860)

@gewarren Pinged you since you recently updated these.

@meziantou