### PR TITLE
Overview page of miscellaneous coding style rules

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/index.md
+++ b/docs/fundamentals/code-analysis/style-rules/index.md
@@ -26,6 +26,10 @@ ms.author: gewarren
 
    Rules that pertain to the naming of code elements. For example, you can specify that `async` method names must have an "Async" suffix.
 
+- [Miscellaneous rules](miscellaneous-rules.md)
+
+   Rules that do not belong in other categories.
+
 ## Index
 
 The following table list all the code style rules by ID and options, if any.

--- a/docs/fundamentals/code-analysis/style-rules/miscellaneous-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/miscellaneous-rules.md
@@ -19,7 +19,6 @@ The rules in this section concern the following miscellaneous rules:
 - [Remove invalid global 'SuppressMessageAttribute' (IDE0076)](ide0076.md)
 - [Avoid legacy format target in global 'SuppressMessageAttribute' (IDE0077)](ide0077.md)
 
-
 ## See also
 
 - [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/miscellaneous-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/miscellaneous-rules.md
@@ -1,0 +1,25 @@
+---
+title: Miscellaneous coding style rules
+description: Learn about the various .NET code style rules.
+ms.date: 02/06/2021
+ms.topic: reference
+author: BartoszKlonowski
+ms.author: BartoszKlonowski
+dev_langs:
+- CSharp
+- VB
+---
+
+# Miscellaneous rules
+
+Rules that do not belong to other categories regards the code quality.
+
+The rules in this section concern the following miscellaneous rules:
+
+- [Remove invalid global 'SuppressMessageAttribute' (IDE0076)](ide0076.md)
+- [Avoid legacy format target in global 'SuppressMessageAttribute' (IDE0077)](ide0077.md)
+
+
+## See also
+
+- [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/miscellaneous-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/miscellaneous-rules.md
@@ -1,20 +1,14 @@
 ---
 title: Miscellaneous coding style rules
-description: Learn about the various .NET code style rules.
+description: Learn about the miscellaneous category of .NET code-style rules.
 ms.date: 02/06/2021
 ms.topic: reference
 author: BartoszKlonowski
-ms.author: BartoszKlonowski
-dev_langs:
-- CSharp
-- VB
 ---
 
 # Miscellaneous rules
 
-Rules that do not belong to other categories regards the code quality.
-
-The rules in this section concern the following miscellaneous rules:
+This section contains code-style rules that don't fit in any other category. The miscellaneous rules are:
 
 - [Remove invalid global 'SuppressMessageAttribute' (IDE0076)](ide0076.md)
 - [Avoid legacy format target in global 'SuppressMessageAttribute' (IDE0077)](ide0077.md)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1253,6 +1253,8 @@ items:
             href: code-analysis/style-rules/ide0110.md
         - name: Miscellaneous rules
           items:
+          - name: Overview
+            href: code-analysis/style-rules/miscellaneous-rules.md
           - name: IDE0076
             href: code-analysis/style-rules/ide0076.md
           - name: IDE0077


### PR DESCRIPTION
This pull request fixes #22196 

It delivers the overview page of miscellaneous rules.

## Summary

The overview page of miscellaneous coding style rules contains the general description mentioning that those rules do not belong to any other categories.
No further explanation is given, so in case of more rules falling into this category there won't be any need to update the description.

These changes also links the overview page with the index and inserts the overview page in the TOC.
