### PR TITLE
Clarify windows support table + linux manual

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -114,7 +114,7 @@ Next, extract the downloaded file and use the `export` command to set variables 
 
 To extract the runtime and make the .NET CLI commands available at the terminal, first download a .NET binary release. Then, open a terminal and run the following commands from the directory where the file was saved. The archive file name may be different depending on what you downloaded.
 
-**Use the following commands to extract the runtime or sdk that you downloaded.** Remember to change the `DOTNET_FILE` value to your file name:
+**Use the following commands to extract the runtime or SDK that you downloaded.** Remember to change the `DOTNET_FILE` value to your file name:
 
 ```bash
 DOTNET_FILE=dotnet-sdk-5.0.102-linux-x64.tar.gz

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -114,20 +114,16 @@ Next, extract the downloaded file and use the `export` command to set variables 
 
 To extract the runtime and make the .NET CLI commands available at the terminal, first download a .NET binary release. Then, open a terminal and run the following commands from the directory where the file was saved. The archive file name may be different depending on what you downloaded.
 
-**Use the following command to extract the runtime**:
+**Use the following commands to extract the runtime or sdk that you downloaded.** Remember to change the `DOTNET_FILE` value to your file name:
 
 ```bash
-mkdir -p "$HOME/dotnet" && tar zxf aspnetcore-runtime-5.0.0-linux-x64.tar.gz -C "$HOME/dotnet"
-export DOTNET_ROOT=$HOME/dotnet
-export PATH=$PATH:$HOME/dotnet
-```
+DOTNET_FILE=dotnet-sdk-5.0.102-linux-x64.tar.gz
+DOTNET_ROOT=$HOME/dotnet
 
-**Use the following command to extract the SDK**:
+mkdir -p $DOTNET_ROOT && tar zxf $DOTNET_FILE -C $DOTNET_ROOT
 
-```bash
-mkdir -p "$HOME/dotnet" && tar zxf dotnet-sdk-5.0.100-linux-x64.tar.gz -C "$HOME/dotnet"
-export DOTNET_ROOT=$HOME/dotnet
-export PATH=$PATH:$HOME/dotnet
+export DOTNET_ROOT=$DOTNET_ROOT
+export PATH=$PATH:$DOTNET_ROOT
 ```
 
 > [!TIP]

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -118,11 +118,10 @@ To extract the runtime and make the .NET CLI commands available at the terminal,
 
 ```bash
 DOTNET_FILE=dotnet-sdk-5.0.102-linux-x64.tar.gz
-DOTNET_ROOT=$HOME/dotnet
+export DOTNET_ROOT=$HOME/dotnet
 
-mkdir -p $DOTNET_ROOT && tar zxf $DOTNET_FILE -C $DOTNET_ROOT
+mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
 
-export DOTNET_ROOT=$DOTNET_ROOT
 export PATH=$PATH:$DOTNET_ROOT
 ```
 

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -30,6 +30,16 @@ The following versions of .NET are ❌ no longer supported. The downloads for th
 
 These unsupported versions aren't detailed in the sections below and your mileage may vary if you try to install them.
 
+## Manual installation
+
+If you don't want to use a package manager to install .NET on Linux, you can install .NET in one of the following ways:
+
+- [Snap package](linux-snap.md)
+- [Scripted install with _install-dotnet.sh_](linux-scripted-manual.md#scripted-install)
+- [Manual binary extraction](linux-scripted-manual.md#manual-install)
+
+Be sure to check the appropriate distribution page for more information about any required dependencies that may be missing when you do a manual installation.
+
 ## Alpine
 
 The following table is a list of currently supported .NET releases and the versions of Alpine they're supported on. These versions remain supported until either the version of [.NET reaches end-of-support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) or the version of [Alpine reaches end-of-life](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases).

--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -50,11 +50,11 @@ The runtime is used to run apps created with .NET. When an app author publishes 
 
 There are two different runtimes you can install on macOS:
 
-*ASP.NET Core runtime*\
-Runs ASP.NET Core apps. Includes the .NET runtime.
+- *ASP.NET Core runtime*\
+  Runs ASP.NET Core apps. Includes the .NET runtime.
 
-*.NET runtime*\
-This runtime is the simplest runtime and doesn't include any other runtime. It's highly recommended that you install *ASP.NET Core runtime* for the best compatibility with .NET apps.
+- *.NET runtime*\
+  This runtime is the simplest runtime and doesn't include any other runtime. It's highly recommended that you install *ASP.NET Core runtime* for the best compatibility with .NET apps.
 
 > [!div class="button"]
 > [Download .NET Runtime](https://dotnet.microsoft.com/download/dotnet-core)
@@ -124,11 +124,10 @@ To extract the runtime and make the .NET CLI commands available at the terminal,
 
 ```bash
 DOTNET_FILE=dotnet-sdk-5.0.102-linux-x64.tar.gz
-DOTNET_ROOT=$HOME/dotnet
+export DOTNET_ROOT=$HOME/dotnet
 
-mkdir -p $DOTNET_ROOT && tar zxf $DOTNET_FILE -C $DOTNET_ROOT
+mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
 
-export DOTNET_ROOT=$DOTNET_ROOT
 export PATH=$PATH:$DOTNET_ROOT
 ```
 

--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -48,7 +48,7 @@ The following versions of .NET are ❌ no longer supported. The downloads for th
 
 The runtime is used to run apps created with .NET. When an app author publishes an app, they can include the runtime with their app. If they don't include the runtime, it's up to the user to install the runtime.
 
-There are three different runtimes you can install on macOS:
+There are two different runtimes you can install on macOS:
 
 *ASP.NET Core runtime*\
 Runs ASP.NET Core apps. Includes the .NET runtime.

--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -120,20 +120,16 @@ Next, extract the downloaded file and use the `export` command to set variables 
 
 To extract the runtime and make the .NET CLI commands available at the terminal, first download a .NET binary release. Then, open a terminal and run the following commands from the directory where the file was saved. The archive file name may be different depending on what you downloaded.
 
-**Use the following command to extract the runtime**:
+**Use the following commands to extract the runtime or sdk that you downloaded.** Remember to change the `DOTNET_FILE` value to your file name:
 
 ```bash
-mkdir -p "$HOME/dotnet" && tar zxf aspnetcore-runtime-5.0.0-osx-x64.tar.gz -C "$HOME/dotnet"
-export DOTNET_ROOT=$HOME/dotnet
-export PATH=$PATH:$HOME/dotnet
-```
+DOTNET_FILE=dotnet-sdk-5.0.102-linux-x64.tar.gz
+DOTNET_ROOT=$HOME/dotnet
 
-**Use the following command to extract the SDK**:
+mkdir -p $DOTNET_ROOT && tar zxf $DOTNET_FILE -C $DOTNET_ROOT
 
-```bash
-mkdir -p "$HOME/dotnet" && tar zxf dotnet-sdk-5.0.100-osx-x64.tar.gz -C "$HOME/dotnet"
-export DOTNET_ROOT=$HOME/dotnet
-export PATH=$PATH:$HOME/dotnet
+export DOTNET_ROOT=$DOTNET_ROOT
+export PATH=$PATH:$DOTNET_ROOT
 ```
 
 > [!TIP]

--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -120,7 +120,7 @@ Next, extract the downloaded file and use the `export` command to set variables 
 
 To extract the runtime and make the .NET CLI commands available at the terminal, first download a .NET binary release. Then, open a terminal and run the following commands from the directory where the file was saved. The archive file name may be different depending on what you downloaded.
 
-**Use the following commands to extract the runtime or sdk that you downloaded.** Remember to change the `DOTNET_FILE` value to your file name:
+**Use the following commands to extract the runtime or SDK that you downloaded.** Remember to change the `DOTNET_FILE` value to your file name:
 
 ```bash
 DOTNET_FILE=dotnet-sdk-5.0.102-linux-x64.tar.gz

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -32,26 +32,24 @@ Windows 10 versions end-of-service dates are segmented by edition. Only **Home**
 
 | Operating System            | .NET Core 2.1 | .NET Core 3.1 | .NET 5 |
 |-----------------------------|---------------|---------------|--------|
-| Windows 10, Version 20H2    | ✔️           | ✔️            | ✔️    |
-| Windows 10, Version 2004    | ✔️           | ✔️            | ✔️    |
-| Windows 10, Version 1909    | ✔️           | ✔️            | ✔️    |
-| Windows 10, Version 1903    | ✔️           | ✔️            | ✔️    |
+| Windows 10 / Windows Server, Version 20H2    | ✔️           | ✔️            | ✔️    |
+| Windows 10 / Windows Server, Version 2004    | ✔️           | ✔️            | ✔️    |
+| Windows 10 / Windows Server, Version 1909    | ✔️           | ✔️            | ✔️    |
+| Windows 10 / Windows Server, Version 1903    | ✔️           | ✔️            | ✔️    |
 | Windows 10, Version 1809    | ✔️           | ✔️            | ✔️    |
 | Windows 10, Version 1803    | ✔️           | ✔️            | ✔️    |
 | Windows 10, Version 1709    | ✔️           | ✔️            | ✔️    |
 | Windows 10, Version 1607    | ✔️           | ✔️            | ✔️    |
 | Windows 8.1                 | ✔️           | ✔️            | ✔️    |
 | Windows 7 SP1 [ESU][esu]    | ✔️           | ✔️            | ✔️    |
-| Windows 10, Version 1607    | ✔️           | ✔️            | ✔️    |
-| Windows 10, Version 1607    | ✔️           | ✔️            | ✔️    |
-| Windows Server 2012 R2      | ✔️           | ✔️            | ✔️    |
+| Windows Server 2019<br>Windows Server 2016<br>Windows Server 2012 R2<br>      | ✔️           | ✔️            | ✔️    |
 | Windows Server Core 2012 R2 | ✔️           | ✔️            | ✔️    |
 | Nano Server, Version 1809+  | ✔️           | ✔️            | ✔️    |
 | Nano Server, Version 1803   | ✔️           | ✔️            | ❌    |
 
 ## Unsupported releases
 
-The following versions of .NET are ❌ no longer supported. The downloads for these versions still remain published:
+The following versions of .NET are ❌ no longer supported:
 
 - 3.0
 - 2.2

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -61,14 +61,14 @@ The runtime is used to run apps created with .NET. When an app author publishes 
 
 There are three different runtimes you can install on Windows:
 
-*ASP.NET Core runtime*\
-Runs ASP.NET Core apps. Includes the .NET runtime.
+- *ASP.NET Core runtime*\
+  Runs ASP.NET Core apps. Includes the .NET runtime.
 
-*Desktop runtime*\
-Runs .NET WPF and Windows Forms desktop apps for Windows. Includes the .NET runtime.
+- *Desktop runtime*\
+  Runs .NET WPF and Windows Forms desktop apps for Windows. Includes the .NET runtime.
 
-*.NET runtime*\
-This runtime is the simplest runtime and doesn't include any other runtime. It's highly recommended that you install both *ASP.NET Core runtime* and *Desktop runtime* for the best compatibility with .NET apps.
+- *.NET runtime*\
+  This runtime is the simplest runtime and doesn't include any other runtime. It's highly recommended that you install both *ASP.NET Core runtime* and *Desktop runtime* for the best compatibility with .NET apps.
 
 > [!div class="button"]
 > [Download .NET Runtime](https://dotnet.microsoft.com/download/dotnet-core)


### PR DESCRIPTION
## Summary

- Removed duplicated entries.
- Added Windows Server versions that were missing.
- Add snap/manual/scripted install info to Linux root page.
- Linux/Macos manual install script updated to better clarify the file name is an input value.

Fixes #22561
Fixes #22589
Fixes #22586