### PR TITLE
Added missing trailing braces to NUnit testing example

### DIFF
--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -114,7 +114,33 @@ dotnet sln add ./PrimeService.Tests/PrimeService.Tests.csproj
 
 You write one failing test, make it pass, then repeat the process. In the *PrimeService.Tests* directory, rename the *UnitTest1.cs* file to *PrimeService_IsPrimeShould.cs* and replace its entire contents with the following code:
 
-[!code-csharp[Sample_FirstTest](~/samples/snippets/core/testing/unit-testing-using-nunit/csharp/PrimeService.Tests/PrimeService_IsPrimeShould.cs?name=Sample_FirstTest)]
+```csharp
+using NUnit.Framework;
+using Prime.Services;
+
+namespace Prime.UnitTests.Services
+{
+    [TestFixture]
+    public class PrimeService_IsPrimeShould
+    {
+        private PrimeService _primeService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _primeService = new PrimeService();
+        }
+
+        [Test]
+        public void IsPrime_InputIs1_ReturnFalse()
+        {
+            var result = _primeService.IsPrime(1);
+
+            Assert.IsFalse(result, "1 should not be prime");
+        }
+    }
+}
+```
 
 The `[TestFixture]` attribute denotes a class that contains unit tests. The `[Test]` attribute indicates a method is a test method.
 

--- a/samples/snippets/core/testing/unit-testing-using-nunit/csharp/PrimeService.Tests/PrimeService_IsPrimeShould.cs
+++ b/samples/snippets/core/testing/unit-testing-using-nunit/csharp/PrimeService.Tests/PrimeService_IsPrimeShould.cs
@@ -1,5 +1,4 @@
-﻿#region Sample_FirstTest
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Prime.Services;
 
 namespace Prime.UnitTests.Services
@@ -22,7 +21,7 @@ namespace Prime.UnitTests.Services
 
             Assert.IsFalse(result, "1 should not be prime");
         }
-#endregion
+
         #region Sample_TestCode
         [TestCase(-1)]
         [TestCase(0)]


### PR DESCRIPTION
## Summary

Changed code snippet link on line 117 to embedded source code. A) DocFX doesn't support excluding nested tags, and B) this aligns with the style seen in other articles in the `testing` directory.

Since the `#region` in question is no longer used, I also removed it. (I included the sample change in this PR because the contributing docs say a new PR is needed for a **new** sample but omits **existing** samples, so I assume existing samples can be merged with other changes on a single fix.)

Fixes #21705 