### PR TITLE
Continuation of #22710 for VB

### DIFF
--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -29,7 +29,7 @@ The following sections describe specific techniques for querying differently in 
 - Call additional LINQ methods
 - Vary the expression tree passed into the LINQ methods
 - Construct an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) expression tree using the factory methods at <xref:System.Linq.Expressions.Expression>
-- Adding method call nodes to an <xref:System.Linq.IQueryable>'s expression tree
+- Add method call nodes to an <xref:System.Linq.IQueryable>'s expression tree
 - Construct strings, and use the [Dynamic LINQ library](https://dynamic-linq.net/)
 
 ## Use runtime state from within the expression tree
@@ -47,7 +47,7 @@ Generally, the [built-in LINQ methods](https://github.com/dotnet/runtime/blob/ma
 * Wrap the current expression tree in a <xref:System.Linq.Expressions.MethodCallExpression> representing the method call.
 * Pass the wrapped expression tree back to the provider, either to return a value via the provider's <xref:System.Linq.IQueryProvider.Execute%2A?displayProperty=nameWithType> method; or to return a translated query object via the <xref:System.Linq.IQueryProvider.CreateQuery%2A?displayProperty=nameWithType> method.
 
-You can replace the original query with the result of an [IQueryable\<T>](xref:System.Linq.IQueryable%601)-returning method, to get a new query. You can do this based on runtime state, as in the following example:
+You can replace the original query with the result of an [IQueryable\<T>](xref:System.Linq.IQueryable%601)-returning method, to get a new query. You can do this conditionally based on runtime state, as in the following example:
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Added_method_calls":::
 
@@ -63,7 +63,7 @@ You might also want to compose the various sub-expressions using a third-party l
 
 ## Construct expression trees and queries using factory methods
 
-In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type. You may need to add different components, depending on the element type. You can create expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression?displayProperty=fullName>, and thus tailor the expression to a specific element type.
+In all the examples up to this point, we've known the element type at compile time&mdash;`string`&mdash;and thus the type of the query&mdash;`IQueryable<string>`. You may need to add components to a query of any element type, or to add different components, depending on the element type. You can create expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression?displayProperty=fullName>, and thus tailor the expression at runtime to a specific element type.
 
 ### Constructing an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601)
 
@@ -71,9 +71,7 @@ When you construct an expression to pass into one of the LINQ methods, you're ac
 
 [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) inherits from <xref:System.Linq.Expressions.LambdaExpression>, which represents a complete lambda expression like the following:
 
-```csharp
-Expression<Func<string, bool>> expr = x => x.StartsWith("a");
-```
+:::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Compiler_generated_expression_tree":::
 
 A <xref:System.Linq.Expressions.LambdaExpression> has two components:
 
@@ -84,25 +82,15 @@ The basic steps in constructing an [Expression\<TDelegate>](xref:System.Linq.Exp
 
 * Define <xref:System.Linq.Expressions.ParameterExpression> objects for each of the parameters (if any) in the lambda expression, using the <xref:System.Linq.Expressions.Expression.Parameter%2A> factory method.
 
-    ```csharp
-    ParameterExpression x = Parameter(typeof(string), "x");
-    ```
+    :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_method_expression_tree_parameter":::
 
-* Construct the body of your <xref:System.Linq.Expressions.LambdaExpression>, using the <xref:System.Linq.Expressions.ParameterExpression> you've defined. For instance, an expression representing `x.StartsWith("a")` could be constructed like this:
+* Construct the body of your <xref:System.Linq.Expressions.LambdaExpression>, using the <xref:System.Linq.Expressions.ParameterExpression>(s) you've defined, and the factory methods at <xref:System.Linq.Expressions.Expression>. For instance, an expression representing `x.StartsWith("a")` could be constructed like this:
 
-    ```csharp
-    Expression body = Call(
-        x,
-        typeof(string).GetMethod("StartsWith", new [] {typeof(string)}),
-        Constant("a")
-    );
-    ```
+    :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_method_expression_tree_body":::
 
 * Wrap the parameters and body in a compile-time-typed [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601), using the appropriate <xref:System.Linq.Expressions.Expression.Lambda%2A> factory method overload:
 
-    ```csharp
-    Expression<Func<string, bool>> expr = Lambda<Func<string, bool>>(body, prm);
-    ```
+    :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_method_expression_tree_lambda":::
 
 The following sections describe a scenario in which you might want to construct an [Expression\<TDelegate>](xref:System.Linq.Expressions.Expression%601) to pass into a LINQ method, and provide a complete example of how to do so using the factory methods.
 
@@ -110,10 +98,7 @@ The following sections describe a scenario in which you might want to construct 
 
 Let's say you have multiple entity types:
 
-```csharp
-record Person(string LastName, string FirstName, DateTime DateOfBirth);
-record Car(string Model, int Year);
-```
+:::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Entities":::
 
 For any of these entity types, you want to filter and return only those entities that have a given text inside one of their `string` fields. For `Person`, you'd want to search the `FirstName` and `LastName` properties:
 
@@ -143,7 +128,7 @@ Because the `TextFilter` function takes and returns an [IQueryable\<T>](xref:Sys
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Factory_methods_expression_of_tdelegate_usage":::
 
-## Adding method call nodes to the <xref:System.Linq.IQueryable>'s expression tree
+## Add method call nodes to the <xref:System.Linq.IQueryable>'s expression tree
 
 If you have an <xref:System.Linq.IQueryable> instead of an [IQueryable\<T>](xref:System.Linq.IQueryable%601), you can't directly call the generic LINQ methods. One alternative is to build the inner expression tree as above, and use reflection to invoke the appropriate LINQ method while passing in the expression tree.
 

--- a/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -36,7 +36,7 @@ The following sections describe specific techniques for querying differently in 
 
 Assuming the LINQ provider supports it, the simplest way to query dynamically is to reference the runtime state directly in the query via a closed-over variable, such as `length` in the following code example:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Runtime_state_from_within_expression_tree":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Runtime_state_from_within_expression_tree":::
 
 The internal expression tree&mdash;and thus the query&mdash;haven't been modified; the query returns different values only because the value of `length` has been changed.
 
@@ -49,17 +49,17 @@ Generally, the [built-in LINQ methods](https://github.com/dotnet/runtime/blob/ma
 
 You can replace the original query with the result of an [IQueryable(Of T)](xref:System.Linq.IQueryable%601)-returning method, to get a new query. You can do this conditionally based on runtime state, as in the following example:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Added_method_calls":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Added_method_calls":::
 
 ## Vary the expression tree passed into the LINQ methods
 
 You can pass in different expressions to the LINQ methods, depending on runtime state:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Varying_expressions":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Varying_expressions":::
 
 You might also want to compose the various sub-expressions using a third-party library such as [LinqKit](http://www.albahari.com/nutshell/linqkit.aspx)'s [PredicateBuilder](http://www.albahari.com/nutshell/predicatebuilder.aspx):
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Compose_expression":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Compose_expression":::
 
 ## Construct expression trees and queries using factory methods
 
@@ -71,7 +71,7 @@ When you construct an expression to pass into one of the LINQ methods, you're ac
 
 [Expression(Of TDelegate))](xref:System.Linq.Expressions.Expression%601) inherits from <xref:System.Linq.Expressions.LambdaExpression>, which represents a complete lambda expression like the following:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Compiler_generated":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Compiler_generated":::
 
 A <xref:System.Linq.Expressions.LambdaExpression> has two components:
 
@@ -82,15 +82,15 @@ The basic steps in constructing an [Expression(Of TDelegate)](xref:System.Linq.E
 
 * Define <xref:System.Linq.Expressions.ParameterExpression> objects for each of the parameters (if any) in the lambda expression, using the <xref:System.Linq.Expressions.Expression.Parameter%2A> factory method.
 
-    :::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_parameter":::
+    :::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_parameter":::
 
 * Construct the body of your <xref:System.Linq.Expressions.LambdaExpression>, using the <xref:System.Linq.Expressions.ParameterExpression>(s) you've defined, and the factory methods at <xref:System.Linq.Expressions.Expression>. For instance, an expression representing `x.StartsWith("a")` could be constructed like this:
 
-    :::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_body":::
+    :::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_body":::
 
 * Wrap the parameters and body in a compile-time-typed [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601), using the appropriate <xref:System.Linq.Expressions.Expression.Lambda%2A> factory method overload:
 
-    :::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_lambda":::
+    :::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_lambda":::
 
 The following sections describe a scenario in which you might want to construct an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601) to pass into a LINQ method, and provide a complete example of how to do so using the factory methods.
 
@@ -98,25 +98,25 @@ The following sections describe a scenario in which you might want to construct 
 
 Let's say you have multiple entity types:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Entities.vb":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Entities.vb":::
 
 For any of these entity types, you want to filter and return only those entities that have a given text inside one of their `string` fields. For `Person`, you'd want to search the `FirstName` and `LastName` properties:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="PersonsQry":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="PersonsQry":::
 
 but for `Car`, you'd want to search only the `Model` property:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="CarsQry":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="CarsQry":::
 
 While you could write one custom function for `IQueryable(Of Person)` and another for `IQueryable(Of Car)`, the following function adds this filtering to any existing query, irrespective of the specific element type.
 
 ### Example
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_expression_of_tdelegate":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_expression_of_tdelegate":::
 
 Because the `TextFilter` function takes and returns an [IQueryable(Of T)](xref:System.Linq.IQueryable%601) (and not just an <xref:System.Linq.IQueryable>), you can add further compile-time-typed query elements after the text filter.
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_expression_of_tdelegate_usage":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_expression_of_tdelegate_usage":::
 
 ## Add method call nodes to the <xref:System.Linq.IQueryable>'s expression tree
 

--- a/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -134,7 +134,7 @@ Constructing expression trees using factory methods is relatively complex; it is
 
 For instance, the previous example (including the expression tree construction) could be rewritten as follows:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Dynamic_linq":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Dynamic_linq":::
 
 ## See also
 

--- a/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -1,108 +1,140 @@
 ---
-description: "Learn more about: How to: Use Expression Trees to Build Dynamic Queries (Visual Basic)"
-title: "How to: Use Expression Trees to Build Dynamic Queries"
-ms.date: 07/20/2015
+title: "Querying based on runtime state (Visual Basic)"
+description: Describes various techniques your code can use to query dynamically depending on runtime state, by varying either LINQ method calls or the expression trees passed into those methods.
+ms.date: 14/02/2021
 ms.assetid: 16278787-7532-4b65-98b2-7a412406c4ee
 ---
-# How to: Use Expression Trees to Build Dynamic Queries (Visual Basic)
+# Querying based on runtime state (C#)
 
-In LINQ, expression trees are used to represent structured queries that target sources of data that implement <xref:System.Linq.IQueryable%601>. For example, the LINQ provider implements the <xref:System.Linq.IQueryable%601> interface for querying relational data stores. The Visual Basic compiler compiles queries that target such data sources into code that builds an expression tree at runtime. The query provider can then traverse the expression tree data structure and translate it into a query language appropriate for the data source.
+Consider code that defines an <xref:System.Linq.IQueryable> or an [IQueryable(Of T)](<xref:System.Linq.IQueryable%601>) against a data source:
 
-Expression trees are also used in LINQ to represent lambda expressions that are assigned to variables of type <xref:System.Linq.Expressions.Expression%601>.
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Initialize":::
 
-This topic describes how to use expression trees to create dynamic LINQ queries. Dynamic queries are useful when the specifics of a query are not known at compile time. For example, an application might provide a user interface that enables the end user to specify one or more predicates to filter the data. In order to use LINQ for querying, this kind of application must use expression trees to create the LINQ query at runtime.
+Every time you run this code, the same exact query will be executed. This is frequently not very useful, as you may want your code to execute different queries depending on conditions at runtime. This article describes how you can execute a different query based on runtime state.
 
-## Example
+## IQueryable / IQueryable(Of T) and expression trees
 
-The following example shows you how to use expression trees to construct a query against an `IQueryable` data source and then execute it. The code builds an expression tree to represent the following query:
+Fundamentally, an <xref:System.Linq.IQueryable> has two components:
 
-`companies.Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16).OrderBy(Function(company) company)`
+* <xref:System.Linq.IQueryable.Expression>&mdash;a language- and datasource-agnostic representation of the current query's components, in the form of an expression tree.
+* <xref:System.Linq.IQueryable.Provider>&mdash;an instance of a LINQ provider, which knows how to materialize the current query into a value or set of values.
 
-The factory methods in the <xref:System.Linq.Expressions> namespace are used to create expression trees that represent the expressions that make up the overall query. The expressions that represent calls to the standard query operator methods refer to the <xref:System.Linq.Queryable> implementations of these methods. The final expression tree is passed to the <xref:System.Linq.IQueryProvider.CreateQuery%60%601%28System.Linq.Expressions.Expression%29> implementation of the provider of the `IQueryable` data source to create an executable query of type `IQueryable`. The results are obtained by enumerating that query variable.
+In the context of dynamic querying, the provider will usually remain the same; the expression tree of the query will differ from query to query.
 
-```vb
-' Add an Imports statement for System.Linq.Expressions.
+Expression trees are immutable; if you want a different expression tree&mdash;and thus a different query&mdash;you'll need to translate the existing expression tree to a new one, and thus to a new <xref:System.Linq.IQueryable>.
 
-Dim companies =
-    {"Consolidated Messenger", "Alpine Ski House", "Southridge Video", "City Power & Light",
-     "Coho Winery", "Wide World Importers", "Graphic Design Institute", "Adventure Works",
-     "Humongous Insurance", "Woodgrove Bank", "Margie's Travel", "Northwind Traders",
-     "Blue Yonder Airlines", "Trey Research", "The Phone Company",
-     "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee"}
+The following sections describe specific techniques for querying differently in response to runtime state:
 
-' The IQueryable data to query.
-Dim queryableData As IQueryable(Of String) = companies.AsQueryable()
+- Use runtime state from within the expression tree
+- Call additional LINQ methods
+- Vary the expression tree passed into the LINQ methods
+- Construct an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601) expression tree using the factory methods at <xref:System.Linq.Expressions.Expression>
+- Add method call nodes to an <xref:System.Linq.IQueryable>'s expression tree
+- Construct strings, and use the [Dynamic LINQ library](https://dynamic-linq.net/)
 
-' Compose the expression tree that represents the parameter to the predicate.
-Dim pe As ParameterExpression = Expression.Parameter(GetType(String), "company")
+## Use runtime state from within the expression tree
 
-' ***** Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16) *****
-' Create an expression tree that represents the expression: company.ToLower() = "coho winery".
-Dim left As Expression = Expression.Call(pe, GetType(String).GetMethod("ToLower", System.Type.EmptyTypes))
-Dim right As Expression = Expression.Constant("coho winery")
-Dim e1 As Expression = Expression.Equal(left, right)
+Assuming the LINQ provider supports it, the simplest way to query dynamically is to reference the runtime state directly in the query via a closed-over variable, such as `length` in the following code example:
 
-' Create an expression tree that represents the expression: company.Length > 16.
-left = Expression.Property(pe, GetType(String).GetProperty("Length"))
-right = Expression.Constant(16, GetType(Integer))
-Dim e2 As Expression = Expression.GreaterThan(left, right)
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Runtime_state_from_within_expression_tree":::
 
-' Combine the expressions to create an expression tree that represents the
-' expression: company.ToLower() = "coho winery" OrElse company.Length > 16).
-Dim predicateBody As Expression = Expression.OrElse(e1, e2)
+The internal expression tree&mdash;and thus the query&mdash;haven't been modified; the query returns different values only because the value of `length` has been changed.
 
-' Create an expression tree that represents the expression:
-' queryableData.Where(Function(company) company.ToLower() = "coho winery" OrElse company.Length > 16)
-Dim whereCallExpression As MethodCallExpression = Expression.Call(
-        GetType(Queryable),
-        "Where",
-        New Type() {queryableData.ElementType},
-        queryableData.Expression,
-        Expression.Lambda(Of Func(Of String, Boolean))(predicateBody, New ParameterExpression() {pe}))
-' ***** End Where *****
+## Call additional LINQ methods
 
-' ***** OrderBy(Function(company) company) *****
-' Create an expression tree that represents the expression:
-' whereCallExpression.OrderBy(Function(company) company)
-Dim orderByCallExpression As MethodCallExpression = Expression.Call(
-        GetType(Queryable),
-        "OrderBy",
-        New Type() {queryableData.ElementType, queryableData.ElementType},
-        whereCallExpression,
-        Expression.Lambda(Of Func(Of String, String))(pe, New ParameterExpression() {pe}))
-' ***** End OrderBy *****
+Generally, the [built-in LINQ methods](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs) at <xref:System.Linq.Queryable> perform two steps:
 
-' Create an executable query from the expression tree.
-Dim results As IQueryable(Of String) = queryableData.Provider.CreateQuery(Of String)(orderByCallExpression)
+* Wrap the current expression tree in a <xref:System.Linq.Expressions.MethodCallExpression> representing the method call.
+* Pass the wrapped expression tree back to the provider, either to return a value via the provider's <xref:System.Linq.IQueryProvider.Execute%2A?displayProperty=nameWithType> method; or to return a translated query object via the <xref:System.Linq.IQueryProvider.CreateQuery%2A?displayProperty=nameWithType> method.
 
-' Enumerate the results.
-For Each company As String In results
-    Console.WriteLine(company)
-Next
+You can replace the original query with the result of an [IQueryable(Of T)](xref:System.Linq.IQueryable%601)-returning method, to get a new query. You can do this conditionally based on runtime state, as in the following example:
 
-' This code produces the following output:
-'
-' Blue Yonder Airlines
-' City Power & Light
-' Coho Winery
-' Consolidated Messenger
-' Graphic Design Institute
-' Humongous Insurance
-' Lucerne Publishing
-' Northwind Traders
-' The Phone Company
-' Wide World Importers
-```
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Added_method_calls":::
 
-This code uses a fixed number of expressions in the predicate that is passed to the `Queryable.Where` method. However, you can write an application that combines a variable number of predicate expressions that depends on the user input. You can also vary the standard query operators that are called in the query, depending on the input from the user.
+## Vary the expression tree passed into the LINQ methods
 
-## Compile the code
+You can pass in different expressions to the LINQ methods, depending on runtime state:
 
-- Create a new **Console Application** project.
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Varying_expressions":::
 
-- Include the System.Linq.Expressions namespace.
+You might also want to compose the various sub-expressions using a third-party library such as [LinqKit](http://www.albahari.com/nutshell/linqkit.aspx)'s [PredicateBuilder](http://www.albahari.com/nutshell/predicatebuilder.aspx):
 
-- Copy the code from the example and paste it into the `Main` `Sub` procedure.
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Compose_expression":::
+
+## Construct expression trees and queries using factory methods
+
+In all the examples up to this point, we've known the element type at compile time&mdash;`String`&mdash;and thus the type of the query&mdash;`IQueryable(Of String)`. You may need to add components to a query of any element type, or to add different components depending on the element type. You can create expression trees from the ground up, using the factory methods at <xref:System.Linq.Expressions.Expression?displayProperty=fullName>, and thus tailor the expression at runtime to a specific element type.
+
+### Constructing an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601)
+
+When you construct an expression to pass into one of the LINQ methods, you're actually constructing an instance of [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601), where `TDelegate` is some delegate type such as `Func(Of String, Boolean)`, `Action`, or a custom delegate type.
+
+[Expression(Of TDelegate))](xref:System.Linq.Expressions.Expression%601) inherits from <xref:System.Linq.Expressions.LambdaExpression>, which represents a complete lambda expression like the following:
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Compiler_generated":::
+
+A <xref:System.Linq.Expressions.LambdaExpression> has two components:
+
+* a parameter list&mdash;`(x As String)`&mdash;represented by the <xref:System.Linq.Expressions.LambdaExpression.Parameters> property
+* a body&mdash;`x.StartsWith("a")`&mdash;represented by the <xref:System.Linq.Expressions.LambdaExpression.Body> property.
+
+The basic steps in constructing an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601) are as follows:
+
+* Define <xref:System.Linq.Expressions.ParameterExpression> objects for each of the parameters (if any) in the lambda expression, using the <xref:System.Linq.Expressions.Expression.Parameter%2A> factory method.
+
+    :::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_parameter":::
+
+* Construct the body of your <xref:System.Linq.Expressions.LambdaExpression>, using the <xref:System.Linq.Expressions.ParameterExpression>(s) you've defined, and the factory methods at <xref:System.Linq.Expressions.Expression>. For instance, an expression representing `x.StartsWith("a")` could be constructed like this:
+
+    :::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_body":::
+
+* Wrap the parameters and body in a compile-time-typed [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601), using the appropriate <xref:System.Linq.Expressions.Expression.Lambda%2A> factory method overload:
+
+    :::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_method_lambda":::
+
+The following sections describe a scenario in which you might want to construct an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601) to pass into a LINQ method, and provide a complete example of how to do so using the factory methods.
+
+### Scenario
+
+Let's say you have multiple entity types:
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Entities.vb":::
+
+For any of these entity types, you want to filter and return only those entities that have a given text inside one of their `string` fields. For `Person`, you'd want to search the `FirstName` and `LastName` properties:
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="PersonsQry":::
+
+but for `Car`, you'd want to search only the `Model` property:
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="CarsQry":::
+
+While you could write one custom function for `IQueryable(Of Person)` and another for `IQueryable(Of Car)`, the following function adds this filtering to any existing query, irrespective of the specific element type.
+
+### Example
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_expression_of_tdelegate":::
+
+Because the `TextFilter` function takes and returns an [IQueryable(Of T)](xref:System.Linq.IQueryable%601) (and not just an <xref:System.Linq.IQueryable>), you can add further compile-time-typed query elements after the text filter.
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_expression_of_tdelegate_usage":::
+
+## Add method call nodes to the <xref:System.Linq.IQueryable>'s expression tree
+
+If you have an <xref:System.Linq.IQueryable> instead of an [IQueryable(Of T)](xref:System.Linq.IQueryable%601), you can't directly call the generic LINQ methods. One alternative is to build the inner expression tree as above, and use reflection to invoke the appropriate LINQ method while passing in the expression tree.
+
+You could also duplicate the LINQ method's functionality, by wrapping the entire tree in a <xref:System.Linq.Expressions.MethodCallExpression> which represents a call to the LINQ method:
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_lambdaexpression":::
+
+Note that in this case you don't have a compile-time `T` generic placeholder, so you'll use the <xref:System.Linq.Expressions.Expression.Lambda%2A> overload which doesn't require compile-time type information, and which produces a <xref:System.Linq.Expressions.LambdaExpression> instead of an an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601).
+
+## The Dynamic LINQ library
+
+Constructing expression trees using factory methods is relatively complex; it is easier to compose strings. The [Dynamic LINQ library](https://dynamic-linq.net/) exposes a set of extension methods on <xref:System.Linq.IQueryable> corresponding to the standard LINQ methods at <xref:System.Linq.Queryable>, and which accept strings in a [special syntax](https://dynamic-linq.net/expression-language) instead of expression trees. The library generates the appropriate expression tree from the string, and can return the resultant translated <xref:System.Linq.IQueryable>.
+
+For instance, the previous example (including the expression tree construction) could be rewritten as follows:
+
+:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Dynamic_linq":::
 
 ## See also
 

--- a/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -1,14 +1,14 @@
 ---
 title: "Querying based on runtime state (Visual Basic)"
 description: Describes various techniques your code can use to query dynamically depending on runtime state, by varying either LINQ method calls or the expression trees passed into those methods.
-ms.date: 14/02/2021
+ms.date: 02/14/2021
 ms.assetid: 16278787-7532-4b65-98b2-7a412406c4ee
 ---
-# Querying based on runtime state (C#)
+# Querying based on runtime state (Visual Basic)
 
 Consider code that defines an <xref:System.Linq.IQueryable> or an [IQueryable(Of T)](<xref:System.Linq.IQueryable%601>) against a data source:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Initialize":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Initialize":::
 
 Every time you run this code, the same exact query will be executed. This is frequently not very useful, as you may want your code to execute different queries depending on conditions at runtime. This article describes how you can execute a different query based on runtime state.
 
@@ -124,7 +124,7 @@ If you have an <xref:System.Linq.IQueryable> instead of an [IQueryable(Of T)](xr
 
 You could also duplicate the LINQ method's functionality, by wrapping the entire tree in a <xref:System.Linq.Expressions.MethodCallExpression> which represents a call to the LINQ method:
 
-:::code language="vbnet" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_lambdaexpression":::
+:::code language="vb" source="../../../../../samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb" id="Factory_methods_lambdaexpression":::
 
 Note that in this case you don't have a compile-time `T` generic placeholder, so you'll use the <xref:System.Linq.Expressions.Expression.Lambda%2A> overload which doesn't require compile-time type information, and which produces a <xref:System.Linq.Expressions.LambdaExpression> instead of an an [Expression(Of TDelegate)](xref:System.Linq.Expressions.Expression%601).
 

--- a/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Entities.vb
+++ b/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Entities.vb
@@ -1,0 +1,10 @@
+﻿Public Class Person
+    Property LastName As String
+    Property FirstName As String
+    Property DateOfBirth As Date
+End Class
+
+Public Class Car
+    Property Model As String
+    Property Year As Integer
+End Class

--- a/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb
+++ b/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb
@@ -1,0 +1,285 @@
+﻿Imports System.Reflection
+Imports System.Linq.Expressions.Expression
+Imports ExpressionTreeToString
+
+Module Program
+    ' <Initialize>
+    Dim companyNames As String() = {
+        "Consolidated Messenger", "Alpine Ski House", "Southridge Video",
+        "City Power & Light", "Coho Winery", "Wide World Importers",
+        "Graphic Design Institute", "Adventure Works", "Humongous Insurance",
+        "Woodgrove Bank", "Margie's Travel", "Northwind Traders",
+        "Blue Yonder Airlines", "Trey Research", "The Phone Company",
+        "Wingtip Toys", "Lucerne Publishing", "Fourth Coffee"
+    }
+
+    ' We're using an in-memory array as the data source, but the IQueryable could have come
+    ' from anywhere -- an ORM backed by a database, a web request, Or any other LINQ provider.
+    Dim companyNamesSource As IQueryable(Of String) = companyNames.AsQueryable
+    Dim fixedQry = companyNamesSource.OrderBy(Function(x) x)
+    ' </Initialize>
+
+    Sub RuntimeStateFromWithinExpressionTree()
+        ' <Runtime_state_from_within_expression_tree>
+        Dim length = 1
+        Dim qry = companyNamesSource.
+            Select(Function(x) x.Substring(0, length)).
+            Distinct
+
+        Console.WriteLine(String.Join(", ", qry))
+        ' prints: C, A, S, W, G, H, M, N, B, T, L, F
+
+        length = 2
+        Console.WriteLine(String.Join(", ", qry))
+        ' prints: Co, Al, So, Ci, Wi, Gr, Ad, Hu, Wo, Ma, No, Bl, Tr, Th, Lu, Fo
+        ' </Runtime_state_from_within_expression_tree>
+    End Sub
+
+    Sub AddedMethodCalls()
+        Dim sortByLength = True
+
+        ' <Added_method_calls>
+        ' Dim sortByLength As Boolean  = ...
+
+        Dim qry = companyNamesSource
+        If sortByLength Then qry = qry.OrderBy(Function(x) x.Length)
+        ' </Added_method_calls>
+    End Sub
+
+    Sub VaryingExpressions()
+        Dim startsWith = ""
+        Dim endsWith = ""
+
+        ' <Varying_expressions>
+        ' Dim startsWith As String = ...
+        ' Dim endsWith As String = ...
+
+        Dim expr As Expression(Of Func(Of String, Boolean))
+        If String.IsNullOrEmpty(startsWith) AndAlso String.IsNullOrEmpty(endsWith) Then
+            expr = Function(x) True
+        ElseIf String.IsNullOrEmpty(startsWith) Then
+            expr = Function(x) x.EndsWith(endsWith)
+        ElseIf String.IsNullOrEmpty(endsWith) Then
+            expr = Function(x) x.StartsWith(startsWith)
+        Else
+            expr = Function(x) x.StartsWith(startsWith) AndAlso x.EndsWith(endsWith)
+        End If
+        Dim qry = companyNamesSource.Where(expr)
+        ' </Varying_expressions>
+    End Sub
+
+    Sub ComposeExpression()
+        Dim startsWith = ""
+        Dim endsWith = ""
+
+        ' <Compose_expression>
+        ' This is functionally equivalent to the previous example.
+
+        ' Imports LinqKit
+        ' Dim startsWith As String = ...
+        ' Dim endsWith As String = ...
+
+        Dim expr As Expression(Of Func(Of String, Boolean)) = PredicateBuilder.[New](Of String)(False)
+        Dim original = expr
+        If Not String.IsNullOrEmpty(startsWith) Then expr = expr.Or(Function(x) x.StartsWith(startsWith))
+        If Not String.IsNullOrEmpty(endsWith) Then expr = expr.Or(Function(x) x.EndsWith(endsWith))
+        If expr Is original Then expr = Function(x) True
+
+        Dim qry = companyNamesSource.Where(expr)
+        ' </Compose_expression>
+    End Sub
+
+    Sub CompilerGeneratedExpression()
+        ' <Compiler_generated>
+        Dim expr As Expression(Of Func(Of String, Boolean)) = Function(x As String) x.StartsWith("a")
+        ' </Compiler_generated>
+    End Sub
+
+    Sub FactoryMethodExpression()
+        ' <Factory_method_parameter>
+        Dim x As ParameterExpression = Parameter(GetType(String), "x")
+        ' </Factory_method_parameter>
+
+        ' <Factory_method_body>
+        Dim body As Expression = [Call](
+            x,
+            GetType(String).GetMethod("StartsWith", {GetType(String)}),
+            Constant("a")
+        )
+        ' </Factory_method_body>
+
+        ' <Factory_method_lambda>
+        Dim expr As Expression(Of Func(Of String, Boolean)) =
+            Lambda(Of Func(Of String, Boolean))(body, x)
+        ' </Factory_method_lambda>
+    End Sub
+
+    ' <Factory_methods_expression_of_tdelegate>
+    ' Imports System.Linq.Expressions.Expression
+    Function TextFilter(Of T)(source As IQueryable(Of T), term As String) As IQueryable(Of T)
+        If String.IsNullOrEmpty(term) Then Return source
+
+        ' T is a compile-time placeholder for the element type of the query
+        Dim elementType = GetType(T)
+
+        ' Get all the string properties on this specific type
+        Dim stringProperties As PropertyInfo() =
+            elementType.GetProperties.
+                Where(Function(x) x.PropertyType = GetType(String)).
+                ToArray
+        If stringProperties.Length = 0 Then Return source
+
+        ' Get the right overload of String.Contains
+        Dim containsMethod As MethodInfo =
+            GetType(String).GetMethod("Contains", {GetType(String)})
+
+        ' Create the parameter for the expression tree --
+        ' the 'x' in 'Function(x) x.PropertyName.Contains("term")'
+        ' The type of the parameter is the query's element type
+        Dim prm As ParameterExpression =
+            Parameter(elementType)
+
+        ' Generate an expression tree node corresponding to each property
+        Dim expressions As IEnumerable(Of Expression) =
+            stringProperties.Select(Of Expression)(Function(prp)
+                                                       ' For each property, we want an expression node like this:
+                                                       ' x.PropertyName.Contains("term")
+                                                       Return [Call](      ' .Contains(...)
+                                                           [Property](     ' .PropertyName
+                                                               prm,        ' x
+                                                               prp
+                                                           ),
+                                                           containsMethod,
+                                                           Constant(term)  ' "term"
+                                                       )
+                                                   End Function)
+
+        ' Combine the individual nodes into a single expression tree node using OrElse
+        Dim body As Expression =
+            expressions.Aggregate(Function(prev, current) [OrElse](prev, current))
+
+        ' Wrap the expression body in a compile-time-typed lambda expression
+        Dim lmbd As Expression(Of Func(Of T, Boolean)) =
+            Lambda(Of Func(Of T, Boolean))(body, prm)
+
+        ' Because the lambda is compile-time-typed, we can use it with the Where method
+        Return source.Where(lmbd)
+    End Function
+    ' </Factory_methods_expression_of_tdelegate>
+
+    Sub TextFilterUsage()
+        ' <Factory_methods_expression_of_tdelegate_usage>
+        Dim qry = TextFilter(
+            (New List(Of Person)).AsQueryable,
+            "abcd"
+        ).Where(Function(x) x.DateOfBirth < #1/1/2001#)
+
+        Dim qry1 = TextFilter(
+            (New List(Of Car)).AsQueryable,
+            "abcd"
+        ).Where(Function(x) x.Year = 2010)
+        ' </Factory_methods_expression_of_tdelegate_usage>
+    End Sub
+
+    Function ConstructBody(elementType As Type, term As String) As (Expression, ParameterExpression)
+        If String.IsNullOrEmpty(term) Then Return Nothing
+        Dim stringProperties = elementType.GetProperties.
+                Where(Function(x) x.PropertyType = GetType(String)).
+                ToArray
+        If stringProperties.Length = 0 Then Return Nothing
+        Dim containsMethod = GetType(String).GetMethod("Contains", {GetType(String)})
+        Dim prm = Parameter(elementType)
+        Dim body = stringProperties.Select(Of Expression)(Function(prp)
+                                                              Return [Call](
+                                                   [Property](prm, prp),
+                                                   containsMethod,
+                                                   Constant(term)
+                                               )
+                                                          End Function).
+                                           Aggregate(Function(prev, current) [OrElse](prev, current))
+        Return (body, prm)
+    End Function
+
+    Sub ManualTextFilter()
+        Dim term = "abcd"
+
+        ' <PersonsQry>
+        ' Dim term = ...
+        Dim personsQry = (New List(Of Person)).AsQueryable.
+            Where(Function(x) x.FirstName.Contains(term) OrElse x.LastName.Contains(term))
+        ' </PersonsQry>
+
+        ' <CarsQry>
+        ' Dim term = ...
+        Dim carsQry = (New List(Of Car)).AsQueryable.
+            Where(Function(x) x.Model.Contains(term))
+        ' </CarsQry>
+    End Sub
+
+    ' <Factory_methods_lambdaexpression>
+    Function TextFilter_Untyped(source As IQueryable, term As String) As IQueryable
+        If String.IsNullOrEmpty(term) Then Return source
+        Dim elementType = source.ElementType
+
+        ' The logic for building the ParameterExpression And the LambdaExpression's body is the same as in the previous
+        ' example, but has been refactored into the ConstructBody function.
+        Dim x As (Expression, ParameterExpression) = ConstructBody(elementType, term)
+        Dim body As Expression = x.Item1
+        Dim prm As ParameterExpression = x.Item2
+        If body Is Nothing Then Return source
+
+        Dim filteredTree As Expression = [Call](
+            GetType(Queryable),
+            "Where",
+            {elementType},
+            source.Expression,
+            Lambda(body, prm)
+        )
+
+        Return source.Provider.CreateQuery(filteredTree)
+    End Function
+    ' </Factory_methods_lambdaexpression>
+
+    Sub TextFilter_Untyped_Usage()
+        Dim qry = TextFilter_Untyped(
+            (New List(Of Person)).AsQueryable(),
+            "abcd"
+        )
+    End Sub
+
+    ' <Dynamic_linq>
+    ' Imports System.Linq.Dynamic.Core
+
+    Function TextFilter_Strings(source As IQueryable, term As String) As IQueryable
+        If String.IsNullOrEmpty(term) Then Return source
+
+        Dim elementType = source.ElementType
+        Dim stringProperties = elementType.GetProperties.
+                Where(Function(x) x.PropertyType = GetType(String)).
+                ToArray
+        If stringProperties.Length = 0 Then Return source
+
+        Dim filterExpr = String.Join(
+            " || ",
+            stringProperties.Select(Function(prp) $"{prp.Name}.Contains(@0)")
+        )
+
+        Return source.Where(filterExpr, term)
+    End Function
+    ' </Dynamic_linq>
+
+    Sub TextFilter_Strings_Usage()
+        Dim qry = (New List(Of Person)).AsQueryable
+        qry = TextFilter_Strings(qry, "abcd")
+    End Sub
+
+    Sub Main()
+        RuntimeStateFromWithinExpressionTree()
+        AddedMethodCalls()
+        VaryingExpressions()
+        ComposeExpression()
+        TextFilterUsage()
+        TextFilter_Untyped_Usage()
+        TextFilter_Strings_Usage()
+    End Sub
+End Module

--- a/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb
+++ b/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/Program.vb
@@ -221,8 +221,8 @@ Module Program
         If String.IsNullOrEmpty(term) Then Return source
         Dim elementType = source.ElementType
 
-        ' The logic for building the ParameterExpression And the LambdaExpression's body is the same as in the previous
-        ' example, but has been refactored into the ConstructBody function.
+        ' The logic for building the ParameterExpression And the LambdaExpression's body is the same as in
+        ' the previous example, but has been refactored into the ConstructBody function.
         Dim x As (Expression, ParameterExpression) = ConstructBody(elementType, term)
         Dim body As Expression = x.Item1
         Dim prm As ParameterExpression = x.Item2

--- a/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/dynamic-linq-expression-trees.vbproj
+++ b/samples/snippets/visualbasic/programming-guide/dynamic-linq-expression-trees/dynamic-linq-expression-trees.vbproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>dynamic_linq_expression_trees</RootNamespace>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ExpressionTreeToString" Version="3.2.54" />
+    <PackageReference Include="LinqKit.Core" Version="1.1.23" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Import Include="LinqKit" />
+    <Import Include="System.Linq.Expressions" />
+    <Import Include="System.Linq.Dynamic.Core" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

1. This is a rewrite of #22710 for the corresponding VB document.
2. Also includes some minor corrections and additional snippets for the C# version

Fixes #6288 

Question: I've included some snippets using the `:::` syntax inside a list item, and it doesn't render properly in the VS Code Preview using the Docs Authoring Pack. Is this a problem only in the VS Code extension, or is this a rendering issue in the docs themselves as well, or are `:::` snippets not meant to be used this way?

(ping @BillWagner per [this comment](https://github.com/dotnet/docs/pull/22710#issuecomment-777151197))