### PR TITLE
Microsoft.Data.Sqlite: Mention in which version features were added

### DIFF
--- a/docs/standard/data/sqlite/blob-io.md
+++ b/docs/standard/data/sqlite/blob-io.md
@@ -1,9 +1,12 @@
 ---
 title: Blob I/O
-ms.date: 12/13/2019
+ms.date: 12/08/2020
 description: Learn how to use SQLite's BLOB I/O feature.
 ---
 # Blob I/O
+
+> [!NOTE]
+> The SqliteBlob class was added in version 3.0.
 
 You can reduce memory usage while reading and writing large objects by streaming the data into and out of the database. This can be especially useful when parsing or transforming the data.
 

--- a/docs/standard/data/sqlite/connection-strings.md
+++ b/docs/standard/data/sqlite/connection-strings.md
@@ -1,6 +1,6 @@
 ---
 title: Connection strings
-ms.date: 12/13/2019
+ms.date: 12/08/2020
 description: The supported keywords and values of connection strings.
 ---
 # Connection strings
@@ -55,9 +55,15 @@ The encryption key. When specified, `PRAGMA key` is sent immediately after openi
 > [!WARNING]
 > Password has no effect when encryption isn't supported by the native SQLite library.
 
+> [!NOTE]
+> The Password keyword was added in version 3.0.
+
 ### Foreign Keys
 
 A value indicating whether to enable foreign key constraints.
+
+> [!NOTE]
+> The Foreign Keys keyword was added in version 3.0.
 
 | Value   | Description
 | ------- | --- |
@@ -71,6 +77,9 @@ SQLite library.
 ### Recursive triggers
 
 A value that indicates whether to enable recursive triggers.
+
+> [!NOTE]
+> The Recursive Triggers keyword was added in version 3.0.
 
 | Value | Description                                                                 |
 | ----- | --------------------------------------------------------------------------- |

--- a/docs/standard/data/sqlite/extensions.md
+++ b/docs/standard/data/sqlite/extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-ms.date: 12/13/2019
+ms.date: 12/08/2020
 description: Learn how to load SQLite extensions.
 ---
 # Extensions
@@ -12,6 +12,9 @@ SQLite supports loading extensions at run time. Extensions include things like a
 To load an extension, call the <xref:Microsoft.Data.Sqlite.SqliteConnection.LoadExtension%2A> method. Microsoft.Data.Sqlite will ensure that the extension remains loaded even if the connection is closed and reopened.
 
 [!code-csharp[](../../../../samples/snippets/standard/data/sqlite/ExtensionsSample/Program.cs?name=snippet_LoadExtension)]
+
+> [!NOTE]
+> The LoadExtension method was added in version 3.0.
 
 ## See also
 


### PR DESCRIPTION
We've found in the EF Core docs that, since 2.1, 3.1 & 5.0 are all supported, including this information can be useful to readers.