### PR TITLE
Add breaking change from 2.0-2.1

### DIFF
--- a/docs/core/compatibility/2.1.md
+++ b/docs/core/compatibility/2.1.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes in .NET Core 2.1
 description: Lists the breaking changes in version 2.1 of .NET Core.
-ms.date: 12/17/2019
+ms.date: 02/19/2020
 ---
 # Breaking changes in .NET Core 2.1
 
@@ -12,10 +12,18 @@ If you're migrating to version 2.1 of .NET Core, the breaking changes listed in 
 - [Private fields added to built-in struct types](#private-fields-added-to-built-in-struct-types)
 - [OpenSSL versions on macOS](#openssl-versions-on-macos)
 
-[!INCLUDE[Private fields added to built-in struct types](~/includes/core-changes/corefx/2.1/instantiate-struct.md)]
+[!INCLUDE[Private fields added to built-in struct types](../../../includes/core-changes/corefx/2.1/instantiate-struct.md)]
 
 ***
 
 [!INCLUDE [OpenSSL versions on macOS](../../../includes/core-changes/corefx/openssl-dependencies-macos.md)]
+
+***
+
+## MSBuild
+
+- [Project tools now included in SDK](#project-tools-now-included-in-sdk)
+
+[!INCLUDE [DotNetCliToolReference project elements removed for bundled tools](../../../includes/core-changes/msbuild/2.1/dotnetclitoolreference.md)]
 
 ***

--- a/docs/core/compatibility/msbuild.md
+++ b/docs/core/compatibility/msbuild.md
@@ -1,9 +1,9 @@
 ---
 title: MSBuild breaking changes
-description: Lists the breaking changes in MSBuild for .NET Core 3.0 - 3.1.
+description: Lists the breaking changes in MSBuild for .NET Core 2.0 - 3.1.
 ms.date: 12/14/2020
 ---
-# MSBuild breaking changes in .NET Core 3.0 - 3.1
+# MSBuild breaking changes in .NET Core 2.0 - 3.1
 
 The following breaking changes are documented on this page:
 
@@ -11,6 +11,7 @@ The following breaking changes are documented on this page:
 | - | - |
 | [Design-time builds only return top-level package references](#design-time-builds-only-return-top-level-package-references) | 3.1 |
 | [Resource manifest file name change](#resource-manifest-file-name-change) | 3.0 |
+| [Project tools now included in SDK](#project-tools-now-included-in-sdk) | 2.1 |
 
 ## .NET Core 3.1
 
@@ -20,6 +21,12 @@ The following breaking changes are documented on this page:
 
 ## .NET Core 3.0
 
-[!INCLUDE[Resource file names](~/includes/core-changes/msbuild/3.0/resource-manifest-name.md)]
+[!INCLUDE[Resource file names](../../../includes/core-changes/msbuild/3.0/resource-manifest-name.md)]
+
+***
+
+## .NET Core 2.1
+
+[!INCLUDE [DotNetCliToolReference project elements removed for bundled tools](../../../includes/core-changes/msbuild/2.1/dotnetclitoolreference.md)]
 
 ***

--- a/docs/core/compatibility/msbuild.md
+++ b/docs/core/compatibility/msbuild.md
@@ -1,9 +1,9 @@
 ---
 title: MSBuild breaking changes
-description: Lists the breaking changes in MSBuild for .NET Core 2.0 - 3.1.
+description: Lists the breaking changes in MSBuild for .NET Core 2.1 - 3.1.
 ms.date: 02/22/2021
 ---
-# MSBuild breaking changes in .NET Core 2.0 - 3.1
+# MSBuild breaking changes in .NET Core 2.1 - 3.1
 
 The following breaking changes are documented on this page:
 

--- a/docs/core/compatibility/msbuild.md
+++ b/docs/core/compatibility/msbuild.md
@@ -1,7 +1,7 @@
 ---
 title: MSBuild breaking changes
 description: Lists the breaking changes in MSBuild for .NET Core 2.0 - 3.1.
-ms.date: 12/14/2020
+ms.date: 02/22/2021
 ---
 # MSBuild breaking changes in .NET Core 2.0 - 3.1
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -548,7 +548,7 @@
           href: msbuild/5.0/publishdepsfilepath-behavior-change.md
         - name: TargetFramework change from netcoreapp to net
           href: msbuild/5.0/targetframework-name-change.md
-      - name: .NET 3.0
+      - name: .NET Core 2.1 - 3.1
         href: msbuild.md
     - name: Networking
       items:

--- a/includes/core-changes/msbuild/2.1/dotnetclitoolreference.md
+++ b/includes/core-changes/msbuild/2.1/dotnetclitoolreference.md
@@ -1,6 +1,6 @@
 ### Project tools now included in SDK
 
-The .NET Core 2.1 SDK now includes common CLI tooling and referencing these from the project is no longer required.
+The .NET Core 2.1 SDK now includes common CLI tooling, and you no longer need to reference these tools from the project.
 
 #### Change description
 

--- a/includes/core-changes/msbuild/2.1/dotnetclitoolreference.md
+++ b/includes/core-changes/msbuild/2.1/dotnetclitoolreference.md
@@ -1,0 +1,32 @@
+### Project tools now included in SDK
+
+The .NET Core 2.1 SDK now includes common CLI tooling and referencing these from the project is no longer required.
+
+#### Change description
+
+In .NET Core 2.0, projects reference external .NET tools with the `<DotNetCliToolReference>` project setting. In .NET Core 2.1, some of these tools are now  included with the .NET Core SDK and the setting is no longer needed. If reference to these tools are included in your project, you'll receive an error similar to the following: **The tool 'Microsoft.EntityFrameworkCore.Tools.DotNet' is now included in the .NET Core SDK.**
+
+Tools now included in .NET Core 2.1 SDK:
+
+| \<DotNetCliToolReference> value                   | Tool                                                                                                            |
+|------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `Microsoft.DotNet.Watcher.Tools`               | [dotnet-watch](https://github.com/dotnet/aspnetcore/blob/master/src/Tools/dotnet-watch/README.md)               |
+| `Microsoft.Extensions.SecretManager.Tools`     | [dotnet-user-secrets](https://github.com/dotnet/aspnetcore/blob/master/src/Tools/dotnet-user-secrets/README.md) |
+| `Microsoft.Extensions.Caching.SqlConfig.Tools` | [dotnet-sql-cache](https://github.com/dotnet/aspnetcore/blob/master/src/Tools/dotnet-sql-cache/README.md)       |
+| `Microsoft.EntityFrameworkCore.Tools.DotNet`   | [dotnet-ef](/ef/core/miscellaneous/cli/dotnet)                                                                  |
+
+#### Version introduced
+
+.NET Core SDK 2.1.300
+
+#### Recommended action
+
+Remove the `<DotNetCliToolReference>` setting from your project.
+
+#### Category
+
+MSBuild
+
+#### Affected APIs
+
+N/A

--- a/includes/core-changes/msbuild/2.1/dotnetclitoolreference.md
+++ b/includes/core-changes/msbuild/2.1/dotnetclitoolreference.md
@@ -4,7 +4,7 @@ The .NET Core 2.1 SDK now includes common CLI tooling, and you no longer need to
 
 #### Change description
 
-In .NET Core 2.0, projects reference external .NET tools with the `<DotNetCliToolReference>` project setting. In .NET Core 2.1, some of these tools are now  included with the .NET Core SDK and the setting is no longer needed. If reference to these tools are included in your project, you'll receive an error similar to the following: **The tool 'Microsoft.EntityFrameworkCore.Tools.DotNet' is now included in the .NET Core SDK.**
+In .NET Core 2.0, projects reference external .NET tools with the `<DotNetCliToolReference>` project setting. In .NET Core 2.1, some of these tools are included with the .NET Core SDK, and the setting is no longer needed. If you include references to these tools in your project, you'll receive an error similar to the following: **The tool 'Microsoft.EntityFrameworkCore.Tools.DotNet' is now included in the .NET Core SDK.**
 
 Tools now included in .NET Core 2.1 SDK:
 


### PR DESCRIPTION
## Summary

I'm working on retiring some of the older information related to .NET Core 2.0 and 1.0. This information is from an article I intend to delete, yet this information may be useful and I wanted to capture it.

@gewarren I tried to follow the pattern I saw in other articles. Please correct anything I missed. 😄 

Contributes to #22858

**Internal previews**
- [2.1 Compatibility](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/2.1?branch=pr-en-us-22917#msbuild)
- [MSbuild](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/msbuild?branch=pr-en-us-22917)
