### PR TITLE
Add details about "." in env var name 

### DIFF
--- a/docs/architecture/dapr-for-net-developers/bindings.md
+++ b/docs/architecture/dapr-for-net-developers/bindings.md
@@ -119,9 +119,9 @@ The Dapr .NET SDK provides language-specific support for .NET Core developers. I
 private async Task SendSMSAsync([FromServices] DaprClient daprClient)
 {
     var message = "Welcome to this awesome service";
-    var metadata = new Dictionary<string, string> 
-    { 
-      { "toNumber", "555-3277" } 
+    var metadata = new Dictionary<string, string>
+    {
+      { "toNumber", "555-3277" }
     };
     await daprClient.InvokeBindingAsync("sms", "create", message, metadata);
 }
@@ -220,7 +220,7 @@ public Task Handle(OrderStartedDomainEvent notification, CancellationToken cance
 {
     var string message = CreateEmailBody(notification);
     var metadata = new Dictionary<string, string>
-    { 
+    {
         {"emailFrom", "eShopOn@dapr.io"},
         {"emailTo", notification.UserName},
         {"subject", $"Your eShopOnDapr order #{notification.Order.Id}"}

--- a/docs/architecture/dapr-for-net-developers/getting-started.md
+++ b/docs/architecture/dapr-for-net-developers/getting-started.md
@@ -74,7 +74,7 @@ You can invoke Dapr APIs across any development platform using Dapr's native sup
    using System.Threading.Tasks;
    using Dapr;
    using Dapr.Client;
-   
+
    namespace DaprCounter
    {
        class Program
@@ -82,15 +82,15 @@ You can invoke Dapr APIs across any development platform using Dapr's native sup
            static async Task Main(string[] args)
            {
                var daprClient = new DaprClientBuilder().Build();
-   
+
                var counter = await daprClient.GetStateAsync<int>("statestore", "counter");
-   
+
                while (true)
                {
                    Console.WriteLine($"Counter = {counter++}");
-   
+
                    await daprClient.SaveStateAsync("statestore", "counter", counter);
-   
+
                    await Task.Delay(1000);
                }
            }
@@ -256,17 +256,17 @@ Now, you'll configure communication between the services using Dapr [service inv
 
    ```csharp
    using System;
-      
+
    namespace DaprFrontEnd
    {
        public class WeatherForecast
        {
            public DateTime Date { get; set; }
-      
+
            public int TemperatureC { get; set; }
-      
+
            public int TemperatureF { get; set; }
-      
+
            public string Summary { get; set; }
        }
    }
@@ -316,7 +316,7 @@ Now, you'll configure communication between the services using Dapr [service inv
    @{
        ViewData["Title"] = "Home page";
    }
-   
+
    <div class="text-center">
        <h1 class="display-4">Welcome</h1>
        <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
@@ -349,14 +349,14 @@ In the final part of this example, you'll add container support and run the solu
 
    ```yaml
    version: '3.4'
-   
+
    services:
      daprfrontend:
        image: ${DOCKER_REGISTRY-}daprfrontend
        build:
          context: .
          dockerfile: DaprFrontEnd/Dockerfile
-   
+
    ```
 
    The *.dockerignore* file contains file types and extensions that you don't want Docker to include in the container. These files are associated with the development environment and source control and not the app or service you're deploying.
@@ -367,14 +367,14 @@ In the final part of this example, you'll add container support and run the solu
 
    ```yaml
    version: '3.4'
-   
+
    services:
      daprfrontend:
        image: ${DOCKER_REGISTRY-}daprfrontend
        build:
          context: .
          dockerfile: DaprFrontEnd/Dockerfile
-   
+
      daprbackend:
        image: ${DOCKER_REGISTRY-}daprbackend
        build:
@@ -386,7 +386,7 @@ In the final part of this example, you'll add container support and run the solu
 
    ```yaml
    version: '3.4'
-   
+
    services:
      daprfrontend:
        image: ${DOCKER_REGISTRY-}daprfrontend
@@ -394,15 +394,15 @@ In the final part of this example, you'll add container support and run the solu
          context: .
          dockerfile: DaprFrontEnd/Dockerfile
        ports:
-         - "51000:50001" 
-   
+         - "51000:50001"
+
      daprfrontend-dapr:
        image: "daprio/daprd:latest"
        command: [ "./daprd", "-app-id", "daprfrontend", "-app-port", "80" ]
        depends_on:
          - daprfrontend
        network_mode: "service:daprfrontend"
-   
+
      daprbackend:
        image: ${DOCKER_REGISTRY-}daprbackend
        build:
@@ -410,13 +410,13 @@ In the final part of this example, you'll add container support and run the solu
          dockerfile: DaprBackEnd/Dockerfile
        ports:
          - "52000:50001"
-   
+
      daprbackend-dapr:
        image: "daprio/daprd:latest"
        command: [ "./daprd", "-app-id", "daprbackend", "-app-port", "80" ]
        depends_on:
          - daprfrontend
-       network_mode: "service:daprbackend" 
+       network_mode: "service:daprbackend"
    ```
 
    In the updated file, we've added `daprfrontend-dapr` and `daprbackend-dapr` sidecars for the `daprfrontend` and `daprbackend` services respectively. In the updated file, pay close attention to the following changes:

--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -143,7 +143,7 @@ echo $Logging__LogLevel__Microsoft
 ```
 
 > [!NOTE]
-> When configuring environment variables with names that contain periods `.`, consider the "Exporting a variable with a dot (.) in it" question on **Stack Exchange** and its corresponding [accepted answer](https://unix.stackexchange.com/a/93533).
+> When configuring environment variables with names that contain `.` (periods), consider the "Exporting a variable with a dot (.) in it" question on **Stack Exchange** and its corresponding [accepted answer](https://unix.stackexchange.com/a/93533).
 
 ---
 

--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -3,7 +3,7 @@ title: Logging in .NET
 author: IEvangelist
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
 ms.author: dapine
-ms.date: 09/30/2020
+ms.date: 02/19/2021
 ---
 
 # Logging in .NET
@@ -87,28 +87,74 @@ In the preceding sample:
 
 ### Set log level by command line, environment variables, and other configuration
 
-Log level can be set by any of the [configuration providers](configuration-providers.md).
+Log level can be set by any of the [configuration providers](configuration-providers.md). For example, you can create a persisted environment variable named `Logging:LogLevel:Microsoft` with a value of `Information`.
 
-The following commands:
+## [Command Line](#tab/command-line)
 
-- Set the environment key `Logging:LogLevel:Microsoft` to a value of `Information` on Windows.
-- Test the settings when using an app created with the .NET Worker service templates. The `dotnet run` command must be run in the project directory after using `set`.
+Create and assign persisted environment variable, given the log level value.
 
-```cmd
-set Logging__LogLevel__Microsoft=Information
+```CMD
+:: Assigns the env var to the value
+setx "Logging__LogLevel__Microsoft" "Information" /M
+```
+
+In a *new* instance of the **Command Prompt**, read the environment variable.
+
+```CMD
+:: Prints the env var value
+echo %Logging__LogLevel__Microsoft%
+```
+
+## [PowerShell](#tab/powershell)
+
+Create and assign persisted environment variable, given the log level value.
+
+```powershell
+# Assigns the env var to the value
+[System.Environment]::SetEnvironmentVariable(
+    "Logging__LogLevel__Microsoft", "Information", "Machine")
+```
+
+In a *new* instance of the **PowerShell**, read the environment variable.
+
+```powershell
+# Prints the env var value
+[System.Environment]::GetEnvironmentVariable(
+    "Logging__LogLevel__Microsoft", "Machine")
+```
+
+## [Bash](#tab/bash)
+
+Create and assign persisted environment variable, given the log level value.
+
+```Bash
+# Assigns the env var to the value, persists it across sessions
+echo export Logging__LogLevel__Microsoft="Information" >> ~/.bashrc && source ~/.bashrc
+```
+
+To read the environment variable.
+
+```Bash
+# Prints the env var value
+echo $Logging__LogLevel__Microsoft
+
+# Or use printenv:
+# printenv Logging__LogLevel__Microsoft
+```
+
+> [!NOTE]
+> When configuring environment variables with names that contain periods `.`, consider the "Exporting a variable with a dot (.) in it" question on **Stack Exchange** and its corresponding [accepted answer](https://unix.stackexchange.com/a/93533).
+
+---
+
+The preceding environment setting is persisted in the environment. To test the settings when using an app created with the .NET Worker service templates, use the `dotnet run` command in the project directory after the environment variable is assigned.
+
+```dotnetcli
 dotnet run
 ```
 
-The preceding environment setting:
-
-- Is only set in processes launched from the command window they were set in.
-- Isn't read by apps launched with Visual Studio.
-
-The following [setx](/windows-server/administration/windows-commands/setx) command also sets the environment key and value on Windows. Unlike `set`, `setx` settings are persisted. The `/M` switch sets the variable in the system environment. If `/M` isn't used, a user environment variable is set.
-
-```cmd
-setx Logging__LogLevel__Microsoft=Information /M
-```
+> [!TIP]
+> After setting an environment variable, restart your integrated development environment (IDE) to ensure that newly added environment variables are available.
 
 On [Azure App Service](https://azure.microsoft.com/services/app-service/), select **New application setting** on the **Settings > Configuration** page. Azure App Service application settings are:
 


### PR DESCRIPTION
## Summary

Added cross-platform bits for env vars, and note/link re: . in names. The pre-push commit is an automated fix to address markdown linter warnings.

Fixes dotnet/runtime#87130
