### PR TITLE
Fix for missing spaces in abstract method example

### DIFF
--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -185,8 +185,8 @@ Use interface types to represent a set of operations. This is preferred to other
 
 ```fsharp
 type Serializer =
-    abstract Serialize<'T>: preserveRefEq: bool -> value: 'T -> string
-    abstract Deserialize<'T>: preserveRefEq: bool -> pickle: string -> 'T
+    abstract Serialize<'T> : preserveRefEq: bool -> value: 'T -> string
+    abstract Deserialize<'T> : preserveRefEq: bool -> pickle: string -> 'T
 ```
 
 In preference to:


### PR DESCRIPTION
## Summary
Added spaces between < and : in abstract method examples.
The missing spaces resulted in compiler errors when copy/pasting the example.

