### PR TITLE
Unexpected error caused by additional argument.

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/object-oriented-programming.md
+++ b/docs/csharp/tutorials/intro-to-csharp/object-oriented-programming.md
@@ -93,7 +93,16 @@ The override applies the monthly deposit set in the constructor. Add the followi
 
 Verify the results. Now, add a similar set of test code for the `LineOfCreditAccount`:
 
-:::code language="csharp" source="./snippets/object-oriented-programming/Program.cs" ID="InitialTestLineOfCredit":::
+```
+    var lineOfCredit = new LineOfCreditAccount("line of credit", 0);
+    // How much is too much to borrow?
+    lineOfCredit.MakeWithdrawal(1000m, DateTime.Now, "Take out monthly advance");
+    lineOfCredit.MakeDeposit(50m, DateTime.Now, "Pay back small amount");
+    lineOfCredit.MakeWithdrawal(5000m, DateTime.Now, "Emergency funds for repairs");
+    lineOfCredit.MakeDeposit(150m, DateTime.Now, "Partial restoration on repairs");
+    lineOfCredit.PerformMonthEndTransactions();
+    Console.WriteLine(lineOfCredit.GetAccountHistory());
+ ```
 
 When you add the preceding code and run the program, you'll see something like the following error:
 

--- a/docs/csharp/tutorials/intro-to-csharp/object-oriented-programming.md
+++ b/docs/csharp/tutorials/intro-to-csharp/object-oriented-programming.md
@@ -93,7 +93,7 @@ The override applies the monthly deposit set in the constructor. Add the followi
 
 Verify the results. Now, add a similar set of test code for the `LineOfCreditAccount`:
 
-:::code language="csharp" source="./snippets/object-oriented-programming/Program.cs" ID="TestLineOfCredit":::
+:::code language="csharp" source="./snippets/object-oriented-programming/Program.cs" ID="InitialTestLineOfCredit":::
 
 When you add the preceding code and run the program, you'll see something like the following error:
 

--- a/docs/csharp/tutorials/intro-to-csharp/snippets/object-oriented-programming/Program.cs
+++ b/docs/csharp/tutorials/intro-to-csharp/snippets/object-oriented-programming/Program.cs
@@ -24,6 +24,17 @@ namespace OOProgramming
             savings.PerformMonthEndTransactions();
             Console.WriteLine(savings.GetAccountHistory());
             // </FirstTests>
+            
+            // <InitialTestLineOfCredit>
+            var lineOfCredit = new LineOfCreditAccount("line of credit", 0);
+            // How much is too much to borrow?
+            lineOfCredit.MakeWithdrawal(1000m, DateTime.Now, "Take out monthly advance");
+            lineOfCredit.MakeDeposit(50m, DateTime.Now, "Pay back small amount");
+            lineOfCredit.MakeWithdrawal(5000m, DateTime.Now, "Emergency funds for repairs");
+            lineOfCredit.MakeDeposit(150m, DateTime.Now, "Partial restoration on repairs");
+            lineOfCredit.PerformMonthEndTransactions();
+            Console.WriteLine(lineOfCredit.GetAccountHistory());
+            // </InitialTestLineOfCredit>
 
             // <TestLineOfCredit>
             var lineOfCredit = new LineOfCreditAccount("line of credit", 0, 2000);

--- a/docs/csharp/tutorials/intro-to-csharp/snippets/object-oriented-programming/Program.cs
+++ b/docs/csharp/tutorials/intro-to-csharp/snippets/object-oriented-programming/Program.cs
@@ -24,17 +24,6 @@ namespace OOProgramming
             savings.PerformMonthEndTransactions();
             Console.WriteLine(savings.GetAccountHistory());
             // </FirstTests>
-            
-            // <InitialTestLineOfCredit>
-            var lineOfCredit = new LineOfCreditAccount("line of credit", 0);
-            // How much is too much to borrow?
-            lineOfCredit.MakeWithdrawal(1000m, DateTime.Now, "Take out monthly advance");
-            lineOfCredit.MakeDeposit(50m, DateTime.Now, "Pay back small amount");
-            lineOfCredit.MakeWithdrawal(5000m, DateTime.Now, "Emergency funds for repairs");
-            lineOfCredit.MakeDeposit(150m, DateTime.Now, "Partial restoration on repairs");
-            lineOfCredit.PerformMonthEndTransactions();
-            Console.WriteLine(lineOfCredit.GetAccountHistory());
-            // </InitialTestLineOfCredit>
 
             // <TestLineOfCredit>
             var lineOfCredit = new LineOfCreditAccount("line of credit", 0, 2000);


### PR DESCRIPTION
## Summary

Describe your changes here.

This fixes an issue where the tutorial purposefully allows for an error for educational reasons.  However the snippet referenced actually results in another error other than the expected one.  

Simply removing the 3rd argument for the constructor at this point in the tutorial allows the reader to continue smoothely. 

IMPORTANT:  this is an alternative solution to https://github.com/dotnet/docs/pull/22466 
