### PR TITLE
Fix typo in Dapr book

### DIFF
--- a/docs/architecture/dapr-for-net-developers/getting-started.md
+++ b/docs/architecture/dapr-for-net-developers/getting-started.md
@@ -38,7 +38,7 @@ You'll start by building a simple .NET Console application that consumes the [Da
    dotnet new console -o DaprCounter
    ```
 
-   The command scaffolds a simple "Hello World" .NET Core application.  
+   The command scaffolds a simple "Hello World" .NET Core application.
 
 1. Then, navigate into the new directory created by the previous command:
 
@@ -202,7 +202,7 @@ spec:
 
 In the first example, you created a simple .NET console application that ran side-by-side with a Dapr sidecar. Modern distributed applications, however, often consist of many moving parts. They can simultaneously run independent microservices. These modern applications are typically containerized and require container orchestration tools such as Docker Compose or Kubernetes.
 
-In the next example, you'll create a multi-container application. You'll also use the [Dapr service invocation](service-invocation.md) building block to communicate between services. The solution will consist of a  web application that retrieves weather forecasts from a  web API. The  and  will each run in a Docker container. You'll use Docker Compose to run the container locally and enable debugging capabilities.
+In the next example, you'll create a multi-container application. You'll also use the [Dapr service invocation](service-invocation.md) building block to communicate between services. The solution will consist of a web application that retrieves weather forecasts from a web API. They will each run in a Docker container. You'll use Docker Compose to run the container locally and enable debugging capabilities.
 
 Make sure you've configured your local environment for Dapr and installed the [.NET Core 3 Development Tools](https://dotnet.microsoft.com/download/dotnet-core/3.1) (instructions are available at the beginning of this chapter).
 


### PR DESCRIPTION
## Summary

Fixed a typo in the Getting Started chapter and removed some double spaces.

This PR fixes #22887