### PR TITLE
Readd implicit package references section

### DIFF
--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -131,16 +131,18 @@ To resolve the errors, do one of the following:
 When targeting .NET Core 1.0 - 2.1 or .NET Standard 1.0 - 2.0, the .NET SDK adds implicit references to certain *metapackages*. A metapackage is a framework-based package that consists only of dependencies on other packages. Metapackages are implicitly referenced based on the target framework(s) specified in the [TargetFramework](msbuild-props.md#targetframework) or [TargetFrameworks](msbuild-props.md#targetframeworks) property of your project file.
 
 ```xml
- <PropertyGroup>
-   <TargetFramework>netcoreapp2.1</TargetFramework>
- </PropertyGroup>
- ```
+<PropertyGroup>
+  <TargetFramework>netcoreapp2.1</TargetFramework>
+</PropertyGroup>
+```
 
- ```xml
- <PropertyGroup>
-   <TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
- </PropertyGroup>
- ```
+```xml
+<PropertyGroup>
+  <TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+</PropertyGroup>
+```
+
+If needed, you can disable implicit package references using the [DisableImplicitFrameworkReferences](msbuild-props.md#disableimplicitframeworkreferences) property, and add explicit references to just the frameworks or packages you need.
 
 Recommendations:
 

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -126,6 +126,28 @@ To resolve the errors, do one of the following:
 
   If you only disable `Compile` globs, Solution Explorer in Visual Studio still shows \*.cs items as part of the project, included as `None` items. To disable the implicit `None` glob, set `EnableDefaultNoneItems` to `false` too.
 
+## Implicit package references
+
+When targeting .NET Core 1.0 - 2.1 or .NET Standard 1.0 - 2.0, the .NET SDK adds implicit references to certain *metapackages*. A metapackage is a framework-based package that consists only of dependencies on other packages. Metapackages are implicitly referenced based on the target framework(s) specified in the [TargetFramework](msbuild-props.md#targetframework) or [TargetFrameworks](msbuild-props.md#targetframeworks) property of your project file.
+
+```xml
+ <PropertyGroup>
+   <TargetFramework>netcoreapp2.1</TargetFramework>
+ </PropertyGroup>
+ ```
+
+ ```xml
+ <PropertyGroup>
+   <TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+ </PropertyGroup>
+ ```
+
+Recommendations:
+
+- When targeting .NET Framework, .NET Core 1.0 - 2.1, or .NET Standard 1.0 - 2.0, don't add an explicit reference to the `Microsoft.NETCore.App` or `NETStandard.Library` metapackages via a `<PackageReference>` item in your project file. For .NET Core 1.0 - 2.1 and .NET Standard 1.0 - 2.0 projects, these metapackages are implicitly referenced. For .NET Framework projects, if any version of `NETStandard.Library` is needed when using a .NET Standard-based NuGet package, NuGet automatically installs that version.
+- If you need a specific version of the runtime when targeting .NET Core 1.0 - 2.1, use the `<RuntimeFrameworkVersion>` property in your project (for example, `1.0.4`) instead of referencing the metapackage. For example, you might need a specific patch version of 1.0.0 LTS runtime if you're using [self-contained deployments](../deploying/index.md#publish-self-contained).
+- If you need a specific version of the `NETStandard.Library` metapackage when targeting .NET Standard 1.0 - 2.0, you can use the `<NetStandardImplicitPackageVersion>` property and set the version you need.
+
 ## Build events
 
 In SDK-style projects, use an MSBuild target named `PreBuild` or `PostBuild` and set the `BeforeTargets` property for `PreBuild` or the `AfterTargets` property for `PostBuild`.

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -128,7 +128,7 @@ To resolve the errors, do one of the following:
 
 ## Implicit package references
 
-When targeting .NET Core 1.0 - 2.1 or .NET Standard 1.0 - 2.0, the .NET SDK adds implicit references to certain *metapackages*. A metapackage is a framework-based package that consists only of dependencies on other packages. Metapackages are implicitly referenced based on the target framework(s) specified in the [TargetFramework](msbuild-props.md#targetframework) or [TargetFrameworks](msbuild-props.md#targetframeworks) property of your project file.
+When targeting .NET Core 1.0 - 2.2 or .NET Standard 1.0 - 2.0, the .NET SDK adds implicit references to certain *metapackages*. A metapackage is a framework-based package that consists only of dependencies on other packages. Metapackages are implicitly referenced based on the target framework(s) specified in the [TargetFramework](msbuild-props.md#targetframework) or [TargetFrameworks](msbuild-props.md#targetframeworks) property of your project file.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -146,8 +146,8 @@ If needed, you can disable implicit package references using the [DisableImplici
 
 Recommendations:
 
-- When targeting .NET Framework, .NET Core 1.0 - 2.1, or .NET Standard 1.0 - 2.0, don't add an explicit reference to the `Microsoft.NETCore.App` or `NETStandard.Library` metapackages via a `<PackageReference>` item in your project file. For .NET Core 1.0 - 2.1 and .NET Standard 1.0 - 2.0 projects, these metapackages are implicitly referenced. For .NET Framework projects, if any version of `NETStandard.Library` is needed when using a .NET Standard-based NuGet package, NuGet automatically installs that version.
-- If you need a specific version of the runtime when targeting .NET Core 1.0 - 2.1, use the `<RuntimeFrameworkVersion>` property in your project (for example, `1.0.4`) instead of referencing the metapackage. For example, you might need a specific patch version of 1.0.0 LTS runtime if you're using [self-contained deployments](../deploying/index.md#publish-self-contained).
+- When targeting .NET Framework, .NET Core 1.0 - 2.2, or .NET Standard 1.0 - 2.0, don't add an explicit reference to the `Microsoft.NETCore.App` or `NETStandard.Library` metapackages via a `<PackageReference>` item in your project file. For .NET Core 1.0 - 2.2 and .NET Standard 1.0 - 2.0 projects, these metapackages are implicitly referenced. For .NET Framework projects, if any version of `NETStandard.Library` is needed when using a .NET Standard-based NuGet package, NuGet automatically installs that version.
+- If you need a specific version of the runtime when targeting .NET Core 1.0 - 2.2, use the `<RuntimeFrameworkVersion>` property in your project (for example, `1.0.4`) instead of referencing the metapackage. For example, you might need a specific patch version of 1.0.0 LTS runtime if you're using [self-contained deployments](../deploying/index.md#publish-self-contained).
 - If you need a specific version of the `NETStandard.Library` metapackage when targeting .NET Standard 1.0 - 2.0, you can use the `<NetStandardImplicitPackageVersion>` property and set the version you need.
 
 ## Build events


### PR DESCRIPTION
For customers targeting older versions, we still need this info as it's linked from the product using https://aka.ms/sdkimplicitrefs. This info used to live in [csproj.md](https://github.com/dotnet/docs/pull/22277).

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/overview?branch=pr-en-us-22314#implicit-package-references).