### PR TITLE
Change EventPipe environment variables that went out of sync

### DIFF
--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -72,10 +72,11 @@ However, you can use the following environment variables to set up an EventPipe 
 
 * `COMPlus_EventPipeOutputPath`: The path to the output EventPipe trace file when it's configured to run via `COMPlus_EnableEventPipe`. The default value is `trace.nettrace`, which will be created in the same directory that the app is running from.
 
-* `COMPlus_CircularBufferMB`: The size of the internal buffer that is used by EventPipe when it's configured to run via `COMPlus_EnableEventPipe`.
+* `COMPlus_EventPipeCircularMB`: A hexadecimal value that represents the size of EventPipe's internal buffer in megabytes. This configuration value is only used when EventPipe is configured to run via `COMPlus_EnableEventPipe`. The default buffer size is 1024MB which translates to this environment variable being set to `400`, since `0x400` == `1024`.
+
+* `COMPlus_EventPipeProcNumbers`: Set this to `1` to enable capturing processor numbers in EventPipe event headers. The default value is `0`.
 
 * `COMPlus_EventPipeConfig`: Sets up the EventPipe session configuration when starting an EventPipe session with `COMPlus_EnableEventPipe`.
-
   The syntax is as follows:
 
   `<provider>:<keyword>:<level>`


### PR DESCRIPTION
## Summary

Our docs on EventPipe environment variables is not in sync with the runtime source. This PR changes the following to keep this in sync:

* `COMPlus_CircularBufferMB` was changed to `COMPlus_EventPipeCircularMB`. 
* Clarify the usage of `COMPlus_EventPipeCircularMB` as well as its default value. 
* Add description on `COMPlus_EventPipeProcNumbers`. 

Note that I didn't document `COMPlus_EventPipeRundown` on purpose because we don't yet have a good documentation on what rundown is in this doc and didn't wanna introduce confusion by documenting this env var. 

Part of https://github.com/dotnet/diagnostics/issues/515. 
