### PR TITLE
Clarify bulk severity levels

### DIFF
--- a/docs/fundamentals/code-analysis/categories.md
+++ b/docs/fundamentals/code-analysis/categories.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
 ---
 # Rule categories
 
-Each code analysis rule belongs to a category of rules. For example, design rules support adherence to the .NET design guidelines, and security rules help prevent security flaws. You can [disable or enable an entire category](configuration-options.md#scope) of rules. You can also [configure additional options](code-quality-rule-options.md#category-of-rules) on a per-category basis.
+Each code analysis rule belongs to a category of rules. For example, design rules support adherence to the .NET design guidelines, and security rules help prevent security flaws. You can [configure the severity level](configuration-options.md#scope) for an entire category of rules. You can also [configure additional options](code-quality-rule-options.md#category-of-rules) on a per-category basis.
 
 The following table shows the different code analysis rule categories and provides a link to the rules in each category.
 

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -53,14 +53,14 @@ Rule-specific options can be applied to a single rule, a set of rules, or all ru
 
 The following table shows the different rule severities that you can configure for all analyzer rules, including [code quality](quality-rules/index.md) and [code style](style-rules/index.md) rules.
 
-| Severity | Build-time behavior |
+| Severity configuration value | Build-time behavior |
 |-|-|
 | `error` | Violations appear as build *errors* and cause builds to fail.|
 | `warning` | Violations appear as build *warnings* but do not cause builds to fail (unless you have an option set to treat warnings as errors). |
 | `suggestion` | Violations appear as build *messages* and as suggestions in the Visual Studio IDE. |
 | `silent` | Violations aren't visible to the user. |
 | `none` | Rule is suppressed completely. |
-| `default` | The default severity of the rule is used. |
+| `default` | The default severity of the rule is used. The default severities for each .NET release are listed in the [roslyn-analyzers repo](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). In that table, "Disabled" corresponds to `none`, "Hidden" corresponds to `silent`, and "Info" corresponds to `suggestion`. |
 
 > [!TIP]
 > For information about how rule severities surface in Visual Studio, see [Severity levels](/visualstudio/ide/editorconfig-language-conventions#severity-levels).
@@ -84,6 +84,9 @@ To set the default rule severity for all analyzer rules, use the following synta
 ```ini
 dotnet_analyzer_diagnostic.severity = <severity value>
 ```
+
+> [!IMPORTANT]
+> When you configure the severity level for multiple rules with a single entry, either for a *category* of rules or for *all* rules, the severity only applies to rules that are [enabled by default](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). To enable rules that are disabled by default, you must add an explicit `dotnet_diagnostic.<rule ID>.severity = <severity>` configuration entry for each rule.
 
 #### Precedence
 

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -86,7 +86,10 @@ dotnet_analyzer_diagnostic.severity = <severity value>
 ```
 
 > [!IMPORTANT]
-> When you configure the severity level for multiple rules with a single entry, either for a *category* of rules or for *all* rules, the severity only applies to rules that are [enabled by default](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). To enable rules that are disabled by default, you must add an explicit `dotnet_diagnostic.<rule ID>.severity = <severity>` configuration entry for each rule.
+> When you configure the severity level for multiple rules with a single entry, either for a *category* of rules or for *all* rules, the severity only applies to rules that are [enabled by default](https://github.com/dotnet/roslyn-analyzers/blob/master/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). To enable rules that are disabled by default, you must either:
+>
+> - Add an explicit `dotnet_diagnostic.<rule ID>.severity = <severity>` configuration entry for each rule.
+> - Enable *all* rules by setting [\<AnalysisMode>](../../core/project-sdk/msbuild-props.md#analysismode) to `AllEnabledByDefault`.
 
 #### Precedence
 

--- a/docs/fundamentals/code-analysis/overview.md
+++ b/docs/fundamentals/code-analysis/overview.md
@@ -52,7 +52,7 @@ You can change the severity of these rules to disable them or elevate them to er
 
 ### Enable additional rules
 
-*Analysis mode* refers to a predefined code analysis configuration where none, some, or all rules are enabled. In the default analysis mode, only a small number of rules are [enabled as build warnings](#enabled-rules). You can change the analysis mode for your project by setting the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) property in the project file. The allowable values are:
+*Analysis mode* refers to a predefined code analysis configuration where none, some, or all rules are enabled. In the default analysis mode, only a small number of rules are [enabled as build warnings](#enabled-rules). You can change the analysis mode for your project by setting the [\<AnalysisMode>](../../core/project-sdk/msbuild-props.md#analysismode) property in the project file. The allowable values are:
 
 | Value | Description |
 | - | - |


### PR DESCRIPTION
Related to dotnet/roslyn#47046. This info already exists in the VS docs.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-options?branch=pr-en-us-22772#scope).