### PR TITLE
Add link to VS tutorial

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/arrays-and-collections.md
+++ b/docs/csharp/tutorials/intro-to-csharp/arrays-and-collections.md
@@ -6,10 +6,9 @@ ms.custom: mvc
 ---
 # Learn to manage data collections using the generic list type
 
-This introductory tutorial provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601>
-class.
+This introductory tutorial provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601> class.
 
-This tutorial expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Windows, Linux, or macOS. A quick overview of the commands you'll use is in [Become familiar with the development tools](local-environment.md), with links to more details.
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
 
 ## A basic list example
 

--- a/docs/csharp/tutorials/intro-to-csharp/arrays-and-collections.md
+++ b/docs/csharp/tutorials/intro-to-csharp/arrays-and-collections.md
@@ -8,7 +8,9 @@ ms.custom: mvc
 
 This introductory tutorial provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601> class.
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
+## Prerequisites
+
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
 
 ## A basic list example
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -9,7 +9,9 @@ ms.custom: mvc
 
 This tutorial teaches you how to write code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
+## Prerequisites
+
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
 
 ## Make decisions using the `if` statement
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -9,7 +9,7 @@ ms.custom: mvc
 
 This tutorial teaches you how to write code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
-This tutorial expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Windows, Linux, or macOS. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
 
 ## Make decisions using the `if` statement
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -19,7 +19,7 @@ Create a directory named *branches-tutorial*. Make that the current directory an
 dotnet new console -n BranchesAndLoops -o .
 ```
 
-This command creates a new .NET Core console application in the current directory.
+This command creates a new .NET console application in the current directory.
 
 Open *Program.cs* in your favorite editor, and replace the line `Console.WriteLine("Hello World!");` with the following code:
 

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction to C# - interactive tutorials
 description: Learn C# in your browser, and get started with your own development environment
-ms.date: 08/22/2019
+ms.date: 02/02/2021
 ms.custom: mvc
 ---
 # Introduction to C\#

--- a/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
+++ b/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
@@ -8,7 +8,9 @@ ms.custom: mvc
 
 In this tutorial, you'll build a console application and see the basic object-oriented features that are part of the C# language.
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
+## Prerequisites
+
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
 
 ## Create your application
 

--- a/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
+++ b/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
@@ -6,7 +6,9 @@ ms.custom: mvc
 ---
 # Explore object oriented programming with classes and objects
 
-This tutorial expects that you have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Windows, Linux, or macOS. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
+In this tutorial, you'll build a console application and see the basic object-oriented features that are part of the C# language.
+
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
 
 ## Create your application
 

--- a/docs/csharp/tutorials/intro-to-csharp/local-environment.md
+++ b/docs/csharp/tutorials/intro-to-csharp/local-environment.md
@@ -17,10 +17,10 @@ The first step in running a tutorial on your machine is to set up a development 
 The instructions in these tutorials assume that you're using the .NET CLI to create, build, and run applications. You'll use the following commands:
 
 * [`dotnet new`](../../../core/tools/dotnet-new.md) creates an application. This command generates the files and assets necessary for your application. The introduction to C# tutorials all use the `console` application type. Once you've got the basics, you can expand to other application types.
-* [`dotnet build`](../../../core/tools/dotnet-build.md) builds the executable,
+* [`dotnet build`](../../../core/tools/dotnet-build.md) builds the executable.
 * [`dotnet run`](../../../core/tools/dotnet-run.md) runs the executable.
 
-If you use Visual Studio 2019 for these tutorials, you'll create, build, and run projects by using a Visual Studio menu selection when tutorial instructions say use a CLI command:
+If you use Visual Studio 2019 for these tutorials, you'll choose a Visual Studio menu selection when a tutorial directs you to run one of these CLI commands:
 
 * **File** > **New** > **Project** creates an application.
 * **Build** >  **Build Solution** builds the executable.
@@ -57,4 +57,4 @@ This tutorial assumes that you have finished the lessons listed above.
 
 ## Introduction to classes
 
-In [Introduction to classes](introduction-to-classes.md), you'll build a console application and see the basic object-oriented features that are part of the C# language. This is the final introduction to C# tutorial. It's only available to run on your machine, using your own local development environment and .NET Core.
+In [Introduction to classes](introduction-to-classes.md), you'll build a console application and see the basic object-oriented features that are part of the C# language. This is the final introduction to C# tutorial. It's only available to run on your machine, using your own local development environment and .NET.

--- a/docs/csharp/tutorials/intro-to-csharp/local-environment.md
+++ b/docs/csharp/tutorials/intro-to-csharp/local-environment.md
@@ -1,30 +1,36 @@
 ---
 title: Introduction to C# - become familiar with the development tools
 description: This article provides a basic introduction to the tools you'll use to develop C# and .NET Applications on your machine.
-ms.date: 10/23/2018
+ms.date: 02/02/2021
 ---
-# Become familiar with the .NET development tools
+# Set up your local environment
 
-The first step in running a tutorial on your machine is to set up a development environment.
-The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting
-up your local development environment on Windows, Linux, or macOS.
+The first step in running a tutorial on your machine is to set up a development environment. Choose one of the following alternatives:
 
-Alternatively, you can install the [.NET Core SDK](https://dotnet.microsoft.com/download) and
+* To use the .NET CLI and your choice of text or code editor, see the .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro). The tutorial has instructions for setting up a development environment on Windows, Linux, or macOS.
+* To use the .NET CLI and Visual Studio Code, install the [.NET SDK](https://dotnet.microsoft.com/download) and
 [Visual Studio Code](https://code.visualstudio.com/).
+* To use Visual Studio 2019 on Windows, see [Tutorial: Create a simple C# console app in Visual Studio](/visualstudio/get-started/csharp/tutorial-console).
 
 ## Basic application development flow
 
-You'll create applications using the [`dotnet new`](../../../core/tools/dotnet-new.md) command. This command
-generates the files and assets necessary for your application. The introduction to C# tutorials all use the `console` application type. Once you've got the basics, you can expand to other application types.
+The instructions in these tutorials assume that you're using the .NET CLI to create, build, and run applications. You'll use the following commands:
 
-The other commands you'll use are [`dotnet build`](../../../core/tools/dotnet-build.md) to build the executable,
-and [`dotnet run`](../../../core/tools/dotnet-run.md) to run the executable.
+* [`dotnet new`](../../../core/tools/dotnet-new.md) creates an application. This command generates the files and assets necessary for your application. The introduction to C# tutorials all use the `console` application type. Once you've got the basics, you can expand to other application types.
+* [`dotnet build`](../../../core/tools/dotnet-build.md) builds the executable,
+* [`dotnet run`](../../../core/tools/dotnet-run.md) runs the executable.
+
+If you use Visual Studio 2019 for these tutorials, you'll create, build, and run projects by using a Visual Studio menu selection when tutorial instructions say use a CLI command:
+
+* **File** > **New** > **Project** creates an application.
+* **Build** >  **Build Solution** builds the executable.
+* **Debug** > **Start Without Debugging** runs the executable.
 
 ## Pick your tutorial
 
 You can start with any of the following tutorials:
 
-## [Numbers in C#](numbers-in-csharp-local.md)
+## Numbers in C\#
 
 In the [Numbers in C#](numbers-in-csharp-local.md) tutorial, you'll learn
 how computers store numbers and how to perform calculations with different
@@ -33,7 +39,7 @@ mathematical calculations using C#.
 
 This tutorial assumes that you have finished the [Hello world](hello-world.yml) lesson.
 
-## [Branches and loops](branches-and-loops-local.md)
+## Branches and loops
 
 The [Branches and loops](branches-and-loops-local.md) tutorial teaches the basics of selecting
 different paths of code execution based on the values stored in variables. You'll learn the
@@ -43,14 +49,12 @@ different actions.
 This tutorial assumes that you have finished the [Hello world](hello-world.yml) and
 [Numbers in C#](numbers-in-csharp-local.md) lessons.
 
-## [List collection](arrays-and-collections.md)
+## List collection
 
-The [List collection](arrays-and-collections.md) lesson gives you
-a tour of the List collection type that stores sequences of data. You'll learn how to add and remove items, search for items, and sort the lists. You'll explore different kinds of lists.
+The [List collection](arrays-and-collections.md) lesson gives you a tour of the List collection type that stores sequences of data. You'll learn how to add and remove items, search for items, and sort the lists. You'll explore different kinds of lists.
 
 This tutorial assumes that you have finished the lessons listed above.
 
-## [Introduction to classes](introduction-to-classes.md)
+## Introduction to classes
 
-This final introduction to C# tutorial is only available to run on your machine, using your own local development environment and .NET Core.
-You'll build a console application and see the basic object-oriented features that are part of the C# language.
+In [Introduction to classes](introduction-to-classes.md), you'll build a console application and see the basic object-oriented features that are part of the C# language. This is the final introduction to C# tutorial. It's only available to run on your machine, using your own local development environment and .NET Core.

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
@@ -9,7 +9,9 @@ ms.custom: mvc
 
 This tutorial teaches you about the numeric types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
+## Prerequisites
+
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
 
 ## Explore integer math
 

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
@@ -1,7 +1,7 @@
 ---
 title: Numbers in C# - Introduction to C# tutorial
 description: Learn C# by exploring numeric types, their uses, properties, and methods.
-ms.date: 10/31/2017
+ms.date: 02/02/2021
 ms.custom: mvc
 ---
 
@@ -9,7 +9,7 @@ ms.custom: mvc
 
 This tutorial teaches you about the numeric types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
-This tutorial expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Windows, Linux, or macOS. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI. On Windows, you can use Visual Studio 2019. For instructions, see [Set up your local environment](local-environment.md).
 
 ## Explore integer math
 


### PR DESCRIPTION
Fixes #19218

The issue only requested a VS link, but the tutorials were written to use CLI commands for project operations, so adding a link to VS for local environment setup required some additional explanatory text.