### PR TITLE
Path attribute on <inheritdoc /> with examples

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/inheritdoc.md
+++ b/docs/csharp/programming-guide/xmldoc/inheritdoc.md
@@ -15,12 +15,24 @@ ms.assetid: 46d329b1-5b84-4537-9e17-73ca97313e4e
 ## Syntax  
   
 ```xml  
-<inheritdoc/>
+<inheritdoc [cref=""] [path=""]/>
 ```  
 
 ## InheritDoc
 
 Inherit XML comments from base classes, interfaces, and similar methods. This eliminates unwanted copying and pasting of duplicate XML comments and automatically keeps XML comments synchronized.
+
+## Attributes
+
+#### cref
+
+Specify the member to inherit documentation from.  
+Already defined tags on the current member are not overridden by the inherited ones.
+
+#### path
+
+The XPath expression query that will result in a node set to show.  
+You can use this attribute to filter which tags to include or exclude from the inherited documentation.
   
 ## Remarks  
 

--- a/docs/csharp/programming-guide/xmldoc/inheritdoc.md
+++ b/docs/csharp/programming-guide/xmldoc/inheritdoc.md
@@ -47,6 +47,8 @@ If you want to copy the comments from a specific member you can use the `cref` a
 [!code-csharp[csProgGuideDocComments#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#16)]  
 
 [!code-csharp[csProgGuideDocComments#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#17)]  
+[!code-csharp[csProgGuideDocComments#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#18)]  
+[!code-csharp[csProgGuideDocComments#14](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs#19)]  
 
 ## See also
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs
@@ -598,3 +598,39 @@ namespace Wrap17
     }
     //</Snippet17>
 }
+
+//-----------------------------------------------------------------------------
+namespace Wrap18
+{
+    //<Snippet18>
+    // compile with: -doc:DocFileName.xml
+    
+    public class InheritOnlyReturns
+    {
+        /// <summary>In this example, this summary is only visible for this method.</summary>
+        /// <returns>A boolean</returns>
+        public static bool MyParentMethod(bool x) { return x; }
+        
+        /// <inheritdoc cref="MyParentMethod" path="/returns"/>
+        public static bool MyChildMethod() { return false; }
+    }
+    //</Snippet18>
+}
+
+namespace Wrap19
+{
+    //<Snippet19>
+    // compile with: -doc:DocFileName.xml
+    
+    public class InheritAllButRemarks
+    {
+        /// <summary>In this example, this summary is visible on all the methods.</summary>
+        /// <remarks>The remarks.</remarks>
+        /// <returns>A boolean</returns>
+        public static bool MyParentMethod(bool x) { return x; }
+        
+        /// <inheritdoc cref="MyParentMethod" path="//*[not(self::remarks)]"/>
+        public static bool MyChildMethod() { return false; }
+    }
+    //</Snippet19>
+}


### PR DESCRIPTION
Adds simple explanations to the ```cref``` and ```path``` attributes, with examples for the ```path``` attribute.

Contributes to #23533 
Doesn't fix the issue because the XPath expression query syntax reference is missing.
