### PR TITLE
Fix redirect for 2.0 - 2.1 information

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -457,7 +457,7 @@
         },
         {
             "source_path": "docs/core/migration/20-21.md",
-            "redirect_url": "/dotnet/core/porting/index.md"
+            "redirect_url": "/dotnet/core/compatibility/2.1"
         },
         {
             "source_path": "docs/core/migration/from-dnx.md",


### PR DESCRIPTION
## Summary

- Redirect had .md in the target (weird, build should have caught that right?)
- Changed to the breaking changes file the content was ported to.

Thanks @gewarren for spotting the orphaned file!

