### PR TITLE
remove bash from Alpine dependencies

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -47,7 +47,6 @@ The following versions of .NET are no longer supported. The downloads for these 
 
 .NET on Alpine Linux requires the following dependencies installed:
 
-- bash
 - icu-libs
 - krb5-libs
 - libgcc


### PR DESCRIPTION
Bash is required to run the install script. It is not required to run .NET apps on Alpine. 

We should document the install script requirements elsewhere, or possibly remove the requirement on bash. (alpine uses ash)
