### PR TITLE
Change class to record

### DIFF
--- a/docs/core/extensions/snippets/configuration/console-json/TransientFaultHandlingOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/TransientFaultHandlingOptions.cs
@@ -2,7 +2,7 @@
 
 namespace ConsoleJson.Example
 {
-    public class TransientFaultHandlingOptions
+    public record TransientFaultHandlingOptions
     {
         public bool Enabled { get; set; }
         public TimeSpan AutoRetryDelay { get; set; }


### PR DESCRIPTION
According the documentation, it would be record.
"Consider the TransientFaultHandlingOptions record type defined as follows:"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
