### PR TITLE
Clarify how project-to-project references are handled

### DIFF
--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -33,7 +33,7 @@ If you want to generate a package that contains the debug symbols, you have two 
 - `--include-symbols` - it creates the symbols package.
 - `--include-source` - it creates the symbols package with a `src` folder inside containing the source files.
 
-NuGet dependencies of the packed project are added to the *.nuspec* file, so they're properly resolved when the package is installed. Project-to-project references aren't packaged inside the project. Currently, you must have a package per project if you have project-to-project dependencies.
+NuGet dependencies of the packed project are added to the *.nuspec* file, so they're properly resolved when the package is installed. If the packed project has references to other projects, the other projects are not included in the package. Currently, you must have a package per project if you have project-to-project dependencies.
 
 By default, `dotnet pack` builds the project first. If you wish to avoid this behavior, pass the `--no-build` option. This option is often useful in Continuous Integration (CI) build scenarios where you know the code was previously built.
 


### PR DESCRIPTION
Fixes #23553
