### PR TITLE
configure csharplang branch

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -48,11 +48,8 @@
     {
       "path_to_root": "_csharplang",
       "url": "https://github.com/dotnet/csharplang",
-      "branch": "master",
-      "include_in_build": true,
-      "branch_mapping": {
-        "main": "master"
-      }
+      "branch": "main",
+      "include_in_build": true
     },
     {
       "path_to_root": "_vblang",


### PR DESCRIPTION
The csharplang branch renaming has completed.
We need to make this change to continue publishing.
