### PR TITLE
Remove CONTRIBUTING.md from landing page

### DIFF
--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -50,10 +50,6 @@ landingContent:
       url: /contribute
     - text: .NET docs contributor guide
       url: /contribute/dotnet/dotnet-contribute
-    - text: .NET API reference docs contributor guide
-      url: https://github.com/dotnet/dotnet-api-docs/blob/master/CONTRIBUTING.md
-    - text: .NET samples contributor guide
-      url: https://github.com/dotnet/samples/blob/master/CONTRIBUTING.md
 - title: .NET developers
   linkLists:
   - linkListType: download


### PR DESCRIPTION
Both links doesn't contain useful information and are about having the contributing guide moved to <https://docs.microsoft.com/en-us/contribute/dotnet/dotnet-contribute>.