### PR TITLE
Add breaking change for TableLayoutSettings

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -1,0 +1,15 @@
+---
+title: Breaking changes in .NET 6.0
+description: Navigate to the breaking changes in .NET 6.0.
+ms.date: 01/18/2021
+---
+# Breaking changes in .NET 6.0
+
+If you're migrating an app to .NET 6.0, the breaking changes listed here might affect you. Changes are grouped by technology area, such as ASP.NET Core or Windows Forms.
+
+> [!NOTE]
+> This article is a work-in-progress. It's not a complete list of breaking changes in .NET 6.0.
+
+## Windows Forms
+
+- [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -18,6 +18,14 @@
   - name: Breaking changes by version
     expanded: true
     items:
+    - name: .NET 6.0
+      items:
+      - name: Overview
+        href: 6.0.md
+      - name: Windows Forms
+        items:
+        - name: TableLayoutSettings properties throw InvalidEnumArgumentException
+          href: tablelayoutsettings-apis-throw-invalidenumargumentexception.md
     - name: .NET 5.0
       items:
       - name: Overview
@@ -551,6 +559,10 @@
         href: visualbasic.md
     - name: Windows Forms
       items:
+      - name: .NET 6.0
+        items:
+        - name: TableLayoutSettings properties throw InvalidEnumArgumentException
+          href: tablelayoutsettings-apis-throw-invalidenumargumentexception.md
       - name: .NET 5.0
         items:
         - name: OutputType set to WinExe

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -25,7 +25,7 @@
       - name: Windows Forms
         items:
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
-          href: tablelayoutsettings-apis-throw-invalidenumargumentexception.md
+          href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
     - name: .NET 5.0
       items:
       - name: Overview
@@ -562,7 +562,7 @@
       - name: .NET 6.0
         items:
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
-          href: tablelayoutsettings-apis-throw-invalidenumargumentexception.md
+          href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
       - name: .NET 5.0
         items:
         - name: OutputType set to WinExe

--- a/docs/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentexception.md
@@ -1,6 +1,6 @@
 ---
 title: "Breaking change: WinForms methods now throw ArgumentException"
-description: Learn about the breaking change in .NET 5.0 where sWindows Forms methods now throw an ArgumentException for invalid arguments.
+description: Learn about the breaking change in .NET 5.0 where some Windows Forms methods now throw an ArgumentException for invalid arguments.
 ms.date: 07/18/2020
 ---
 # WinForms methods now throw ArgumentException

--- a/docs/core/compatibility/windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
@@ -22,7 +22,7 @@ Throwing <xref:System.ComponentModel.InvalidEnumArgumentException> is in line wi
 ## Recommended action
 
 - Update the code to prevent assigning incorrect values.
-- If necessary, handle an <xref:System.InvalidEnumArgumentException> when accessing these APIs.
+- If necessary, handle an <xref:System.ComponentModel.InvalidEnumArgumentException> when accessing these APIs.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
@@ -1,0 +1,47 @@
+---
+title: "Breaking change: Some TableLayoutSettings properties throw InvalidEnumArgumentException"
+description: Learn about the breaking change in .NET 6.0 where some TableLayoutSettings APIs now throw an InvalidEnumArgumentException for invalid arguments.
+ms.date: 01/18/2021
+---
+# Selected TableLayoutSettings properties throw InvalidEnumArgumentException
+
+Selected <xref:System.Windows.Forms.TableLayoutSettings> properties now throw an <xref:System.ComponentModel.InvalidEnumArgumentException> if you attempt to assign an incorrect value.
+
+## Change description
+
+In previous .NET versions, these properties throw an <xref:System.ArgumentOutOfRangeException> if you attempt to assign an incorrect value. Starting in .NET 6.0, these properties throw an <xref:System.ComponentModel.InvalidEnumArgumentException> in such cases.
+
+## Reason for change
+
+Throwing <xref:System.ComponentModel.InvalidEnumArgumentException> is in line with the existing Windows Forms API in similar situations. Throwing this exception also provides developers with a better debug experience.
+
+## Version introduced
+
+.NET 6.0
+
+## Recommended action
+
+- Update the code to prevent assigning incorrect values.
+- If necessary, handle an <xref:System.InvalidEnumArgumentException> when accessing these APIs.
+
+## Affected APIs
+
+The following table lists the affected properties:
+
+| Property | Version changed |
+|-|-|-|-|
+| <xref:System.Windows.Forms.TableLayoutPanel.CellBorderStyle?displayProperty=fullName> | Preview 1 |
+| <xref:System.Windows.Forms.TableLayoutPanel.GrowStyle?displayProperty=fullName> | Preview 1 |
+
+<!--
+
+### Affected APIs
+
+- `P:System.Windows.Forms.TableLayoutPanel.CellBorderStyle`
+- `P:System.Windows.Forms.TableLayoutPanel.GrowStyle`
+
+### Category
+
+Windows Forms
+
+-->


### PR DESCRIPTION
Contributes to #21239.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception?branch=pr-en-us-22382).