### PR TITLE
Update the guide to target .NET 5

### DIFF
--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -17,7 +17,10 @@ This tutorial shows you how to create a custom <xref:System.Runtime.Loader.Assem
 
 ## Prerequisites
 
-- Install the [.NET Core 3.0 SDK](https://dotnet.microsoft.com/download) or a newer version.
+- Install the [.NET 5 SDK](https://dotnet.microsoft.com/download) or a newer version.
+
+> [!NOTE]
+> The sample code targets .NET 5, but all the features it uses were introduced in .NET Core 3.0 and are available in all .NET releases since then.
 
 ## Create the application
 
@@ -234,7 +237,7 @@ Now, open the *HelloPlugin.csproj* file. It should look similar to the following
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
 </Project>
@@ -282,7 +285,7 @@ This prevents the `A.PluginBase` assemblies from being copied to the output dire
 
 ## Plugin target framework recommendations
 
-Because plugin dependency loading uses the *.deps.json* file, there is a gotcha related to the plugin's target framework. Specifically, your plugins should target a runtime, such as .NET Core 3.0, instead of a version of .NET Standard. The *.deps.json* file is generated based on which framework the project targets, and since many .NET Standard-compatible packages ship reference assemblies for building against .NET Standard and implementation assemblies for specific runtimes, the *.deps.json* may not correctly see implementation assemblies, or it may grab the .NET Standard version of an assembly instead of the .NET Core version you expect.
+Because plugin dependency loading uses the *.deps.json* file, there is a gotcha related to the plugin's target framework. Specifically, your plugins should target a runtime, such as .NET 5, instead of a version of .NET Standard. The *.deps.json* file is generated based on which framework the project targets, and since many .NET Standard-compatible packages ship reference assemblies for building against .NET Standard and implementation assemblies for specific runtimes, the *.deps.json* may not correctly see implementation assemblies, or it may grab the .NET Standard version of an assembly instead of the .NET Core version you expect.
 
 ## Plugin framework references
 

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/AppWithPlugin/AppWithPlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/AppWithPlugin/AppWithPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/AppWithPlugin/Program.cs
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/AppWithPlugin/Program.cs
@@ -21,12 +21,12 @@ namespace AppWithPlugin
 
                 string[] pluginPaths = new string[]
                 {
-                    @"HelloPlugin\bin\Debug\netcoreapp3.0\HelloPlugin.dll",
-                    @"JsonPlugin\bin\Debug\netcoreapp3.0\JsonPlugin.dll",
-                    @"XcopyablePlugin\bin\Debug\netcoreapp3.0\XcopyablePlugin.dll",
-                    @"OldJsonPlugin\bin\Debug\netcoreapp2.1\OldJsonPlugin.dll",
-                    @"FrenchPlugin\bin\Debug\netcoreapp2.1\FrenchPlugin.dll",
-                    @"UVPlugin\bin\Debug\netcoreapp2.1\UVPlugin.dll",
+                    @"HelloPlugin\bin\Debug\net5\HelloPlugin.dll",
+                    @"JsonPlugin\bin\Debug\net5\JsonPlugin.dll",
+                    @"XcopyablePlugin\bin\Debug\net5\XcopyablePlugin.dll",
+                    @"OldJsonPlugin\bin\Debug\net5\OldJsonPlugin.dll",
+                    @"FrenchPlugin\bin\Debug\net5\FrenchPlugin.dll",
+                    @"UVPlugin\bin\Debug\net5\UVPlugin.dll",
                 };
 
                 IEnumerable<ICommand> commands = pluginPaths.SelectMany(pluginPath =>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/FrenchPlugin/FrenchPlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/FrenchPlugin/FrenchPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/HelloPlugin/HelloPlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/HelloPlugin/HelloPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/JsonPlugin/JsonPlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/JsonPlugin/JsonPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/OldJsonPlugin/OldJsonPlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/OldJsonPlugin/OldJsonPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/PluginBase/PluginBase.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/PluginBase/PluginBase.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/ReadMe.md
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/ReadMe.md
@@ -10,8 +10,8 @@ By using `AssemblyDependencyResolver` along with a custom `AssemblyLoadContext`,
 
 ## Build and Run
 
-1. Install .NET Core 3.0 Preview 2 or newer.
-2. Use the .NET Core SDK to build the project via `dotnet build`.
+1. Install .NET 5 or newer. The sample targets .NET 5, but support for all the features it uses was added in .NET Core 3.0.
+2. Use the .NET SDK to build the project via `dotnet build`.
    - The AppWithPlugin project does not contain any references to the plugin projects, so you need to build the solution.
 3. Go to the AppWithPlugin directory and use `dotnet run` to run the app.
     - You should see the app output a list of installed commands.

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/UVPlugin/UVPlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/UVPlugin/UVPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/XcopyablePlugin/XcopyablePlugin.csproj
+++ b/samples/snippets/core/tutorials/creating-app-with-plugin-support/csharp/XcopyablePlugin/XcopyablePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 


### PR DESCRIPTION
3.0 is out of support.

The respective sample is updated to .NET 5 in https://github.com/dotnet/samples/pull/4096.