### PR TITLE
Added jitter additional resources back to the page

### DIFF
--- a/docs/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
+++ b/docs/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
@@ -68,6 +68,9 @@ var retryPolicy = Policy
 - **Polly (.NET resilience and transient-fault-handling library)**  
   <https://github.com/App-vNext/Polly>
 
+- **Polly: Retry with Jitter**  
+  <https://github.com/App-vNext/Polly/wiki/Retry-with-jitter>
+
 - **Marc Brooker. Jitter: Making Things Better With Randomness**  
   <https://brooker.co.za/blog/2015/03/21/backoff.html>
 


### PR DESCRIPTION
This PR adds the - **Polly: Retry with Jitter**  link in the additional resource section in the `implement-http-call-retries-exponential-backoff-polly` page.
