### PR TITLE
Document the correct way to apply an F# attribute to a .NET module.

### DIFF
--- a/docs/fsharp/language-reference/attributes.md
+++ b/docs/fsharp/language-reference/attributes.md
@@ -49,7 +49,7 @@ Typically encountered attributes include the `Obsolete` attribute, attributes fo
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-2/snippet6605.fs)]
 
-For the attribute targets `assembly` and `module`, you apply the attributes to a top-level `do` binding in your assembly. You can include the word `assembly` or `module` in the attribute declaration, as follows:
+For the attribute targets `assembly` and `module`, you apply the attributes to a top-level `do` binding in your assembly. You can include the word `assembly` or ``` ``module`` ``` in the attribute declaration, as follows:
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-2/snippet6606.fs)]
 
@@ -65,6 +65,10 @@ Although you do not usually need to specify the attribute target explicitly, val
   <tr>
     <td>assembly</td>
     <td><pre><code class="lang-fsharp">[&lt;assembly: AssemblyVersion("1.0.0.0")&gt;]</code></pre></td>
+  </tr>
+  <tr>
+    <td>module</td>
+    <td><pre><code class="lang-fsharp">[&lt;``module``: MyCustomAttributeThatWorksOnModules&gt;]</code></pre></td>
   </tr>
   <tr>
     <td>return</td>

--- a/samples/snippets/fsharp/lang-ref-2/snippet6606.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet6606.fs
@@ -1,4 +1,5 @@
 open System.Reflection
 [<assembly:AssemblyVersionAttribute("1.0.0.0")>]
+[<``module``:MyCustomModuleAttribute>]
 do
    printfn "Executing..."


### PR DESCRIPTION
Using `[<module: MyAttribute>]` fails with a mysterious compiler error, and the correct way is not apparent. This PR documents that it is ```[<``module``: MyAttribute>]```.