### PR TITLE
Typo in docker image version

### DIFF
--- a/docs/architecture/microservices/net-core-net-framework-containers/official-net-docker-images.md
+++ b/docs/architecture/microservices/net-core-net-framework-containers/official-net-docker-images.md
@@ -43,7 +43,7 @@ When you explore the .NET image repositories at Docker Hub, you will find multip
 | Image | Comments |
 |-------|----------|
 | mcr.microsoft.com/dotnet/aspnet:**5.0** | ASP.NET Core, with runtime only and ASP.NET Core optimizations, on Linux and Windows (multi-arch) |
-| mcr.microsoft.com/dotnet/sdk:**5.01** | .NET 5, with SDKs included, on Linux and Windows (multi-arch) |
+| mcr.microsoft.com/dotnet/sdk:**5.0** | .NET 5, with SDKs included, on Linux and Windows (multi-arch) |
 
 > [!div class="step-by-step"]
 > [Previous](net-container-os-targets.md)


### PR DESCRIPTION


## Summary

I believe that there is a typo error in the docker image version number as identified version 5.01 does not exist and this should read 5.0 as modified.

Fixes #Issue_Number (if available)
