### PR TITLE
Add notes about win7 certificates

### DIFF
--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -51,7 +51,7 @@ Windows 10 versions end-of-service dates are segmented by edition. Only **Home**
 
 ## Unsupported releases
 
-The following versions of .NET are ❌ no longer supported. The downloads for these still remain published:
+The following versions of .NET are ❌ no longer supported. The downloads for these versions still remain published:
 
 - 3.0
 - 2.2
@@ -169,6 +169,18 @@ The following Windows versions are supported with .NET Core 2.1:
 
 For more information about .NET Core 2.1 supported operating systems, distributions, and lifecycle policy, see [.NET Core 2.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md).
 
+### Notes about Windows 7
+
+When doing an offline install for .NET Core 2.1 on Windows 7, you'll first need to make sure that the latest [Microsoft Root Certificate Authority 2011](https://www.microsoft.com/pkiops/Docs/Repository.htm) has been installed on the target machine.
+
+The _certmgr.exe_ tool can automate installing a certificate and is obtained from Visual Studio or the Windows SDK. The following command is used to install the certificate before running the .NET Core 2.1 installer:
+
+```console
+certmgr.exe /add MicRooCerAut2011_2011_03_22.crt /s /r localMachine root
+```
+
+Be sure to review the dependencies required for [Windows 7 below](#additional-deps).
+
 ---
 
 <!-- markdownlint-disable MD001 -->
@@ -179,7 +191,7 @@ More dependencies are required if you're installing the .NET SDK or runtime on t
 
 | Operating System         | Prerequisites                                                                    |
 |--------------------------|----------------------------------------------------------------------------------|
-| Windows 7 SP1 [ESU][esu] | - Microsoft Visual C++ 2015-2019 Redistributable [64-bit][vcc64] / [32-bit][vcc32] <br> - KB3063858 [64-bit][kb64] / [32-bit][kb32] <br> - [MicrosoftRootCertificateAuthority2011.cer](https://go.microsoft.com/fwlink/?linkid=747875&clcid=0x409) (.NET Core 2.1 only) |
+| Windows 7 SP1 [ESU][esu] | - Microsoft Visual C++ 2015-2019 Redistributable [64-bit][vcc64] / [32-bit][vcc32] <br> - KB3063858 [64-bit][kb64] / [32-bit][kb32] <br> - [Microsoft Root Certificate Authority 2011](https://www.microsoft.com/pkiops/Docs/Repository.htm) (.NET Core 2.1 offline installer only) |
 | Windows Vista SP 2       | Microsoft Visual C++ 2015-2019 Redistributable [64-bit][vcc64] / [32-bit][vcc32] |
 | Windows 8.1              | Microsoft Visual C++ 2015-2019 Redistributable [64-bit][vcc64] / [32-bit][vcc32] |
 | Windows Server 2008 R2   | Microsoft Visual C++ 2015-2019 Redistributable [64-bit][vcc64] / [32-bit][vcc32] |
@@ -283,7 +295,7 @@ For more information, see [Standard Installer Command-Line Options](/windows/win
 
 ## Download and manually install
 
-As an alternative to the Windows installers for .NET, you can download and manually install the SDK or runtime. Manual install is usually performed as part of continuous integration testing. For a developer or user, it's generally better to use an [installer](https://dotnet.microsoft.com/download/dotnet-core).
+As an alternative to the Windows installers for .NET, you can download and manually install the SDK or runtime. Manual install is usually done as part of continuous integration testing. For a developer or user, it's generally better to use an [installer](https://dotnet.microsoft.com/download/dotnet-core).
 
 Both .NET SDK and .NET Runtime can be manually installed after they've been downloaded. If you install .NET SDK, you don't need to install the corresponding runtime. First, download a binary release for either the SDK or the runtime from one of the following sites:
 
@@ -326,5 +338,5 @@ For more information about using .NET in a Docker container, see [Introduction t
 [esu]: /troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq
 [vcc64]: https://aka.ms/vs/16/release/vc_redist.x64.exe
 [vcc32]: https://aka.ms/vs/16/release/vc_redist.x86.exe
-[kb64]: https://www.microsoft.com/en-us/download/details.aspx?id=47442
-[kb32]: https://www.microsoft.com/en-us/download/details.aspx?id=47409
+[kb64]: https://www.microsoft.com/download/details.aspx?id=47442
+[kb32]: https://www.microsoft.com/download/details.aspx?id=47409

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -169,7 +169,7 @@ The following Windows versions are supported with .NET Core 2.1:
 
 For more information about .NET Core 2.1 supported operating systems, distributions, and lifecycle policy, see [.NET Core 2.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md).
 
-### Notes about Windows 7
+### Offline install for Windows 7
 
 When doing an offline install for .NET Core 2.1 on Windows 7, you'll first need to make sure that the latest [Microsoft Root Certificate Authority 2011](https://www.microsoft.com/pkiops/Docs/Repository.htm) has been installed on the target machine.
 

--- a/docs/framework/install/on-windows-7.md
+++ b/docs/framework/install/on-windows-7.md
@@ -29,8 +29,6 @@ The _certmgr.exe_ tool can automate installing a certificate and is obtained fro
 certmgr.exe /add MicRooCerAut2011_2011_03_22.crt /s /r localMachine root
 ```
 
-Be sure to review the dependencies required for [Windows 7 below](#additional-deps).
-
 ## .NET Framework 3.5
 
 The [.NET Framework 3.5](https://dotnet.microsoft.com/download/dotnet-framework/net35-sp1) is included with Windows 7.

--- a/docs/framework/install/on-windows-7.md
+++ b/docs/framework/install/on-windows-7.md
@@ -19,6 +19,18 @@ These instructions will help you install the .NET Framework versions you need. T
 
 The [.NET Framework 4.8](https://github.com/Microsoft/dotnet/tree/master/releases/net48) can be used to run applications built for .NET Framework 4.0 or later.
 
+### Offline installer
+
+When doing an offline install for .NET Framework on Windows 7, you'll first need to make sure that the latest [Microsoft Root Certificate Authority 2011](https://www.microsoft.com/pkiops/Docs/Repository.htm) has been installed on the target machine.
+
+The _certmgr.exe_ tool can automate installing a certificate and is obtained from Visual Studio or the Windows SDK. The following command is used to install the certificate before running the .NET Framework installer:
+
+```console
+certmgr.exe /add MicRooCerAut2011_2011_03_22.crt /s /r localMachine root
+```
+
+Be sure to review the dependencies required for [Windows 7 below](#additional-deps).
+
 ## .NET Framework 3.5
 
 The [.NET Framework 3.5](https://dotnet.microsoft.com/download/dotnet-framework/net35-sp1) is included with Windows 7.


### PR DESCRIPTION
## Summary

- Added a section about .NET Core 2.1 on Win7 requiring an updated cert root.
- Added a section about .NET Framework on Win7 requiring an updated cert root.

Fixes #22308
