### PR TITLE
Remove the ErrorReport option

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -924,7 +924,7 @@
         },
         {
             "source_path": "docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md",
-            "redirect_url": "/dotnet/csharp/language-reference/compiler-options/advanced"
+            "redirect_url": "/dotnet/csharp/language-reference/compiler-options"
         },
         {
             "source_path": "docs/csharp/language-reference/compiler-options/checked-compiler-option.md",
@@ -960,7 +960,7 @@
         },
         {
             "source_path": "docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md",
-            "redirect_url": "/dotnet/csharp/language-reference/compiler-options/advanced"
+            "redirect_url": "/dotnet/csharp/language-reference/compiler-options"
         },
         {
             "source_path": "docs/csharp/language-reference/compiler-options/filealign-compiler-option.md",

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1076,7 +1076,7 @@
         },
         {
             "source_path": "docs/csharp/language-reference/compiler-options/recurse-compiler-option.md",
-            "redirect_url": "/dotnet/csharp/language-reference/compiler-options/index"
+            "redirect_url": "/dotnet/csharp/language-reference/compiler-options"
         },
         {
             "source_path": "docs/csharp/language-reference/compiler-options/reference-compiler-option.md",

--- a/docs/csharp/language-reference/compiler-options/advanced.md
+++ b/docs/csharp/language-reference/compiler-options/advanced.md
@@ -19,7 +19,6 @@ helpviewer_keywords:
   - "PreferredUILang compiler option [C#]"
   - "SubsystemVersion compiler option [C#]"
   - "AdditionalLibPaths compiler option [C#]"
-  - "ErrorReport compiler option [C#]"
   - "ApplicationConfiguration compiler option [C#]"
   - "ModuleAssemblyName compiler option [C#]"
 
@@ -31,7 +30,6 @@ The following options support advanced scenarios. The new MSBuild syntax is show
 - **MainEntryPoint**, **StartupObject** / `-main`: Specify the type that contains the entry point.
 - **PdbFile** / `-pdb`: Specify debug information file name.
 - **PathMap** / `-pathmap`: Specify a mapping for source path names output by the compiler.
-- **ErrorReport** / `-errorreport`: Specify how to handle internal compiler errors.
 - **ApplicationConfiguration** / `-appconfig`: Specify an application configuration file containing assembly binding settings.
 - **AdditionalLibPaths** / `-lib`: Specify additional directories to search in for references.
 - **GenerateFullPaths** / `-fullpath`: Compiler generates fully qualified paths.
@@ -88,28 +86,6 @@ The compiler writes the source path into its output for the following reasons:
 1. The source path is substituted for an argument when the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute> is applied to an optional parameter.
 1. The source path is embedded in a PDB file.
 1. The path of the PDB file is embedded into a PE (portable executable) file.
-
-## ErrorReport
-
-This option provides a convenient way to report a C# internal compiler error to Microsoft.
-
-> [!NOTE]
-> On Windows Vista and Windows Server 2008, the error reporting settings that you make for Visual Studio do not override the settings made through Windows Error Reporting (WER). WER settings always take precedence over Visual Studio error reporting settings.
-
-```xml
-<ErrorReport>setting</ErrorReport>
-```
-
-The argument must be one of:
-
-- **none**: Reports about internal compiler errors won't be collected or sent to Microsoft.
-- **prompt**: Prompts you to send a report when you receive an internal compiler error. **prompt** is the default when you compile an application in the development environment.
-- **queue**: Queues the error report. When you sign in with administrative credentials, you can report any failures since the last time that you were logged on. You won't be prompted to send reports for failures more than once every three days. **queue** is the default when you compile an application at the command line.
-- **send**: Automatically sends reports of internal compiler errors to Microsoft. To enable this option, you must first agree to the Microsoft data collection policy. The first time that you specify `<ErrorReport>send</ErrorReport>` on a computer, a compiler message will refer you to a Web site that contains the Microsoft data collection policy.
-
-An internal compiler error (ICE) results when the compiler can't process a source code file. When an ICE occurs, the compiler doesn't produce an output file or any useful diagnostic that you can use to fix your code.
-
-By using **ErrorReport**, you can provide ICE information to the C# team. Your error reports can help improve future compiler releases. A user's ability to send reports depends on computer and user policy permissions.
 
 ## ApplicationConfiguration
 

--- a/docs/csharp/misc/cs0010.md
+++ b/docs/csharp/misc/cs0010.md
@@ -16,8 +16,4 @@ Unexpected fatal error -- 'error'.
   
 ## To correct this error  
   
-1. Recompile another project. If you receive the same error, try reinstalling Visual Studio. If you receive this error, send an error report to Microsoft.  
-  
-## See also
-
-- [**ErrorReport** (C# Compiler Options)](../language-reference/compiler-options/advanced.md#errorreport)
+Recompile another project. If you receive the same error, try reinstalling Visual Studio. If you receive this error, send an error report to Microsoft.  

--- a/docs/csharp/misc/cs0583.md
+++ b/docs/csharp/misc/cs0583.md
@@ -10,11 +10,7 @@ ms.assetid: 67a9b339-af79-42a3-afe7-b1732bd43f8f
 ---
 # Compiler Error CS0583
 
-Internal Compiler Error. An internal error has occurred in the compiler. To work around this problem, try simplifying or changing the program near the locations listed below. Locations at the top of the list are closer to the point at which the internal error occurred. Errors such as this can be reported to Microsoft by using the /errorreport option.
-
- Please create a bug report file with the **ErrorReport** option, and submit the report to your assigned problem reporting contact.
-
- Use the [-bugreport](../language-reference/compiler-options/advanced.md#errorreport) compiler option to capture the problem.
+Internal Compiler Error. An internal error has occurred in the compiler. To work around this problem, try simplifying or changing the program near the locations listed below. Locations at the top of the list are closer to the point at which the internal error occurred.
 
 > [!NOTE]
 > This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs1630.md
+++ b/docs/csharp/misc/cs1630.md
@@ -12,4 +12,7 @@ ms.assetid: 15f39e1f-326b-4caf-9fb7-77ddd7851dcf
 
 Invalid option 'option' for **ErrorReport**; must be **prompt**, **send**, **queue**, or **none**  
   
- The command line option [**ErrorReport**](../language-reference/compiler-options/advanced.md#errorreport) must be followed by **prompt**, **send**, **queue**, or **none**, specifying what action you want taken when an internal compiler error occurs.
+ The command line option **ErrorReport** must be followed by **prompt**, **send**, **queue**, or **none**, specifying what action you want taken when an internal compiler error occurs.
+
+> {!NOTE}
+> This compiler option is no longer supported.

--- a/docs/csharp/misc/cs1727.md
+++ b/docs/csharp/misc/cs1727.md
@@ -27,7 +27,3 @@ class Test
     static void Main(){}
 }
 ```
-
-## See also
-
-- [**ErrorReport** (C# Compiler Options)](../language-reference/compiler-options/advanced.md#errorreport)

--- a/docs/csharp/misc/cs2012.md
+++ b/docs/csharp/misc/cs2012.md
@@ -15,4 +15,4 @@ Cannot open 'file' for writing
 While using the `-bugreport:`, `file` compiler option, the file could not be opened for writing. Make sure you specified a valid file name and that the file is not read-only.
 
 > [!IMPORTANT]
-> The `bugreport` option is no longer supported. Use the [**ErrorReport**](../language-reference/compiler-options/advanced.md#errorreport) option instead.
+> The `bugreport` option is no longer supported.

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1379,7 +1379,7 @@ items:
       displayName: ResponseFiles, @, NoLogo, nologo, NoConfig, noconfig
       href: language-reference/compiler-options/miscellaneous.md
     - name: Advanced options
-      displayName: MainEntryPoint, StartupObject, main, PdbFile, pdb, PathMap, pathmap, ErrorReport, errorreport, ApplicationConfiguration, appconfig, AdditionalLibPaths, lib, GenerateFullPaths, fullpath, PreferredUILang, preferreduilang, BaseAddress, baseaddress, ChecksumAlgorithm, checksumalgorithm, CodePage, codepage, Utf8Output, utf8output, FileAlignment, filealign, ErrorEndLocation, errorendlocation, NoStandardLib, nostdlib, SubsystemVersion, subsystemversion, ModuleAssemblyName, moduleassemblyname
+      displayName: MainEntryPoint, StartupObject, main, PdbFile, pdb, PathMap, pathmap, ApplicationConfiguration, appconfig, AdditionalLibPaths, lib, GenerateFullPaths, fullpath, PreferredUILang, preferreduilang, BaseAddress, baseaddress, ChecksumAlgorithm, checksumalgorithm, CodePage, codepage, Utf8Output, utf8output, FileAlignment, filealign, ErrorEndLocation, errorendlocation, NoStandardLib, nostdlib, SubsystemVersion, subsystemversion, ModuleAssemblyName, moduleassemblyname
       href: language-reference/compiler-options/advanced.md
   - name: Compiler errors
     href: language-reference/compiler-messages/index.md


### PR DESCRIPTION
It's deprecated, and should be removed.

Fixes #23323 
