### PR TITLE
Remove redundant link in system-text-json-immutability.md

### DIFF
--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -41,7 +41,7 @@ Records in C# 9 are also supported, as shown in the following example:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/Records.cs":::
 
-For types that are immutable because all their property setters are non-public, see the following section about [non-public property accessors](#non-public-property-accessors).
+For types that are immutable because all their property setters are non-public, see the section below.
 ::: zone-end
 
 ::: zone pivot="dotnet-core-3-1"

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -41,7 +41,7 @@ Records in C# 9 are also supported, as shown in the following example:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/Records.cs":::
 
-For types that are immutable because all their property setters are non-public, see the section below.
+For types that are immutable because all their property setters are non-public, see the following section.
 ::: zone-end
 
 ::: zone pivot="dotnet-core-3-1"


### PR DESCRIPTION
The following sentence:

> For types that are immutable because all their property setters are non-public, see the following section about **non-public property accessors**.

...references and links to the section titled **Non-public property accessors** but that section is literally one line below the above sentence, so the link is not really required (clicking the link makes the browser scroll just a few pixels down). I have removed the link and edited the sentence accordingly.