### PR TITLE
Move stackoverflow debug tutorial under Diagnostics Tutorials

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -398,8 +398,6 @@ items:
       - name: Overview
         displayName: dumps
         href: ../core/diagnostics/dumps.md
-      - name: Debug a StackOverflow
-        href: ../core/diagnostics/debug-stackoverflow.md
       - name: Linux dumps
         href: ../core/diagnostics/debug-linux-dumps.md
       - name: SOS debugger extension
@@ -468,6 +466,8 @@ items:
         href: ../core/diagnostics/debug-highcpu.md
       - name: Debug deadlock
         href: ../core/diagnostics/debug-deadlock.md
+      - name: Debug a StackOverflow
+        href: ../core/diagnostics/debug-stackoverflow.md
   - name: Code analysis
     items:
     - name: Overview


### PR DESCRIPTION
This tutorial doc was under diagnostics > Dumps. I'm moving this to be under diagnostics > diagnostic tutorials to make it consistent with the other diagnostics tutorials we have.