### PR TITLE
Add redirect for parse-strings

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -11475,6 +11475,11 @@
             "redirect_url": "/dotnet/standard/base-types/how-to-pad-a-number-with-leading-zeros"
         },
         {
+            "source_path": "docs/standard/base-types/parse-strings.md",
+            "redirect_url": "/dotnet/standard/base-types/divide-up-strings",
+            "redirect_document_id": true
+        },
+        {
             "source_path": "docs/standard/base-types/performing-formatting-operations.md",
             "redirect_url": "/dotnet/standard/base-types/how-to-pad-a-number-with-leading-zeros"
         },


### PR DESCRIPTION
Oops! Should have been added in November with #21329.

[Preview link to old file](https://review.docs.microsoft.com/en-us/dotnet/standard/base-types/parse-strings?branch=pr-en-us-22521).