### PR TITLE
Update deploy-with-cli.md

### DIFF
--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -134,7 +134,7 @@ For .NET 2.1, you must use the following switches with the `dotnet publish` comm
   This switch uses an identifier (RID) to specify the target platform. For a list of runtime identifiers, see [Runtime Identifier (RID) catalog](../rid-catalog.md).
 
 - `--self-contained false`
-  This switch tells the .NET Core SDK to not create a self-contained deployment (SCD), which is the default when -r switch is used. 
+  This switch disables the default behavior of the `-r` switch, which is to create a self-contained deployment (SCD). This switch creates an FDE.
 
 | Publish Mode                   | SDK Version | Command                                                     |
 |--------------------------------|-------------|-------------------------------------------------------------|

--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -134,7 +134,7 @@ For .NET 2.1, you must use the following switches with the `dotnet publish` comm
   This switch uses an identifier (RID) to specify the target platform. For a list of runtime identifiers, see [Runtime Identifier (RID) catalog](../rid-catalog.md).
 
 - `--self-contained false`
-  This switch tells the .NET Core SDK to create an executable as an FDE.
+  This switch tells the .NET Core SDK to not create a self-contained deployment (SCD), which is the default when -r switch is used. 
 
 | Publish Mode                   | SDK Version | Command                                                     |
 |--------------------------------|-------------|-------------------------------------------------------------|


### PR DESCRIPTION
## Summary

The "**--self-contained false**" switch  is actually added here to prevent creation of self contained deployment ( which, in addition to the application and its dependencies, also  includes the dotnet runtime and libraries ).  Self contained deployment  is the default when an '**-r <RID>**' switch is used with the "**dotnet publish**" command.

Fixes #Issue_Number (if available)
