### PR TITLE
IL and IL assembly : remove confusion

### DIFF
--- a/docs/framework/tools/ilasm-exe-il-assembler.md
+++ b/docs/framework/tools/ilasm-exe-il-assembler.md
@@ -15,7 +15,7 @@ ms.assetid: 4ca3a4f0-4400-47ce-8936-8e219961c76f
 ---
 # Ilasm.exe (IL Assembler)
 
-The IL Assembler generates a portable executable (PE) file from intermediate language (IL) assemby. (For more information on IL, see [Managed Execution Process](../../standard/managed-execution-process.md).) You can run the resulting executable, which contains IL and the required metadata, to determine whether the IL performs as expected.
+The IL Assembler generates a portable executable (PE) file from intermediate language (IL) assembly. (For more information on IL, see [Managed Execution Process](../../standard/managed-execution-process.md).) You can run the resulting executable, which contains IL and the required metadata, to determine whether the IL performs as expected.
 
 This tool is automatically installed with Visual Studio. To run the tool, use the Developer Command Prompt for Visual Studio (or the Visual Studio Command Prompt in Windows 7). For more information, see [Command Prompts](developer-command-prompt-for-vs.md).
 

--- a/docs/framework/tools/ilasm-exe-il-assembler.md
+++ b/docs/framework/tools/ilasm-exe-il-assembler.md
@@ -1,6 +1,6 @@
 ---
 title: "Ilasm.exe (IL Assembler)"
-description: Get started with Ilasm.exe, the IL Assembler. This tool generates a portable executable (PE) file from intermediate language (IL).
+description: Get started with Ilasm.exe, the IL Assembler. This tool generates a portable executable (PE) file from intermediate language (IL) assembly.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "MSIL generators"
@@ -15,7 +15,7 @@ ms.assetid: 4ca3a4f0-4400-47ce-8936-8e219961c76f
 ---
 # Ilasm.exe (IL Assembler)
 
-The IL Assembler generates a portable executable (PE) file from intermediate language (IL). (For more information on IL, see [Managed Execution Process](../../standard/managed-execution-process.md).) You can run the resulting executable, which contains IL and the required metadata, to determine whether the IL performs as expected.
+The IL Assembler generates a portable executable (PE) file from intermediate language (IL) assemby. (For more information on IL, see [Managed Execution Process](../../standard/managed-execution-process.md).) You can run the resulting executable, which contains IL and the required metadata, to determine whether the IL performs as expected.
 
 This tool is automatically installed with Visual Studio. To run the tool, use the Developer Command Prompt for Visual Studio (or the Visual Studio Command Prompt in Windows 7). For more information, see [Command Prompts](developer-command-prompt-for-vs.md).
 


### PR DESCRIPTION
Since the result of the tool's execution contains already **Intermediate Language** (Binary), I think that we should make it clear that the entry is written in IL **assembly language** (.il)

Source: https://docs.microsoft.com/en-us/dotnet/framework/tools/ilasm-exe-il-assembler


