### PR TITLE
Add Desktop SDK MSBuild properties article

### DIFF
--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -81,7 +81,7 @@ The following table shows which elements and which [globs](https://en.wikipedia.
 | Page                  | \*\*/\*.xaml                 | \*\*/\*.user; \*\*/\*.\*proj; \*\*/\*.sln; \*\*/\*.vssscc<br>Any XAML defined by *ApplicationDefinition* | N/A          |
 | None                  | N/A                          | N/A                                                                | \*\*/\*.xaml |
 
-For reference, here are the default include and exclude for all project types. For more information, see [Default includes and excludes](overview.md#default-includes-and-excludes).
+Here are the default include and exclude settings for all project types. For more information, see [Default includes and excludes](overview.md#default-includes-and-excludes).
 
 | Element           | Include glob                              | Exclude glob                                                  | Remove glob              |
 |-------------------|-------------------------------------------|---------------------------------------------------------------|--------------------------|
@@ -91,7 +91,7 @@ For reference, here are the default include and exclude for all project types. F
 
 ### Errors related to "duplicate" items
 
-If you have XAML globs in your project or explicitly add files to your project, you'll possibly get one of the following errors:
+If you explicitly added files to your project, or have XAML globs to automatically include files in your project, you'll possibly get one of the following errors:
 
 * Duplicate 'ApplicationDefinition' items were included.
 * Duplicate 'Page' items were included.

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -1,6 +1,6 @@
 ---
 title: MSBuild properties for Microsoft.NET.Sdk.Desktop
-description: Reference for the MSBuild properties and items that are understood by the .NET Desktop SDK which includes WPF and WinForms.
+description: Reference for the MSBuild properties and items that are understood by the .NET Desktop SDK, which includes WPF and WinForms.
 ms.date: 02/04/2021
 ms.topic: reference
 author: adegeo
@@ -21,7 +21,7 @@ To use WinForms or WPF, configure your project file.
 
 ### .NET 5.0
 
-WinForms and WPF projects should specify the following settings in the project file:
+Specify the following settings in the project file of your WinForms or WPF project:
 
 - Target the .NET SDK `Microsoft.NET.Sdk`. For more information, see [Project files](overview.md#project-files).
 - Set the `TargetFramework` to `net5.0-windows`.
@@ -47,6 +47,8 @@ WinForms and WPF projects should specify the following settings in the project f
 
 ### .NET Core 3.1
 
+Specify the following settings in the project file of your WinForms or WPF project:
+
 - Target the .NET SDK `Microsoft.NET.Sdk.WindowsDesktop`. For more information, see [Project files](overview.md#project-files).
 - Set the `TargetFramework` to `netcoreapp3.1`.
 - Set one of the following to enable a UI framework:
@@ -71,11 +73,11 @@ WinForms and WPF projects should specify the following settings in the project f
 
 ## WPF default include exclude
 
-SDK project files define a set of rules to implicitly include or exclude files from the project. These rules also automatically set the file's build action. This is unlike the older non-SDK .NET Framework projects, which had no default include or exclude rules. .NET Framework projects required you to explicitly declare which files to include in the project.
+SDK projects define a set of rules to implicitly include or exclude files from the project. These rules also automatically set the file's build action. This is unlike the older non-SDK .NET Framework projects, which have no default include or exclude rules. .NET Framework projects require you to explicitly declare which files to include in the project.
 
 .NET project files include a [standard set of rules](overview.md#default-includes-and-excludes) for automatically processing files. WPF projects add additional rules.
 
-The following table shows which elements and which [globs](https://en.wikipedia.org/wiki/Glob_(programming)) are included and excluded in the .NET Desktop SDK when the [`UseWPF`](#usewpf) project property is set to `true`:
+The following table shows which elements and [globs](https://en.wikipedia.org/wiki/Glob_(programming)) are included and excluded in the .NET Desktop SDK when the [`UseWPF`](#usewpf) project property is set to `true`:
 
 | Element               | Include glob                 | Exclude glob                                                                                           | Remove glob  |
 |-----------------------|------------------------------|--------------------------------------------------------------------|--------------|
@@ -93,12 +95,12 @@ Here are the default include and exclude settings for all project types. For mor
 
 ### Errors related to "duplicate" items
 
-If you explicitly added files to your project, or have XAML globs to automatically include files in your project, you'll possibly get one of the following errors:
+If you explicitly added files to your project, or have XAML globs to automatically include files in your project, you might get one of the following errors:
 
 * Duplicate 'ApplicationDefinition' items were included.
 * Duplicate 'Page' items were included.
 
-These errors are a result of the implicit *Include* globs conflicting with your settings. To work around this problem, either set [`EnableDefaultApplicationDefinition`](#enabledefaultapplicationdefinition) or [`EnableDefaultPageItems`](#enabledefaultpageitems) to `false`. Setting these values to `false` reverts to the behavior of previous SDKs where you had to explicitly define the default globs in your project, or explicitly define the files to include in the project.
+These errors are a result of the implicit *Include* globs conflicting with your settings. To work around this problem, set either [`EnableDefaultApplicationDefinition`](#enabledefaultapplicationdefinition) or [`EnableDefaultPageItems`](#enabledefaultpageitems) to `false`. Setting these values to `false` reverts to the behavior of previous SDKs where you had to explicitly define the default globs in your project, or explicitly define the files to include in the project.
 
 You can completely disable all implicit includes by setting the [`EnableDefaultItems` property](msbuild-props.md#enabledefaultitems) to `false`.
 
@@ -108,7 +110,7 @@ You can completely disable all implicit includes by setting the [`EnableDefaultI
 - [EnableDefaultApplicationDefinition](#enabledefaultapplicationdefinition)
 - [EnableDefaultPageItems](#enabledefaultpageitems)
 
-For more information about standard .NET SDK project settings, see [MSBuild reference for .NET SDK projects](msbuild-props.md).
+For information about non-WPF-specific project settings, see [MSBuild reference for .NET SDK projects](msbuild-props.md).
 
 ### UseWPF
 
@@ -120,7 +122,7 @@ The `UseWPF` property controls whether or not to include references to WPF libra
 </PropertyGroup>
 ```
 
-.NET 5.0 projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk) when this property is set to `true`.
+When this property is set to `true`, .NET 5.0+ projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk).
 
 .NET Core 3.1 projects need to explicitly target the [.NET Desktop SDK](#enable-net-desktop-sdk) to use this property.
 
@@ -152,7 +154,7 @@ This property requires that the [`EnableDefaultItems` property](msbuild-props.md
 
 - [UseWindowsForms](#usewindowsforms)
 
-For more information about standard .NET SDK project properties, see [MSBuild reference for .NET SDK projects](msbuild-props.md).
+For information about non-WinForms-specific project properties, see [MSBuild reference for .NET SDK projects](msbuild-props.md).
 
 ### UseWindowsForms
 
@@ -164,7 +166,7 @@ The `UseWindowsForms` property controls whether or not your application is built
 </PropertyGroup>
 ```
 
-.NET 5.0 projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk) when this property is set to `true`.
+When this property is set to `true`, .NET 5.0+ projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk).
 
 .NET Core 3.1 projects need to explicitly target the [.NET Desktop SDK](#enable-net-desktop-sdk) to use this property.
 

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -25,7 +25,7 @@ Specify the following settings in the project file of your WinForms or WPF proje
 
 - Target the .NET SDK `Microsoft.NET.Sdk`. For more information, see [Project files](overview.md#project-files).
 - Set [`TargetFramework`](msbuild-props.md#targetframework) to `net5.0-windows`.
-- Add a UI framework property:
+- Add a UI framework property (or both, if necessary):
   - Set `UseWPF` to `true` to import and use WPF.
   - Set `UseWindowsForms` to `true` to import and use WinForms.
 - (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
@@ -71,7 +71,7 @@ Specify the following settings in the project file of your WinForms or WPF proje
 </Project>
 ```
 
-## WPF default include exclude
+## WPF default includes and excludes
 
 SDK projects define a set of rules to implicitly include or exclude files from the project. These rules also automatically set the file's build action. This is unlike the older non-SDK .NET Framework projects, which have no default include or exclude rules. .NET Framework projects require you to explicitly declare which files to include in the project.
 

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -38,7 +38,7 @@ Specify the following settings in the project file of your WinForms or WPF proje
     <TargetFramework>net5.0-windows</TargetFramework>
 
     <UseWPF>true</UseWPF>
-    <!-- or -->
+    <!-- and/or -->
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
@@ -51,7 +51,7 @@ Specify the following settings in the project file of your WinForms or WPF proje
 
 - Target the .NET SDK `Microsoft.NET.Sdk.WindowsDesktop`. For more information, see [Project files](overview.md#project-files).
 - Set [`TargetFramework`](msbuild-props.md#targetframework) to `netcoreapp3.1`.
-- Set one of the following to enable a UI framework:
+- Add a UI framework property (or both, if necessary):
   - Set [`UseWPF`](#usewpf) to `true` to import and use WPF.
   - Set [`UseWindowsForms`](#usewindowsforms) to `true` to import and use WinForms.
 - (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
@@ -64,7 +64,7 @@ Specify the following settings in the project file of your WinForms or WPF proje
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <UseWPF>true</UseWPF>
-    <!-- or -->
+    <!-- and/or -->
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
@@ -150,7 +150,7 @@ The `EnableDefaultPageItems` property controls whether `Page` items, which are _
 
 This property requires that the [`EnableDefaultItems` property](msbuild-props.md#enabledefaultitems) property is set to `true`, which is the default setting.
 
-## WinForms settings
+## Windows Forms settings
 
 - [UseWindowsForms](#usewindowsforms)
 

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -1,6 +1,6 @@
 ---
 title: MSBuild properties for Microsoft.NET.Sdk.Desktop
-description: Reference for the MSBuild properties and items that are understood by the .NET Desktop SDK
+description: Reference for the MSBuild properties and items that are understood by the .NET Desktop SDK which includes WPF and WinForms.
 ms.date: 02/04/2021
 ms.topic: reference
 author: adegeo
@@ -25,9 +25,9 @@ WinForms and WPF projects should specify the following settings in the project f
 
 - Target the .NET SDK `Microsoft.NET.Sdk`. For more information, see [Project files](overview.md#project-files).
 - Set the `TargetFramework` to `net5.0-windows`.
-- Set one of the following to enable a UI framework:
-  - Set `UseWPF` to `true` to use WPF.
-  - Set `UseWindowsForms` to `true` to use WinForms.
+- Add a UI framework property:
+  - Set `UseWPF` to `true` to import and use WPF.
+  - Set `UseWindowsForms` to `true` to import and use WinForms.
 - (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
 
 ```xml
@@ -71,7 +71,9 @@ WinForms and WPF projects should specify the following settings in the project f
 
 ## WPF default include exclude
 
-SDK project files define a set of rules to implicitly include or exclude files, and to set their build action. This is unlike the older non-SDK .NET Framework projects, which had no default include or exclude rules and required you to explicitly declare which files to include in the project. WPF projects include rules in addition to the [standard .NET SDK rules](overview.md#default-includes-and-excludes) for automatically processing files.
+SDK project files define a set of rules to implicitly include or exclude files from the project. These rules also automatically set the file's build action. This is unlike the older non-SDK .NET Framework projects, which had no default include or exclude rules. .NET Framework projects required you to explicitly declare which files to include in the project.
+
+.NET project files include a [standard set of rules](overview.md#default-includes-and-excludes) for automatically processing files. WPF projects add additional rules.
 
 The following table shows which elements and which [globs](https://en.wikipedia.org/wiki/Glob_(programming)) are included and excluded in the .NET Desktop SDK when the [`UseWPF`](#usewpf) project property is set to `true`:
 
@@ -96,7 +98,7 @@ If you explicitly added files to your project, or have XAML globs to automatical
 * Duplicate 'ApplicationDefinition' items were included.
 * Duplicate 'Page' items were included.
 
-These errors are a result of the implicit *Include* globs conflicting with your settings. To work around this problem, either set [`EnableDefaultApplicationDefinition`](#enabledefaultapplicationdefinition) or [`EnableDefaultPageItems`](#enabledefaultpageitems) to `false`. Setting these to `false` reverts to the behavior of previous SDKs where you had to explicitly define the default globs in your project, or explicitly define the files to include in the project.
+These errors are a result of the implicit *Include* globs conflicting with your settings. To work around this problem, either set [`EnableDefaultApplicationDefinition`](#enabledefaultapplicationdefinition) or [`EnableDefaultPageItems`](#enabledefaultpageitems) to `false`. Setting these values to `false` reverts to the behavior of previous SDKs where you had to explicitly define the default globs in your project, or explicitly define the files to include in the project.
 
 You can completely disable all implicit includes by setting the [`EnableDefaultItems` property](msbuild-props.md#enabledefaultitems) to `false`.
 
@@ -154,7 +156,7 @@ For more information about standard .NET SDK project properties, see [MSBuild re
 
 ### UseWindowsForms
 
-The `UseWindowsForms` property controls whether or not your application is built to target Windows Forms. This property alters the MSBuild pipeline to correctly process a WinForms project and related files. The default value is `false`. Set the `UseWindowsForms` property to `true` to enable WinForms support. You can only target the Windows platform when this setting is enabled.
+The `UseWindowsForms` property controls whether or not your application is built to target Windows Forms. This property alters the MSBuild pipeline to correctly process a Windows Forms project and related files. The default value is `false`. Set the `UseWindowsForms` property to `true` to enable Windows Forms support. You can only target the Windows platform when this setting is enabled.
 
 ```xml
 <PropertyGroup>
@@ -165,6 +167,24 @@ The `UseWindowsForms` property controls whether or not your application is built
 .NET 5.0 projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk) when this property is set to `true`.
 
 .NET Core 3.1 projects need to explicitly target the [.NET Desktop SDK](#enable-net-desktop-sdk) to use this property.
+
+## Shared settings
+
+- [DisableWinExeOutputInference](#disablewinExeoutputinference)
+
+### DisableWinExeOutputInference
+
+Applies to .NET 5.0 SDK and later.
+
+When an app has the `Exe` value set for the `OutputType` property, a console window is created if the app isn't running from a console. This is generally not the desired behavior of a Windows Desktop app. With the `WinExe` value, a console window isn't created. Starting with the .NET 5.0 SDK, the `Exe` value is automatically transformed to `WinExe`.
+
+The `DisableWinExeOutputInference` property reverts the behavior of treating `Exe` as `WinExe`. Set this value to `true` to restore the behavior of the `OutputType` property value of `Exe`. The default value is `false`.
+
+```xml
+<PropertyGroup>
+  <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+</PropertyGroup>
+```
 
 ## See also
 

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -24,7 +24,7 @@ To use WinForms or WPF, configure your project file.
 Specify the following settings in the project file of your WinForms or WPF project:
 
 - Target the .NET SDK `Microsoft.NET.Sdk`. For more information, see [Project files](overview.md#project-files).
-- Set the `TargetFramework` to `net5.0-windows`.
+- Set [`TargetFramework`](msbuild-props.md#targetframework) to `net5.0-windows`.
 - Add a UI framework property:
   - Set `UseWPF` to `true` to import and use WPF.
   - Set `UseWindowsForms` to `true` to import and use WinForms.
@@ -50,7 +50,7 @@ Specify the following settings in the project file of your WinForms or WPF proje
 Specify the following settings in the project file of your WinForms or WPF project:
 
 - Target the .NET SDK `Microsoft.NET.Sdk.WindowsDesktop`. For more information, see [Project files](overview.md#project-files).
-- Set the `TargetFramework` to `netcoreapp3.1`.
+- Set [`TargetFramework`](msbuild-props.md#targetframework) to `netcoreapp3.1`.
 - Set one of the following to enable a UI framework:
   - Set `UseWPF` to `true` to use WPF.
   - Set `UseWindowsForms` to `true` to use WinForms.

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -172,7 +172,7 @@ When this property is set to `true`, .NET 5.0+ projects will automatically impor
 
 ## Shared settings
 
-- [DisableWinExeOutputInference](#disablewinExeoutputinference)
+- [DisableWinExeOutputInference](#disablewinexeoutputinference)
 
 ### DisableWinExeOutputInference
 

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -26,8 +26,8 @@ Specify the following settings in the project file of your WinForms or WPF proje
 - Target the .NET SDK `Microsoft.NET.Sdk`. For more information, see [Project files](overview.md#project-files).
 - Set [`TargetFramework`](msbuild-props.md#targetframework) to `net5.0-windows`.
 - Add a UI framework property (or both, if necessary):
-  - Set `UseWPF` to `true` to import and use WPF.
-  - Set `UseWindowsForms` to `true` to import and use WinForms.
+  - Set [`UseWPF`](#usewpf) to `true` to import and use WPF.
+  - Set [`UseWindowsForms`](#usewindowsforms) to `true` to import and use WinForms.
 - (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
 
 ```xml
@@ -52,8 +52,8 @@ Specify the following settings in the project file of your WinForms or WPF proje
 - Target the .NET SDK `Microsoft.NET.Sdk.WindowsDesktop`. For more information, see [Project files](overview.md#project-files).
 - Set [`TargetFramework`](msbuild-props.md#targetframework) to `netcoreapp3.1`.
 - Set one of the following to enable a UI framework:
-  - Set `UseWPF` to `true` to use WPF.
-  - Set `UseWindowsForms` to `true` to use WinForms.
+  - Set [`UseWPF`](#usewpf) to `true` to import and use WPF.
+  - Set [`UseWindowsForms`](#usewindowsforms) to `true` to import and use WinForms.
 - (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
 
 ```xml

--- a/docs/core/project-sdk/msbuild-props-desktop.md
+++ b/docs/core/project-sdk/msbuild-props-desktop.md
@@ -1,0 +1,175 @@
+---
+title: MSBuild properties for Microsoft.NET.Sdk.Desktop
+description: Reference for the MSBuild properties and items that are understood by the .NET Desktop SDK
+ms.date: 02/04/2021
+ms.topic: reference
+author: adegeo
+ms.author: adegeo
+ms.custom: updateeachrelease
+no-loc: ["App.xaml", "Application.xaml", "ApplicationDefinition", "Page", "EmbeddedResource", "Compile", "None"]
+---
+# MSBuild reference for .NET Desktop SDK projects
+
+This page is a reference for the MSBuild properties and items that you use to configure Windows Forms (WinForms) and Windows Presentation Foundation (WPF) projects with the .NET Desktop SDK.
+
+> [!NOTE]
+> This article documents a subset of the MSBuild properties for the .NET SDK as it relates to desktop apps. For a list of common .NET SDK-specific MSBuild properties, see [MSBuild reference for .NET SDK projects](msbuild-props.md). For a list of common MSBuild properties, see [Common MSBuild properties](/visualstudio/msbuild/common-msbuild-project-properties).
+
+## Enable .NET Desktop SDK
+
+To use WinForms or WPF, configure your project file.
+
+### .NET 5.0
+
+WinForms and WPF projects should specify the following settings in the project file:
+
+- Target the .NET SDK `Microsoft.NET.Sdk`. For more information, see [Project files](overview.md#project-files).
+- Set the `TargetFramework` to `net5.0-windows`.
+- Set one of the following to enable a UI framework:
+  - Set `UseWPF` to `true` to use WPF.
+  - Set `UseWindowsForms` to `true` to use WinForms.
+- (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net5.0-windows</TargetFramework>
+
+    <UseWPF>true</UseWPF>
+    <!-- or -->
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>
+```
+
+### .NET Core 3.1
+
+- Target the .NET SDK `Microsoft.NET.Sdk.WindowsDesktop`. For more information, see [Project files](overview.md#project-files).
+- Set the `TargetFramework` to `netcoreapp3.1`.
+- Set one of the following to enable a UI framework:
+  - Set `UseWPF` to `true` to use WPF.
+  - Set `UseWindowsForms` to `true` to use WinForms.
+- (Optional) Set `OutputType` to `WinExe`. This produces an app as opposed to a library. To produce a library, omit this property.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <UseWPF>true</UseWPF>
+    <!-- or -->
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>
+```
+
+## WPF default include exclude
+
+SDK project files define a set of rules to implicitly include or exclude files, and to set their build action. This is unlike the older non-SDK .NET Framework projects, which had no default include or exclude rules and required you to explicitly declare which files to include in the project. WPF projects include rules in addition to the [standard .NET SDK rules](overview.md#default-includes-and-excludes) for automatically processing files.
+
+The following table shows which elements and which [globs](https://en.wikipedia.org/wiki/Glob_(programming)) are included and excluded in the .NET Desktop SDK when the [`UseWPF`](#usewpf) project property is set to `true`:
+
+| Element               | Include glob                 | Exclude glob                                                                                           | Remove glob  |
+|-----------------------|------------------------------|--------------------------------------------------------------------|--------------|
+| ApplicationDefinition | App.xaml or Application.xaml | N/A                                                                | N/A          |
+| Page                  | \*\*/\*.xaml                 | \*\*/\*.user; \*\*/\*.\*proj; \*\*/\*.sln; \*\*/\*.vssscc<br>Any XAML defined by *ApplicationDefinition* | N/A          |
+| None                  | N/A                          | N/A                                                                | \*\*/\*.xaml |
+
+For reference, here are the default include and exclude for all project types. For more information, see [Default includes and excludes](overview.md#default-includes-and-excludes).
+
+| Element           | Include glob                              | Exclude glob                                                  | Remove glob              |
+|-------------------|-------------------------------------------|---------------------------------------------------------------|--------------------------|
+| Compile           | \*\*/\*.cs; \*\*/\*.vb (or other language extensions) | \*\*/\*.user;  \*\*/\*.\*proj;  \*\*/\*.sln;  \*\*/\*.vssscc  | N/A          |
+| EmbeddedResource  | \*\*/\*.resx                              | \*\*/\*.user; \*\*/\*.\*proj; \*\*/\*.sln; \*\*/\*.vssscc     | N/A                      |
+| None              | \*\*/\*                                   | \*\*/\*.user; \*\*/\*.\*proj; \*\*/\*.sln; \*\*/\*.vssscc     | \*\*/\*.cs; \*\*/\*.resx |
+
+### Errors related to "duplicate" items
+
+If you have XAML globs in your project or explicitly add files to your project, you'll possibly get one of the following errors:
+
+* Duplicate 'ApplicationDefinition' items were included.
+* Duplicate 'Page' items were included.
+
+These errors are a result of the implicit *Include* globs conflicting with your settings. To work around this problem, either set [`EnableDefaultApplicationDefinition`](#enabledefaultapplicationdefinition) or [`EnableDefaultPageItems`](#enabledefaultpageitems) to `false`. Setting these to `false` reverts to the behavior of previous SDKs where you had to explicitly define the default globs in your project, or explicitly define the files to include in the project.
+
+You can completely disable all implicit includes by setting the [`EnableDefaultItems` property](msbuild-props.md#enabledefaultitems) to `false`.
+
+## WPF settings
+
+- [UseWPF](#usewpf)
+- [EnableDefaultApplicationDefinition](#enabledefaultapplicationdefinition)
+- [EnableDefaultPageItems](#enabledefaultpageitems)
+
+For more information about standard .NET SDK project settings, see [MSBuild reference for .NET SDK projects](msbuild-props.md).
+
+### UseWPF
+
+The `UseWPF` property controls whether or not to include references to WPF libraries. This also alters the MSBuild pipeline to correctly process a WPF project and related files. The default value is `false`. Set the `UseWPF` property to `true` to enable WPF support. You can only target the Windows platform when this property is enabled.
+
+```xml
+<PropertyGroup>
+  <UseWPF>true</UseWPF>
+</PropertyGroup>
+```
+
+.NET 5.0 projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk) when this property is set to `true`.
+
+.NET Core 3.1 projects need to explicitly target the [.NET Desktop SDK](#enable-net-desktop-sdk) to use this property.
+
+### EnableDefaultApplicationDefinition
+
+The `EnableDefaultApplicationDefinition` property controls whether `ApplicationDefinition` items are implicitly included in the project. The default value is `true`. Set the `EnableDefaultApplicationDefinition` property to `false` to disable the implicit file inclusion.
+
+```xml
+<PropertyGroup>
+  <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
+</PropertyGroup>
+```
+
+This property requires that the [`EnableDefaultItems` property](msbuild-props.md#enabledefaultitems) property is set to `true`, which is the default setting.
+
+### EnableDefaultPageItems
+
+The `EnableDefaultPageItems` property controls whether `Page` items, which are _.xaml_ files, are implicitly included in the project. The default value is `true`. Set the `EnableDefaultPageItems` property to `false` to disable the implicit file inclusion.
+
+```xml
+<PropertyGroup>
+  <EnableDefaultPageItems>false</EnableDefaultPageItems>
+</PropertyGroup>
+```
+
+This property requires that the [`EnableDefaultItems` property](msbuild-props.md#enabledefaultitems) property is set to `true`, which is the default setting.
+
+## WinForms settings
+
+- [UseWindowsForms](#usewindowsforms)
+
+For more information about standard .NET SDK project properties, see [MSBuild reference for .NET SDK projects](msbuild-props.md).
+
+### UseWindowsForms
+
+The `UseWindowsForms` property controls whether or not your application is built to target Windows Forms. This property alters the MSBuild pipeline to correctly process a WinForms project and related files. The default value is `false`. Set the `UseWindowsForms` property to `true` to enable WinForms support. You can only target the Windows platform when this setting is enabled.
+
+```xml
+<PropertyGroup>
+  <UseWindowsForms>true</UseWindowsForms>
+</PropertyGroup>
+```
+
+.NET 5.0 projects will automatically import the [.NET Desktop SDK](#enable-net-desktop-sdk) when this property is set to `true`.
+
+.NET Core 3.1 projects need to explicitly target the [.NET Desktop SDK](#enable-net-desktop-sdk) to use this property.
+
+## See also
+
+- [.NET project SDKs](overview.md)
+- [MSBuild reference for .NET SDK projects](msbuild-props.md)
+- [MSBuild schema reference](/visualstudio/msbuild/msbuild-project-file-schema-reference)
+- [Common MSBuild properties](/visualstudio/msbuild/common-msbuild-project-properties)
+- [Customize a build](/visualstudio/msbuild/customize-your-build)

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -93,6 +93,8 @@ The following table shows which elements and which [globs](https://en.wikipedia.
 > [!NOTE]
 > The `./bin` and `./obj` folders, which are represented by the `$(BaseOutputPath)` and `$(BaseIntermediateOutputPath)` MSBuild properties, are excluded from the globs by default. Excludes are represented by the [DefaultItemExcludes property](msbuild-props.md#defaultitemexcludes).
 
+The .NET Desktop SDK has more includes and excludes for WPF. For more information, see [WPF default includes and excludes](msbuild-props-desktop.md#wpf-default-includes-and-excludes).
+
 ### Build errors
 
 If you explicitly define any of these items in your project file, you're likely to get a "NETSDK1022" build error similar to the following:

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -4,6 +4,7 @@ titleSuffix: ""
 description: Learn about the .NET project SDKs.
 ms.date: 09/17/2020
 ms.topic: conceptual
+no-loc: ["App.xaml", "Application.xaml", "ApplicationDefinition", "Page", "EmbeddedResource", "Compile", "None"]
 ---
 # .NET project SDKs
 
@@ -92,13 +93,23 @@ The following table shows which elements and which [globs](https://en.wikipedia.
 > [!NOTE]
 > The `./bin` and `./obj` folders, which are represented by the `$(BaseOutputPath)` and `$(BaseIntermediateOutputPath)` MSBuild properties, are excluded from the globs by default. Excludes are represented by the [DefaultItemExcludes property](msbuild-props.md#defaultitemexcludes).
 
+### WPF includes and excludes
+
+The .NET Desktop SDK defines additional includes and excludes for common files when the `<UseWPF>` project property is set to `true`.
+
+| Element               | Include glob                 | Exclude glob                                                                                           | Remove glob  |
+|-----------------------|------------------------------|--------------------------------------------------------------------|--------------|
+| ApplicationDefinition | App.xaml or Application.xaml | N/A                                                                | N/A          |
+| Page                  | \*\*/\*.xaml                 | \*\*/\*.user; \*\*/\*.\*proj; \*\*/\*.sln; \*\*/\*.vssscc<br>Any XAML defined by *ApplicationDefinition* | N/A          |
+| None                  | N/A                          | N/A                                                                | \*\*/\*.xaml |
+
 ### Build errors
 
 If you explicitly define any of these items in your project file, you're likely to get a "NETSDK1022" build error similar to the following:
 
-  > Duplicate 'Compile' items were included. The .NET SDK includes 'Compile' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultCompileItems' property to 'false' if you want to explicitly include them in your project file.
+> Duplicate 'Compile' items were included. The .NET SDK includes 'Compile' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultCompileItems' property to 'false' if you want to explicitly include them in your project file.
 
-  > Duplicate 'EmbeddedResource' items were included. The .NET SDK includes 'EmbeddedResource' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultEmbeddedResourceItems' property to 'false' if you want to explicitly include them in your project file.
+> Duplicate 'EmbeddedResource' items were included. The .NET SDK includes 'EmbeddedResource' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultEmbeddedResourceItems' property to 'false' if you want to explicitly include them in your project file.
 
 To resolve the errors, do one of the following:
 

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -4,7 +4,7 @@ titleSuffix: ""
 description: Learn about the .NET project SDKs.
 ms.date: 09/17/2020
 ms.topic: conceptual
-no-loc: ["App.xaml", "Application.xaml", "ApplicationDefinition", "Page", "EmbeddedResource", "Compile", "None"]
+no-loc: ["EmbeddedResource", "Compile", "None"]
 ---
 # .NET project SDKs
 
@@ -20,7 +20,7 @@ The following SDKs are available:
 | `Microsoft.NET.Sdk.Web` | The .NET [Web SDK](/aspnet/core/razor-pages/web-sdk) | <https://github.com/dotnet/sdk> |
 | `Microsoft.NET.Sdk.Razor` | The .NET [Razor SDK](/aspnet/core/razor-pages/sdk) |
 | `Microsoft.NET.Sdk.Worker` | The .NET Worker Service SDK |
-| `Microsoft.NET.Sdk.WindowsDesktop` | The WinForms and WPF SDK\* | <https://github.com/dotnet/winforms> and <https://github.com/dotnet/wpf> |
+| `Microsoft.NET.Sdk.WindowsDesktop` | The .NET [Desktop SDK](#msbuild-props-desktop.md), which includes Windows Forms (WinForms) and Windows Presentation Foundation (WPF).\* | <https://github.com/dotnet/winforms> and <https://github.com/dotnet/wpf> |
 
 The .NET SDK is the base SDK for .NET. The other SDKs reference the .NET SDK, and projects that are associated with the other SDKs have all the .NET SDK properties available to them. The Web SDK, for example, depends on both the .NET SDK and the Razor SDK.
 
@@ -92,16 +92,6 @@ The following table shows which elements and which [globs](https://en.wikipedia.
 
 > [!NOTE]
 > The `./bin` and `./obj` folders, which are represented by the `$(BaseOutputPath)` and `$(BaseIntermediateOutputPath)` MSBuild properties, are excluded from the globs by default. Excludes are represented by the [DefaultItemExcludes property](msbuild-props.md#defaultitemexcludes).
-
-### WPF includes and excludes
-
-The .NET Desktop SDK defines additional includes and excludes for common files when the `<UseWPF>` project property is set to `true`.
-
-| Element               | Include glob                 | Exclude glob                                                                                           | Remove glob  |
-|-----------------------|------------------------------|--------------------------------------------------------------------|--------------|
-| ApplicationDefinition | App.xaml or Application.xaml | N/A                                                                | N/A          |
-| Page                  | \*\*/\*.xaml                 | \*\*/\*.user; \*\*/\*.\*proj; \*\*/\*.sln; \*\*/\*.vssscc<br>Any XAML defined by *ApplicationDefinition* | N/A          |
-| None                  | N/A                          | N/A                                                                | \*\*/\*.xaml |
 
 ### Build errors
 

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -20,7 +20,7 @@ The following SDKs are available:
 | `Microsoft.NET.Sdk.Web` | The .NET [Web SDK](/aspnet/core/razor-pages/web-sdk) | <https://github.com/dotnet/sdk> |
 | `Microsoft.NET.Sdk.Razor` | The .NET [Razor SDK](/aspnet/core/razor-pages/sdk) |
 | `Microsoft.NET.Sdk.Worker` | The .NET Worker Service SDK |
-| `Microsoft.NET.Sdk.WindowsDesktop` | The .NET [Desktop SDK](#msbuild-props-desktop.md), which includes Windows Forms (WinForms) and Windows Presentation Foundation (WPF).\* | <https://github.com/dotnet/winforms> and <https://github.com/dotnet/wpf> |
+| `Microsoft.NET.Sdk.WindowsDesktop` | The .NET [Desktop SDK](msbuild-props-desktop.md), which includes Windows Forms (WinForms) and Windows Presentation Foundation (WPF).\* | <https://github.com/dotnet/winforms> and <https://github.com/dotnet/wpf> |
 
 The .NET SDK is the base SDK for .NET. The other SDKs reference the .NET SDK, and projects that are associated with the other SDKs have all the .NET SDK properties available to them. The Web SDK, for example, depends on both the .NET SDK and the Razor SDK.
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -343,6 +343,8 @@ items:
           href: /aspnet/core/razor-pages/web-sdk?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
         - name: Microsoft.NET.Sdk.Razor
           href: /aspnet/core/razor-pages/sdk?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
+        - name: Microsoft.NET.Sdk.Desktop
+          href: ../core/project-sdk/msbuild-props-desktop.md
     - name: Target frameworks
       href: ../standard/frameworks.md
     - name: Dependency management


### PR DESCRIPTION
## Summary

- Added new article detailing WPF and WinForms MSBuild settings.

Needs more WinForms specific settings.

Fixes #13884

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props-desktop?branch=pr-en-us-22676#enabledefaultapplicationdefinition)

@rladuca @gewarren 