### PR TITLE
Fix #6288

### DIFF
--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -67,7 +67,7 @@ The internal expression tree&mdash;and thus the query&mdash;haven't been modifie
 
 ## Call additional LINQ methods
 
-Generally, the built-in LINQ methods at <xref:System.Linq.Queryable> perform two steps:
+Generally, the [built-in LINQ methods at <xref:System.Linq.Queryable>](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs) perform two steps:
 
 * Wrap the current expression tree in a <xref:System.Linq.Expressions.MethodCallExpression> representing the method call.
 * Pass the wrapped expression tree back to the provider, either to return a value via the provider's <xref:System.Linq.IQueryProvider.Execute%2A?displayProperty=nameWithType> method; or to return a translated query object via the <xref:System.Linq.IQueryProvider.CreateQuery%2A?displayProperty=nameWithType> method.

--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -6,7 +6,7 @@ ms.assetid: 52cd44dd-a3ec-441e-b93a-4eca388119c7
 ---
 # Querying based on runtime state (C#)
 
-Consider code that defines an <xref:System.Linq.IQueryable%601> or an <xref:System.Linq.IQueryable> against a data source:
+Consider code that defines an <xref:System.Linq.IQueryable> or an [IQueryable\<T>](<xref:System.Linq.IQueryable%601>) against a data source:
 
 ```csharp
 var companyNames = new[] {
@@ -20,14 +20,14 @@ var companyNames = new[] {
 
 // We're using an in-memory array as the data source, but the IQueryable could have come
 // from anywhere -- an ORM backed by a database, a web request, or any other LINQ provider.
-IQueryable<string> companyNamesSource = companyNames.AsQueryable();
-
-var qry = companyNames.OrderBy(x => x);
+IQueryable<string> companyNamesQry = companyNames
+    .AsQueryable()
+    .OrderBy(x => x);
 ```
 
 Every time you run this code, the same exact query will be executed. This is frequently not very useful, as you may want your code to execute different queries under varying conditions. This article describes how you can execute a different query based on runtime state.
 
-## IQueryable, IQueryable\<T> and expression trees
+## IQueryable / IQueryable\<T> and expression trees
 
 Fundamentally, an <xref:System.Linq.IQueryable> has two components:
 
@@ -36,14 +36,16 @@ Fundamentally, an <xref:System.Linq.IQueryable> has two components:
 
 In the context of dynamic querying, the provider will usually remain the same; the expression tree of the query will differ from query to query.
 
-Because expression trees are immutable, if you want a different expression tree&mdash;and thus a different query&mdash;you'll need to translate the existing expression tree to a new one, and thus to a new **IQueryable**.
+Because expression trees are immutable, if you want a different expression tree&mdash;and thus a different query&mdash;you'll need to translate the existing expression tree to a new one, and thus to a new <xref:System.Linq.IQueryable>.
 
 The following sections describe specific techniques for querying differently in response to runtime state:
 
 - Use runtime state from within the expression tree
 - Call additional LINQ methods
 - Vary the expression tree passed into the LINQ methods
-- Construct expression trees using the factory methods at <xref:System.Linq.Expressions.Expression>
+- Construct an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) expression tree using the factory methods at <xref:System.Linq.Expressions.Expression>
+- Adding method call nodes to an <xref:System.Linq.IQueryable>'s expression tree
+- Construct expression trees from strings using the [Dynamic LINQ library](dynamic-linq.net/)
 
 ## Use runtime state from within the expression tree
 
@@ -67,7 +69,7 @@ The internal expression tree&mdash;and thus the query&mdash;haven't been modifie
 
 ## Call additional LINQ methods
 
-Generally, the [built-in LINQ methods at <xref:System.Linq.Queryable>](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs) perform two steps:
+Generally, the [built-in LINQ methods](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs) at <xref:System.Linq.Queryable> perform two steps:
 
 * Wrap the current expression tree in a <xref:System.Linq.Expressions.MethodCallExpression> representing the method call.
 * Pass the wrapped expression tree back to the provider, either to return a value via the provider's <xref:System.Linq.IQueryProvider.Execute%2A?displayProperty=nameWithType> method; or to return a translated query object via the <xref:System.Linq.IQueryProvider.CreateQuery%2A?displayProperty=nameWithType> method.
@@ -110,8 +112,8 @@ You might also want to compose the various sub-expressions using a third-party l
 
 // This is functionally equivalent to the previous example.
 
-string startsWith = /* ... */;
-string endsWith = /* ... */;
+string startsWith? = /* ... */;
+string endsWith? = /* ... */;
 
 var qry = companyNamesSource;
 
@@ -134,7 +136,50 @@ if (hasStartsWith || hasEndsWith) {
 
 In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type; you may need to add different components, depending on the element type. You can create the expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression>.
 
-For example, let's say you have multiple entity types:
+### Constructing an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601)
+
+When you construct an expression to pass into one of the LINQ methods, you're actually constructing an instance of [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601), where `TDelegate` is some delegate type such as `Func<string, bool>`, `Action`, or a custom delegate type.
+
+[Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) inherits from <xref:System.Linq.Expressions.LambdaExpression>, which represents a complete lambda expression like the following:
+
+```csharp
+Expression<Func<string, bool>> expr = x => x.StartsWith("a");
+```
+
+A LambdaExpression has two components:
+
+* a parameter list--`(string x)`, and
+* a body -- `x.StartsWith("a")`
+
+The basic steps in constructing an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) are as follows:
+
+* Define <xref:System.Linq.Expressions.ParameterExpression> objects for each of the parameters (if any) in the lambda expression, using the Parameter factory method.
+
+    ```csharp
+    ParameterExpression x = Parameter(typeof(string), "x");
+    ```
+
+* Construct the body of your <xref:System.Linq.Expressions.LambdaExpression>, using the <xref:System.Linq.Expressions.ParameterExpression> you've defined. For instance, `x.StartsWith("a")` could be constructed like this:
+
+    ```csharp
+    Expression body = Call(
+        x,
+        typeof(string).GetMethod("StartsWith", new [] {typeof(string)}),
+        Constant("a")
+    );
+    ```
+
+* Wrap the parameters and body in a compile-time-typed [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601), using the appropriate <xref:System.Linq.Expressions.Expression.Lambda%2A> factory method overload:
+
+    ```csharp
+    Expression<Func<string, bool>> expr = Lambda<Func<string, bool>>(body, prm);
+    ```
+
+The following sections describe a scenario in which you might want to construct an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) to pass into a LINQ method, and provide a complete example of how to do so using the factory methods.
+
+### Scenario
+
+Let's say you have multiple entity types:
 
 ```csharp
 record Person(string LastName, string FirstName, DateTime DateOfBirth);
@@ -159,7 +204,9 @@ var carsQry = new List<Car>()
     .Where(x => x.Model.Contains(term));
 ```
 
-While you could write one custom function for `IQueryable<Person>` and another for `IQueryable<Car>`, the following example shows a function that adds this filtering to any existing query, irrespective of the specific element type. Note that because it takes and returns an `IQueryable<T>`, you can add further strongly-typed query elements after the text filter.
+While you could write one custom function for `IQueryable<Person>` and another for `IQueryable<Car>`, the following function adds this filtering to any existing query, irrespective of the specific element type.
+
+### Example
 
 ```csharp
 IQueryable<T> TextFilter<T>(IQueryable<T> source, string term) {
@@ -178,7 +225,8 @@ IQueryable<T> TextFilter<T>(IQueryable<T> source, string term) {
     // Get the right overload of String.Contains
     var containsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) })!;
 
-    // Create a parameter for the expression tree; the `x`
+    // Create a parameter for the expression tree:
+    // the 'x' in 'x => x.PropertyName.Contains("term")'
     // The type of this parameter is the query's element type
     var prm = Parameter(elementType);
 
@@ -209,7 +257,11 @@ IQueryable<T> TextFilter<T>(IQueryable<T> source, string term) {
     // Because the lambda is strongly typed (albeit with a generic parameter), we can use it with the Where method
     return source.Where(lambda);
 }
+```
 
+Note that because the function takes and returns an [IQueryable\<T>](xref:System.Linq.IQueryable%601) (and not just an <xref:System.Linq.IQueryable>), you can add further compile-time-typed query elements after the text filter.
+
+```csharp
 var qry = TextFilter(
         new List<Person>().AsQueryable(), 
         "abcd"
@@ -223,17 +275,18 @@ var qry1 = TextFilter(
     .Where(x => x.Year == 2010);
 ```
 
-Finally, if all you have is an `IQueryable` and not an `IQueryable<T>`, you can't directly call the generic LINQ methods at <xref:System.Linq.Queryable>. One alternative is to build the inner expression tree, and invoke the appropriate LINQ method with that expression tree using reflection.
+## Adding method call nodes to the <xref:System.Linq.IQueryable>'s expression tree
 
-You could also duplicate the LINQ method's functionality, by wrapping the entire tree in a `MethodCallExpression` node which represents a call to the LINQ method:
+If all you have is an <xref:System.Linq.IQueryable> and not an [IQueryable\<T>](xref:System.Linq.IQueryable%601), you can't directly call the generic LINQ methods at <xref:System.Linq.Queryable>. One alternative is to build the inner expression tree as above, and invoke the appropriate LINQ method with that expression tree using reflection.
+
+You could also duplicate the LINQ method's functionality, by wrapping the entire tree in a <xref:System.Linq.Expressions.MethodCallExpression> which represents a call to the LINQ method:
 
 ```csharp
 IQueryable TextFilter(IQueryable source, string term) {
     if (string.IsNullOrEmpty(term)) { return source; }
     var type = source.ElementType;
 
-    // build the expression body based on the element type's string properties
-    // as in the previous example
+    // build the ParameterExpression and LambdaExpression body based on the element type's string properties, as in the previous example
     var (body, prm) = /* ... */;
 
     var filteredTree = Call(
@@ -247,6 +300,8 @@ IQueryable TextFilter(IQueryable source, string term) {
     return source.Provider.CreateQuery(filteredTree);
 }
 ```
+
+Note that in this case you don't have a compile-time `T` generic placeholder, so you'll use the <xref:System.Linq.Expressions.Expression.Lambda%2A> overload which doesn't require compile-time type information, and which produces only a <xref:System.Linq.Expressions.LambdaExpression> instead of an an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601).
 
 ## The Dynamic LINQ library
 

--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -1,7 +1,7 @@
 ---
 title: "Querying based on runtime state (C#)"
 description: Describes various techniques your code can use to query dynamically depending on runtime state, by varying either LINQ method calls or the expression trees passed into those methods.
-ms.date: 07/20/2015
+ms.date: 02/11/2021
 ms.assetid: 52cd44dd-a3ec-441e-b93a-4eca388119c7
 ---
 # Querying based on runtime state (C#)
@@ -30,7 +30,7 @@ The following sections describe specific techniques for querying differently in 
 - Vary the expression tree passed into the LINQ methods
 - Construct an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) expression tree using the factory methods at <xref:System.Linq.Expressions.Expression>
 - Adding method call nodes to an <xref:System.Linq.IQueryable>'s expression tree
-- Construct strings, and use the [Dynamic LINQ library](dynamic-linq.net/)
+- Construct strings, and use the [Dynamic LINQ library](https://dynamic-linq.net/)
 
 ## Use runtime state from within the expression tree
 
@@ -63,7 +63,7 @@ You might also want to compose the various sub-expressions using a third-party l
 
 ## Construct expression trees and queries using factory methods
 
-In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type; you may need to add different components, depending on the element type. You can create expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression?displayProperty=fullName>, and thus tailor the expression to a specific element type.
+In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type. You may need to add different components, depending on the element type. You can create expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression?displayProperty=fullName>, and thus tailor the expression to a specific element type.
 
 ### Constructing an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601)
 
@@ -139,19 +139,19 @@ While you could write one custom function for `IQueryable<Person>` and another f
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_methods_expression_of_tdelegate":::
 
-Note that because the `TextFilter` function takes and returns an [IQueryable\<T>](xref:System.Linq.IQueryable%601) (and not just an <xref:System.Linq.IQueryable>), you can add further compile-time-typed query elements after the text filter.
+Because the `TextFilter` function takes and returns an [IQueryable\<T>](xref:System.Linq.IQueryable%601) (and not just an <xref:System.Linq.IQueryable>), you can add further compile-time-typed query elements after the text filter.
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_methods_expression_of_tdelegate_usage":::
 
 ## Adding method call nodes to the <xref:System.Linq.IQueryable>'s expression tree
 
-If all you have is an <xref:System.Linq.IQueryable> and not an [IQueryable\<T>](xref:System.Linq.IQueryable%601), you can't directly call the generic LINQ methods at <xref:System.Linq.Queryable>. One alternative is to build the inner expression tree as above, and use reflection to invoke the appropriate LINQ method while passing in the expression tree.
+If you have an <xref:System.Linq.IQueryable> instead of an [IQueryable\<T>](xref:System.Linq.IQueryable%601), you can't directly call the generic LINQ methods. One alternative is to build the inner expression tree as above, and use reflection to invoke the appropriate LINQ method while passing in the expression tree.
 
 You could also duplicate the LINQ method's functionality, by wrapping the entire tree in a <xref:System.Linq.Expressions.MethodCallExpression> which represents a call to the LINQ method:
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_methods_lambdaexpression":::
 
-Note that in this case you don't have a compile-time `T` generic placeholder, so you'll use the <xref:System.Linq.Expressions.Expression.Lambda%2A> overload which doesn't require compile-time type information, and which produces only a <xref:System.Linq.Expressions.LambdaExpression> instead of an an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601).
+Note that in this case you don't have a compile-time `T` generic placeholder, so you'll use the <xref:System.Linq.Expressions.Expression.Lambda%2A> overload which doesn't require compile-time type information, and which produces a <xref:System.Linq.Expressions.LambdaExpression> instead of an an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601).
 
 ## The Dynamic LINQ library
 

--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -74,9 +74,7 @@ Generally, the [built-in LINQ methods](https://github.com/dotnet/runtime/blob/ma
 * Wrap the current expression tree in a <xref:System.Linq.Expressions.MethodCallExpression> representing the method call.
 * Pass the wrapped expression tree back to the provider, either to return a value via the provider's <xref:System.Linq.IQueryProvider.Execute%2A?displayProperty=nameWithType> method; or to return a translated query object via the <xref:System.Linq.IQueryProvider.CreateQuery%2A?displayProperty=nameWithType> method.
 
-You can replace the original query with the result of an [IQueryable\<T>](xref:System.Linq.IQueryable%601)-returning method, to get a new query.
-
-You can do this based on runtime state, as in the following example:
+You can replace the original query with the result of an [IQueryable\<T>](xref:System.Linq.IQueryable%601)-returning method, to get a new query. You can do this based on runtime state, as in the following example:
 
 ```csharp
 bool sortByLength = /* ... */;
@@ -112,29 +110,28 @@ You might also want to compose the various sub-expressions using a third-party l
 
 // This is functionally equivalent to the previous example.
 
-string startsWith? = /* ... */;
-string endsWith? = /* ... */;
+string startsWith = /* ... */;
+string endsWith = /* ... */;
 
 var qry = companyNamesSource;
 
-bool hasStartsWith = !string.IsNullOrEmpty(startsWith);
-bool hasEndsWith = !string.IsNullOrEmpty(endsWith);
-
-if (hasStartsWith || hasEndsWith) {
-    Expression<Func<string, bool>>? expr = PredicateBuilder.New<string>(false);
-    if (hasStartsWith) {
-        expr = expr.Or(x => x.StartsWith(startsWith));
-    }
-    if (hasEndsWith) {
-        expr = expr.Or(x => x.EndsWith(endsWith));
-    }
-    qry = qry.Where(expr);
+Expression<Func<string, bool>>? expr = PredicateBuilder.New<string>(false);
+var original = expr;
+if (!string.IsNullOrEmpty(startsWith)) {
+    expr = expr.Or(x => x.StartsWith(startsWith));
 }
+if (!string.IsNullOrEmpty(endsWith)) {
+    expr = expr.Or(x => x.EndsWith(endsWith));
+}
+if (expr == original) {
+    expr = x => true;
+}
+qry = qry.Where(expr);
 ```
 
 ## Construct expression trees and queries using factory methods
 
-In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type; you may need to add different components, depending on the element type. You can create the expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression>.
+In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type; you may need to add different components, depending on the element type. You can create the expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression>, and thus tailer the expression to a specific element type.
 
 ### Constructing an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601)
 
@@ -305,7 +302,7 @@ Note that in this case you don't have a compile-time `T` generic placeholder, so
 
 ## The Dynamic LINQ library
 
-Constructing expression trees using factory methods is relatively complex; it is easier to compose strings. The [Dynamic LINQ library](https://dynamic-linq.net/) exposes a set of extension methods on <xref:System.Linq.IQueryable> corresponding to the standard LINQ methods at <xref:System.Linq.Queryable>, and which accept strings in a [special syntax](https://dynamic-linq.net/expression-language) instead of expression trees. The library generates the appropriate expression tree from the string, and returns the resultant translated <xref:System.Linq.IQueryable>.
+Constructing expression trees using factory methods is relatively complex; it is easier to compose strings. The [Dynamic LINQ library](https://dynamic-linq.net/) exposes a set of extension methods on <xref:System.Linq.IQueryable> corresponding to the standard LINQ methods at <xref:System.Linq.Queryable>, and which accept strings in a [special syntax](https://dynamic-linq.net/expression-language) instead of expression trees. The library generates the appropriate expression tree from the string, and can return the resultant translated <xref:System.Linq.IQueryable>.
 
 For instance, the previous example could be rewritten as follows:
 

--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -25,7 +25,7 @@ IQueryable<string> companyNamesSource = companyNames.AsQueryable();
 var qry = companyNames.OrderBy(x => x);
 ```
 
-Every time you run this code, the same exact query will be executed. This is frequently not very useful, as you may want your code to execute different queries under varying conditions. This topic describes how you can execute a different query based on runtime state.
+Every time you run this code, the same exact query will be executed. This is frequently not very useful, as you may want your code to execute different queries under varying conditions. This article describes how you can execute a different query based on runtime state.
 
 ## IQueryable, IQueryable\<T> and expression trees
 
@@ -63,9 +63,9 @@ Console.WriteLine(string.Join(",", qry));
 // prints: Co, Al, So, Ci, Wi, Gr, Ad, Hu, Wo, Ma, No, Bl, Tr, Th, Lu, Fo 
 ```
 
-Note that the expression tree hasn't been modified; the query returns different values only because the value of `length` has been changed.
+The expression tree hasn't been modified; the query returns different values only because the value of `length` has been changed.
 
-## Calling additional LINQ methods
+## Call additional LINQ methods
 
 The LINQ methods on <xref:System.Linq.Queryable> which don't execute the query but rather return a new translated query object, generally consist of two steps:
 
@@ -107,9 +107,9 @@ if (sortByLength) {
 }
 ```
 
-## Varying the expression tree passed into the LINQ methods
+## Vary the expression tree passed into the LINQ methods
 
-You can also choose to pass in different expressions to the LINQ methods, depending on runtime state:
+You can pass in different expressions to the LINQ methods, depending on runtime state:
 
 ```csharp
 string startsWith = /* ... */;
@@ -148,7 +148,7 @@ if (!string.IsNullOrEmpty(endsWith)) {
 var qry = companyNamesSource.Where(expr);
 ```
 
-## Constructing expression trees and queries using factory methods
+## Construct expression trees and queries using factory methods
 
 In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. But what if you want to add components to a query without limiting yourself to a specific element type? And moreover, what if the components you want to add are different depending on the type?
 
@@ -161,7 +161,7 @@ record Person(string LastName, string FirstName, DateTime DateOfBirth);
 record Car(string Model, int Year);
 ```
 
-and for any of these entity types, you want to filter and return only those entities that have a given text inside one of their `string` fields. For `Person`, we'd want to search the `FirstName` and `LastName` properties:
+For any of these entity types, you want to filter and return only those entities that have a given text inside one of their `string` fields. For `Person`, we'd want to search the `FirstName` and `LastName` properties:
 
 ```csharp
 string term = /* ... */;

--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -1,107 +1,266 @@
 ---
-title: "How to use expression trees to build dynamic queries (C#)"
-description: Learn how to use expression trees to create dynamic LINQ queries. These queries are useful when the specifics of a query are unknown at compile time.
+title: "Querying based on runtime state (C#)"
+description: Describes various techniques your code can use to query dynamically depending on runtime state, by varying either LINQ method calls or the expression trees passed into those methods.
 ms.date: 07/20/2015
 ms.assetid: 52cd44dd-a3ec-441e-b93a-4eca388119c7
 ---
-# How to use expression trees to build dynamic queries (C#)
+# Querying based on runtime state (C#)
 
-In LINQ, expression trees are used to represent structured queries that target sources of data that implement <xref:System.Linq.IQueryable%601>. For example, the LINQ provider implements the <xref:System.Linq.IQueryable%601> interface for querying relational data stores. The C# compiler compiles queries that target such data sources into code that builds an expression tree at runtime. The query provider can then traverse the expression tree data structure and translate it into a query language appropriate for the data source.  
-  
- Expression trees are also used in LINQ to represent lambda expressions that are assigned to variables of type <xref:System.Linq.Expressions.Expression%601>.  
-  
- This topic describes how to use expression trees to create dynamic LINQ queries. Dynamic queries are useful when the specifics of a query are not known at compile time. For example, an application might provide a user interface that enables the end user to specify one or more predicates to filter the data. In order to use LINQ for querying, this kind of application must use expression trees to create the LINQ query at runtime.  
-  
-## Example  
+Consider code that defines an <xref:System.Linq.IQueryable%601> or an <xref:System.Linq.IQueryable> against a data source:
 
- The following example shows you how to use expression trees to construct a query against an `IQueryable` data source and then execute it. The code builds an expression tree to represent the following query:  
-  
- ```csharp
- companies.Where(company => (company.ToLower() == "coho winery" || company.Length > 16))
-          .OrderBy(company => company)
- ```
-  
- The factory methods in the <xref:System.Linq.Expressions> namespace are used to create expression trees that represent the expressions that make up the overall query. The expressions that represent calls to the standard query operator methods refer to the <xref:System.Linq.Queryable> implementations of these methods. The final expression tree is passed to the <xref:System.Linq.IQueryProvider.CreateQuery%60%601%28System.Linq.Expressions.Expression%29> implementation of the provider of the `IQueryable` data source to create an executable query of type `IQueryable`. The results are obtained by enumerating that query variable.  
-  
-```csharp  
-// Add a using directive for System.Linq.Expressions.  
-  
-string[] companies = { "Consolidated Messenger", "Alpine Ski House", "Southridge Video", "City Power & Light",  
-                   "Coho Winery", "Wide World Importers", "Graphic Design Institute", "Adventure Works",  
-                   "Humongous Insurance", "Woodgrove Bank", "Margie's Travel", "Northwind Traders",  
-                   "Blue Yonder Airlines", "Trey Research", "The Phone Company",  
-                   "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee" };  
-  
-// The IQueryable data to query.  
-IQueryable<String> queryableData = companies.AsQueryable<string>();  
-  
-// Compose the expression tree that represents the parameter to the predicate.  
-ParameterExpression pe = Expression.Parameter(typeof(string), "company");  
-  
-// ***** Where(company => (company.ToLower() == "coho winery" || company.Length > 16)) *****  
-// Create an expression tree that represents the expression 'company.ToLower() == "coho winery"'.  
-Expression left = Expression.Call(pe, typeof(string).GetMethod("ToLower", System.Type.EmptyTypes));  
-Expression right = Expression.Constant("coho winery");  
-Expression e1 = Expression.Equal(left, right);  
-  
-// Create an expression tree that represents the expression 'company.Length > 16'.  
-left = Expression.Property(pe, typeof(string).GetProperty("Length"));  
-right = Expression.Constant(16, typeof(int));  
-Expression e2 = Expression.GreaterThan(left, right);  
-  
-// Combine the expression trees to create an expression tree that represents the  
-// expression '(company.ToLower() == "coho winery" || company.Length > 16)'.  
-Expression predicateBody = Expression.OrElse(e1, e2);  
-  
-// Create an expression tree that represents the expression  
-// 'queryableData.Where(company => (company.ToLower() == "coho winery" || company.Length > 16))'  
-MethodCallExpression whereCallExpression = Expression.Call(  
-    typeof(Queryable),  
-    "Where",  
-    new Type[] { queryableData.ElementType },  
-    queryableData.Expression,  
-    Expression.Lambda<Func<string, bool>>(predicateBody, new ParameterExpression[] { pe }));  
-// ***** End Where *****  
-  
-// ***** OrderBy(company => company) *****  
-// Create an expression tree that represents the expression  
-// 'whereCallExpression.OrderBy(company => company)'  
-MethodCallExpression orderByCallExpression = Expression.Call(  
-    typeof(Queryable),  
-    "OrderBy",  
-    new Type[] { queryableData.ElementType, queryableData.ElementType },  
-    whereCallExpression,  
-    Expression.Lambda<Func<string, string>>(pe, new ParameterExpression[] { pe }));  
-// ***** End OrderBy *****  
-  
-// Create an executable query from the expression tree.  
-IQueryable<string> results = queryableData.Provider.CreateQuery<string>(orderByCallExpression);  
-  
-// Enumerate the results.  
-foreach (string company in results)  
-    Console.WriteLine(company);  
-  
-/*  This code produces the following output:  
-  
-    Blue Yonder Airlines  
-    City Power & Light  
-    Coho Winery  
-    Consolidated Messenger  
-    Graphic Design Institute  
-    Humongous Insurance  
-    Lucerne Publishing  
-    Northwind Traders  
-    The Phone Company  
-    Wide World Importers  
-*/  
-```  
-  
- This code uses a fixed number of expressions in the predicate that is passed to the `Queryable.Where` method. However, you can write an application that combines a variable number of predicate expressions that depends on the user input. You can also vary the standard query operators that are called in the query, depending on the input from the user.  
-  
-## Compiling the Code  
-  
-- Include the System.Linq.Expressions namespace.  
-  
+```csharp
+var companyNames = new[] {
+    "Consolidated Messenger", "Alpine Ski House", "Southridge Video",
+    "City Power & Light", "Coho Winery", "Wide World Importers",
+    "Graphic Design Institute", "Adventure Works", "Humongous Insurance",
+    "Woodgrove Bank", "Margie's Travel", "Northwind Traders",
+    "Blue Yonder Airlines", "Trey Research", "The Phone Company",
+    "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee"
+};
+
+// We're using an in-memory array as the data source, but the IQueryable could have come
+// from anywhere -- an ORM backed by a database, a web request, or any other LINQ provider.
+IQueryable<string> companyNamesSource = companyNames.AsQueryable();
+
+var qry = companyNames.OrderBy(x => x);
+```
+
+Every time you run this code, the same exact query will be executed. This is frequently not very useful, as you may want your code to execute different queries under varying conditions. This topic describes how you can execute a different query based on runtime state.
+
+## IQueryable, IQueryable\<T> and expression trees
+
+Fundamentally, an <xref:System.Linq.IQueryable> has two components:
+
+* <xref:System.Linq.IQueryable.Expression>&mdash;a language- and datasource-agnostic representation of the current query's elements, in the form of an expression tree.
+* <xref:System.Linq.IQueryable.Provider>&mdash;an object which knows how to translate the current query into actual .NET objects, a.k.a. an instance of a LINQ provider.
+
+In the context of dynamic querying, the provider will usually remain the same; the expression tree of the query will be different from query to query.
+
+Because expression trees are immutable, if you want a different expression tree&mdash;and thus a different query&mdash;you'll need to translate the existing expression tree to a new one, and thus to a new **IQueryable**.
+
+The following sections describe specific techniques for querying differently in response to runtime state:
+
+- Referencing runtime state directly in the expression tree
+- Calling additional LINQ methods
+- Varying the expression tree passed into the LINQ methods
+- Constructing expression trees using the factory methods at <xref:System.Linq.Expressions.Expression>
+
+## Referencing runtime state from the expression tree
+
+Assuming the LINQ provider supports it, the simplest way to query dynamically is to reference the runtime state directly in the query, via a closed-over variable:
+
+```csharp
+var length = 1;
+var qry = companyNamesSource
+    .Select(x => x.Substring(0, length))
+    .Distinct();
+    
+Console.WriteLine(string.Join(",", qry));
+// prints: C, A, S, W, G, H, M, N, B, T, L, F
+
+length = 2;
+Console.WriteLine(string.Join(",", qry));
+// prints: Co, Al, So, Ci, Wi, Gr, Ad, Hu, Wo, Ma, No, Bl, Tr, Th, Lu, Fo 
+```
+
+Note that the expression tree hasn't been modified; the query returns different values only because the value of `length` has been changed.
+
+## Calling additional LINQ methods
+
+The LINQ methods on <xref:System.Linq.Queryable> which don't execute the query but rather return a new translated query object, generally consist of two steps:
+
+* wrap the current expression tree in a <xref:System.Linq.Expressions.MethodCallExpression> representing the method call, and
+* pass the newly wrapped expression tree back into the provider for optional additional processing.
+
+For example, the source code for <xref:System.Linq.Queryable.Take> looks something like this:
+
+```csharp
+public static IQueryable<TSource> Take<TSource>(this IQueryable<TSource> source, int count) {
+
+    // wrap the original expression in a MethodCallExpression using the Call factory method    
+    var wrapped =
+        Expression.Call(
+            null,
+            CachedReflectionInfo.Take_TSource_2(typeof(TSource)),
+
+            // the original expression
+            source.Expression, 
+
+            Expression.Constant(count)
+        )
+
+    // pass the wrapped expression back to the provider
+    var newQuery = source.Provider.CreateQuery<TSource>(wrapped);
+
+    return newQuery;
+}
+```
+
+Thus, based on runtime state, you can conditionally replace the original query object with the result of these method calls, to get a new query.
+
+```csharp
+bool sortByLength = /* ... */;
+
+var qry = companyNamesSource;
+if (sortByLength) {
+    qry = qry.OrderBy(x => x.Length);
+}
+```
+
+## Varying the expression tree passed into the LINQ methods
+
+You can also choose to pass in different expressions to the LINQ methods, depending on runtime state:
+
+```csharp
+string startsWith = /* ... */;
+string endsWith = /* ... */;
+
+Expression<Func<string, bool>>? expr = null;
+if (!string.IsNullOrEmpty(startsWith) && !string.IsNullOrEmpty(endsWith)) {
+    expr = x => x.StartsWith(startsWith) || x.EndsWith(endsWith);
+} else if (!string.IsNullOrEmpty(startsWith)) {
+    expr = x => x.StartsWith(startsWith);
+} else if (!string.IsNullOrEmpty(endsWith)) {
+    expr = x => x.EndsWith(endsWith);
+} else {
+    expr = x => true;
+}
+
+var qry = companyNamesSource.Where(expr);
+```
+
+You might also want to compose the various sub-expressions using a third-party library such as [LinqKit](http://www.albahari.com/nutshell/linqkit.aspx)'s [PredicateBuilder](http://www.albahari.com/nutshell/predicatebuilder.aspx):
+
+```csharp
+// This is functionally equivalent to the previous example.
+
+string startsWith = /* ... */;
+string endsWith = /* ... */;
+
+Expression<Func<string, bool>>? expr = PredicateBuilder.New<string>(true);
+if (!string.IsNullOrEmpty(startsWith)) {
+    expr = expr.Or(x => x.StartsWith(startsWith));
+}
+if (!string.IsNullOrEmpty(endsWith)) {
+    expr = expr.Or(x => x.EndsWith(endsWith));
+}
+
+var qry = companyNamesSource.Where(expr);
+```
+
+## Constructing expression trees and queries using factory methods
+
+In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. But what if you want to add components to a query without limiting yourself to a specific element type? And moreover, what if the components you want to add are different depending on the type?
+
+To do this, you must create the expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression>.
+
+For example, let's say you have multiple entity types:
+
+```csharp
+record Person(string LastName, string FirstName, DateTime DateOfBirth);
+record Car(string Model, int Year);
+```
+
+and for any of these entity types, you want to filter and return only those entities that have a given text inside one of their `string` fields. For `Person`, we'd want to search the `FirstName` and `LastName` properties:
+
+```csharp
+string term = /* ... */;
+var personsQry = new List<Person>()
+    .AsQueryable()
+    .Where(x => x.FirstName.Contains(term) || x.LastName.Contains(term));
+```
+
+but for `Car`, we'd want to search only the `Model` property:
+
+```csharp
+string term = /* ... */;
+var carsQry = new List<Car>()
+    .AsQueryable()
+    .Where(x => x.Model.Contains(term));
+```
+
+The following example shows a function that adds this filtering to an existing query, irrespective of the specific element type. Note that because it takes and returns an `IQueryable<T>`, you can add further strongly-typed query elements after the text filter.
+
+```csharp
+// using static System.Linq.Expressions.Expression
+
+IQueryable<T> TextFilter<T>(IQueryable<T> source, string term) {
+    if (string.IsNullOrEmpty(term)) { return source; }
+
+    // T is a compile-time placeholder for the element type of the query.
+    var type = typeof(T);
+
+    // Get all the string properties on this specific type.
+    var stringProperties = 
+        type.GetProperties()
+            .Where(x => x.PropertyType == typeof(string))
+            .ToArray();
+    if (!stringProperties.Any()) { return source; }
+
+    // Get a hold of the right overload of the Contains method
+    var containsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) })!;
+
+    // First, create a parameter for the expression tree; the `x`
+    // The type of this parameter is the query's element type, or T
+    var prm = Parameter(type);
+
+    Expression? body = null;
+    foreach (var prp in stringProperties) {
+        // For each field, we have to construct an expression tree like x.PropertyName.Contains("term")
+
+        var clause =
+
+            // .Contains(...) 
+            Call(
+
+                // .PropertyName
+                Property(prm, prp),
+
+                containsMethod,
+                
+                // "term"
+                Constant(term)
+            );
+
+        // If this is the first clause
+        if (body is null) {
+            body = clause;
+        } else {
+            // Combine this clause with the current body using ||
+            body = Or(body, clause);
+        }
+    }
+
+    // Wrap the expression body in a strongly-typed lambda expression
+    Expression<Func<T, bool>> lambda = Lambda<Func<T, bool>>(body, prm);
+
+    // Because the lambda is strongly typed (albeit with a generic parameter), we can use it with the Where method
+    return source.Where(lambda);
+}
+```
+
+Finally, if you don't even have an `IQueryable<T>`, but rather the element type itself is unknown at runtime, you can still construct the expression tree as in the previous example, and wrap the entire tree in a `MethodCallExpression` calling the appropriate LINQ method:
+
+```csharp
+IQueryable TextFilter(IQueryable source, string term) {
+    if (string.IsNullOrEmpty(term)) { return source; }
+    var type = source.ElementType;
+
+    // build the expression body based on the element type's string properties
+    // as above
+
+    var filteredTree = Call(
+        typeof(Queryable),
+        "Where",
+        new[] { source.ElementType },
+        source.Expression,
+        Lambda(body, prm)
+    );
+
+    return source.Provider.CreateQuery(filteredTree);
+}
+```
+
 ## See also
 
 - [Expression Trees (C#)](./index.md)

--- a/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs
+++ b/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs
@@ -1,0 +1,264 @@
+﻿using LinqKit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+using System.Reflection;
+using System.Linq.Dynamic.Core;
+using ExpressionTreeToString;
+
+// <Initialize>
+var companyNames = new[] {
+    "Consolidated Messenger", "Alpine Ski House", "Southridge Video",
+    "City Power & Light", "Coho Winery", "Wide World Importers",
+    "Graphic Design Institute", "Adventure Works", "Humongous Insurance",
+    "Woodgrove Bank", "Margie's Travel", "Northwind Traders",
+    "Blue Yonder Airlines", "Trey Research", "The Phone Company",
+    "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee"
+};
+
+// We're using an in-memory array as the data source, but the IQueryable could have come
+// from anywhere -- an ORM backed by a database, a web request, or any other LINQ provider.
+IQueryable<string> companyNamesSource = companyNames.AsQueryable();
+var fixedQry = companyNames.OrderBy(x => x);
+// </Initialize>
+
+{
+    // <Runtime_state_from_within_expression_tree>
+    var length = 1;
+    var qry = companyNamesSource
+        .Select(x => x.Substring(0, length))
+        .Distinct();
+
+    Console.WriteLine(string.Join(",", qry));
+    // prints: C, A, S, W, G, H, M, N, B, T, L, F
+
+    length = 2;
+    Console.WriteLine(string.Join(",", qry));
+    // prints: Co, Al, So, Ci, Wi, Gr, Ad, Hu, Wo, Ma, No, Bl, Tr, Th, Lu, Fo 
+    // </Runtime_state_from_within_expression_tree>
+}
+
+{
+    bool sortByLength = true;
+
+    // <Added_method_calls>
+    // bool sortByLength = /* ... */;
+    
+    var qry = companyNamesSource;
+    if (sortByLength)
+    {
+        qry = qry.OrderBy(x => x.Length);
+    }
+    // </Added_method_calls>
+}
+
+{
+    string? startsWith = "";
+    string? endsWith = "";
+
+    // <Varying_expressions>
+    // string? startsWith = /* ... */;
+    // string? endsWith = /* ... */;
+
+    Expression<Func<string, bool>> expr = (startsWith, endsWith) switch
+    {
+        ("" or null, "" or null) => x => true,
+        (_, "" or null) => x => x.StartsWith(startsWith),
+        ("" or null, _) => x => x.EndsWith(endsWith),
+        (_, _) => x => x.StartsWith(startsWith) || x.EndsWith(endsWith)
+    };
+
+    var qry = companyNamesSource.Where(expr);
+    // </Varying_expressions>
+}
+
+{
+    string? startsWith = "";
+    string? endsWith = "";
+
+    // <Compose_expressions>
+    // This is functionally equivalent to the previous example.
+    
+    // using LinqKit;
+    // string? startsWith = /* ... */;
+    // string? endsWith = /* ... */;
+
+    var qry = companyNamesSource;
+
+    Expression<Func<string, bool>>? expr = PredicateBuilder.New<string>(false);
+    var original = expr;
+    if (!string.IsNullOrEmpty(startsWith))
+    {
+        expr = expr.Or(x => x.StartsWith(startsWith));
+    }
+    if (!string.IsNullOrEmpty(endsWith))
+    {
+        expr = expr.Or(x => x.EndsWith(endsWith));
+    }
+    if (expr == original)
+    {
+        expr = x => true;
+    }
+    qry = qry.Where(expr);
+    // </Compose_expressions>
+}
+
+{
+    // <Factory_methods_expression_of_tdelegate>
+    // using static System.Linq.Expressions.Expression;
+
+    IQueryable<T> TextFilter<T>(IQueryable<T> source, string term)
+    {
+        if (string.IsNullOrEmpty(term)) { return source; }
+
+        // T is a compile-time placeholder for the element type of the query.
+        Type elementType = typeof(T);
+
+        // Get all the string properties on this specific type.
+        PropertyInfo[] stringProperties =
+            elementType.GetProperties()
+                .Where(x => x.PropertyType == typeof(string))
+                .ToArray();
+        if (!stringProperties.Any()) { return source; }
+
+        // Get the right overload of String.Contains
+        MethodInfo containsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) })!;
+
+        // Create a parameter for the expression tree:
+        // the 'x' in 'x => x.PropertyName.Contains("term")'
+        // The type of this parameter is the query's element type
+        ParameterExpression prm = Parameter(elementType);
+
+        // Map each property to an expression tree node
+        IEnumerable<Expression> expressions = stringProperties
+            .Select(prp =>
+                // For each property, we have to construct an expression tree node like x.PropertyName.Contains("term")
+                Call(                  // .Contains(...) 
+                    Property(          // .PropertyName
+                        prm,           // x 
+                        prp
+                    ),
+                    containsMethod,
+                    Constant(term)     // "term" 
+                )
+            );
+
+        // Combine all the resultant expression nodes using ||
+        Expression body = expressions
+            .Aggregate(
+                (prev, current) => Or(prev, current)
+            );
+
+        // Wrap the expression body in a compile-time-typed lambda expression
+        Expression<Func<T, bool>> lambda = Lambda<Func<T, bool>>(body, prm);
+
+        // Because the lambda is compile-time-typed (albeit with a generic parameter), we can use it with the Where method
+        return source.Where(lambda);
+    }
+    // </Factory_methods_expression_of_tdelegate>
+
+    // <Factory_methods_expression_of_tdelegate_usage>
+    var qry = TextFilter(
+            new List<Person>().AsQueryable(), 
+            "abcd"
+        )
+        .Where(x => x.DateOfBirth < new DateTime(2001, 1, 1));
+
+    var qry1 = TextFilter(
+            new List<Car>().AsQueryable(), 
+            "abcd"
+        )
+        .Where(x => x.Year == 2010);
+    // </Factory_methods_expression_of_tdelegate_usage>
+}
+
+{
+    // This function has the logic for constructing the body of the TextFilter expression.
+    (Expression? body, ParameterExpression? prm) constructBody(Type elementType, string term) {
+        PropertyInfo[] stringProperties =
+            elementType.GetProperties()
+                .Where(x => x.PropertyType == typeof(string))
+                .ToArray();
+        if (!stringProperties.Any()) { return (null, null); }
+
+        var containsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) })!;
+
+        var prm = Parameter(elementType);
+        var body = stringProperties
+            .Select(prp =>
+                Call(
+                    Property(prm, prp),
+                    containsMethod,
+                    Constant(term)
+                )
+            )
+            .Aggregate<Expression>(
+                (prev, current) => Or(prev, current)
+            );
+
+        return (body, prm);
+    }
+
+    // <Factory_methods_lambdaexpression>
+    IQueryable TextFilter_Untyped(IQueryable source, string term)
+    {
+        if (string.IsNullOrEmpty(term)) { return source; }
+        Type type = source.ElementType;
+
+        // The logic for building the ParameterExpression and the LambdaExpression's body is the same as in the previous example,
+        // but has been refactored into the constructBody function.
+        (Expression? body, ParameterExpression? prm) = constructBody(type, term);
+        if (body is null) {return source;}
+
+        Expression filteredTree = Call(
+            typeof(Queryable),
+            "Where",
+            new[] { source.ElementType },
+            source.Expression,
+            Lambda(body, prm)
+        );
+
+        return source.Provider.CreateQuery(filteredTree);
+    }
+    // </Factory_methods_lambdaexpression>
+
+    IQueryable qry = TextFilter(
+        new List<Person>().AsQueryable(), 
+        "abcd"
+    );
+}
+
+{
+    // <Dynamic_linq>
+    // using System.Linq.Dynamic.Core
+
+    IQueryable TextFilter_Strings(IQueryable source, string term) {
+        if (string.IsNullOrEmpty(term)) { return source; }
+
+        var elementType = source.ElementType;
+
+        // Get all the string property names on this specific type.
+        var stringProperties = 
+            elementType.GetProperties()
+                .Where(x => x.PropertyType == typeof(string))
+                .ToArray();
+        if (!stringProperties.Any()) { return source; }
+
+        // Build the string expression
+        string filterExpr = string.Join(
+            " || ",
+            stringProperties.Select(prp => $"{prp.Name}.Contains(@0)")
+        );
+
+        return source.Where(filterExpr, term);
+    }
+    // </Dynamic_linq>
+
+    IQueryable qry = new List<Person>().AsQueryable();
+    qry = TextFilter(qry, "abcd");
+}
+
+record Person(string LastName, string FirstName, DateTime DateOfBirth);
+record Car(string Model, int Year);

--- a/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs
+++ b/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs
@@ -224,7 +224,7 @@ var fixedQry = companyNames.OrderBy(x => x);
     }
     // </Factory_methods_lambdaexpression>
 
-    IQueryable qry = TextFilter(
+    IQueryable qry = TextFilter_Untyped(
         new List<Person>().AsQueryable(), 
         "abcd"
     );
@@ -257,7 +257,7 @@ var fixedQry = companyNames.OrderBy(x => x);
     // </Dynamic_linq>
 
     IQueryable qry = new List<Person>().AsQueryable();
-    qry = TextFilter(qry, "abcd");
+    qry = TextFilter_Strings(qry, "abcd");
 }
 
 record Person(string LastName, string FirstName, DateTime DateOfBirth);

--- a/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/dynamic-linq-expression-trees.csproj
+++ b/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/dynamic-linq-expression-trees.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>dynamic_linq_expression_trees</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ExpressionTreeToString" Version="3.2.54" />
+    <PackageReference Include="LinqKit.Core" Version="1.1.23" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.7" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Expands the scope of this topic from "constructing the complete tree behind a query using factory methods" to "dynamic querying based on runtime state".

I've tried to illustrate why you'd want to use local variables, when you'd want to call additional LINQ methods, when you'd want to vary the expression passed into those same methods; and when there's no recourse but to construct the expression tree by hand, either to pass into the LINQ methods, or to include the LINQ method call on the tree.

Ping @aaron-old @DeveloperLookBook @Miggleness @psxvoid -- as upvoters on the original issue, I'd be very interested in feedback from you.

Fixes #6288.

I also think some mention should be made of Dynamic LINQ, at least in it's [current incarnation](https://dynamic-linq.net/), and how much easier it is to construct expression trees by building strings vs calling the factory methods.