### PR TITLE
Add some notes about potential issues with diagnostic tools

### DIFF
--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -64,7 +64,7 @@ You can collect multiple `.gcdump`s and open them simultaneously in Visual Studi
 Collects a GC dump from a currently running process.
 
 > [!WARNING]
-> This will trigger a gen-2 (full) garbage collection to the application to walk the GC heap which can suspend the runtime for a long time, especially when the GC heap is large. Do not use this command in performance-sensitive environments in such cases.
+> To walk the GC heap, this command triggers a generation 2 (full) garbage collection, which can suspend the runtime for a long time, especially when the GC heap is large. Don't use this command in performance-sensitive environments when the GC heap is large.
 
 ### Synopsis
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -63,6 +63,9 @@ You can collect multiple `.gcdump`s and open them simultaneously in Visual Studi
 
 Collects a GC dump from a currently running process.
 
+> [!WARNING]
+> This will trigger a gen-2 (full) garbage collection to the application to walk the GC heap which can suspend the runtime for a long time, especially when the GC heap is large. Do not use this command in performance-sensitive environments in such cases.
+
 ### Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -129,7 +129,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
   > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.
 
 > [!NOTE]
-> Stopping the trace may take a long time for large applications. The runtime needs to send over "rundown information" which needs to iterate through the type cache for all managed code that was captured in the trace. 
+> Stopping the trace may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured in the trace.
 
 ## dotnet-trace convert
 
@@ -156,6 +156,9 @@ dotnet-trace convert [<input-filename>] [--format <Chromium|NetTrace|Speedscope>
 - **`-o|--output <output-filename>`**
 
   Output filename. Extension of target format will be added.
+
+> [!NOTE]
+> Converting `nettrace` files to `chromium` or `speedscope` files is irreversible - `speedscope` or `chromium` files do not have all the information to reconstruct `nettrace` file. The `convert` command still preserves the original `nettrace` file, so do not delete this file if you will be opening the nettrace file in the future.
 
 ## dotnet-trace ps
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -158,7 +158,7 @@ dotnet-trace convert [<input-filename>] [--format <Chromium|NetTrace|Speedscope>
   Output filename. Extension of target format will be added.
 
 > [!NOTE]
-> Converting `nettrace` files to `chromium` or `speedscope` files is irreversible - `speedscope` or `chromium` files do not have all the information to reconstruct `nettrace` file. The `convert` command still preserves the original `nettrace` file, so do not delete this file if you will be opening the nettrace file in the future.
+> Converting `nettrace` files to `chromium` or `speedscope` files is irreversible. `speedscope` and `chromium` files don't have all the information necessary to reconstruct `nettrace` files. However, the `convert` command preserves the original `nettrace` file, so don't delete this file if you plan to open it in the future.
 
 ## dotnet-trace ps
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -128,6 +128,9 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
   > [!NOTE]
   > Using this option monitors the first .NET 5.0 process that communicates back to the tool, which means if your command launches multiple .NET applications, it will only collect the first app. Therefore, it is recommended you use this option on self-contained applications, or using the `dotnet exec <app.dll>` option.
 
+> [!NOTE]
+> Stopping the trace may take a long time for large applications. The runtime needs to send over "rundown information" which needs to iterate through the type cache for all managed code that was captured in the trace. 
+
 ## dotnet-trace convert
 
 Converts `nettrace` traces to alternate formats for use with alternate trace analysis tools.


### PR DESCRIPTION
## Summary

* Add warning about triggering gen 2 GC for dotnet-gcdump

* Add warning about rundown taking a while for dotnet-trace.

* Add warning about converting to chromium/speedscope being irreversible. 

Related issues: 
https://github.com/dotnet/diagnostics/issues/1737
https://github.com/dotnet/diagnostics/issues/515