### PR TITLE
fix typo

### DIFF
--- a/docs/csharp/tutorials/generate-consume-asynchronous-stream.md
+++ b/docs/csharp/tutorials/generate-consume-asynchronous-stream.md
@@ -42,7 +42,7 @@ The starter application is a console application that uses the [GitHub GraphQL](
 
 :::code language="csharp" source="snippets/generate-consume-asynchronous-streams/start/Program.cs" id="SnippetStarterAppMain" :::
 
-You can either set a `GitHubKey` environment variable to your personal access token, or you can replace the last argument in the call to `GenEnvVariable` with your personal access token. Don't put your access code in source code if you'll be sharing the source with others. Never upload access codes to a shared source repository.
+You can either set a `GitHubKey` environment variable to your personal access token, or you can replace the last argument in the call to `GetEnvVariable` with your personal access token. Don't put your access code in source code if you'll be sharing the source with others. Never upload access codes to a shared source repository.
 
 After creating the GitHub client, the code in `Main` creates a progress reporting object and a cancellation token. Once those objects are created, `Main` calls `runPagedQueryAsync` to retrieve the most recent 250 created issues. After that task has finished, the results are displayed.
 


### PR DESCRIPTION
`GenEnvVariable` didn't appear in csharp/tutorials/AsyncStreams/start/IssuePRreport/IssuePRreport/Program.cs . so I think it's typo,
I'm just getting start in c# and not sure this should be `GetEnvVariable`. Some of issue mention GetEnvVariable and didn't say it's typo , so sorry if it's already correct. Also sorry for my suck English.

## Summary

fix typo (maybe)
