### PR TITLE
Update console-webapiclient.md

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -48,7 +48,7 @@ dotnet new console --name WebAPIClient
 
 This creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient". As this is a new project, none of the dependencies are in place. The first run will download the .NET Core framework, install a development certificate, and run the NuGet package manager to restore missing dependencies.
 
-Before you start making modifications, type
+Before you start making modifications, `cd` into the "WebAPIClient" directory and type
 `dotnet run` ([see note](#dotnet-restore-note)) at the command prompt to
 run your application. `dotnet run` automatically performs `dotnet restore`
 if your environment is missing dependencies. It also performs `dotnet build` if your application needs to be rebuilt.


### PR DESCRIPTION
## Summary

Before `dotnet run`, the user should be inside the directory which contains the csproj otherwise it'll error out. 
