### PR TITLE
Do not capitalize keyword

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -26,7 +26,7 @@ Not all access modifiers are valid for all types or members in all contexts. In 
 
 ## Class and struct accessibility  
 
-Classes and structs declared directly within a namespace (in other words, that aren't nested within other classes or structs) can be either `public` or `internal`. `Internal` is the default if no access modifier is specified.  
+Classes and structs declared directly within a namespace (in other words, that aren't nested within other classes or structs) can be either `public` or `internal`. `internal` is the default if no access modifier is specified.
 
 Struct members, including nested classes and structs, can be declared `public`, `internal`, or `private`. Class members, including nested classes and structs, can be `public`, `protected internal`, `protected`, `internal`, `private protected`, or `private`. Class and struct members,  including nested classes and structs, have `private` access by default. Private nested types aren't accessible from outside the containing type.
 


### PR DESCRIPTION
## Summary

Do not capitalize keyword. `Internal` -> `internal`
