### PR TITLE
Fix struct example

### DIFF
--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
@@ -12,7 +12,9 @@ ms.assetid: 4084581e-b931-498b-9534-cf7ef5b68690
 ---
 # How to define value equality for a class or struct (C# Programming Guide)
 
-When you define a [record](../classes-and-structs/records.md), the compiler automatically implements value equality. When you define a class or struct, you decide whether it makes sense to create a custom definition of value equality (or equivalence) for the type. Typically, you implement value equality when you expect to add objects of the type to a collection, or when their primary purpose is to store a set of fields or properties. You can base your definition of value equality on a comparison of all the fields and properties in the type, or you can base the definition on a subset.
+[Records](../classes-and-structs/records.md) automatically implement value equality. Consider defining a `record` instead of a `class` when your type models data and should implement value equality.
+
+When you define a class or struct, you decide whether it makes sense to create a custom definition of value equality (or equivalence) for the type. Typically, you implement value equality when you expect to add objects of the type to a collection, or when their primary purpose is to store a set of fields or properties. You can base your definition of value equality on a comparison of all the fields and properties in the type, or you can base the definition on a subset.
 
 In either case, and in both classes and structs, your implementation should follow the five guarantees of equivalence (for the following rules, assume that `x`, `y` and `z` are not null):  
   

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
@@ -1,7 +1,7 @@
 ---
 title: "How to define value equality for a class or struct - C# Programming Guide"
-description: Learn how to define value equality for a class or struct. See code examples and view additional available resources.
-ms.date: 07/20/2015
+description: Learn how to define value equality for a class or struct. See code examples and view available resources.
+ms.date: 03/26/2021
 helpviewer_keywords: 
   - "overriding Equals method [C#]"
   - "object equivalence [C#]"
@@ -12,19 +12,19 @@ ms.assetid: 4084581e-b931-498b-9534-cf7ef5b68690
 ---
 # How to define value equality for a class or struct (C# Programming Guide)
 
-When you define a [record](../classes-and-structs/records.md), the compiler automatically implements value equality. When you define a class or struct, you decide whether it makes sense to create a custom definition of value equality (or equivalence) for the type. Typically, you implement value equality when objects of the type are expected to be added to a collection of some sort, or when their primary purpose is to store a set of fields or properties. You can base your definition of value equality on a comparison of all the fields and properties in the type, or you can base the definition on a subset.
+When you define a [record](../classes-and-structs/records.md), the compiler automatically implements value equality. When you define a class or struct, you decide whether it makes sense to create a custom definition of value equality (or equivalence) for the type. Typically, you implement value equality when you expect to add objects of the type to a collection, or when their primary purpose is to store a set of fields or properties. You can base your definition of value equality on a comparison of all the fields and properties in the type, or you can base the definition on a subset.
 
-In either case, and in both classes and structs, your implementation should follow the five guarantees of equivalence (For the following rules, assume that `x`, `y` and `z` are not null):  
+In either case, and in both classes and structs, your implementation should follow the five guarantees of equivalence (for the following rules, assume that `x`, `y` and `z` are not null):  
   
-1. `x.Equals(x)` returns `true`. This is called the reflexive property.  
+1. The reflexive property: `x.Equals(x)` returns `true`.
   
-2. `x.Equals(y)` returns the same value as `y.Equals(x)`. This is called the symmetric property.  
+2. The symmetric property: `x.Equals(y)` returns the same value as `y.Equals(x)`.
   
-3. if `(x.Equals(y) && y.Equals(z))` returns `true`, then `x.Equals(z)` returns `true`. This is called the transitive property.  
+3. The transitive property: if `(x.Equals(y) && y.Equals(z))` returns `true`, then `x.Equals(z)` returns `true`.
   
-4. Successive invocations of `x.Equals(y)` return the same value as long as the objects referenced by x and y are not modified.  
+4. Successive invocations of `x.Equals(y)` return the same value as long as the objects referenced by x and y aren't modified.  
   
-5. Any non-null value is not equal to null. However, the CLR checks for null on all method calls and throws a `NullReferenceException` if the `this` reference would be null. Therefore, `x.Equals(y)` throws an exception when `x` is null. That breaks rules 1 or 2, depending on the argument to `Equals`.
+5. Any non-null value isn't equal to null. However, `x.Equals(y)` throws an exception when `x` is null. That breaks rules 1 or 2, depending on the argument to `Equals`.
 
 Any struct that you define already has a default implementation of value equality that it inherits from the <xref:System.ValueType?displayProperty=nameWithType> override of the <xref:System.Object.Equals%28System.Object%29?displayProperty=nameWithType> method. This implementation uses reflection to examine all the fields and properties in the type. Although this implementation produces correct results, it is relatively slow compared to a custom implementation that you write specifically for the type.  
   
@@ -32,7 +32,11 @@ The implementation details for value equality are different for classes and stru
   
 1. Override the [virtual](../../language-reference/keywords/virtual.md) <xref:System.Object.Equals%28System.Object%29?displayProperty=nameWithType> method. In most cases, your implementation of `bool Equals( object obj )` should just call into the type-specific `Equals` method that is the implementation of the <xref:System.IEquatable%601?displayProperty=nameWithType> interface. (See step 2.)  
   
-2. Implement the <xref:System.IEquatable%601?displayProperty=nameWithType> interface by providing a type-specific `Equals` method. This is where the actual equivalence comparison is performed. For example, you might decide to define equality by comparing only one or two fields in your type. Do not throw exceptions from `Equals`. For classes only: This method should examine only fields that are declared in the class. It should call `base.Equals` to examine fields that are in the base class. (Do not do this if the type inherits directly from <xref:System.Object>, because the <xref:System.Object> implementation of <xref:System.Object.Equals%28System.Object%29?displayProperty=nameWithType> performs a reference equality check.)  
+2. Implement the <xref:System.IEquatable%601?displayProperty=nameWithType> interface by providing a type-specific `Equals` method. This is where the actual equivalence comparison is performed. For example, you might decide to define equality by comparing only one or two fields in your type. Don't throw exceptions from `Equals`. For classes that are related by inheritance:
+
+   * This method should examine only fields that are declared in the class. It should call `base.Equals` to examine fields that are in the base class. (Don't call `base.Equals` if the type inherits directly from <xref:System.Object>, because the <xref:System.Object> implementation of <xref:System.Object.Equals%28System.Object%29?displayProperty=nameWithType> performs a reference equality check.)
+
+   * Two variables should be deemed equal only if the run-time types of the variables being compared are the same. Also, make sure that the `IEquatable` implementation of the `Equals` method for the run-time type is used if the run-time and compile-time types of a variable are different. One strategy for making sure run-time types are always compared correctly is to implement `IEquatable` only in `sealed` classes. For more information, see the [class example](#class-example) later in this article.
   
 3. Optional but recommended: Overload the [==](../../language-reference/operators/equality-operators.md#equality-operator-) and [!=](../../language-reference/operators/equality-operators.md#inequality-operator-) operators.  
   
@@ -47,21 +51,34 @@ The implementation details for value equality are different for classes and stru
 
 The following example shows how to implement value equality in a class (reference type).
 
-[!code-csharp[csProgGuideStatements#19](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs#19)]
+:::code language="csharp" source="snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs":::
 
 On classes (reference types), the default implementation of both <xref:System.Object.Equals%28System.Object%29?displayProperty=nameWithType> methods performs a reference equality comparison, not a value equality check. When an implementer overrides the virtual method, the purpose is to give it value equality semantics.
 
 The `==` and `!=` operators can be used with classes even if the class does not overload them. However, the default behavior is to perform a reference equality check. In a class, if you overload the `Equals` method, you should overload the `==` and `!=` operators, but it is not required.
 
+> [!IMPORTANT]
+> The preceding example code may not handle every inheritance scenario the way you expect. Consider the following code:
+>
+> ```csharp
+> TwoDPoint p1 = new ThreeDPoint(1, 2, 3);
+> TwoDPoint p2 = new ThreeDPoint(1, 2, 4);
+> Console.WriteLine(p1.Equals(p2)); // output: True
+> ```
+>
+> This code reports that `p1` equals `p2` despite the difference in `z` values. The difference is ignored because the compiler picks the `TwoDPoint` implementation of `IEquatable` based on the compile-time type.
+>
+> The built-in value equality of `record` types handles scenarios like this correctly . If `TwoDPoint` and `ThreeDPoint` were `record` types, the result of `p1.Equals(p2)` would be `False`. For more information, see [Equality in `record` type inheritance hierarchies](../../language-reference/builtin-types/record.md#equality-in-inheritance-hierarchies).
+
 ## Struct example
 
 The following example shows how to implement value equality in a struct (value type):
 
-[!code-csharp[csProgGuideStatements#20](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs#20)]
+:::code language="csharp" source="snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/Program.cs":::
   
 For structs, the default implementation of <xref:System.Object.Equals%28System.Object%29?displayProperty=nameWithType> (which is the overridden version in <xref:System.ValueType?displayProperty=nameWithType>) performs a value equality check by using reflection to compare the values of every field in the type. When an implementer overrides the virtual `Equals` method in a struct, the purpose is to provide a more efficient means of performing the value equality check and optionally to base the comparison on some subset of the struct's field or properties.
   
-The [==](../../language-reference/operators/equality-operators.md#equality-operator-) and [!=](../../language-reference/operators/equality-operators.md#inequality-operator-) operators cannot operate on a struct unless the struct explicitly overloads them.
+The [==](../../language-reference/operators/equality-operators.md#equality-operator-) and [!=](../../language-reference/operators/equality-operators.md#inequality-operator-) operators can't operate on a struct unless the struct explicitly overloads them.
 
 ## See also
 

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md
@@ -68,7 +68,7 @@ The `==` and `!=` operators can be used with classes even if the class does not 
 >
 > This code reports that `p1` equals `p2` despite the difference in `z` values. The difference is ignored because the compiler picks the `TwoDPoint` implementation of `IEquatable` based on the compile-time type.
 >
-> The built-in value equality of `record` types handles scenarios like this correctly . If `TwoDPoint` and `ThreeDPoint` were `record` types, the result of `p1.Equals(p2)` would be `False`. For more information, see [Equality in `record` type inheritance hierarchies](../../language-reference/builtin-types/record.md#equality-in-inheritance-hierarchies).
+> The built-in value equality of `record` types handles scenarios like this correctly. If `TwoDPoint` and `ThreeDPoint` were `record` types, the result of `p1.Equals(p2)` would be `False`. For more information, see [Equality in `record` type inheritance hierarchies](../../language-reference/builtin-types/record.md#equality-in-inheritance-hierarchies).
 
 ## Struct example
 

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
@@ -1,0 +1,202 @@
+﻿namespace ValueEqualityClass
+{
+    using System;
+    class TwoDPoint : IEquatable<TwoDPoint>
+    {
+        // Readonly auto-implemented properties.
+        public int X { get; private set; }
+        public int Y { get; private set; }
+
+        // Set the properties in the constructor.
+        public TwoDPoint(int x, int y)
+        {
+            if ((x < 1) || (x > 2000) || (y < 1) || (y > 2000))
+            {
+                throw new System.ArgumentException("Point must be in range 1 - 2000");
+            }
+            this.X = x;
+            this.Y = y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as TwoDPoint);
+        }
+
+        public bool Equals(TwoDPoint p)
+        {
+            // If parameter is null, return false.
+            if (Object.ReferenceEquals(p, null))
+            {
+                return false;
+            }
+
+            // Optimization for a common success case.
+            if (Object.ReferenceEquals(this, p))
+            {
+                return true;
+            }
+
+            // If run-time types are not exactly the same, return false.
+            if (this.GetType() != p.GetType())
+            {
+                return false;
+            }
+
+            // Return true if the fields match.
+            // Note that the base class is not invoked because it is
+            // System.Object, which defines Equals as reference equality.
+            return (X == p.X) && (Y == p.Y);
+        }
+
+        public override int GetHashCode()
+        {
+            return X * 0x00010000 + Y;
+        }
+
+        public static bool operator ==(TwoDPoint lhs, TwoDPoint rhs)
+        {
+            // Check for null on left side.
+            if (Object.ReferenceEquals(lhs, null))
+            {
+                if (Object.ReferenceEquals(rhs, null))
+                {
+                    // null == null = true.
+                    return true;
+                }
+
+                // Only the left side is null.
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(TwoDPoint lhs, TwoDPoint rhs)
+        {
+            return !(lhs == rhs);
+        }
+    }
+
+    // For the sake of simplicity, assume a ThreeDPoint IS a TwoDPoint.
+    class ThreeDPoint : TwoDPoint, IEquatable<ThreeDPoint>
+    {
+        public int Z { get; private set; }
+
+        public ThreeDPoint(int x, int y, int z)
+            : base(x, y)
+        {
+            if ((z < 1) || (z > 2000))
+            {
+                throw new System.ArgumentException("Point must be in range 1 - 2000");
+            }
+            this.Z = z;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as ThreeDPoint);
+        }
+
+        public bool Equals(ThreeDPoint p)
+        {
+            // If parameter is null, return false.
+            if (Object.ReferenceEquals(p, null))
+            {
+                return false;
+            }
+
+            // Optimization for a common success case.
+            if (Object.ReferenceEquals(this, p))
+            {
+                return true;
+            }
+
+            // Check properties that this class declares.
+            if (Z == p.Z)
+            {
+                // Let base class check its own fields
+                // and do the run-time type comparison.
+                return base.Equals((TwoDPoint)p);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return (X * 0x100000) + (Y * 0x1000) + Z;
+        }
+
+        public static bool operator ==(ThreeDPoint lhs, ThreeDPoint rhs)
+        {
+            // Check for null.
+            if (Object.ReferenceEquals(lhs, null))
+            {
+                if (Object.ReferenceEquals(rhs, null))
+                {
+                    // null == null = true.
+                    return true;
+                }
+
+                // Only the left side is null.
+                return false;
+            }
+            // Equals handles the case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(ThreeDPoint lhs, ThreeDPoint rhs)
+        {
+            return !(lhs == rhs);
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            ThreeDPoint pointA = new ThreeDPoint(3, 4, 5);
+            ThreeDPoint pointB = new ThreeDPoint(3, 4, 5);
+            ThreeDPoint pointC = null;
+            int i = 5;
+
+            Console.WriteLine("pointA.Equals(pointB) = {0}", pointA.Equals(pointB));
+            Console.WriteLine("pointA == pointB = {0}", pointA == pointB);
+            Console.WriteLine("null comparison = {0}", pointA.Equals(pointC));
+            Console.WriteLine("Compare to some other type = {0}", pointA.Equals(i));
+
+            TwoDPoint pointD = null;
+            TwoDPoint pointE = null;
+
+            Console.WriteLine("Two null TwoDPoints are equal: {0}", pointD == pointE);
+
+            pointE = new TwoDPoint(3, 4);
+            Console.WriteLine("(pointE == pointA) = {0}", pointE == pointA);
+            Console.WriteLine("(pointA == pointE) = {0}", pointA == pointE);
+            Console.WriteLine("(pointA != pointE) = {0}", pointA != pointE);
+
+            System.Collections.ArrayList list = new System.Collections.ArrayList();
+            list.Add(new ThreeDPoint(3, 4, 5));
+            Console.WriteLine("pointE.Equals(list[0]): {0}", pointE.Equals(list[0]));
+
+            // Keep the console window open in debug mode.
+            Console.WriteLine("Press any key to exit.");
+            Console.ReadKey();
+        }
+    }
+
+    /* Output:
+        pointA.Equals(pointB) = True
+        pointA == pointB = True
+        null comparison = False
+        Compare to some other type = False
+        Two null TwoDPoints are equal: True
+        (pointE == pointA) = False
+        (pointA == pointE) = False
+        (pointA != pointE) = True
+        pointE.Equals(list[0]): False
+    */
+}

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
@@ -9,9 +9,9 @@ namespace ValueEqualityClass
 
         public TwoDPoint(int x, int y)
         {
-            if ((x < 1) || (x > 2000) || (y < 1) || (y > 2000))
+            if (x is (< 1 or > 2000) || y is (< 1 or > 2000))
             {
-                throw new System.ArgumentException("Point must be in range 1 - 2000");
+                throw new ArgumentException("Point must be in range 1 - 2000");
             }
             this.X = x;
             this.Y = y;

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
@@ -1,13 +1,12 @@
-﻿namespace ValueEqualityClass
+﻿using System;
+
+namespace ValueEqualityClass
 {
-    using System;
     class TwoDPoint : IEquatable<TwoDPoint>
     {
-        // Readonly auto-implemented properties.
         public int X { get; private set; }
         public int Y { get; private set; }
 
-        // Set the properties in the constructor.
         public TwoDPoint(int x, int y)
         {
             if ((x < 1) || (x > 2000) || (y < 1) || (y > 2000))
@@ -18,14 +17,10 @@
             this.Y = y;
         }
 
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as TwoDPoint);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as TwoDPoint);
 
         public bool Equals(TwoDPoint p)
         {
-            // If parameter is null, return false.
             if (Object.ReferenceEquals(p, null))
             {
                 return false;
@@ -49,19 +44,14 @@
             return (X == p.X) && (Y == p.Y);
         }
 
-        public override int GetHashCode()
-        {
-            return X * 0x00010000 + Y;
-        }
+        public override int GetHashCode() => (X, Y).GetHashCode();
 
         public static bool operator ==(TwoDPoint lhs, TwoDPoint rhs)
         {
-            // Check for null on left side.
             if (Object.ReferenceEquals(lhs, null))
             {
                 if (Object.ReferenceEquals(rhs, null))
                 {
-                    // null == null = true.
                     return true;
                 }
 
@@ -72,10 +62,7 @@
             return lhs.Equals(rhs);
         }
 
-        public static bool operator !=(TwoDPoint lhs, TwoDPoint rhs)
-        {
-            return !(lhs == rhs);
-        }
+        public static bool operator !=(TwoDPoint lhs, TwoDPoint rhs) => !(lhs == rhs);
     }
 
     // For the sake of simplicity, assume a ThreeDPoint IS a TwoDPoint.
@@ -88,19 +75,15 @@
         {
             if ((z < 1) || (z > 2000))
             {
-                throw new System.ArgumentException("Point must be in range 1 - 2000");
+                throw new ArgumentException("Point must be in range 1 - 2000");
             }
             this.Z = z;
         }
 
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as ThreeDPoint);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as ThreeDPoint);
 
         public bool Equals(ThreeDPoint p)
         {
-            // If parameter is null, return false.
             if (Object.ReferenceEquals(p, null))
             {
                 return false;
@@ -125,14 +108,10 @@
             }
         }
 
-        public override int GetHashCode()
-        {
-            return (X * 0x100000) + (Y * 0x1000) + Z;
-        }
+        public override int GetHashCode() => (X, Y, Z).GetHashCode();
 
         public static bool operator ==(ThreeDPoint lhs, ThreeDPoint rhs)
         {
-            // Check for null.
             if (Object.ReferenceEquals(lhs, null))
             {
                 if (Object.ReferenceEquals(rhs, null))
@@ -148,10 +127,7 @@
             return lhs.Equals(rhs);
         }
 
-        public static bool operator !=(ThreeDPoint lhs, ThreeDPoint rhs)
-        {
-            return !(lhs == rhs);
-        }
+        public static bool operator !=(ThreeDPoint lhs, ThreeDPoint rhs) => !(lhs == rhs);
     }
 
     class Program

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/Program.cs
@@ -21,7 +21,7 @@ namespace ValueEqualityClass
 
         public bool Equals(TwoDPoint p)
         {
-            if (Object.ReferenceEquals(p, null))
+            if (p is null)
             {
                 return false;
             }
@@ -48,9 +48,9 @@ namespace ValueEqualityClass
 
         public static bool operator ==(TwoDPoint lhs, TwoDPoint rhs)
         {
-            if (Object.ReferenceEquals(lhs, null))
+            if (lhs is null)
             {
-                if (Object.ReferenceEquals(rhs, null))
+                if (rhs is null)
                 {
                     return true;
                 }
@@ -84,7 +84,7 @@ namespace ValueEqualityClass
 
         public bool Equals(ThreeDPoint p)
         {
-            if (Object.ReferenceEquals(p, null))
+            if (p is null)
             {
                 return false;
             }
@@ -112,9 +112,9 @@ namespace ValueEqualityClass
 
         public static bool operator ==(ThreeDPoint lhs, ThreeDPoint rhs)
         {
-            if (Object.ReferenceEquals(lhs, null))
+            if (lhs is null)
             {
-                if (Object.ReferenceEquals(rhs, null))
+                if (rhs is null)
                 {
                     // null == null = true.
                     return true;

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/ValueEqualityClass.csproj
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityClass/ValueEqualityClass.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/Program.cs
@@ -1,0 +1,120 @@
+﻿namespace ValueEqualityStruct
+{
+    using System;
+    struct TwoDPoint : IEquatable<TwoDPoint>
+    {
+        // Read/write auto-implemented properties.
+        public int X { get; private set; }
+        public int Y { get; private set; }
+
+        public TwoDPoint(int x, int y)
+            : this()
+        {
+            if ((x < 1) || (x > 2000) || (y < 1) || (y > 2000))
+            {
+                throw new System.ArgumentException("Point must be in range 1 - 2000");
+            }
+            X = x;
+            Y = y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TwoDPoint)
+            {
+                return this.Equals((TwoDPoint)obj);
+            }
+            return false;
+        }
+
+        public bool Equals(TwoDPoint p)
+        {
+            return (X == p.X) && (Y == p.Y);
+        }
+
+        public override int GetHashCode()
+        {
+            return X * 0x00010000 + Y;
+        }
+
+        public static bool operator ==(TwoDPoint lhs, TwoDPoint rhs)
+        {
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(TwoDPoint lhs, TwoDPoint rhs)
+        {
+            return !(lhs.Equals(rhs));
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            TwoDPoint pointA = new TwoDPoint(3, 4);
+            TwoDPoint pointB = new TwoDPoint(3, 4);
+            int i = 5;
+
+            // Compare using virtual Equals, static Equals, and == and != operators.
+            // True:
+            Console.WriteLine("pointA.Equals(pointB) = {0}", pointA.Equals(pointB));
+            // True:
+            Console.WriteLine("pointA == pointB = {0}", pointA == pointB);
+            // True:
+            Console.WriteLine("object.Equals(pointA, pointB) = {0}", object.Equals(pointA, pointB));
+            // False:
+            Console.WriteLine("pointA.Equals(null) = {0}", pointA.Equals(null));
+            // False:
+            Console.WriteLine("(pointA == null) = {0}", pointA == null);
+            // True:
+            Console.WriteLine("(pointA != null) = {0}", pointA != null);
+            // False:
+            Console.WriteLine("pointA.Equals(i) = {0}", pointA.Equals(i));
+            // CS0019:
+            // Console.WriteLine("pointA == i = {0}", pointA == i);
+
+            // Compare unboxed to boxed.
+            System.Collections.ArrayList list = new System.Collections.ArrayList();
+            list.Add(new TwoDPoint(3, 4));
+            // True:
+            Console.WriteLine("pointA.Equals(list[0]): {0}", pointA.Equals(list[0]));
+
+            // Compare nullable to nullable and to non-nullable.
+            TwoDPoint? pointC = null;
+            TwoDPoint? pointD = null;
+            // False:
+            Console.WriteLine("pointA == (pointC = null) = {0}", pointA == pointC);
+            // True:
+            Console.WriteLine("pointC == pointD = {0}", pointC == pointD);
+
+            TwoDPoint temp = new TwoDPoint(3, 4);
+            pointC = temp;
+            // True:
+            Console.WriteLine("pointA == (pointC = 3,4) = {0}", pointA == pointC);
+
+            pointD = temp;
+            // True:
+            Console.WriteLine("pointD == (pointC = 3,4) = {0}", pointD == pointC);
+
+            // Keep the console window open in debug mode.
+            Console.WriteLine("Press any key to exit.");
+            Console.ReadKey();
+        }
+    }
+
+    /* Output:
+        pointA.Equals(pointB) = True
+        pointA == pointB = True
+        Object.Equals(pointA, pointB) = True
+        pointA.Equals(null) = False
+        (pointA == null) = False
+        (pointA != null) = True
+        pointA.Equals(i) = False
+        pointE.Equals(list[0]): True
+        pointA == (pointC = null) = False
+        pointC == pointD = True
+        pointA == (pointC = 3,4) = True
+        pointD == (pointC = 3,4) = True
+    */
+}

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/Program.cs
@@ -1,51 +1,32 @@
-﻿namespace ValueEqualityStruct
+﻿using System;
+
+namespace ValueEqualityStruct
 {
-    using System;
     struct TwoDPoint : IEquatable<TwoDPoint>
     {
-        // Read/write auto-implemented properties.
         public int X { get; private set; }
         public int Y { get; private set; }
 
         public TwoDPoint(int x, int y)
             : this()
         {
-            if ((x < 1) || (x > 2000) || (y < 1) || (y > 2000))
+            if (x is (< 1 or > 2000) || y is (< 1 or > 2000))
             {
-                throw new System.ArgumentException("Point must be in range 1 - 2000");
+                throw new ArgumentException("Point must be in range 1 - 2000");
             }
             X = x;
             Y = y;
         }
 
-        public override bool Equals(object obj)
-        {
-            if (obj is TwoDPoint)
-            {
-                return this.Equals((TwoDPoint)obj);
-            }
-            return false;
-        }
+        public override bool Equals(object obj) => obj is TwoDPoint other && this.Equals(other);
 
-        public bool Equals(TwoDPoint p)
-        {
-            return (X == p.X) && (Y == p.Y);
-        }
+        public bool Equals(TwoDPoint p) => X == p.X && Y == p.Y;
 
-        public override int GetHashCode()
-        {
-            return X * 0x00010000 + Y;
-        }
+        public override int GetHashCode() => (X, Y).GetHashCode();
 
-        public static bool operator ==(TwoDPoint lhs, TwoDPoint rhs)
-        {
-            return lhs.Equals(rhs);
-        }
+        public static bool operator ==(TwoDPoint lhs, TwoDPoint rhs) => lhs.Equals(rhs);
 
-        public static bool operator !=(TwoDPoint lhs, TwoDPoint rhs)
-        {
-            return !(lhs.Equals(rhs));
-        }
+        public static bool operator !=(TwoDPoint lhs, TwoDPoint rhs) => !(lhs == rhs);
     }
 
     class Program
@@ -56,7 +37,6 @@
             TwoDPoint pointB = new TwoDPoint(3, 4);
             int i = 5;
 
-            // Compare using virtual Equals, static Equals, and == and != operators.
             // True:
             Console.WriteLine("pointA.Equals(pointB) = {0}", pointA.Equals(pointB));
             // True:
@@ -97,7 +77,6 @@
             // True:
             Console.WriteLine("pointD == (pointC = 3,4) = {0}", pointD == pointC);
 
-            // Keep the console window open in debug mode.
             Console.WriteLine("Press any key to exit.");
             Console.ReadKey();
         }

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/ValueEqualityStruct.csproj
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-define-value-equality-for-a-type/ValueEqualityStruct/ValueEqualityStruct.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs
@@ -121,8 +121,7 @@
         //</Snippet18>
     }
 
-    // Replaced on 10-13-08 with new correct version.
-    // This goes into new topic "how to: implement value equality in a type"
+    // This is no longer in docs, replaced by ~docs\docs\csharp\programming-guide\statements-expressions-operators\snippets\how-to-define-value-equality-for-a-type\ValueEqualityClass\Program.cs
     //<Snippet19>
     namespace ValueEquality
     {
@@ -400,6 +399,7 @@
         }
     }
 
+    // This is no longer in docs, replaced by ~docs\docs\csharp\programming-guide\statements-expressions-operators\snippets\how-to-define-value-equality-for-a-type\ValueEqualityStruct\Program.cs
     namespace ValueEqualityValueTypes
     {
         //<Snippet20>


### PR DESCRIPTION
Fixes #20015
Fixes #9972 

There's no diff on the code because I created new files. I’m fixing error number 2 in #20015 by adding the class example’s constructor validation to the struct, ensuring that x and y are  between 1 and 2000. The struct code can then adopt the class example’s hash override of `return X * 0x00010000 + Y;` in the struct without the possibility of overflow. There is no change to the class example code.

The Snippets 5000 error is because I added "no longer in use" comments to the struct and class examples in ~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs, which doesn't have a project file.
