### PR TITLE
Escape ‘|’ character to fix table rendering (and avoid upcoming markdownlint violation)

### DIFF
--- a/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
+++ b/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
@@ -40,7 +40,7 @@ The following example searches an input string and displays all the href="…" v
 |`\s*`|Match zero or more white-space characters.|  
 |`=`|Match the equals sign.|  
 |`\s*`|Match zero or more white-space characters.|  
-|`(?:\["'\](?<1>\[^"'\]*)["']|(?<1>\S+))`|Match one of the following without assigning the result to a captured group:<br /> <ul><li><p>A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.</p></li><li><p>One or more non-white-space characters. The group named `1` is included in this pattern.</p></li></ul>|  
+|`(?:\["'\](?<1>\[^"'\]*)["']\|(?<1>\S+))`|Match one of the following without assigning the result to a captured group:<br /> <ul><li><p>A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.</p></li><li><p>One or more non-white-space characters. The group named `1` is included in this pattern.</p></li></ul>|  
 |`(?<1>[^"']*)`|Assign zero or more occurrences of any character other than a quotation mark or apostrophe to the capturing group named `1`.|  
 |`(?<1>\S+)`|Assign one or more non-white-space characters to the capturing group named `1`.|  
   


### PR DESCRIPTION
## Summary

To see the problem, visit <https://github.com/dotnet/docs/blob/master/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md> and look at the fifth row of the first table. The unescaped pipe character in the example ends the first table cell prematurely, breaks the inline code element, and hides the second cell’s contents.