### PR TITLE
Typo "Azure Blob storage"→"Azure Blob Storage"

### DIFF
--- a/docs/azure/landing-page.yml
+++ b/docs/azure/landing-page.yml
@@ -153,7 +153,7 @@ landingContent:
             url: /learn/modules/develop-app-that-queries-azure-sql/
           - text: Build a .NET Core app for Azure Cosmos DB in Visual Studio Code
             url: /learn/modules/build-cosmos-db-app-with-vscode/
-          - text: Store application data with Azure Blob storage
+          - text: Store application data with Azure Blob Storage
             url: /learn/modules/store-app-data-with-azure-blob-storage/
           - text: Persist and retrieve relational data with Entity Framework Core
             url: /learn/modules/persist-data-ef-core/


### PR DESCRIPTION
## Summary
Typo "Azure Blob storage"→"Azure Blob Storage"
https://docs.microsoft.com/en-us/dotnet/azure/landing-page


