### PR TITLE
Add link to distributed tracing doc from toc

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -418,6 +418,8 @@ items:
         href: ../core/diagnostics/logging-tracing.md
       - name: Well-known event providers
         href: ../core/diagnostics/well-known-event-providers.md
+      - name: Distributed Tracing
+        href: ../core/diagnostics/distributed-tracing.md
     - name: Runtime events
       items:
       - name: Overview


### PR DESCRIPTION
## Summary

Add link to the distributed tracing documentation from toc. 

cc @noahfalk 