### PR TITLE
Update cs0101.md

### DIFF
--- a/docs/csharp/misc/cs0101.md
+++ b/docs/csharp/misc/cs0101.md
@@ -33,7 +33,7 @@ namespace MyNamespace
 }  
 ```
 
-A CS0101 is also generated when your class name clashes with your namespace name.  This can happen when expanding with helper classes for the base class where you attempt to keep the name space route the same.  In the below example, the UTF8 class should clearly be a subsidiary of the String class, but attempting to force it into the same name space by declaring said name space as Utilities.String will cause a CS0101 error:
+A CS0101 is also generated when your class name clashes with your namespace name.  This can happen when expanding with helper classes for the base class where you attempt to keep the namespace route the same.  In the below example, the UTF8 class should clearly be a subsidiary of the String class, but attempting to force it into the same name space by declaring said namespace as Utilities.String will cause a CS0101 error:
 
 ```csharp
 //CS0101-Utilities.String.cs

--- a/docs/csharp/misc/cs0101.md
+++ b/docs/csharp/misc/cs0101.md
@@ -32,3 +32,25 @@ namespace MyNamespace
    }  
 }  
 ```
+
+A CS0101 is also generated when your class name clashes with your namespace name.  This can happen when expanding with helper classes for the base class where you attempt to keep the name space route the same.  In the below example, the UTF8 class should clearly be a subsidiary of the String class, but attempting to force it into the same name space by declaring said name space as Utilities.String will cause a CS0101 error:
+
+```csharp
+//CS0101-Utilities.String.cs
+namespace Utilities
+{  
+   public class String
+   {  
+        public string MyString;
+   }  
+}
+
+//CS0101-Utilities.String.UTF8.cs
+namespace Utilities.String  // CS0101  
+{  
+   public class UTF8
+   {  
+        public string MySecondString;
+   }  
+}  
+```


### PR DESCRIPTION
Added another example and explanation showing how the name space can also clash with the class definition to throw a CS0101 error.

## Summary

Added another example and explanation showing how the name space can also clash with the class definition to throw a CS0101 error.

Fixes #Issue_Number (if available)
