### PR TITLE
Redirect csharp-6.yml

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2701,6 +2701,10 @@
             "redirect_url": "/dotnet/csharp/tutorials/default-interface-methods-versions"
         },
         {
+            "source_path": "docs/csharp/tutorials/exploration/csharp-6.yml",
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-7"
+        },
+        {
             "source_path": "docs/csharp/tutorials/exploration/csharp-7.yml",
             "redirect_url": "/dotnet/csharp/whats-new/csharp-7"
         },


### PR DESCRIPTION
Follow-up to #21892, which deleted docs/csharp/tutorials/exploration/csharp-6.yml but didn't redirect.
