### PR TITLE
Fix ICorProfilerInfo9 .NET Core version, Fix COR_PRF_REJIT_FLAGS .NET Core version

### DIFF
--- a/docs/framework/unmanaged-api/profiling/cor-prf-rejit-flags-enumeration.md
+++ b/docs/framework/unmanaged-api/profiling/cor-prf-rejit-flags-enumeration.md
@@ -46,7 +46,7 @@ typedef enum
   
  **Library:** CorGuids.lib  
   
- **.NET Framework Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-22-md.md)]
+ **.NET Framework Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
   
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-enumerateobjectreferences-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-enumerateobjectreferences-method.md
@@ -51,7 +51,7 @@ The `EnumerateObjectReferences` method is similar to [ObjectReferences](icorprof
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-getlohobjectsizethreshold-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-getlohobjectsizethreshold-method.md
@@ -41,7 +41,7 @@ Objects larger than the large object heap threshold will be allocated on the lar
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-interface.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-interface.md
@@ -24,7 +24,7 @@ A subclass of [ICorProfilerInfo9](icorprofilerinfo9-interface.md) that provides 
 
 **Platforms:** See [.NET Core supported operating systems](../../../core/install/windows.md?pivots=os-windows).  
 **Header:** CorProf.idl, CorProf.h  
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-isfrozenobject-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-isfrozenobject-method.md
@@ -42,7 +42,7 @@ HRESULT IsFrozenObject( [in]  ObjectID objectId,
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-requestrejitwithinliners-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-requestrejitwithinliners-method.md
@@ -56,7 +56,7 @@ HRESULT RequestReJITWithInliners( [in]                       DWORD       dwRejit
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-resumeruntime-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-resumeruntime-method.md
@@ -31,7 +31,7 @@ HRESULT ResumeRuntime();
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-suspendruntime-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo10-suspendruntime-method.md
@@ -31,7 +31,7 @@ HRESULT SuspendRuntime();
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-30-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_30](../../../../includes/net-core-30-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-getcodeinfo4-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-getcodeinfo4-method.md
@@ -65,7 +65,7 @@ Alternatively, you can first call `GetCodeInfo4` with a zero-length `codeInfos` 
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-22-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_21](../../../../includes/net-core-21-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-getiltonativemapping3-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-getiltonativemapping3-method.md
@@ -56,7 +56,7 @@ When tiered compilation is enabled, a method may have more than one native code 
 
 **Library:** CorGuids.lib
 
-**.NET Framework Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-22-md.md)]
+**.NET Framework Versions:** [!INCLUDE[net_core_21](../../../../includes/net-core-21-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-getnativecodestartaddresses-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-getnativecodestartaddresses-method.md
@@ -61,7 +61,7 @@ When tiered compilation is enabled, a function may have more than one native cod
 
 **Library:** CorGuids.lib
 
-**.NET Versions:** [!INCLUDE[net_core_22](../../../../includes/net-core-22-md.md)]
+**.NET Versions:** [!INCLUDE[net_core_21](../../../../includes/net-core-21-md.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-interface.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo9-interface.md
@@ -21,7 +21,7 @@ A subclass of [ICorProfilerInfo8](icorprofilerinfo8-interface.md) that provides 
 
 **Platforms:** See [.NET Core supported operating systems](../../../core/install/windows.md?pivots=os-windows).  
 **Header:** CorProf.idl, CorProf.h  
-**.NET Versions:** [!INCLUDE[net_core](../../../../includes/net-core-22-md.md)]  
+**.NET Versions:** [!INCLUDE[net_core](../../../../includes/net-core-21-md.md)]  
 
 ## See also
 

--- a/includes/net-core-21-md.md
+++ b/includes/net-core-21-md.md
@@ -1,0 +1,1 @@
+Available since .NET Core 2.1

--- a/includes/net-core-22-md.md
+++ b/includes/net-core-22-md.md
@@ -1,1 +1,0 @@
-Available since .NET Core 2.2


### PR DESCRIPTION
## Summary

- ICorProfilerInfo9 was available since .NET Core 2.1
  - https://github.com/dotnet/coreclr/blob/v2.1.0/src/pal/prebuilt/inc/corprof.h#L14229
  - https://github.com/dotnet/coreclr/blob/v2.1.0/src/vm/proftoeeinterfaceimpl.cpp#L6626

- COR_PRF_REJIT_FLAGS were available in .NET Core 3.0 (not .NET Core 2.2)
  - https://github.com/dotnet/coreclr/blob/v3.0.0/src/pal/prebuilt/inc/corprof.h#L600
  - https://github.com/dotnet/coreclr/blob/v3.0.0/src/inc/corprof.idl#L724

I can split these into separate PR's if needed.