### PR TITLE
Deprecate CA1801 in favor of IDE0060

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -45,6 +45,10 @@ This rule does not examine the following kinds of methods:
 
 This rule does not flag parameters that are named with the [discard](../../../csharp/discards.md) symbol, for example, `_`, `_1`, and `_2`. This reduces warning noise on parameters that are needed for signature requirements, for example, a method used as a delegate, a parameter with special attributes, or a parameter whose value is implicitly accessed at run time by a framework but is not referenced in code.
 
+> [!NOTE]
+> This rule has been deprecated in favor of [IDE0060](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060). You can enforce this analyzer by following [this guide](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/overview#code-style-analysis).
+> For more information, see [Deprecated rules](https://docs.microsoft.com/visualstudio/code-quality/fxcop-unported-deprecated-rules).
+
 ## Rule description
 
 Review parameters in non-virtual methods that are not used in the method body to make sure no incorrectness exists around failure to access them. Unused parameters incur maintenance and performance costs.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -46,8 +46,7 @@ This rule does not examine the following kinds of methods:
 This rule does not flag parameters that are named with the [discard](../../../csharp/discards.md) symbol, for example, `_`, `_1`, and `_2`. This reduces warning noise on parameters that are needed for signature requirements, for example, a method used as a delegate, a parameter with special attributes, or a parameter whose value is implicitly accessed at run time by a framework but is not referenced in code.
 
 > [!NOTE]
-> This rule has been deprecated in favor of [IDE0060](../style-rules/ide0060.md). You can enforce this analyzer by following [this guide](../overview.md#code-style-analysis).
-> For more information, see [Deprecated rules](https://docs.microsoft.com/visualstudio/code-quality/fxcop-unported-deprecated-rules).
+> This rule has been deprecated in favor of [IDE0060](../style-rules/ide0060.md). For information about how to enforce the IDE0060 analyzer at build, see [code-style analysis](../overview.md#code-style-analysis).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -46,7 +46,7 @@ This rule does not examine the following kinds of methods:
 This rule does not flag parameters that are named with the [discard](../../../csharp/discards.md) symbol, for example, `_`, `_1`, and `_2`. This reduces warning noise on parameters that are needed for signature requirements, for example, a method used as a delegate, a parameter with special attributes, or a parameter whose value is implicitly accessed at run time by a framework but is not referenced in code.
 
 > [!NOTE]
-> This rule has been deprecated in favor of [IDE0060](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060). You can enforce this analyzer by following [this guide](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/overview#code-style-analysis).
+> This rule has been deprecated in favor of [IDE0060](../style-rules/ide0060.md). You can enforce this analyzer by following [this guide](../overview.md#code-style-analysis).
 > For more information, see [Deprecated rules](https://docs.microsoft.com/visualstudio/code-quality/fxcop-unported-deprecated-rules).
 
 ## Rule description


### PR DESCRIPTION
## Summary

Deprecate CA1801 in favor of IDE0060.

Relates to https://github.com/dotnet/roslyn-analyzers/issues/4498
