### PR TITLE
Update how-to-write-csharp-analyzer-code-fix.md

### DIFF
--- a/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
+++ b/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
@@ -262,11 +262,11 @@ The template uses [Microsoft.CodeAnalysis.Testing](https://github.com/dotnet/ros
 > - `[|text|]`: indicates that a diagnostic is reported for `text`. By default, this form may only be used for testing analyzers with exactly one `DiagnosticDescriptor` provided by `DiagnosticAnalyzer.SupportedDiagnostics`.
 > - `{|ExpectedDiagnosticId:text|}`: indicates that a diagnostic with <xref:Microsoft.CodeAnalysis.Diagnostic.Id> `ExpectedDiagnosticId` is reported for `text`.
 
-Add the following test method to the `MakeConstUnitTest` class:
+Replace the template tests in the `MakeConstUnitTest` class with the following test method:
 
 [!code-csharp[test method for fix test](snippets/how-to-write-csharp-analyzer-code-fix/MakeConst/MakeConst.Test/MakeConstUnitTests.cs#FirstFixTest "test method for fix test")]
 
-Run these two tests to make sure they pass. In Visual Studio, open the **Test Explorer** by selecting **Test** > **Windows** > **Test Explorer**. Then select **Run All**.
+Run this test to make sure it passes. In Visual Studio, open the **Test Explorer** by selecting **Test** > **Windows** > **Test Explorer**. Then select **Run All**.
 
 ## Create tests for valid declarations
 


### PR DESCRIPTION
Build Unit Tests doesn't remove the test methods created by the template, which will no longer pass based on the changes to the analyzer and code fix.  Then, the tutorial gives a single test method to add but asks the user to run "these two tests" -- fixed to refer to only the single, added test.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
