### PR TITLE
Add NReco.Logging as a 3rd party provider to the logging docs

### DIFF
--- a/docs/architecture/porting-existing-aspnet-apps/configuration-differences.md
+++ b/docs/architecture/porting-existing-aspnet-apps/configuration-differences.md
@@ -46,7 +46,7 @@ public class TestModel : PageModel
     public ContentResult OnGet()
     {
         var myKeyValue = _configuration["MyKey"];
-        
+
         // ...
     }
 }

--- a/docs/architecture/porting-existing-aspnet-apps/example-migration-eshop.md
+++ b/docs/architecture/porting-existing-aspnet-apps/example-migration-eshop.md
@@ -139,7 +139,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     }
 
     app.UseStaticFiles();
-    
+
     // ...
 }
 ```
@@ -742,7 +742,7 @@ public class ApplicationModule : Module
     {
         _useMockData = useMockData;
     }
-    
+
     protected override void Load(ContainerBuilder builder)
     {
         if (_useMockData)

--- a/docs/architecture/porting-existing-aspnet-apps/routing-differences.md
+++ b/docs/architecture/porting-existing-aspnet-apps/routing-differences.md
@@ -111,7 +111,7 @@ public class ProductsController : ApiController
 {
     // matched by name and (lack of) parameters
     public IEnumerable<Product> GetAll() { }
-    
+
     // matched by GET and string parameter
     [HttpGet]
     public IEnumerable<Product> FindProductsByName(string name) { }

--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -3,7 +3,7 @@ title: Logging providers in .NET
 description: Learn how the logging provider API is used in .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 12/04/2020
+ms.date: 02/16/2021
 ---
 
 # Logging providers in .NET
@@ -224,6 +224,7 @@ Here are some third-party logging frameworks that work with various .NET workloa
 - [Log4Net](https://logging.apache.org/log4net) ([GitHub repo](https://github.com/apache/logging-log4net))
 - [Loggr](https://loggr.net) ([GitHub repo](https://github.com/imobile3/Loggr.Extensions.Logging))
 - [NLog](https://nlog-project.org) ([GitHub repo](https://github.com/NLog/NLog.Extensions.Logging))
+- [NReco.Logging](https://github.com/nreco/logging/blob/master/README.md) ([GitHub repo](https://github.com/nreco/logging))
 - [Sentry](https://sentry.io/welcome) ([GitHub repo](https://github.com/getsentry/sentry-dotnet))
 - [Serilog](https://serilog.net) ([GitHub repo](https://github.com/serilog/serilog-sinks-console))
 - [Stackdriver](https://cloud.google.com/dotnet/docs/stackdriver#logging) ([GitHub repo](https://github.com/googleapis/google-cloud-dotnet))


### PR DESCRIPTION
## Summary

Add NReco.Logging as a 3rd party provider to the logging docs

Fixes #22825
