### PR TITLE
Remove contextual TOC bit

### DIFF
--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,7 +12,7 @@
     - name: Breaking changes
       href: fx-core.md
     - name: Unavailable technologies
-      href: ../porting/net-framework-tech-unavailable.md?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
+      href: ../porting/net-framework-tech-unavailable.md
     - name: APIs that always throw
       href: unsupported-apis.md
   - name: Breaking changes by version

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2290,7 +2290,7 @@ items:
     - name: Organize projects for .NET Core
       href: ../core/porting/project-structure.md
     - name: Unavailable technologies
-      href: ../core/porting/net-framework-tech-unavailable.md
+      href: ../core/porting/net-framework-tech-unavailable.md?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
     - name: Tools
       href: ../core/porting/tools.md
     - name: Use the Windows Compatibility Pack


### PR DESCRIPTION
The contextual TOC bit needed to be moved to the other TOC that referenced the file.