### PR TITLE
Auto remove wont fix on reopen

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -200,6 +200,11 @@
         }
       }
     },
+    "reopened": {
+      "processor-default": {
+        "labels-remove": [ "won't fix" ]
+      }
+    },
     "closed": {
       "processor-default": {
         "labels-remove": [ "in-progress", ":watch: Not Triaged" ]


### PR DESCRIPTION
## Summary

Removes the won't fix label from an issue when reopened
