### PR TITLE
Fixed mismatch of class name in text and snippet

### DIFF
--- a/docs/csharp/language-reference/keywords/public.md
+++ b/docs/csharp/language-reference/keywords/public.md
@@ -24,7 +24,7 @@ See [Access Modifiers](../../programming-guide/classes-and-structs/access-modifi
 
 ## Example
 
-In the following example, two classes are declared, `PointTest` and `MainClass`. The public members `x` and `y` of `PointTest` are accessed directly from `MainClass`.
+In the following example, two classes are declared, `PointTest` and `Program`. The public members `x` and `y` of `PointTest` are accessed directly from `Program`.
 
 [!code-csharp[csrefKeywordsModifiers#13](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#13)]
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -405,7 +405,7 @@ namespace csrefKeywordsModifiers
         public int y;
     }
 
-    class MainClass
+    class Program
     {
         static void Main()
         {

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -405,7 +405,7 @@ namespace csrefKeywordsModifiers
         public int y;
     }
 
-    class MainClass4
+    class MainClass
     {
         static void Main()
         {


### PR DESCRIPTION
## Summary

I've changed the name of the class in the snippet to match the class name in the text.

Fixes #20773
