### PR TITLE
Document breaking change for Kestrel log message attributes

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes in .NET 6.0
 description: Navigate to the breaking changes in .NET 6.0.
-ms.date: 01/19/2021
+ms.date: 02/01/2021
 ---
 # Breaking changes in .NET 6.0
 
@@ -9,6 +9,10 @@ If you're migrating an app to .NET 6.0, the breaking changes listed here might a
 
 > [!NOTE]
 > This article is a work-in-progress. It's not a complete list of breaking changes in .NET 6.0.
+
+## ASP.NET Core
+
+- [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md)
 
 ## Windows Forms
 

--- a/docs/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed.md
+++ b/docs/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed.md
@@ -7,7 +7,7 @@ ms.date: 02/01/2021
 ---
 # Kestrel: Log message attributes changed
 
-Kestrel log messages have associated IDs and names. These attributes uniquely identify different kinds of log messages. Some of those IDs and names were incorrectly duplicated. This duplication problem is being fixed in .NET 6.0.
+Kestrel log messages have associated IDs and names. These attributes uniquely identify different kinds of log messages. Some of those IDs and names were incorrectly duplicated. This duplication problem is fixed in ASP.NET Core 6.0.
 
 ## Version introduced
 

--- a/docs/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed.md
+++ b/docs/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed.md
@@ -1,0 +1,52 @@
+---
+title: "Breaking change: Kestrel: Log message attributes changed"
+description: "Learn about the breaking change in ASP.NET Core 6.0 titled Kestrel: Log message attributes changed"
+author: scottaddie
+ms.author: scaddie
+ms.date: 02/01/2021
+---
+# Kestrel: Log message attributes changed
+
+Kestrel log messages have associated IDs and names. These attributes uniquely identify different kinds of log messages. Some of those IDs and names were incorrectly duplicated. This duplication problem is being fixed in .NET 6.0.
+
+## Version introduced
+
+6.0
+
+## Old behavior
+
+The following table shows the state of the affected log messages before ASP.NET Core 6.0.
+
+| Message description                   | Name                    | ID |
+|---------------------------------------|-------------------------|----|
+| HTTP/2 connection closed log messages | `Http2ConnectionClosed` | 36 |
+| HTTP/2 frame sending log messages     | `Http2FrameReceived`    | 37 |
+
+## New behavior
+
+The following table shows the state of the affected log messages in ASP.NET Core 6.0.
+
+| Message description                   | Name                    | ID |
+|---------------------------------------|-------------------------|----|
+| HTTP/2 connection closed log messages | `Http2ConnectionClosed` | 48 |
+| HTTP/2 frame sending log messages     | `Http2FrameSending`     | 49 |
+
+## Reason for change
+
+Log IDs and names should be unique so different message types can be identified.
+
+## Recommended action
+
+If you have code or configuration that references the old IDs and names, update those references to use the new IDs and names.
+
+<!--
+
+## Category
+
+ASP.NET Core
+
+## Affected APIs
+
+Not detectable via API analysis
+
+-->

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -22,6 +22,10 @@
       items:
       - name: Overview
         href: 6.0.md
+      - name: ASP.NET Core
+        items:
+        - name: "Kestrel: Log message attributes changed"
+          href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
       - name: Windows Forms
         items:
         - name: NotifyIcon.Text maximum text length increased
@@ -294,6 +298,10 @@
     items:
     - name: ASP.NET Core
       items:
+      - name: .NET 6.0
+        items:
+        - name: "Kestrel: Log message attributes changed"
+          href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
       - name: .NET 5.0
         items:
         - name: ASP.NET Core apps deserialize quoted numbers


### PR DESCRIPTION
Document the breaking change described at https://github.com/aspnet/Announcements/issues/447

[Internal review page](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed?branch=pr-en-us-22604)