### PR TITLE
Add status check for build warnings

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -1,0 +1,10 @@
+on: [pull_request]
+
+jobs:
+  status_checker_job:
+    runs-on: ubuntu-latest
+    name: Checks the OPS status check for build warnings
+    steps:
+    - uses: dotnet/samples/.github/actions/status-checker@main
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -1,4 +1,12 @@
-on: [pull_request]
+on: 
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'The reason for running the workflow'
+        required: true
+        default: 'Manual run'
 
 jobs:
   status_checker_job:


### PR DESCRIPTION
This workflow calls a GitHub action that creates a new status check with state=failure IFF there are OPS build warnings.