### PR TITLE
Fixed un-escaped characters in example

### DIFF
--- a/docs/framework/network-programming/proxy-configuration.md
+++ b/docs/framework/network-programming/proxy-configuration.md
@@ -67,7 +67,7 @@ A proxy server handles client requests for resources. A proxy can return a reque
                 bypassonlocal="True"  
         />  
         <bypasslist>  
-            <add address="[a-z]+.blueyonderairlines.com$" />  
+            <add address="[a-z]+\.blueyonderairlines\.com$" />  
         </bypasslist>  
     </defaultProxy>  
 </system.net>  


### PR DESCRIPTION
## Summary

The regular expression was missing escape characters for the dots, thus matching any character, instead of exactly a dot.

Fixes #21501
