### PR TITLE
Fixed use case for fixed string log categories

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -164,7 +164,7 @@ namespace Example
 }
 ```
 
-Calling `CreateLogger` with a fixed name can be useful when used in multiple methods so the events can be organized by category.
+Calling `CreateLogger` with a fixed name can be useful when used in multiple classes/types so the events can be organized by category.
 
 `ILogger<T>` is equivalent to calling `CreateLogger` with the fully qualified type name of `T`.
 


### PR DESCRIPTION
## Summary

In <https://docs.microsoft.com/en-us/dotnet/core/extensions/logging#log-category> it is stated (emphasis by me):

> Calling `CreateLogger` with a fixed name can be useful when used in multiple **methods** so the events can be organized by category.

However, I think this makes no sense. It should read "when used in multiple **classes/types**" (or something similar) because - by default (e.g. `ILogger<DefaultService>`) - loggers *already* group methods.