### PR TITLE
Add missing redirect

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -199,6 +199,10 @@
             "redirect_url": "/dotnet/core/compatibility/3.0"
         },
         {
+            "source_path": "docs/core/compatibility/2.2-3.1.md",
+            "redirect_url": "/dotnet/core/compatibility/3.1"
+        },
+        {
             "source_path": "docs/core/compatibility/3.0.6-3.0.7.md",
             "redirect_url": "/dotnet/core/compatibility/3.0"
         },


### PR DESCRIPTION
I found this by running this query in Kusto:

PageView
| where StartDateTime > ago(14d)
| where Site == "docs.microsoft.com"
| where Url contains "/dotnet/core/"
| join TopicMetadata on TopicKey
    | where LiveUrl matches regex "https://docs.microsoft.com/[A-z][A-z]-[A-z][A-z]/404"
| summarize PageViews=dcount(PageViewId) by Url=trim_start("https://docs.microsoft.com/[A-z][A-z]-[A-z][A-z].*/dotnet", Url)
| sort by PageViews desc