### PR TITLE
document GC committed counter

### DIFF
--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -38,6 +38,7 @@ The following counters are published as part of .NET runtime (CoreCLR) and are m
 | :::no-loc text="Working Set"::: (`working-set`) | The amount of physical memory mapped to the process context at a point in time base on <xref:System.Environment.WorkingSet?displayProperty=nameWithType> |
 | :::no-loc text="IL Bytes Jitted"::: (`il-bytes-jitted`) | The total size of ILs that are JIT-compiled, in bytes (available on .NET 5 and later versions) |
 | :::no-loc text="Method Jitted Count"::: (`method-jitted-count`) | The number of methods that are JIT-compiled (available on .NET 5 and later versions) |
+| :::no-loc text="GC Committed Bytes"::: (`gc-committed-bytes`) | The number of bytes committed by the GC (available on .NET 6 and later versions) |
 
 ## "Microsoft.AspNetCore.Hosting" counters
 


### PR DESCRIPTION
## Summary

This documents the GC committed bytes counter that was added via https://github.com/dotnet/runtime/pull/50604.


