### PR TITLE
Update tutorial to have an example of Environment.NewLine

### DIFF
--- a/docs/core/tutorials/snippets/with-visual-studio/csharp/Program.cs
+++ b/docs/core/tutorials/snippets/with-visual-studio/csharp/Program.cs
@@ -10,11 +10,11 @@ namespace HelloWorld
         public static void Main(string[] args)
         {
             // <MainMethod>
-            Console.WriteLine("\nWhat is your name? ");
+            Console.WriteLine($"{Environment.NewLine}What is your name? ");
             var name = Console.ReadLine();
             var date = DateTime.Now;
             Console.WriteLine($"{Environment.NewLine}Hello, {name}, on {date:d} at {date:t}!");
-            Console.Write("\nPress any key to exit...");
+            Console.Write($"{Environment.NewLine}Press any key to exit...");
             Console.ReadKey(true);
             // </MainMethod>
         }

--- a/docs/core/tutorials/snippets/with-visual-studio/csharp/Program.cs
+++ b/docs/core/tutorials/snippets/with-visual-studio/csharp/Program.cs
@@ -13,7 +13,7 @@ namespace HelloWorld
             Console.WriteLine("\nWhat is your name? ");
             var name = Console.ReadLine();
             var date = DateTime.Now;
-            Console.WriteLine($"\nHello, {name}, on {date:d} at {date:t}!");
+            Console.WriteLine($"{Environment.NewLine}Hello, {name}, on {date:d} at {date:t}!");
             Console.Write("\nPress any key to exit...");
             Console.ReadKey(true);
             // </MainMethod>

--- a/docs/core/tutorials/snippets/with-visual-studio/vb/Program.vb
+++ b/docs/core/tutorials/snippets/with-visual-studio/vb/Program.vb
@@ -1,11 +1,11 @@
 ﻿Module Program
     Sub Main(args As String())
         ' <MainMethod>
-        Console.WriteLine(vbCrLf + "What is your name? ")
+        Console.WriteLine($"{Environment.NewLine}What is your name? ")
         Dim name = Console.ReadLine()
         Dim currentDate = DateTime.Now
         Console.WriteLine($"{Environment.NewLine}Hello, {name}, on {currentDate:d} at {currentDate:t}")
-        Console.Write(vbCrLf + "Press any key to exit... ")
+        Console.Write($"{Environment.NewLine}Press any key to exit... ")
         Console.ReadKey(True)
         ' </MainMethod>
     End Sub

--- a/docs/core/tutorials/snippets/with-visual-studio/vb/Program.vb
+++ b/docs/core/tutorials/snippets/with-visual-studio/vb/Program.vb
@@ -4,7 +4,7 @@
         Console.WriteLine(vbCrLf + "What is your name? ")
         Dim name = Console.ReadLine()
         Dim currentDate = DateTime.Now
-        Console.WriteLine($"{vbCrLf}Hello, {name}, on {currentDate:d} at {currentDate:t}")
+        Console.WriteLine($"{Environment.NewLine}Hello, {name}, on {currentDate:d} at {currentDate:t}")
         Console.Write(vbCrLf + "Press any key to exit... ")
         Console.ReadKey(True)
         ' </MainMethod>

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -87,7 +87,7 @@ Enhance the application to prompt the user for their name and display it along w
 
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date`. And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
-   The `\n` represents a newline character.
+   <xref:System.Environment.NewLine> is a platform-independent and language-independent way to represent a line break. Alternatives are `\n` in C# and `vbCrLf` in Visual Basic.
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 

--- a/docs/core/tutorials/with-visual-studio-mac.md
+++ b/docs/core/tutorials/with-visual-studio-mac.md
@@ -78,7 +78,7 @@ Enhance the application to prompt the user for their name and display it along w
 
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date`. And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
-   The `\n` represents a newline character.
+   <xref:System.Environment.NewLine> is a platform-independent and language-independent way to represent a line break. Alternatives are `\n` in C# and `vbCrLf` in Visual Basic.
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -102,8 +102,7 @@ Enhance the application to prompt the user for their name and display it along w
 
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
-   The `\n` (or `vbCrLf` in the Visual Basic code) represents a newline character.
-   The `Environment.NewLine` is another way to represent a newline character, but is platform independent and works in both C# and Visual Basic code. This is further described in the [Environment.NewLine](https://docs.microsoft.com/dotnet/api/system.environment.newline) document.
+   <xref:System.Environment.NewLine> is a platform-independent and language-independent way to represent a line break. Alternatives are `\n` in C# and `vbCrLf` in Visual Basic.
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -103,6 +103,7 @@ Enhance the application to prompt the user for their name and display it along w
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
    The `\n` (or `vbCrLf` in the Visual Basic code) represents a newline character.
+   The `Environment.NewLine` is the most robuse option however being platform independent and working in both C# and Visual Basic code([NewLine Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline))
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -103,7 +103,7 @@ Enhance the application to prompt the user for their name and display it along w
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
    The `\n` (or `vbCrLf` in the Visual Basic code) represents a newline character.
-   The `Environment.NewLine` is another way to represent a newline character, but is platform independent and works in both C# and Visual Basic code. This is further described in [Environment.NewLine Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline).
+   The `Environment.NewLine` is another way to represent a newline character, but is platform independent and works in both C# and Visual Basic code. This is further described in the [Environment.NewLine](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline) document.
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -103,7 +103,7 @@ Enhance the application to prompt the user for their name and display it along w
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
    The `\n` (or `vbCrLf` in the Visual Basic code) represents a newline character.
-   The `Environment.NewLine` is the most robuse option however being platform independent and working in both C# and Visual Basic code([NewLine Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline))
+   The `Environment.NewLine` is another way to represent a newline character, but is platform independent and works in both C# and Visual Basic code. This is further described in [Environment.NewLine Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline).
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -103,7 +103,7 @@ Enhance the application to prompt the user for their name and display it along w
    This code displays a prompt in the console window and waits until the user enters a string followed by the <kbd>Enter</kbd> key. It stores this string in a variable named `name`. It also retrieves the value of the <xref:System.DateTime.Now?displayProperty=nameWithType> property, which contains the current local time, and assigns it to a variable named `date` (`currentDate` in Visual Basic). And it displays these values in the console window. Finally, it displays a prompt in the console window and calls the <xref:System.Console.ReadKey(System.Boolean)?displayProperty=nameWithType> method to wait for user input.
 
    The `\n` (or `vbCrLf` in the Visual Basic code) represents a newline character.
-   The `Environment.NewLine` is another way to represent a newline character, but is platform independent and works in both C# and Visual Basic code. This is further described in the [Environment.NewLine](https://docs.microsoft.com/en-us/dotnet/api/system.environment.newline) document.
+   The `Environment.NewLine` is another way to represent a newline character, but is platform independent and works in both C# and Visual Basic code. This is further described in the [Environment.NewLine](https://docs.microsoft.com/dotnet/api/system.environment.newline) document.
 
    The dollar sign (`$`) in front of a string lets you put expressions such as variable names in curly braces in the string. The expression value is inserted into the string in place of the expression. This syntax is referred to as [interpolated strings](../../csharp/language-reference/tokens/interpolated.md).
 


### PR DESCRIPTION
## Summary

Having an example of Environment.NewLine I think could be good practice as it is a more versatile option compared to `/n` and is platform independent, and only downside is that it can't be used to define a constant, but that is a more rare scenario, so having an example of it in the tutorial allows new users to get used to a good option for newlines. 
