### PR TITLE
Fixed issue where wording did not match code snippets

### DIFF
--- a/docs/core/extensions/snippets/configuration/worker-service-options/WorkItem.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/WorkItem.cs
@@ -1,14 +1,16 @@
 ﻿using System;
-using WorkerServiceOptions.Example;
 
-public record WorkItem(
-    string Name, Priority Priority, bool IsCompleted = false)
+namespace WorkerServiceOptions.Example
 {
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public record WorkItem(
+        string Name, Priority Priority, bool IsCompleted = false)
+    {
+        public Guid Id { get; init; } = Guid.NewGuid();
 
-    public WorkItem MarkAsComplete() => 
-        this with { IsCompleted = true };
+        public WorkItem MarkAsComplete() =>
+            this with { IsCompleted = true };
 
-    public override string ToString() =>
-        $"Priority-{Priority} ({Id}): '{Name}'";
+        public override string ToString() =>
+            $"Priority-{Priority} ({Id}): '{Name}'";
+    }
 }


### PR DESCRIPTION
## Summary

Fixed issue where wording did not match code snippets

Fixes #22137

## Preview

✔️ [High-performance logging in .NET](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging?branch=pr-en-us-22211)