### PR TITLE
CS0216 - Equality operators instead of boolean

### DIFF
--- a/docs/csharp/misc/cs0216.md
+++ b/docs/csharp/misc/cs0216.md
@@ -14,13 +14,13 @@ The operator 'operator' requires a matching operator 'missing_operator' to also 
   
  A user-defined [==](../language-reference/operators/equality-operators#equality-operator-) operator requires a user-defined [!=](../language-reference/operators/inequality-operators#inequality-operator-) operator, and vice versa.  
  The same applies also to a user-defined [true](../language-reference/operators/true-false-operators.md) operator and a user-defined [false](../language-reference/operators/true-false-operators.md) operator.  
-   
+  
  The following sample generates CS0216:  
   
 ```csharp  
 // CS0216.cs  
 class MyClass  
-{
+{  
    public static bool operator == (MyClass MyIntLeft, MyClass MyIntRight)   // CS0216  
    {  
       return MyIntLeft == MyIntRight;  
@@ -34,16 +34,16 @@ class MyClass
    }  
    */  
   
-   public override bool Equals (object obj)
-   {
-      return base.Equals (obj);
-   }
-
-   public override int GetHashCode()
-   {
-      return base.GetHashCode();
-   }
-
+   public override bool Equals (object obj)  
+   {  
+      return base.Equals (obj);  
+   }  
+  
+   public override int GetHashCode()  
+   {  
+      return base.GetHashCode();  
+   }  
+  
    public static void Main()  
    {  
    }  

--- a/docs/csharp/misc/cs0216.md
+++ b/docs/csharp/misc/cs0216.md
@@ -12,27 +12,38 @@ ms.assetid: afb3dd29-3eff-4b62-8267-eb726c2bcee4
 
 The operator 'operator' requires a matching operator 'missing_operator' to also be defined  
   
- A user-defined [true](../language-reference/operators/true-false-operators.md) operator requires a user-defined [false](../language-reference/operators/true-false-operators.md) operator, and vice versa.
-  
+ A user-defined [==](../language-reference/operators/equality-operators#equality-operator-) operator requires a user-defined [!=](../language-reference/operators/inequality-operators#inequality-operator-) operator, and vice versa.  
+ The same applies also to a user-defined [true](../language-reference/operators/true-false-operators.md) operator and a user-defined [false](../language-reference/operators/true-false-operators.md) operator.  
+   
  The following sample generates CS0216:  
   
 ```csharp  
 // CS0216.cs  
 class MyClass  
-{  
-   public static bool operator true (MyClass MyInt)   // CS0216  
+{
+   public static bool operator == (MyClass MyIntLeft, MyClass MyIntRight)   // CS0216  
    {  
-      return true;  
+      return MyIntLeft == MyIntRight;  
    }  
   
    // to resolve, uncomment the following operator definition  
    /*  
-   public static bool operator false (MyClass MyInt)  
+   public static bool operator != (MyClass MyIntLeft, MyClass MyIntRight)  
    {  
-      return true;  
+      return MyIntLeft != MyIntRight;  
    }  
    */  
   
+   public override bool Equals (object obj)
+   {
+      return base.Equals (obj);
+   }
+
+   public override int GetHashCode()
+   {
+      return base.GetHashCode();
+   }
+
    public static void Main()  
    {  
    }  


### PR DESCRIPTION
This pull request fixes #21986 

It delivers the overloaded `==` and `!=` operators as an example of *CS0216* error.
This change is done due to equality operators being more commonly used, so it's considered easier to understand having them as an example.

---

Changes done in this PR:
* Implements the basic example of overloaded equality operators `==` and `!=`
This implementation adds these operators returning boolean result of object's basic comparison.
**NOTE:** `Equals()` and `GetHashCode()` methods are also implemented (basic implementation) to avoid *CS0660* and *CS0661* warnings when user/developer will use the code as-is.
* Modifies the description so it now says mainly about the equality operators, **but** mentions also the boolean operators used before.


