### PR TITLE
Change what's new section in the landing page to C# 9

### DIFF
--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -71,38 +71,20 @@ landingContent:
           - text: "What's new in C# 9.0"
             url: whats-new/csharp-9.md
 
-  - title: "New features in C# 8.0"
+  - title: "New features in C# 9.0"
     linkLists:
       - linkListType: whats-new
         links:
-          - text: "What's new in C# 8.0"
-            url: whats-new/csharp-8.md
-      - linkListType: overview
-        links:
-          - text: Pattern matching
-            url: pattern-matching.md
-          - text: Nullable reference types
-            url: nullable-references.md
-      - linkListType: concept
-        links:
-          - text: Choose a nullable migration strategy
-            url: nullable-migration-strategies.md
+          - text: "What's new in C# 9.0"
+            url: whats-new/csharp-9.md
       - linkListType: tutorial
         links:
-          - text: Consume and generate async streams
-            url: tutorials/generate-consume-asynchronous-stream.md
-          - text: Develop with nullable reference types
-            url: tutorials/nullable-reference-types.md
-          - text: Upgrade existing code to use nullable reference types
-            url: tutorials/upgrade-to-nullable-references.md
-          - text: Use pattern matching for more expressive algorithms
-            url: tutorials/pattern-matching.md
-          - text: Safely version interfaces with default interface members
-            url: tutorials/default-interface-methods-versions.md
-          - text: Mix in functionality with default interface members
-            url: tutorials/mixins-with-default-interface-methods.md
-          - text: Work with subsets using ranges and indices
-            url: tutorials/ranges-indexes.md
+          - text: Explore record types
+            url: tutorials/exploration/records.md
+          - text: Explore top level statements
+            url: tutorials/exploration/top-level-statements.md
+          - text: Explore new patterns
+            url: tutorials/exploration/patterns-objects.md
       - linkListType: reference
         links:
           - text: Breaking changes in the C# compiler


### PR DESCRIPTION
Instead of the C# 8 tutorials, point to the C# 9 material.

