### PR TITLE
Update field naming convention

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/fields.md
+++ b/docs/csharp/programming-guide/classes-and-structs/fields.md
@@ -20,11 +20,11 @@ Fields are declared in the class block by specifying the access level of the fie
 
 [!code-csharp[fields#1](snippets/fields/Program.cs#1)]
 
-To access a field in an object, add a period after the object name, followed by the name of the field, as in `objectname.fieldname`. For example:
+To access a field in an object, add a period after the object name, followed by the name of the field, as in `objectname._fieldName`. For example:
 
 [!code-csharp[fields#2](snippets/fields/Program.cs#2)]
 
-A field can be given an initial value by using the assignment operator when the field is declared. To automatically assign the `day` field to `"Monday"`, for example, you would declare `day` as in the following example:
+A field can be given an initial value by using the assignment operator when the field is declared. To automatically assign the `Day` field to `"Monday"`, for example, you would declare `Day` as in the following example:
 
 [!code-csharp[fields#3](snippets/fields/Program.cs#3)]
 

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/fields/Program.cs
@@ -3,25 +3,23 @@
 //<Snippet1>
 public class CalendarEntry
 {
-    // private field
-    private DateTime date;
 
-    // public field (Generally not recommended.)
-    public string day;
+    // private field (Located near wrapping "Date" property).
+    private DateTime _date;
 
-    // Public property exposes date field safely.
+    // Public property exposes _date field safely.
     public DateTime Date
     {
         get
         {
-            return date;
+            return _date;
         }
         set
         {
             // Set some reasonable boundaries for likely birth dates.
             if (value.Year > 1900 && value.Year <= DateTime.Today.Year)
             {
-                date = value;
+                _date = value;
             }
             else
             {
@@ -30,7 +28,10 @@ public class CalendarEntry
         }
     }
 
-    // Public method also exposes date field safely.
+    // public field (Generally not recommended).
+    public string Day;
+
+    // Public method also exposes _date field safely.
     // Example call: birthday.SetDate("1975, 6, 30");
     public void SetDate(string dateString)
     {
@@ -39,7 +40,7 @@ public class CalendarEntry
         // Set some reasonable boundaries for likely birth dates.
         if (dt.Year > 1900 && dt.Year <= DateTime.Today.Year)
         {
-            date = dt;
+            _date = dt;
         }
         else
         {
@@ -51,9 +52,9 @@ public class CalendarEntry
     {
         DateTime dt = Convert.ToDateTime(dateString);
 
-        if (dt.Ticks < date.Ticks)
+        if (dt.Ticks < _date.Ticks)
         {
-            return date - dt;
+            return _date - dt;
         }
         else
         {
@@ -69,7 +70,7 @@ class TestCalendarDate
     {
         //<Snippet2>
         CalendarEntry birthday = new CalendarEntry();
-        birthday.day = "Saturday";
+        birthday.Day = "Saturday";
         //</Snippet2>
     }
 }
@@ -77,7 +78,7 @@ class TestCalendarDate
 //<Snippet3>
 public class CalendarDateWithInitialization
 {
-    public string day = "Monday";
+    public string Day = "Monday";
     //...
 }
 //</Snippet3>


### PR DESCRIPTION
## Summary

- Updated field names to follow coding guidelines.
- Put `_date` next to its wrapping property.
- Placed public field below the public property as it shouldn't generally be used.

Fixes #22822