### PR TITLE
Update the .NET hub page

### DIFF
--- a/docs/fundamentals/index.yml
+++ b/docs/fundamentals/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: .NET documentation
   description: Learn about .NET, an open-source developer platform for building many different types of applications.
   ms.topic: landing-page
-  ms.date: 08/31/2020
+  ms.date: 03/10/2021
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
 
@@ -24,11 +24,7 @@ landingContent:
         links:
           - text: What is .NET?
             url: https://dotnet.microsoft.com/learn/dotnet/what-is-dotnet
-          - text: Tour of .NET
-            url: ../core/introduction.md
-          - text: Introduction to .NET Core
-            url: ../core/introduction.md
-          - text: .NET Core overview
+          - text: Introduction to .NET
             url: ../core/introduction.md
           - text: .NET Core SDK overview
             url: ../core/sdk.md
@@ -44,8 +40,6 @@ landingContent:
         links:
           - text: .NET Standard
             url: ../standard/net-standard.md
-          - text: .NET Core
-            url: ../core/introduction.md
           - text: Target frameworks
             url: ../standard/frameworks.md
           - text: Common Language Runtime (CLR)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -173,7 +173,7 @@ items:
   - name: Overview
     displayName: diagnostics,tools,tooling,productivity,instrumentation
     href: tools-and-productivity.md
-  - name: .NET Core SDK
+  - name: .NET SDK
     items:
     - name: Overview
       displayName: '.net sdk,software development kit,software dev kit,tool'

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -88,9 +88,6 @@ conceptualContent:
         - url: https://channel9.msdn.com/series/net-core-101/what-is-net
           itemType: video
           text: What is .NET?
-        - url: /answers/products/dotnet
-          itemType: get-started
-          text: .NET on Q&A
         - url: standard/net-standard.md
           itemType: overview
           text: .NET Standard
@@ -106,12 +103,15 @@ conceptualContent:
         - url: framework/index.yml
           itemType: overview
           text: .NET Framework (Windows) apps
+        - url: /answers/products/dotnet
+          itemType: get-started
+          text: .NET on Q&A
     # Card
     - title: Develop .NET apps
       links:
         - url: core/sdk.md
-          itemType: download
-          text: Download the .NET SDK
+          itemType: overview
+          text: .NET SDK overview
         - url: core/tools/index.md
           itemType: overview
           text: .NET CLI overview

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -212,11 +212,11 @@ additionalContent:
           - url: /uwp
             text: Universal Windows apps
           - url: /dotnet/desktop/wpf/?view=netdesktop-5.0&preserve-view=true
-            text: Windows Presentation Foundation (.NET 5)
+            text: Windows Presentation Foundation (.NET 5+)
           - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Presentation Foundation (.NET Framework)
           - url: /dotnet/desktop/winforms/?view=netdesktop-5.0&preserve-view=true
-            text: Windows Forms (.NET 5)
+            text: Windows Forms (.NET 5+)
           - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Forms (.NET Framework)
           - url: /xamarin/mac

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -238,28 +238,6 @@ additionalContent:
           - url: architecture/microservices/index.md
             text: ".NET Microservices: Architecture for Containerized .NET Applications"
       # Card
-      - title: Game Development
-        links:
-          - url: https://visualstudio.microsoft.com/vs/features/game-development/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link
-            text: Game development with Visual Studio
-          - url: https://docs.cryengine.com/display/CEPROG/C%23+Programming
-            text: Learn how to use CRYENGINE to build games with C#
-          - url: https://docs.monogame.net/?page=main
-            text: Build games with C# using the MonoGame library
-          - url: https://docs.unity3d.com/Manual/index.html
-            text: Learn how to use Unity to build 2D and 3D games with C#
-      # Card
-      - title: Machine learning and AI
-        links:
-          - url: machine-learning/index.yml
-            text: Build custom AI solutions with ML.NET
-          - url: /azure/cognitive-services/
-            text: Azure Cognitive Services
-          - url: /azure/machine-learning
-            text: Azure machine learning
-          - url: spark/index.yml
-            text: .NET for Apache Spark
-      # Card
       - title: Cloud
         links:
           - url: ./azure/index.yml
@@ -272,6 +250,28 @@ additionalContent:
             text: Azure .NET SDK
           - url: ./fsharp/using-fsharp-on-azure/index.md
             text: Use F# on Azure
+      # Card
+      - title: Machine learning and AI
+        links:
+          - url: machine-learning/index.yml
+            text: Build custom AI solutions with ML.NET
+          - url: /azure/cognitive-services/
+            text: Azure Cognitive Services
+          - url: /azure/machine-learning
+            text: Azure machine learning
+          - url: spark/index.yml
+            text: .NET for Apache Spark
+      # Card
+      - title: Game Development
+        links:
+          - url: https://visualstudio.microsoft.com/vs/features/game-development/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link
+            text: Game development with Visual Studio
+          - url: https://docs.cryengine.com/display/CEPROG/C%23+Programming
+            text: Learn how to use CRYENGINE to build games with C#
+          - url: https://docs.monogame.net/?page=main
+            text: Build games with C# using the MonoGame library
+          - url: https://docs.unity3d.com/Manual/index.html
+            text: Learn how to use Unity to build 2D and 3D games with C#
       # Card
       - title: Internet of things (IoT)
         links:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -105,7 +105,7 @@ conceptualContent:
           text: .NET Framework (Windows) apps
         - url: /answers/products/dotnet
           itemType: get-started
-          text: .NET on Q&A
+          text: .NET Q&A
     # Card
     - title: Develop .NET apps
       links:
@@ -157,7 +157,7 @@ conceptualContent:
         text: All architecture guides
 
 # tools section (optional)
-## Languages: C#, F#, and VB
+## Languages: C#, F#, and Visual Basic
 tools:
   title: Programming languages # < 60 chars (optional)
   summary: "You can write .NET apps in C#, F#, or Visual Basic."
@@ -225,22 +225,22 @@ additionalContent:
       - title: Microservices
         links:
           - url: architecture/dapr-for-net-developers/index.md
-            text: Dapr for .NET Developers
+            text: Dapr for .NET developers
           - url: architecture/cloud-native/index.md
             text: Cloud native .NET apps
-          - url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
+          - url: /learn/aspnet/microservice-tutorial/intro
             text: Create your first .NET microservice
           - url: architecture/serverless/index.md
             text: Serverless apps with Azure
           - url: architecture/microservices/index.md
-            text: Architecture for Containerized .NET apps
+            text: Architecture for containerized .NET apps
       # Card
       - title: Cloud
         links:
           - url: azure/index.yml
             text: Azure for .NET developers
           - url: /dotnet/azure/migration/app-service?view=azure-dotnet
-            text: Migrate .NET web app or service
+            text: Migrate on-premises .NET web apps or services
           - url: /dotnet/azure/key-azure-services
             text: Azure services for .NET developers
           - url: /dotnet/azure/sdk/azure-sdk-for-dotnet

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 03/08/2021
+  ms.date: 03/09/2021
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -201,39 +201,23 @@ additionalContent:
             text: ASP.NET MVC apps in Windows containers
           - url: /aspnet/core/blazor/
             text: "Blazor: Interactive client-side web UI with .NET"
-
-      # Card
-      - title: Cloud native and microservices
-        links:
-          - url: ./azure/index.yml
-            text: Azure for .NET documentation
-          - url: /azure/storage
-            text: Storage
-          - url: ./fsharp/using-fsharp-on-azure/index.md
-            text: Using F# on Azure
-          - url: architecture/serverless/index.md
-            text: "Serverless apps: Architecture, patterns, and Azure implementation"
-          - url: architecture/microservices/index.md
-            text: ".NET Microservices: Architecture for Containerized .NET Applications"
-
       # Card
       - title: Mobile
         links:
-          - url: /xamarin/ios/
+          - url: /xamarin/xamarin-forms
+            text: Xamarin.Forms
+          - url: /xamarin/ios
             text: Xamarin.iOS
           - url: /xamarin/android
             text: Xamarin.Android
-          - url: /xamarin/xamarin-forms
-            text: Xamarin.Forms
           - url: /azure/developer/mobile-apps
             text: Develop Xamarin apps with Azure
-
       # Card
       - title: Desktop
         links:
           - url: /uwp
             text: Universal Windows apps
-          - url: /dotnet/desktop/wpf/
+          - url: /dotnet/desktop/wpf
             text: Windows Presentation Foundation (.NET Core)
           - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8
             text: Windows Presentation Foundation (.NET Framework)
@@ -242,7 +226,20 @@ additionalContent:
           - url: /xamarin/mac
             text: Xamarin for macOS
       # Card
-      - title: Gaming
+      - title: Microservices
+        links:
+          - url: architecture/dapr-for-net-developers/index.md
+            text: Dapr for .NET Developers
+          - url: architecture/cloud-native/index.md
+            text: Cloud native .NET apps
+          - url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
+            text: Your first .NET microservice
+          - url: architecture/serverless/index.md
+            text: "Serverless apps: Architecture, patterns, and Azure implementation"
+          - url: architecture/microservices/index.md
+            text: ".NET Microservices: Architecture for Containerized .NET Applications"
+      # Card
+      - title: Game Development
         links:
           - url: https://visualstudio.microsoft.com/vs/features/game-development/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link
             text: Game development with Visual Studio
@@ -252,7 +249,6 @@ additionalContent:
             text: Build games with C# using the MonoGame library
           - url: https://docs.unity3d.com/Manual/index.html
             text: Learn how to use Unity to build 2D and 3D games with C#
-
       # Card
       - title: Machine learning and AI
         links:
@@ -264,6 +260,19 @@ additionalContent:
             text: Azure machine learning
           - url: spark/index.yml
             text: .NET for Apache Spark
+      # Card
+      - title: Cloud
+        links:
+          - url: ./azure/index.yml
+            text: Azure for .NET developers
+          - url: /dotnet/azure/migration/app-service?view=azure-dotnet
+            text: Migrate .NET web app or service
+          - url: /dotnet/azure/key-azure-services
+            text: Azure services for .NET developers
+          - url: /dotnet/azure/sdk/azure-sdk-for-dotnet
+            text: Azure .NET SDK
+          - url: ./fsharp/using-fsharp-on-azure/index.md
+            text: Use F# on Azure
       # Card
       - title: Internet of things (IoT)
         links:
@@ -315,5 +324,6 @@ additionalContent:
       - title: "Visual Basic language reference"
         summary: Visual Basic language reference and specification
         url: visual-basic/language-reference/index.md
+
   # footer (optional)
   footer: "Contribute to .NET docs. Read our [contributor guide](/contribute/dotnet/dotnet-contribute)."

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 10/9/2020
+  ms.date: 03/08/2021
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -201,6 +201,7 @@ additionalContent:
             text: ASP.NET MVC apps in Windows containers
           - url: /aspnet/core/blazor/
             text: "Blazor: Interactive client-side web UI with .NET"
+
       # Card
       - title: Cloud native and microservices
         links:
@@ -214,6 +215,7 @@ additionalContent:
             text: "Serverless apps: Architecture, patterns, and Azure implementation"
           - url: architecture/microservices/index.md
             text: ".NET Microservices: Architecture for Containerized .NET Applications"
+
       # Card
       - title: Mobile
         links:
@@ -225,6 +227,7 @@ additionalContent:
             text: Xamarin.Forms
           - url: /azure/developer/mobile-apps
             text: Develop Xamarin apps with Azure
+
       # Card
       - title: Desktop
         links:
@@ -249,6 +252,7 @@ additionalContent:
             text: Build games with C# using the MonoGame library
           - url: https://docs.unity3d.com/Manual/index.html
             text: Learn how to use Unity to build 2D and 3D games with C#
+
       # Card
       - title: Machine learning and AI
         links:
@@ -275,7 +279,11 @@ additionalContent:
     - title: API and language reference # < 60 chars (optional)
       summary: Search the .NET API and language reference documentation. # < 160 chars (optional)
       items:
-        # Card
+      # Card
+      - title: ".NET API reference"
+        summary: API reference documentation for .NET
+        url: ../api/index.md?view=net-5.0
+      # Card
       - title: ".NET Core API reference"
         summary: API reference documentation for .NET Core
         url: ../api/index.md?view=netcore-3.1

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -60,17 +60,14 @@ conceptualContent:
   items:
     # Card
     - title: Open-source .NET
-      summary: Learn about .NET Core
+      summary: Learn about .NET
       links:
         - url: core/introduction.md
           itemType: overview
-          text: .NET Core overview
-        - url: core/whats-new/dotnet-core-3-1.md
+          text: .NET overview
+        - url: core/dotnet-five.md
           itemType: whats-new
-          text: What's new in .NET Core 3.1
-        - url: ./core/introduction.md
-          itemType: overview
-          text: Tour of .NET
+          text: What's new in .NET 5
         - url: core/deploying/index.md
           itemType: deploy
           text: Deploy .NET Core apps

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -63,25 +63,22 @@ conceptualContent:
       links:
         - url: core/introduction.md
           itemType: overview
-          text: Overview of .NET
-        - url: core/dotnet-five.md
-          itemType: whats-new
-          text: What's new in .NET 5
+          text: .NET overview
         - url: core/tutorials/index.md
           itemType: tutorial
           text: .NET tutorials
+        - url: core/dotnet-five.md
+          itemType: whats-new
+          text: What's new in .NET 5
         - url: core/deploying/index.md
           itemType: deploy
           text: Deploy .NET apps
-        - url: core/docker/build-container.md
-          itemType: tutorial
-          text: Containerize .NET apps with Docker
-        - url: https://dotnet.microsoft.com/platform/community
-          itemType: whats-new
-          text: .NET developer community
         - url: https://dotnetfoundation.org
           itemType: overview
           text: .NET Foundation
+        - url: https://dotnet.microsoft.com/platform/community
+          itemType: whats-new
+          text: .NET developer community
         - url: standard/library-guidance/index.md
           itemType: concept
           text: Open source library guidance
@@ -124,6 +121,9 @@ conceptualContent:
         - url: core/porting/index.md
           itemType: overview
           text: Port from .NET Framework to .NET
+        - url: core/docker/build-container.md
+          itemType: tutorial
+          text: Containerize .NET apps with Docker
         - url: core/compatibility/index.md
           itemType: concept
           text: .NET breaking changes

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -88,9 +88,9 @@ conceptualContent:
         - url: https://channel9.msdn.com/series/net-core-101/what-is-net
           itemType: video
           text: What is .NET?
-        - url: standard/net-standard.md
-          itemType: overview
-          text: .NET Standard
+        - url: fundamentals/index.md
+          itemType: concept
+          text: .NET fundamentals
         - url: /aspnet/core/
           itemType: overview
           text: ASP.NET Core
@@ -115,9 +115,9 @@ conceptualContent:
         - url: core/tools/index.md
           itemType: overview
           text: .NET CLI overview
-        - url: fundamentals/index.md
-          itemType: concept
-          text: .NET fundamentals
+        - url: standard/net-standard.md
+          itemType: overview
+          text: .NET Standard
         - url: core/porting/index.md
           itemType: overview
           text: Port from .NET Framework to .NET

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -158,13 +158,13 @@ conceptualContent:
         text: All architecture guides
 
 # tools section (optional)
-## Languages: C#, VB, F#, 
+## Languages: C#, F#, and VB
 tools:
   title: Programming languages # < 60 chars (optional)
   summary: "You can write .NET apps in C#, F#, or Visual Basic."
   items:
     # Card
-    - title: "A modern, object-oriented, type-safe member of the C family"
+    - title: "A modern, object-oriented, and type-safe language"
       imageSrc: https://docs.microsoft.com/media/logos/logo_Csharp.svg
       url: csharp/index.yml
     # Card

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -1,12 +1,12 @@
 ### YamlMime:Hub
 
 title: .NET documentation
-summary: Learn to use .NET to create applications on any platform using C#, Visual Basic, and F#. Browse API reference, sample code, tutorials, and more.
+summary: Learn to use .NET to create applications on any platform using C#, F#, and Visual Basic. Browse API reference, sample code, tutorials, and more.
 brand: dotnet
 
 metadata:
   title: .NET documentation
-  description: Learn to use .NET to create applications on any platform using C#, Visual Basic, and F#. Browse API reference, sample code, tutorials, and more.
+  description: Learn to use .NET to create applications on any platform using C#, F#, and Visual Basic. Browse API reference, sample code, tutorials, and more.
   ms.product: dotnet
   ms.topic: hub-page
   ms.collection: collection
@@ -24,33 +24,33 @@ highlightedContent:
       itemType: download
       url: https://dotnet.microsoft.com/download
     # Card
-    - title: "C# introduction. A quick interactive start."
-      itemType: get-started
-      url: ./csharp/tour-of-csharp/tutorials/hello-world.yml
+    - title: "Build .NET apps with C#"
+      itemType: learn
+      url: /learn/paths/build-dotnet-applications-csharp
     # Card
-    - title: "Create your first console app."
+    - title: Create your first console app
       itemType: tutorial
       url: core/get-started.md
     # Card
-    - title: "Create your first web app."
+    - title: Create your first web app
       itemType: learn
       url: https://dotnet.microsoft.com/learn/aspnet/hello-world-tutorial/intro
     # Card
-    - title: "Build .NET applications with C#"
-      itemType: learn
-      url: /learn/paths/build-dotnet-applications-csharp/
-    # Card
-    - title: "Browse all .NET Learning paths and modules"
+    - title: "Browse .NET learning paths"
       itemType: learn
       url: /learn/dotnet/
+    # Card
+    - title: "Azure for .NET developers"
+      itemType: overview
+      url: azure/index.yml
     # Card
     - title: "What's new in .NET docs"
       itemType: whats-new
       url: whats-new/index.yml
     # Card
-    - title: "Azure for .NET developers"
-      itemType: overview
-      url: azure/index.yml
+    - title: "Introduction to C#"
+      itemType: get-started
+      url: ./csharp/tour-of-csharp/tutorials/hello-world.yml
 
 # conceptualContent section (optional)
 conceptualContent:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -128,14 +128,14 @@ conceptualContent:
           itemType: overview
           text: .NET Core CLI overview
         - url: core/porting/index.md
-          itemType: how-to-guide
-          text: Port from .NET Framework to .NET Core
+          itemType: overview
+          text: Port from .NET Framework to .NET
         - url: core/compatibility/index.md
           itemType: concept
           text: .NET Core breaking changes
-        - url: /dotnet/desktop/wpf/overview/
-          itemType: overview
-          text: Create .NET Core desktop apps for Windows
+        - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-5.0
+          itemType: tutorial
+          text: Create .NET desktop apps for Windows
         - url: standard/library-guidance/index.md
           itemType: concept
           text: Open source library guidance
@@ -217,12 +217,14 @@ additionalContent:
         links:
           - url: /uwp
             text: Universal Windows apps
-          - url: /dotnet/desktop/wpf
-            text: Windows Presentation Foundation (.NET Core)
+          - url: /dotnet/desktop/wpf/?view=netdesktop-5.0
+            text: Windows Presentation Foundation (.NET 5)
           - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8
             text: Windows Presentation Foundation (.NET Framework)
+          - url: /dotnet/desktop/winforms/?view=netdesktop-5.0
+            text: Windows Forms (.NET 5)
           - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8
-            text: Windows Forms
+            text: Windows Forms (.NET Framework)
           - url: /xamarin/mac
             text: Xamarin for macOS
       # Card

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -322,4 +322,4 @@ additionalContent:
         url: visual-basic/language-reference/index.md
 
   # footer (optional)
-  footer: "Contribute to .NET docs. Read our [contributor guide](/contribute/dotnet/dotnet-contribute)."
+  footer: "Are you interested in contributing to the .NET docs? For more information, see our [contributor guide](/contribute/dotnet/dotnet-contribute)."

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -50,7 +50,7 @@ highlightedContent:
     # Card
     - title: "Interactive introduction to C#"
       itemType: get-started
-      url: ./csharp/tour-of-csharp/tutorials/hello-world.yml
+      url: csharp/tour-of-csharp/tutorials/hello-world.yml
 
 # conceptualContent section (optional)
 conceptualContent:
@@ -60,45 +60,40 @@ conceptualContent:
   items:
     # Card
     - title: Open source .NET
-      summary: Learn about .NET
       links:
         - url: core/introduction.md
           itemType: overview
-          text: .NET overview
+          text: Overview of .NET
         - url: core/dotnet-five.md
           itemType: whats-new
           text: What's new in .NET 5
+        - url: core/tutorials/index.md
+          itemType: tutorial
+          text: .NET tutorials
         - url: core/deploying/index.md
           itemType: deploy
           text: Deploy .NET apps
         - url: core/docker/build-container.md
           itemType: tutorial
           text: Containerize .NET apps with Docker
-        - url: core/tutorials/index.md
-          itemType: tutorial
-          text: Tutorials
         - url: https://dotnet.microsoft.com/platform/community
           itemType: whats-new
-          text: Community
-        - url: https://dotnetfoundation.org/
+          text: .NET developer community
+        - url: https://dotnetfoundation.org
           itemType: overview
           text: .NET Foundation
+        - url: standard/library-guidance/index.md
+          itemType: concept
+          text: Open source library guidance
     # Card
     - title: .NET concepts
-      summary: Learn the fundamental concepts of .NET
       links:
-        - url: https://channel9.msdn.com/Series/NET-Core-101/What-is-NET
+        - url: https://channel9.msdn.com/series/net-core-101/what-is-net
           itemType: video
           text: What is .NET?
         - url: /answers/products/dotnet
           itemType: get-started
           text: .NET on Q&A
-        - url: ./core/introduction.md
-          itemType: overview
-          text: Overview of .NET
-        - url: core/dotnet-five.md
-          itemType: concept
-          text: What's new in .NET 5
         - url: standard/net-standard.md
           itemType: overview
           text: .NET Standard
@@ -116,7 +111,6 @@ conceptualContent:
           text: .NET Framework (Windows) apps
     # Card
     - title: Develop .NET apps
-      summary: Start developing with .NET
       links:
         - url: core/sdk.md
           itemType: download
@@ -124,6 +118,9 @@ conceptualContent:
         - url: core/tools/index.md
           itemType: overview
           text: .NET CLI overview
+        - url: fundamentals/index.md
+          itemType: concept
+          text: .NET fundamentals
         - url: core/porting/index.md
           itemType: overview
           text: Port from .NET Framework to .NET
@@ -133,25 +130,24 @@ conceptualContent:
         - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-5.0
           itemType: tutorial
           text: Create .NET desktop apps for Windows
-        - url: standard/library-guidance/index.md
-          itemType: concept
-          text: Open source library guidance
     # Card
     - title: .NET architectural guides
-      summary: Explore architectural guidance for .NET
       links:
         - url: architecture/dapr-for-net-developers/index.md
           itemType: architecture
-          text: "Dapr for .NET developers"
+          text: Dapr for .NET developers
         - url: architecture/microservices/index.md
           itemType: architecture
-          text: "Architecture for containerized .NET apps"
+          text: Architecture for containerized .NET apps
         - url: architecture/modern-web-apps-azure/index.md
           itemType: architecture
           text: Modern web apps with ASP.NET Core and Azure
         - url: architecture/containerized-lifecycle/index.md
           itemType: architecture
-          text: "Containerized Docker app lifecycle"
+          text: Containerized Docker app lifecycle
+        - url: architecture/cloud-native/index.md
+          itemType: architecture
+          text: Cloud native .NET apps for Azure
         - url: architecture/modernize-with-azure-containers/index.md
           itemType: architecture
           text: Modernize .NET apps with Azure
@@ -241,7 +237,7 @@ additionalContent:
       # Card
       - title: Cloud
         links:
-          - url: ./azure/index.yml
+          - url: azure/index.yml
             text: Azure for .NET developers
           - url: /dotnet/azure/migration/app-service?view=azure-dotnet
             text: Migrate .NET web app or service
@@ -249,7 +245,7 @@ additionalContent:
             text: Azure services for .NET developers
           - url: /dotnet/azure/sdk/azure-sdk-for-dotnet
             text: Azure .NET SDK
-          - url: ./fsharp/using-fsharp-on-azure/index.md
+          - url: fsharp/using-fsharp-on-azure/index.md
             text: Use F# on Azure
       # Card
       - title: Machine learning and AI
@@ -263,7 +259,7 @@ additionalContent:
           - url: spark/index.yml
             text: .NET for Apache Spark
       # Card
-      - title: Game Development
+      - title: Game development
         links:
           - url: https://visualstudio.microsoft.com/vs/features/game-development/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link
             text: Game development with Visual Studio
@@ -276,11 +272,11 @@ additionalContent:
       # Card
       - title: Internet of things (IoT)
         links:
-          - url: ./iot/index.yml
+          - url: iot/index.yml
             text: .NET IoT Libraries
-          - url: ./iot/quickstarts/sensehat.md
+          - url: iot/quickstarts/sensehat.md
             text: Get started in 5 minutes
-          - url: ./iot/tutorials/blink-led.md
+          - url: iot/tutorials/blink-led.md
             text: Blink an LED
           - url: https://aka.ms/IoTNet101
             text: .NET IoT 101 video series

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 03/10/2021
+  ms.date: 03/11/2021
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -127,7 +127,7 @@ conceptualContent:
         - url: core/compatibility/index.md
           itemType: concept
           text: .NET breaking changes
-        - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-5.0
+        - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-5.0&preserve-view=true
           itemType: tutorial
           text: Create .NET desktop apps for Windows
     # Card
@@ -138,7 +138,7 @@ conceptualContent:
           text: Dapr for .NET developers
         - url: architecture/microservices/index.md
           itemType: architecture
-          text: Architecture for containerized .NET apps
+          text: .NET microservices architecture guidance
         - url: architecture/modern-web-apps-azure/index.md
           itemType: architecture
           text: Modern web apps with ASP.NET Core and Azure
@@ -211,13 +211,13 @@ additionalContent:
         links:
           - url: /uwp
             text: Universal Windows apps
-          - url: /dotnet/desktop/wpf/?view=netdesktop-5.0
+          - url: /dotnet/desktop/wpf/?view=netdesktop-5.0&preserve-view=true
             text: Windows Presentation Foundation (.NET 5)
-          - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8
+          - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Presentation Foundation (.NET Framework)
-          - url: /dotnet/desktop/winforms/?view=netdesktop-5.0
+          - url: /dotnet/desktop/winforms/?view=netdesktop-5.0&preserve-view=true
             text: Windows Forms (.NET 5)
-          - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8
+          - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Forms (.NET Framework)
           - url: /xamarin/mac
             text: Xamarin for macOS
@@ -239,7 +239,7 @@ additionalContent:
         links:
           - url: azure/index.yml
             text: Azure for .NET developers
-          - url: /dotnet/azure/migration/app-service?view=azure-dotnet
+          - url: /dotnet/azure/migration/app-service?view=azure-dotnet&preserve-view=true
             text: Migrate on-premises .NET web apps or services
           - url: /dotnet/azure/key-azure-services
             text: Azure services for .NET developers
@@ -291,23 +291,23 @@ additionalContent:
       # Card
       - title: ".NET Core API reference"
         summary: API reference documentation for .NET Core
-        url: ../api/index.md?view=netcore-3.1
+        url: ../api/index.md?view=netcore-3.1&preserve-view=true
       # Card
       - title: ".NET Framework API reference"
         summary: API reference documentation for .NET Framework
-        url: ../api/index.md?view=netframework-4.8
+        url: ../api/index.md?view=netframework-4.8&preserve-view=true
       # Card
       - title: "ASP.NET Core API reference"
         summary: API reference documentation for ASP.NET Core
-        url: ../api/index.md?view=aspnetcore-3.1
+        url: ../api/index.md?view=aspnetcore-3.1&preserve-view=true
       # Card
       - title: "ML.NET API reference"
         summary: API reference documentation for ML.NET
-        url: ../api/index.md?view=ml-dotnet
+        url: ../api/index.md?view=ml-dotnet&preserve-view=true
       # Card
       - title: ".NET for Apache Spark API reference"
         summary: API reference documentation for .NET for Apache Spark
-        url: ../api/index.md?view=spark-dotnet
+        url: ../api/index.md?view=spark-dotnet&preserve-view=true
       # Card
       - title: "C# language reference"
         summary: C# language reference and specification

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -59,7 +59,7 @@ conceptualContent:
   summary: "A developer platform for building all your apps: web, mobile, desktop, gaming, IoT, and more. Supported on Windows, Linux, and macOS."
   items:
     # Card
-    - title: Open-source .NET
+    - title: Open source .NET
       summary: Learn about .NET
       links:
         - url: core/introduction.md
@@ -235,11 +235,11 @@ additionalContent:
           - url: architecture/cloud-native/index.md
             text: Cloud native .NET apps
           - url: https://dotnet.microsoft.com/learn/aspnet/microservice-tutorial/intro
-            text: Your first .NET microservice
+            text: Create your first .NET microservice
           - url: architecture/serverless/index.md
-            text: "Serverless apps: Architecture, patterns, and Azure implementation"
+            text: Serverless apps with Azure
           - url: architecture/microservices/index.md
-            text: ".NET Microservices: Architecture for Containerized .NET Applications"
+            text: Architecture for Containerized .NET apps
       # Card
       - title: Cloud
         links:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 03/09/2021
+  ms.date: 03/10/2021
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -48,7 +48,7 @@ highlightedContent:
       itemType: whats-new
       url: whats-new/index.yml
     # Card
-    - title: "Introduction to C#"
+    - title: "Interactive introduction to C#"
       itemType: get-started
       url: ./csharp/tour-of-csharp/tutorials/hello-world.yml
 
@@ -70,10 +70,10 @@ conceptualContent:
           text: What's new in .NET 5
         - url: core/deploying/index.md
           itemType: deploy
-          text: Deploy .NET Core apps
+          text: Deploy .NET apps
         - url: core/docker/build-container.md
           itemType: tutorial
-          text: Containerize .NET Core apps with Docker
+          text: Containerize .NET apps with Docker
         - url: core/tutorials/index.md
           itemType: tutorial
           text: Tutorials
@@ -120,16 +120,16 @@ conceptualContent:
       links:
         - url: core/sdk.md
           itemType: download
-          text: Download the .NET Core SDK
+          text: Download the .NET SDK
         - url: core/tools/index.md
           itemType: overview
-          text: .NET Core CLI overview
+          text: .NET CLI overview
         - url: core/porting/index.md
           itemType: overview
           text: Port from .NET Framework to .NET
         - url: core/compatibility/index.md
           itemType: concept
-          text: .NET Core breaking changes
+          text: .NET breaking changes
         - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-5.0
           itemType: tutorial
           text: Create .NET desktop apps for Windows
@@ -189,8 +189,6 @@ additionalContent:
       # Card
       - title: Web
         links:
-          - url: /aspnet/core/getting-started
-            text: Create your first web app
           - url: /aspnet/core/tutorials
             text: ASP.NET Core tutorials
           - url: /aspnet/core

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -138,20 +138,23 @@ conceptualContent:
           text: Open source library guidance
     # Card
     - title: .NET architectural guides
-      summary: Read foundational development and architectural guidance for .NET
+      summary: Explore architectural guidance for .NET
       links:
+        - url: architecture/dapr-for-net-developers/index.md
+          itemType: architecture
+          text: "Dapr for .NET developers"
         - url: architecture/microservices/index.md
           itemType: architecture
-          text: ".NET Microservices: Architecture for containerized .NET apps"
+          text: "Architecture for containerized .NET apps"
         - url: architecture/modern-web-apps-azure/index.md
           itemType: architecture
-          text: Architect modern web applications with ASP.NET Core and Azure
+          text: Modern web apps with ASP.NET Core and Azure
         - url: architecture/containerized-lifecycle/index.md
           itemType: architecture
-          text: "Containerized Docker application lifecycle with Microsoft platform and tools"
+          text: "Containerized Docker app lifecycle"
         - url: architecture/modernize-with-azure-containers/index.md
           itemType: architecture
-          text: "Modernize existing .NET applications with Azure cloud and Windows containers"
+          text: Modernize .NET apps with Azure
       # footerLink (optional)
       footerLink:
         url: architecture/index.yml


### PR DESCRIPTION
## Summary

- Align with <https://dot.net> landing page
- Update the order in which we refer to programming languages, as they were inconsistent
  - Ordered alphabetically as: C#, F#, and VB
- Strive to keep line-breaks consistent, mainly for my OCD but also for visual parity / symmetry
- Add .NET 5 API ref card
- Drop "Core" wording from text where appropriate - refer to .NET
  - Exceptions: ASP.NET Core, Entity Framework Core, .NET Core 1..3.1, etc.
- Leverage the MDM to determine clicks, use this to help decide which link should go where
- Split cloud and microservices cards, add a few more links to each
- Add new Azure for .NET content links
- Adjust wording:
  - Prefer verbs, call to actions, etc.
  - Address inconsistencies, "Open source" vs. "Open-source", "applications" vs "apps", etc.
- Account for changes to order proposed in https://github.com/dotnet/website/issues/2773

Fixes #20970 and closes #23027

### Internal preview

✔️ [.NET docs hub page](https://review.docs.microsoft.com/en-us/dotnet/?branch=pr-en-us-23229)

### Before

![image](https://user-images.githubusercontent.com/7679720/110699652-b2df3100-81b4-11eb-9498-84dcb1d529e6.png)

### After

![image](https://user-images.githubusercontent.com/7679720/110699665-b70b4e80-81b4-11eb-946a-5b7cb74630b5.png)

### Before

![image](https://user-images.githubusercontent.com/7679720/110699820-e28e3900-81b4-11eb-9f30-5215e3b4305c.png)

### After

![image](https://user-images.githubusercontent.com/7679720/110699849-ea4ddd80-81b4-11eb-8661-4104d47a0820.png)

### Before

![image](https://user-images.githubusercontent.com/7679720/110700002-10737d80-81b5-11eb-8207-8d258531d596.png)

### After

![image](https://user-images.githubusercontent.com/7679720/110700026-16695e80-81b5-11eb-9ff6-b3687a7006f6.png)

### Before

![image](https://user-images.githubusercontent.com/7679720/110700225-54668280-81b5-11eb-8d00-6d22952c6176.png)

### After

![image](https://user-images.githubusercontent.com/7679720/110700239-5892a000-81b5-11eb-9181-92e54038b28b.png)

As an aside, I'm not thrilled about this layout changing from 4x2 to 3x3, 4x2 is ideal and I already reported this issue to the platform team.