### PR TITLE
Update Fedora docs for .NET 5.0

### DIFF
--- a/docs/core/install/includes/linux-rpm-install-dependencies.md
+++ b/docs/core/install/includes/linux-rpm-install-dependencies.md
@@ -4,6 +4,7 @@ When you install with a package manager, these libraries are installed for you. 
 - krb5-libs
 - libicu
 - openssl-libs
+- zlib
 
 If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need to install **compat-openssl10**.
 

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -94,9 +94,9 @@ This section provides information on common errors you may get while using the p
 
 For more information on installing .NET without a package manager, see one of the following articles:
 
-- [Install the .NET SDK or the .NET Runtime with Snap.](../linux-snap.md)
-- [Install the .NET SDK or the .NET Runtime with a script.](../linux-scripted-manual.md#scripted-install)
-- [Install the .NET SDK or the .NET Runtime manually.](../linux-scripted-manual.md#manual-install)
+- [Install the .NET SDK or the .NET Runtime with Snap.](linux-snap.md)
+- [Install the .NET SDK or the .NET Runtime with a script.](linux-scripted-manual.md#scripted-install)
+- [Install the .NET SDK or the .NET Runtime manually.](linux-scripted-manual.md#manual-install)
 
 ### Failed to fetch
 

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -14,9 +14,9 @@ ms.date: 02/17/2021
 
 For more information on installing .NET without a package manager, see one of the following articles:
 
-- [Install the .NET SDK or the .NET Runtime with Snap.](../linux-snap.md)
-- [Install the .NET SDK or the .NET Runtime with a script.](../linux-scripted-manual.md#scripted-install)
-- [Install the .NET SDK or the .NET Runtime manually.](../linux-scripted-manual.md#manual-install)
+- [Install the .NET SDK or the .NET Runtime with Snap.](linux-snap.md)
+- [Install the .NET SDK or the .NET Runtime with a script.](linux-scripted-manual.md#scripted-install)
+- [Install the .NET SDK or the .NET Runtime manually.](linux-scripted-manual.md#manual-install)
 
 ## Install .NET 5.0
 

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -3,7 +3,7 @@ title: Install .NET on Fedora - .NET
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Fedora.
 author: adegeo
 ms.author: adegeo
-ms.date: 01/06/2021
+ms.date: 02/17/2021
 ---
 
 # Install the .NET SDK or the .NET Runtime on Fedora
@@ -12,31 +12,19 @@ ms.date: 01/06/2021
 
 [!INCLUDE [linux-intro-sdk-vs-runtime](includes/linux-intro-sdk-vs-runtime.md)]
 
-[!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
+For more information on installing .NET without a package manager, see one of the following articles:
+
+- [Install the .NET SDK or the .NET Runtime with Snap.](../linux-snap.md)
+- [Install the .NET SDK or the .NET Runtime with a script.](../linux-scripted-manual.md#scripted-install)
+- [Install the .NET SDK or the .NET Runtime manually.](../linux-scripted-manual.md#manual-install)
 
 ## Install .NET 5.0
 
-[!INCLUDE [linux-prep-intro-generic](includes/linux-prep-intro-generic.md)]
-
-**Fedora 32**
-
-```bash
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo wget -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/32/prod.repo
-```
-
-**Fedora 33**
-
-```bash
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo wget -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/33/prod.repo
-```
+The latest version of .NET available in the default package repositories for Fedora is .NET 5.0.
 
 [!INCLUDE [linux-dnf-install-50](includes/linux-install-50-dnf.md)]
 
 ## Install .NET Core 3.1
-
-The latest version of .NET available in the default package repositories for Fedora is .NET Core 3.1.
 
 [!INCLUDE [linux-dnf-install-31](includes/linux-install-31-dnf.md)]
 
@@ -104,7 +92,11 @@ This section provides information on common errors you may get while using the p
 
 ### Unable to find package
 
-[!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
+For more information on installing .NET without a package manager, see one of the following articles:
+
+- [Install the .NET SDK or the .NET Runtime with Snap.](../linux-snap.md)
+- [Install the .NET SDK or the .NET Runtime with a script.](../linux-scripted-manual.md#scripted-install)
+- [Install the .NET SDK or the .NET Runtime manually.](../linux-scripted-manual.md#manual-install)
 
 ### Failed to fetch
 


### PR DESCRIPTION
## Summary

.NET 5.0 is now available in the default Fedora repositories. Update docs to make that clearer.
