### PR TITLE
Text annotation inconsistent w/ image

### DIFF
--- a/docs/architecture/microservices/architect-microservice-container-applications/communication-in-microservice-architecture.md
+++ b/docs/architecture/microservices/architect-microservice-container-applications/communication-in-microservice-architecture.md
@@ -97,7 +97,7 @@ As Figure 4-17 shows, real-time HTTP communication means that you can have serve
 
 ![Diagram showing push and real-time comms based on SignalR.](./media/communication-in-microservice-architecture/one-to-many-communication.png)
 
-**Figure 4-17**. One-to-one real-time asynchronous message communication
+**Figure 4-17**. One-to-many real-time asynchronous message communication
 
 SignalR is a good way to achieve real-time communication for pushing content to the clients from a back-end server. Since communication is in real time, client apps show the changes almost instantly. This is usually handled by a protocol such as WebSockets, using many WebSockets connections (one per client). A typical example is when a service communicates a change in the score of a sports game to many client web apps simultaneously.
 


### PR DESCRIPTION
## Summary

"One-to-one" changed to "One-to-many" to be consistent with the image and section content.

Fixes #21981
