### PR TITLE
NotifyIcon.Text limit increase

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes in .NET 6.0
 description: Navigate to the breaking changes in .NET 6.0.
-ms.date: 01/18/2021
+ms.date: 01/19/2021
 ---
 # Breaking changes in .NET 6.0
 
@@ -13,3 +13,4 @@ If you're migrating an app to .NET 6.0, the breaking changes listed here might a
 ## Windows Forms
 
 - [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md)
+- [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -24,6 +24,8 @@
         href: 6.0.md
       - name: Windows Forms
         items:
+        - name: NotifyIcon.Text maximum text length increased
+          href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
     - name: .NET 5.0
@@ -560,6 +562,8 @@
       items:
       - name: .NET 6.0
         items:
+        - name: NotifyIcon.Text maximum text length increased
+          href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
       - name: .NET 5.0

--- a/docs/core/compatibility/windows-forms/6.0/notifyicon-text-max-text-length-increased.md
+++ b/docs/core/compatibility/windows-forms/6.0/notifyicon-text-max-text-length-increased.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: NotifyIcon.Text maximum text length increased"
+description: Learn about the breaking change in .NET 6.0 where some the maximum text length for the NotifyIcon.Text property increased.
+ms.date: 01/19/2021
+---
+# NotifyIcon.Text maximum text length increased
+
+The maximum text length allowed for the <xref:System.Windows.Forms.NotifyIcon.Text?displayProperty=nameWithType> property increased from 63 to 127.
+
+## Change description
+
+In previous .NET versions, the maximum text length allowed for the <xref:System.Windows.Forms.NotifyIcon.Text?displayProperty=nameWithType> property is 63 characters. Starting in .NET 6.0, the maximum allowed text length is 127 characters. In any version, an <xref:System.ArgumentException> is thrown when you attempt to set a value that's longer than the limit.
+
+## Reason for change
+
+The maximum allowed text length was increased to be in line with the [underlying Windows API](/windows/win32/api/shellapi/ns-shellapi-notifyicondataw#nif_showtip-0x00000080). The Windows API was updated in Windows 2000, but due to compatibility reasons, the size limit for this property wasn't updated in .NET Framework.
+
+## Version introduced
+
+.NET 6.0 Preview 1
+
+## Recommended action
+
+Review your code and relax any existing guard conditions, if necessary.
+
+## Affected APIs
+
+<xref:System.Windows.Forms.NotifyIcon.Text?displayProperty=fullName>
+
+<!--
+
+### Affected APIs
+
+- `P:System.Windows.Forms.NotifyIcon.Text`
+
+### Category
+
+Windows Forms
+
+-->


### PR DESCRIPTION
Fixes #22018.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/6.0/notifyicon-text-max-text-length-increased?branch=pr-en-us-22417).