### PR TITLE
Add bash to prereqs for dotnet-install.sh on Alpine

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -63,7 +63,7 @@ You can use a command like this:
 apk add bash icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
 ```
 
-To install libgdiplus you may need to specify a repository:
+To install libgdiplus, you may need to specify a repository:
 
 ```bash
 apk add libgdiplus --repository https://dl-3.alpinelinux.org/alpine/edge/testing/

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -46,14 +46,20 @@ The following versions of .NET are no longer supported. The downloads for these 
 
 .NET on Alpine Linux requires the following dependencies installed:
 
+- bash
 - icu-libs
 - krb5-libs
 - libgcc
+- libgdiplus (if you expect to use System.Drawing)
 - libintl
 - libssl1.1 (Alpine v3.9 or greater)
 - libssl1.0 (Alpine v3.8 or lower)
 - libstdc++
 - zlib
+
+You can use a command like `apk add bash icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib`
+
+To install libgdiplus you may need to specify a repository: `apk add libgdiplus --repository https://dl-3.alpinelinux.org/alpine/edge/testing/`
 
 ## Next steps
 

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -50,20 +50,20 @@ The following versions of .NET are no longer supported. The downloads for these 
 - icu-libs
 - krb5-libs
 - libgcc
-- libgdiplus (if you expect to use System.Drawing)
+- libgdiplus (if the .NET app requires the *System.Drawing.Common* assembly)
 - libintl
 - libssl1.1 (Alpine v3.9 or greater)
 - libssl1.0 (Alpine v3.8 or lower)
 - libstdc++
 - zlib
 
-You can use a command like this:
+To install the needed requirements, run the following command:
 
 ```bash
 apk add bash icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
 ```
 
-To install libgdiplus, you may need to specify a repository:
+To install **libgdiplus**, you may need to specify a repository:
 
 ```bash
 apk add libgdiplus --repository https://dl-3.alpinelinux.org/alpine/edge/testing/

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -57,9 +57,17 @@ The following versions of .NET are no longer supported. The downloads for these 
 - libstdc++
 - zlib
 
-You can use a command like `apk add bash icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib`
+You can use a command like this:
 
-To install libgdiplus you may need to specify a repository: `apk add libgdiplus --repository https://dl-3.alpinelinux.org/alpine/edge/testing/`
+```bash
+apk add bash icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
+```
+
+To install libgdiplus you may need to specify a repository:
+
+```bash
+apk add libgdiplus --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
+```
 
 ## Next steps
 


### PR DESCRIPTION
Otherwise you get
```
[2021/03/13 18:40:35][INFO] $ /home/dan/git/performance/tools/dotnet/x64/dotnet-install.sh -InstallDir /home/dan/git/performance/tools/dotnet/x64 -Architecture x64 -Channel 5.0
[2021/03/13 18:40:35][INFO] env: ‘bash’: No such file or directory
```
bash is not installed by default on Alpine.

Also added a note for libgdiplus.
