### PR TITLE
Shared framework breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes in .NET 6
 description: Navigate to the breaking changes in .NET 6.
-ms.date: 02/24/2021
+ms.date: 04/02/2021
 no-loc: [Blazor]
 ---
 # Breaking changes in .NET 6
@@ -13,6 +13,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
+- [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md)
 - [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md)
 - [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md)
 - [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md)

--- a/docs/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework.md
+++ b/docs/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework.md
@@ -1,0 +1,64 @@
+---
+title: "Breaking change: Assemblies removed from Microsoft.AspNetCore.App shared framework"
+description: "Learn about the breaking change in ASP.NET Core 6.0 where some assemblies where removed from the Microsoft.AspNetCore.App shared framework."
+ms.date: 04/02/2021
+---
+# Assemblies removed from Microsoft.AspNetCore.App shared framework
+
+The following two assemblies were removed from the ASP.NET Core targeting pack:
+
+- System.Security.Permissions
+- System.Windows.Extensions
+
+In addition, the following assemblies were removed from the ASP.NET Core runtime pack:
+
+- Microsoft.Win32.SystemEvents
+- System.Drawing.Common
+- System.Security.Permissions
+- System.Windows.Extensions
+
+## Version introduced
+
+6.0
+
+## Old behavior
+
+Applications could use APIs provided by these libraries by referencing the *Microsoft.AspNetCore.App* shared framework.
+
+## New behavior
+
+If you use APIs from the affected assemblies without having a [PackageReference](../../../project-sdk/msbuild-props.md#packagereference) in your project file, you might see run-time errors. For example, an application that uses reflection to access APIs from one of these assemblies without adding an explicit reference to the package will have run-time errors. The `PackageReference` ensures that the assemblies are present as part of the application output.
+
+## Reason for change
+
+This change was introduced to reduce the size of the ASP.NET Core shared framework.
+
+## Recommended action
+
+To continue using these APIs in your project, add a [PackageReference](../../../project-sdk/msbuild-props.md#packagereference). For example:
+
+```xml
+<PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+```
+
+## Affected APIs
+
+- <xref:System.Security.Permissions?displayProperty=fullName>
+- <xref:System.Media?displayProperty=fullName>
+- <xref:System.Security.Cryptography.X509Certificates.X509Certificate2UI?displayProperty=fullName>
+- <xref:System.Xaml.Permissions.XamlAccessLevel?displayProperty=fullName>
+
+<!--
+
+## Category
+
+ASP.NET Core
+
+## Affected APIs
+
+- `N:System.Security.Permissions`
+- `N:System.Media`
+- `N:System.Security.Cryptography.X509Certificates.X509Certificate2UI`
+- `N:System.Xaml.Permissions.XamlAccessLevel`
+
+-->

--- a/docs/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework.md
+++ b/docs/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework.md
@@ -23,7 +23,7 @@ In addition, the following assemblies were removed from the ASP.NET Core runtime
 
 ## Old behavior
 
-Applications could use APIs provided by these libraries by referencing the *Microsoft.AspNetCore.App* shared framework.
+Applications could use APIs provided by these libraries by referencing the [Microsoft.AspNetCore.App](/aspnet/core/fundamentals/metapackage-app) shared framework.
 
 ## New behavior
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -25,6 +25,8 @@ items:
         href: 6.0.md
       - name: ASP.NET Core
         items:
+        - name: Assemblies removed from shared framework
+          href: aspnet-core/6.0/assemblies-removed-from-shared-framework.md
         - name: Nullable reference type annotations changed
           href: aspnet-core/6.0/nullable-reference-type-annotations-changed.md
         - name: Obsoleted and removed APIs
@@ -32,7 +34,7 @@ items:
         - name: "Blazor: Parameter name changed in RequestImageFileAsync method"
           href: aspnet-core/6.0/blazor-parameter-name-changed-in-method.md
         - name: "Blazor: WebEventDescriptor.EventArgsType property replaced"
-          href: aspnet-core/6.0/blazor-eventargstype-property-replaced.md          
+          href: aspnet-core/6.0/blazor-eventargstype-property-replaced.md
         - name: "Kestrel: Log message attributes changed"
           href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
         - name: "Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports"
@@ -331,9 +333,11 @@ items:
       items:
       - name: .NET 6
         items:
-        - name: "Nullable reference type annotations changed"
+        - name: Assemblies removed from shared framework
+          href: aspnet-core/6.0/assemblies-removed-from-shared-framework.md
+        - name: Nullable reference type annotations changed
           href: aspnet-core/6.0/nullable-reference-type-annotations-changed.md
-        - name: "Obsoleted and removed APIs"
+        - name: Obsoleted and removed APIs
           href: aspnet-core/6.0/obsolete-removed-apis.md
         - name: "Blazor: Parameter name changed in RequestImageFileAsync method"
           href: aspnet-core/6.0/blazor-parameter-name-changed-in-method.md


### PR DESCRIPTION
Contributes to aspnet/Announcements#456.

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework?branch=pr-en-us-23607).