### PR TITLE
fix link to async return types spec, clarify Task-like return types.

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/async-return-types.md
+++ b/docs/csharp/programming-guide/concepts/async/async-return-types.md
@@ -76,11 +76,13 @@ The following example shows the behavior of an async event handler. In the examp
 
 Starting with C# 7.0, an async method can return any type that has an accessible `GetAwaiter` method that returns an instance of an *awaiter type*. In addition, the type returned from the `GetAwaiter` method must have the <xref:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute?displayProperty=nameWithType> attribute. You can learn more in the feature spec for [Task like return types](../../../../../_csharplang/proposals/csharp-7.0/task-types.md).
 
-Because <xref:System.Threading.Tasks.Task> and <xref:System.Threading.Tasks.Task%601> are reference types, memory allocation in performance-critical paths, particularly when allocations occur in tight loops, can adversely affect performance. Support for generalized return types means that you can return a lightweight value type instead of a reference type to avoid additional memory allocations.
+This feature is the complement to [awaitable expressions](../../../../../_csharplang/spec/expressions.md#awaitable-expressions), which describes the requirements for the operand of `await`. Generalized async return types enable the compiler to generate `async` methods that return different types. Generalized async return types enabled performance improvements in the .NET libraries. Because <xref:System.Threading.Tasks.Task> and <xref:System.Threading.Tasks.Task%601> are reference types, memory allocation in performance-critical paths, particularly when allocations occur in tight loops, can adversely affect performance. Support for generalized return types means that you can return a lightweight value type instead of a reference type to avoid additional memory allocations.
 
 .NET provides the <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> structure as a lightweight implementation of a generalized task-returning value. To use the <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> type, you must add the `System.Threading.Tasks.Extensions` NuGet package to your project. The following example uses the <xref:System.Threading.Tasks.ValueTask%601> structure to retrieve the value of two dice rolls.
 
 :::code language="csharp" source="snippets/async-return-types/async-valuetask.cs":::
+
+Writing a generalized async return type is an advanced scenario. You should use `Task`, `Task<T>` and `ValueTask<T>`. Those types cover most scenarios for asynchronous code.
 
 ## Async streams with IAsyncEnumerable\<T\>
 

--- a/docs/csharp/programming-guide/concepts/async/async-return-types.md
+++ b/docs/csharp/programming-guide/concepts/async/async-return-types.md
@@ -82,7 +82,7 @@ This feature is the complement to [awaitable expressions](../../../../../_csharp
 
 :::code language="csharp" source="snippets/async-return-types/async-valuetask.cs":::
 
-Writing a generalized async return type is an advanced scenario. Consider using the `Task`, `Task<T>` and `ValueTask<T>` types instead, which cover most scenarios for asynchronous code.
+Writing a generalized async return type is an advanced scenario, and is targeted for use in very specific environments. Consider using the `Task`, `Task<T>` and `ValueTask<T>` types instead, which cover most scenarios for asynchronous code.
 
 ## Async streams with IAsyncEnumerable\<T\>
 

--- a/docs/csharp/programming-guide/concepts/async/async-return-types.md
+++ b/docs/csharp/programming-guide/concepts/async/async-return-types.md
@@ -74,7 +74,7 @@ The following example shows the behavior of an async event handler. In the examp
 
 ## Generalized async return types and ValueTask\<TResult\>
 
-Starting with C# 7.0, an async method can return any type that has an accessible `GetAwaiter` method that returns an instance of an *awaiter type*. In addition, the type returned from the `GetAwaiter` method must have the <xref:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute?displayProperty=nameWithType> attribute. You can learn more in the feature spec for [Task like return types](../../../../_csharplang/proposals/csharp-7.0/task-types.md).
+Starting with C# 7.0, an async method can return any type that has an accessible `GetAwaiter` method that returns an instance of an *awaiter type*. In addition, the type returned from the `GetAwaiter` method must have the <xref:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute?displayProperty=nameWithType> attribute. You can learn more in the feature spec for [Task like return types](../../../../../_csharplang/proposals/csharp-7.0/task-types.md).
 
 Because <xref:System.Threading.Tasks.Task> and <xref:System.Threading.Tasks.Task%601> are reference types, memory allocation in performance-critical paths, particularly when allocations occur in tight loops, can adversely affect performance. Support for generalized return types means that you can return a lightweight value type instead of a reference type to avoid additional memory allocations.
 

--- a/docs/csharp/programming-guide/concepts/async/async-return-types.md
+++ b/docs/csharp/programming-guide/concepts/async/async-return-types.md
@@ -82,7 +82,7 @@ This feature is the complement to [awaitable expressions](../../../../../_csharp
 
 :::code language="csharp" source="snippets/async-return-types/async-valuetask.cs":::
 
-Writing a generalized async return type is an advanced scenario. You should use `Task`, `Task<T>` and `ValueTask<T>`. Those types cover most scenarios for asynchronous code.
+Writing a generalized async return type is an advanced scenario. Consider using the `Task`, `Task<T>` and `ValueTask<T>` types instead, which cover most scenarios for asynchronous code.
 
 ## Async streams with IAsyncEnumerable\<T\>
 


### PR DESCRIPTION
In addition to fixing the broken link, add clarification on awaitables vs. Task like types.  See https://github.com/dotnet/docs/pull/23370#issuecomment-802247786. Furthermore, recommend using `Task`, `Task<T>` and `ValueTask<T>` instead of writing your own.