### PR TITLE
Change sample class name

### DIFF
--- a/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
+++ b/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
@@ -16,7 +16,7 @@ helpviewer_keywords:
 
 The `where` clause in a generic definition specifies constraints on the types that are used as arguments for type parameters in a generic type, method, delegate, or local function. Constraints can specify interfaces, base classes, or require a generic type to be a reference, value, or unmanaged type. They declare capabilities that the type argument must have.
 
-For example, you can declare a generic class, `MyGenericClass`, such that the type parameter `T` implements the <xref:System.IComparable%601> interface:
+For example, you can declare a generic class, `AGenericClass`, such that the type parameter `T` implements the <xref:System.IComparable%601> interface:
 
 [!code-csharp[using an interface constraint](snippets/GenericWhereConstraints.cs#1)]
 


### PR DESCRIPTION
The original name conflicts with another in the same sample.

Fixes #23415
