### PR TITLE
Wrong order in code snippet example.

### DIFF
--- a/samples/snippets/fsharp/lists/snippet30.fs
+++ b/samples/snippets/fsharp/lists/snippet30.fs
@@ -1,4 +1,4 @@
-let sumListBack list = List.foldBack (fun acc elem -> acc + elem) list 0
+let sumListBack list = List.foldBack (fun elem acc -> acc + elem) list 0
 printfn "%d" (sumListBack [1; 2; 3])
 
 // For a calculation in which the order of traversal is important, fold and foldBack have different


### PR DESCRIPTION
"acc" and "elem" should be switched in sumListBack. The "acc" actually refers to the element in question and vice versa. Misleading, since the folder function for fold and foldback have different types.

## Summary

Switched acc and elem
