### PR TITLE
Fix dotnet-symbol CLI tool reference

### DIFF
--- a/docs/core/diagnostics/dotnet-symbol.md
+++ b/docs/core/diagnostics/dotnet-symbol.md
@@ -95,5 +95,5 @@ dotnet-symbol --host-only --debugging <dump file path>
 
 ## See also
 
-* [Debugging with symbols](/windows/win32/dxtecharts/debugging-with-symbols?redirectedfrom=MSDN)
-* [Portable PDB's](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md)
+* [Debugging with symbols](/windows/win32/dxtecharts/debugging-with-symbols)
+* [Portable PDBs](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md)

--- a/docs/core/diagnostics/dotnet-symbol.md
+++ b/docs/core/diagnostics/dotnet-symbol.md
@@ -9,7 +9,7 @@ ms.date: 11/17/2020
 
 ## Install
 
-To install the latest release version of the `dotnet-trace` [NuGet package](https://www.nuget.org/packages/dotnet-trace), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
+To install the latest release version of the `dotnet-symbol` [NuGet package](https://www.nuget.org/packages/dotnet-symbol), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
 
 ```dotnetcli
 dotnet tool install --global dotnet-symbol
@@ -92,3 +92,8 @@ dotnet-symbol --host-only --debugging <dump file path>
 - 404 Not Found while downloading symbols.
 
    Symbol download is only supported for official .NET Core runtime versions acquired through official channels such as [the official web site](https://dotnet.microsoft.com/download/dotnet-core) and the [default sources in the dotnet installation scripts](../tools/dotnet-install-script.md). A 404 error while downloading debugging files may indicate that the dump was created with a .NET Core runtime from another source, such as one built from source locally or for a particular Linux distro, or from community sites like archlinux. In such cases, file necessary for debugging (dotnet, libcoreclr.so, and libmscordaccore.so) should be copied from those sources or from the environment the dump file was created in.
+
+## See also
+
+* [Debugging with symbols](/windows/win32/dxtecharts/debugging-with-symbols?redirectedfrom=MSDN)
+* [Portable PDB's](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md)


### PR DESCRIPTION
Update the dotnet-symbol install section to reference the dotnet-symbol CLI tool rather than dotnet-trace
Also added a See also section to reference existing conceptual docs on symbols, symbol servers, and portable PDBs