### PR TITLE
Add SDK run props

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -443,6 +443,36 @@ Restoring a referenced package installs all of its direct dependencies and all t
 </PropertyGroup>
 ```
 
+## Run properties
+
+The following properties are used for launching an app during development in Visual Studio or with the [`dotnet run`](../tools/dotnet-run.md) command:
+
+- [RunArguments](#runarguments)
+- [RunWorkingDirectory](#runworkingdirectory)
+
+### RunArguments
+
+The `RunArguments` property defines the arguments that are passed to the app when it is run.
+
+```xml
+<PropertyGroup>
+  <RunArguments>-mode dryrun</RunArguments>
+</PropertyGroup>
+```
+
+> [!TIP]
+> You can specify additional arguments to be passed to the app by using the [`--` option for `dotnet run`](../tools/dotnet-run.md#options).
+
+### RunWorkingDirectory
+
+The `RunWorkingDirectory` property defines the working directory for the application process to be started in.
+
+```xml
+<PropertyGroup>
+  <RunWorkingDirectory>c:\temp</RunWorkingDirectory>
+</PropertyGroup>
+```
+
 ## Hosting properties and items
 
 - [EnableComHosting](#enablecomhosting)

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -465,7 +465,7 @@ The `RunArguments` property defines the arguments that are passed to the app whe
 
 ### RunWorkingDirectory
 
-The `RunWorkingDirectory` property defines the working directory for the application process to be started in.
+The `RunWorkingDirectory` property defines the working directory for the application process to be started in. If you don't specify a directory, `OutDir` is used as the working directory.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -445,7 +445,7 @@ Restoring a referenced package installs all of its direct dependencies and all t
 
 ## Run properties
 
-The following properties are used for launching an app during development in Visual Studio or with the [`dotnet run`](../tools/dotnet-run.md) command:
+The following properties are used for launching an app with the [`dotnet run`](../tools/dotnet-run.md) command:
 
 - [RunArguments](#runarguments)
 - [RunWorkingDirectory](#runworkingdirectory)


### PR DESCRIPTION
Fixes #18191. It appears that `StartArguments` is not an SDK-specific property, so I left it out.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-22143#run-properties).