### PR TITLE
Fix regression caused by OPS portal

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -49,6 +49,7 @@
       "path_to_root": "_csharplang",
       "url": "https://github.com/dotnet/csharplang",
       "branch": "master",
+      "include_in_build": true,
       "branch_mapping": {
         "main": "master"
       }
@@ -57,6 +58,7 @@
       "path_to_root": "_vblang",
       "url": "https://github.com/dotnet/vblang",
       "branch": "master",
+      "include_in_build": true,
       "branch_mapping": {
         "main": "master"
       }
@@ -80,10 +82,6 @@
   ],
   "branch_target_mapping": {
     "live": [
-      "Publish",
-      "Pdf"
-    ],
-    "master": [
       "Publish",
       "Pdf"
     ],

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -37,17 +37,13 @@
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft",
       "branch": "master",
-      "branch_mapping": {
-        "main": "master"
-      }
+      "branch_mapping": {}
     },
     {
       "path_to_root": "_themes.pdf",
       "url": "https://github.com/Microsoft/templates.docs.msft.pdf",
       "branch": "master",
-      "branch_mapping": {
-        "main": "master"
-      }
+      "branch_mapping": {}
     },
     {
       "path_to_root": "_csharplang",
@@ -84,6 +80,10 @@
   ],
   "branch_target_mapping": {
     "live": [
+      "Publish",
+      "Pdf"
+    ],
+    "master": [
       "Publish",
       "Pdf"
     ],


### PR DESCRIPTION
Include _csharplang and _vblang in build - regression introduced by OPS portal in https://github.com/dotnet/docs/commit/88334d5e0b73ba43749448ecf5b88793f73a5b1d#.