### PR TITLE
Add link to Visual Studio memory leak tutorial

### DIFF
--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -9,9 +9,9 @@ ms.date: 04/20/2020
 
 **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 
-A memory leak may happen when your app has issues that causes the garbage collector to not be able to an increasing number of some objects in the managed heap because there are still references to them.
+A memory leak may happen when your app references objects that it no longer needs to perform the desired task. Referencing said objects makes the garbage collector to be unable to reclaim the memory used, often resulting in performance degradation and potentially end up throwing a <xref:System.OutOfMemoryException>.
 
-This tutorial demonstrates the tools to analyze a memory leak in a .NET Core app using the .NET diagnostics CLI tools. If you are on Windows, you may be able to [use Visual Studio](/visualstudio/profiling/memory-usage) to debug the memory leak.
+This tutorial demonstrates the tools to analyze a memory leak in a .NET Core app using the .NET diagnostics CLI tools. If you are on Windows, you may be able to [use Visual Studio's Memory Diagnostic tools](/visualstudio/profiling/memory-usage) to debug the memory leak.
 
 This tutorial uses a sample app, which is designed to intentionally leak memory. The sample is provided as an exercise. You can analyze an app that is unintentionally leaking memory too.
 

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -9,7 +9,9 @@ ms.date: 04/20/2020
 
 **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 
-This tutorial demonstrates the tools to analyze a .NET Core memory leak.
+A memory leak may happen when your app has issues that causes the garbage collector to not be able to an increasing number of some objects in the managed heap because there are still references to them.
+
+This tutorial demonstrates the tools to analyze a memory leak in a .NET Core app using the .NET diagnostics CLI tools. If you are on Windows, you may be able to [use Visual Studio](/visualstudio/profiling/memory-usage) to debug the memory leak. 
 
 This tutorial uses a sample app, which is designed to intentionally leak memory. The sample is provided as an exercise. You can analyze an app that is unintentionally leaking memory too.
 
@@ -233,6 +235,7 @@ You can also delete the dump file that was created.
 - [dotnet-counters](dotnet-counters.md) to check managed memory usage
 - [dotnet-dump](dotnet-dump.md) to collect and analyze a dump file
 - [dotnet/diagnostics](https://github.com/dotnet/diagnostics/tree/master/documentation/tutorial)
+- [Use Visual Studio to debug memory leaks](/visualstudio/profiling/memory-usage)
 
 ## Next steps
 

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -11,7 +11,7 @@ ms.date: 04/20/2020
 
 A memory leak may happen when your app has issues that causes the garbage collector to not be able to an increasing number of some objects in the managed heap because there are still references to them.
 
-This tutorial demonstrates the tools to analyze a memory leak in a .NET Core app using the .NET diagnostics CLI tools. If you are on Windows, you may be able to [use Visual Studio](/visualstudio/profiling/memory-usage) to debug the memory leak. 
+This tutorial demonstrates the tools to analyze a memory leak in a .NET Core app using the .NET diagnostics CLI tools. If you are on Windows, you may be able to [use Visual Studio](/visualstudio/profiling/memory-usage) to debug the memory leak.
 
 This tutorial uses a sample app, which is designed to intentionally leak memory. The sample is provided as an exercise. You can analyze an app that is unintentionally leaking memory too.
 


### PR DESCRIPTION
## Summary

Add a link to the Visual Studio memory leak analysis doc from the .NET diagnostics memory leak debugging tutorial doc to show how one can do this via VS.
