### PR TITLE
Update statement about SIMD platform support

### DIFF
--- a/docs/standard/simd.md
+++ b/docs/standard/simd.md
@@ -27,8 +27,7 @@ The .NET SIMD-accelerated types include the following types:
   > [!NOTE]
   > The <xref:System.Numerics.Vector%601> type is not included in the .NET Framework. You must install the [System.Numerics.Vectors](https://www.nuget.org/packages/System.Numerics.Vectors) NuGet package to get access to this type.
   
-The SIMD-accelerated types are implemented in such a way that they can be used with non-SIMD-accelerated hardware or JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be run by the runtime that uses the **RyuJIT** compiler. A **RyuJIT** compiler is included in .NET Core and in .NET Framework 4.6 and later. SIMD support is only provided when targeting 64-bit processors.
-
+The SIMD-accelerated types are implemented in such a way that they can be used with non-SIMD-accelerated hardware or JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be run by the runtime that uses the **RyuJIT** compiler. A **RyuJIT** compiler is included in .NET Core, .NET 5 and in .NET Framework 4.6 and later.
 ## How to use SIMD?
 
 Before executing custom SIMD algorithms, it's possible to check if the host machine supports SIMD by using <xref:System.Numerics.Vector.IsHardwareAccelerated?displayProperty=nameWithType>, which returns a <xref:System.Boolean>. This doesn't guarantee that SIMD-acceleration is enabled for a specific type, but is an indicator that it's supported by some types.

--- a/docs/standard/simd.md
+++ b/docs/standard/simd.md
@@ -27,7 +27,7 @@ The .NET SIMD-accelerated types include the following types:
   > [!NOTE]
   > The <xref:System.Numerics.Vector%601> type is not included in the .NET Framework. You must install the [System.Numerics.Vectors](https://www.nuget.org/packages/System.Numerics.Vectors) NuGet package to get access to this type.
   
-The SIMD-accelerated types are implemented in such a way that they can be used with non-SIMD-accelerated hardware or JIT compilers. To take advantage of SIMD instructions, your  apps must be run by the runtime that uses the **RyuJIT** compiler. A **RyuJIT** compiler is included in .NET Core, .NET 5 and in .NET Framework 4.6 and later.
+The SIMD-accelerated types are implemented in such a way that they can be used with non-SIMD-accelerated hardware or JIT compilers. To take advantage of SIMD instructions, your apps must be run by the runtime that uses the **RyuJIT** compiler. A **RyuJIT** compiler is included in .NET Core, .NET 5 and in .NET Framework 4.6 and later.
 ## How to use SIMD?
 
 Before executing custom SIMD algorithms, it's possible to check if the host machine supports SIMD by using <xref:System.Numerics.Vector.IsHardwareAccelerated?displayProperty=nameWithType>, which returns a <xref:System.Boolean>. This doesn't guarantee that SIMD-acceleration is enabled for a specific type, but is an indicator that it's supported by some types.

--- a/docs/standard/simd.md
+++ b/docs/standard/simd.md
@@ -27,7 +27,7 @@ The .NET SIMD-accelerated types include the following types:
   > [!NOTE]
   > The <xref:System.Numerics.Vector%601> type is not included in the .NET Framework. You must install the [System.Numerics.Vectors](https://www.nuget.org/packages/System.Numerics.Vectors) NuGet package to get access to this type.
   
-The SIMD-accelerated types are implemented in such a way that they can be used with non-SIMD-accelerated hardware or JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be run by the runtime that uses the **RyuJIT** compiler. A **RyuJIT** compiler is included in .NET Core, .NET 5 and in .NET Framework 4.6 and later.
+The SIMD-accelerated types are implemented in such a way that they can be used with non-SIMD-accelerated hardware or JIT compilers. To take advantage of SIMD instructions, your  apps must be run by the runtime that uses the **RyuJIT** compiler. A **RyuJIT** compiler is included in .NET Core, .NET 5 and in .NET Framework 4.6 and later.
 ## How to use SIMD?
 
 Before executing custom SIMD algorithms, it's possible to check if the host machine supports SIMD by using <xref:System.Numerics.Vector.IsHardwareAccelerated?displayProperty=nameWithType>, which returns a <xref:System.Boolean>. This doesn't guarantee that SIMD-acceleration is enabled for a specific type, but is an indicator that it's supported by some types.


### PR DESCRIPTION
`Console.WriteLine(System.Numerics.Vector.IsHardwareAccelerated);` reports `true` on `win-x86` platform. .NET Core 2+ and .NET 5+ have supported hardware accelerated vector types through RyuJIT for quite a while on x86 and ARM platforms (https://devblogs.microsoft.com/dotnet/the-ryujit-transition-is-complete/). Additionally, Mono (and MonoVM in .NET 6) also supports these types on some platforms and configurations though the support matrix is not an easy one and it's a moving target in case of .NET 6.

I am not sure how to modify the wording but the current statement is outright incorrect.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
