### PR TITLE
Add breaking change for TreeNodeCollection.Item

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -14,3 +14,4 @@ If you're migrating an app to .NET 6.0, the breaking changes listed here might a
 
 - [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md)
 - [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md)
+- [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -28,6 +28,8 @@
           href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
+        - name: TreeNodeCollection.Item throws exception if node is assigned elsewhere
+          href: windows-forms/6.0/treenodecollection-item-throws-argumentexception.md
     - name: .NET 5.0
       items:
       - name: Overview
@@ -566,6 +568,8 @@
           href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
+        - name: TreeNodeCollection.Item throws exception if node is assigned elsewhere
+          href: windows-forms/6.0/treenodecollection-item-throws-argumentexception.md
       - name: .NET 5.0
         items:
         - name: OutputType set to WinExe

--- a/docs/core/compatibility/windows-forms/6.0/treenodecollection-item-throws-argumentexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/treenodecollection-item-throws-argumentexception.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: TreeNodeCollection.Item(Int32) throws ArgumentException for in-use node"
+description: Learn about the breaking change in .NET 6.0 where TreeNodeCollection.Item(Int32) now throws an ArgumentException if the node being assigned is already assigned to a TreeView.
+ms.date: 01/19/2021
+---
+# TreeNodeCollection.Item throws exception if node is assigned elsewhere
+
+<xref:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)?displayProperty=nameWithType> throws an <xref:System.ArgumentException> if the node being assigned is already bound to another <xref:System.Windows.Forms.TreeView> or to this <xref:System.Windows.Forms.TreeView> at a different index.
+
+## Change description
+
+In previous .NET versions, you can assign a tree node to a collection even if it's already bound to a <xref:System.Windows.Forms.TreeView>. This can lead to duplicated nodes. Starting in .NET 6.0, <xref:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)?displayProperty=nameWithType> throws an <xref:System.ArgumentException> if the node being assigned is already bound to another <xref:System.Windows.Forms.TreeView> or to this <xref:System.Windows.Forms.TreeView> at a different index.
+
+## Reason for change
+
+Validating the input parameter is consistent with the behavior of other `TreeNodeCollection` APIs.
+
+## Version introduced
+
+.NET 6.0 Preview 1
+
+## Recommended action
+
+Make sure to unbind a `TreeNode` before assigning it to the collection.
+
+## Affected APIs
+
+<xref:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)?displayProperty=fullName>
+
+<!--
+
+### Affected APIs
+
+- `P:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)`
+
+### Category
+
+Windows Forms
+
+-->


### PR DESCRIPTION
Fixes #22020.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/6.0/treenodecollection-item-throws-argumentexception?branch=pr-en-us-22418).