### PR TITLE
Corrected wording about record specific allowances to options pattern

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -279,7 +279,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   > dotnet-counters list
 
   Showing well-known counters for .NET (Core) version 3.1 only. Specific processes may support additional counters.
-  System.Runtime              
+  System.Runtime
       cpu-usage                          The percent of process' CPU usage relative to all of the system CPU resources [0-100]
       working-set                        Amount of working set used by the process (MB)
       gc-heap-size                       Total heap size reported by the GC (MB)
@@ -313,7 +313,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   > dotnet-counters list --runtime-version 5.0
 
   Showing well-known counters for .NET (Core) version 5.0 only. Specific processes may support additional counters.
-  System.Runtime                     
+  System.Runtime
       cpu-usage                          The percent of process' CPU usage relative to all of the system CPU resources [0-100]
       working-set                        Amount of working set used by the process (MB)
       gc-heap-size                       Total heap size reported by the GC (MB)
@@ -338,7 +338,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
       il-bytes-jitted                    Total IL bytes jitted
       methods-jitted-count               Number of methods jitted
 
-  Microsoft.AspNetCore.Hosting       
+  Microsoft.AspNetCore.Hosting
       requests-per-second   Number of requests between update intervals
       total-requests        Total number of requests
       current-requests      Current number of requests
@@ -355,7 +355,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
       connection-queue-length     Length of Kestrel Connection Queue
       request-queue-length        Length total HTTP request queue
 
-  System.Net.Http                    
+  System.Net.Http
       requests-started        Total Requests Started
       requests-started-rate   Number of Requests Started between update intervals
       requests-aborted        Total Requests Aborted

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -17,7 +17,7 @@ Options also provide a mechanism to validate configuration data. For more inform
 
 ## Bind hierarchical configuration
 
-The preferred way to read related configuration values is using the options pattern. The options pattern is possible through the <xref:Microsoft.Extensions.Options.IOptions%601> interface, where the generic type parameter `T` is constrained to `class`. The `IOptions<T>` can later be provided through dependency injection. For more information, see [Dependency injection in .NET](dependency-injection.md).
+The preferred way to read related configuration values is using the options pattern. The options pattern is possible through the <xref:Microsoft.Extensions.Options.IOptions%601> interface, where the generic type parameter `TOptions` is constrained to `class`. The `IOptions<TOptions>` can later be provided through dependency injection. For more information, see [Dependency injection in .NET](dependency-injection.md).
 
 For example, to read the following configuration values:
 
@@ -27,6 +27,7 @@ Create the following `TransientFaultHandlingOptions` class:
 
 :::code language="csharp" source="snippets/configuration/console-json/TransientFaultHandlingOptions.cs" range="5-9":::
 
+<span id="options-class"></span>
 When using the options pattern, an options class:
 
 - Must be non-abstract with a public parameterless constructor
@@ -39,9 +40,6 @@ The following code:
 
 :::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="31-38":::
 
-> [!NOTE]
-> The <xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration,System.Object)?displayProperty=nameWithType> extension method allows for any `object` to be bound and is **not** constrained to a `class`.
-
 In the preceding code, changes to the JSON configuration file after the app has started are read.
 
 [`ConfigurationBinder.Get<T>`](xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Get%2A) binds and returns the specified type. `ConfigurationBinder.Get<T>` may be more convenient than using `ConfigurationBinder.Bind`. The following code shows how to use `ConfigurationBinder.Get<T>` with the `TransientFaultHandlingOptions` class:
@@ -51,13 +49,16 @@ IConfigurationRoot configurationRoot = configuration.Build();
 
 var options =
     configurationRoot.GetSection(nameof(TransientFaultHandlingOptions))
-        .Get<TransientFaultHandlingOptions>();
+                     .Get<TransientFaultHandlingOptions>();
 
 Console.WriteLine($"TransientFaultHandlingOptions.Enabled={options.Enabled}");
 Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRetryDelay}");
 ```
 
 In the preceding code, changes to the JSON configuration file after the app has started are read.
+
+> [!IMPORTANT]
+> The <xref:Microsoft.Extensions.Configuration.ConfigurationBinder> class exposes several APIs, such as `.Bind(object instance)` and `.Get<T>()` that are ***not*** contained to `class`. When using any of the [Options interfaces](#options-interfaces), you must adhere to aforementioned [options class constraints](#options-class).
 
 An alternative approach when using the options pattern is to bind the `"TransientFaultHandlingOptions"` section and add it to the [dependency injection service container](dependency-injection.md). In the following code, `TransientFaultHandlingOptions` is added to the service container with <xref:Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure%2A> and bound to configuration:
 

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -3,7 +3,7 @@ title: Options pattern in .NET
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine
-ms.date: 12/04/2020
+ms.date: 01/04/2021
 ---
 
 # Options pattern in .NET
@@ -27,8 +27,8 @@ Create the following `TransientFaultHandlingOptions` class:
 
 An options class:
 
-- It allows for either parameterless constructors, or for constructors where all parameters have default values
-- Properties can be read-write, or read-init only
+- Must be a non-abstract class with either a public parameterless constructor, or a public constructor where all parameters have default values.
+- All bindable properties must be read-write, or init only. Fields are **not** bound.
 
 The following code:
 

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -58,7 +58,7 @@ Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRe
 In the preceding code, changes to the JSON configuration file after the app has started are read.
 
 > [!IMPORTANT]
-> The <xref:Microsoft.Extensions.Configuration.ConfigurationBinder> class exposes several APIs, such as `.Bind(object instance)` and `.Get<T>()` that are ***not*** contained to `class`. When using any of the [Options interfaces](#options-interfaces), you must adhere to aforementioned [options class constraints](#options-class).
+> The <xref:Microsoft.Extensions.Configuration.ConfigurationBinder> class exposes several APIs, such as `.Bind(object instance)` and `.Get<T>()` that are ***not*** constrained to `class`. When using any of the [Options interfaces](#options-interfaces), you must adhere to aforementioned [options class constraints](#options-class).
 
 An alternative approach when using the options pattern is to bind the `"TransientFaultHandlingOptions"` section and add it to the [dependency injection service container](dependency-injection.md). In the following code, `TransientFaultHandlingOptions` is added to the service container with <xref:Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure%2A> and bound to configuration:
 

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -3,7 +3,7 @@ title: Options pattern in .NET
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine
-ms.date: 01/04/2021
+ms.date: 01/06/2021
 ---
 
 # Options pattern in .NET
@@ -17,18 +17,20 @@ Options also provide a mechanism to validate configuration data. For more inform
 
 ## Bind hierarchical configuration
 
-The preferred way to read related configuration values is using the options pattern. For example, to read the following configuration values:
+The preferred way to read related configuration values is using the options pattern. The options pattern is possible through the <xref:Microsoft.Extensions.Options.IOptions%601> interface, where the generic type parameter `T` is constrained to `class`. The `IOptions<T>` can later be provided through dependency injection. For more information, see [Dependency injection in .NET](dependency-injection.md).
+
+For example, to read the following configuration values:
 
 :::code language="json" source="snippets/configuration/console-json/appsettings.json" range="3-6":::
 
 Create the following `TransientFaultHandlingOptions` class:
 
-:::code language="csharp" source="snippets/configuration/console-json/TransientFaultHandlingOptions.cs" range="5-6":::
+:::code language="csharp" source="snippets/configuration/console-json/TransientFaultHandlingOptions.cs" range="5-9":::
 
-An options class:
+When using the options pattern, an options class:
 
-- Must be a non-abstract class with either a public parameterless constructor, or a public constructor where all parameters have default values.
-- All bindable properties must be read-write, or init only. Fields are **not** bound.
+- Must be non-abstract with a public parameterless constructor
+- Contain public read-write properties to bind (fields are ***not*** bound)
 
 The following code:
 
@@ -36,6 +38,9 @@ The following code:
 * Displays the configuration data.
 
 :::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="31-38":::
+
+> [!NOTE]
+> The <xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration,System.Object)?displayProperty=nameWithType> extension method allows for any `object` to be bound and is **not** constrained to a `class`.
 
 In the preceding code, changes to the JSON configuration file after the app has started are read.
 

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -27,8 +27,8 @@ Create the following `TransientFaultHandlingOptions` class:
 
 An options class:
 
-* Must be non-abstract with a public parameterless constructor
-* Contain public read-write properties to bind (fields are ***not*** bound)
+- It allows for either parameterless constructors, or for constructors where all parameters have default values
+- Properties can be read-write, or read-init only
 
 The following code:
 

--- a/docs/core/extensions/snippets/configuration/console-json/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/Program.cs
@@ -30,7 +30,7 @@ namespace ConsoleJson.Example
 
                     IConfigurationRoot configurationRoot = configuration.Build();
 
-                    var options = new TransientFaultHandlingOptions();
+                    TransientFaultHandlingOptions options = new();
                     configurationRoot.GetSection(nameof(TransientFaultHandlingOptions))
                                      .Bind(options);
 

--- a/docs/core/extensions/snippets/configuration/console-json/TransientFaultHandlingOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/TransientFaultHandlingOptions.cs
@@ -2,6 +2,9 @@
 
 namespace ConsoleJson.Example
 {
-    public record TransientFaultHandlingOptions(
-        bool Enabled = false, TimeSpan AutoRetryDelay = default);
+    public class TransientFaultHandlingOptions
+    {
+        public bool Enabled { get; set; }
+        public TimeSpan AutoRetryDelay { get; set; }
+    }
 }


### PR DESCRIPTION
## Summary

Corrected wording about record specific allowances to options pattern

Fixes #22134

## Preview

✔️ [Options pattern in .NET](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/options?branch=pr-en-us-22210)