### PR TITLE
fix typo

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2328.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2328.md
@@ -51,7 +51,7 @@ This rule finds [Newtonsoft.Json.JsonSerializerSettings](https://www.newtonsoft.
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.
 - You've taken one of the precautions in [How to fix violations](#how-to-fix-violations).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2330.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2330.md
@@ -44,7 +44,7 @@ This rule finds [Newtonsoft.Json.JsonSerializer](https://www.newtonsoft.com/json
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.
 - You've taken one of the precautions in [How to fix violations](#how-to-fix-violations).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2352.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2352.md
@@ -39,7 +39,7 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - The type found by this rule is never deserialized, either directly or indirectly.
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.

--- a/docs/fundamentals/code-analysis/quality-rules/ca2353.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2353.md
@@ -59,7 +59,7 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - The type found by this rule is never deserialized, either directly or indirectly.
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.

--- a/docs/fundamentals/code-analysis/quality-rules/ca2362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2362.md
@@ -41,7 +41,7 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - The type found by this rule is never deserialized, either directly or indirectly.
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5358.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5358.md
@@ -36,7 +36,7 @@ These modes are vulnerable to attacks and may cause exposure of sensitive inform
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - Cryptography experts have reviewed and approved the cipher mode's usage.
 - The referenced <xref:System.Security.Cryptography.CipherMode> isn't used for a cryptographic operation.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5360.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5360.md
@@ -61,7 +61,7 @@ Remove these dangerous methods from automatically run deserialization callbacks.
 
 ## When to suppress warnings
 
-It's safe to suppress this rule i:
+It's safe to suppress this rule if:
 
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.
 - The serialized data is tamper-proof. After serialization, cryptographically sign the serialized data. Before deserialization, validate the cryptographic signature. Protect the cryptographic key from being disclosed and design for key rotations.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5362.md
@@ -33,7 +33,7 @@ Don't serialize the class and remove the <xref:System.SerializableAttribute>. Or
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - You know the input is trusted. Consider that your application's trust boundary and data flows may change over time.
 - All code processing the deserialized data detects and handles reference cycles without going into an infinite loop or using excessive resources.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5368.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5368.md
@@ -33,7 +33,7 @@ Set the <xref:System.Web.UI.Page.ViewStateUserKey> property to a unpredictable a
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule i:
+It's safe to suppress a warning from this rule if:
 
 - The ASP.NET Web Form page does not perform sensitive operations.
 - Cross-site request forgery attacks are mitigated in a way that this rule doesn't detect. For example, if the page inherits from a master page that contains CSRF defenses.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5388.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5388.md
@@ -34,7 +34,7 @@ Set the iteration count greater than or equal with 100k before calling <xref:Sys
 
 ## When to suppress warnings
 
-It's safe to suppress warnings from this rule i:
+It's safe to suppress warnings from this rule if:
 
 - You need to use a smaller iteration count for compatibility with existing data.
 - You're sure that the iteration count is set above 100,000.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5392.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5392.md
@@ -34,7 +34,7 @@ Use <xref:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute> t
 
 ## When to suppress warnings
 
-It's safe to suppress this rule i:
+It's safe to suppress this rule if:
 
 - You're sure the loaded assembly is what you want. For example, your application runs on a trusted server and you completely trust the files.
 - The imported assembly is a commonly used system assembly, like user32.dll, and the search path strategy follows the [Known DLLs mechanism](/archive/blogs/larryosterman/what-are-known-dlls-anyway).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -41,7 +41,7 @@ Use safe values of <xref:System.Runtime.InteropServices.DllImportSearchPath> to 
 
 ## When to suppress warnings
 
-It's safe to suppress this rule i:
+It's safe to suppress this rule if:
 
 - You're sure the loaded assembly is what you want.
 - The imported assembly is a commonly used system assembly, like user32.dll, and the search path strategy follows the [Known DLLs mechanism](/archive/blogs/larryosterman/what-are-known-dlls-anyway).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5395.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5395.md
@@ -30,7 +30,7 @@ Mark the action methods with `HttpVerb` attribute.
 
 ## When to suppress warnings
 
-It's safe to suppress warnings from this rule i:
+It's safe to suppress warnings from this rule if:
 
 - You're sure that no modifying operation is taking place in the action method. Or, it's not an action method at all.
 - Solutions other than using antiforgery token attributes are adopted to mitigate CSRF vulnerabilities. For more information, see [Prevent Cross-Site Request Forgery (XSRF/CSRF) attacks in ASP.NET Core](/aspnet/core/security/anti-request-forgery).


### PR DESCRIPTION
## Summary

Just replaced `rule i:` to `rule if:`.
I guess those are typos.