### PR TITLE
Move code comments to article text

### DIFF
--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -162,9 +162,9 @@ The following declaration uses the full syntax.
 
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet17b":::
 
-### && and &#124;&#124; operators  
+### `&&` and `||` operators  
   
-To avoid exceptions and increase performance by skipping unnecessary comparisons, use [&&](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [&](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [&#124;&#124;](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [&#124;](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  
+To avoid exceptions and increase performance by skipping unnecessary comparisons, use [&&](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [&](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [`||`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [`|`](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet18":::
 

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -213,6 +213,20 @@ Call [static](../../language-reference/keywords/static.md) members by using the 
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet27":::
 
+- Use implicit typing in the declaration of query variables and range variables.  
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet25":::
+
+- Align query clauses under the [from](../../language-reference/keywords/from-clause.md) clause, as shown in the previous examples.  
+
+- Use [where](../../language-reference/keywords/where-clause.md) clauses before other query clauses to ensure that later query clauses operate on the reduced, filtered set of data.  
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet29":::
+
+- Use multiple `from` clauses instead of a [join](../../language-reference/keywords/join-clause.md) clause to access inner collections. For example, a collection of `Student` objects might each contain a collection of test scores. When the following query is executed, it returns each score that is over 90, along with the last name of the student who received the score.  
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet30":::
+
 ## Security  
 
 Follow the guidelines in [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md).  

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -123,7 +123,7 @@ If you use explicit instantiation, you can use `var`.
 
 If you specify an array size, you have to initialize the elements one at a time.
   
-:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet1":::
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet13c":::
   
 ### Delegates  
   

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -130,7 +130,7 @@ Use [`Func<>` and `Action<>`](../../../standard/delegates-lambdas.md) instead of
 
 :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet14a":::
 
-Call the method using the signature defined by the `Func<>` or `Action<>` delegate:
+Call the method using the signature defined by the `Func<>` or `Action<>` delegate.
 
 :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15a":::
 

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -162,6 +162,10 @@ The following declaration uses the full syntax.
 
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet17b":::
 
+  In C# 8 and later versions, use the new [`using` syntax](../../language-reference/keywords/using-statement.md) that doesn't require braces:
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet17c":::
+
 ### `&&` and `||` operators  
   
 To avoid exceptions and increase performance by skipping unnecessary comparisons, use [&&](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [&](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [`||`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [`|`](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -89,7 +89,7 @@ The following sections describe practices that the C# team follows to prepare co
 
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet10":::
 
-- Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md).  
+- Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md). Use `dynamic` when you want run-time type inference. For more information, see [Using type dynamic (C# Programming Guide)](../types/using-type-dynamic.md).
   
 - Use implicit typing to determine the type of the loop variable in [for](../../language-reference/keywords/for.md) loops.  
   
@@ -232,5 +232,6 @@ Follow the guidelines in [Secure Coding Guidelines](../../../standard/security/s
   
 ## See also
 
+- [.NET runtime coding guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)
 - [Visual Basic Coding Conventions](../../../visual-basic/programming-guide/program-structure/coding-conventions.md)
 - [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md)

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -1,12 +1,11 @@
 ---
 title: "C# Coding Conventions - C# Programming Guide"
 description: Learn about coding conventions in C#. Coding conventions create a consistent look to the code and facilitate copying, changing, and maintaining the code.
-ms.date: 07/20/2015
+ms.date: 03/31/2021
 helpviewer_keywords: 
   - "coding conventions, C#"
   - "Visual C#, coding conventions"
   - "C# language, coding conventions"
-ms.assetid: f4f60de9-d49b-4fb6-bab1-20e19ea24710
 ---
 # C# Coding Conventions (C# Programming Guide)
 
@@ -22,7 +21,7 @@ Coding conventions serve the following purposes:
 
 The guidelines in this article are used by Microsoft to develop samples and documentation.  
   
-## Naming Conventions  
+## Naming conventions  
   
 - In short examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they are too long for a single line, as shown in the following example.
 
@@ -30,7 +29,7 @@ The guidelines in this article are used by Microsoft to develop samples and docu
 
 - You don't have to change the names of objects that were created by using the Visual Studio designer tools to make them fit other guidelines.  
   
-## Layout Conventions  
+## Layout conventions  
 
 Good layout uses formatting to emphasize the structure of your code and to make the code easier to read. Microsoft examples and samples conform to the following conventions:  
   
@@ -48,7 +47,7 @@ Good layout uses formatting to emphasize the structure of your code and to make 
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet2":::
 
-## Commenting Conventions  
+## Commenting conventions  
   
 - Place the comment on a separate line, not at the end of a line of code.  
   
@@ -62,11 +61,11 @@ Good layout uses formatting to emphasize the structure of your code and to make 
 
 - Don't create formatted blocks of asterisks around comments.  
   
-## Language Guidelines  
+## Language guidelines  
 
 The following sections describe practices that the C# team follows to prepare code examples and samples.  
   
-### String Data Type  
+### String data type  
   
 - Use [string interpolation](../../language-reference/tokens/interpolated.md) to concatenate short strings, as shown in the following code.  
   
@@ -76,7 +75,7 @@ The following sections describe practices that the C# team follows to prepare co
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet7":::
 
-### Implicitly Typed Local Variables  
+### Implicitly typed local variables  
   
 - Use [implicit typing](../classes-and-structs/implicitly-typed-local-variables.md) for local variables when the type of the variable is obvious from the right side of the assignment, or when the precise type is not important.  
   
@@ -107,7 +106,7 @@ The following sections describe practices that the C# team follows to prepare co
   > [!NOTE]
   > Be careful not to accidentally change a type of an element of the iterable collection. For example, it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.IEnumerable?displayProperty=nameWithType> in a `foreach` statement, which changes the execution of a query.
 
-### Unsigned Data Type  
+### Unsigned data types  
   
 In general, use `int` rather than unsigned types. The use of `int` is common throughout C#, and it is easier to interact with other libraries when you use `int`.  
   
@@ -139,7 +138,7 @@ The following declaration uses the full syntax.
 
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15b":::
 
-### try-catch and using Statements in Exception Handling  
+### `try`-`catch` and `using` statements in exception handling  
   
 - Use a [try-catch](../../language-reference/keywords/try-catch.md) statement for most exception handling.  
   
@@ -155,13 +154,13 @@ The following declaration uses the full syntax.
 
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet17b":::
 
-### && and &#124;&#124; Operators  
+### && and &#124;&#124; operators  
   
 To avoid exceptions and increase performance by skipping unnecessary comparisons, use [&&](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [&](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [&#124;&#124;](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [&#124;](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet18":::
 
-If the divisor is 0, the second clause in the `if` statement would cause a run-time error. But the && operator short circuits when the first expression is false. That is, it doesn't evaluate the second expression. The & operator would evaluate both, resulting in a run-time error when `divisor` is 0.
+If the divisor is 0, the second clause in the `if` statement would cause a run-time error. But the && operator short-circuits when the first expression is false. That is, it doesn't evaluate the second expression. The & operator would evaluate both, resulting in a run-time error when `divisor` is 0.
   
 ### `new` operator  
   
@@ -185,7 +184,7 @@ If the divisor is 0, the second clause in the `if` statement would cause a run-t
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet21b":::
 
-### Event Handling  
+### Event handling  
   
 If you're defining an event handler that you don't need to remove later, use a lambda expression.  
   
@@ -195,11 +194,11 @@ The lambda expression shortens the following traditional definition.
 
 :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet23":::
 
-### Static Members  
+### Static members  
   
 Call [static](../../language-reference/keywords/static.md) members by using the class name: *ClassName.StaticMember*. This practice makes code more readable by making static access clear.  Don't qualify a static member defined in a base class with the name of a derived class.  While that code compiles, the code readability is misleading, and the code may break in the future if you add a static member with the same name to the derived class.  
   
-### LINQ Queries  
+### LINQ queries  
   
 - Use meaningful names for query variables. The following example uses `seattleCustomers` for customers who are located in Seattle.  
   

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -126,17 +126,25 @@ If you specify an array size, you have to initialize the elements one at a time.
   
 ### Delegates  
   
-Use the concise syntax to create instances of a delegate type. In the `Program` class, define the delegate type and a method that has a matching signature.  
+Use [`Func<>` and `Action<>`](../../../standard/delegates-lambdas.md) instead of defining delegate types. In a class, define the delegate method.  
+
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet14a":::
+
+Call the method using the signature defined by the `Func<>` or `Action<>` delegate:
+
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15a":::
+
+If you create instances of a delegate type, use the concise syntax. In a class, define the delegate type and a method that has a matching signature.  
   
-  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet14":::
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet14b":::
 
-In the `Main` method, create an instance of the delegate type. The following declaration shows the condensed syntax.
+Create an instance of the delegate type and call it. The following declaration shows the condensed syntax.
 
-  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15a":::
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15b":::
 
 The following declaration uses the full syntax.
 
-  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15b":::
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15c":::
 
 ### `try`-`catch` and `using` statements in exception handling  
   

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -168,7 +168,7 @@ The following declaration uses the full syntax.
 
 ### `&&` and `||` operators  
   
-To avoid exceptions and increase performance by skipping unnecessary comparisons, use [&&](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [&](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [`||`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [`|`](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  
+To avoid exceptions and increase performance by skipping unnecessary comparisons, use [`&&`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [`&`](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [`||`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [`|`](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet18":::
 

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -75,14 +75,14 @@ The following sections describe practices that the C# team follows to prepare co
 - To append strings in loops, especially when you're working with large amounts of text, use a <xref:System.Text.StringBuilder> object.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet7":::
- 
+
 ### Implicitly Typed Local Variables  
   
 - Use [implicit typing](../classes-and-structs/implicitly-typed-local-variables.md) for local variables when the type of the variable is obvious from the right side of the assignment, or when the precise type is not important.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet8":::
   
-- Don't use [var](../../language-reference/keywords/var.md) when the type is not apparent from the right side of the assignment. Don't assume the type is clear from a method name. A variable type is considered clear if it's a new operator or an explicit cast.
+- Don't use [var](../../language-reference/keywords/var.md) when the type is not apparent from the right side of the assignment. Don't assume the type is clear from a method name. A variable type is considered clear if it's a `new` operator or an explicit cast.
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet9":::
 
@@ -163,13 +163,17 @@ To avoid exceptions and increase performance by skipping unnecessary comparisons
 
 If the divisor is 0, the second clause in the `if` statement would cause a run-time error. But the && operator short circuits when the first expression is false. That is, it doesn't evaluate the second expression. The & operator would evaluate both, resulting in a run-time error when `divisor` is 0.
   
-### New Operator  
+### `new` operator  
   
-- Use one of the concise forms of object instantiation, as shown in the following declarations. The second line shows syntax that is available starting in C# 9.  
+- Use one of the concise forms of object instantiation, as shown in the following declarations. The second example shows syntax that is available starting in C# 9.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet19":::
   
-  The previous lines are equivalent to the following declaration.  
+  ```csharp
+  ExampleClass instance2 = new();
+  ```
+  
+  The preceding declarations are equivalent to the following declaration.  
   
   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet20":::
 

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -24,11 +24,11 @@ The guidelines in this article are used by Microsoft to develop samples and docu
   
 ## Naming Conventions  
   
-- In short examples that do not include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you do not have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they are too long for a single line, as shown in the following example.  
-  
-     [!code-csharp[csProgGuideCodingConventions#1](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#1)]  
-  
-- You do not have to change the names of objects that were created by using the Visual Studio designer tools to make them fit other guidelines.  
+- In short examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they are too long for a single line, as shown in the following example.
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet1":::
+
+- You don't have to change the names of objects that were created by using the Visual Studio designer tools to make them fit other guidelines.  
   
 ## Layout Conventions  
 
@@ -46,8 +46,8 @@ Good layout uses formatting to emphasize the structure of your code and to make 
   
 - Use parentheses to make clauses in an expression apparent, as shown in the following code.  
   
-     [!code-csharp[csProgGuideCodingConventions#2](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#2)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet2":::
+
 ## Commenting Conventions  
   
 - Place the comment on a separate line, not at the end of a line of code.  
@@ -58,9 +58,9 @@ Good layout uses formatting to emphasize the structure of your code and to make 
   
 - Insert one space between the comment delimiter (//) and the comment text, as shown in the following example.  
   
-     [!code-csharp[csProgGuideCodingConventions#3](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#3)]  
-  
-- Do not create formatted blocks of asterisks around comments.  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet3":::
+
+- Don't create formatted blocks of asterisks around comments.  
   
 ## Language Guidelines  
 
@@ -70,42 +70,42 @@ The following sections describe practices that the C# team follows to prepare co
   
 - Use [string interpolation](../../language-reference/tokens/interpolated.md) to concatenate short strings, as shown in the following code.  
   
-     [!code-csharp[csProgGuideCodingConventions#6](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#6)]  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet6":::
+
+- To append strings in loops, especially when you're working with large amounts of text, use a <xref:System.Text.StringBuilder> object.  
   
-- To append strings in loops, especially when you are working with large amounts of text, use a <xref:System.Text.StringBuilder> object.  
-  
-     [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#7)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet7":::
+ 
 ### Implicitly Typed Local Variables  
   
 - Use [implicit typing](../classes-and-structs/implicitly-typed-local-variables.md) for local variables when the type of the variable is obvious from the right side of the assignment, or when the precise type is not important.  
   
-     [!code-csharp[csProgGuideCodingConventions#8](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#8)]  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet8":::
   
-- Do not use [var](../../language-reference/keywords/var.md) when the type is not apparent from the right side of the assignment.  
+- Don't use [var](../../language-reference/keywords/var.md) when the type is not apparent from the right side of the assignment. Don't assume the type is clear from a method name. A variable type is considered clear if it's a new operator or an explicit cast.
   
-     [!code-csharp[csProgGuideCodingConventions#9](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#9)]  
-  
-- Do not rely on the variable name to specify the type of the variable. It might not be correct.  
-  
-     [!code-csharp[csProgGuideCodingConventions#10](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#10)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet9":::
+
+- Don't rely on the variable name to specify the type of the variable. It might not be correct. In the following example, the variable name `inputInt` is misleading. It's a string.
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet10":::
+
 - Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md).  
   
 - Use implicit typing to determine the type of the loop variable in [for](../../language-reference/keywords/for.md) loops.  
   
-     The following example uses implicit typing in a `for` statement.  
-  
-     [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#7)]  
+  The following example uses implicit typing in a `for` statement.  
 
-- Do not use implicit typing to determine the type of the loop variable in [foreach](../../language-reference/keywords/foreach-in.md) loops.
+    :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet7":::
 
-     The following example uses explicit typing in a `foreach` statement.
+- Don't use implicit typing to determine the type of the loop variable in [foreach](../../language-reference/keywords/foreach-in.md) loops.
 
-     [!code-csharp[csProgGuideCodingConventions#12](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#12)]
+  The following example uses explicit typing in a `foreach` statement.
 
-     > [!NOTE]
-     > Be careful not to accidentally change a type of an element of the iterable collection. For example, it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.IEnumerable?displayProperty=nameWithType> in a `foreach` statement, which changes the execution of a query.
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet12":::
+
+  > [!NOTE]
+  > Be careful not to accidentally change a type of an element of the iterable collection. For example, it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.IEnumerable?displayProperty=nameWithType> in a `foreach` statement, which changes the execution of a query.
 
 ### Unsigned Data Type  
   
@@ -113,88 +113,102 @@ In general, use `int` rather than unsigned types. The use of `int` is common thr
   
 ### Arrays  
   
-Use the concise syntax when you initialize arrays on the declaration line.  
+Use the concise syntax when you initialize arrays on the declaration line. In the following example, note that you can't use `var` instead of `string[]`.  
   
-[!code-csharp[csProgGuideCodingConventions#13](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#13)]  
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet13a":::
+
+If you use explicit instantiation, you can use `var`.
+
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet13b":::
+
+If you specify an array size, you have to initialize the elements one at a time.
+  
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet1":::
   
 ### Delegates  
   
-Use the concise syntax to create instances of a delegate type.  
+Use the concise syntax to create instances of a delegate type. In the `Program` class, define the delegate type and a method that has a matching signature.  
   
-[!code-csharp[csProgGuideCodingConventions#14](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#14)]  
-  
-[!code-csharp[csProgGuideCodingConventions#15](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#15)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet14":::
+
+In the `Main` method, create an instance of the delegate type. The following declaration shows the condensed syntax.
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15a":::
+
+The following declaration uses the full syntax.
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet15b":::
+
 ### try-catch and using Statements in Exception Handling  
   
 - Use a [try-catch](../../language-reference/keywords/try-catch.md) statement for most exception handling.  
   
-     [!code-csharp[csProgGuideCodingConventions#16](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#16)]  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet16":::
+
+- Simplify your code by using the C# [using statement](../../language-reference/keywords/using-statement.md). If you have a [try-finally](../../language-reference/keywords/try-finally.md) statement in which the only code in the `finally` block is a call to the <xref:System.IDisposable.Dispose%2A> method, use a `using` statement instead.
+
+  In the following example, the `try`-`finally` statement only calls `Dispose` in the `finally` block.
   
-- Simplify your code by using the C# [using statement](../../language-reference/keywords/using-statement.md). If you have a [try-finally](../../language-reference/keywords/try-finally.md) statement in which the only code in the `finally` block is a call to the <xref:System.IDisposable.Dispose%2A> method, use a `using` statement instead.  
-  
-     [!code-csharp[csProgGuideCodingConventions#17](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#17)]  
-  
+   :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet17a":::
+
+  You can do the same thing with a `using` statement.
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet17b":::
+
 ### && and &#124;&#124; Operators  
   
 To avoid exceptions and increase performance by skipping unnecessary comparisons, use [&&](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [&](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [&#124;&#124;](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [&#124;](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.  
   
-[!code-csharp[csProgGuideCodingConventions#18](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#18)]  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet18":::
+
+If the divisor is 0, the second clause in the `if` statement would cause a run-time error. But the && operator short circuits when the first expression is false. That is, it doesn't evaluate the second expression. The & operator would evaluate both, resulting in a run-time error when `divisor` is 0.
   
 ### New Operator  
   
-- Use the concise form of object instantiation, with implicit typing, as shown in the following declaration.  
+- Use one of the concise forms of object instantiation, as shown in the following declarations. The second line shows syntax that is available starting in C# 9.  
   
-     [!code-csharp[csProgGuideCodingConventions#19](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#19)]  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet19":::
   
-     The previous line is equivalent to the following declaration.  
+  The previous lines are equivalent to the following declaration.  
   
-     [!code-csharp[csProgGuideCodingConventions#20](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#20)]  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet20":::
+
+- Use object initializers to simplify object creation, as shown in the following example.
+
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet21a":::
+
+  The following example sets the same properties as the preceding example but doesn't use initializers.
   
-- Use object initializers to simplify object creation.  
-  
-     [!code-csharp[csProgGuideCodingConventions#21](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#21)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet21b":::
+
 ### Event Handling  
   
-If you are defining an event handler that you do not need to remove later, use a lambda expression.  
+If you're defining an event handler that you don't need to remove later, use a lambda expression.  
   
-[!code-csharp[csProgGuideCodingConventions#22](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#22)]  
-  
-[!code-csharp[csProgGuideCodingConventions#23](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#23)]  
-  
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet22":::
+
+The lambda expression shortens the following traditional definition.
+
+:::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet23":::
+
 ### Static Members  
   
-Call [static](../../language-reference/keywords/static.md) members by using the class name: *ClassName.StaticMember*. This practice makes code more readable by making static access clear.  Do not qualify a static member defined in a base class with the name of a derived class.  While that code compiles, the code readability is misleading, and the code may break in the future if you add a static member with the same name to the derived class.  
+Call [static](../../language-reference/keywords/static.md) members by using the class name: *ClassName.StaticMember*. This practice makes code more readable by making static access clear.  Don't qualify a static member defined in a base class with the name of a derived class.  While that code compiles, the code readability is misleading, and the code may break in the future if you add a static member with the same name to the derived class.  
   
 ### LINQ Queries  
   
 - Use meaningful names for query variables. The following example uses `seattleCustomers` for customers who are located in Seattle.  
   
-     [!code-csharp[csProgGuideCodingConventions#25](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#25)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet25":::
+
 - Use aliases to make sure that property names of anonymous types are correctly capitalized, using Pascal casing.  
   
-     [!code-csharp[csProgGuideCodingConventions#26](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#26)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet26":::
+
 - Rename properties when the property names in the result would be ambiguous. For example, if your query returns a customer name and a distributor ID, instead of leaving them as `Name` and `ID` in the result, rename them to clarify that `Name` is the name of a customer, and `ID` is the ID of a distributor.  
   
-     [!code-csharp[csProgGuideCodingConventions#27](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#27)]  
-  
-- Use implicit typing in the declaration of query variables and range variables.  
-  
-     [!code-csharp[csProgGuideCodingConventions#25](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#25)]  
-  
-- Align query clauses under the [from](../../language-reference/keywords/from-clause.md) clause, as shown in the previous examples.  
-  
-- Use [where](../../language-reference/keywords/where-clause.md) clauses before other query clauses to ensure that later query clauses operate on the reduced, filtered set of data.  
-  
-     [!code-csharp[csProgGuideCodingConventions#29](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#29)]  
-  
-- Use multiple `from` clauses instead of a [join](../../language-reference/keywords/join-clause.md) clause to access inner collections. For example, a collection of `Student` objects might each contain a collection of test scores. When the following query is executed, it returns each score that is over 90, along with the last name of the student who received the score.  
-  
-     [!code-csharp[csProgGuideCodingConventions#30](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#30)]  
-  
+  :::code language="csharp" source="../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs" id="Snippet27":::
+
 ## Security  
 
 Follow the guidelines in [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md).  

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/coding conventions examples.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/coding conventions examples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Coding_Conventions_Examples</RootNamespace>
     <AssemblyName>Coding Conventions Examples</AssemblyName>
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -365,7 +365,6 @@ namespace Coding_Conventions_Examples
         };
 
             //<snippet30>
-            // Use a compound from to access the inner sequence within each element.
             var scoreQuery = from student in students
                              from score in student.Scores
                              where score > 90

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -166,25 +166,26 @@ namespace Coding_Conventions_Examples
             }
             //</snippet18>
 
+
             //<snippet19>
             var instance1 = new ExampleClass();
-            ExampleClass instance2 = new();
             //</snippet19>
+            // Can't show `ExampleClass instance1 = new()` because this projet targets net48.
 
             //<snippet20>
-            ExampleClass instance3 = new ExampleClass();
+            ExampleClass instance2 = new ExampleClass();
             //</snippet20>
 
             //<snippet21a>
-            var instance4 = new ExampleClass { Name = "Desktop", ID = 37414,
+            var instance3 = new ExampleClass { Name = "Desktop", ID = 37414,
                 Location = "Redmond", Age = 2.3 };
             //</snippet21a>
             //<snippet21b>
-            var instance5 = new ExampleClass();
-            instance5.Name = "Desktop";
-            instance5.ID = 37414;
-            instance5.Location = "Redmond";
-            instance5.Age = 2.3;
+            var instance4 = new ExampleClass();
+            instance4.Name = "Desktop";
+            instance4.ID = 37414;
+            instance4.Location = "Redmond";
+            instance4.Age = 2.3;
             //</snippet21b>
 
             // #22 and #23 are in Coding_Conventions_WF, below.

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -9,14 +9,21 @@ namespace Coding_Conventions_Examples
 {
     class Program
     {
-        //<snippet14>
+        //<snippet14a>
+        public static Action<string> ActionExample1 = x => Console.WriteLine($"x is: {x}");
+        public static Action<string, string> ActionExample2 = (x, y) => 
+            Console.WriteLine($"x is: {x}, y is {y}");
+        public static Func<string, int> FuncExample1 = x => Convert.ToInt32(x);
+        public static Func<int, int, int> FuncExample2 = (x, y) => x + y;
+        //</snippet14a>
+        //<snippet14b>
         public delegate void Del(string message);
 
         public static void DelMethod(string str)
         {
             Console.WriteLine("DelMethod argument: {0}", str);
         }
-        //</snippet14>
+        //</snippet14b>
 
         static void Main(string[] args)
         {
@@ -114,15 +121,22 @@ namespace Coding_Conventions_Examples
             // And so on.
             //</snippet13c>
 
+
             //<snippet15a>
-            Del exampleDel2 = DelMethod;
+            ActionExample1("string for x");
+            ActionExample2("string for x", "string for y");
+            Console.WriteLine($"The value is {FuncExample1("1")}");
+            Console.WriteLine($"The sum is {FuncExample2(1, 2)}");
             //</snippet15a>
             //<snippet15b>
-            Del exampleDel1 = new Del(DelMethod);
+            Del exampleDel2 = DelMethod;
+            exampleDel2("Hey");
             //</snippet15b>
-
+            //<snippet15c>
+            Del exampleDel1 = new Del(DelMethod);
             exampleDel1("Hey");
-            exampleDel2(" hey");
+            //</snippet15c>
+
 
             // #16 is below Main.
             Console.WriteLine(GetValueFromArray(vowels1, 1));

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -159,9 +159,13 @@ namespace Coding_Conventions_Examples
             //<snippet17b>
             using (Font font2 = new Font("Arial", 10.0f))
             {
-                byte charset = font2.GdiCharSet;
+                byte charset2 = font2.GdiCharSet;
             }
             //</snippet17b>
+            //<snippet17c>
+            using Font font3 = new Font("Arial", 10.0f);
+            byte charset3 = font3.GdiCharSet;
+            //</snippet17c>
 
             //<snippet18>
             Console.Write("Enter a dividend: ");

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -10,13 +10,8 @@ namespace Coding_Conventions_Examples
     class Program
     {
         //<snippet14>
-        // First, in class Program, define the delegate type and a method that
-        // has a matching signature.
-
-        // Define the type.
         public delegate void Del(string message);
 
-        // Define a method that has a matching signature.
         public static void DelMethod(string str)
         {
             Console.WriteLine("DelMethod argument: {0}", str);
@@ -71,23 +66,16 @@ namespace Coding_Conventions_Examples
             //</snippet7>
 
             //<snippet8>
-            // When the type of a variable is clear from the context, use var
-            // in the declaration.
             var var1 = "This is clearly a string.";
             var var2 = 27;
             //</snippet8>
 
             //<snippet9>
-            // When the type of a variable is not clear from the context, use an
-            // explicit type. You generally don't assume the type clear from a method name.
-            // A variable type is considered clear if it's a new operator or an explicit cast.
-            int var3 = Convert.ToInt32(Console.ReadLine());
+            int var3 = Convert.ToInt32(Console.ReadLine()); 
             int var4 = ExampleClass.ResultSoFar();
             //</snippet9>
 
             //<snippet10>
-            // Naming the following variable inputInt is misleading.
-            // It is a string.
             var inputInt = Console.ReadLine();
             Console.WriteLine(inputInt);
             //</snippet10>
@@ -113,29 +101,25 @@ namespace Coding_Conventions_Examples
             Console.WriteLine();
             //</snippet12>
 
-            //<snippet13>
-            // Preferred syntax. Note that you cannot use var here instead of string[].
+            //<snippet13a>
             string[] vowels1 = { "a", "e", "i", "o", "u" };
-
-            // If you use explicit instantiation, you can use var.
+            //</snippet13a>
+            //<snippet13b>
             var vowels2 = new string[] { "a", "e", "i", "o", "u" };
-
-            // If you specify an array size, you must initialize the elements one at a time.
+            //</snippet13b>
+            //<snippet13c>
             var vowels3 = new string[5];
             vowels3[0] = "a";
             vowels3[1] = "e";
             // And so on.
-            //</snippet13>
+            //</snippet13c>
 
-            //<snippet15>
-            // In the Main method, create an instance of Del.
-
-            // Preferred: Create an instance of Del by using condensed syntax.
+            //<snippet15a>
             Del exampleDel2 = DelMethod;
-
-            // The following declaration uses the full syntax.
+            //</snippet15a>
+            //<snippet15b>
             Del exampleDel1 = new Del(DelMethod);
-            //</snippet15>
+            //</snippet15b>
 
             exampleDel1("Hey");
             exampleDel2(" hey");
@@ -144,8 +128,7 @@ namespace Coding_Conventions_Examples
             Console.WriteLine(GetValueFromArray(vowels1, 1));
 
             // 17 requires System.Drawing
-            //<snippet17>
-            // This try-finally statement only calls Dispose in the finally block.
+            //<snippet17a>
             Font font1 = new Font("Arial", 10.0f);
             try
             {
@@ -158,26 +141,21 @@ namespace Coding_Conventions_Examples
                     ((IDisposable)font1).Dispose();
                 }
             }
-
-            // You can do the same thing with a using statement.
+            //</snippet17a>
+            //<snippet17b>
             using (Font font2 = new Font("Arial", 10.0f))
             {
                 byte charset = font2.GdiCharSet;
             }
-            //</snippet17>
+            //</snippet17b>
 
             //<snippet18>
             Console.Write("Enter a dividend: ");
-            var dividend = Convert.ToInt32(Console.ReadLine());
+            int dividend = Convert.ToInt32(Console.ReadLine());
 
             Console.Write("Enter a divisor: ");
-            var divisor = Convert.ToInt32(Console.ReadLine());
+            int divisor = Convert.ToInt32(Console.ReadLine());
 
-            // If the divisor is 0, the second clause in the following condition
-            // causes a run-time error. The && operator short circuits when the
-            // first expression is false. That is, it does not evaluate the
-            // second expression. The & operator evaluates both, and causes
-            // a run-time error when divisor is 0.
             if ((divisor != 0) && (dividend / divisor > 0))
             {
                 Console.WriteLine("Quotient: {0}", dividend / divisor);
@@ -190,28 +168,28 @@ namespace Coding_Conventions_Examples
 
             //<snippet19>
             var instance1 = new ExampleClass();
+            ExampleClass instance2 = new();
             //</snippet19>
 
             //<snippet20>
-            ExampleClass instance2 = new ExampleClass();
+            ExampleClass instance3 = new ExampleClass();
             //</snippet20>
 
-            //<snippet21>
-            // Object initializer.
-            var instance3 = new ExampleClass { Name = "Desktop", ID = 37414,
+            //<snippet21a>
+            var instance4 = new ExampleClass { Name = "Desktop", ID = 37414,
                 Location = "Redmond", Age = 2.3 };
-
-            // Default constructor and assignment statements.
-            var instance4 = new ExampleClass();
-            instance4.Name = "Desktop";
-            instance4.ID = 37414;
-            instance4.Location = "Redmond";
-            instance4.Age = 2.3;
-            //</snippet21>
+            //</snippet21a>
+            //<snippet21b>
+            var instance5 = new ExampleClass();
+            instance5.Name = "Desktop";
+            instance5.ID = 37414;
+            instance5.Location = "Redmond";
+            instance5.Age = 2.3;
+            //</snippet21b>
 
             // #22 and #23 are in Coding_Conventions_WF, below.
 
-            // Save 24 in case we add an exxample to Static Members.
+            // Save 24 in case we add an example to Static Members.
 
             ExampleClass.totalInstances = 1;
 
@@ -414,7 +392,6 @@ namespace Coding_Conventions_WF2
         //<snippet22>
         public Form2()
         {
-            // You can use a lambda expression to define an event handler.
             this.Click += (s, e) =>
                 {
                     MessageBox.Show(
@@ -434,7 +411,6 @@ namespace Coding_Conventions_WF2
     public partial class Form1 : Form
     {
         //<snippet23>
-        // Using a lambda expression shortens the following traditional definition.
         public Form1()
         {
             this.Click += new EventHandler(Form1_Click);

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -11,9 +11,12 @@ namespace Coding_Conventions_Examples
     {
         //<snippet14a>
         public static Action<string> ActionExample1 = x => Console.WriteLine($"x is: {x}");
+
         public static Action<string, string> ActionExample2 = (x, y) => 
             Console.WriteLine($"x is: {x}, y is {y}");
+
         public static Func<string, int> FuncExample1 = x => Convert.ToInt32(x);
+
         public static Func<int, int, int> FuncExample2 = (x, y) => x + y;
         //</snippet14a>
         //<snippet14b>
@@ -124,8 +127,11 @@ namespace Coding_Conventions_Examples
 
             //<snippet15a>
             ActionExample1("string for x");
+
             ActionExample2("string for x", "string for y");
+
             Console.WriteLine($"The value is {FuncExample1("1")}");
+
             Console.WriteLine($"The sum is {FuncExample2(1, 2)}");
             //</snippet15a>
             //<snippet15b>


### PR DESCRIPTION
* Moves code comments to article text.
* Fixes #23282 
* Fixes #12430 
* Fixes #12442
* Adds the option to use C# 9 target-typed `new` statement
* Implements Acrolinx suggestions
* Uses new code snippet syntax