### PR TITLE
Do not add the suffix "Delegate" to a delegate as per https://docs.mi…

### DIFF
--- a/docs/csharp/programming-guide/delegates/how-to-declare-instantiate-and-use-a-delegate.md
+++ b/docs/csharp/programming-guide/delegates/how-to-declare-instantiate-and-use-a-delegate.md
@@ -28,7 +28,7 @@ In C# 1.0 and later, delegates can be declared as shown in the following example
   
  For more information, see [Lambda Expressions](../../language-reference/operators/lambda-expressions.md).  
   
- The following example illustrates declaring, instantiating, and using a delegate. The `BookDB` class encapsulates a bookstore database that maintains a database of books. It exposes a method, `ProcessPaperbackBooks`, which finds all paperback books in the database and calls a delegate for each one. The `delegate` type that is used is named `ProcessBookDelegate`. The `Test` class uses this class to print the titles and average price of the paperback books.  
+ The following example illustrates declaring, instantiating, and using a delegate. The `BookDB` class encapsulates a bookstore database that maintains a database of books. It exposes a method, `ProcessPaperbackBooks`, which finds all paperback books in the database and calls a delegate for each one. The `delegate` type that is used is named `ProcessBookCallback`. The `Test` class uses this class to print the titles and average price of the paperback books.  
   
  The use of delegates promotes good separation of functionality between the bookstore database and the client code. The client code has no knowledge of how the books are stored or how the bookstore code finds paperback books. The bookstore code has no knowledge of what processing is performed on the paperback books after it finds them.  
   

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDelegates/CS/Delegates.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDelegates/CS/Delegates.cs
@@ -496,7 +496,7 @@ namespace WrapContravariance
 
             // Declare a delegate type for processing a book:
             //<Snippet16>
-            public delegate void ProcessBookDelegate(Book book);
+            public delegate void ProcessBookCallback(Book book);
             //</Snippet16>
 
             // Maintains a book database.
@@ -512,7 +512,7 @@ namespace WrapContravariance
                 }
 
                 // Call a passed-in delegate on each paperback book to process it:
-                public void ProcessPaperbackBooks(ProcessBookDelegate processBook)
+                public void ProcessPaperbackBooks(ProcessBookCallback processBook)
                 {
                     foreach (Book b in list)
                     {


### PR DESCRIPTION
…crosoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types

## Summary

Fixed an issue I reported some time ago where the example delegate code doesn't follow naming convention for delegate classes. I didn't try to add "Callback" / "EventHandler" suffixes to all the example delegate types, but I did fix the one instance where the word "Delegate" was added as a suffix to a delegate type.

Fixes #12706