### PR TITLE
Update subscribe-events.md

### DIFF
--- a/docs/architecture/microservices/multi-container-microservice-net-applications/subscribe-events.md
+++ b/docs/architecture/microservices/multi-container-microservice-net-applications/subscribe-events.md
@@ -196,9 +196,7 @@ public async Task<IActionResult> UpdateProduct([FromBody]CatalogItem productToUp
            _catalogContext.CatalogItems.Update(catalogItem);
            await _catalogContext.SaveChangesAsync();
 
-           // Save to EventLog only if product price changed
-           if(raiseProductPriceChangedEvent)
-               await _integrationEventLogService.SaveEventAsync(priceChangedEvent);
+           await _integrationEventLogService.SaveEventAsync(priceChangedEvent);
 
            transaction.Commit();
         }


### PR DESCRIPTION
There is not need to check `raiseProductPriceChangedEvent` twice.

## Summary

When we have first if we no longer need to `raiseProductPriceChangedEvent` to check for second time.

Fixes #Issue_Number (if available)
