### PR TITLE
CA1034 rule mentioned in nested types description

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -19,7 +19,9 @@ You can also specify an [access modifier](../../language-reference/keywords/acce
 - Nested types of a **class** can be [public](../../language-reference/keywords/public.md), [protected](../../language-reference/keywords/protected.md), [internal](../../language-reference/keywords/internal.md), [protected internal](../../language-reference/keywords/protected-internal.md), [private](../../language-reference/keywords/private.md) or [private protected](../../language-reference/keywords/private-protected.md).
 
    However, defining a `protected`, `protected internal` or `private protected` nested class inside a [sealed class](../../language-reference/keywords/sealed.md) generates compiler warning [CS0628](../../misc/cs0628.md), "new protected member declared in sealed class."
-  
+
+   Also be aware that making a nested type externally visible will trigger the [CA1034](~/docs/fundamentals/code-analysis/quality-rules/ca1034.md) "Nested types should not be visible" compiler warning.
+
 - Nested types of a **struct** can be [public](../../language-reference/keywords/public.md), [internal](../../language-reference/keywords/internal.md), or [private](../../language-reference/keywords/private.md).
 
 The following example makes the `Nested` class public:

--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -44,3 +44,4 @@ In the previous declaration, the full name of class `Nested` is `Container.Neste
 - [Classes and Structs](./index.md)
 - [Access Modifiers](./access-modifiers.md)
 - [Constructors](./constructors.md)
+- [CA1034 warning](~/docs/fundamentals/code-analysis/quality-rules/ca1034.md)


### PR DESCRIPTION
This pull request fixes #20784 

It mentiones the *CA1034* compiler warning to the nested types topic's description.

---

The *CA1034* has been mentioned as a subpoint of the access modifiers section, just like the *CS0628* compiler warning.
The reason for that is the fact that *CS1034* is all about the nested types accesses.

The additional change done to the nested types description is that the *CS1034* is linked within the "See also" section.

