### PR TITLE
Correction of a delegate related information

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -8,7 +8,7 @@ ms.assetid: f2e1b315-e3d1-48ce-977f-7bae0960ba99
 ---
 # Nested Types (C# Programming Guide)
 
-A type defined within a [class](../../language-reference/keywords/class.md), [struct](../../language-reference/builtin-types/struct.md), [delegate](../../language-reference/builtin-types/reference-types.md#the-delegate-type) or [interface](../../language-reference/keywords/interface.md) is called a nested type. For example
+A type defined within a [class](../../language-reference/keywords/class.md), [struct](../../language-reference/builtin-types/struct.md), or [interface](../../language-reference/keywords/interface.md) is called a nested type. For example
 
 [!code-csharp[DeclareNestedClass](~/samples/snippets/csharp/objectoriented/nestedtypes.cs#DeclareNestedClass)]
 


### PR DESCRIPTION
## Summary

"delegate" cannot be an outer type. A type cannot be defined "within" a delegate. Therefore, the statement "A type defined within a class, struct, delegate or interface is called a nested type." is not fully correct and "delegate" should be removed from this statement.