### PR TITLE
Clarify language; reorder sections

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -43,7 +43,7 @@ The order of the properties is not important.
 
 **\<kind>** specifies which kind of element is being defined&mdash;naming rule, symbol group, or naming style&mdash;and must be one of the following:
 
-| To set a property for | Use the prefix | Example |
+| To set a property for | Use the \<kind> value | Example |
 | --- | --- | -- |
 | Naming rule | `dotnet_naming_rule` | `dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion` |
 | Symbol group | `dotnet_naming_symbols` | `dotnet_naming_symbols.interface.applicable_kinds = interface` |

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -23,7 +23,7 @@ In your `.editorconfig` file, you can define **naming rules** for how .NET progr
 
 A naming rule has three components:
 
-* The *symbol group*&mdash;the group of symbols the rule applies to.
+* The **symbol group**&mdash;the group of symbols the rule applies to.
 * The **naming style** to associate with the rule.
 * The severity for enforcing the convention.
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -23,7 +23,7 @@ In your `.editorconfig` file, you can define **naming rules** for how .NET progr
 
 A naming rule has three components:
 
-* The **symbol group** -- the group of symbols the rule applies to.
+* The *symbol group*&mdash;the group of symbols the rule applies to.
 * The **naming style** to associate with the rule.
 * The severity for enforcing the convention.
 

--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -19,31 +19,29 @@ helpviewer_keywords:
 ---
 # Naming rules
 
-Naming rules concern the naming of .NET programming language code elements, such as classes, properties, and methods. For example, you can specify that public members must be capitalized or that private fields must begin with `_`.
+In your `.editorconfig` file, you can define **naming rules** for how .NET programming language code elements&mdash;such as classes, properties, and methods&mdash;should be named. For example, you can specify that public members must be capitalized, or that private fields must begin with `_`.
 
-A naming rule has three parts:
+A naming rule has three components:
 
-* The group of symbols it applies to.
-* The naming style to associate with the rule.
+* The **symbol group** -- the group of symbols the rule applies to.
+* The **naming style** to associate with the rule.
 * The severity for enforcing the convention.
-
-You define naming rules in an EditorConfig file.
 
 ## General syntax
 
 To define a naming rule, symbol group, or naming style, set one or more properties using the following syntax:
 
 ```ini
-<prefix>.<title>.<propertyName> = <propertyValue>
+<kind>.<title>.<propertyName> = <propertyValue>
 ```
 
 Each property should only be set once, but some settings allow multiple, comma-separated values.
 
 The order of the properties is not important.
 
-### \<prefix>
+### \<kind>
 
-**\<prefix>** specifies which kind of element is being defined&mdash;naming rule, symbol group, or naming style&mdash;and must be one of the following:
+**\<kind>** specifies which kind of element is being defined&mdash;naming rule, symbol group, or naming style&mdash;and must be one of the following:
 
 | To set a property for | Use the prefix | Example |
 | --- | --- | -- |
@@ -71,25 +69,17 @@ All naming rule properties are required for a rule to take effect.
 
 | Property | Description |
 | -- | -- |
-| `symbols` | The title of the symbol group, defining the symbols to which this rule should be applied |
+| `symbols` | The title of a symbol group; the naming rule will be applied to the symbols in this group |
 | `style` | The title of the naming style which should be associated with this rule |
 | `severity` |  Sets the severity with which to enforce the naming rule. Set the associated value to one of the available [severity levels](../configuration-options.md#severity-level).<sup>1</sup> |
 
 **Notes:**
 
-1. Severity specification within a naming rule is only respected inside development IDEs, such as Visual Studio. This setting is not understood by the C# or VB compilers, hence not respected during build. Instead, to enforce naming style rules on build, you should set the severity by using the rule ID-based severity configuration as explained in [this section](#rule-id-ide1006-naming-rule-violation). For more information, see this [GitHub issue](https://github.com/dotnet/roslyn/issues/44201).
-
-## Rule order
-
-The order in which naming rules are defined in an EditorConfig file doesn't matter. The naming rules are automatically ordered according to the definition of the rules themselves. The [EditorConfig Language Service extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.EditorConfig) can analyze an EditorConfig file and report cases where the rule ordering in the file is different to what the compiler will use at run time.
-
-> [!NOTE]
->
-> If you're using a version of Visual Studio earlier than Visual Studio 2019 version 16.2, naming rules should be ordered from most-specific to least-specific in the EditorConfig file. The first rule encountered that can be applied is the only rule that is applied. However, if there are multiple rule *properties* with the same name, the most recently found property with that name takes precedence. For more information, see [File hierarchy and precedence](/visualstudio/ide/create-portable-custom-editor-options#file-hierarchy-and-precedence).
+1. Severity specification within a naming rule is only respected inside development IDEs, such as Visual Studio. This setting is not understood by the C# or VB compilers, hence not respected during build. To enforce naming style rules on build, you should instead set the severity by using [code rule severity configuration](#rule-id-ide1006-naming-rule-violation). For more information, see this [GitHub issue](https://github.com/dotnet/roslyn/issues/44201).
 
 ## Symbol group properties
 
-You can set the following properties for symbol groups, to limit which symbols are included in the group. To specify multiple values in a single property setting, separate them with a comma.
+You can set the following properties for symbol groups, to limit which symbols are included in the group. To specify multiple values for a single property, separate the values with a comma.
 
 | Property | Description | Allowed values | Required |
 | -- | -- | -- | -- |
@@ -125,6 +115,14 @@ You can set the following properties for a naming style:
 
 1. You must specify a capitalization style as part of your naming style, otherwise your naming style might be ignored.
 
+## Rule order
+
+The order in which naming rules are defined in an EditorConfig file doesn't matter. The naming rules are automatically ordered according to the definition of the rules themselves. The [EditorConfig Language Service extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.EditorConfig) can analyze an EditorConfig file and report cases where the rule ordering in the file is different to what the compiler will use at run time.
+
+> [!NOTE]
+>
+> If you're using a version of Visual Studio earlier than Visual Studio 2019 version 16.2, naming rules should be ordered from most-specific to least-specific in the EditorConfig file. The first rule encountered that can be applied is the only rule that is applied. However, if there are multiple rule *properties* with the same name, the most recently found property with that name takes precedence. For more information, see [File hierarchy and precedence](/visualstudio/ide/create-portable-custom-editor-options#file-hierarchy-and-precedence).
+
 ## Default naming styles
 
 If you don't specify any custom naming rules, the following default styles are used:
@@ -132,6 +130,16 @@ If you don't specify any custom naming rules, the following default styles are u
 - For classes, structs, enumerations, properties, and events with `public`, `private`, `internal`, `protected`, or `protected_internal` accessibility, the default naming style is Pascal case.
 
 - For interfaces with `public`, `private`, `internal`, `protected`, or `protected_internal` accessibility, the default naming style is Pascal case with a required prefix of **I**.
+
+## <a name="rule-id-ide1006-naming-rule-violation"></a>Code Rule ID: `IDE1006 (Naming rule violation)`
+
+All naming options have rule ID `IDE1006` and title `Naming rule violation`. You can configure the severity of naming violations globally in an EditorConfig file with the following syntax:
+
+```ini
+dotnet_diagnostic.IDE1006.severity = <severity value>
+```
+
+The severity value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
 
 ## Example
 
@@ -155,16 +163,6 @@ dotnet_naming_rule.public_members_must_be_capitalized.style    = first_word_uppe
 # and setting the severity.
 dotnet_naming_rule.public_members_must_be_capitalized.severity = suggestion
 ```
-
-## <a name="rule-id-ide1006-naming-rule-violation"></a>Rule ID: "IDE1006" (Naming rule violation)
-
-All naming options have rule ID `IDE1006` and title `Naming rule violation`. You can configure the severity of naming violations globally in an EditorConfig file with the following syntax:
-
-```ini
-dotnet_diagnostic.IDE1006.severity = <severity value>
-```
-
-The severity value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
 
 ## See also
 


### PR DESCRIPTION
1. Rename `prefix` to `kind`; that is the whole purpose of the prefix in these property settings.
2. Emphasize the three kinds of entities for which properties can be defined -- naming rule, symbol group, naming style -- in the first section.
3. Consolidate "naming rule properties", "symbol group properties", "naming style properties" together, and move other sections not describing the specific properties to the end.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
