### PR TITLE
remove (empty) branch mapping array from vblang node

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -55,8 +55,7 @@
       "path_to_root": "_vblang",
       "url": "https://github.com/dotnet/vblang",
       "branch": "main",
-      "include_in_build": true,
-      "branch_mapping": {}
+      "include_in_build": true
     },
     {
       "path_to_root": "machinelearning-samples",


### PR DESCRIPTION
This makes it consistent with the csharplang version. see https://github.com/dotnet/docs/pull/23298#discussion_r594546181
