### PR TITLE
improve navigation for async tutorial

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -262,5 +262,5 @@ A recommended goal is to achieve complete or near-complete [Referential Transpar
 ## Other resources
 
 * [Async in-depth](../standard/async-in-depth.md) provides more information about how Tasks work.
-* [Asynchronous programming with async and await (C#)](./programming-guide/concepts/async/index.md)
+* [The Task asynchronous programming model (C#)](./programming-guide/concepts/async/task-asynchronous-programming-model.md)
 * Lucian Wischik's [Six Essential Tips for Async](https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async) are a wonderful resource for async programming

--- a/docs/csharp/programming-guide/concepts/async/index.md
+++ b/docs/csharp/programming-guide/concepts/async/index.md
@@ -188,4 +188,4 @@ This final code is asynchronous. It more accurately reflects how a person would 
 ## Next steps
 
 > [!div class="nextstepaction"]
-> [Learn about the task asynchronous programming model](task-asynchronous-programming-model.md)
+> [Explore real world scenarios for asynchronous programs](../../../async.md)

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -187,8 +187,6 @@ items:
       href: linq/handle-null-values-in-query-expressions.md
     - name: Handle exceptions in query expressions
       href: linq/handle-exceptions-in-query-expressions.md
-  - name: Asynchronous programming
-    href: async.md
   - name: Pattern Matching
     href: pattern-matching.md
   - name: Write safe, efficient code
@@ -318,6 +316,8 @@ items:
       - name: Overview
         displayName: asynchronous programming
         href: programming-guide/concepts/async/index.md
+      - name: Asynchronous programming scenarios
+        href: async.md
       - name: Task asynchronous programming model
         href: programming-guide/concepts/async/task-asynchronous-programming-model.md
       - name: Async return types


### PR DESCRIPTION
Fixes #16988

We did have a well-written second asynchronous tutorial. It was hidden in the wrong section, and didn't naturally follow the existing tutorial.

This PR updates the TOC to highlight the next tutorial.
