### PR TITLE
Fix misleading link in system-text-json-converters-how-to.md

### DIFF
--- a/docs/standard/serialization/system-text-json-converters-how-to.md
+++ b/docs/standard/serialization/system-text-json-converters-how-to.md
@@ -142,7 +142,7 @@ You can throw other exceptions as needed, but they don't automatically include J
 
 ## Registration sample - Converters collection
 
-Here's an example that makes the <xref:System.ComponentModel.DateTimeOffsetConverter> the default for properties of type <xref:System.DateTimeOffset>:
+Here's an example that makes the [DateTimeOffsetConverter](#sample-basic-converter) the default for properties of type <xref:System.DateTimeOffset>:
 
 :::code language="csharp" source="snippets/system-text-json-how-to/csharp/RegisterConverterWithConvertersCollection.cs" id="Serialize":::
 


### PR DESCRIPTION
The following code in the [Registration sample - Converters collection](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to?pivots=dotnet-5-0#registration-sample---converters-collection) section does NOT compile:

```csharp
var serializeOptions = new JsonSerializerOptions
{
    WriteIndented = true,
    Converters =
    {
        new DateTimeOffsetConverter()
    }
};

jsonString = JsonSerializer.Serialize(weatherForecast, serializeOptions);
```

The problem is that the [JsonSerializerOptions.Converters](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions.converters?view=net-5.0) property is of type `IList<JsonConverter>` and we are trying to add an instance of `DateTimeOffsetConverter` which inherits from `TypeConverter` instead of the expected `JsonConverter`. The compiler reports the error as follows:

![image](https://user-images.githubusercontent.com/20465797/108979642-eb065000-769b-11eb-8be3-efb79b3a6d19.png)

While filing an issue for the bug, I noticed that the `DateTimeOffsetConverter` class being referenced in the sample code is not in fact the standard `System.ComponentModel.DateTimeOffsetConverter` but the custom version created in the [Sample basic converter](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to?pivots=dotnet-5-0#sample-basic-converter) section. So I simply changed the link to point to the custom implementation instead of `System.ComponentModel.DateTimeOffsetConverter`.