### PR TITLE
Parameter name matching for parameterized ctors

### DIFF
--- a/docs/standard/serialization/snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs
+++ b/docs/standard/serialization/snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ImmutableTypesCtorParms
+{
+    public struct Forecast
+    {
+        public DateTime Date { get; }
+        [JsonPropertyName("celsius")]
+        public int TemperatureC { get; }
+        public string Summary { get; }
+ 
+        [JsonConstructor]
+        public Forecast(DateTime date, int temperatureC, string summary) =>
+            (Date, TemperatureC, Summary) = (date, temperatureC, summary);
+    }
+
+    public class Program
+    {
+        public static void Main()
+        {
+            var json = @"{""date"":""2020-09-06T11:31:01.923395-07:00"",""celsius"":-1,""summary"":""Cold""} ";
+            Console.WriteLine($"Input JSON: {json}");
+
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+            var forecast = JsonSerializer.Deserialize<Forecast>(json, options);
+
+            Console.WriteLine($"forecast.Date: {forecast.Date}");
+            Console.WriteLine($"forecast.TemperatureC: {forecast.TemperatureC}");
+            Console.WriteLine($"forecast.Summary: {forecast.Summary}");
+
+            var roundTrippedJson =
+                JsonSerializer.Serialize<Forecast>(forecast, options);
+
+            Console.WriteLine($"Output JSON: {roundTrippedJson}");
+
+        }
+    }
+}
+
+// Produces output like the following example:
+//
+//Input JSON: { "date":"2020-09-06T11:31:01.923395-07:00","temperatureC":-1,"summary":"Cold"}
+//forecast.Date: 9 / 6 / 2020 11:31:01 AM
+//forecast.TemperatureC: -1
+//forecast.Summary: Cold
+//Output JSON: { "date":"2020-09-06T11:31:01.923395-07:00","temperatureC":-1,"summary":"Cold"}

--- a/docs/standard/serialization/snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs
+++ b/docs/standard/serialization/snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs
@@ -42,8 +42,8 @@ namespace ImmutableTypesCtorParms
 
 // Produces output like the following example:
 //
-//Input JSON: { "date":"2020-09-06T11:31:01.923395-07:00","temperatureC":-1,"summary":"Cold"}
+//Input JSON: { "date":"2020-09-06T11:31:01.923395-07:00","celsius":-1,"summary":"Cold"}
 //forecast.Date: 9 / 6 / 2020 11:31:01 AM
 //forecast.TemperatureC: -1
 //forecast.Summary: Cold
-//Output JSON: { "date":"2020-09-06T11:31:01.923395-07:00","temperatureC":-1,"summary":"Cold"}
+//Output JSON: { "date":"2020-09-06T11:31:01.923395-07:00","celsius":-1,"summary":"Cold"}

--- a/docs/standard/serialization/snippets/system-text-json-how-to-5-0/csharp/Program.cs
+++ b/docs/standard/serialization/snippets/system-text-json-how-to-5-0/csharp/Program.cs
@@ -15,6 +15,10 @@ namespace SystemTextJsonHowTo
             ImmutableTypes.Program.Main();
             Console.WriteLine();
 
+            Console.WriteLine("======== Immutable types =========");
+            ImmutableTypesCtorParms.Program.Main();
+            Console.WriteLine();
+
             Console.WriteLine("======== Record support =========");
             Records.Program.Main();
             Console.WriteLine();

--- a/docs/standard/serialization/system-text-json-customize-properties.md
+++ b/docs/standard/serialization/system-text-json-customize-properties.md
@@ -1,7 +1,7 @@
 ---
 title: How to customize property names and values with System.Text.Json
 description: "Learn how to customize property names and values when serializing with System.Text.Json in .NET."
-ms.date: 11/30/2020
+ms.date: 02/01/2021
 no-loc: [System.Text.Json, Newtonsoft.Json]
 helpviewer_keywords:
   - "JSON serialization"
@@ -46,6 +46,7 @@ The property name set by this attribute:
 
 * Applies in both directions, for serialization and deserialization.
 * Takes precedence over property naming policies.
+* [Doesn't affect parameter name matching for parameterized constructors](system-text-json-immutability.md#immutable-types-and-records).
 
 ## Use camel case for all JSON property names
 

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -24,7 +24,7 @@ This article shows how to use immutable types, parameterized constructors, and n
 
 The parameter names of a parameterized constructor must match the property names. Matching is case-insensitive, and the constructor parameter must match the actual property name even if you use [[JsonPropertyName]](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) to rename a property. In the following example, the name for the `TemperatureC` property is changed to `celsius` in the JSON, but the constructor parameter is still named `temperatureC`:
 
-:::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs" highlight="13":::
+:::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs" highlight="10,14-16":::
 
 Records in C# 9 are also supported, as shown in the following example:
 

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -18,7 +18,7 @@ This article shows how to use immutable types, parameterized constructors, and n
 ## Immutable types and Records
 
 ::: zone pivot="dotnet-5-0"
-`System.Text.Json` can use a parameterized constructor, which makes it possible to deserialize an immutable class or struct. For a class, if the only constructor is a parameterized one, that constructor will be used. For a struct, or a class with multiple constructors, specify the one to use by applying the [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute) attribute. When the attribute is not used, a public parameterless constructor is always used if present. The attribute can only be used with public constructors. The following example uses the `[JsonConstructor]` attribute:
+`System.Text.Json` can use a public parameterized constructor, which makes it possible to deserialize an immutable class or struct. For a class, if the only constructor is a parameterized one, that constructor will be used. For a struct, or a class with multiple constructors, specify the one to use by applying the [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute) attribute. When the attribute is not used, a public parameterless constructor is always used if present. The attribute can only be used with public constructors. The following example uses the `[JsonConstructor]` attribute:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/ImmutableTypes.cs" highlight="13":::
 

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -1,7 +1,7 @@
 ---
 title: How to use immutable types and non-public accessors with System.Text.Json
 description: "Learn how to use immutable types and non-public accessors while serializing to and deserializing from JSON in .NET."
-ms.date: 02/01/2021
+ms.date: 02/08/2021
 no-loc: [System.Text.Json, Newtonsoft.Json]
 zone_pivot_groups: dotnet-version
 helpviewer_keywords:
@@ -13,7 +13,7 @@ helpviewer_keywords:
 
 # How to use immutable types and non-public accessors with System.Text.Json
 
-This article shows how to use immutable types, parameterized constructors, and non-public accessors with the `System.Text.Json` namespace.
+This article shows how to use immutable types, public parameterized constructors, and non-public accessors with the `System.Text.Json` namespace.
 
 ## Immutable types and Records
 
@@ -25,6 +25,13 @@ This article shows how to use immutable types, parameterized constructors, and n
 The parameter names of a parameterized constructor must match the property names. Matching is case-insensitive, and the constructor parameter must match the actual property name even if you use [[JsonPropertyName]](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) to rename a property. In the following example, the name for the `TemperatureC` property is changed to `celsius` in the JSON, but the constructor parameter is still named `temperatureC`:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs" highlight="10,14-16":::
+
+Besides `[JsonPropertyName]` the following attributes support deserialization with parameterized constructors:
+
+* [[JsonConverter]](xref:System.Text.Json.Serialization.JsonConverterAttribute)
+* [[JsonIgnore]](xref:System.Text.Json.Serialization.JsonIgnoreAttribute)
+* [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute)
+* [[JsonNumberHandling]](xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute)
 
 Records in C# 9 are also supported, as shown in the following example:
 

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -1,7 +1,7 @@
 ---
 title: How to use immutable types and non-public accessors with System.Text.Json
 description: "Learn how to use immutable types and non-public accessors while serializing to and deserializing from JSON in .NET."
-ms.date: 11/30/2020
+ms.date: 02/01/2021
 no-loc: [System.Text.Json, Newtonsoft.Json]
 zone_pivot_groups: dotnet-version
 helpviewer_keywords:
@@ -13,14 +13,18 @@ helpviewer_keywords:
 
 # How to use immutable types and non-public accessors with System.Text.Json
 
-In this article, you will learn how to use immutable types, such as Records, with the `System.Text.Json` namespace.
+This article shows how to use immutable types, parameterized constructors, and non-public accessors with the `System.Text.Json` namespace.
 
 ## Immutable types and Records
 
 ::: zone pivot="dotnet-5-0"
-`System.Text.Json` can use a parameterized constructor, which makes it possible to deserialize an immutable class or struct. For a class, if the only constructor is a parameterized one, that constructor will be used. For a struct, or a class with multiple constructors, specify the one to use by applying the [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute.%23ctor%2A) attribute. When the attribute is not used, a public parameterless constructor is always used if present. The attribute can only be used with public constructors. The following example uses the `[JsonConstructor]` attribute:
+`System.Text.Json` can use a parameterized constructor, which makes it possible to deserialize an immutable class or struct. For a class, if the only constructor is a parameterized one, that constructor will be used. For a struct, or a class with multiple constructors, specify the one to use by applying the [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute) attribute. When the attribute is not used, a public parameterless constructor is always used if present. The attribute can only be used with public constructors. The following example uses the `[JsonConstructor]` attribute:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/ImmutableTypes.cs" highlight="13":::
+
+The parameter names of a parameterized constructor must match the property names. Matching is case-insensitive, and the constructor parameter must match the actual property name even if you use [[JsonPropertyName]](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) to rename a property. In the following example, the name for the `TemperatureC` property is changed to `celsius` in the JSON, but the constructor parameter is still named `temperatureC`:
+
+:::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/ImmutableTypesCtorParms.cs" highlight="13":::
 
 Records in C# 9 are also supported, as shown in the following example:
 


### PR DESCRIPTION
Fixes #22488

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-immutability?branch=pr-en-us-22602)
