### PR TITLE
Add note about not closing handle returned from ICorProfilerInfo::GetHandleFromThread

### DIFF
--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo-gethandlefromthread-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo-gethandlefromthread-method.md
@@ -39,6 +39,8 @@ HRESULT GetHandleFromThread(
 ## Remarks  
 
  The profiler must call the Win32 `DuplicateHandle` function on the handle before using it.  
+
+ The handle returned from this method is owned by the runtime and the profiler should never close it.
   
 ## Requirements  
 


### PR DESCRIPTION
## Summary

Fix #21970 

cc @davmason 