### PR TITLE
Move telemetry doc to the SDK section

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -178,6 +178,8 @@ items:
     - name: Overview
       displayName: '.net sdk,software development kit,software dev kit,tool'
       href: ../core/sdk.md
+    - name: Telemetry
+      href: ../core/tools/telemetry.md      
     - name: Error messages
       items:
       - name: NETSDK1005 and NETSDK1047
@@ -293,8 +295,6 @@ items:
           href: ../core/tools/dotnet-remove-package.md
     - name: global.json overview
       href: ../core/tools/global-json.md
-    - name: Telemetry
-      href: ../core/tools/telemetry.md
     - name: Elevated access
       href: ../core/tools/elevated-access.md
     - name: Enable Tab completion


### PR DESCRIPTION
Given that we now have a SDK and a CLI section, I'm thinking we should have the telemetry doc under SDK instead of CLI


