### PR TITLE
Recategorize ms.topic for standard/basetypes

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -204,7 +204,8 @@
         "docs/framework/additional-apis/**/**.md": "managed-reference",
         "docs/framework/unmanaged-api/**/**.md": "reference",
         "docs/fsharp/language-reference/**/**.md": "language-reference",
-        "docs/standard/**/*how-to*.md": "how-to"
+        "docs/standard/**/*how-to*.md": "how-to",
+        "docs/standard/base-types/*.md": "how-to"
       },
       "dev_langs": {
         "docs/fsharp/**/**.md": ["fsharp"],

--- a/docs/standard/base-types/basic-string-operations.md
+++ b/docs/standard/base-types/basic-string-operations.md
@@ -2,6 +2,7 @@
 title: Basic String Operations in .NET
 description: Learn about the basic operations that you can perform on strings.
 ms.date: "03/30/2017"
+ms.topic: conceptual
 helpviewer_keywords:
   - "strings [.NET], basic string operations"
   - "custom strings"

--- a/docs/standard/base-types/best-practices-display-data.md
+++ b/docs/standard/base-types/best-practices-display-data.md
@@ -2,6 +2,7 @@
 title: Best practices for displaying and persisting formatted data in .NET
 description: Learn how to display and persist numeric and date data effectively in .NET applications.
 ms.date: 05/01/2019
+ms.topic: conceptual
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/best-practices-strings.md
+++ b/docs/standard/base-types/best-practices-strings.md
@@ -2,6 +2,7 @@
 title: "Best Practices for Comparing Strings in .NET"
 description: Learn how to compare strings effectively in .NET applications.
 ms.date: "05/01/2019"
+ms.topic: conceptual
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/best-practices.md
+++ b/docs/standard/base-types/best-practices.md
@@ -2,6 +2,7 @@
 title: Best Practices for Regular Expressions in .NET
 description: Learn how to create efficient, effective regular expressions in .NET.
 ms.date: "06/30/2020"
+ms.topic: conceptual
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/character-encoding-introduction.md
+++ b/docs/standard/base-types/character-encoding-introduction.md
@@ -2,6 +2,7 @@
 title: Introduction to character encoding in .NET
 description: Learn about character encoding and decoding in .NET.
 ms.date: 03/09/2020
+ms.topic: conceptual
 no-loc: [Rune, char, string]
 dev_langs:
   - "csharp"

--- a/docs/standard/base-types/character-escapes-in-regular-expressions.md
+++ b/docs/standard/base-types/character-escapes-in-regular-expressions.md
@@ -2,6 +2,7 @@
 title: Character Escapes in .NET Regular Expressions
 description: Learn about special characters and escaped characters in .NET regular expressions.
 ms.date: "03/30/2017"
+ms.topic: conceptual
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/choosing-between-anonymous-and-tuple.md
+++ b/docs/standard/base-types/choosing-between-anonymous-and-tuple.md
@@ -3,6 +3,7 @@ title: Choosing between anonymous and tuple types
 description: Learn when it's appropriate to choose between anonymous types, and tuple type.
 author: IEvangelist
 ms.author: dapine
+ms.topic: conceptual
 ms.date: 07/01/2020
 ---
 # Choosing between anonymous and tuple types

--- a/docs/standard/base-types/common-type-system.md
+++ b/docs/standard/base-types/common-type-system.md
@@ -2,6 +2,7 @@
 title: Common Type System
 description: Explore the type system in .NET. Read about types in .NET (value types or reference types), type definition, type members, and type member characteristics.
 ms.date: "03/30/2017"
+ms.topic: conceptual
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/comparing.md
+++ b/docs/standard/base-types/comparing.md
@@ -2,6 +2,7 @@
 title: "Comparing Strings in .NET"
 description: Read about methods to compare strings in .NET. Learn about the Compare, CompareOrdinal, CompareTo, StartsWith, EndsWith, Equals, IndexOf, & LastIndexOf methods.
 ms.date: "03/30/2017"
+ms.topic: conceptual
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/compilation-and-reuse-in-regular-expressions.md
+++ b/docs/standard/base-types/compilation-and-reuse-in-regular-expressions.md
@@ -1,5 +1,7 @@
 ---
 title: "Compilation and Reuse in Regular Expressions"
+description: "Learn about compilation and reuse in Regular Expressions."
+ms.topic: conceptual
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "parsing text with regular expressions, compilation"

--- a/docs/standard/base-types/composite-formatting.md
+++ b/docs/standard/base-types/composite-formatting.md
@@ -2,6 +2,7 @@
 title: "Composite formatting"
 description: Learn about .NET composite formatting, which takes as input a list of objects and a composite format string, containing fixed text with indexed placeholders.
 ms.date: "10/26/2018"
+ms.topic: conceptual
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/conversion-tables.md
+++ b/docs/standard/base-types/conversion-tables.md
@@ -1,6 +1,7 @@
 ---
 title: "Type Conversion Tables in .NET"
 ms.date: "03/30/2017"
+ms.topic: reference
 helpviewer_keywords: 
   - "widening conversions"
   - "narrowing conversions"

--- a/docs/standard/base-types/custom-numeric-format-strings.md
+++ b/docs/standard/base-types/custom-numeric-format-strings.md
@@ -2,6 +2,7 @@
 title: "Custom numeric format strings"
 description: Learn how to create a custom numeric format string to format numeric data in .NET. A custom numeric format string has one or more custom numeric specifiers.
 ms.date: "06/25/2018"
+ms.topic: reference
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/custom-timespan-format-strings.md
+++ b/docs/standard/base-types/custom-timespan-format-strings.md
@@ -2,6 +2,7 @@
 title: "Custom TimeSpan format strings"
 description: Understand custom TimeSpan format strings in .NET. A custom format string contains one or more TimeSpan format specifiers & any number of literal characters.
 ms.date: "03/30/2017"
+ms.topic: reference
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/details-of-regular-expression-behavior.md
+++ b/docs/standard/base-types/details-of-regular-expression-behavior.md
@@ -1,6 +1,7 @@
 ---
 title: Regular Expression behavior
 ms.date: "03/30/2017"
+ms.topic: conceptual
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/miscellaneous-constructs-in-regular-expressions.md
+++ b/docs/standard/base-types/miscellaneous-constructs-in-regular-expressions.md
@@ -1,6 +1,7 @@
 ---
 title: "Miscellaneous Constructs in Regular Expressions"
 ms.date: "03/30/2017"
+ms.topic: conceptual
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/parsing-strings.md
+++ b/docs/standard/base-types/parsing-strings.md
@@ -2,6 +2,7 @@
 title: "Convert strings to types"
 description: Understand string parsing in .NET. Parsing converts a string representing a .NET base type into that base type. Parsing is the reverse operation to formatting.
 ms.date: "03/30/2017"
+ms.topic: conceptual
 helpviewer_keywords:
   - "parsing strings, about parsing strings"
   - "IFormatProvider interface, parsing strings"

--- a/docs/standard/base-types/quantifiers-in-regular-expressions.md
+++ b/docs/standard/base-types/quantifiers-in-regular-expressions.md
@@ -2,6 +2,7 @@
 title: "Quantifiers in Regular Expressions"
 description: Learn about regular expression quantifiers, which specify how many instances of a character, group, or character class must be present in the input to match.
 ms.date: "03/30/2017"
+ms.topic: conceptual
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/regular-expression-language-quick-reference.md
+++ b/docs/standard/base-types/regular-expression-language-quick-reference.md
@@ -2,6 +2,7 @@
 title: "Regular Expression Language - Quick Reference"
 description: In this quick reference, learn to use regular expression patterns to match input text. A pattern has one or more character literals, operators, or constructs.
 ms.date: "03/30/2017"
+ms.topic: reference
 f1_keywords:
   - "VS.RegularExpressionBuilder"
 helpviewer_keywords:

--- a/docs/standard/base-types/regular-expressions.md
+++ b/docs/standard/base-types/regular-expressions.md
@@ -1,6 +1,7 @@
 ---
 title: ".NET Regular Expressions"
 description: Use regular expressions to find specific character patterns, validate text, work with text substrings, & add extracted strings to a collection in .NET.
+ms.topic: conceptual
 ms.date: "06/30/2020"
 dev_langs: 
   - "csharp"

--- a/docs/standard/base-types/standard-date-and-time-format-strings.md
+++ b/docs/standard/base-types/standard-date-and-time-format-strings.md
@@ -2,6 +2,7 @@
 title: "Standard date and time format strings"
 description: Learn how to use a standard date and time format string to define the text representation of a date and time value in .NET.
 ms.date: 12/07/2020
+ms.topic: reference
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/standard-date-and-time-format-strings.md
+++ b/docs/standard/base-types/standard-date-and-time-format-strings.md
@@ -2,7 +2,6 @@
 title: "Standard date and time format strings"
 description: Learn how to use a standard date and time format string to define the text representation of a date and time value in .NET.
 ms.date: 12/07/2020
-ms.topic: reference
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -2,6 +2,7 @@
 title: "Standard numeric format strings"
 description: In this article, learn to use standard numeric format strings to format common numeric types into text representations in .NET.
 ms.date: "06/10/2018"
+ms.topic: reference
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/standard-timespan-format-strings.md
+++ b/docs/standard/base-types/standard-timespan-format-strings.md
@@ -2,6 +2,7 @@
 title: "Standard TimeSpan format strings"
 description: Review standard TimeSpan format strings, which use a single format specifier to define the text representation of a TimeSpan value in .NET.
 ms.date: "03/30/2017"
+ms.topic: reference
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -1,6 +1,7 @@
 ---
 title: Behavior changes when comparing strings on .NET 5+
 description: Learn about string-comparison behavior changes in .NET 5 and later versions on Windows.
+ms.topic: conceptual
 ms.date: 12/07/2020
 ---
 # Behavior changes when comparing strings on .NET 5+

--- a/docs/standard/base-types/substitutions-in-regular-expressions.md
+++ b/docs/standard/base-types/substitutions-in-regular-expressions.md
@@ -1,6 +1,7 @@
 ---
 title: "Substitutions in Regular Expressions"
 description: Make substitutions to replace matched text using regular expressions in .NET. Substitutions are language elements recognized only within replacement patterns.
+ms.topic: conceptual
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/docs/standard/base-types/the-regular-expression-object-model.md
+++ b/docs/standard/base-types/the-regular-expression-object-model.md
@@ -1,6 +1,7 @@
 ---
 title: "The Regular Expression Object Model"
 description: Review the regular expression object model in .NET. Work with the regular expression engine, & objects & collections related to matching, grouping, & capturing.
+ms.topic: conceptual
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/docs/standard/base-types/thread-safety-in-regular-expressions.md
+++ b/docs/standard/base-types/thread-safety-in-regular-expressions.md
@@ -1,6 +1,7 @@
 ---
 title: "Thread Safety in Regular Expressions"
 ms.date: "03/30/2017"
+ms.topic: conceptual
 helpviewer_keywords: 
   - ".NET regular expressions, threads"
   - "regular expressions, threads"

--- a/docs/standard/base-types/type-conversion.md
+++ b/docs/standard/base-types/type-conversion.md
@@ -1,6 +1,7 @@
 ---
 title: "Type Conversion in .NET"
 description: Read about type conversion in .NET, which creates a value in a new type that's equivalent to the old type's value, but may not keep the original's identity.
+ms.topic: conceptual
 ms.date: 03/30/2017
 dev_langs: 
   - "csharp"


### PR DESCRIPTION
Content performance project for Q3

Recategorizing default from for standard/base-types folder from conceptual to how-to, overriding non-how-to docs at file level.