### PR TITLE
Update TFMs for .NET 6

### DIFF
--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -48,7 +48,7 @@ A target framework is typically referenced by a TFM. The following table shows t
 
 ### .NET 5+ OS-specific TFMs
 
-The `net5.0` and `net6.0` TFMs only include technologies that work across different platforms. Specifying an *OS-specific TFM* makes APIs that are specific to an operating system available to your app, for example, Windows Forms or iOS bindings. OS-specific TFMs also inherit every API available to their base TFM, for example, the `net5.0` TFM.
+The `net5.0` and `net6.0` TFMs include technologies that work across different platforms. Specifying an *OS-specific TFM* makes APIs that are specific to an operating system available to your app, for example, Windows Forms or iOS bindings. OS-specific TFMs also inherit every API available to their base TFM, for example, the `net5.0` TFM.
 
 .NET 5 introduced the `net5.0-windows` OS-specific TFM, which includes Windows-specific bindings for WinForms, WPF, and UWP APIs. .NET 6 introduces further OS-specific TFMs.
 
@@ -80,7 +80,7 @@ Use these guidelines to determine which TFM to use in your app:
 
 #### OS version in TFMs
 
-You can also specify an optional OS version at the end of the TFM, for example, `net6.0-ios13.0`, which indicates what APIs are available to your app. (The .NET 6 SDK will be updated to include support for newer OS versions as they are released.) To gain access to newly released APIs, increment the OS version in the TFM. You can still make your app compatible with earlier OS versions (and add guards around calls to later-version APIs) by adding the `SupportedOSPlatformVersion` element to your project file. The `SupportedOSPlatformVersion` element indicates the minimum OS version required to run your app.
+You can also specify an optional OS version at the end of the TFM, for example, `net6.0-ios13.0`, which indicates what APIs are available to your app. (The corresponding .NET SDK will be updated to include support for newer OS versions as they are released.) To gain access to newly released APIs, increment the OS version in the TFM. You can still make your app compatible with earlier OS versions (and add guards around calls to later-version APIs) by adding the `SupportedOSPlatformVersion` element to your project file. The `SupportedOSPlatformVersion` element indicates the minimum OS version required to run your app.
 
 For example, the following project file excerpt specifies that iOS 14 APIs are available to the app, but it can run on iOS 13 or later machines.
 

--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -35,7 +35,7 @@ A target framework is typically referenced by a TFM. The following table shows t
 
 | Target Framework           | TFM |
 | -------------------------- | --- |
-| .NET 5+ (and .NET Core)    | netcoreapp1.0<br>netcoreapp1.1<br>netcoreapp2.0<br>netcoreapp2.1<br>netcoreapp2.2<br>netcoreapp3.0<br>netcoreapp3.1<br>net5.0<br>net6.0* |
+| .NET 5+ (and .NET Core)    | netcoreapp1.0<br>netcoreapp1.1<br>netcoreapp2.0<br>netcoreapp2.1<br>netcoreapp2.2<br>netcoreapp3.0<br>netcoreapp3.1<br>net5.0*<br>net6.0* |
 | .NET Standard              | netstandard1.0<br>netstandard1.1<br>netstandard1.2<br>netstandard1.3<br>netstandard1.4<br>netstandard1.5<br>netstandard1.6<br>netstandard2.0<br>netstandard2.1 |
 | .NET Framework             | net11<br>net20<br>net35<br>net40<br>net403<br>net45<br>net451<br>net452<br>net46<br>net461<br>net462<br>net47<br>net471<br>net472<br>net48 |
 | Windows Store              | netcore [netcore45]<br>netcore45 [win] [win8]<br>netcore451 [win81] |
@@ -44,31 +44,29 @@ A target framework is typically referenced by a TFM. The following table shows t
 | Windows Phone              | wp [wp7]<br>wp7<br>wp75<br>wp8<br>wp81<br>wpa81 |
 | Universal Windows Platform | uap [uap10.0]<br>uap10.0 [win10] [netcore50] |
 
-\* .NET 6 and later TFMs include operating system-specific variations. For more information, see the following section, [.NET 6 OS-specific TFMs](#net-6-os-specific-tfms).
+\* .NET 5 and later TFMs include some operating system-specific variations. For more information, see the following section, [.NET 5+ OS-specific TFMs](#net-5-os-specific-tfms).
 
 ### .NET 5+ OS-specific TFMs
 
-In .NET 5, the Windows-specific TFM `net5.0-windows` is available. Starting in .NET 6, even more OS-specific TFMs are available. These TFMs include OS-specific bindings. These variations are shown in the following table.
+The `net5.0` and `net6.0` TFMs only include technologies that work across different platforms. Specifying an *OS-specific TFM* makes APIs that are specific to an operating system available to your app, for example, Windows Forms or iOS bindings. OS-specific TFMs also inherit every API available to their base TFM, for example, the `net5.0` TFM.
 
-| OS-specific format | Example        |
-|--------------------|----------------|
-| \<base-tfm>-android | net6.0-android |
-| \<base-tfm>-ios     | net6.0-ios     |
-| \<base-tfm>-macos   | net6.0-macos   |
-| \<base-tfm>-tvos    | net6.0-tvos    |
-| \<base-tfm>-watchos | net6.0-watchos |
-| \<base-tfm>-windows | net6.0-windows |
+.NET 5 introduced the `net5.0-windows` OS-specific TFM, which includes Windows-specific bindings for WinForms, WPF, and UWP APIs. .NET 6 introduces further OS-specific TFMs.
 
-The `net5.0` and `net6.0` TFMs only includes technologies that work across different platforms. Specifying an OS-specific TFM makes APIs that are specific to an operating system available to your app, for example, Windows Forms or iOS bindings. OS-specific TFMs also inherit every API available to their base TFM, for example, `net6.0`.
+The following table shows the compatibility of the .NET 5+ TFMs.
+
+| TFM                | Compatible with                                                                                                         |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------|
+| net5.0             | net1..4 (with NU1701 warning)<br />netcoreapp1..3.1 (warning when WinForms or WPF is referenced)<br />netstandard1..2.1 |
+| net5.0-windows     | netcoreapp1..3.1 (plus everything else inherited from `net5.0`)                                                         |
+| net6.0             | (subsequent version of `net5.0`)                                                                                        |
+| net6.0-android     | `xamarin.android` (+everything else inherited from `net6.0`)                                                            |
+| net6.0-ios         | `xamarin.ios` (+everything else inherited from `net6.0`)                                                                |
+| net6.0-macos       | `xamarin.mac` (+everything else inherited from `net6.0`)                                                                |
+| net6.0-maccatalyst | `xamarin.ios` (+everything else inherited from `net6.0`)                                                                |
+| net6.0-tvos        | `xamarin.tvos` (+everything else inherited from `net6.0`)                                                               |
+| net6.0-windows     | (subsequent version of `net5.0-windows`)                                                                                |
 
 To make your app portable across different platforms but still have access to OS-specific APIs, you can target multiple OS-specific TFMs and add platform guards around OS-specific API calls using `#if` preprocessor directives.
-
-The following table shows the compatibility of the .NET 5 TFMs with TFMs for previous .NET versions.
-
-| TFM             | Compatible with                                            | Notes |
-|-----------------|------------------------------------------------------------|-|
-| net5.0          | net1..4 (with NU1701 warning)<br />netcoreapp1..3.1 (warning when WinForms or WPF is referenced)<br />netstandard1..2.1 | |
-| net5.0-windows  | netcoreapp1..3.1 (plus everything else inherited from `net5.0`) | Includes WinForms, WPF, and UWP APIs.<br />For information, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance). |
 
 #### Suggested targets
 
@@ -181,6 +179,7 @@ The following target frameworks are deprecated. Packages that target these targe
 ## See also
 
 - [Target framework names in .NET 5](https://github.com/dotnet/designs/blob/master/accepted/2020/net5/net5.md)
+- [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance)
 - [Developing Libraries with Cross Platform Tools](../core/tutorials/libraries.md)
 - [.NET Standard](net-standard.md)
 - [.NET Core Versioning](../core/versions/index.md)

--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -1,7 +1,7 @@
 ---
 title: Target frameworks in SDK-style projects - .NET
 description: Learn about target frameworks for .NET apps and libraries.
-ms.date: 11/06/2020
+ms.date: 03/03/2021
 ms.prod: "dotnet"
 ms.custom: "updateeachrelease"
 ms.technology: dotnet-standard
@@ -35,7 +35,7 @@ A target framework is typically referenced by a TFM. The following table shows t
 
 | Target Framework           | TFM |
 | -------------------------- | --- |
-| .NET 5 (and .NET Core)     | netcoreapp1.0<br>netcoreapp1.1<br>netcoreapp2.0<br>netcoreapp2.1<br>netcoreapp2.2<br>netcoreapp3.0<br>netcoreapp3.1<br>net5.0* |
+| .NET 5+ (and .NET Core)    | netcoreapp1.0<br>netcoreapp1.1<br>netcoreapp2.0<br>netcoreapp2.1<br>netcoreapp2.2<br>netcoreapp3.0<br>netcoreapp3.1<br>net5.0<br>net6.0* |
 | .NET Standard              | netstandard1.0<br>netstandard1.1<br>netstandard1.2<br>netstandard1.3<br>netstandard1.4<br>netstandard1.5<br>netstandard1.6<br>netstandard2.0<br>netstandard2.1 |
 | .NET Framework             | net11<br>net20<br>net35<br>net40<br>net403<br>net45<br>net451<br>net452<br>net46<br>net461<br>net462<br>net47<br>net471<br>net472<br>net48 |
 | Windows Store              | netcore [netcore45]<br>netcore45 [win] [win8]<br>netcore451 [win81] |
@@ -44,50 +44,45 @@ A target framework is typically referenced by a TFM. The following table shows t
 | Windows Phone              | wp [wp7]<br>wp7<br>wp75<br>wp8<br>wp81<br>wpa81 |
 | Universal Windows Platform | uap [uap10.0]<br>uap10.0 [win10] [netcore50] |
 
-\* .NET 5.0 and later TFMs include operating system-specific variations. For more information, see the following section, [.NET 5 OS-specific TFMs](#net-5-os-specific-tfms).
+\* .NET 6 and later TFMs include operating system-specific variations. For more information, see the following section, [.NET 6 OS-specific TFMs](#net-6-os-specific-tfms).
 
-### .NET 5 OS-specific TFMs
+### .NET 5+ OS-specific TFMs
 
-For each .NET 5.0 and later TFM, for example, `net5.0`, there are TFM variations that include OS-specific bindings. These variations are shown in the following table.
+In .NET 5, the Windows-specific TFM `net5.0-windows` is available. Starting in .NET 6, even more OS-specific TFMs are available. These TFMs include OS-specific bindings. These variations are shown in the following table.
 
 | OS-specific format | Example        |
 |--------------------|----------------|
-| \<base-tfm>-android | net5.0-android |
-| \<base-tfm>-ios     | net5.0-ios     |
-| \<base-tfm>-macos   | net5.0-macos   |
-| \<base-tfm>-tvos    | net5.0-tvos    |
-| \<base-tfm>-watchos | net5.0-watchos |
-| \<base-tfm>-windows | net5.0-windows |
+| \<base-tfm>-android | net6.0-android |
+| \<base-tfm>-ios     | net6.0-ios     |
+| \<base-tfm>-macos   | net6.0-macos   |
+| \<base-tfm>-tvos    | net6.0-tvos    |
+| \<base-tfm>-watchos | net6.0-watchos |
+| \<base-tfm>-windows | net6.0-windows |
 
-The `net5.0` TFM only includes technologies that work cross-platform. Specifying an OS-specific TFM makes APIs that are specific to an operating system available to your app, for example, Windows Forms or iOS bindings. OS-specific TFMs also inherit every API available to the `net5.0` TFM.
+The `net5.0` and `net6.0` TFMs only includes technologies that work across different platforms. Specifying an OS-specific TFM makes APIs that are specific to an operating system available to your app, for example, Windows Forms or iOS bindings. OS-specific TFMs also inherit every API available to their base TFM, for example, `net6.0`.
 
-To make your app portable across different platforms, you can target multiple OS-specific TFMs and add platform guards around OS-specific API calls using `#if` preprocessor directives.
+To make your app portable across different platforms but still have access to OS-specific APIs, you can target multiple OS-specific TFMs and add platform guards around OS-specific API calls using `#if` preprocessor directives.
 
 The following table shows the compatibility of the .NET 5 TFMs with TFMs for previous .NET versions.
 
 | TFM             | Compatible with                                            | Notes |
 |-----------------|------------------------------------------------------------|-|
 | net5.0          | net1..4 (with NU1701 warning)<br />netcoreapp1..3.1 (warning when WinForms or WPF is referenced)<br />netstandard1..2.1 | |
-| net5.0-android  | xamarin.android (plus everything else inherited from `net5.0`) | |
-| net5.0-ios      | xamarin.ios (plus everything else inherited from `net5.0`) | |
-| net5.0-macos    | xamarin.mac (plus everything else inherited from `net5.0`) | |
-| net5.0-tvos     | xamarin.tvos (plus everything else inherited from `net5.0`) | |
-| net5.0-watchos  | xamarin.watchos (plus everything else inherited from `net5.0`) | |
 | net5.0-windows  | netcoreapp1..3.1 (plus everything else inherited from `net5.0`) | Includes WinForms, WPF, and UWP APIs.<br />For information, see [Call Windows Runtime APIs in desktop apps](/windows/apps/desktop/modernize/desktop-to-uwp-enhance). |
 
 #### Suggested targets
 
 Use these guidelines to determine which TFM to use in your app:
 
-- Apps that are portable to multiple platforms should target `net5.0`. This includes most libraries but also ASP.NET Core and Entity Framework.
+- Apps that are portable to multiple platforms should target a base TFM, for example, `net5.0`. This includes most libraries but also ASP.NET Core and Entity Framework.
 
-- Platform-specific libraries should target platform-specific flavors. For example, WinForms and WPF projects should target `net5.0-windows`.
+- Platform-specific libraries should target platform-specific flavors. For example, WinForms and WPF projects should target `net5.0-windows` or `net6.0-windows`.
 
-- Cross-platform application models (Xamarin Forms, ASP.NET Core) and bridge packs (Xamarin Essentials) should at least target `net5.0`, but might also target additional platform-specific flavors to light-up more APIs or features.
+- Cross-platform application models (Xamarin Forms, ASP.NET Core) and bridge packs (Xamarin Essentials) should at least target the base TFM, for example, `net6.0`, but might also target additional platform-specific flavors to light-up more APIs or features.
 
 #### OS version in TFMs
 
-You can also specify an optional OS version at the end of the TFM, for example, `net5.0-ios13.0`, which indicates what APIs are available to your app. (The .NET 5 SDK will be updated to include support for newer OS versions as they are released.) To gain access to newly released APIs, increment the OS version in the TFM. You can still make your app compatible with earlier OS versions (and add guards around calls to later-version APIs) by adding the `SupportedOSPlatformVersion` element to your project file. The `SupportedOSPlatformVersion` element indicates the minimum OS version required to run your app.
+You can also specify an optional OS version at the end of the TFM, for example, `net6.0-ios13.0`, which indicates what APIs are available to your app. (The .NET 6 SDK will be updated to include support for newer OS versions as they are released.) To gain access to newly released APIs, increment the OS version in the TFM. You can still make your app compatible with earlier OS versions (and add guards around calls to later-version APIs) by adding the `SupportedOSPlatformVersion` element to your project file. The `SupportedOSPlatformVersion` element indicates the minimum OS version required to run your app.
 
 For example, the following project file excerpt specifies that iOS 14 APIs are available to the app, but it can run on iOS 13 or later machines.
 
@@ -95,7 +90,7 @@ For example, the following project file excerpt specifies that iOS 14 APIs are a
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-ios14.0</TargetFramework>
+    <TargetFramework>net6.0-ios14.0</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion> (minimum os platform version)
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #21650 and adds TFMs for .NET 6. Based on https://github.com/dotnet/designs/blob/main/accepted/2021/net6.0-tfms/net6.0-tfms.md.

[Internal preview URL](https://review.docs.microsoft.com/en-us/dotnet/standard/frameworks?branch=pr-en-us-23099#net-5-os-specific-tfms).