### PR TITLE
Update files to reflect proposed field naming convention change

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
@@ -51,7 +51,7 @@ public class CalendarEntry
     {
         DateTime dt = Convert.ToDateTime(dateString);
 
-        if (dt.Ticks < date.Ticks)
+        if (dt.Ticks < _Date.Ticks)
         {
             return _Date - dt;
         }

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
@@ -7,7 +7,7 @@ public class CalendarEntry
     private DateTime _Date;
 
     // public field (Generally not recommended.)
-    public string day;
+    public string _Day;
 
     // Public property exposes _Date field safely.
     public DateTime Date
@@ -69,7 +69,7 @@ class TestCalendarDate
     {
         //<Snippet2>
         CalendarEntry birthday = new CalendarEntry();
-        birthday.day = "Saturday";
+        birthday._Day = "Saturday";
         //</Snippet2>
     }
 }
@@ -77,7 +77,7 @@ class TestCalendarDate
 //<Snippet3>
 public class CalendarDateWithInitialization
 {
-    public string day = "Monday";
+    public string _Day = "Monday";
     //...
 }
 //</Snippet3>

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
@@ -3,11 +3,11 @@
 //<Snippet1>
 public class CalendarEntry
 {
+    // public field (Generally not recommended.)
+    public string Day;
+    
     // private field
     private DateTime _Date;
-
-    // public field (Generally not recommended.)
-    public string _Day;
 
     // Public property exposes _Date field safely.
     public DateTime Date
@@ -69,7 +69,7 @@ class TestCalendarDate
     {
         //<Snippet2>
         CalendarEntry birthday = new CalendarEntry();
-        birthday._Day = "Saturday";
+        birthday.Day = "Saturday";
         //</Snippet2>
     }
 }
@@ -77,7 +77,7 @@ class TestCalendarDate
 //<Snippet3>
 public class CalendarDateWithInitialization
 {
-    public string _Day = "Monday";
+    public string Day = "Monday";
     //...
 }
 //</Snippet3>

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
@@ -4,24 +4,24 @@
 public class CalendarEntry
 {
     // private field
-    private DateTime date;
+    private DateTime _Date;
 
     // public field (Generally not recommended.)
     public string day;
 
-    // Public property exposes date field safely.
+    // Public property exposes _Date field safely.
     public DateTime Date
     {
         get
         {
-            return date;
+            return _Date;
         }
         set
         {
             // Set some reasonable boundaries for likely birth dates.
             if (value.Year > 1900 && value.Year <= DateTime.Today.Year)
             {
-                date = value;
+                _Date = value;
             }
             else
             {
@@ -30,7 +30,7 @@ public class CalendarEntry
         }
     }
 
-    // Public method also exposes date field safely.
+    // Public method also exposes _Date field safely.
     // Example call: birthday.SetDate("1975, 6, 30");
     public void SetDate(string dateString)
     {
@@ -39,7 +39,7 @@ public class CalendarEntry
         // Set some reasonable boundaries for likely birth dates.
         if (dt.Year > 1900 && dt.Year <= DateTime.Today.Year)
         {
-            date = dt;
+            _Date = dt;
         }
         else
         {
@@ -53,7 +53,7 @@ public class CalendarEntry
 
         if (dt.Ticks < date.Ticks)
         {
-            return date - dt;
+            return _Date - dt;
         }
         else
         {


### PR DESCRIPTION
## Summary

Detailed explanation in Issue #22822
Issue: Fields should not be named camelCase because it overlaps with local variable names
Solution: To either prefix with a _fieldName or _PropertyName so that it matches the property name.

Fixes #22822
