### PR TITLE
Removed init keyword from property

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -59,8 +59,8 @@ namespace builtin_types
                 Y = y;
             }
 
-            public double X { get; init; }
-            public double Y { get; init; }
+            public double X { get; }
+            public double Y { get; }
 
             public override string ToString() => $"({X}, {Y})";
         }


### PR DESCRIPTION
## Summary

Documentation introduces this snippet by talking about language features available from 7.2. The init accessor isn't available until 9.0. While this is mentioned later it's confusing.

