### PR TITLE
Changed out the AzureFundamentals Hero item 

### DIFF
--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -35,7 +35,7 @@ highlightedContent:
     - itemType: learn 
       title: Secure custom APIs with Microsoft Identity
       url: /learn/modules/identity-secure-custom-api/
-    - itemType: concept
+    - itemType: get-started
       title: Azure SDK for .NET
       url: sdk/azure-sdk-for-dotnet
 

--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -35,9 +35,9 @@ highlightedContent:
     - itemType: learn 
       title: Secure custom APIs with Microsoft Identity
       url: /learn/modules/identity-secure-custom-api/
-    - itemType: learn
-      title: Azure fundamentals
-      url: /learn/paths/azure-fundamentals/
+    - itemType: concept
+      title: Azure SDK for .NET
+      url: sdk/azure-sdk-for-dotnet
 
 conceptualContent:
   title: Featured content


### PR DESCRIPTION
Now item points to Azure SDK for .NET.  That Learn module is deprecated at this point anyway
