### PR TITLE
dotnet-install scripts: added new --os option, deprecated --runtime-id

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -151,9 +151,15 @@ The install scripts do not update the registry on Windows. They just download th
   - `aspnetcore` - the `Microsoft.AspNetCore.App` shared runtime.
   - `windowsdesktop` - the `Microsoft.WindowsDesktop.App` shared runtime.
 
-- **`--runtime-id <RID>`**
+- **`--runtime-id <RID>` [Deprecated]**
 
-  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS.)
+  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS and for versions earlier than .Net Core 2.1.)
+
+  **`--os <OPERATING_SYSTEM>`**
+
+  Specifies the operating system for which the tools are being installed (Valid for .Net Core 2.1 and above.). Possible values are: `osx`, `linux`, `linux-musl`, `freebsd`, `rhel.6`. 
+  
+  Specifying this option should only be necessary when running the script from an uncommon Unix based operating system and the script fails to determine for which of the supported operating systems to install the tools.
 
 - **`-SharedRuntime|--shared-runtime`**
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -153,13 +153,13 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`--runtime-id <RID>` [Deprecated]**
 
-  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS and for versions earlier than .Net Core 2.1.)
+  Specifies the [runtime identifier](../rid-catalog.md) for which the tools are being installed. Use `linux-x64` for portable Linux. (Only valid for Linux/macOS and for versions earlier than .NET Core 2.1.)
 
   **`--os <OPERATING_SYSTEM>`**
 
-  Specifies the operating system for which the tools are being installed (Valid for .Net Core 2.1 and above.). Possible values are: `osx`, `linux`, `linux-musl`, `freebsd`, `rhel.6`.
+  Specifies the operating system for which the tools are being installed. Possible values are: `osx`, `linux`, `linux-musl`, `freebsd`, `rhel.6`. (Valid for .NET Core 2.1 and later.)
 
-  Specifying this option should only be necessary when running the script from an uncommon Unix based operating system and the script fails to determine for which of the supported operating systems to install the tools.
+  The parameter is optional and should only be used when it's required to override the operating system that is detected by the script.
 
 - **`-SharedRuntime|--shared-runtime`**
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -157,8 +157,8 @@ The install scripts do not update the registry on Windows. They just download th
 
   **`--os <OPERATING_SYSTEM>`**
 
-  Specifies the operating system for which the tools are being installed (Valid for .Net Core 2.1 and above.). Possible values are: `osx`, `linux`, `linux-musl`, `freebsd`, `rhel.6`. 
-  
+  Specifies the operating system for which the tools are being installed (Valid for .Net Core 2.1 and above.). Possible values are: `osx`, `linux`, `linux-musl`, `freebsd`, `rhel.6`.
+
   Specifying this option should only be necessary when running the script from an uncommon Unix based operating system and the script fails to determine for which of the supported operating systems to install the tools.
 
 - **`-SharedRuntime|--shared-runtime`**


### PR DESCRIPTION
We have recently updated dotnet-install scripts, and the docs need to be updated to accommodate the changes.

- The option `--runtime-id` is deprecated and should only be used for installing .Net Core versions below 2.1.
- A new `--os` options was added to be used instead of `--runtime-id` for installing .Net Core versions 2.1 and above.
