### PR TITLE
Clean up IoT hub YML

### DIFF
--- a/docs/iot/index.yml
+++ b/docs/iot/index.yml
@@ -11,7 +11,7 @@ metadata:
   ms.collection: collection
   author: camsoper
   ms.author: casoper
-  ms.date: 11/13/2020
+  ms.date: 03/09/2021
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
 
@@ -21,30 +21,30 @@ landingContent:
     linkLists:
       - linkListType: quickstart
         links:
-          - text: Sense HAT quickstart  
-            url: quickstarts/sensehat.md  
+          - text: Sense HAT quickstart
+            url: quickstarts/sensehat.md
 
   - title: Learn
     linkLists:
       - linkListType: overview
         links:
-          - text: .NET IoT Libraries overview  
-            url: intro.md               
+          - text: .NET IoT Libraries overview
+            url: intro.md
       - linkListType: get-started
         links:
           - text: .NET IoT on Q&A
             url: /answers/topics/dotnet-iot.html
       - linkListType: deploy
         links:
-          - text: Deploy .NET apps to Raspberry Pi  
-            url: deployment.md               
+          - text: Deploy .NET apps to Raspberry Pi
+            url: deployment.md
       - linkListType: concept
         links:
-          - text: Debug .NET apps on Raspberry Pi  
+          - text: Debug .NET apps on Raspberry Pi
             url: debugging.md
       - linkListType: reference
         links:
-          - text: API Reference 
+          - text: API Reference
             url: ../../api/index.md?view=iot-dotnet-1.1
 
   - title: Connect to devices
@@ -64,35 +64,35 @@ landingContent:
     linkLists:
       - linkListType: download
         links:
-          - text: System.Device.Gpio on NuGet >>
+          - text: System.Device.Gpio on NuGet
             url: https://www.nuget.org/packages/System.Device.Gpio/
-          - text: Iot.Device.Bindings on NuGet >>
+          - text: Iot.Device.Bindings on NuGet
             url: https://www.nuget.org/packages/Iot.Device.Bindings/
-          - text: .NET IoT Libraries source on GitHub >>
+          - text: .NET IoT Libraries source on GitHub
             url: https://github.com/dotnet/iot
-          - text: Device bindings with samples on GitHub >>
+          - text: Device bindings with samples on GitHub
             url: https://github.com/dotnet/iot/blob/master/src/devices
   
-  - title: Video learning 
+  - title: Video learning
     linkLists:
       - linkListType: video
         links:
-          - text: .NET IoT 101 (series) >>
+          - text: .NET IoT 101 (series)
             url: https://aka.ms/IoTNet101
-          - text: BBQ, Bots, and .NET Core >>
+          - text: BBQ, Bots, and .NET Core
             url: https://channel9.msdn.com/Shows/On-NET/BBQ-Bots-and-NET-Core
 
-  - title: Resources 
+  - title: Resources
     linkLists:
       - linkListType: concept
         links:
-          - text: Raspberry Pi documentation >>
+          - text: Raspberry Pi documentation
             url: https://www.raspberrypi.org/documentation/
       - linkListType: how-to-guide
         links:
-          - text: Passwordless SSH access >>
+          - text: Passwordless SSH access
             url: https://www.raspberrypi.org/documentation/remote-access/ssh/passwordless.md
-          - text: Setting up a Raspberry Pi headless >>
+          - text: Setting up a Raspberry Pi headless
             url: https://www.raspberrypi.org/documentation/configuration/wireless/headless.md
-          - text: Run a .NET app automatically at boot >>
+          - text: Run a .NET app automatically at boot
             url: https://github.com/dotnet/iot/blob/master/Documentation/How-to-start-your-app-automatically-on-boot.md


### PR DESCRIPTION
## Summary

Since we now have external icons out-of-the-box, let's remove the `>>`.