### PR TITLE
XML parse breaking change in 4.5.2

### DIFF
--- a/docs/framework/configure-apps/file-schema/appsettings/appsettings-element-for-configuration.md
+++ b/docs/framework/configure-apps/file-schema/appsettings/appsettings-element-for-configuration.md
@@ -1,9 +1,9 @@
 ---
 title: "<appSettings> element for <configuration>"
 ms.date: "05/01/2017"
-f1_keywords: 
+f1_keywords:
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#configuration/appSettings"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "appSettings Element"
   - "<appSettings> Element"
 ms.assetid: 39694cc4-6b84-45a6-9329-385a0d8b48fe
@@ -12,7 +12,7 @@ ms.assetid: 39694cc4-6b84-45a6-9329-385a0d8b48fe
 
 Contains custom application settings. This is a predefined configuration section provided by the .NET Framework.
 
-[**\<configuration>**](../configuration-element.md)
+[**\<configuration>**](../configuration-element.md)\
 &nbsp;&nbsp;**\<appSettings>**
 
 ## Syntax

--- a/docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element copy.md
+++ b/docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element copy.md
@@ -1,0 +1,46 @@
+---
+title: EnableLegacyXmlSettings element
+ms.date: 12/08/2020
+---
+# \<EnableLegacyXmlSettings> Element
+
+Specifies whether to use XML parsing settings from .NET Framework 4.5.1 and earlier versions.
+
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<EnableLegacyXmlSettings>**
+
+## Syntax
+
+```xml
+<EnableLegacyXmlSettings enabled="0"|"1" />
+```
+
+## Attributes
+
+|Attribute|Description|
+|---------------|-----------------|
+|`enabled`|Required attribute.<br /><br />Specifies whether to use XML parsing settings from .NET Framework 4.5.1 and earlier versions.|
+
+### enabled attribute
+
+|Value|Description|
+|-----------|-----------------|
+|0|.|
+|1.|
+
+## Parent elements
+
+|Element|Description|
+|-------------|-----------------|
+|`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|
+|`runtime`|Contains information about runtime initialization options.|
+
+## Remarks
+
+
+
+## See also
+
+- [\<runtime> Element](runtime-element.md)
+- [\<configuration> Element](../configuration-element.md)

--- a/docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element.md
@@ -38,9 +38,15 @@ Specifies whether to use XML parsing settings from .NET Framework 4.5.1 and earl
 
 ## Remarks
 
+A breaking change was introduced in .NET Framework 4.5.2. The following default values were changed:
 
+- <xref:System.Xml.XmlReaderSettings.MaxCharactersFromEntities?displayProperty=nameWithType> is set to 10 million by default.
+- <xref:System.Xml.XmlReaderSettings.XmlResolver?displayProperty=nameWithType> is set to `null` by default.
+
+To revert to pre-4.5.2 defaults, set the `EnableLegacyXmlSettings` element to `1`.
 
 ## See also
 
 - [\<runtime> Element](runtime-element.md)
 - [\<configuration> Element](../configuration-element.md)
+- [XML parsing changes](../../../../../includes/migration-guide/runtime/xml/xml-parse-changes.md)

--- a/docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element.md
@@ -24,17 +24,17 @@ Specifies whether to use XML parsing settings from .NET Framework 4.5.1 and earl
 
 ### enabled attribute
 
-|Value|Description|
-|-----------|-----------------|
-|0|.|
-|1.|
+| Value | Description                           |
+|-------|---------------------------------------|
+| 0     | Don't use legacy XML reader settings. |
+| 1     | Use legacy XML reader settings.       |
 
 ## Parent elements
 
-|Element|Description|
-|-------------|-----------------|
-|`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|
-|`runtime`|Contains information about runtime initialization options.|
+| Element         | Description                                                                                                       |
+|-----------------|-------------------------------------------------------------------------------------------------------------------|
+| `configuration` | The root element in every configuration file used by the common language runtime and .NET Framework applications. |
+| `runtime`       | Contains information about runtime initialization options.                                                        |
 
 ## Remarks
 
@@ -49,4 +49,4 @@ To revert to pre-4.5.2 defaults, set the `EnableLegacyXmlSettings` element to `1
 
 - [\<runtime> Element](runtime-element.md)
 - [\<configuration> Element](../configuration-element.md)
-- [XML parsing changes](../../../../../includes/migration-guide/runtime/xml/xml-parse-changes.md)
+- [XML runtime changes for .NET Framework 4.5.2](../../../migration-guide/runtime/4.5.1-4.5.2.md)

--- a/docs/framework/configure-apps/file-schema/runtime/index.md
+++ b/docs/framework/configure-apps/file-schema/runtime/index.md
@@ -36,6 +36,7 @@ Run-time settings are used by the common language runtime to configure applicati
 &nbsp;&nbsp;&nbsp;&nbsp;[\<disableCommitThreadStack>](disablecommitthreadstack-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<disableFusionUpdatesFromADManager>](disablefusionupdatesfromadmanager-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<EnableAmPmParseAdjustment>](enableampmparseadjustment-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[\<EnableLegacyXmlSettings>](enablelegacyxmlsettings-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<enforceFIPSPolicy>](enforcefipspolicy-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<etwEnable>](etwenable-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<forcePerformanceCounterUniqueSharedMemoryReads>](forceperformancecounteruniquesharedmemoryreads-element.md)\

--- a/docs/framework/configure-apps/file-schema/runtime/toc.yml
+++ b/docs/framework/configure-apps/file-schema/runtime/toc.yml
@@ -50,6 +50,8 @@
     href: disablefusionupdatesfromadmanager-element.md
   - name: <EnableAmPmParseAdjustment> element
     href: enableampmparseadjustment-element.md
+  - name: <EnableLegacyXmlSettings> element
+    href: enablelegacyxmlsettings-element.md
   - name: <enforceFIPSPolicy> element
     href: enforcefipspolicy-element.md
   - name: <etwEnable> element

--- a/docs/framework/migration-guide/runtime/4.0-4.5.2.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.5.2.md
@@ -197,3 +197,5 @@ If you are migrating from the .NET Framework 4.0 to 4.5.2, review the following 
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.6.1.md
@@ -217,3 +217,5 @@ If you are migrating from the .NET Framework 4.0 to 4.6.1, review the following 
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.6.2.md
@@ -231,3 +231,5 @@ If you are migrating from the .NET Framework 4.0 to 4.6.2, review the following 
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.6.md
@@ -207,3 +207,5 @@ If you are migrating from the .NET Framework 4.0 to 4.6, review the following to
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.7.1.md
@@ -237,3 +237,5 @@ If you are migrating from the .NET Framework 4.0 to 4.7.1, review the following 
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.7.2.md
@@ -249,3 +249,5 @@ If you are migrating from the .NET Framework 4.0 to 4.7.2, review the following 
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.7.md
@@ -239,3 +239,5 @@ If you are migrating from the .NET Framework 4.0 to 4.7, review the following to
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.0-4.8.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.8.md
@@ -271,3 +271,5 @@ If you are migrating from the .NET Framework 4.0 to 4.8, review the following to
 [!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
 [!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.5.2.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.5.2.md
@@ -73,3 +73,7 @@ If you are migrating from the .NET Framework 4.5 to 4.5.2, review the following 
 [!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
 [!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.6.1.md
@@ -127,3 +127,7 @@ If you are migrating from the .NET Framework 4.5 to 4.6.1, review the following 
 [!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
 [!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.6.2.md
@@ -145,3 +145,7 @@ If you are migrating from the .NET Framework 4.5 to 4.6.2, review the following 
 [!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
 [!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.6.md
@@ -117,3 +117,7 @@ If you are migrating from the .NET Framework 4.5 to 4.6, review the following to
 [!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
 [!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.7.1.md
@@ -153,3 +153,7 @@ If you are migrating from the .NET Framework 4.5 to 4.7.1, review the following 
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.7.2.md
@@ -167,3 +167,7 @@ If you are migrating from the .NET Framework 4.5 to 4.7.2, review the following 
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.7.md
@@ -155,3 +155,7 @@ If you are migrating from the .NET Framework 4.5 to 4.7, review the following to
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5-4.8.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.8.md
@@ -189,3 +189,7 @@ If you are migrating from the .NET Framework 4.5 to 4.8, review the following to
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.5.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.5.2.md
@@ -37,3 +37,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.5.2, review the followin
 [!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
 [!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.6.1.md
@@ -105,3 +105,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.6.1, review the followin
 [!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
 [!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.6.2.md
@@ -123,3 +123,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.6.2, review the followin
 [!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
 [!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.6.md
@@ -95,3 +95,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.6, review the following 
 [!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
 [!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.7.1.md
@@ -131,3 +131,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.7.1, review the followin
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.7.2.md
@@ -145,3 +145,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.7.2, review the followin
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.7.md
@@ -133,3 +133,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.7, review the following 
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/docs/framework/migration-guide/runtime/4.5.1-4.8.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.8.md
@@ -167,3 +167,7 @@ If you are migrating from the .NET Framework 4.5.1 to 4.8, review the following 
 [!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
 [!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+
+## XML
+
+[!INCLUDE [xml-parse-changes](~/includes/migration-guide/runtime/xml/xml-parse-changes.md)]

--- a/includes/migration-guide/runtime/xml/xml-parse-changes.md
+++ b/includes/migration-guide/runtime/xml/xml-parse-changes.md
@@ -12,7 +12,7 @@ For security reasons, the following changes were introduced into XML parsing API
 
 #### Suggestion
 
-To revert to the previous behavior, set [\<EnableLegacyXmlSettings> element](../../../../docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element copy.md) to `1`.
+To revert to the previous behavior, set [\<EnableLegacyXmlSettings> element](../../../../docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element.md) to `1`.
 
 | Name    | Value   |
 |:--------|:--------|

--- a/includes/migration-guide/runtime/xml/xml-parse-changes.md
+++ b/includes/migration-guide/runtime/xml/xml-parse-changes.md
@@ -30,6 +30,6 @@ To revert to the previous behavior, set [\<EnableLegacyXmlSettings> element](../
 #### Affected APIs
 
 - `P:System.Xml.XmlReaderSettings.MaxCharactersFromEntities`
-- `P:System.Xml.XmlTextReader.XmlResolver`
+- `P:System.Xml.XmlReaderSettings.XmlResolver`
 
 -->

--- a/includes/migration-guide/runtime/xml/xml-parse-changes.md
+++ b/includes/migration-guide/runtime/xml/xml-parse-changes.md
@@ -1,0 +1,35 @@
+### XML parsing changes
+
+#### Details
+
+For security reasons, the following changes were introduced into XML parsing APIS:
+
+- <xref:System.Xml.XmlReaderSettings.MaxCharactersFromEntities?displayProperty=nameWithType> is set to 10 million when <xref:System.Xml.XmlReaderSettings> is initialized.
+- <xref:System.Xml.XmlReaderSettings.XmlResolver?displayProperty=nameWithType> is set to `null` by default.
+
+> [!NOTE]
+> <xref:System.Xml.XmlReaderSettings> is used by all XML parsers, so while this change helps the <xref:System.Xml.XmlReader> case, it also affects other scenarios.
+
+#### Suggestion
+
+To revert to the previous behavior, set [\<EnableLegacyXmlSettings> element](../../../../docs/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element copy.md) to `1`.
+
+| Name    | Value   |
+|:--------|:--------|
+| Scope   | Minor   |
+| Version | 4.5.2   |
+| Type    | Runtime |
+
+#### Affected APIs
+
+- <xref:System.Xml.XmlReaderSettings.MaxCharactersFromEntities?displayProperty=fullName>
+- <xref:System.Xml.XmlReaderSettings.XmlResolver?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- `P:System.Xml.XmlReaderSettings.MaxCharactersFromEntities`
+- `P:System.Xml.XmlTextReader.XmlResolver`
+
+-->


### PR DESCRIPTION
Fixes #21710.

- Adds EnableLegacyXmlSettings element to config docs.
- Adds breaking change in 4.5.2 for XmlReaderSettings.

Preview links:

- [EnableLegacyXmlSettings](https://review.docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/enablelegacyxmlsettings-element?branch=pr-en-us-21876).
- [XML breaking change](https://review.docs.microsoft.com/en-us/dotnet/framework/migration-guide/runtime/4.5.1-4.5.2?branch=pr-en-us-21876#xml-parsing-changes)