### PR TITLE
Update environment-osversion-returns-correct-version for macOS

### DIFF
--- a/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
+++ b/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
@@ -9,7 +9,7 @@ ms.date: 11/01/2020
 
 ## Change description
 
-In previous .NET versions, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns an OS version that may be incorrect when an application runs under Windows compatibility mode. For more information, see [GetVersionExA function remarks](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa#remarks). On macOS, it returns the underlying Darwin kernel version.
+In previous .NET versions, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns an OS version that may be incorrect when an application runs under Windows compatibility mode. For more information, see [GetVersionExA function remarks](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa#remarks). On macOS, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns the underlying Darwin kernel version.
 
 Starting in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns the actual version of the operating system for Windows and macOS.
 

--- a/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
+++ b/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
@@ -17,7 +17,7 @@ Starting in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWit
 
 Users of this property expect it to return the actual version of the operating system. Most .NET apps don't specify their supported version in their application manifest, and thus get the default supported version from the dotnet host. As a result, the compatibility shim is rarely meaningful for the app that's running. When Windows releases a new version and an older dotnet host is still in use, these apps may get an incorrect OS version. Returning the actual version is more inline with developers' expectations of this API.
 
-With the introduction of <xref:System.OperatingSystem.IsWindowsVersionAtLeast?displayProperty=nameWithType>, <xref:System.OperatingSystem.IsMacOSVersionAtLeast?displayProperty=nameWithType>, and <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute?displayProperty=nameWithType> in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> was changed to be consistent for Windows and macOS.
+With the introduction of <xref:System.OperatingSystem.IsWindowsVersionAtLeast%2A?displayProperty=nameWithType>, <xref:System.OperatingSystem.IsMacOSVersionAtLeast%2A?displayProperty=nameWithType>, and <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute?displayProperty=nameWithType> in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> was changed to be consistent for Windows and macOS.
 
 ## Version introduced
 

--- a/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
+++ b/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
@@ -15,7 +15,7 @@ Starting in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWit
 
 The following table shows the difference in behavior.
 
-|  | Previous .NET Versions | .NET 5 |
+|  | Previous .NET versions | .NET 5+ |
 |--|------------------------|---------|
 | Windows | 6.2.9200.0 | 10.0.19042.0 |
 | macOS | 19.6.0.0 | 10.15.7 |

--- a/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
+++ b/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
@@ -13,6 +13,13 @@ In previous .NET versions, <xref:System.Environment.OSVersion?displayProperty=na
 
 Starting in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns the actual version of the operating system for Windows and macOS.
 
+The following table shows the difference in behavior.
+
+|  | Previous .NET Versions | .NET 5 |
+|--|------------------------|---------|
+| Windows | 6.2.9200.0 | 10.0.19042.0 |
+| macOS | 19.6.0.0 | 10.15.7 |
+
 ## Reason for change
 
 Users of this property expect it to return the actual version of the operating system. Most .NET apps don't specify their supported version in their application manifest, and thus get the default supported version from the dotnet host. As a result, the compatibility shim is rarely meaningful for the app that's running. When Windows releases a new version and an older dotnet host is still in use, these apps may get an incorrect OS version. Returning the actual version is more inline with developers' expectations of this API.

--- a/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
+++ b/docs/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version.md
@@ -9,13 +9,15 @@ ms.date: 11/01/2020
 
 ## Change description
 
-In previous .NET versions, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns an OS version that may be incorrect when an application runs under Windows compatibility mode. For more information, see [GetVersionExA function remarks](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa#remarks).
+In previous .NET versions, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns an OS version that may be incorrect when an application runs under Windows compatibility mode. For more information, see [GetVersionExA function remarks](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa#remarks). On macOS, it returns the underlying Darwin kernel version.
 
-Starting in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns the actual version of the operating system.
+Starting in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> returns the actual version of the operating system for Windows and macOS.
 
 ## Reason for change
 
 Users of this property expect it to return the actual version of the operating system. Most .NET apps don't specify their supported version in their application manifest, and thus get the default supported version from the dotnet host. As a result, the compatibility shim is rarely meaningful for the app that's running. When Windows releases a new version and an older dotnet host is still in use, these apps may get an incorrect OS version. Returning the actual version is more inline with developers' expectations of this API.
+
+With the introduction of <xref:System.OperatingSystem.IsWindowsVersionAtLeast?displayProperty=nameWithType>, <xref:System.OperatingSystem.IsMacOSVersionAtLeast?displayProperty=nameWithType>, and <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute?displayProperty=nameWithType> in .NET 5.0, <xref:System.Environment.OSVersion?displayProperty=nameWithType> was changed to be consistent for Windows and macOS.
 
 ## Version introduced
 


### PR DESCRIPTION
## Summary

Update OSVersion breaking change documentation to mention the breaking change made for macOS. The existing document only mentions Windows, but a similar change was made for macOS.

Fixes https://github.com/dotnet/docs/issues/21920
