### PR TITLE
Increase iterations in example

### DIFF
--- a/samples/snippets/csharp/programming-guide/discards/standalone-discard1.cs
+++ b/samples/snippets/csharp/programming-guide/discards/standalone-discard1.cs
@@ -12,7 +12,7 @@ public class Example
    {
       Console.WriteLine("About to launch a task...");
       _ = Task.Run(() => { var iterations = 0;
-                           for (int ctr = 0; ctr < int.MaxValue; ctr++)
+                           for (long ctr = 0; ctr < long.MaxValue; ctr++)
                               iterations++;
                            Console.WriteLine("Completed looping operation...");
                            throw new InvalidOperationException();


### PR DESCRIPTION
Prior to this change I was able to unexpectedly encounter the `InvalidOperationException` because the loop completed.

This example is viewable at https://docs.microsoft.com/en-us/dotnet/csharp/discards#a-standalone-discard.