### PR TITLE
Update wcf-web-http-service-help-page.md

### DIFF
--- a/docs/framework/wcf/feature-details/wcf-web-http-service-help-page.md
+++ b/docs/framework/wcf/feature-details/wcf-web-http-service-help-page.md
@@ -25,12 +25,12 @@ ms.assetid: 63c7c695-44b6-4f31-bb9c-00f2763f525e
 SyndicationFeedFormatter GetTemplate1();  
 ```  
   
- To turn on the WCF WEB HTTP Help page, you must add an endpoint behavior to your service's endpoints. This can be done in configuration or code. To enable the WCF WEB HTTP Help age in configuration, add an endpoint behavior with a `<webHttp>` element, set `enableHelp` to `true`, and add an endpoint and configure it to use the endpoint behavior. The following configuration code shows how to do this.  
+ To turn on the WCF WEB HTTP Help page, you must add an endpoint behavior to your service's endpoints. This can be done in configuration or code. To enable the WCF WEB HTTP Help age in configuration, add an endpoint behavior with a `<webHttp>` element, set `helpEnabled` to `true`, and add an endpoint and configure it to use the endpoint behavior. The following configuration code shows how to do this.  
   
 ```xml  
 <endpointBehaviors>  
    <behavior name="RESTEndpointBehavior">  
-      <webHttp enableHelp="true"/>  
+      <webHttp helpEnabled="true"/>  
    </behavior>  
 </endpointBehaviors>  
 <!-- ... -->  


### PR DESCRIPTION
This doc was claiming the config value to enable the helppage is  `enabledHelp` but it seems to be `helpEnabled`. See also this page with the correct config in it: https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.description.webhttpbehavior.helpenabled?view=netframework-4.6.1

## Summary

Fixed the wrong config attribute in the article to the correct one.


