### PR TITLE
Replace sensitive terms

### DIFF
--- a/docs/architecture/serverless/architecture-deployment-approaches.md
+++ b/docs/architecture/serverless/architecture-deployment-approaches.md
@@ -95,7 +95,7 @@ For more information about Docker containers, see [What is Docker](../microservi
 
 Managing containers across hosts typically requires an orchestration tool such as Kubernetes. Configuring and managing orchestration solutions may add additional overhead and complexity to projects. Fortunately, many cloud providers provide orchestration services through PaaS solutions to simplify the management of containers.
 
-The following image illustrates an example Kubernetes installation. Nodes in the installation address scale out and failover. They run Docker container instances that are managed by the master server. The *kubelet* is the client that relays commands from Kubernetes to Docker.
+The following image illustrates an example Kubernetes installation. Nodes in the installation address scale out and failover. They run Docker container instances that are managed by the primary server. The *kubelet* is the client that relays commands from Kubernetes to Docker.
 
 ![Kubernetes](./media/kubernetes-example.png)
 

--- a/docs/framework/mef/composition-analysis-tool-mefx.md
+++ b/docs/framework/mef/composition-analysis-tool-mefx.md
@@ -124,11 +124,11 @@ from: ClassLibrary1.ChainOne from: AssemblyCatalog (Assembly="ClassLibrary1, Ver
   
 <a name="white_lists"></a>
 
-## White Lists  
+## Allow lists
 
- The `/whitelist` option enables you to specify a text file that lists parts that are expected to be rejected. Unexpected rejections will then be flagged. This can be useful when you analyze an incomplete library, or a sub-library that is missing some dependencies. The `/whitelist` option can be applied to the `/rejected` or `/causes` actions.  
+ The `/whitelist` option enables you to specify a text file that lists parts that are expected to be rejected. Unexpected rejections will then be flagged. This can be useful when you analyze an incomplete library, or a sublibrary that's missing some dependencies. The `/whitelist` option can be applied to the `/rejected` or `/causes` actions.  
   
- Consider a file named test.txt that contains the text "ClassLibrary1.ChainOne". If you run the `/rejected` action with the `/whitelist` option on the previous example, it will produce the following output:  
+ Consider a file named test.txt that contains the text "ClassLibrary1.ChainOne". If you run the `/rejected` action with the `/whitelist` option on the previous example, it produces the following output:  
   
 ```console
 mefx /file:ClassLibrary1.dll /rejected /whitelist:test.txt  

--- a/docs/spark/how-to-guides/connect-to-mongo-db.md
+++ b/docs/spark/how-to-guides/connect-to-mongo-db.md
@@ -14,7 +14,7 @@ In this article, you learn how to connect to a MongoDB instance from your .NET f
 
 ## Prerequisites
 
-1. Have a MongoDB server up and running with a [database and some collection](https://docs.mongodb.com/manual/core/databases-and-collections/) added to it (Download [this community server](https://www.mongodb.com/try/download/community) for a local server or you can try [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) for a cloud MongoDB service.)
+- Have a MongoDB server up and running with a [database and some collection](https://docs.mongodb.com/manual/core/databases-and-collections/) added to it (Download [this community server](https://www.mongodb.com/try/download/community) for a local server or you can try [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) for a cloud MongoDB service.)
 
 ## Set up your MongoDB instance
 
@@ -33,7 +33,7 @@ In order to get .NET for Apache Spark to talk to your MongoDB instance you need 
     )
     ```
 
-2. Make sure the IP address of the machine your .NET for Apache Spark application is running on is whitelisted for the MongoDB server to be able to connect to. You can refer to [this guide](https://docs.atlas.mongodb.com/security/add-ip-address-to-list/) to learn how to do that.
+2. Make sure the IP address of the machine your .NET for Apache Spark application is running on is allowlisted for the MongoDB server to be able to connect to. You can refer to [this guide](https://docs.atlas.mongodb.com/security/add-ip-address-to-list/) to learn how to do that.
 
 ## Configure your .NET for Apache Spark application
 
@@ -74,7 +74,7 @@ In order to get .NET for Apache Spark to talk to your MongoDB instance you need 
 
 ## Run your application
 
-In order to run your .NET for Apache Spark application, you should define the `mongo-spark-connector` module as part of the build definition in your Spark project, using `libraryDependency` in `build.sbt` for sbt projects. For Spark environments such as `spark-submit` (or `spark-shell`) you should use the `--packages` command-line option like so:
+In order to run your .NET for Apache Spark application, you should define the `mongo-spark-connector` module as part of the build definition in your Spark project, using `libraryDependency` in `build.sbt` for sbt projects. For Spark environments such as `spark-submit` (or `spark-shell`), use the `--packages` command-line option like so:
 
 ```bash
 spark-submit --master local --packages org.mongodb.spark:mongo-spark-connector_2.12:3.0.0 --class org.apache.spark.deploy.dotnet.DotnetRunner microsoft-spark-<spark_majorversion-spark_minorversion>_<scala_majorversion.scala_minorversion>-<spark_dotnet_version>.jar yourApp.exe
@@ -83,7 +83,7 @@ spark-submit --master local --packages org.mongodb.spark:mongo-spark-connector_2
 > [!NOTE]
 > Make sure to include the package version in accordance with the version of Spark being run.
 
-The result as displayed is the DataFrame (`df`) as shown below:
+The result as displayed is the DataFrame (`df`) shown here:
 
 ```text
 +--------------------+----+-------+


### PR DESCRIPTION
I've requested an exemption for the remaining warnings since they are for the name of an option in a tool.