### PR TITLE
Fix typo in dependency-injection-guidelines.md

### DIFF
--- a/docs/core/extensions/dependency-injection-guidelines.md
+++ b/docs/core/extensions/dependency-injection-guidelines.md
@@ -144,7 +144,7 @@ The following third-party containers can be used with ASP.NET Core apps:
 
 Create thread-safe singleton services. If a singleton service has a dependency on a transient service, the transient service may also require thread safety depending on how it's used by the singleton.
 
-The factory method of single service, such as the second argument to [AddSingleton\<TService>(IServiceCollection, Func\<IServiceProvider,TService>)](xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton%2A), doesn't need to be thread-safe. Like a type (`static`) constructor, it's guaranteed to be called only once by a single thread.
+The factory method of a singleton service, such as the second argument to [AddSingleton\<TService>(IServiceCollection, Func\<IServiceProvider,TService>)](xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton%2A), doesn't need to be thread-safe. Like a type (`static`) constructor, it's guaranteed to be called only once by a single thread.
 
 ## Recommendations
 


### PR DESCRIPTION
I believe the following sentence:

> `The factory method of single service...`

Should read:

> `The factory method of a singleton service...`
