### PR TITLE
Additional Queryable overloads can break reflection code

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -24,6 +24,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 ## Core .NET libraries
 
 - [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md)
+- [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md)
 - [Some parameters in Stream-derived types are renamed](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md)
 - [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md)
 

--- a/docs/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads.md
+++ b/docs/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads.md
@@ -1,0 +1,66 @@
+---
+title: ".NET 6 breaking change: Additional overloads of LINQ Queryable methods"
+description: Learn about the .NET 6 breaking change in core .NET libraries where additional method overloads were added to the System.Linq.Queryable type.
+ms.date: 03/31/2021
+---
+# New System.Linq.Queryable method overloads
+
+New public method overloads have been added to <xref:System.Linq.Queryable?displayProperty=fullName> as part of the new features implemented in <https://github.com/dotnet/runtime/pull/47231>. If your reflection code isn't sufficiently robust when looking up methods, these additions can break your query provider implementations.
+
+## Change description
+
+In .NET 6, new overloads were added to the methods listed in the [Affected APIs](#affected-apis) section. Reflection code such as that shown in the following example may break as a result of these additions:
+
+```csharp
+typeof(System.Linq.Queryable)
+    .GetMethods(BindingFlags.Public | BindingFlags.Static)
+    .Where(m => m.Name == "ElementAt")
+    .Single();
+```
+
+This reflection code will now throw an <xref:System.InvalidOperationException> with a message similar to: **Sequence contains more than one element**.
+
+## Version introduced
+
+6.0 Preview 3 and Preview 4
+
+## Reason for change
+
+The new overloads were added to extend the LINQ `Queryable` API.
+
+## Recommended action
+
+If you're a query-provider library author, ensure that your reflection code is tolerant of method overload additions. For example, use a <xref:System.Type.GetMethod%2A?displayProperty=nameWithType> overload that explicitly accepts the method's parameter types.
+
+## Affected APIs
+
+New overloads were added for the following <xref:System.Linq.Queryable> extension methods:
+
+- <xref:System.Linq.Queryable.ElementAt%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.Take%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.Min%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.Max%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.FirstOrDefault%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.LastOrDefault%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.SingleOrDefault%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.Zip%2A?displayProperty=fullName>
+
+<!--
+
+### Category
+
+- Core .NET libraries
+- LINQ
+
+### Affected APIs
+
+- `Overload:System.Linq.Queryable.ElementAt`
+- `Overload:System.Linq.Queryable.Take`
+- `Overload:System.Linq.Queryable.Min`
+- `Overload:System.Linq.Queryable.Max`
+- `Overload:System.Linq.Queryable.FirstOrDefault`
+- `Overload:System.Linq.Queryable.LastOrDefault`
+- `Overload:System.Linq.Queryable.SingleOrDefault`
+- `Overload:System.Linq.Queryable.Zip`
+
+-->

--- a/docs/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads.md
+++ b/docs/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads.md
@@ -5,11 +5,11 @@ ms.date: 03/31/2021
 ---
 # New System.Linq.Queryable method overloads
 
-New public method overloads have been added to <xref:System.Linq.Queryable?displayProperty=fullName> as part of the new features implemented in <https://github.com/dotnet/runtime/pull/47231>. If your reflection code isn't sufficiently robust when looking up methods, these additions can break your query provider implementations.
+Additional public method overloads have been added to <xref:System.Linq.Queryable?displayProperty=fullName> as part of the new features implemented in <https://github.com/dotnet/runtime/pull/47231>. If your reflection code isn't sufficiently robust when looking up methods, these additions can break your query provider implementations.
 
 ## Change description
 
-In .NET 6, new overloads were added to the methods listed in the [Affected APIs](#affected-apis) section. Reflection code such as that shown in the following example may break as a result of these additions:
+In .NET 6, new overloads were added to the methods listed in the [Affected APIs](#affected-apis) section. Reflection code, such as that shown in the following example, may break as a result of these additions:
 
 ```csharp
 typeof(System.Linq.Queryable)

--- a/docs/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads.md
+++ b/docs/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads.md
@@ -37,6 +37,7 @@ If you're a query-provider library author, ensure that your reflection code is t
 New overloads were added for the following <xref:System.Linq.Queryable> extension methods:
 
 - <xref:System.Linq.Queryable.ElementAt%2A?displayProperty=fullName>
+- <xref:System.Linq.Queryable.ElementAtOrDefault%2A?displayProperty=fullName>
 - <xref:System.Linq.Queryable.Take%2A?displayProperty=fullName>
 - <xref:System.Linq.Queryable.Min%2A?displayProperty=fullName>
 - <xref:System.Linq.Queryable.Max%2A?displayProperty=fullName>
@@ -55,6 +56,7 @@ New overloads were added for the following <xref:System.Linq.Queryable> extensio
 ### Affected APIs
 
 - `Overload:System.Linq.Queryable.ElementAt`
+- `Overload:System.Linq.Queryable.ElementAtOrDefault`
 - `Overload:System.Linq.Queryable.Take`
 - `Overload:System.Linq.Queryable.Min`
 - `Overload:System.Linq.Queryable.Max`

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -43,6 +43,8 @@ items:
         items:
         - name: Nullability annotation changes
           href: core-libraries/6.0/nullable-ref-type-annotation-changes.md
+        - name: New Queryable method overloads
+          href: core-libraries/6.0/additional-linq-queryable-method-overloads.md
         - name: Parameters renamed in Stream-derived types
           href: core-libraries/6.0/parameters-renamed-on-stream-derived-types.md
         - name: Standard numeric format parsing precision
@@ -445,6 +447,8 @@ items:
         items:
         - name: Nullability annotation changes
           href: core-libraries/6.0/nullable-ref-type-annotation-changes.md
+        - name: New Queryable method overloads
+          href: core-libraries/6.0/additional-linq-queryable-method-overloads.md
         - name: Parameters renamed in Stream-derived types
           href: core-libraries/6.0/parameters-renamed-on-stream-derived-types.md
         - name: Standard numeric format parsing precision


### PR DESCRIPTION
Fixes #23421.

[Preview URL](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/additional-linq-queryable-method-overloads?branch=pr-en-us-23557).