### PR TITLE
Separate out list of well-known counters into its own doc

### DIFF
--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -11,7 +11,7 @@ The .NET runtime and libraries implement and publish several [`EventCounter`](./
 
 ## System.Runtime counters
 
-The following counters are published as part of .NET runtime (CoreCLR), and are maintained in the [`RuntimeEventSource.cs`](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSource.cs).
+The following counters are published as part of .NET runtime (CoreCLR) and are maintained in the [`RuntimeEventSource.cs`](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSource.cs).
 
 | Counter | Description |
 |--|--|

--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -7,7 +7,7 @@ ms.date: 12/17/2020
 
 # Well-known EventCounters in .NET
 
-The .NET runtime and libraries implement and publish several [`EventCounter`](./event-counters.md) that can be used to identify and diagnose various performance issues.
+The .NET runtime and libraries implement and publish several [`EventCounter`](./event-counters.md) that can be used to identify and diagnose various performance issues. This document is a reference on the providers that can be used to monitor these `EventCounters` and their descriptions.
 
 ## System.Runtime counters
 
@@ -20,13 +20,13 @@ The following counters are published as part of .NET runtime (CoreCLR), and are 
 | :::no-loc text="CPU Usage"::: (`cpu-usage`) | The percent of CPU usage of the process |
 | :::no-loc text="Exception Count"::: (`exception-count`) | The number of exceptions that have occurred |
 | :::no-loc text="GC Heap Size"::: (`gc-heap-size`) | The number of bytes thought to be allocated based on <xref:System.GC.GetTotalMemory(System.Boolean)?displayProperty=nameWithType> |
-| :::no-loc text="Gen 0 GC Count"::: (`gen-0-gc-count`) | The number of times GC has occurred for Gen 0 |
+| :::no-loc text="Gen 0 GC Count"::: (`gen-0-gc-count`) | The number of times GC has occurred for Gen 0 per update interval |
 | :::no-loc text="Gen 0 Size"::: (`gen-0-size`) | The number of bytes for Gen 0 GC |
-| :::no-loc text="Gen 1 GC Count"::: (`gen-1-gc-count`) | The number of times GC has occurred for Gen 1 |
+| :::no-loc text="Gen 1 GC Count"::: (`gen-1-gc-count`) | The number of times GC has occurred for Gen 1 per update interval |
 | :::no-loc text="Gen 1 Size"::: (`gen-1-size`) | The number of bytes for Gen 1 GC |
-| :::no-loc text="Gen 2 GC Count"::: (`gen-2-gc-count`) | The number of times GC has occurred for Gen 2 |
+| :::no-loc text="Gen 2 GC Count"::: (`gen-2-gc-count`) | The number of times GC has occurred for Gen 2 per update interval |
 | :::no-loc text="Gen 2 Size"::: (`gen-2-size`) | The number of bytes for Gen 2 GC |
-| :::no-loc text="LOH Size"::: (`loh-size`) | The number of bytes for Gen 3 GC |
+| :::no-loc text="LOH Size"::: (`loh-size`) | The number of bytes for the large object heap |
 | :::no-loc text="POH Size"::: (`poh-size`) | The number of bytes for the pinned object heap (available on .NET 5 and later versions) |
 | :::no-loc text="GC Fragmentation"::: (`gc-fragmentation`) | The GC Heap Fragmentation (available on .NET 5 and later versions) |
 | :::no-loc text="Monitor Lock Contention Count"::: (`monitor-lock-contention-count`) | The number of times there was contention when trying to take the monitor's lock, based on <xref:System.Threading.Monitor.LockContentionCount?displayProperty=nameWithType> |

--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -1,10 +1,17 @@
-## Available counters
+---
+title: Well-known EventCounters in .NET
+description: Review EventCounters published by the .NET runtime and libraries.
+ms.topic: reference
+ms.date: 12/17/2020
+---
 
-Throughout various .NET packages, basic metrics on Garbage Collection (GC), Just-in-Time (JIT), assemblies, exceptions, threading, networking, and web requests are published using EventCounters.
+# Well-known EventCounters in .NET
 
-### "System.Runtime" counters
+The .NET runtime and libraries implement and publish several [`EventCounter`](./event-counters.md) that can be used to identify and diagnose various performance issues.
 
-The following counters are published as part of .NET runtime, and are maintained in the [`RuntimeEventSource.cs`](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSource.cs).
+## System.Runtime
+
+The following counters are published as part of .NET runtime (CoreCLR), and are maintained in the [`RuntimeEventSource.cs`](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSource.cs).
 
 | Counter | Description |
 |--|--|
@@ -32,7 +39,7 @@ The following counters are published as part of .NET runtime, and are maintained
 | :::no-loc text="IL Bytes Jitted"::: (`il-bytes-jitted`) | The total size of ILs that are JIT-compiled, in bytes (available on .NET 5 and later versions) |
 | :::no-loc text="Method Jitted Count"::: (`method-jitted-count`) | The number of methods that are JIT-compiled (available on .NET 5 and later versions) |
 
-### "Microsoft.AspNetCore.Hosting" counters
+## "Microsoft.AspNetCore.Hosting" counters
 
 The following counters are published as part of [ASP.NET Core](/aspnet/core) and are maintained in [`HostingEventSource.cs`](https://github.com/dotnet/aspnetcore/blob/master/src/Hosting/Hosting/src/Internal/HostingEventSource.cs).
 
@@ -43,7 +50,7 @@ The following counters are published as part of [ASP.NET Core](/aspnet/core) and
 | :::no-loc text="Request Rate"::: (`requests-per-second`) | The number of requests that occur per update interval |
 | :::no-loc text="Total Requests"::: (`total-requests`) | The total number of requests that have occurred for the life of the app |
 
-### "Microsoft.AspNetCore.Http.Connections" counters
+## "Microsoft.AspNetCore.Http.Connections" counters
 
 The following counters are published as part of [ASP.NET Core SignalR](/aspnet/core/signalr/introduction) and are maintained in [`HttpConnectionsEventSource.cs`](https://github.com/dotnet/aspnetcore/blob/master/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsEventSource.cs).
 
@@ -55,7 +62,7 @@ The following counters are published as part of [ASP.NET Core SignalR](/aspnet/c
 | :::no-loc text="Total Connections Stopped"::: (`connections-stopped`) | The total number of connections that have stopped |
 | :::no-loc text="Total Connections Timed Out"::: (`connections-timed-out`) | The total number of connections that have timed out |
 
-### "Microsoft-AspNetCore-Server-Kestrel" counters
+## "Microsoft-AspNetCore-Server-Kestrel" counters
 
 The following counters are published as part of the [ASP.NET Core Kestrel web server](/aspnet/core/fundamentals/servers/kestrel) and are maintained in [`KestrelEventSource.cs`](https://github.com/dotnet/aspnetcore/blob/master/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs).
 

--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -9,7 +9,7 @@ ms.date: 12/17/2020
 
 The .NET runtime and libraries implement and publish several [`EventCounter`](./event-counters.md) that can be used to identify and diagnose various performance issues.
 
-## System.Runtime
+## System.Runtime counters
 
 The following counters are published as part of .NET runtime (CoreCLR), and are maintained in the [`RuntimeEventSource.cs`](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSource.cs).
 

--- a/docs/core/diagnostics/event-counters.md
+++ b/docs/core/diagnostics/event-counters.md
@@ -10,13 +10,11 @@ ms.date: 08/07/2020
 
 EventCounters are .NET Core APIs used for lightweight, cross-platform, and near real-time performance metric collection. EventCounters were added as a cross-platform alternative to the "performance counters" of the .NET Framework on Windows. In this article you'll learn what EventCounters are, how to implement them, and how to consume them.
 
-The .NET Core runtime and a few .NET libraries publish basic diagnostics information using EventCounters starting in .NET Core 3.0. Apart from the EventCounters that are provided by the .NET runtime, you may choose to implement your own EventCounters. EventCounters can be used to track various metrics.
+The .NET Core runtime and a few .NET libraries publish basic diagnostics information using EventCounters starting in .NET Core 3.0. Apart from the EventCounters that are provided by the .NET runtime, you may choose to implement your own EventCounters. EventCounters can be used to track various metrics. Learn more about them in the [well-known EventCounters in .NET](available-counters.md)
 
 EventCounters live as a part of an <xref:System.Diagnostics.Tracing.EventSource>, and are automatically pushed to listener tools on a regular basis. Like all other events on an <xref:System.Diagnostics.Tracing.EventSource>, they can be consumed both in-proc and out-of-proc via <xref:System.Diagnostics.Tracing.EventListener> and [EventPipe](./eventpipe.md). This article focuses on the cross-platform capabilities of EventCounters, and intentionally excludes PerfView and ETW (Event Tracing for Windows) - although both can be used with EventCounters.
 
 ![EventCounters in-proc and out-of-proc diagram image](media/event-counters.svg)
-
-[!INCLUDE [available-counters](includes/available-counters.md)]
 
 ## EventCounter API overview
 

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -19,6 +19,10 @@ This article helps you find the various tools you need.
 
 [Logging and tracing](logging-tracing.md) are related techniques. They refer to instrumenting code to create log files. The files record the details of what a program does. These details can be used to diagnose the most complex problems. When combined with time stamps, these techniques are also valuable in performance investigations.
 
+## Metrics
+
+[EventCounters](event-counters.md) allows you to write metrics to identify and monitor performance issues. Metrics incur lower performance overhead compared to tracing, making it more suitable for an always-on performance monitoring. The .NET runtime and libraries publish several [well-known EventCounters](available-counters.md) that you can monitor as well.
+
 ## Unit testing
 
 [Unit testing](../testing/index.md) is a key component of continuous integration and deployment of high-quality software. Unit tests are designed to give you an early warning when you break something.
@@ -30,10 +34,6 @@ A [dump](./dumps.md) is a file that contains a snapshot of the process at the ti
 ## Collect diagnostics in containers
 
 The same diagnostics tools that are used in non-containerized Linux environments can also be used to [collect diagnostics in containers](diagnostics-in-containers.md). There are just a few usage changes needed to make sure the tools work in a Docker container.
-
-## Debug Linux dumps
-
-[Debug Linux dumps](debug-linux-dumps.md) explains how to collect and analyze dumps on Linux.
 
 ## .NET Core diagnostic global tools
 
@@ -78,6 +78,10 @@ The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Colle
 ### Debug deadlock
 
 [Tutorial: Debug deadlock](debug-deadlock.md) shows you how to use the [dotnet-dump](dotnet-dump.md) tool to investigate threads and locks.
+
+### Debug Linux dumps
+
+[Debug Linux dumps](debug-linux-dumps.md) explains how to collect and analyze dumps on Linux.
 
 ### Measure performance using EventCounters
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -396,7 +396,12 @@ items:
       - name: Linux dumps
         href: ../core/diagnostics/debug-linux-dumps.md
     - name: EventCounters
-      href: ../core/diagnostics/event-counters.md
+      items:
+      - name: Overview
+        displayName: EventCounters
+        href: ../core/diagnostics/event-counters.md
+      - name: Well-known Counters in .NET
+        href: ../core/diagnostics/available-counters.md
     - name: EventPipe
       href: ../core/diagnostics/eventpipe.md
     - name: Logging and tracing


### PR DESCRIPTION
## Summary

This PR separates the list of well-known counters to its own reference doc. We also need to do some more work to ensure the new counters added in the BCL is documented, so I will be following up with another PR for that. 

I also fixed some counter descriptions and added a link to the EventCounter docs from the main diagnostics landing page. 

Part of https://github.com/dotnet/diagnostics/issues/515
