### PR TITLE
Parallel.ForEach should not be used for IO bound tasks

### DIFF
--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -1,7 +1,7 @@
 ---
 title: Write a simple parallel program using Parallel.ForEach
 description: In this article, learn how to enable data parallelism in .NET. Write a Parallel.ForEach loop over any IEnumerable or IEnumerable<T> data source.
-ms.date: 02/14/2019
+ms.date: 02/23/2021
 dev_langs:
   - "csharp"
   - "vb"
@@ -19,7 +19,7 @@ This example shows how to use a <xref:System.Threading.Tasks.Parallel.ForEach%2A
 
 ## Example
 
-This example assumes you have several .jpg files in a *C:\Users\Public\Pictures\Sample Pictures* folder and creates a new sub-folder named *Modified*. When you run the example, it rotates each .jpg image in *Sample Pictures* and saves it to *Modified*. You can modify the two paths as necessary.
+This example showcases the power of Parallel.ForEach for CPU intensive operations. Only for demonstration purpose we have picked up operation around Prime numbers. When you run the example, it randomly generates 2 million numbers and tries to filter only Prime Numbers. In first case we iterate over the collection via simple for loop, in second case we iterate over the collection via Parallel.ForEach. In the end we display the time taken in both the cases.
 
 [!code-csharp[TPL_Parallel#03](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.cs#03)]
 [!code-vb[TPL_Parallel#03](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb#03)]
@@ -42,14 +42,6 @@ You can compile the code as a console application for .NET Framework or as a con
 In Visual Studio, there are Visual Basic and C# console application templates for Windows Desktop and .NET Core.
 
 From the command line, you can use either the .NET Core CLI commands (for example, `dotnet new console` or `dotnet new console -lang vb`), or you can create the file and use the command-line compiler for a .NET Framework application.
-
-For a .NET Core project, you must reference the **System.Drawing.Common** NuGet package. In Visual Studio, use the NuGet Package Manager to install the package. Alternatively, you can add a reference to the package in your \*.csproj or \*.vbproj file:
-
-```xml
-<ItemGroup>
-     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
-</ItemGroup>
-```
 
 To run a .NET Core console application from the command line, use `dotnet run` from the folder that contains your application.
 

--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -19,7 +19,7 @@ This example shows how to use a <xref:System.Threading.Tasks.Parallel.ForEach%2A
 
 ## Example
 
-This example showcases the power of Parallel.ForEach for CPU intensive operations. Only for demonstration purpose we have picked up operation around Prime numbers. When you run the example, it randomly generates 2 million numbers and tries to filter only Prime Numbers. In first case we iterate over the collection via simple for loop, in second case we iterate over the collection via Parallel.ForEach. In the end we display the time taken in both the cases.
+This example demonstrates <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType> for CPU intensive operations. When you run the example, it randomly generates 2 million numbers and tries to filter to prime numbers. The first case iterates over the collection via a `for` loop. The second case iterates over the collection via <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType>. The resulting time taken by each iteration is displayed when the application is finished.
 
 [!code-csharp[TPL_Parallel#03](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.cs#03)]
 [!code-vb[TPL_Parallel#03](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb#03)]

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.cs
@@ -10,29 +10,22 @@ namespace ParallelExample
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             // 2 million
-            int limit = 2 * 1000000;
-            var inputs = new List<int>(limit);
-            Random radomGenerator = new Random();
-            for (int index = 0; index < limit; index++)
-            {
-                inputs.Add(radomGenerator.Next());
-            }
+            var limit = 2_000_000;
+            var numbers = Enumerable.Range(0, limit).ToList();
 
-            var watch = new Stopwatch();
-            watch.Start();
-            var primeNumbers = GetPrimeList(inputs);
+            var watch = Stopwatch.StartNew();
+            var primeNumbersFromForeach = GetPrimeList(numbers);
             watch.Stop();
 
-            var watchForParallel = new Stopwatch();
-            watchForParallel.Start();
-            var primeNumbersFromParallel = GetPrimeListWithParallel(inputs);
+            var watchForParallel = Stopwatch.StartNew();
+            var primeNumbersFromParallelForeach = GetPrimeListWithParallel(numbers);
             watchForParallel.Stop();
 
-            Console.WriteLine($"Classical For loop    | Total prime numbers : {primeNumbersFromParallel.Count} | Time Taken : {watch.ElapsedMilliseconds} ms.");
-            Console.WriteLine($"Parallel.ForEach loop | Total prime numbers : {primeNumbersFromParallel.Count} | Time Taken : {watchForParallel.ElapsedMilliseconds} ms.");
+            Console.WriteLine($"Classical foreach loop | Total prime numbers : {primeNumbersFromForeach.Count} | Time Taken : {watch.ElapsedMilliseconds} ms.");
+            Console.WriteLine($"Parallel.ForEach loop  | Total prime numbers : {primeNumbersFromParallelForeach.Count} | Time Taken : {watchForParallel.ElapsedMilliseconds} ms.");
 
             Console.WriteLine("Press any key to exit.");
             Console.ReadLine();
@@ -43,35 +36,22 @@ namespace ParallelExample
         /// </summary>
         /// <param name="inputs"></param>
         /// <returns></returns>
-        static IList<int> GetPrimeList(IList<int> inputs)
-        {
-            var primeNumbers = new List<int>();
-
-            foreach (var item in inputs)
-            {
-                if (IsPrime(item))
-                {
-                    primeNumbers.Add(item);
-                }
-            }
-
-            return primeNumbers;
-        }
+        private static IList<int> GetPrimeList(IList<int> numbers) => numbers.Where(IsPrime).ToList();
 
         /// <summary>
         /// GetPrimeListWithParallel returns Prime numbers by using Parallel.ForEach
         /// </summary>
-        /// <param name="inputs"></param>
+        /// <param name="numbers"></param>
         /// <returns></returns>
-        static IList<int> GetPrimeListWithParallel(IList<int> inputs)
+        private static IList<int> GetPrimeListWithParallel(IList<int> numbers)
         {
             var primeNumbers = new ConcurrentBag<int>();
 
-            Parallel.ForEach(inputs, item =>
+            Parallel.ForEach(numbers, number =>
             {
-                if (IsPrime(item))
+                if (IsPrime(number))
                 {
-                    primeNumbers.Add(item);
+                    primeNumbers.Add(number);
                 }
             });
 
@@ -83,24 +63,16 @@ namespace ParallelExample
         /// </summary>
         /// <param name="number"></param>
         /// <returns></returns>
-        static bool IsPrime(int number)
+        private static bool IsPrime(int number)
         {
-
-            if (number <= 1)
+            if (number < 2)
             {
                 return false;
             }
 
-            if (number == 2 || number % 2 == 0)
+            for (var divisor = 2; divisor <= Math.Sqrt(number); divisor++)
             {
-                return true;
-            }
-
-            int limit = (int)Math.Floor(Math.Sqrt(number));
-
-            for (int index = 3; index <= limit; index += 2)
-            {
-                if (number % index == 0)
+                if (number % divisor == 0)
                 {
                     return false;
                 }

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.csproj
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  
+</Project>

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb
@@ -1,37 +1,83 @@
 ﻿'<snippet03>
-Imports System.IO
-Imports System.Threading
-Imports System.Threading.Tasks
-Imports System.Drawing
+Imports System.Collections.Concurrent
 
-Module ForEachDemo
+Namespace ParallelExample
+    Class Program
+        Shared Sub Main()
 
-    Sub Main()
-        ' A simple source for demonstration purposes. Modify this path as necessary.
-        Dim files As String() = Directory.GetFiles("C:\Users\Public\Pictures\Sample Pictures", "*.jpg")
-        Dim newDir As String = "C:\Users\Public\Pictures\Sample Pictures\Modified"
-        Directory.CreateDirectory(newDir)
+            '2 million
+            Dim limit As Integer = 2 * 1000000
+            Dim inputs = New List(Of Integer)(limit)
+            Dim radomGenerator As Random = New Random()
 
-        Parallel.ForEach(files, Sub(currentFile)
-                                    ' The more computational work you do here, the greater 
-                                    ' the speedup compared to a sequential foreach loop.
-                                    Dim filename As String = Path.GetFileName(currentFile)
-                                    Dim bitmap As New Bitmap(currentFile)
+            For index As Integer = 0 To limit - 1
+                inputs.Add(radomGenerator.[Next]())
+            Next
 
-                                    bitmap.RotateFlip(System.Drawing.RotateFlipType.Rotate180FlipNone)
-                                    bitmap.Save(Path.Combine(newDir, filename))
+            Dim watch = New Stopwatch()
+            watch.Start()
+            Dim primeNumbers = GetPrimeList(inputs)
+            watch.Stop()
 
-                                    ' Peek behind the scenes to see how work is parallelized.
-                                    ' But be aware: Thread contention for the Console slows down parallel loops!!!
+            Dim watchForParallel = New Stopwatch()
+            watchForParallel.Start()
+            Dim primeNumbersFromParallel = GetPrimeListWithParallel(inputs)
+            watchForParallel.Stop()
 
-                                    Console.WriteLine($"Processing {filename} on thread {Thread.CurrentThread.ManagedThreadId}")
-                                    'close lambda expression and method invocation
-                                End Sub)
+            Console.WriteLine($"Classical For loop    | Total prime numbers : {primeNumbersFromParallel.Count} | Time Taken : {watch.ElapsedMilliseconds} ms.")
+            Console.WriteLine($"Parallel.ForEach loop | Total prime numbers : {primeNumbersFromParallel.Count} | Time Taken : {watchForParallel.ElapsedMilliseconds} ms.")
 
+            Console.WriteLine("Press any key to exit.")
+            Console.ReadLine()
+        End Sub
 
-        ' Keep the console window open in debug mode.
-        Console.WriteLine("Processing complete. Press any key to exit.")
-        Console.ReadKey()
-    End Sub
-End Module
+        ' GetPrimeList returns Prime numbers by using sequential ForEach
+        Private Shared Function GetPrimeList(inputs As IList(Of Integer)) As IList(Of Integer)
+            Dim primeNumbers = New List(Of Integer)()
+
+            For Each item In inputs
+
+                If IsPrime(item) Then
+                    primeNumbers.Add(item)
+                End If
+            Next
+
+            Return primeNumbers
+        End Function
+
+        ' GetPrimeListWithParallel returns Prime numbers by using Parallel.ForEach
+        Private Shared Function GetPrimeListWithParallel(inputs As IList(Of Integer)) As IList(Of Integer)
+            Dim primeNumbers = New ConcurrentBag(Of Integer)()
+            Parallel.ForEach(inputs, Sub(item)
+
+                                         If IsPrime(item) Then
+                                             primeNumbers.Add(item)
+                                         End If
+                                     End Sub)
+            Return primeNumbers.ToList()
+        End Function
+
+        ' IsPrime returns true if number is Prime, else false.(https://en.wikipedia.org/wiki/Prime_number)
+        Private Shared Function IsPrime(number As Integer) As Boolean
+            If number <= 1 Then
+                Return False
+            End If
+
+            If number = 2 OrElse number Mod 2 = 0 Then
+                Return True
+            End If
+
+            Dim limit As Integer = CInt(Math.Floor(Math.Sqrt(number)))
+
+            For index As Integer = 3 To limit Step 2
+
+                If number Mod index = 0 Then
+                    Return False
+                End If
+            Next
+
+            Return True
+        End Function
+    End Class
+End Namespace
 '</snippet03>

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb
@@ -4,74 +4,51 @@ Imports System.Collections.Concurrent
 Namespace ParallelExample
     Class Program
         Shared Sub Main()
+            ' 2 million
+            Dim limit = 2_000_000
+            Dim numbers = Enumerable.Range(0, limit).ToList()
 
-            '2 million
-            Dim limit As Integer = 2 * 1000000
-            Dim inputs = New List(Of Integer)(limit)
-            Dim radomGenerator As Random = New Random()
-
-            For index As Integer = 0 To limit - 1
-                inputs.Add(radomGenerator.[Next]())
-            Next
-
-            Dim watch = New Stopwatch()
-            watch.Start()
-            Dim primeNumbers = GetPrimeList(inputs)
+            Dim watch = Stopwatch.StartNew()
+            Dim primeNumbersFromForeach = GetPrimeList(numbers)
             watch.Stop()
 
-            Dim watchForParallel = New Stopwatch()
-            watchForParallel.Start()
-            Dim primeNumbersFromParallel = GetPrimeListWithParallel(inputs)
+            Dim watchForParallel = Stopwatch.StartNew()
+            Dim primeNumbersFromParallelForeach = GetPrimeListWithParallel(numbers)
             watchForParallel.Stop()
 
-            Console.WriteLine($"Classical For loop    | Total prime numbers : {primeNumbersFromParallel.Count} | Time Taken : {watch.ElapsedMilliseconds} ms.")
-            Console.WriteLine($"Parallel.ForEach loop | Total prime numbers : {primeNumbersFromParallel.Count} | Time Taken : {watchForParallel.ElapsedMilliseconds} ms.")
+            Console.WriteLine($"Classical foreach loop | Total prime numbers : {primeNumbersFromForeach.Count} | Time Taken : {watch.ElapsedMilliseconds} ms.")
+            Console.WriteLine($"Parallel.ForEach loop  | Total prime numbers : {primeNumbersFromParallelForeach.Count} | Time Taken : {watchForParallel.ElapsedMilliseconds} ms.")
 
             Console.WriteLine("Press any key to exit.")
             Console.ReadLine()
         End Sub
 
         ' GetPrimeList returns Prime numbers by using sequential ForEach
-        Private Shared Function GetPrimeList(inputs As IList(Of Integer)) As IList(Of Integer)
-            Dim primeNumbers = New List(Of Integer)()
-
-            For Each item In inputs
-
-                If IsPrime(item) Then
-                    primeNumbers.Add(item)
-                End If
-            Next
-
-            Return primeNumbers
+        Private Shared Function GetPrimeList(numbers As IList(Of Integer)) As IList(Of Integer)
+            Return numbers.Where(AddressOf IsPrime).ToList()
         End Function
 
         ' GetPrimeListWithParallel returns Prime numbers by using Parallel.ForEach
-        Private Shared Function GetPrimeListWithParallel(inputs As IList(Of Integer)) As IList(Of Integer)
+        Private Shared Function GetPrimeListWithParallel(numbers As IList(Of Integer)) As IList(Of Integer)
             Dim primeNumbers = New ConcurrentBag(Of Integer)()
-            Parallel.ForEach(inputs, Sub(item)
+            Parallel.ForEach(numbers, Sub(number)
 
-                                         If IsPrime(item) Then
-                                             primeNumbers.Add(item)
-                                         End If
-                                     End Sub)
+                                          If IsPrime(number) Then
+                                              primeNumbers.Add(number)
+                                          End If
+                                      End Sub)
             Return primeNumbers.ToList()
         End Function
 
         ' IsPrime returns true if number is Prime, else false.(https://en.wikipedia.org/wiki/Prime_number)
         Private Shared Function IsPrime(number As Integer) As Boolean
-            If number <= 1 Then
+            If number < 2 Then
                 Return False
             End If
 
-            If number = 2 OrElse number Mod 2 = 0 Then
-                Return True
-            End If
+            For divisor = 2 To Math.Sqrt(number)
 
-            Dim limit As Integer = CInt(Math.Floor(Math.Sqrt(number)))
-
-            For index As Integer = 3 To limit Step 2
-
-                If number Mod index = 0 Then
+                If number Mod divisor = 0 Then
                     Return False
                 End If
             Next

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vbproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  
+</Project>


### PR DESCRIPTION
## Summary

Showcase the power of Parallel.ForEach for CPU intensive operations.
Currently in docs example "How to: Write a simple Parallel.ForEach loop", IO bound operation is being used in Parallel.ForEach example, which is an anti-pattern.

With this change we are processing 2 million integers for PrimeNumber (CPU - intensive operation).
Case - I : Iterate over inputs via For loop.
Case - II : Iterate over inputs via Parallel.ForEach.

Print the time taken by both the cases.
Looking at time taken by both the cases, it is very evident how one can speed up execution by putting Paralle.ForEach to the right use.
[](url)
Fixes #22232 

Output from program
![image](https://user-images.githubusercontent.com/12485087/108846804-fbb7b700-7604-11eb-8bee-5eb3c9e59024.png)

