### PR TITLE
Grammar fix: move indefinite article

### DIFF
--- a/docs/architecture/cloud-native/deploy-containers-azure.md
+++ b/docs/architecture/cloud-native/deploy-containers-azure.md
@@ -14,7 +14,7 @@ We've discussed containers in this chapter and in chapter 1. We've seen that con
 
 ## Azure Container Registry
 
-When containerizing a microservice, you first a build container "image." The image is a binary representation of the service code, dependencies, and runtime. While you can manually create an image using the `Docker Build` command from the Docker API, a better approach is to create it as part of an automated build process.
+When containerizing a microservice, you first build a container "image." The image is a binary representation of the service code, dependencies, and runtime. While you can manually create an image using the `Docker Build` command from the Docker API, a better approach is to create it as part of an automated build process.
 
 Once created, container images are stored in container registries. They enable you to build, store, and manage container images. There are many registries available, both public and private. Azure Container Registry (ACR) is a fully managed container registry service in the Azure cloud. It persists your images inside the Azure network, reducing the time to deploy them to Azure container hosts. You can also secure them using the same security and identity procedures that you use for other Azure resources.
 


### PR DESCRIPTION
## Summary

Small grammar fix. Typo in the use of indefinite article 'a'
