### PR TITLE
Clarify WinExe property breaking change

### DIFF
--- a/docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md
+++ b/docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md
@@ -17,7 +17,7 @@ In previous versions of the .NET SDK, the value that's specified for `OutputType
 </PropertyGroup>
 ```
 
-Starting in the 5.0.100 version of the .NET SDK, when the `OutputType` property is present, `OutputType` is automatically set to `WinExe` for WPF and Windows Forms apps that target any framework version, including .NET Framework. For example:
+Starting in the 5.0.100 version of the .NET SDK, when `OutputType` is set to `Exe`, it is automatically changed to `WinExe` for WPF and Windows Forms apps that target any framework version, including .NET Framework.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md
+++ b/docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md
@@ -25,6 +25,8 @@ Starting in the 5.0.100 version of the .NET SDK, when `OutputType` is set to `Ex
 </PropertyGroup>
 ```
 
+ If `OutputType` is not specified in the project file, it defaults to `Library` and that value doesn't change.
+
 ## Reason for change
 
 It's assumed that most users don't want a console window to open when a WPF or Windows Forms app is executed. In addition, [now that these application types use the .NET SDK](sdk-and-target-framework-change.md) instead of the Windows Desktop SDK, the correct default will be set. Further, when support for targeting iOS and Android is added, it will be easier to multi-target between multiple platforms if they all use the same output type.

--- a/docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md
+++ b/docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md
@@ -17,7 +17,7 @@ In previous versions of the .NET SDK, the value that's specified for `OutputType
 </PropertyGroup>
 ```
 
-Starting in the 5.0.100 version of the .NET SDK, `OutputType` is automatically set to `WinExe` for WPF and Windows Forms apps that target any framework version, including .NET Framework. For example:
+Starting in the 5.0.100 version of the .NET SDK, when the `OutputType` property is present, `OutputType` is automatically set to `WinExe` for WPF and Windows Forms apps that target any framework version, including .NET Framework. For example:
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
## Summary

Clarify property usage. If the property is omitted, it's not automatically set to `WinExe` as the description implies. This clarifies that it only applies when it's present. You still get a library output and not an exe output if you omit the property.

