### PR TITLE
Fix regex for csharp

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.grouping/cs/grouping1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.grouping/cs/grouping1.cs
@@ -1,4 +1,4 @@
-﻿// <Snippet1>
+// <Snippet1>
 using System;
 using System.Text.RegularExpressions;
 
@@ -6,7 +6,7 @@ public class Example
 {
    public static void Main()
    {
-      string pattern = @"(\w+)\s(\1)";
+      string pattern = @"(\w+)\s(\1)\W";
       string input = "He said that that was the the correct answer.";
       foreach (Match match in Regex.Matches(input, pattern, RegexOptions.IgnoreCase))
          Console.WriteLine("Duplicate '{0}' found at positions {1} and {2}.",


### PR DESCRIPTION
## Summary

Add the `\W` in the csharp code to match the description. The VB code already has this.

Fixes #22865
