### PR TITLE
Add explicit call to `FlushFinalBlock` that was missing from implicit `Dispose`

### DIFF
--- a/docs/standard/security/decrypting-data.md
+++ b/docs/standard/security/decrypting-data.md
@@ -1,7 +1,7 @@
 ---
-title: "Decrypting Data"
+title: "Decrypting data"
 description: Learn how to decrypt data in .NET, using a symmetric algorithm or an asymmetric algorithm.
-ms.date: 07/16/2020
+ms.date: 03/22/2021
 dev_langs:
   - "csharp"
   - "vb"
@@ -13,11 +13,11 @@ helpviewer_keywords:
 ms.assetid: 9b266b6c-a9b2-4d20-afd8-b3a0d8fd48a0
 ---
 
-# Decrypting Data
+# Decrypting data
 
 Decryption is the reverse operation of encryption. For secret-key encryption, you must know both the key and IV that were used to encrypt the data. For public-key encryption, you must know either the public key (if the data was encrypted using the private key) or the private key (if the data was encrypted using the public key).
 
-## Symmetric Decryption
+## Symmetric decryption
 
 The decryption of data encrypted with symmetric algorithms is similar to the process used to encrypt data with symmetric algorithms. The <xref:System.Security.Cryptography.CryptoStream> class is used with symmetric cryptography classes provided by .NET to decrypt data read from any managed stream object.
 
@@ -25,12 +25,14 @@ The following example illustrates how to create a new instance of the default im
 
 ```vb
 Dim aes As Aes = Aes.Create()
-Dim cryptStream As New CryptoStream(myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read)
+Dim cryptStream As New CryptoStream(
+    myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read)
 ```
 
 ```csharp
 Aes aes = Aes.Create();
-CryptoStream cryptStream = new CryptoStream(myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read);
+CryptoStream cryptStream = new CryptoStream(
+    myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read);
 ```
 
 The following example shows the entire process of creating a stream, decrypting the stream, reading from the stream, and closing the streams. A file stream object is created that reads a file named *TestData.txt*. The file stream is then decrypted using the **CryptoStream** class and the **Aes** class. This example specifies key value that is used in the symmetric encryption example for [Encrypting Data](encrypting-data.md). It does not show the code needed to encrypt and transfer these values.
@@ -40,7 +42,7 @@ The following example shows the entire process of creating a stream, decrypting 
 
 The preceding example uses the same key, and algorithm used in the symmetric encryption example for [Encrypting Data](encrypting-data.md). It decrypts the *TestData.txt* file that is created by that example and displays the original text on the console.
 
-## Asymmetric Decryption
+## Asymmetric decryption
 
 Typically, a party (party A) generates both a public and private key and stores the key either in memory or in a cryptographic key container. Party A then sends the public key to another party (party B). Using the public key, party B encrypts data and sends the data back to party A. After receiving the data, party A decrypts it using the private key that corresponds. Decryption will be successful only if party A uses the private key that corresponds to the public key Party B used to encrypt the data.
 
@@ -74,10 +76,10 @@ symmetricIV = rsa.Decrypt(encryptedSymmetricIV , RSAEncryptionPadding.Pkcs1);
 
 ## See also
 
-- [Generating Keys for Encryption and Decryption](generating-keys-for-encryption-and-decryption.md)
-- [Encrypting Data](encrypting-data.md)
-- [Cryptographic Services](cryptographic-services.md)
-- [Cryptography Model](cryptography-model.md)
-- [Cross-Platform Cryptography](cross-platform-cryptography.md)
+- [Generating keys for encryption and decryption](generating-keys-for-encryption-and-decryption.md)
+- [Encrypting data](encrypting-data.md)
+- [Cryptographic services](cryptographic-services.md)
+- [Cryptography model](cryptography-model.md)
+- [Cross-platform cryptography](cross-platform-cryptography.md)
 - [Timing vulnerabilities with CBC-mode symmetric decryption using padding](vulnerabilities-cbc-mode.md)
-- [ASP.NET Core Data Protection](/aspnet/core/security/data-protection/introduction)
+- [ASP.NET Core data protection](/aspnet/core/security/data-protection/introduction)

--- a/docs/standard/security/encrypting-data.md
+++ b/docs/standard/security/encrypting-data.md
@@ -1,84 +1,87 @@
 ---
-title: "Encrypting Data"
+title: "Encrypting data"
 description: Learn how to encrypt data in .NET, using a symmetric algorithm or an asymmetric algorithm.
-ms.date: 07/14/2020
-dev_langs: 
+ms.date: 03/22/2021
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "encryption [.NET], symmetric"
   - "symmetric encryption"
   - "cryptography [.NET], asymmetric"
   - "asymmetric encryption"
 ms.assetid: 7ecce51f-db5f-4bd4-9321-cceb6fcb2a77
 ---
-# Encrypting Data
 
-Symmetric encryption and asymmetric encryption are performed using different processes. Symmetric encryption is performed on streams and is therefore useful to encrypt large amounts of data. Asymmetric encryption is performed on a small number of bytes and is therefore useful only for small amounts of data.  
-  
-## Symmetric Encryption  
+# Encrypting data
 
-The managed symmetric cryptography classes are used with a special stream class called a <xref:System.Security.Cryptography.CryptoStream> that encrypts data read into the stream. The **CryptoStream** class is initialized with a managed stream class, a class that implements the <xref:System.Security.Cryptography.ICryptoTransform> interface (created from a class that implements a cryptographic algorithm), and a <xref:System.Security.Cryptography.CryptoStreamMode> enumeration that describes the type of access permitted to the **CryptoStream**. The **CryptoStream** class can be initialized using any class that derives from the <xref:System.IO.Stream> class, including <xref:System.IO.FileStream>, <xref:System.IO.MemoryStream>, and <xref:System.Net.Sockets.NetworkStream>. Using these classes, you can perform symmetric encryption on a variety of stream objects.  
-  
+Symmetric encryption and asymmetric encryption are performed using different processes. Symmetric encryption is performed on streams and is therefore useful to encrypt large amounts of data. Asymmetric encryption is performed on a small number of bytes and is therefore useful only for small amounts of data.
+
+## Symmetric encryption
+
+The managed symmetric cryptography classes are used with a special stream class called a <xref:System.Security.Cryptography.CryptoStream> that encrypts data read into the stream. The **CryptoStream** class is initialized with a managed stream class, a class that implements the <xref:System.Security.Cryptography.ICryptoTransform> interface (created from a class that implements a cryptographic algorithm), and a <xref:System.Security.Cryptography.CryptoStreamMode> enumeration that describes the type of access permitted to the **CryptoStream**. The **CryptoStream** class can be initialized using any class that derives from the <xref:System.IO.Stream> class, including <xref:System.IO.FileStream>, <xref:System.IO.MemoryStream>, and <xref:System.Net.Sockets.NetworkStream>. Using these classes, you can perform symmetric encryption on a variety of stream objects.
+
 The following example illustrates how to create a new instance of the default implementation class for the <xref:System.Security.Cryptography.Aes> algorithm. The instance is used to perform encryption on a **CryptoStream** class. In this example, the **CryptoStream** is initialized with a stream object called `myStream` that can be any type of managed stream. The **CreateEncryptor** method from the **Aes** class is passed the key and IV that are used for encryption. In this case, the default key and IV generated from `aes` are used.
-  
-```vb  
-Dim aes As Aes = Aes.Create()  
-Dim cryptStream As New CryptoStream(myStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write)  
-```  
-  
-```csharp  
-Aes aes = Aes.Create();  
-CryptoStream cryptStream = new CryptoStream(myStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write);  
-```  
-  
-After this code is executed, any data written to the **CryptoStream** object is encrypted using the AES algorithm.  
-  
+
+```vb
+Dim aes As Aes = Aes.Create()
+Dim cryptStream As New CryptoStream(
+    myStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write)
+```
+
+```csharp
+Aes aes = Aes.Create();
+CryptoStream cryptStream = new CryptoStream(
+    myStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write);
+```
+
+After this code is executed, any data written to the **CryptoStream** object is encrypted using the AES algorithm.
+
 The following example shows the entire process of creating a stream, encrypting the stream, writing to the stream, and closing the stream. This example creates a file stream that is encrypted using the **CryptoStream** class and the **Aes** class. Generated IV is written to beginning of <xref:System.IO.FileStream>, so it can be read and used for decryption. Then a message is written to the encrypted stream with the <xref:System.IO.StreamWriter> class. While the same key can be used multiple times to encrypt and decrypt data, it is recommended to generate a new random IV each time. This way the encrypted data is always different, even when plain text is the same.
-  
+
 :::code language="csharp" source="snippets/encrypting-data/csharp/aes-encrypt.cs":::
 :::code language="vb" source="snippets/encrypting-data/vb/aes-encrypt.vb":::
 
 The code encrypts the stream using the AES symmetric algorithm, and writes IV and then encrypted "Hello World!" to the stream. If the code is successful, it creates an encrypted file named *TestData.txt* and displays the following text to the console:
-  
-```console  
+
+```console
 The text was encrypted.
-```  
+```
 
 You can decrypt the file by using the symmetric decryption example in [Decrypting Data](decrypting-data.md). That example and this example specify the same key.
 
 However, if an exception is raised, the code displays the following text to the console:
-  
-```console  
+
+```console
 The encryption failed.
 ```
 
-## Asymmetric Encryption
+## Asymmetric encryption
 
-Asymmetric algorithms are usually used to encrypt small amounts of data such as the encryption of a symmetric key and IV. Typically, an individual performing asymmetric encryption uses the public key generated by another party. The <xref:System.Security.Cryptography.RSA> class is provided by .NET for this purpose.  
-  
-The following example uses public key information to encrypt a symmetric key and IV. Two byte arrays are initialized that represent the public key of a third party. An <xref:System.Security.Cryptography.RSAParameters> object is initialized to these values. Next, the **RSAParameters** object (along with the public key it represents) is imported into an **RSA** instance using the <xref:System.Security.Cryptography.RSA.ImportParameters%2A?displayProperty=nameWithType> method. Finally, the private key and IV created by an <xref:System.Security.Cryptography.Aes> class are encrypted. This example requires systems to have 128-bit encryption installed.  
-  
-```vb  
+Asymmetric algorithms are usually used to encrypt small amounts of data such as the encryption of a symmetric key and IV. Typically, an individual performing asymmetric encryption uses the public key generated by another party. The <xref:System.Security.Cryptography.RSA> class is provided by .NET for this purpose.
+
+The following example uses public key information to encrypt a symmetric key and IV. Two byte arrays are initialized that represent the public key of a third party. An <xref:System.Security.Cryptography.RSAParameters> object is initialized to these values. Next, the **RSAParameters** object (along with the public key it represents) is imported into an **RSA** instance using the <xref:System.Security.Cryptography.RSA.ImportParameters%2A?displayProperty=nameWithType> method. Finally, the private key and IV created by an <xref:System.Security.Cryptography.Aes> class are encrypted. This example requires systems to have 128-bit encryption installed.
+
+```vb
 Imports System
 Imports System.Security.Cryptography
 
 Module Module1
 
     Sub Main()
-        'Initialize the byte arrays to the public key information.  
+        'Initialize the byte arrays to the public key information.
         Dim modulus As Byte() = {214, 46, 220, 83, 160, 73, 40, 39, 201, 155, 19, 202, 3, 11, 191, 178, 56, 74, 90, 36, 248, 103, 18, 144, 170, 163, 145, 87, 54, 61, 34, 220, 222, 207, 137, 149, 173, 14, 92, 120, 206, 222, 158, 28, 40, 24, 30, 16, 175, 108, 128, 35, 230, 118, 40, 121, 113, 125, 216, 130, 11, 24, 90, 48, 194, 240, 105, 44, 76, 34, 57, 249, 228, 125, 80, 38, 9, 136, 29, 117, 207, 139, 168, 181, 85, 137, 126, 10, 126, 242, 120, 247, 121, 8, 100, 12, 201, 171, 38, 226, 193, 180, 190, 117, 177, 87, 143, 242, 213, 11, 44, 180, 113, 93, 106, 99, 179, 68, 175, 211, 164, 116, 64, 148, 226, 254, 172, 147}
 
         Dim exponent As Byte() = {1, 0, 1}
 
-        'Create values to store encrypted symmetric keys.  
+        'Create values to store encrypted symmetric keys.
         Dim encryptedSymmetricKey() As Byte
         Dim encryptedSymmetricIV() As Byte
 
         'Create a new instance of the default RSA implementation class.
         Dim rsa As RSA = RSA.Create()
 
-        'Create a new instance of the RSAParameters structure.  
+        'Create a new instance of the RSAParameters structure.
         Dim rsaKeyInfo As New RSAParameters()
 
         'Set rsaKeyInfo to the public key values.
@@ -88,18 +91,18 @@ Module Module1
         'Import key parameters into rsa
         rsa.ImportParameters(rsaKeyInfo)
 
-        'Create a new instance of the default Aes implementation class.  
+        'Create a new instance of the default Aes implementation class.
         Dim aes As Aes = Aes.Create()
 
-        'Encrypt the symmetric key and IV.  
+        'Encrypt the symmetric key and IV.
         encryptedSymmetricKey = rsa.Encrypt(aes.Key, RSAEncryptionPadding.Pkcs1)
         encryptedSymmetricIV = rsa.Encrypt(aes.IV, RSAEncryptionPadding.Pkcs1)
     End Sub
 
 End Module
-```  
-  
-```csharp  
+```
+
+```csharp
 using System;
 using System.Security.Cryptography;
 
@@ -107,50 +110,53 @@ class Class1
 {
     static void Main()
     {
-        //Initialize the byte arrays to the public key information.  
-        byte[] modulus = {214,46,220,83,160,73,40,39,201,155,19,202,3,11,191,178,56,
+        //Initialize the byte arrays to the public key information.
+        byte[] modulus =
+        {
+            214,46,220,83,160,73,40,39,201,155,19,202,3,11,191,178,56,
             74,90,36,248,103,18,144,170,163,145,87,54,61,34,220,222,
             207,137,149,173,14,92,120,206,222,158,28,40,24,30,16,175,
             108,128,35,230,118,40,121,113,125,216,130,11,24,90,48,194,
             240,105,44,76,34,57,249,228,125,80,38,9,136,29,117,207,139,
             168,181,85,137,126,10,126,242,120,247,121,8,100,12,201,171,
             38,226,193,180,190,117,177,87,143,242,213,11,44,180,113,93,
-            106,99,179,68,175,211,164,116,64,148,226,254,172,147};
+            106,99,179,68,175,211,164,116,64,148,226,254,172,147
+        };
 
         byte[] exponent = { 1, 0, 1 };
 
-        //Create values to store encrypted symmetric keys.  
+        //Create values to store encrypted symmetric keys.
         byte[] encryptedSymmetricKey;
         byte[] encryptedSymmetricIV;
 
-        //Create a new instance of the RSA class.  
+        //Create a new instance of the RSA class.
         RSA rsa = RSA.Create();
 
-        //Create a new instance of the RSAParameters structure.  
+        //Create a new instance of the RSAParameters structure.
         RSAParameters rsaKeyInfo = new RSAParameters();
 
         //Set rsaKeyInfo to the public key values.
         rsaKeyInfo.Modulus = modulus;
         rsaKeyInfo.Exponent = exponent;
 
-        //Import key parameters into rsa.  
+        //Import key parameters into rsa.
         rsa.ImportParameters(rsaKeyInfo);
 
-        //Create a new instance of the default Aes implementation class.  
+        //Create a new instance of the default Aes implementation class.
         Aes aes = Aes.Create();
 
-        //Encrypt the symmetric key and IV.  
+        //Encrypt the symmetric key and IV.
         encryptedSymmetricKey = rsa.Encrypt(aes.Key, RSAEncryptionPadding.Pkcs1);
         encryptedSymmetricIV = rsa.Encrypt(aes.IV, RSAEncryptionPadding.Pkcs1);
     }
 }
-```  
-  
+```
+
 ## See also
 
-- [Generating Keys for Encryption and Decryption](generating-keys-for-encryption-and-decryption.md)
-- [Decrypting Data](decrypting-data.md)
-- [Cryptographic Services](cryptographic-services.md)
-- [Cross-Platform Cryptography](cross-platform-cryptography.md)
+- [Generating keys for encryption and decryption](generating-keys-for-encryption-and-decryption.md)
+- [Decrypting data](decrypting-data.md)
+- [Cryptographic services](cryptographic-services.md)
+- [Cross-platform cryptography](cross-platform-cryptography.md)
 - [Timing vulnerabilities with CBC-mode symmetric decryption using padding](vulnerabilities-cbc-mode.md)
-- [ASP.NET Core Data Protection](/aspnet/core/security/data-protection/introduction)
+- [ASP.NET Core data protection](/aspnet/core/security/data-protection/introduction)

--- a/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
+++ b/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
@@ -39,6 +39,8 @@ public class EncryptExample
             //Write to the stream.  
             sWriter.WriteLine("Hello World!");
 
+            cryptStream.FlushFinalBlock();
+
             //Inform the user that the message was written  
             //to the stream.  
             Console.WriteLine("The file was encrypted.");


### PR DESCRIPTION
## Summary

Add explicit call to `FlushFinalBlock` that was missing from implicit `Dispose` calling from scoped using.

Fixes #23224