### PR TITLE
Update net-container-os-targets.md

### DIFF
--- a/docs/architecture/microservices/net-core-net-framework-containers/net-container-os-targets.md
+++ b/docs/architecture/microservices/net-core-net-framework-containers/net-container-os-targets.md
@@ -22,9 +22,6 @@ When deploying legacy .NET Framework applications you have to target Windows Ser
 
 You can also create your own Docker image in cases where you want to use a different Linux distro or where you want an image with versions not provided by Microsoft. For example, you might create an image with ASP.NET Core running on the traditional .NET Framework and Windows Server Core, which is a not-so-common scenario for Docker.
 
-> [!IMPORTANT]
-> When using Windows Server Core images, you might find that some DLLs are missing, when compared to full Windows images. You might be able to solve this problem by creating a custom Server Core image, adding the missing files at image build time, as mentioned in this [GitHub comment](https://github.com/microsoft/dotnet-framework-docker/issues/299#issuecomment-511537448).
-
 When you add the image name to your Dockerfile file, you can select the operating system and version depending on the tag you use, as in the following examples:
 
 | Image | Comments |


### PR DESCRIPTION
## Summary

We should not be encouraging users to incorporate arbitrary system .dlls from host machines during Windows container image build process. It opens security and patch-ability risks for the user, and non-redistributable .dlls should not be redistributed.
