### PR TITLE
Refer to #error pragma

### DIFF
--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -48,7 +48,7 @@ If you must specify your C# version explicitly, you can do so in several ways:
 - Configure the [`-langversion` compiler option](compiler-options/langversion-compiler-option.md).
 
 > [!TIP]
-> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler produce a diagnostic, CS8304, with a message containing the compiler version being used and the current selected language version.
+> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](/preprocessor-directives/preprocessor-error) for more information.
 
 ### Edit the project file
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -48,7 +48,7 @@ If you must specify your C# version explicitly, you can do so in several ways:
 - Configure the [`-langversion` compiler option](compiler-options/langversion-compiler-option.md).
 
 > [!TIP]
-> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](preprocessor-directives/preprocessor-error) for more information.
+> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](preprocessor-directives/preprocessor-error.md) for more information.
 
 ### Edit the project file
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -48,7 +48,7 @@ If you must specify your C# version explicitly, you can do so in several ways:
 - Configure the [`-langversion` compiler option](compiler-options/langversion-compiler-option.md).
 
 > [!TIP]
-> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](/preprocessor-directives/preprocessor-error) for more information.
+> To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](preprocessor-directives/preprocessor-error) for more information.
 
 ### Edit the project file
 


### PR DESCRIPTION
Fixes #21563 🛠️

👉 Made it more clear that the compiler will report an error and referenced the [#error](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-error) preprocessor directive.