### PR TITLE
Updating MessageBox to MsgBox

### DIFF
--- a/docs/framework/interop/specifying-an-entry-point.md
+++ b/docs/framework/interop/specifying-an-entry-point.md
@@ -71,7 +71,7 @@ using System.Runtime.InteropServices;
 internal static class NativeMethods
 {
     [DllImport("user32.dll", EntryPoint = "MessageBoxA")]
-    internal static extern int MessageBox(
+    internal static extern int MsgBox(
         IntPtr hWnd, string lpText, string lpCaption, uint uType);
 }
 ```


### PR DESCRIPTION

in this session you should be taught to rename the "MessageBox" function to "MsgBox", but in the C # version this did not happen. Now it's fixed!