### PR TITLE
Remove extra underscore in configuration-providers.md

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -191,9 +191,9 @@ The prefix is stripped off when the configuration key-value pairs are read.
 The following commands test the custom prefix:
 
 ```dotnetcli
-set CustomPrefix_SecretKey="Secret key with CustomPrefix_ environment"
-set CustomPrefix_TransientFaultHandlingOptions__Enabled=true
-set CustomPrefix_TransientFaultHandlingOptions__AutoRetryDelay=00:00:21
+set CustomPrefix__SecretKey="Secret key with CustomPrefix_ environment"
+set CustomPrefix__TransientFaultHandlingOptions__Enabled=true
+set CustomPrefix__TransientFaultHandlingOptions__AutoRetryDelay=00:00:21
 
 dotnet run
 ```

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -191,7 +191,7 @@ The prefix is stripped off when the configuration key-value pairs are read.
 The following commands test the custom prefix:
 
 ```dotnetcli
-set CustomPrefix__SecretKey="Secret key with CustomPrefix_ environment"
+set CustomPrefix_SecretKey="Secret key with CustomPrefix_ environment"
 set CustomPrefix_TransientFaultHandlingOptions__Enabled=true
 set CustomPrefix_TransientFaultHandlingOptions__AutoRetryDelay=00:00:21
 


### PR DESCRIPTION
## Summary

I think there's a typo in <https://docs.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider>. Instead of `CustomPrefix__SecretKey` it should read `CustomPrefix_SecretKey` (only one underscore). Or am I interpreting this wrong?