### PR TITLE
How to compare strings: correct the list of ordinal-comparison operations

### DIFF
--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -30,7 +30,6 @@ equality, but some differences, such as case differences, may be ignored.
 
 By default, the most common operations:
 
-- <xref:System.String.CompareTo%2A?displayProperty=nameWithType>
 - <xref:System.String.Equals%2A?displayProperty=nameWithType>
 - <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively
 


### PR DESCRIPTION
The `String.CompareTo` is mentioned twice in the [Default ordinal comparisons section](https://docs.microsoft.com/en-us/dotnet/csharp/how-to/compare-strings#default-ordinal-comparisons):

- first, before the example, as the one performing ordinal comparison
- second, after the example, as the one that differs from those that perform ordinal comparison

Contradiction.

The [String.CompareTo API page (remarks)](https://docs.microsoft.com/en-us/dotnet/api/system.string.compareto?view=net-5.0#remarks) says:

> ...You cannot use this method to perform culture-insensitive or ordinal comparisons...

That's why I've removed its mention from the first list