### PR TITLE
Remove multiple internal feeds

### DIFF
--- a/docs/csharp/roslyn-sdk/tutorials/snippets/how-to-write-csharp-analyzer-code-fix/NuGet.config
+++ b/docs/csharp/roslyn-sdk/tutorials/snippets/how-to-write-csharp-analyzer-code-fix/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
NuGet Security Analysis found 1 vulnerable package manifest in the repository. Visit https://aka.ms/nugetmultifeed for more details.