### PR TITLE
Add WinForms exception changes for .NET 6

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -30,6 +30,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 ## Windows Forms
 
 - [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md)
+- [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md)
 - [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md)
 - [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md)
 - [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -51,6 +51,8 @@ items:
         items:
         - name: APIs throw ArgumentNullException
           href: windows-forms/6.0/apis-throw-argumentnullexception.md
+        - name: DataGridView APIs throw InvalidOperationException
+          href: windows-forms/6.0/null-owner-causes-invalidoperationexception.md
         - name: NotifyIcon.Text maximum text length increased
           href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
@@ -619,6 +621,8 @@ items:
         items:
         - name: APIs throw ArgumentNullException
           href: windows-forms/6.0/apis-throw-argumentnullexception.md
+        - name: DataGridView APIs throw InvalidOperationException
+          href: windows-forms/6.0/null-owner-causes-invalidoperationexception.md
         - name: NotifyIcon.Text maximum text length increased
           href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException

--- a/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
@@ -1,15 +1,15 @@
 ---
-title: "Breaking change: DataGridView-related APIs throw InvalidOperationException"
+title: ".NET 5 breaking change: DataGridView-related APIs throw InvalidOperationException"
 description: Learn about the breaking change in .NET 5 where some APIs related to DataGridView throw an exception if the object's DataGridViewCellAccessibleObject.Owner value is null.
 ms.date: 09/18/2020
 ---
-# DataGridView-related APIs now throw InvalidOperationException
+# DataGridView-related APIs throw InvalidOperationException
 
 Some APIs related to <xref:System.Windows.Forms.DataGridView> now throw an <xref:System.InvalidOperationException> if the object's <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner?displayProperty=nameWithType> value is `null`.
 
 ## Change description
 
-In previous .NET versions, the affected APIs throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null`. Starting in .NET 5, these APIs throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null` when they are invoked.
+In previous .NET versions, the affected APIs throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null`. Starting in .NET 5, these APIs throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null` when they're invoked.
 
 ## Reason for change
 

--- a/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
@@ -9,7 +9,9 @@ Some APIs related to <xref:System.Windows.Forms.DataGridView> now throw an <xref
 
 ## Change description
 
-In previous .NET versions, the affected APIs throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> value is `null`. Starting in .NET 5, these APIs throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> value is `null` when they are invoked.
+In previous .NET versions, the affected APIs throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null`. Starting in .NET 5, these APIs throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null` when they are invoked.
+
+## Reason for change
 
 Throwing an <xref:System.InvalidOperationException> conforms to the behavior of the .NET runtime. It also improves the debugging experience by clearly communicating the invalid property.
 
@@ -40,6 +42,10 @@ The following table lists the affected APIs:
 > | <xref:System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation)?displayProperty=nameWithType> | <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> | 5.0 |
 > | <xref:System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DoDefaultAction?displayProperty=nameWithType> | <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> | 5.0 |
 > | <xref:System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DoDefaultAction?displayProperty=nameWithType> | <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> | 5.0 |
+
+## See also
+
+- [DataGridView-related APIs throw InvalidOperationException (.NET 6)](../6.0/null-owner-causes-invalidoperationexception.md)
 
 <!--
 

--- a/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
@@ -23,7 +23,7 @@ Review your code and, if necessary, update it to prevent constructing the affect
 
 ## Affected APIs
 
-The following table lists the affected properties and parameters:
+The following table lists the affected APIs:
 
 > [!div class="mx-tdBreakAll"]
 > | Affected method or property | Validated property | Version added |

--- a/docs/core/compatibility/windows-forms/5.0/sdk-and-target-framework-change.md
+++ b/docs/core/compatibility/windows-forms/5.0/sdk-and-target-framework-change.md
@@ -52,7 +52,7 @@ In your WPF or Windows Forms project file:
 
 ## Affected APIs
 
-Not detectable via API analysis.
+None.
 
 <!--
 

--- a/docs/core/compatibility/windows-forms/6.0/apis-throw-argumentnullexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/apis-throw-argumentnullexception.md
@@ -28,17 +28,23 @@ Throwing <xref:System.ArgumentNullException> conforms to .NET Runtime behavior. 
 
 ## Affected APIs
 
-The following table lists the affected properties:
+The following table lists the affected APIs and specific parameters:
 
-| Property | Version changed |
-|-|-|-|-|
-| <xref:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)?displayProperty=fullName> | Preview 1 |
+| Method/property | Parameter name | Version changed |
+|-|-|-|
+| <xref:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)?displayProperty=fullName> | `index` | Preview 1 |
+| <xref:System.Windows.Forms.DataGridViewRowStateChangedEventArgs.%23ctor(System.Windows.Forms.DataGridViewRow,System.Windows.Forms.DataGridViewElementStates)> | `dataGridViewRow` | Preview 4 |
+
+## See also
+
+- [TreeNodeCollection.Item throws exception if node is assigned elsewhere](treenodecollection-item-throws-argumentexception.md)
 
 <!--
 
 ### Affected APIs
 
 - `P:System.Windows.Forms.TreeNodeCollection.Item(System.Int32)`
+- `M:System.Windows.Forms.DataGridViewRowStateChangedEventArgs.#ctor(System.Windows.Forms.DataGridViewRow,System.Windows.Forms.DataGridViewElementStates)`
 
 ### Category
 

--- a/docs/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception.md
@@ -1,15 +1,15 @@
 ---
-title: "Breaking change: DataGridView-related APIs throw InvalidOperationException"
+title: ".NET 6 breaking change: DataGridView-related APIs throw InvalidOperationException"
 description: Learn about the breaking change in .NET 6 where some APIs related to DataGridView throw an exception if the object's DataGridViewCellAccessibleObject.Owner value is null.
 ms.date: 03/29/2021
 ---
 # DataGridView-related APIs now throw InvalidOperationException
 
-Some properties related to <xref:System.Windows.Forms.DataGridView> now throw an <xref:System.InvalidOperationException> if the object's <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner?displayProperty=nameWithType> value is `null`.
+Some APIs related to <xref:System.Windows.Forms.DataGridView> now throw an <xref:System.InvalidOperationException> if the object's <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner?displayProperty=nameWithType> value is `null`.
 
 ## Change description
 
-In previous .NET versions, the affected properties throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null`. Starting in .NET 5, these properties throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null` when they are invoked.
+In previous .NET versions, the affected APIs throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null`. Starting in .NET 6, these APIs throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null` when they're invoked.
 
 ## Reason for change
 
@@ -25,15 +25,16 @@ Review your code and, if necessary, update it to prevent constructing the affect
 
 ## Affected APIs
 
-The following table lists the affected properties:
+The following table lists the affected properties and methods:
 
-| Affected property | Version added |
-|-|-|
-| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Bounds?displayProperty=fullName> | Preview 4 |
-| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DefaultAction?displayProperty=fullName> | Preview 4 |
-| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Name?displayProperty=fullName> | Preview 4 |
-| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Navigate?displayProperty=fullName> | Preview 4 |
-| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.State?displayProperty=fullName> | Preview 4 |
+> [!div class="mx-tdBreakAll"]
+> | Affected method or property | Validated property | Version added |
+> |-|-|-|
+> | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Bounds?displayProperty=fullName> | Preview 4 |
+> | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DefaultAction?displayProperty=fullName> | Preview 4 |
+> | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Name?displayProperty=fullName> | Preview 4 |
+>| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation)?displayProperty=fullName> | Preview 4 |
+> | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.State?displayProperty=fullName> | Preview 4 |
 
 ## See also
 
@@ -46,7 +47,7 @@ The following table lists the affected properties:
 - `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Bounds`
 - `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DefaultAction`
 - `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Name`
-- `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Navigate`
+- `M:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation)`
 - `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.State`
 
 ### Category

--- a/docs/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception.md
@@ -28,8 +28,8 @@ Review your code and, if necessary, update it to prevent constructing the affect
 The following table lists the affected properties and methods:
 
 > [!div class="mx-tdBreakAll"]
-> | Affected method or property | Validated property | Version added |
-> |-|-|-|
+> | Affected method or property | Version added |
+> |-|-|
 > | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Bounds?displayProperty=fullName> | Preview 4 |
 > | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DefaultAction?displayProperty=fullName> | Preview 4 |
 > | <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Name?displayProperty=fullName> | Preview 4 |

--- a/docs/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception.md
@@ -1,0 +1,56 @@
+---
+title: "Breaking change: DataGridView-related APIs throw InvalidOperationException"
+description: Learn about the breaking change in .NET 6 where some APIs related to DataGridView throw an exception if the object's DataGridViewCellAccessibleObject.Owner value is null.
+ms.date: 03/29/2021
+---
+# DataGridView-related APIs now throw InvalidOperationException
+
+Some properties related to <xref:System.Windows.Forms.DataGridView> now throw an <xref:System.InvalidOperationException> if the object's <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner?displayProperty=nameWithType> value is `null`.
+
+## Change description
+
+In previous .NET versions, the affected properties throw a <xref:System.NullReferenceException> when they are invoked and the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null`. Starting in .NET 5, these properties throw an <xref:System.InvalidOperationException> instead of a <xref:System.NullReferenceException> if the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property value is `null` when they are invoked.
+
+## Reason for change
+
+Throwing an <xref:System.InvalidOperationException> conforms to the behavior of the .NET runtime. It also improves the debugging experience by clearly communicating the invalid property.
+
+## Version introduced
+
+.NET 6.0
+
+## Recommended action
+
+Review your code and, if necessary, update it to prevent constructing the affected types with the <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> property as `null`.
+
+## Affected APIs
+
+The following table lists the affected properties:
+
+| Affected property | Version added |
+|-|-|
+| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Bounds?displayProperty=fullName> | Preview 4 |
+| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DefaultAction?displayProperty=fullName> | Preview 4 |
+| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Name?displayProperty=fullName> | Preview 4 |
+| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Navigate?displayProperty=fullName> | Preview 4 |
+| <xref:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.State?displayProperty=fullName> | Preview 4 |
+
+## See also
+
+- [DataGridView-related APIs throw InvalidOperationException (.NET 5)](../5.0/null-owner-causes-invalidoperationexception.md)
+
+<!--
+
+### Affected APIs
+
+- `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Bounds`
+- `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DefaultAction`
+- `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Name`
+- `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.Navigate`
+- `P:System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.State`
+
+### Category
+
+Windows Forms
+
+-->


### PR DESCRIPTION
Contributes to #23529.

[Preview URL](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/6.0/null-owner-causes-invalidoperationexception?branch=pr-en-us-23541).