### PR TITLE
Add a new section for runtime download components.

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -140,6 +140,7 @@ The SDK download includes the following components:
 * The desktop runtime. Provides basic services for Windows desktop apps, including Windows Forms and WPF.
 
 The runtime download includes the following components:
+
 * The desktop or ASP.NET Core runtime.
 * The [.NET runtime](#clr). Provides a type system, assembly loading, a garbage collector, native interop, and other basic services.
 * [Runtime libraries](#runtime-libraries). Provides primitive data types and fundamental utilities.

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -139,6 +139,12 @@ The SDK download includes the following components:
 * The ASP.NET Core runtime. Provides basic services for internet-connected apps, such as web apps, IoT apps, and mobile backends.
 * The desktop runtime. Provides basic services for Windows desktop apps, including Windows Forms and WPF.
 
+The runtime download includes the following components:
+* The desktop or ASP.NET Core runtime.
+* The [.NET runtime](#clr). Provides a type system, assembly loading, a garbage collector, native interop, and other basic services.
+* [Runtime libraries](#runtime-libraries). Provides primitive data types and fundamental utilities.
+* The `dotnet` [driver](tools/index.md#driver). A CLI command that runs framework-dependent apps.
+
 For more information, see the following resources:
 
 * [.NET SDK overview](sdk.md)

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -141,7 +141,7 @@ The SDK download includes the following components:
 
 The runtime download includes the following components:
 
-* The desktop or ASP.NET Core runtime.
+* Optionally, the desktop or ASP.NET Core runtime.
 * The [.NET runtime](#clr). Provides a type system, assembly loading, a garbage collector, native interop, and other basic services.
 * [Runtime libraries](#runtime-libraries). Provides primitive data types and fundamental utilities.
 * The `dotnet` [driver](tools/index.md#driver). A CLI command that runs framework-dependent apps.


### PR DESCRIPTION
## Summary

It is clear from the introduction.md documentation file that what is included in SDK download but not clear what is included in runtime download. So I have made a new section and add some points for runtime download components in introduction.md file.

Fixes #22203