### PR TITLE
[DRAFT] Update completion scripts, add links to upstream

### DIFF
--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -54,7 +54,7 @@ Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
  }
  ```
 
-Latest version of this script lives at https://github.com/dotnet/toolset/blob/master/scripts/register-completions.ps1.
+Latest version of this script lives at <https://github.com/dotnet/toolset/blob/master/scripts/register-completions.ps1>.
 
 ## bash
 
@@ -79,7 +79,7 @@ _dotnet_bash_complete()
 complete -f -F _dotnet_bash_complete dotnet
 ```
 
-Latest version of this script lives at https://github.com/dotnet/toolset/blob/master/scripts/register-completions.bash.
+Latest version of this script lives at <https://github.com/dotnet/toolset/blob/master/scripts/register-completions.bash>.
 
 ## zsh
 
@@ -106,4 +106,4 @@ _dotnet_zsh_complete()
 compdef _dotnet_zsh_complete dotnet
 ```
 
-Latest version of this script lives at https://github.com/dotnet/toolset/blob/master/scripts/register-completions.zsh.
+Latest version of this script lives at <https://github.com/dotnet/toolset/blob/master/scripts/register-completions.zsh>.

--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -52,7 +52,9 @@ Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
          }
  }
-```
+ ```
+
+Latest version of this script lives at https://github.com/dotnet/toolset/blob/master/scripts/register-completions.ps1.
 
 ## bash
 
@@ -77,6 +79,8 @@ _dotnet_bash_complete()
 complete -f -F _dotnet_bash_complete dotnet
 ```
 
+Latest version of this script lives at https://github.com/dotnet/toolset/blob/master/scripts/register-completions.bash.
+
 ## zsh
 
 To add tab completion to your **zsh** shell for the .NET CLI, add the following code to your `.zshrc` file:
@@ -84,12 +88,22 @@ To add tab completion to your **zsh** shell for the .NET CLI, add the following 
 ```zsh
 # zsh parameter completion for the dotnet CLI
 
-_dotnet_zsh_complete()
+_dotnet_zsh_complete() 
 {
   local completions=("$(dotnet complete "$words")")
 
-  reply=( "${(ps:\n:)completions}" )
+  # If the completion list is empty, just continue with filename selection
+  if [ -z "$completions" ]
+  then
+    _arguments '*::arguments: _normal'
+    return
+  fi
+
+  # This is not a variable assigment, don't remove spaces!
+  _values = "${(ps:\n:)completions}"
 }
 
-compctl -K _dotnet_zsh_complete dotnet
+compdef _dotnet_zsh_complete dotnet
 ```
+
+Latest version of this script lives at https://github.com/dotnet/toolset/blob/master/scripts/register-completions.zsh.


### PR DESCRIPTION
## Summary

Hereby, I'd like to draw you attention to the problem at hands.

Linked "upstream" scripts' repository[1] is already deprecated. New
directory's location is at dotnet/sdk[2].  But scripts were
de-synchronized after move: new commit to the deprecated toolset repo
added features and fixed bugs.

I wonder, why repository wasn't archived after move, and/or automated
to apply patched from the dotnet/sdk.  Currently, situation requires
cross-repo coordinated effort to
 * Merge changes between toolset and sdk;
 * Archive deprecated repo, to avoid such caveats in future.
 * Either
   - add a comment to completion scripts, kinda like
     "Whenever changing this script, change docs there as well",
   - or remove sources of scripts from documentation completely,
     and only leave links.

[1]: https://github.com/dotnet/toolset
[2]: https://github.com/dotnet/sdk/tree/master/scripts