### PR TITLE
GroupCollection breaking change

### DIFF
--- a/docs/core/compatibility/3.0.md
+++ b/docs/core/compatibility/3.0.md
@@ -281,6 +281,7 @@ If you're migrating to version 3.0 of .NET Core, ASP.NET Core, or EF Core, the b
 - [TypeDescriptionProviderAttribute moved to another assembly](#typedescriptionproviderattribute-moved-to-another-assembly)
 - [ZipArchiveEntry no longer handles archives with inconsistent entry sizes](#ziparchiveentry-no-longer-handles-archives-with-inconsistent-entry-sizes)
 - [FieldInfo.SetValue throws exception for static, init-only fields](#fieldinfosetvalue-throws-exception-for-static-init-only-fields)
+- [Passing GroupCollection to extension methods taking IEnumerable\<T> requires disambiguation](#passing-groupcollection-to-extension-methods-taking-ienumerablet-requires-disambiguation)
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 
@@ -315,6 +316,10 @@ If you're migrating to version 3.0 of .NET Core, ASP.NET Core, or EF Core, the b
 ***
 
 [!INCLUDE [FieldInfo.SetValue throws exception for static, init-only fields](~/includes/core-changes/corefx/3.0/fieldinfo-setvalue-exception.md)]
+
+***
+
+[!INCLUDE [disambiguate-generic-type-for-groupcollection](../../../includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md)]
 
 ***
 

--- a/docs/core/compatibility/corefx.md
+++ b/docs/core/compatibility/corefx.md
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 
 | Breaking change | Version introduced |
 | - | :-: |
+| [Passing GroupCollection to extension methods taking IEnumerable\<T> requires disambiguation](#passing-groupcollection-to-extension-methods-taking-ienumerablet-requires-disambiguation) | 3.0 |
 | [APIs that report version now report product and not file version](#apis-that-report-version-now-report-product-and-not-file-version) | 3.0 |
 | [Custom EncoderFallbackBuffer instances cannot fall back recursively](#custom-encoderfallbackbuffer-instances-cannot-fall-back-recursively) | 3.0 |
 | [Floating point formatting and parsing behavior changes](#floating-point-formatting-and-parsing-behavior-changed) | 3.0 |
@@ -29,6 +30,10 @@ The following breaking changes are documented on this page:
 | [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start) | 1.0 |
 
 ## .NET Core 3.0
+
+[!INCLUDE [disambiguate-generic-type-for-groupcollection](../../../includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md)]
+
+***
 
 [!INCLUDE[APIs that report version now report product and not file version](~/includes/core-changes/corefx/3.0/version-information-changes.md)]
 

--- a/includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md
+++ b/includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md
@@ -1,0 +1,67 @@
+### Passing GroupCollection to extension methods taking IEnumerable\<T> requires disambiguation
+
+When calling an extension method that takes an `IEnumerable<T>` on a <xref:System.Text.RegularExpressions.GroupCollection>, you must disambiguate the type using a cast.
+
+#### Change description
+
+Starting in .NET Core 3.0, <xref:System.Text.RegularExpressions.GroupCollection?displayProperty=nameWithType> implements `IEnumerable<KeyValuePair<String,Group>>` in addition to the other types it implements, including `IEnumerable<Group>`. This results in ambiguity when calling an extension method that takes an <xref:System.Collections.Generic.IEnumerable%601>. If you call such an extension method on a <xref:System.Text.RegularExpressions.GroupCollection> instance, for example, <xref:System.Linq.Enumerable.Count%2A?displayProperty=nameWithType>, you'll see the following compiler error:
+
+**CS1061: 'GroupCollection' does not contain a definition for 'Count' and no accessible extension method 'Count' accepting a first argument of type 'GroupCollection' could be found (are you missing a using directive or an assembly reference?)**
+
+In previous versions of .NET, there was no ambiguity and no compiler error.
+
+#### Version introduced
+
+3.0
+
+#### Reason for change
+
+This was an [unintentional breaking change](https://github.com/dotnet/corefx/pull/30077). Because it has been like this for some time, we don't plan to revert it. In additional, such a change would itself be breaking.
+
+#### Recommended action
+
+For <xref:System.Text.RegularExpressions.GroupCollection> instances, disambiguate calls to extension methods that accept an `IEnumerable<T>` with a cast.
+
+```csharp
+// Without a cast - causes CS1061.
+match.Groups.Count(_ => true)
+
+// With a disambiguating cast.
+((IEnumerable<Group>)m.Groups).Count(_ => true);
+```
+
+#### Category
+
+Core .NET libraries
+
+#### Affected APIs
+
+Any extension method that accepts an <xref:System.Collections.Generic.IEnumerable%601> is affected. For example:
+
+- <xref:System.Collections.Immutable.ImmutableArray.ToImmutableArray%60%601(System.Collections.Generic.IEnumerable{%60%600})?displayProperty=fullName>
+- <xref:System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary%2A?displayProperty=fullName>
+- <xref:System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet%2A?displayProperty=fullName>
+- <xref:System.Collections.Immutable.ImmutableList.ToImmutableList%60%601(System.Collections.Generic.IEnumerable{%60%600})?displayProperty=fullName>
+- <xref:System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary%2A?displayProperty=fullName>
+- <xref:System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet%2A?displayProperty=fullName>
+- <xref:System.Data.DataTableExtensions.CopyToDataTable%2A?displayProperty=fullName>
+- Most of the `System.Linq.Enumerable` methods, for example, <xref:System.Linq.Enumerable.Count%2A?displayProperty=fullName>
+- <xref:System.Linq.ParallelEnumerable.AsParallel%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.AsQueryable%2A?displayProperty=fullName>
+
+<!--
+
+#### Affected APIs
+
+- ```M:System.Collections.Immutable.ImmutableArray.ToImmutableArray``1(System.Collections.Generic.IEnumerable{``0})```
+- `Overload:System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary`
+- `Overload:System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet`
+- ```M:System.Collections.Immutable.ImmutableList.ToImmutableList``1(System.Collections.Generic.IEnumerable{``0})```
+- `Overload:System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary`
+- `Overload:System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet`
+- `Overload:System.Data.DataTableExtensions.CopyToDataTable`
+- `Overload:System.Linq.Enumerable.Count`
+- `Overload:System.Linq.ParallelEnumerable.AsParallel`
+- `Overload:System.Linq.Queryable.AsQueryable```
+
+-->

--- a/includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md
+++ b/includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md
@@ -62,6 +62,6 @@ Any extension method that accepts an <xref:System.Collections.Generic.IEnumerabl
 - `Overload:System.Data.DataTableExtensions.CopyToDataTable`
 - `Overload:System.Linq.Enumerable.Count`
 - `Overload:System.Linq.ParallelEnumerable.AsParallel`
-- `Overload:System.Linq.Queryable.AsQueryable```
+- `Overload:System.Linq.Queryable.AsQueryable`
 
 -->

--- a/includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md
+++ b/includes/core-changes/corefx/3.0/disambiguate-generic-type-for-groupcollection.md
@@ -16,7 +16,7 @@ In previous versions of .NET, there was no ambiguity and no compiler error.
 
 #### Reason for change
 
-This was an [unintentional breaking change](https://github.com/dotnet/corefx/pull/30077). Because it has been like this for some time, we don't plan to revert it. In additional, such a change would itself be breaking.
+This was an [unintentional breaking change](https://github.com/dotnet/corefx/pull/30077). Because it has been like this for some time, we don't plan to revert it. In addition, such a change would itself be breaking.
 
 #### Recommended action
 
@@ -53,10 +53,10 @@ Any extension method that accepts an <xref:System.Collections.Generic.IEnumerabl
 
 #### Affected APIs
 
-- ```M:System.Collections.Immutable.ImmutableArray.ToImmutableArray``1(System.Collections.Generic.IEnumerable{``0})```
+- ``M:System.Collections.Immutable.ImmutableArray.ToImmutableArray``1(System.Collections.Generic.IEnumerable{``0})``
 - `Overload:System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary`
 - `Overload:System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet`
-- ```M:System.Collections.Immutable.ImmutableList.ToImmutableList``1(System.Collections.Generic.IEnumerable{``0})```
+- ``M:System.Collections.Immutable.ImmutableList.ToImmutableList``1(System.Collections.Generic.IEnumerable{``0})``
 - `Overload:System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary`
 - `Overload:System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet`
 - `Overload:System.Data.DataTableExtensions.CopyToDataTable`


### PR DESCRIPTION
[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/3.0?branch=pr-en-us-21947#passing-groupcollection-to-extension-methods-taking-ienumerablet-requires-disambiguation).

Fixes #19545.