### PR TITLE
Remove core from asp.net in migration

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2316,7 +2316,7 @@ items:
         href: ../core/porting/upgrade-assistant-wpf-framework.md
       - name: Windows Forms
         href: ../core/porting/upgrade-assistant-winforms-framework.md
-      - name: ASP.NET Core
+      - name: ASP.NET
         href: ../core/porting/upgrade-assistant-aspnetmvc.md
     - name: Analyze third-party dependencies
       href: ../core/porting/third-party-deps.md


### PR DESCRIPTION
## Summary

The migration guide entry for the upgrade tool isn't for ASP.NET Core, it's for ASP.NET
