### PR TITLE
Remove unnecessary note in Best Practices for Strings Doc

### DIFF
--- a/docs/standard/base-types/best-practices-strings.md
+++ b/docs/standard/base-types/best-practices-strings.md
@@ -161,9 +161,6 @@ is equivalent to (but faster than) this comparison:
 
 These comparisons are still very fast.
 
-> [!NOTE]
-> The string behavior of the file system, registry keys and values, and environment variables is best represented by <xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType>.
-
 Both <xref:System.StringComparison.Ordinal?displayProperty=nameWithType> and <xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> use the binary values directly, and are best suited for matching. When you are not sure about your comparison settings, use one of these two values. However, because they perform a byte-by-byte comparison, they do not sort by a linguistic sort order (like an English dictionary) but by a binary sort order. The results may look odd in most contexts if displayed to users.
 
 Ordinal semantics are the default for <xref:System.String.Equals%2A?displayProperty=nameWithType> overloads that do not include a <xref:System.StringComparison> argument (including the equality operator). In any case, we recommend that you call an overload that has a <xref:System.StringComparison> parameter.


### PR DESCRIPTION
## Summary
Removed the unnecessary note as mentioned in the [issue](https://github.com/dotnet/docs/issues/21297).

Fixes #21297
