### PR TITLE
fix issues with EventCounter sample due to race in EventListener

### DIFF
--- a/docs/core/diagnostics/event-counters.md
+++ b/docs/core/diagnostics/event-counters.md
@@ -191,11 +191,11 @@ You can consume the counter values via the <xref:System.Diagnostics.Tracing.Even
 
 First, the <xref:System.Diagnostics.Tracing.EventSource> that produces the counter value needs to be enabled. Override the <xref:System.Diagnostics.Tracing.EventListener.OnEventSourceCreated%2A?displayProperty=nameWithType> method to get a notification when an <xref:System.Diagnostics.Tracing.EventSource> is created, and if this is the correct <xref:System.Diagnostics.Tracing.EventSource> with your EventCounters, then you can call <xref:System.Diagnostics.Tracing.EventListener.EnableEvents%2A?displayProperty=nameWithType> on it. Here is an example override:
 
-:::code language="csharp" source="snippets/EventCounters/SimpleEventListener.cs" range="16-27":::
+:::code language="csharp" source="snippets/EventCounters/SimpleEventListener.cs" range="11-22":::
 
 #### Sample code
 
-Here is a sample <xref:System.Diagnostics.Tracing.EventListener> class that prints out all the counter names and values from the .NET runtime's <xref:System.Diagnostics.Tracing.EventSource>, for publishing its internal counters (`System.Runtime`) at some interval.
+Here is a sample <xref:System.Diagnostics.Tracing.EventListener> class that prints out all the counter names and values from the .NET runtime's <xref:System.Diagnostics.Tracing.EventSource>, for publishing its internal counters (`System.Runtime`) every second.
 
 :::code language="csharp" source="snippets/EventCounters/SimpleEventListener.cs":::
 

--- a/docs/core/diagnostics/snippets/EventCounters/SimpleEventListener.cs
+++ b/docs/core/diagnostics/snippets/EventCounters/SimpleEventListener.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Tracing;
 
 public class SimpleEventListener : EventListener
 {
-    private readonly int _intervalSec;
+    private int _intervalSec = 1;
 
     public int EventCount { get; private set; }
 

--- a/docs/core/diagnostics/snippets/EventCounters/SimpleEventListener.cs
+++ b/docs/core/diagnostics/snippets/EventCounters/SimpleEventListener.cs
@@ -10,7 +10,7 @@ public class SimpleEventListener : EventListener
 
     private EventSource _systemRuntime;
 
-    // used to lock the fields _intervalSec and _isEnabled
+    // used to lock the fields _intervalSec, _fullyInitialized, and _receivedCallback
     private object _lock = new object();
 
     public SimpleEventListener(int intervalSec)

--- a/docs/core/diagnostics/snippets/EventCounters/SimpleEventListener.cs
+++ b/docs/core/diagnostics/snippets/EventCounters/SimpleEventListener.cs
@@ -4,32 +4,8 @@ using System.Diagnostics.Tracing;
 
 public class SimpleEventListener : EventListener
 {
-    private int _intervalSec;
-    private bool _fullyInitialized = false;
-    private bool _receivedCallback = false;
-
-    private EventSource _systemRuntime;
-
-    // used to lock the fields _intervalSec, _fullyInitialized, and _receivedCallback
-    private object _lock = new object();
-
-    public SimpleEventListener(int intervalSec)
+    public SimpleEventListener()
     {
-        lock (_lock)
-        {
-            _intervalSec = intervalSec <= 0
-                ? throw new ArgumentException("Interval must be at least 1 second.", nameof(intervalSec))
-                : intervalSec;
-
-            if (_receivedCallback)
-            {
-                EnableEvents(_systemRuntime, EventLevel.Verbose, EventKeywords.All, new Dictionary<string, string>()
-                {
-                    ["EventCounterIntervalSec"] = _intervalSec.ToString()
-                });
-            }
-            _fullyInitialized = true;
-        }
     }
 
     protected override void OnEventSourceCreated(EventSource source)
@@ -39,18 +15,10 @@ public class SimpleEventListener : EventListener
             return;
         }
 
-        lock (_lock)
+        EnableEvents(source, EventLevel.Verbose, EventKeywords.All, new Dictionary<string, string>()
         {
-            if (_fullyInitialized)
-            {
-                EnableEvents(source, EventLevel.Verbose, EventKeywords.All, new Dictionary<string, string>()
-                {
-                    ["EventCounterIntervalSec"] = _intervalSec.ToString()
-                });
-            }
-            _systemRuntime = source;
-            _receivedCallback = true;
-        }
+            ["EventCounterIntervalSec"] = "1"
+        });
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)


### PR DESCRIPTION
## Summary

EventListener's OnEventWritten callback can race with the constructor of a subclass of EventListener because the base constructor registers the instance as callable and the child constructor runs after the base ctor. This code snippet relies on the ctor have to finished running, which makes it vulnerable to the described race condition causing a NRE. 

This fixes the race condition in the sample code.

Fixes #21506.
