### PR TITLE
Fix build suggestion

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3769,8 +3769,7 @@
         },
         {
             "source_path": "docs/framework/tools/developer-command-prompt-for-vs.md",
-            "redirect_url": "/visualstudio/ide/reference/command-prompt-powershell",
-            "redirect_document_id": false
+            "redirect_url": "/visualstudio/ide/reference/command-prompt-powershell"
         },
         {
             "source_path": "docs/framework/ui-automation/ui-automation-specification-and-community-promise.md",

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3770,7 +3770,7 @@
         {
             "source_path": "docs/framework/tools/developer-command-prompt-for-vs.md",
             "redirect_url": "/visualstudio/ide/reference/command-prompt-powershell",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "docs/framework/ui-automation/ui-automation-specification-and-community-promise.md",


### PR DESCRIPTION
Found the following build suggestion:

> Can't redirect document ID for redirected file 'docs/framework/tools/developer-command-prompt-for-vs.md' because redirect URL '/visualstudio/ide/reference/command-prompt-powershell' is invalid or is in a different docset. Specify a redirect_url in the same docset, or set redirect_document_id to false in .openpublishing.redirection.json.

I'm not sure if we should follow what it says or simply ignore it.

If the suggestion should be ignored you can close this PR.