### PR TITLE
fix typo

### DIFF
--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -34,7 +34,7 @@ Beginning with C# 7.3, you can use the ref assignment operator `= ref` to reassi
 
 [!code-csharp[ref assignment operator](snippets/shared/AssignmentOperator.cs#RefAssignment)]
 
-In the case of the ref assignment operator, the both of its operands must be of the same type.
+In the case of the ref assignment operator, both of its operands must be of the same type.
 
 ## Compound assignment
 


### PR DESCRIPTION
There is an extra "the" on line 37:
"In the case of the ref assignment operator, the both of its operands must be of the same type."
should be
"In the case of the ref assignment operator, both of its operands must be of the same type."

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
