### PR TITLE
Document more remarks about the diagnostics CLI tools

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -29,6 +29,9 @@ There are two ways to download and install `dotnet-counters`:
   | macOS   | [x64](https://aka.ms/dotnet-counters/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-counters/linux-x64) \| [arm](https://aka.ms/dotnet-counters/linux-arm) \| [arm64](https://aka.ms/dotnet-counters/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) \| [musl-arm64](https://aka.ms/dotnet-counters/linux-musl-arm64) |
 
+> [!NOTE]
+> To use `dotnet-counters` on an x86 app, you need a corresponding x86 version of the tool.
+
 ## Synopsis
 
 ```console
@@ -107,6 +110,12 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
   > [!NOTE]
   > Launching a .NET executable via dotnet-counters will make its input/output to be redirected and you won't be able to interact with its stdin/stdout. Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process. If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable. If you need to use stdin/stdout, you can use the `--diagnostic-port` option. See [Using diagnostic port](#using-diagnostic-port) for more information.
+
+> [!NOTE]
+> On Linux and macOS, this command expects the target application and `dotnet-counters` to share the same `TMPDIR` environment variable.
+
+> [!NOTE]
+> To collect metrics using `dotnet-counters`, it needs to be run as the same user as the user running target process or as root.
 
 ### Examples
 
@@ -218,6 +227,9 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
 > [!NOTE]
 > On Linux and macOS, this command expects the target application and `dotnet-counters` to share the same `TMPDIR` environment variable.
+
+> [!NOTE]
+> To monitor metrics using `dotnet-counters`, it needs to be run as the same user as the user running target process or as root.
 
 ### Examples
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -216,6 +216,9 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   > [!NOTE]
   > Launching a .NET executable via dotnet-counters will make its input/output to be redirected and you won't be able to interact with its stdin/stdout. Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process. If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable. If you need to use stdin/stdout, you can use the `--diagnostic-port` option. See [Using diagnostic port](#using-diagnostic-port) for more information.
 
+> [!NOTE]
+> On Linux and macOS, this command expects the target application and `dotnet-counters` to share the same `TMPDIR` environment variable.
+
 ### Examples
 
 - Monitor all counters from `System.Runtime` at a refresh interval of 3 seconds:

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -112,10 +112,10 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   > Launching a .NET executable via dotnet-counters will make its input/output to be redirected and you won't be able to interact with its stdin/stdout. Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process. If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable. If you need to use stdin/stdout, you can use the `--diagnostic-port` option. See [Using diagnostic port](#using-diagnostic-port) for more information.
 
 > [!NOTE]
-> On Linux and macOS, this command expects the target application and `dotnet-counters` to share the same `TMPDIR` environment variable.
+> On Linux and macOS, this command expects the target application and `dotnet-counters` to share the same `TMPDIR` environment variable. Otherwise, the command will time out.
 
 > [!NOTE]
-> To collect metrics using `dotnet-counters`, it needs to be run as the same user as the user running target process or as root.
+> To collect metrics using `dotnet-counters`, it needs to be run as the same user as the user running target process or as root. Otherwise, the tool will fail to establish a connection with the target process.
 
 ### Examples
 

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -32,6 +32,9 @@ There are two ways to download and install `dotnet-dump`:
   | macOS   | [x64](https://aka.ms/dotnet-dump/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-dump/linux-x64) \| [arm](https://aka.ms/dotnet-dump/linux-arm) \| [arm64](https://aka.ms/dotnet-dump/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) \| [musl-arm64](https://aka.ms/dotnet-dump/linux-musl-arm64) |
 
+> [!NOTE]
+> To use `dotnet-dump` on an x86 app, you need a corresponding x86 version of the tool.
+
 ## Synopsis
 
 ```console
@@ -107,6 +110,12 @@ dotnet-dump collect [-h|--help] [-p|--process-id] [-n|--name] [--type] [-o|--out
 - **`--diag`**
 
   Enables dump collection diagnostic logging.
+
+> [!NOTE]
+> On Linux and macOS, this command expects the target application and `dotnet-dump` to share the same `TMPDIR` environment variable.
+
+> [!NOTE]
+> To collect a dump using `dotnet-dump`, it needs to be run as the same user as the user running target process or as root.
 
 ## dotnet-dump analyze
 

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -112,10 +112,10 @@ dotnet-dump collect [-h|--help] [-p|--process-id] [-n|--name] [--type] [-o|--out
   Enables dump collection diagnostic logging.
 
 > [!NOTE]
-> On Linux and macOS, this command expects the target application and `dotnet-dump` to share the same `TMPDIR` environment variable.
+> On Linux and macOS, this command expects the target application and `dotnet-dump` to share the same `TMPDIR` environment variable. Otherwise, the command will time out.
 
 > [!NOTE]
-> To collect a dump using `dotnet-dump`, it needs to be run as the same user as the user running target process or as root.
+> To collect a dump using `dotnet-dump`, it needs to be run as the same user as the user running target process or as root. Otherwise, the tool will fail to establish a connection with the target process.
 
 ## dotnet-dump analyze
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -102,10 +102,10 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
   The name of the process to collect the GC dump from.
 
 > [!NOTE]
-> On Linux and macOS, this command expects the target application and `dotnet-gcdump` to share the same `TMPDIR` environment variable.
+> On Linux and macOS, this command expects the target application and `dotnet-gcdump` to share the same `TMPDIR` environment variable. Otherwise, the command will time out.
 
 > [!NOTE]
-> To collect a GC dump using `dotnet-gcdump`, it needs to be run as the same user as the user running target process or as root.
+> To collect a GC dump using `dotnet-gcdump`, it needs to be run as the same user as the user running target process or as root. Otherwise, the tool will fail to establish a connection with the target process.
 
 ## `dotnet-gcdump ps`
 

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -29,6 +29,9 @@ There are two ways to download and install `dotnet-gcdump`:
   | macOS   | [x64](https://aka.ms/dotnet-gcdump/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-gcdump/linux-x64) \| [arm](https://aka.ms/dotnet-gcdump/linux-arm) \| [arm64](https://aka.ms/dotnet-gcdump/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) \| [musl-arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64) |
 
+> [!NOTE]
+> To use `dotnet-gcdump` on an x86 app, you need a corresponding x86 version of the tool.
+
 ## Synopsis
 
 ```console
@@ -97,6 +100,12 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
 - **`-n|--name <name>`**
 
   The name of the process to collect the GC dump from.
+
+> [!NOTE]
+> On Linux and macOS, this command expects the target application and `dotnet-gcdump` to share the same `TMPDIR` environment variable.
+
+> [!NOTE]
+> To collect a GC dump using `dotnet-gcdump`, it needs to be run as the same user as the user running target process or as root.
 
 ## `dotnet-gcdump ps`
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -29,6 +29,9 @@ There are two ways to download and install `dotnet-trace`:
   | macOS   | [x64](https://aka.ms/dotnet-trace/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-trace/linux-x64) \| [arm](https://aka.ms/dotnet-trace/linux-arm) \| [arm64](https://aka.ms/dotnet-trace/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) \| [musl-arm64](https://aka.ms/dotnet-trace/linux-musl-arm64) |
 
+> [!NOTE]
+> To use `dotnet-trace` on an x86 app, you need a corresponding x86 version of the tool.
+
 ## Synopsis
 
 ```console
@@ -143,6 +146,9 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
 > [!NOTE]
 > On Linux and macOS, this command expects the target application and `dotnet-trace` to share the same `TMPDIR` environment variable.
+
+> [!NOTE]
+> To collect a trace using `dotnet-trace`, it needs to be run as the same user as the user running target process or as root.
 
 ## dotnet-trace convert
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -145,10 +145,10 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 > Stopping the trace may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured in the trace.
 
 > [!NOTE]
-> On Linux and macOS, this command expects the target application and `dotnet-trace` to share the same `TMPDIR` environment variable.
+> On Linux and macOS, this command expects the target application and `dotnet-trace` to share the same `TMPDIR` environment variable. Otherwise, the command will time out.
 
 > [!NOTE]
-> To collect a trace using `dotnet-trace`, it needs to be run as the same user as the user running target process or as root.
+> To collect a trace using `dotnet-trace`, it needs to be run as the same user as the user running target process or as root. Otherwise, the tool will fail to establish a connection with the target process.
 
 ## dotnet-trace convert
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -141,6 +141,9 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 > [!NOTE]
 > Stopping the trace may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured in the trace.
 
+> [!NOTE]
+> On Linux and macOS, this command expects the target application and `dotnet-trace` to share the same `TMPDIR` environment variable.
+
 ## dotnet-trace convert
 
 Converts `nettrace` traces to alternate formats for use with alternate trace analysis tools.


### PR DESCRIPTION
## Summary

Checks rest of the checkboxes from https://github.com/dotnet/diagnostics/issues/1737

- Tools targeting x86 need to be started using the x86 host.
- Tools need to share a TMPDIR environment variable value with the target application.
- Tools need run as same user as the target application to access diagnostic pipes

Part of https://github.com/dotnet/diagnostics/issues/515. 