### PR TITLE
Add links to CA categories, Fixes #22087

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1000.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1000|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -65,7 +65,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1001|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking - If the type is not visible outside the assembly.<br/><br/>Breaking - If the type is visible outside the assembly.|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-These options can be configured for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+These options can be configured for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1002|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -54,7 +54,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1003.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1003           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause
@@ -49,7 +49,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1005.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1005|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -44,7 +44,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1008|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking - When you're prompted to add a `None` value to a non-flag enumeration. Breaking - When you're prompted to rename or remove any enumeration values.|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1010.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1010           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause
@@ -55,7 +55,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Additional required generic interfaces](#additional-required-generic-interfaces)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -19,7 +19,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1012           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1014.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1014           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1016.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1016           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1017.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1017.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1017           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1018.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1018           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1019.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1019           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1021.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1021           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause
@@ -54,7 +54,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1024           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause
@@ -59,7 +59,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1027           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1028           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1030|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -51,6 +51,6 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1031.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1031.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1031           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Disallowed exception type names](#disallowed-exception-type-names)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Disallowed exception type names
 
@@ -74,7 +74,7 @@ Examples:
 |`dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS.ExceptionType` | Matches specific types named 'ExceptionType' with given fully qualified name.
 |`dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS1.ExceptionType1|T:NS1.ExceptionType2` | Matches types named 'ExceptionType1' and 'ExceptionType2' with respective fully qualified names
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1032.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1032.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1032           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1033.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1033.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1033           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1034.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1034.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1034           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1036           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause
@@ -58,7 +58,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1040.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1040.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1040           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking         |
 
 ## Cause
@@ -49,7 +49,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1041.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1041.md
@@ -20,7 +20,7 @@ dev_langs:
 | Item                                     | Value            |
 |------------------------------------------|------------------|
 | RuleId                                   | CA1041           |
-| Category                                 | Microsoft.Design |
+| Category                                 | [Microsoft.Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking     |
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1043|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1044.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1044.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1044|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1045.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1045.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1045|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -53,7 +53,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1046.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1046.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1046|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -63,7 +63,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1047|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1050.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1050.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1050|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1051.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1051.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1051|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -54,7 +54,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Exclude structs](#exclude-structs)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1052.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1052.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1052|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -55,7 +55,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1053.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1053.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1053|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 > [!NOTE]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1054.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1054.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1054|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1055|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1056.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1056.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1056|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1058.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1058.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1058|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -83,6 +83,6 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1060.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1060.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1060|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1061.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1061.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1061|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1062.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1062.md
@@ -21,7 +21,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1062|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -53,7 +53,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude extension method 'this' parameter](#exclude-extension-method-this-parameter)
 - [Null check validation methods](#null-check-validation-methods)
 
-These options can be configured for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+These options can be configured for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1063.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1063.md
@@ -19,7 +19,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1063|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -82,7 +82,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1064.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1064.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1064|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1065.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1065.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1065|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1066.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1066.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1066|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1067.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1067.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1067|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1068|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -69,7 +69,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1069.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1069.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1069|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1070.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1070.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1070|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -51,7 +51,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1071.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1071.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1071|
-| **Category** |Microsoft.Design|
+| **Category** |[Microsoft.Design](design-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1200.md
@@ -19,7 +19,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1200|
-| **Category** |Microsoft.Documentation|
+| **Category** |[Microsoft.Documentation](documentation-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1303.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1303.md
@@ -21,7 +21,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1303|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -66,7 +66,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 - [Use naming heuristic](#use-naming-heuristic)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Globalization). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Globalization](globalization-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1304.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1304.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1304|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -60,7 +60,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Globalization). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Globalization](globalization-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -19,7 +19,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1305|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1307.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1307.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1307|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1308.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1308.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1308|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1309.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1309.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 |                                     | Value                   |
 |-------------------------------------|-------------------------|
 | **Rule ID**                         | CA1309                  |
-| **Category**                        | Microsoft.Globalization |
+| **Category**                        | [Microsoft.Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking            |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1310.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1310.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1310|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1401.md
@@ -20,7 +20,7 @@ dev_langs:
 |                                     | Value                      |
 |-------------------------------------|----------------------------|
 | **Rule ID**                          | CA1401                     |
-| **Category**                        | Microsoft.Interoperability |
+| **Category**                        | [Microsoft.Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                   |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1416.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1416.md
@@ -17,7 +17,7 @@ ms.author: bunamnan
 |||
 |-|-|
 | **Rule ID** |CA1416|
-| **Category** |Microsoft.Interoperability|
+| **Category** |[Microsoft.Interoperability](interoperability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1417.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1417.md
@@ -17,7 +17,7 @@ ms.author: elfung
 | | Value |
 |-|-|
 | **Rule ID** |CA1417|
-| **Category** |Microsoft.Interoperability|
+| **Category** |[Microsoft.Interoperability](interoperability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1501|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Inheritance excluded type or namespace names](#inheritance-excluded-type-or-namespace-names)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Maintainability). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Maintainability](maintainability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Inheritance excluded type or namespace names
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1502.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1502.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1502|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1505.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1505.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1505|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1506.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1506.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1506|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1507.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1507.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1507|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1508.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1508.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1508|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-Breaking|
 
 ## Cause
@@ -69,7 +69,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Maintainability). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Maintainability](maintainability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1509.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1509.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1509|
-| **Category** |Microsoft.Maintainability|
+| **Category** |[Microsoft.Maintainability](maintainability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1700.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1700.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1700|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -52,7 +52,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1707|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking - when raised on assemblies<br/><br/>Non-breaking - when raised on type parameters|
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1708.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1708.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1708|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1710|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -92,7 +92,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude indirect base types](#exclude-indirect-base-types)
 - [Additional required suffixes](#additional-required-suffixes)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1711|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -74,7 +74,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Allow suffixes](#allow-suffixes)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1712.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1712.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1712|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -77,7 +77,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Enum values prefix trigger](#enum-values-prefix-trigger)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Enum values prefix trigger
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1713.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1713.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1713|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1714.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1714.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1714|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1715.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1715.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1715|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking - when fired on interfaces.<br/><br/>Non-breaking - when raised on generic type parameters.|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Single-character type parameters](#single-character-type-parameters)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1716|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -53,7 +53,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Analyzed symbol kinds](#analyzed-symbol-kinds)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1717.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1717.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1717|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -48,7 +48,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1720.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1720.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1720|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -100,7 +100,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1721.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1721.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1721|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -53,7 +53,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1724.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1724.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1724|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1725|
-| **Category** |Microsoft.Naming|
+| **Category** |[Microsoft.Naming](naming-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -44,6 +44,6 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Naming). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1801|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br/><br/>Non-breaking - If you change the member to use the parameter within its body.<br/><br/>Breaking - If you remove the parameter and it is visible outside the assembly.|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1802|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -55,7 +55,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Required modifiers](#required-modifiers)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Performance). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1805.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1805.md
@@ -17,7 +17,7 @@ ms.author: stoub
 | | Value |
 |-|-|
 | **Rule ID** |CA1805|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1806|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1810.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1810.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1810|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1812.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1812.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1812|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1813.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1813.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1813|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1814.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1814.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1814|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1815.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1815.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1815|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -44,7 +44,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Performance). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1816.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1816.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1816|
-| **Category** |Microsoft. Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1819.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1819.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1819|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause
@@ -51,7 +51,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Performance). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1820.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1820.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1820|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1821.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1821.md
@@ -16,7 +16,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1821|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1822|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br /><br />Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/><br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly.|
 
 ## Cause
@@ -42,7 +42,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Performance). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1823.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1823.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1823|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1824.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1824.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA1824|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1825.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1825.md
@@ -19,7 +19,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1825|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1826.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1826.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1826|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1827|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1828.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1828.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1828|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1829.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1829.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA1829|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1830.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1830.md
@@ -17,7 +17,7 @@ ms.author: stoub
 | | Value |
 |-|-|
 | **Rule ID** |CA1830|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1831.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1831.md
@@ -17,7 +17,7 @@ ms.author: bunamnan
 | | Value |
 |-|-|
 | **Rule ID** |CA1831|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1832.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1832.md
@@ -17,7 +17,7 @@ ms.author: bunamnan
 | | Value |
 |-|-|
 | **Rule ID** |CA1832|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1833.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1833.md
@@ -17,7 +17,7 @@ ms.author: bunamnan
 | | Value |
 |-|-|
 | **Rule ID** |CA1833|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1834.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1834.md
@@ -17,7 +17,7 @@ ms.author: prgovi
 | | Value |
 |-|-|
 | **Rule ID** |CA1834|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -21,7 +21,7 @@ dev_langs:
 |-|-|
 |TypeName|PreferStreamAsyncMemoryOverlodas|
 | **Rule ID** |CA1835|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1836.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1836.md
@@ -17,7 +17,7 @@ ms.author: dacantu
 | | Value |
 |-|-|
 | **Rule ID** |CA1836|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1837.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1837.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1837
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca1838.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1838.md
@@ -18,7 +18,7 @@ ms.author: elfung
 | | Value |
 |-|-|
 | **Rule ID** |CA1838|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -21,7 +21,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2000|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -80,7 +80,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Reliability). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Reliability](reliability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2002.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2002|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2007.md
@@ -18,7 +18,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2007|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -74,7 +74,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude async void methods](#exclude-async-void-methods)
 - [Output kind](#output-kind)
 
-You can configure all of these options for just this rule, for all rules, or for all rules in this category (Reliability). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure all of these options for just this rule, for all rules, or for all rules in this category ([Reliability](reliability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Exclude async void methods
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2007.md
@@ -18,7 +18,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2007|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -72,7 +72,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude async void methods](#exclude-async-void-methods)
 - [Output kind](#output-kind)
 
-You can configure all of these options for just this rule, for all rules, or for all rules in this category (Reliability). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure all of these options for just this rule, for all rules, or for all rules in this category ([Reliability](reliability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Exclude async void methods
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2008.md
@@ -16,7 +16,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2008|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2009.md
@@ -16,7 +16,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA2009|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2011.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA2011|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2012.md
@@ -17,7 +17,7 @@ ms.author: stoub
 | | Value |
 |-|-|
 | **Rule ID** |CA2012|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2013.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2013.md
@@ -17,7 +17,7 @@ ms.author: bunamnan
 | | Value |
 |-|-|
 | **Rule ID** |CA2013|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2014.md
@@ -17,7 +17,7 @@ ms.author: stoub
 | | Value |
 |-|-|
 | **Rule ID** |CA2014|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2015.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2015.md
@@ -17,7 +17,7 @@ ms.author: bunamnan
 | | Value |
 |-|-|
 | **Rule ID** |CA2015|
-| **Category** |Microsoft.Reliability|
+| **Category** |[Microsoft.Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -21,7 +21,7 @@ dev_langs:
 |-|-|
 |TypeName|ForwardCancellationTokenToInvocations|
 | **Rule ID** |CA2016|
-| **Category** |Microsoft.Performance|
+| **Category** |[Microsoft.Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2100.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2100.md
@@ -21,7 +21,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2100|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -79,7 +79,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2101.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2101.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2101|
-| **Category** |Microsoft.Globalization|
+| **Category** |[Microsoft.Globalization](globalization-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2109|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2119.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2119.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2119|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2153.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2153.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2153|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2200.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2200|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2201.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2201.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2201|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2207.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2207.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2207|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2208|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2211.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2211.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2211|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2213.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2213.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2213|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2214.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2214.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2214|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2215.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2215.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2215|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2216.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2216.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2216|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2217.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2217.md
@@ -20,7 +20,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2217|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2218.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2218.md
@@ -17,7 +17,7 @@ dev_langs:
 |Item|Value|
 |-|-|
 |RuleId|CA2218|
-|Category|Microsoft.Usage|
+|Category|[Microsoft.Usage](usage-warnings.md)|
 |Breaking change|Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2219.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2219.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2219|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking, Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -16,7 +16,7 @@ helpviewer_keywords:
 |Item|Value|
 |-|-|
 |RuleId|CA2224|
-|Category|Microsoft.Usage|
+|Category|[Microsoft.Usage](usage-warnings.md)|
 |Breaking change|Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2225.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2225.md
@@ -19,7 +19,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2225|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -96,7 +96,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2226.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2226.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2226|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2227.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2227.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2227|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2229.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2229.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2229|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2231.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2231.md
@@ -21,7 +21,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2231|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -64,7 +64,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2234.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2234.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2234|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](~/includes/code-analysis/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2235.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2235.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2235|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2237.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2237.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2237|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2241.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2241.md
@@ -21,7 +21,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2241|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2242.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2242.md
@@ -19,7 +19,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA2242|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2243.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2243.md
@@ -17,7 +17,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA2243|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2244.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2244.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA2244|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2245.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2245.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA2245|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2246.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2246.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA2246|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -17,7 +17,7 @@ ms.author: stoub
 | | Value |
 |-|-|
 | **Rule ID** |CA2247|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2248.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2248.md
@@ -15,7 +15,7 @@ ms.author: mavasani
 | | Value |
 |-|-|
 | **Rule ID** |CA2248|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2249.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2249.md
@@ -15,7 +15,7 @@ ms.author: prgovi
 | | Value |
 |-|-|
 | **Rule ID** |CA2249|
-| **Category** |Microsoft.Usage|
+| **Category** |[Microsoft.Usage](usage-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2300.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2300.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2300|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2301.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2301.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2301|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2302.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2302.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2302|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -52,7 +52,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2305.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2305|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2310.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2310.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2310|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2311.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2311.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2311|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2312.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2312.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2312|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -54,7 +54,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2315.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2315.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2315|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2321.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2321.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2321|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -49,7 +49,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2322.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2322.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2322|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -49,7 +49,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2326.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2326.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2326|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2327.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2327.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2327|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -58,7 +58,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2328.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2328.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2328|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -64,7 +64,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2329.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2329.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2329|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2330.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2330.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2330|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -57,7 +57,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2350.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2350|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2351.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2351|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2352.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2352.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2352|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2353.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2353.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2353|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2354.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2354.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2354|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2355.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2355.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2355|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2356.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2356.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2356|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2361.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2361|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2362.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA2362|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca3001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3001.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3001|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3002.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3002|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -57,7 +57,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3003.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3003|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -58,7 +58,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3004.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3004.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3004|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3005.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3005|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -56,7 +56,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3006.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3006.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3006|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3007.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3007|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -56,7 +56,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3008.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3008|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -54,7 +54,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3009.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3009|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -54,7 +54,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3010.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3010|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3011.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3011|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -50,7 +50,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3012.md
@@ -14,7 +14,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3012|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -55,7 +55,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3061.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3061.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA3061|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca3075.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3075.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA3075|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca3076.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3076.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA3076|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca3077.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3077.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA3077|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca3147.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3147.md
@@ -13,7 +13,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA3147|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5350.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA5350|
-| **Category** |Microsoft.Cryptography|
+| **Category** |[Microsoft.Cryptography](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 > [!NOTE]

--- a/docs/fundamentals/code-analysis/quality-rules/ca5351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5351.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 | | Value |
 |-|-|
 | **Rule ID** |CA5351|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 > [!NOTE]

--- a/docs/fundamentals/code-analysis/quality-rules/ca5358.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5358.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5358|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5359.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5359.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5359|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5360.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5360.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5360|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5361.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5361|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5362.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5362|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5363.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5363.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5363|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5364.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5364.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5364|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5365.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5365.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5365|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5366.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5366.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5366|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5367.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5367.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5367|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5368.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5368.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5368|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5369.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5369.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5369|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5370.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5370.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5370|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5371.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5371.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5371|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5372.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5372.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5372|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5373.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5373.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5373|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5374.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5374.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5374|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5375.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5375.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5375|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5376.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5376.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5376|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -42,7 +42,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5377.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5377.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5377|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -42,7 +42,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5378.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5378.md
@@ -17,7 +17,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5378|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -47,7 +47,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5379.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5379.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5379|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5380.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5380.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5380|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -44,7 +44,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5381.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5381.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5381|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -44,7 +44,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5382.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5382.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5382|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -60,7 +60,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5383.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5383.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5383|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -60,7 +60,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5384.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5384.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5384|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -45,7 +45,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5385.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5385.md
@@ -14,7 +14,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5385|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5386.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5386.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5386|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5387.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5387.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5387|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -43,7 +43,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5388.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5388.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5388|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5389.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5389.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5389|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5390.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5390.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5390|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -46,7 +46,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5391.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5391.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5391|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5392.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5392.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5392|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5393|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -52,7 +52,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Unsafe DllImportSearchPath bits](#unsafe-dllimportsearchpath-bits)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Unsafe DllImportSearchPath bits
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5394.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5394.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5394|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5395.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5395.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5395|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5396.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5396.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5396|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5397.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5397.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5397|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5398.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5398.md
@@ -16,7 +16,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5398|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5399.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5399.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5399|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -41,7 +41,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5400|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause
@@ -41,7 +41,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Security). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](~/includes/code-analysis/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5401.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5401|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5402.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5402.md
@@ -13,7 +13,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5402|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca5403.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5403.md
@@ -15,7 +15,7 @@ f1_keywords:
 | | Value |
 |-|-|
 | **Rule ID** |CA5403|
-| **Category** |Microsoft.Security|
+| **Category** |[Microsoft.Security](security-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause


### PR DESCRIPTION
## Summary

For each CA rule, each time they mention their CA rule category I added a link to the category overview page.

Fixes #22087