### PR TITLE
Numeric parsing precision breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -22,6 +22,7 @@ If you're migrating an app to .NET 6.0, the breaking changes listed here might a
 ## Core .NET libraries
 
 - [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md)
+- [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md)
 
 ## Windows Forms
 

--- a/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
+++ b/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
@@ -5,11 +5,22 @@ ms.date: 02/26/2021
 ---
 # Standard numeric format parsing precision
 
-
+In .NET 6+, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType> when formatting numbers as strings using `ToString` and `TryFormat`.
 
 ## Change description
 
+In previous .NET versions, the standard numeric format parsing logic is limited to a precision of 99 or less. Some numeric types have more precision, but `ToString(string format)` does not expose it correctly. If you specify a precision greater than 99, for example, `32.ToString("C100")`, the format string is interpreted as a custom numeric format string instead of "currency with precision 100". In custom numeric format strings, characters are interpreted as character literals. In addition, a format string that contains an invalid format specifier (that is, the character at the beginning of the string) is interpreted differently depending on the precision value. `H99` throws a <xref:System.FormatException> for the invalid format specifier, while `H100` is interpreted as a custom numeric format string.
 
+Starting in .NET 6, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType>. A format string that consists of a valid format specifier with any number of digits is interpreted as a standard numeric format string with precision. If you specify a precision that's greater than <xref:System.Int32.MaxValue?displayProperty=nameWithType>, a <xref:System.FormatException> is thrown. This change was implemented in the parsing logic that affects all numeric types.
+
+The following table shows how the behavior for various format strings changed.
+
+| Format string | Previous behavior | .NET 6+ behavior |
+| - | - | - |
+| `C2` | Denotes currency with two decimal digits | Denotes currency with two decimal digits (no change) |
+| `C100` | Denotes custom numeric format string that prints "C100" | Denotes currency with 100 decimal digits |
+| `H99` | Throws <xref:System.FormatException> due to invalid standard format specifier "H" | Denotes custom numeric format string |
+| `H100` | Denotes custom numeric format string | Denotes custom numeric format string (no change) |
 
 ## Version introduced
 
@@ -17,15 +28,68 @@ ms.date: 02/26/2021
 
 ## Reason for change
 
-
+This change corrects unexpected behavior when using higher precision for numeric format parsing.
 
 ## Recommended action
 
+In most cases, no action is necessary and the correct precision will be shown in the resulting strings.
 
+However, if you want to revert to the previous (incorrect) behavior where the alphabetic character in the format string is interpreted as a literal character when the precision is greater than 99, you can wrap the first character in single quotes or escape it with a backslash. For example, in previous .NET versions, `42.ToString("G999")` returns `G999`. To maintain that behavior, change the format string to `"'G'999"`. This will work on .NET Framework, .NET Core, and .NET 5+.
+
+The following format strings will continue to be interpreted as custom numeric format strings:
+
+- Start with any character that is not an ASCII alphabetical character, for example, `$` or `è`.
+- Start with an ASCII alphabetical character that's not followed by an ASCII digit, for example, `A$`.
+- Start with an ASCII alphabetical character, followed by an ASCII digit sequence, and then any character that is not an ASCII digit character, for example, `A55A`.
 
 ## Affected APIs
 
+This change was implemented in the parsing logic that affects all numeric types.
 
+- <xref:System.Numerics.BigInteger.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Numerics.BigInteger.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Numerics.BigInteger.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Int32.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Int32.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Int32.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.UInt32.ToString(System.String)?displayProperty=fullName>
+- <xref:System.UInt32.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.UInt32.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Byte.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Byte.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Byte.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.SByte.ToString(System.String)?displayProperty=fullName>
+- <xref:System.SByte.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.SByte.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Int16.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Int16.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Int16.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.UInt16.ToString(System.String)?displayProperty=fullName>
+- <xref:System.UInt16.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.UInt16.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Int64.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Int64.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Int64.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.UInt64.ToString(System.String)?displayProperty=fullName>
+- <xref:System.UInt64.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.UInt64.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Half.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Half.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Half.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Single.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Single.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Single.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Double.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Double.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Double.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Decimal.ToString(System.String)?displayProperty=fullName>
+- <xref:System.Decimal.ToString(System.String,System.IFormatProvider)?displayProperty=fullName>
+- <xref:System.Decimal.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=fullName>
+
+## See also
+
+- [Standard numeric format strings](../../../../standard/base-types/standard-numeric-format-strings.md)
+- [Character literals in custom format strings](../../../../standard/base-types/custom-numeric-format-strings.md#character-literals)
 
 <!--
 
@@ -35,6 +99,44 @@ Core .NET libraries
 
 ### Affected APIs
 
-- ``
+- `M:System.Numerics.BigInteger.ToString(System.String)`
+- `M:System.Numerics.BigInteger.ToString(System.String,System.IFormatProvider)`
+- `M:System.Numerics.BigInteger.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Int32.ToString(System.String)`
+- `M:System.Int32.ToString(System.String,System.IFormatProvider)`
+- `M:System.Int32.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.UInt32.ToString(System.String)`
+- `M:System.UInt32.ToString(System.String,System.IFormatProvider)`
+- `M:System.UInt32.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Byte.ToString(System.String)`
+- `M:System.Byte.ToString(System.String,System.IFormatProvider)`
+- `M:System.Byte.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.SByte.ToString(System.String)`
+- `M:System.SByte.ToString(System.String,System.IFormatProvider)`
+- `M:System.SByte.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Int16.ToString(System.String)`
+- `M:System.Int16.ToString(System.String,System.IFormatProvider)`
+- `M:System.Int16.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.UInt16.ToString(System.String)`
+- `M:System.UInt16.ToString(System.String,System.IFormatProvider)`
+- `M:System.UInt16.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Int64.ToString(System.String)`
+- `M:System.Int64.ToString(System.String,System.IFormatProvider)`
+- `M:System.Int64.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.UInt64.ToString(System.String)`
+- `M:System.UInt64.ToString(System.String,System.IFormatProvider)`
+- `M:System.UInt64.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Half.ToString(System.String)`
+- `M:System.Half.ToString(System.String,System.IFormatProvider)`
+- `M:System.Half.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Single.ToString(System.String)`
+- `M:System.Single.ToString(System.String,System.IFormatProvider)`
+- `M:System.Single.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Double.ToString(System.String)`
+- `M:System.Double.ToString(System.String,System.IFormatProvider)`
+- `M:System.Double.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
+- `M:System.Decimal.ToString(System.String)`
+- `M:System.Decimal.ToString(System.String,System.IFormatProvider)`
+- `M:System.Decimal.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)`
 
 -->

--- a/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
+++ b/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
@@ -13,7 +13,12 @@ When formatting numbers as strings, the *precision specifier* in the format stri
 
 In previous .NET versions, the standard numeric format parsing logic is limited to a precision of 99 or less. Some numeric types have more precision, but `ToString(string format)` does not expose it correctly. If you specify a precision greater than 99, for example, `32.ToString("C100")`, the format string is interpreted as a custom numeric format string instead of "currency with precision 100". In custom numeric format strings, characters are interpreted as [character literals](../../../../standard/base-types/custom-numeric-format-strings.md#character-literals). In addition, a format string that contains an invalid format specifier (that is, the character at the beginning of the string) is interpreted differently depending on the precision value. `H99` throws a <xref:System.FormatException> for the invalid format specifier, while `H100` is interpreted as a custom numeric format string.
 
-Starting in .NET 6, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType>. A format string that consists of a valid format specifier with any number of digits is interpreted as a standard numeric format string with precision. If you specify a precision that's greater than <xref:System.Int32.MaxValue?displayProperty=nameWithType>, a <xref:System.FormatException> is thrown. This change was implemented in the parsing logic that affects all numeric types.
+Starting in .NET 6, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType>. A format string that consists of a format specifier with any number of digits is interpreted as a standard numeric format string with precision. A <xref:System.FormatException> is thrown for either or both of the following conditions:
+
+- The format specifier character is not a [standard format specifier](../../../../standard/base-types/standard-numeric-format-strings.md#standard-format-specifiers).
+- The precision is greater than <xref:System.Int32.MaxValue?displayProperty=nameWithType>.
+
+This change was implemented in the parsing logic that affects all numeric types.
 
 The following table shows the behavior changes for various format strings.
 
@@ -21,8 +26,8 @@ The following table shows the behavior changes for various format strings.
 | - | - | - |
 | `C2` | Denotes currency with two decimal digits | Denotes currency with two decimal digits (no change) |
 | `C100` | Denotes custom numeric format string that prints "C100" | Denotes currency with 100 decimal digits |
-| `H99` | Throws <xref:System.FormatException> due to invalid standard format specifier "H" | Denotes custom numeric format string |
-| `H100` | Denotes custom numeric format string | Denotes custom numeric format string (no change) |
+| `H99` | Throws <xref:System.FormatException> due to invalid standard format specifier "H" | Throws <xref:System.FormatException> due to invalid standard format specifier "H" (no change) |
+| `H100` | Denotes custom numeric format string | Throws <xref:System.FormatException> due to invalid standard format specifier "H" |
 
 ## Version introduced
 
@@ -42,7 +47,7 @@ The following format strings will continue to be interpreted as custom numeric f
 
 - Start with any character that is not an ASCII alphabetical character, for example, `$` or `è`.
 - Start with an ASCII alphabetical character that's not followed by an ASCII digit, for example, `A$`.
-- Start with an ASCII alphabetical character, followed by an ASCII digit sequence, and then any character that is not an ASCII digit character, for example, `A55A`.
+- Start with an ASCII alphabetical character, followed by an ASCII digit sequence, and then any character that is not an ASCII digit character, for example, `A12A`.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
+++ b/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
@@ -5,15 +5,17 @@ ms.date: 02/26/2021
 ---
 # Standard numeric format parsing precision
 
-In .NET 6+, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType> when formatting numbers as strings using `ToString` and `TryFormat`.
+In .NET 6+, .NET supports greater precision values when formatting numbers as strings using `ToString` and `TryFormat`.
 
 ## Change description
 
-In previous .NET versions, the standard numeric format parsing logic is limited to a precision of 99 or less. Some numeric types have more precision, but `ToString(string format)` does not expose it correctly. If you specify a precision greater than 99, for example, `32.ToString("C100")`, the format string is interpreted as a custom numeric format string instead of "currency with precision 100". In custom numeric format strings, characters are interpreted as character literals. In addition, a format string that contains an invalid format specifier (that is, the character at the beginning of the string) is interpreted differently depending on the precision value. `H99` throws a <xref:System.FormatException> for the invalid format specifier, while `H100` is interpreted as a custom numeric format string.
+When formatting numbers as strings, the *precision specifier* in the format string represents the number of digits in the resulting string. Depending on the *format specifier*, the precision can represent the total number of digits, the number of significant digits, or the number of decimal digits.
+
+In previous .NET versions, the standard numeric format parsing logic is limited to a precision of 99 or less. Some numeric types have more precision, but `ToString(string format)` does not expose it correctly. If you specify a precision greater than 99, for example, `32.ToString("C100")`, the format string is interpreted as a custom numeric format string instead of "currency with precision 100". In custom numeric format strings, characters are interpreted as [character literals](../../../../standard/base-types/custom-numeric-format-strings.md#character-literals). In addition, a format string that contains an invalid format specifier (that is, the character at the beginning of the string) is interpreted differently depending on the precision value. `H99` throws a <xref:System.FormatException> for the invalid format specifier, while `H100` is interpreted as a custom numeric format string.
 
 Starting in .NET 6, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType>. A format string that consists of a valid format specifier with any number of digits is interpreted as a standard numeric format string with precision. If you specify a precision that's greater than <xref:System.Int32.MaxValue?displayProperty=nameWithType>, a <xref:System.FormatException> is thrown. This change was implemented in the parsing logic that affects all numeric types.
 
-The following table shows how the behavior for various format strings changed.
+The following table shows the behavior changes for various format strings.
 
 | Format string | Previous behavior | .NET 6+ behavior |
 | - | - | - |
@@ -34,7 +36,7 @@ This change corrects unexpected behavior when using higher precision for numeric
 
 In most cases, no action is necessary and the correct precision will be shown in the resulting strings.
 
-However, if you want to revert to the previous (incorrect) behavior where the alphabetic character in the format string is interpreted as a literal character when the precision is greater than 99, you can wrap the first character in single quotes or escape it with a backslash. For example, in previous .NET versions, `42.ToString("G999")` returns `G999`. To maintain that behavior, change the format string to `"'G'999"`. This will work on .NET Framework, .NET Core, and .NET 5+.
+However, if you want to revert to the previous (incorrect) behavior where the format specifier is interpreted as a literal character when the precision is greater than 99, you can wrap that character in single quotes or escape it with a backslash. For example, in previous .NET versions, `42.ToString("G999")` returns `G999`. To maintain that behavior, change the format string to `"'G'999"` or `"\\G999"`. This will work on .NET Framework, .NET Core, and .NET 5+.
 
 The following format strings will continue to be interpreted as custom numeric format strings:
 

--- a/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
+++ b/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
@@ -5,13 +5,13 @@ ms.date: 02/26/2021
 ---
 # Standard numeric format parsing precision
 
-In .NET 6+, .NET supports greater precision values when formatting numbers as strings using `ToString` and `TryFormat`.
+.NET now supports greater precision values when formatting numbers as strings using `ToString` and `TryFormat`.
 
 ## Change description
 
-When formatting numbers as strings, the *precision specifier* in the format string represents the number of digits in the resulting string. Depending on the *format specifier*, the precision can represent the total number of digits, the number of significant digits, or the number of decimal digits.
+When formatting numbers as strings, the *precision specifier* in the [format string](../../../../standard/base-types/standard-numeric-format-strings.md) represents the number of digits in the resulting string. Depending on the *format specifier*, which is the [character at the beginning of the string](../../../../standard/base-types/standard-numeric-format-strings.md#standard-format-specifiers), the precision can represent the total number of digits, the number of significant digits, or the number of decimal digits.
 
-In previous .NET versions, the standard numeric format parsing logic is limited to a precision of 99 or less. Some numeric types have more precision, but `ToString(string format)` does not expose it correctly. If you specify a precision greater than 99, for example, `32.ToString("C100")`, the format string is interpreted as a custom numeric format string instead of "currency with precision 100". In custom numeric format strings, characters are interpreted as [character literals](../../../../standard/base-types/custom-numeric-format-strings.md#character-literals). In addition, a format string that contains an invalid format specifier (that is, the character at the beginning of the string) is interpreted differently depending on the precision value. `H99` throws a <xref:System.FormatException> for the invalid format specifier, while `H100` is interpreted as a custom numeric format string.
+In previous .NET versions, the standard numeric format parsing logic is limited to a precision of 99 or less. Some numeric types have more precision, but `ToString(string format)` does not expose it correctly. If you specify a precision greater than 99, for example, `32.ToString("C100")`, the format string is interpreted as a [custom numeric format string](../../../../standard/base-types/custom-numeric-format-strings.md) instead of "currency with precision 100". In custom numeric format strings, characters are interpreted as [character literals](../../../../standard/base-types/custom-numeric-format-strings.md#character-literals). In addition, a format string that contains an invalid format specifier is interpreted differently depending on the precision value. `H99` throws a <xref:System.FormatException> for the invalid format specifier, while `H100` is interpreted as a custom numeric format string.
 
 Starting in .NET 6, .NET supports precision up to <xref:System.Int32.MaxValue?displayProperty=nameWithType>. A format string that consists of a format specifier with any number of digits is interpreted as a standard numeric format string with precision. A <xref:System.FormatException> is thrown for either or both of the following conditions:
 
@@ -24,9 +24,9 @@ The following table shows the behavior changes for various format strings.
 
 | Format string | Previous behavior | .NET 6+ behavior |
 | - | - | - |
-| `C2` | Denotes currency with two decimal digits | Denotes currency with two decimal digits (no change) |
+| `C2` | Denotes currency with two decimal digits | Denotes currency with two decimal digits (*no change*) |
 | `C100` | Denotes custom numeric format string that prints "C100" | Denotes currency with 100 decimal digits |
-| `H99` | Throws <xref:System.FormatException> due to invalid standard format specifier "H" | Throws <xref:System.FormatException> due to invalid standard format specifier "H" (no change) |
+| `H99` | Throws <xref:System.FormatException> due to invalid standard format specifier "H" | Throws <xref:System.FormatException> due to invalid standard format specifier "H" (*no change*) |
 | `H100` | Denotes custom numeric format string | Throws <xref:System.FormatException> due to invalid standard format specifier "H" |
 
 ## Version introduced
@@ -41,7 +41,7 @@ This change corrects unexpected behavior when using higher precision for numeric
 
 In most cases, no action is necessary and the correct precision will be shown in the resulting strings.
 
-However, if you want to revert to the previous (incorrect) behavior where the format specifier is interpreted as a literal character when the precision is greater than 99, you can wrap that character in single quotes or escape it with a backslash. For example, in previous .NET versions, `42.ToString("G999")` returns `G999`. To maintain that behavior, change the format string to `"'G'999"` or `"\\G999"`. This will work on .NET Framework, .NET Core, and .NET 5+.
+However, if you want to revert to the previous behavior where the format specifier is interpreted as a literal character when the precision is greater than 99, you can wrap that character in single quotes or escape it with a backslash. For example, in previous .NET versions, `42.ToString("G999")` returns `G999`. To maintain that behavior, change the format string to `"'G'999"` or `"\\G999"`. This will work on .NET Framework, .NET Core, and .NET 5+.
 
 The following format strings will continue to be interpreted as custom numeric format strings:
 

--- a/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
+++ b/docs/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: Standard numeric format parsing precision"
+description: Learn about the .NET 6.0 breaking change in core .NET libraries where standard numeric format parsing now handles higher precisions.
+ms.date: 02/26/2021
+---
+# Standard numeric format parsing precision
+
+
+
+## Change description
+
+
+
+## Version introduced
+
+6.0 Preview 2
+
+## Reason for change
+
+
+
+## Recommended action
+
+
+
+## Affected APIs
+
+
+
+<!--
+
+### Category
+
+Core .NET libraries
+
+### Affected APIs
+
+- ``
+
+-->

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -40,6 +40,8 @@
         items:
         - name: Nullability annotation changes
           href: core-libraries/6.0/nullable-ref-type-annotation-changes.md
+        - name: Standard numeric format parsing precision
+          href: core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
       - name: Windows Forms
         items:
         - name: APIs throw ArgumentNullException
@@ -434,6 +436,8 @@
         items:
         - name: Nullability annotation changes
           href: core-libraries/6.0/nullable-ref-type-annotation-changes.md
+        - name: Standard numeric format parsing precision
+          href: core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
       - name: .NET 5.0
         items:
         - name: Assembly-related API changes for single-file publishing

--- a/docs/csharp/tutorials/exploration/interpolated-strings-local.md
+++ b/docs/csharp/tutorials/exploration/interpolated-strings-local.md
@@ -1,4 +1,3 @@
-
 ---
 title: String interpolation - C# tutorial
 description: This tutorial shows you how to use the C# string interpolation feature to include formatted expression results in a larger string.

--- a/docs/csharp/tutorials/exploration/interpolated-strings-local.md
+++ b/docs/csharp/tutorials/exploration/interpolated-strings-local.md
@@ -1,3 +1,4 @@
+
 ---
 title: String interpolation - C# tutorial
 description: This tutorial shows you how to use the C# string interpolation feature to include formatted expression results in a larger string.
@@ -97,7 +98,7 @@ In the previous section, two poorly formatted strings were inserted into the res
 Console.WriteLine($"On {date:d}, the price of {item} was {price:C2} per {unit}.");
 ```
 
-You specify a format string by following the interpolation expression with a colon (":") and the format string. "d" is a [standard date and time format string](../../../standard/base-types/standard-date-and-time-format-strings.md#the-short-date-d-format-specifier) that represents the short date format. "C2" is a  [standard numeric format string](../../../standard/base-types/standard-numeric-format-strings.md#the-currency-c-format-specifier) that represents a number as a currency value with two digits after the decimal point.
+You specify a format string by following the interpolation expression with a colon (":") and the format string. "d" is a [standard date and time format string](../../../standard/base-types/standard-date-and-time-format-strings.md#the-short-date-d-format-specifier) that represents the short date format. "C2" is a  [standard numeric format string](../../../standard/base-types/standard-numeric-format-strings.md#currency-format-specifier-c) that represents a number as a currency value with two digits after the decimal point.
 
 A number of types in the .NET libraries support a predefined set of format strings. These include all the numeric types and the date and time types. For a complete list of types that support format strings, see [Format Strings and .NET Class Library Types](../../../standard/base-types/formatting-types.md#format-strings-and-net-types) in the [Formatting Types in .NET](../../../standard/base-types/formatting-types.md) article.
 

--- a/docs/csharp/tutorials/exploration/interpolated-strings.yml
+++ b/docs/csharp/tutorials/exploration/interpolated-strings.yml
@@ -64,7 +64,7 @@ items:
     Console.WriteLine($"On {date:d}, the price of {item.Name} was {item.Price:C2} per {item.perPackage} items");
     ```
 
-    You specify a format string by following the interpolation expression with a colon (":") and the format string. "d" is a [standard date and time format string](../../../standard/base-types/standard-date-and-time-format-strings.md#the-short-date-d-format-specifier) that represents the short date format. "C2" is a [standard numeric format string](../../../standard/base-types/standard-numeric-format-strings.md#the-currency-c-format-specifier) that represents a number as a currency value with two digits after the decimal point.
+    You specify a format string by following the interpolation expression with a colon (":") and the format string. "d" is a [standard date and time format string](../../../standard/base-types/standard-date-and-time-format-strings.md#the-short-date-d-format-specifier) that represents the short date format. "C2" is a [standard numeric format string](../../../standard/base-types/standard-numeric-format-strings.md#currency-format-specifier-c) that represents a number as a currency value with two digits after the decimal point.
 
     A number of types in the .NET libraries support a predefined set of format strings. These include all the numeric types and the date and time types. For a complete list of types that support format strings, see [Format Strings and .NET Class Library Types](../../../standard/base-types/formatting-types.md#format-strings-and-net-types) in the [Formatting Types in .NET](../../../standard/base-types/formatting-types.md) article.
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -46,6 +46,8 @@ Standard numeric format strings are supported by:
 > [!TIP]
 > You can download the **Formatting Utility**, a .NET Core Windows Forms application that lets you apply format strings to either numeric or date and time values and displays the result string. Source code is available for [C#](/samples/dotnet/samples/windowsforms-formatting-utility-cs) and [Visual Basic](/samples/dotnet/samples/windowsforms-formatting-utility-vb).
 
+## Standard format specifiers
+
 <a name="table"></a> The following table describes the standard numeric format specifiers and displays sample output produced by each format specifier. See the [Notes](#NotesStandardFormatting) section for additional information about using standard numeric format strings, and the [Example](#example) section for a comprehensive illustration of their use.
 
 |Format specifier|Name|Description|Examples|
@@ -63,7 +65,7 @@ Standard numeric format strings are supported by:
 
 <a name="Using"></a>
 
-## Using Standard Numeric Format Strings
+## Use standard numeric format strings
 
 [!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
@@ -93,7 +95,7 @@ The following sections provide detailed information about each of the standard n
 
 <a name="CFormatString"></a>
 
-## The Currency ("C") Format Specifier
+## Currency format specifier (C)
 
 The "C" (or currency) format specifier converts a number to a string that represents a currency amount. The precision specifier indicates the desired number of decimal places in the result string. If the precision specifier is omitted, the default precision is defined by the <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits%2A?displayProperty=nameWithType> property.
 
@@ -122,7 +124,7 @@ The following example formats a <xref:System.Double> value with the currency for
 
 <a name="DFormatString"></a>
 
-## The Decimal ("D") Format Specifier
+## Decimal format specifier (D)
 
 The "D" (or decimal) format specifier converts a number to a string of decimal digits (0-9), prefixed by a minus sign if the number is negative. This format is supported only for integral types.
 
@@ -144,7 +146,7 @@ The following example formats an <xref:System.Int32> value with the decimal form
 
 <a name="EFormatString"></a>
 
-## The Exponential ("E") Format Specifier
+## Exponential format specifier (E)
 
 The exponential ("E") format specifier converts a number to a string of the form "-d.ddd…E+ddd" or "-d.ddd…e+ddd", where each "d" indicates a digit (0-9). The string starts with a minus sign if the number is negative. Exactly one digit always precedes the decimal point.
 
@@ -170,7 +172,7 @@ The following example formats a <xref:System.Double> value with the exponential 
 
 <a name="FFormatString"></a>
 
-## The Fixed-Point ("F") Format Specifier
+## Fixed-point format specifier (F)
 
 The fixed-point ("F") format specifier converts a number to a string of the form "-ddd.ddd…" where each "d" indicates a digit (0-9). The string starts with a minus sign if the number is negative.
 
@@ -194,7 +196,7 @@ The following example formats a <xref:System.Double> and an <xref:System.Int32> 
 
 <a name="GFormatString"></a>
 
-## The General ("G") Format Specifier
+## General format specifier (G)
 
 The general ("G") format specifier converts a number to the more compact of either fixed-point or scientific notation, depending on the type of the number and whether a precision specifier is present. The precision specifier defines the maximum number of significant digits that can appear in the result string. If the precision specifier is omitted or zero, the type of the number determines the default precision, as indicated in the following table.
 
@@ -241,7 +243,7 @@ The following example formats assorted floating-point values with the general fo
 
 <a name="NFormatString"></a>
 
-## The Numeric ("N") Format Specifier
+## Numeric format specifier (N)
 
 The numeric ("N") format specifier converts a number to a string of the form "-d,ddd,ddd.ddd…", where "-" indicates a negative number symbol if required, "d" indicates a digit (0-9), "," indicates a group separator, and "." indicates a decimal point symbol. The precision specifier indicates the desired number of digits after the decimal point. If the precision specifier is omitted, the number of decimal places is defined by the current <xref:System.Globalization.NumberFormatInfo.NumberDecimalDigits%2A?displayProperty=nameWithType> property.
 
@@ -266,7 +268,7 @@ The following example formats assorted floating-point values with the number for
 
 <a name="PFormatString"></a>
 
-## The Percent ("P") Format Specifier
+## Percent format specifier (P)
 
 The percent ("P") format specifier multiplies a number by 100 and converts it to a string that represents a percentage. The precision specifier indicates the desired number of decimal places. If the precision specifier is omitted, the default numeric precision supplied by the current <xref:System.Globalization.NumberFormatInfo.PercentDecimalDigits%2A> property is used.
 
@@ -293,7 +295,7 @@ The following example formats floating-point values with the percent format spec
 
 <a name="RFormatString"></a>
 
-## The Round-trip ("R") Format Specifier
+## Round-trip format specifier (R)
 
 The round-trip ("R") format specifier attempts to ensure that a numeric value that is converted to a string is parsed back into the same numeric value. This format is supported only for the <xref:System.Single>, <xref:System.Double>, and <xref:System.Numerics.BigInteger> types.
 
@@ -328,7 +330,7 @@ To work around the problem of <xref:System.Double> values formatted with the "R"
 
 <a name="XFormatString"></a>
 
-## The Hexadecimal ("X") Format Specifier
+## Hexadecimal format specifier (X)
 
 The hexadecimal ("X") format specifier converts a number to a string of hexadecimal digits. The case of the format specifier indicates whether to use uppercase or lowercase characters for hexadecimal digits that are greater than 9. For example, use "X" to produce "ABCDEF", and "x" to produce "abcdef". This format is supported only for integral types.
 
@@ -348,24 +350,24 @@ The following example formats <xref:System.Int32> values with the hexadecimal fo
 
 ## Notes
 
-### Control Panel Settings
+### Control Panel settings
 
 The settings in the **Regional and Language Options** item in Control Panel influence the result string produced by a formatting operation. Those settings are used to initialize the <xref:System.Globalization.NumberFormatInfo> object associated with the current thread culture, which provides values used to govern formatting. Computers that use different settings generate different result strings.
 
 In addition, if the <xref:System.Globalization.CultureInfo.%23ctor%28System.String%29> constructor is used to instantiate a new <xref:System.Globalization.CultureInfo> object that represents the same culture as the current system culture, any customizations established by the **Regional and Language Options** item in Control Panel will be applied to the new <xref:System.Globalization.CultureInfo> object. You can use the <xref:System.Globalization.CultureInfo.%23ctor%28System.String%2CSystem.Boolean%29> constructor to create a <xref:System.Globalization.CultureInfo> object that does not reflect a system's customizations.
 
-### NumberFormatInfo Properties
+### NumberFormatInfo properties
 
 Formatting is influenced by the properties of the current <xref:System.Globalization.NumberFormatInfo> object, which is provided implicitly by the current thread culture or explicitly by the <xref:System.IFormatProvider> parameter of the method that invokes formatting. Specify a <xref:System.Globalization.NumberFormatInfo> or <xref:System.Globalization.CultureInfo> object for that parameter.
 
 > [!NOTE]
 > For information about customizing the patterns or strings used in formatting numeric values, see the <xref:System.Globalization.NumberFormatInfo> class topic.
 
-### Integral and Floating-Point Numeric Types
+### Integral and floating-point numeric types
 
 Some descriptions of standard numeric format specifiers refer to integral or floating-point numeric types. The integral numeric types are <xref:System.Byte>, <xref:System.SByte>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>, and <xref:System.Numerics.BigInteger>. The floating-point numeric types are <xref:System.Decimal>, <xref:System.Single>, and <xref:System.Double>.
 
-### Floating-Point Infinities and NaN
+### Floating-point infinities and NaN
 
 Regardless of the format string, if the value of a <xref:System.Single> or <xref:System.Double> floating-point type is positive infinity, negative infinity, or not a number (NaN), the formatted string is the value of the respective <xref:System.Globalization.NumberFormatInfo.PositiveInfinitySymbol%2A>, <xref:System.Globalization.NumberFormatInfo.NegativeInfinitySymbol%2A>, or <xref:System.Globalization.NumberFormatInfo.NaNSymbol%2A> property that is specified by the currently applicable <xref:System.Globalization.NumberFormatInfo> object.
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -1,7 +1,7 @@
 ---
-title: "Standard numeric format strings"
+title: Standard numeric format strings
 description: In this article, learn to use standard numeric format strings to format common numeric types into text representations in .NET.
-ms.date: "06/10/2018"
+ms.date: 02/26/2021
 ms.topic: reference
 dev_langs:
   - "csharp"
@@ -20,11 +20,11 @@ helpviewer_keywords:
 ---
 # Standard numeric format strings
 
-Standard numeric format strings are used to format common numeric types. A standard numeric format string takes the form `Axx`, where:
+Standard numeric format strings are used to format common numeric types. A standard numeric format string takes the form `Axxx`, where:
 
 - `A` is a single alphabetic character called the *format specifier*. Any numeric format string that contains more than one alphabetic character, including white space, is interpreted as a custom numeric format string. For more information, see [Custom Numeric Format Strings](custom-numeric-format-strings.md).
 
-- `xx` is an optional integer called the *precision specifier*. The precision specifier ranges from 0 to 99 and affects the number of digits in the result. Note that the precision specifier controls the number of digits in the string representation of a number. It does not round the number itself. To perform a rounding operation, use the <xref:System.Math.Ceiling%2A?displayProperty=nameWithType>, <xref:System.Math.Floor%2A?displayProperty=nameWithType>, or <xref:System.Math.Round%2A?displayProperty=nameWithType> method.
+- `xxx` is an optional integer called the *precision specifier*. The precision specifier affects the number of digits in the resulting string. In .NET 6 and later versions, the maximum precision value is <xref:System.Int32.MaxValue?displayProperty=nameWithType>. In previous .NET versions, the precision can range from 0 to 99. The precision specifier controls the number of digits in the string representation of a number. It does not round the number itself. To perform a rounding operation, use the <xref:System.Math.Ceiling%2A?displayProperty=nameWithType>, <xref:System.Math.Floor%2A?displayProperty=nameWithType>, or <xref:System.Math.Round%2A?displayProperty=nameWithType> method.
 
   When *precision specifier* controls the number of fractional digits in the result string, the result string reflects a number that is rounded to a representable result nearest to the infinitely precise result. If there are two equally near representable results:
   - **On .NET Framework and .NET Core up to .NET Core 2.0**, the runtime selects the result with the greater least significant digit (that is, using <xref:System.MidpointRounding.AwayFromZero?displayProperty=nameWithType>).
@@ -36,6 +36,8 @@ Standard numeric format strings are used to format common numeric types. A stand
 Standard numeric format strings are supported by:
 
 - Some overloads of the `ToString` method of all numeric types. For example, you can supply a numeric format string to the <xref:System.Int32.ToString%28System.String%29?displayProperty=nameWithType> and <xref:System.Int32.ToString%28System.String%2CSystem.IFormatProvider%29?displayProperty=nameWithType> methods.
+
+- The `TryFormat` method of all numeric types, for example, <xref:System.Int32.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=nameWithType> and <xref:System.Single.TryFormat(System.Span{System.Char},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)?displayProperty=nameWithType>.
 
 - The .NET [composite formatting feature](composite-formatting.md), which is used by some `Write` and `WriteLine` methods of the <xref:System.Console> and <xref:System.IO.StreamWriter> classes, the <xref:System.String.Format%2A?displayProperty=nameWithType> method, and the <xref:System.Text.StringBuilder.AppendFormat%2A?displayProperty=nameWithType> method. The composite format feature allows you to include the string representation of multiple data items in a single string, to specify field width, and to align numbers in a field. For more information, see [Composite Formatting](composite-formatting.md).
 
@@ -65,9 +67,9 @@ Standard numeric format strings are supported by:
 
 [!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
-A standard numeric format string can be used to define the formatting of a numeric value in one of two ways:
+A standard numeric format string can be used to define the formatting of a numeric value in one of the following ways:
 
-- It can be passed to an overload of the `ToString` method that has a `format` parameter. The following example formats a numeric value as a currency string in the current culture (in this case, the en-US culture).
+- It can be passed to the `TryFormat` method or an overload of the `ToString` method that has a `format` parameter. The following example formats a numeric value as a currency string in the current culture (in this case, the en-US culture).
 
   [!code-cpp[Formatting.Numeric.Standard#10](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/standardusage1.cpp#10)]
   [!code-csharp-interactive[Formatting.Numeric.Standard#10](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#10)]
@@ -85,7 +87,7 @@ A standard numeric format string can be used to define the formatting of a numer
   [!code-csharp-interactive[Formatting.Numeric.Standard#12](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#12)]
   [!code-vb[Formatting.Numeric.Standard#12](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/standardusage1.vb#12)]
 
-- It can be supplied as the `formatString` argument in an interpolated expression item of an interpolated string. For more information, see the [String interpolation](../../csharp/language-reference/tokens/interpolated.md) topic in the C# reference or the [Interpolated strings](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md) topic in the Visual Basic reference.
+- It can be supplied as the `formatString` argument in an interpolated expression item of an interpolated string. For more information, see the [String interpolation](../../csharp/language-reference/tokens/interpolated.md) article in the C# reference or the [Interpolated strings](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md) article in the Visual Basic reference.
 
 The following sections provide detailed information about each of the standard numeric format strings.
 
@@ -368,8 +370,6 @@ Some descriptions of standard numeric format specifiers refer to integral or flo
 Regardless of the format string, if the value of a <xref:System.Single> or <xref:System.Double> floating-point type is positive infinity, negative infinity, or not a number (NaN), the formatted string is the value of the respective <xref:System.Globalization.NumberFormatInfo.PositiveInfinitySymbol%2A>, <xref:System.Globalization.NumberFormatInfo.NegativeInfinitySymbol%2A>, or <xref:System.Globalization.NumberFormatInfo.NaNSymbol%2A> property that is specified by the currently applicable <xref:System.Globalization.NumberFormatInfo> object.
 
 ## Example
-
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-partial-note.md)]
 
 The following example formats an integral and a floating-point numeric value using the en-US culture and all the standard numeric format specifiers. This example uses two particular numeric types (<xref:System.Double> and <xref:System.Int32>), but would yield similar results for any of the other numeric base types (<xref:System.Byte>, <xref:System.SByte>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>, <xref:System.Numerics.BigInteger>, <xref:System.Decimal>, and <xref:System.Single>).
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -20,11 +20,11 @@ helpviewer_keywords:
 ---
 # Standard numeric format strings
 
-Standard numeric format strings are used to format common numeric types. A standard numeric format string takes the form `Axxx`, where:
+Standard numeric format strings are used to format common numeric types. A standard numeric format string takes the form *`[format specifier][precision specifier]`*, where:
 
-- `A` is a single alphabetic character called the *format specifier*. Any numeric format string that contains more than one alphabetic character, including white space, is interpreted as a custom numeric format string. For more information, see [Custom Numeric Format Strings](custom-numeric-format-strings.md).
+- *Format specifier* is a single alphabetic character that specifies the type of number format, for example, currency or percent. Any numeric format string that contains more than one alphabetic character, including white space, is interpreted as a custom numeric format string. For more information, see [Custom numeric format strings](custom-numeric-format-strings.md).
 
-- `xxx` is an optional integer called the *precision specifier*. The precision specifier affects the number of digits in the resulting string. In .NET 6 and later versions, the maximum precision value is <xref:System.Int32.MaxValue?displayProperty=nameWithType>. In previous .NET versions, the precision can range from 0 to 99. The precision specifier controls the number of digits in the string representation of a number. It does not round the number itself. To perform a rounding operation, use the <xref:System.Math.Ceiling%2A?displayProperty=nameWithType>, <xref:System.Math.Floor%2A?displayProperty=nameWithType>, or <xref:System.Math.Round%2A?displayProperty=nameWithType> method.
+- *Precision specifier* is an optional integer that affects the number of digits in the resulting string. In .NET 6 and later versions, the maximum precision value is <xref:System.Int32.MaxValue?displayProperty=nameWithType>. In previous .NET versions, the precision can range from 0 to 99. The precision specifier controls the number of digits in the string representation of a number. It does not round the number itself. To perform a rounding operation, use the <xref:System.Math.Ceiling%2A?displayProperty=nameWithType>, <xref:System.Math.Floor%2A?displayProperty=nameWithType>, or <xref:System.Math.Round%2A?displayProperty=nameWithType> method.
 
   When *precision specifier* controls the number of fractional digits in the result string, the result string reflects a number that is rounded to a representable result nearest to the infinitely precise result. If there are two equally near representable results:
   - **On .NET Framework and .NET Core up to .NET Core 2.0**, the runtime selects the result with the greater least significant digit (that is, using <xref:System.MidpointRounding.AwayFromZero?displayProperty=nameWithType>).

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -48,22 +48,20 @@ Standard numeric format strings are supported by:
 
 ## Standard format specifiers
 
-<a name="table"></a> The following table describes the standard numeric format specifiers and displays sample output produced by each format specifier. See the [Notes](#NotesStandardFormatting) section for additional information about using standard numeric format strings, and the [Example](#example) section for a comprehensive illustration of their use.
+The following table describes the standard numeric format specifiers and displays sample output produced by each format specifier. See the [Notes](#notes) section for additional information about using standard numeric format strings, and the [Code example](#code-example) section for a comprehensive illustration of their use.
 
 |Format specifier|Name|Description|Examples|
 |----------------------|----------|-----------------|--------------|
-|"C" or "c"|Currency|Result: A currency value.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Currency ("C") Format Specifier](#CFormatString).|123.456 ("C", en-US) -> \\$123.46<br /><br /> 123.456 ("C", fr-FR) -> 123,46 &euro;<br /><br /> 123.456 ("C", ja-JP) -> ¥123<br /><br /> -123.456 ("C3", en-US) -> (\\$123.456)<br /><br /> -123.456 ("C3", fr-FR) -> -123,456 &euro;<br /><br /> -123.456 ("C3", ja-JP) -> -¥123.456|
-|"D" or "d"|Decimal|Result: Integer digits with optional negative sign.<br /><br /> Supported by: Integral types only.<br /><br /> Precision specifier: Minimum number of digits.<br /><br /> Default precision specifier: Minimum number of digits required.<br /><br /> More information: [The Decimal("D") Format Specifier](#DFormatString).|1234 ("D") -> 1234<br /><br /> -1234 ("D6") -> -001234|
-|"E" or "e"|Exponential (scientific)|Result: Exponential notation.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: 6.<br /><br /> More information: [The Exponential ("E") Format Specifier](#EFormatString).|1052.0329112756 ("E", en-US) -> 1.052033E+003<br /><br /> 1052.0329112756 ("e", fr-FR) -> 1,052033e+003<br /><br /> -1052.0329112756 ("e2", en-US) -> -1.05e+003<br /><br /> -1052.0329112756 ("E2", fr-FR) -> -1,05E+003|
-|"F" or "f"|Fixed-point|Result: Integral and decimal digits with optional negative sign.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.NumberDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Fixed-Point ("F") Format Specifier](#FFormatString).|1234.567 ("F", en-US) -> 1234.57<br /><br /> 1234.567 ("F", de-DE) -> 1234,57<br /><br /> 1234 ("F1", en-US) -> 1234.0<br /><br /> 1234 ("F1", de-DE) -> 1234,0<br /><br /> -1234.56 ("F4", en-US) -> -1234.5600<br /><br /> -1234.56 ("F4", de-DE) -> -1234,5600|
-|"G" or "g"|General|Result: The more compact of either fixed-point or scientific notation.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of significant digits.<br /><br /> Default precision specifier: Depends on numeric type.<br /><br /> More information: [The General ("G") Format Specifier](#GFormatString).|-123.456 ("G", en-US) -> -123.456<br /><br /> -123.456 ("G", sv-SE) -> -123,456<br /><br /> 123.4546 ("G4", en-US) -> 123.5<br /><br /> 123.4546 ("G4", sv-SE) -> 123,5<br /><br /> -1.234567890e-25 ("G", en-US) -> -1.23456789E-25<br /><br /> -1.234567890e-25 ("G", sv-SE) -> -1,23456789E-25|
-|"N" or "n"|Number|Result: Integral and decimal digits, group separators, and a decimal separator with optional negative sign.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Desired number of decimal places.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.NumberDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Numeric ("N") Format Specifier](#NFormatString).|1234.567 ("N", en-US) -> 1,234.57<br /><br /> 1234.567 ("N", ru-RU) -> 1 234,57<br /><br /> 1234 ("N1", en-US) -> 1,234.0<br /><br /> 1234 ("N1", ru-RU) -> 1 234,0<br /><br /> -1234.56 ("N3", en-US) -> -1,234.560<br /><br /> -1234.56 ("N3", ru-RU) -> -1 234,560|
-|"P" or "p"|Percent|Result: Number multiplied by 100 and displayed with a percent symbol.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Desired number of decimal places.<br /><br /> Default precision specifier: Defined by  <xref:System.Globalization.NumberFormatInfo.PercentDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Percent ("P") Format Specifier](#PFormatString).|1 ("P", en-US) -> 100.00 %<br /><br /> 1 ("P", fr-FR) -> 100,00 %<br /><br /> -0.39678 ("P1", en-US) -> -39.7 %<br /><br /> -0.39678 ("P1", fr-FR) -> -39,7 %|
-|"R" or "r"|Round-trip|Result: A string that can round-trip to an identical number.<br /><br /> Supported by: <xref:System.Single>, <xref:System.Double>, and <xref:System.Numerics.BigInteger>.<br /><br /> Note: Recommended for the <xref:System.Numerics.BigInteger> type only. For <xref:System.Double> types, use "G17"; for <xref:System.Single> types, use "G9". <br> Precision specifier: Ignored.<br /><br /> More information: [The Round-trip ("R") Format Specifier](#RFormatString).|123456789.12345678 ("R") -> 123456789.12345678<br /><br /> -1234567890.12345678 ("R") -> -1234567890.1234567|
-|"X" or "x"|Hexadecimal|Result: A hexadecimal string.<br /><br /> Supported by: Integral types only.<br /><br /> Precision specifier: Number of digits in the result string.<br /><br /> More information: [The HexaDecimal ("X") Format Specifier](#XFormatString).|255 ("X") -> FF<br /><br /> -1 ("x") -> ff<br /><br /> 255 ("x4") -> 00ff<br /><br /> -1 ("X4") -> 00FF|
+|"C" or "c"|Currency|Result: A currency value.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Currency ("C") Format Specifier](#CFormatString).|123.456 ("C", en-US)<br />-> \\$123.46<br /><br /> 123.456 ("C", fr-FR)<br />-> 123,46 &euro;<br /><br /> 123.456 ("C", ja-JP)<br />-> ¥123<br /><br /> -123.456 ("C3", en-US)<br />-> (\\$123.456)<br /><br /> -123.456 ("C3", fr-FR)<br />-> -123,456 &euro;<br /><br /> -123.456 ("C3", ja-JP)<br />-> -¥123.456|
+|"D" or "d"|Decimal|Result: Integer digits with optional negative sign.<br /><br /> Supported by: Integral types only.<br /><br /> Precision specifier: Minimum number of digits.<br /><br /> Default precision specifier: Minimum number of digits required.<br /><br /> More information: [The Decimal("D") Format Specifier](#DFormatString).|1234 ("D")<br />-> 1234<br /><br /> -1234 ("D6")<br />-> -001234|
+|"E" or "e"|Exponential (scientific)|Result: Exponential notation.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: 6.<br /><br /> More information: [The Exponential ("E") Format Specifier](#EFormatString).|1052.0329112756 ("E", en-US)<br />-> 1.052033E+003<br /><br /> 1052.0329112756 ("e", fr-FR)<br />-> 1,052033e+003<br /><br /> -1052.0329112756 ("e2", en-US)<br />-> -1.05e+003<br /><br /> -1052.0329112756 ("E2", fr-FR)<br />-> -1,05E+003|
+|"F" or "f"|Fixed-point|Result: Integral and decimal digits with optional negative sign.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.NumberDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Fixed-Point ("F") Format Specifier](#FFormatString).|1234.567 ("F", en-US)<br />-> 1234.57<br /><br /> 1234.567 ("F", de-DE)<br />-> 1234,57<br /><br /> 1234 ("F1", en-US)<br />-> 1234.0<br /><br /> 1234 ("F1", de-DE)<br />-> 1234,0<br /><br /> -1234.56 ("F4", en-US)<br />-> -1234.5600<br /><br /> -1234.56 ("F4", de-DE)<br />-> -1234,5600|
+|"G" or "g"|General|Result: The more compact of either fixed-point or scientific notation.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of significant digits.<br /><br /> Default precision specifier: Depends on numeric type.<br /><br /> More information: [The General ("G") Format Specifier](#GFormatString).|-123.456 ("G", en-US)<br />-> -123.456<br /><br /> -123.456 ("G", sv-SE)<br />-> -123,456<br /><br /> 123.4546 ("G4", en-US)<br />-> 123.5<br /><br /> 123.4546 ("G4", sv-SE)<br />-> 123,5<br /><br /> -1.234567890e-25 ("G", en-US)<br />-> -1.23456789E-25<br /><br /> -1.234567890e-25 ("G", sv-SE)<br />-> -1,23456789E-25|
+|"N" or "n"|Number|Result: Integral and decimal digits, group separators, and a decimal separator with optional negative sign.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Desired number of decimal places.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.NumberDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Numeric ("N") Format Specifier](#NFormatString).|1234.567 ("N", en-US)<br />-> 1,234.57<br /><br /> 1234.567 ("N", ru-RU)<br />-> 1 234,57<br /><br /> 1234 ("N1", en-US)<br />-> 1,234.0<br /><br /> 1234 ("N1", ru-RU)<br />-> 1 234,0<br /><br /> -1234.56 ("N3", en-US)<br />-> -1,234.560<br /><br /> -1234.56 ("N3", ru-RU)<br />-> -1 234,560|
+|"P" or "p"|Percent|Result: Number multiplied by 100 and displayed with a percent symbol.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Desired number of decimal places.<br /><br /> Default precision specifier: Defined by  <xref:System.Globalization.NumberFormatInfo.PercentDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Percent ("P") Format Specifier](#PFormatString).|1 ("P", en-US)<br />-> 100.00 %<br /><br /> 1 ("P", fr-FR)<br />-> 100,00 %<br /><br /> -0.39678 ("P1", en-US)<br />-> -39.7 %<br /><br /> -0.39678 ("P1", fr-FR)<br />-> -39,7 %|
+|"R" or "r"|Round-trip|Result: A string that can round-trip to an identical number.<br /><br /> Supported by: <xref:System.Single>, <xref:System.Double>, and <xref:System.Numerics.BigInteger>.<br /><br /> Note: Recommended for the <xref:System.Numerics.BigInteger> type only. For <xref:System.Double> types, use "G17"; for <xref:System.Single> types, use "G9". <br> Precision specifier: Ignored.<br /><br /> More information: [The Round-trip ("R") Format Specifier](#RFormatString).|123456789.12345678 ("R")<br />-> 123456789.12345678<br /><br /> -1234567890.12345678 ("R")<br />-> -1234567890.1234567|
+|"X" or "x"|Hexadecimal|Result: A hexadecimal string.<br /><br /> Supported by: Integral types only.<br /><br /> Precision specifier: Number of digits in the result string.<br /><br /> More information: [The HexaDecimal ("X") Format Specifier](#XFormatString).|255 ("X")<br />-> FF<br /><br /> -1 ("x")<br />-> ff<br /><br /> 255 ("x4")<br />-> 00ff<br /><br /> -1 ("X4")<br />-> 00FF|
 |Any other single character|Unknown specifier|Result: Throws a <xref:System.FormatException> at run time.||
-
-<a name="Using"></a>
 
 ## Use standard numeric format strings
 
@@ -120,8 +118,6 @@ The following example formats a <xref:System.Double> value with the currency for
 [!code-csharp[Formatting.Numeric.Standard#1](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#1)]
 [!code-vb[Formatting.Numeric.Standard#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#1)]
 
-[Back to table](#table)
-
 <a name="DFormatString"></a>
 
 ## Decimal format specifier (D)
@@ -141,8 +137,6 @@ The following example formats an <xref:System.Int32> value with the decimal form
 [!code-cpp[Formatting.Numeric.Standard#2](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/Standard.cpp#2)]
 [!code-csharp-interactive[Formatting.Numeric.Standard#2](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#2)]
 [!code-vb[Formatting.Numeric.Standard#2](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#2)]
-
-[Back to table](#table)
 
 <a name="EFormatString"></a>
 
@@ -168,8 +162,6 @@ The following example formats a <xref:System.Double> value with the exponential 
 [!code-csharp[Formatting.Numeric.Standard#3](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#3)]
 [!code-vb[Formatting.Numeric.Standard#3](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#3)]
 
-[Back to table](#table)
-
 <a name="FFormatString"></a>
 
 ## Fixed-point format specifier (F)
@@ -191,8 +183,6 @@ The following example formats a <xref:System.Double> and an <xref:System.Int32> 
 [!code-cpp[Formatting.Numeric.Standard#4](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/Standard.cpp#4)]
 [!code-csharp[Formatting.Numeric.Standard#4](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#4)]
 [!code-vb[Formatting.Numeric.Standard#4](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#4)]
-
-[Back to table](#table)
 
 <a name="GFormatString"></a>
 
@@ -239,8 +229,6 @@ The following example formats assorted floating-point values with the general fo
 [!code-csharp[Formatting.Numeric.Standard#5](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#5)]
 [!code-vb[Formatting.Numeric.Standard#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#5)]
 
-[Back to table](#table)
-
 <a name="NFormatString"></a>
 
 ## Numeric format specifier (N)
@@ -263,8 +251,6 @@ The following example formats assorted floating-point values with the number for
 [!code-cpp[Formatting.Numeric.Standard#6](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/Standard.cpp#6)]
 [!code-csharp[Formatting.Numeric.Standard#6](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#6)]
 [!code-vb[Formatting.Numeric.Standard#6](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#6)]
-
-[Back to table](#table)
 
 <a name="PFormatString"></a>
 
@@ -290,8 +276,6 @@ The following example formats floating-point values with the percent format spec
 [!code-cpp[Formatting.Numeric.Standard#7](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/Standard.cpp#7)]
 [!code-csharp[Formatting.Numeric.Standard#7](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#7)]
 [!code-vb[Formatting.Numeric.Standard#7](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#7)]
-
-[Back to table](#table)
 
 <a name="RFormatString"></a>
 
@@ -326,8 +310,6 @@ To work around the problem of <xref:System.Double> values formatted with the "R"
 [!code-csharp[System.Double.ToString#5](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.Double.ToString/cs/roundtripex1.cs#RoundTrip)]
 [!code-vb[System.Double.ToString#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Double.ToString/vb/roundtripex1.vb#5)]
 
-[Back to table](#table)
-
 <a name="XFormatString"></a>
 
 ## Hexadecimal format specifier (X)
@@ -344,11 +326,9 @@ The following example formats <xref:System.Int32> values with the hexadecimal fo
 [!code-csharp-interactive[Formatting.Numeric.Standard#9](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#9)]
 [!code-vb[Formatting.Numeric.Standard#9](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#9)]
 
-[Back to table](#table)
-
-<a name="NotesStandardFormatting"></a>
-
 ## Notes
+
+This section contains additional information about using standard numeric format strings.
 
 ### Control Panel settings
 
@@ -371,7 +351,7 @@ Some descriptions of standard numeric format specifiers refer to integral or flo
 
 Regardless of the format string, if the value of a <xref:System.Single> or <xref:System.Double> floating-point type is positive infinity, negative infinity, or not a number (NaN), the formatted string is the value of the respective <xref:System.Globalization.NumberFormatInfo.PositiveInfinitySymbol%2A>, <xref:System.Globalization.NumberFormatInfo.NegativeInfinitySymbol%2A>, or <xref:System.Globalization.NumberFormatInfo.NaNSymbol%2A> property that is specified by the currently applicable <xref:System.Globalization.NumberFormatInfo> object.
 
-## Example
+## Code example
 
 The following example formats an integral and a floating-point numeric value using the en-US culture and all the standard numeric format specifiers. This example uses two particular numeric types (<xref:System.Double> and <xref:System.Int32>), but would yield similar results for any of the other numeric base types (<xref:System.Byte>, <xref:System.SByte>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>, <xref:System.Numerics.BigInteger>, <xref:System.Decimal>, and <xref:System.Single>).
 


### PR DESCRIPTION
Fixes #22458.

Also updates "Standard numeric format strings" to include the new precision limit and to add the `TryFormat` method (available since .NET Core).

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision?branch=pr-en-us-23046).