### PR TITLE
CA5399 & CA5400: Note that target framework upgrade may be necessary

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5399.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5399.md
@@ -28,7 +28,7 @@ A revoked certificate isn't trusted anymore. It could be used by attackers passi
 
 ## How to fix violations
 
-Set the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList?displayProperty=fullName> property to `true` explicitly. If the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList> property is unavailable, you need to upgrade your target framework.
+Set the <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=fullName> property to `true` explicitly. If the <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList> property is unavailable, you need to upgrade your target framework.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5399.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5399.md
@@ -28,7 +28,7 @@ A revoked certificate isn't trusted anymore. It could be used by attackers passi
 
 ## How to fix violations
 
-Set the `CheckCertificateRevocationList` property to `true`.
+Set the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList?displayProperty=fullName> property to `true` explicitly. If the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList> property is unavailable, you need to upgrade your target framework.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -28,7 +28,7 @@ A revoked certificate isn't trusted anymore. It could be used by attackers passi
 
 ## How to fix violations
 
-Set the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList?displayProperty=fullName> property to `true` explicitly. If the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList> property is unavailable, you need to upgrade your target framework.
+Set the <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=fullName> property to `true` explicitly. If the <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList> property is unavailable, you need to upgrade your target framework.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -28,7 +28,7 @@ A revoked certificate isn't trusted anymore. It could be used by attackers passi
 
 ## How to fix violations
 
-Set the `CheckCertificateRevocationList` property to `true` explicitly.
+Set the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList?displayProperty=fullName> property to `true` explicitly. If the <xref:System.Net.Http.HttpClient.CheckCertificateRevocationList> property is unavailable, you need to upgrade your target framework.
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

CheckCertificateRevocationList isn't available in all .NET versions, so note that developers may need to upgrade.