### PR TITLE
Change string interp typo to no string interpolation for vscode

### DIFF
--- a/docs/fsharp/get-started/get-started-vscode.md
+++ b/docs/fsharp/get-started/get-started-vscode.md
@@ -138,7 +138,7 @@ Now, in the `main` function, call your Pig Latin generator function on the argum
 let main argv =
     for name in argv do
         let newName = PigLatin.toPigLatin name
-        printfn %"{name} in Pig Latin is: {newName}"
+        printfn "%s in Pig Latin is: %s" name newName
 
     0
 ```


### PR DESCRIPTION
fixes https://github.com/dotnet/docs/issues/22052