### PR TITLE
Updates to Dapr for .Net Developers

### DIFF
--- a/docs/architecture/dapr-for-net-developers/bindings.md
+++ b/docs/architecture/dapr-for-net-developers/bindings.md
@@ -243,7 +243,7 @@ You implement a binding with a Dapr component. These components are contributed 
 
 ### References
 
-[1]: https://docs.dapr.io/operations/components/setup-bindings/supported-bindings/ "Dapr documentation for resource bindings"
+- [Dapr documentation for resource bindings](https://docs.dapr.io/operations/components/setup-bindings/supported-bindings/)
 
 >[!div class="step-by-step"]
 >[Previous](publish-subscribe.md)

--- a/docs/architecture/dapr-for-net-developers/the-world-is-distributed.md
+++ b/docs/architecture/dapr-for-net-developers/the-world-is-distributed.md
@@ -91,8 +91,6 @@ In this chapter, we discussed the adoption of distributed applications. We contr
 
 Now, sit back, relax, and let us introduce you the new world of Dapr.
 
-### References
-
 >[!div class="step-by-step"]
 >[Previous](foreword.md)
 >[Next](dapr-at-20000-feet.md)

--- a/docs/architecture/dapr-for-net-developers/the-world-is-distributed.md
+++ b/docs/architecture/dapr-for-net-developers/the-world-is-distributed.md
@@ -7,8 +7,6 @@ ms.date: 02/07/2021
 
 # The world is distributed
 
-[!INCLUDE [book-preview](../../../includes/book-preview.md)]
-
 Just ask any 'cool kid': *Modern, distributed systems are in, and monolithic apps are out!*
 
 But, it's not just "cool kids." Progressive IT Leaders, corporate architects, and astute developers are echoing these same thoughts as they explore and evaluate modern distributed applications. Many have bought in. They're designing new and replatforming existing enterprise applications following the principles, patterns, and practices of distributed microservice applications.

--- a/docs/architecture/dapr-for-net-developers/toc.yml
+++ b/docs/architecture/dapr-for-net-developers/toc.yml
@@ -3,37 +3,25 @@
   items:
   - name: Foreword
     href: foreword.md
-    displayName: mark russinovich, foreword by mark russinovich, distributed system future, distributed application future, distributed architecture, microservice, monolithic, monolithic architecture
   - name: The world is distributed
     href: the-world-is-distributed.md
-    displayName: distributed system, distributed application, distributed architecture, microservice, SOA, monolithic, monolithic architecture
   - name: Dapr at 20,000 feet
     href: dapr-at-20000-feet.md
-    displayName: dapr, distributed system, distributed application, dapr building blocks, dapr components, microservice, sidecar architecture, service mesh
   - name: Getting started
     href: getting-started.md
-    displayName: dapr, distributed system, distributed application, service invocation, state management, install dapr, component configuration files, multi-container dapr application
   - name: Reference application
     href: reference-application.md
-    displayName: dapr, distributed system, distributed application, dapr building blocks, dapr components, microservice, eshop
   - name: State management
     href: state-management.md
-    displayName: dapr, distributed system, distributed application, state management, dapr state management building block, cap theorem, concurrency, transactions
   - name: Service invocation
     href: service-invocation.md
-    displayName: dapr, distributed system, distributed application, service invocation, dapr service invocation building block, envoy
   - name: Publish & subscribe
     href: publish-subscribe.md
-    displayName: dapr, distributed system, distributed application, pub/sub, publish and subscribe, cloud events, publishing events, subscribing to events, dapr publish-subscribe building block
   - name: Bindings
     href: bindings.md
-    displayName: dapr bindings building block, input binding, output binding, binding components, dapr bindings building block
   - name: Observability
     href: observability.md
-    displayName: dapr, distributed system, distributed application, observability, distributed tracing, traces, metrics, logging, zipkin, jaeger, prometheus, new relic, dapr observability building block
   - name: Secrets
     href: secrets.md
-    displayName: dapr, distributed system, distributed application, secrets, dapr secrets building block, kubernetes secrets, azure key vault
   - name: Summary and the road ahead
     href: summary.md
-    displayName: dapr, distributed system, distributed application, dapr building blocks, dapr components, microservice, sidecar architecture, dapr futures

--- a/docs/architecture/dapr-for-net-developers/toc.yml
+++ b/docs/architecture/dapr-for-net-developers/toc.yml
@@ -3,25 +3,37 @@
   items:
   - name: Foreword
     href: foreword.md
+    displayName: mark russinovich, foreword by mark russinovich, distributed system future, distributed application future, distributed architecture, microservice, monolithic, monolithic architecture
   - name: The world is distributed
     href: the-world-is-distributed.md
+    displayName: distributed system, distributed application, distributed architecture, microservice, SOA, monolithic, monolithic architecture
   - name: Dapr at 20,000 feet
     href: dapr-at-20000-feet.md
+    displayName: dapr, distributed system, distributed application, dapr building blocks, dapr components, microservice, sidecar architecture, service mesh
   - name: Getting started
     href: getting-started.md
+    displayName: dapr, distributed system, distributed application, service invocation, state management, install dapr, component configuration files, multi-container dapr application
   - name: Reference application
     href: reference-application.md
+    displayName: dapr, distributed system, distributed application, dapr building blocks, dapr components, microservice, eshop
   - name: State management
     href: state-management.md
+    displayName: dapr, distributed system, distributed application, state management, dapr state management building block, cap theorem, concurrency, transactions
   - name: Service invocation
     href: service-invocation.md
+    displayName: dapr, distributed system, distributed application, service invocation, dapr service invocation building block, envoy
   - name: Publish & subscribe
     href: publish-subscribe.md
+    displayName: dapr, distributed system, distributed application, pub/sub, publish and subscribe, cloud events, publishing events, subscribing to events, dapr publish-subscribe building block
   - name: Bindings
     href: bindings.md
+    displayName: dapr bindings building block, input binding, output binding, binding components, dapr bindings building block
   - name: Observability
     href: observability.md
+    displayName: dapr, distributed system, distributed application, observability, distributed tracing, traces, metrics, logging, zipkin, jaeger, prometheus, new relic, dapr observability building block
   - name: Secrets
     href: secrets.md
+    displayName: dapr, distributed system, distributed application, secrets, dapr secrets building block, kubernetes secrets, azure key vault
   - name: Summary and the road ahead
     href: summary.md
+    displayName: dapr, distributed system, distributed application, dapr building blocks, dapr components, microservice, sidecar architecture, dapr futures

--- a/docs/architecture/index.yml
+++ b/docs/architecture/index.yml
@@ -35,6 +35,8 @@ landingContent:
             url: serverless/index.md
           - text: ".NET Microservices: Architecture for containerized .NET applications"
             url: microservices/index.md
+          - text: Dapr for .NET Developers
+            url: dapr-for-net-developers/index.md
       - linkListType: learn
         links:
           - text: Hello World Microservice tutorial

--- a/docs/architecture/toc.yml
+++ b/docs/architecture/toc.yml
@@ -21,3 +21,5 @@
       href: microservices/
     - name: "Serverless apps: Architecture, patterns, and Azure implementation"
       href: serverless/
+    - name: "Dapr for .NET Developers"
+      href: dapr-for-net-developers/


### PR DESCRIPTION
This PR updates the following pages :

- Index
- Updates toc.yml for dotnet-architecture specific navigations.
- Removed displayname in dapr-for-net-developers/toc.yml
- updated references section on 'The Dapr bindings building block' Chapter
- removed references section on the-world-is-distributed chapter
