### PR TITLE
Add example of using Convert.ToHexString()

### DIFF
--- a/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
@@ -55,6 +55,12 @@ These examples show you how to perform the following tasks:
   
  [!code-csharp[csProgGuideTypes#38](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#38)]  
   
+## Example  
+
+ The following example shows how to convert a [byte](../../language-reference/builtin-types/integral-numeric-types.md) array to a hexadecimal string by calling the <xref:System.Convert.ToHexString?displayProperty=nameWithType> method.  
+  
+ [!code-csharp[csProgGuideTypes#40](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#40)]  
+  
 ## See also
 
 - [Standard Numeric Format Strings](../../../standard/base-types/standard-numeric-format-strings.md)

--- a/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
@@ -59,7 +59,7 @@ These examples show you how to perform the following tasks:
 
  The following example shows how to convert a [byte](../../language-reference/builtin-types/integral-numeric-types.md) array to a hexadecimal string by calling the <xref:System.Convert.ToHexString?displayProperty=nameWithType> method.  
   
- [!code-csharp[csProgGuideTypes#40](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#40)]  
+ [!code-csharp[csProgGuideTypes#47](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#47)]  
   
 ## See also
 

--- a/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
+++ b/docs/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types.md
@@ -57,7 +57,7 @@ These examples show you how to perform the following tasks:
   
 ## Example  
 
- The following example shows how to convert a [byte](../../language-reference/builtin-types/integral-numeric-types.md) array to a hexadecimal string by calling the <xref:System.Convert.ToHexString?displayProperty=nameWithType> method.  
+ The following example shows how to convert a [byte](../../language-reference/builtin-types/integral-numeric-types.md) array to a hexadecimal string by calling the <xref:System.Convert.ToHexString%2A?displayProperty=nameWithType> method introduced in .NET 5.0.
   
  [!code-csharp[csProgGuideTypes#47](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#47)]  
   

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/CS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
@@ -555,6 +555,17 @@ namespace CsProgGuideTypes
 
             // Output: 200.0056
             //</snippet39>
+
+            //<snippet40>
+            byte[] array = { 0x64, 0x6f, 0x74, 0x63, 0x65, 0x74 };
+
+            string hexValue = Convert.ToHexString(array);
+            Console.WriteLine(hexValue);
+
+            /*Output:
+              646F74636574
+             */
+            //</snippet40>
             // Keep the console window open in debug mode.
             System.Console.WriteLine("Press any key to exit.");
             System.Console.ReadKey();

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
@@ -556,7 +556,7 @@ namespace CsProgGuideTypes
             // Output: 200.0056
             //</snippet39>
 
-            //<snippet40>
+            //<snippet47>
             byte[] array = { 0x64, 0x6f, 0x74, 0x63, 0x65, 0x74 };
 
             string hexValue = Convert.ToHexString(array);
@@ -565,7 +565,7 @@ namespace CsProgGuideTypes
             /*Output:
               646F74636574
              */
-            //</snippet40>
+            //</snippet47>
             // Keep the console window open in debug mode.
             System.Console.WriteLine("Press any key to exit.");
             System.Console.ReadKey();


### PR DESCRIPTION
## Summary

Show an example of converting a `byte[]` to a hex string using the new .NET 5.0 [`Convert.ToHexString()`](https://docs.microsoft.com/en-us/dotnet/api/system.convert.tohexstring?view=net-5.0) method.

I've gone for an additive approach, but it could be argued it could replace the [`BitConverter` example](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/how-to-convert-between-hexadecimal-strings-and-numeric-types#example-4), depending on whether or not the fact the new method only works in .NET 5.0+ would prevent it being a "better" replacement or not.