### PR TITLE
Moved record from reserved to contextual keywords

### DIFF
--- a/docs/csharp/language-reference/keywords/contextual-keywords.md
+++ b/docs/csharp/language-reference/keywords/contextual-keywords.md
@@ -25,6 +25,7 @@ A contextual keyword is used to provide a specific meaning in the code, but it i
 |[nuint](../builtin-types/nint-nuint.md)|Defines a native-sized unsigned integer data type.|  
 |[or](../operators/patterns.md#logical-patterns)|Creates a pattern that matches when either of nested patterns matches.|  
 |[partial](./partial-type.md)|Defines partial classes, structs, and interfaces throughout the same compilation unit.|  
+|[record](../builtin-types/record.md)|Used to define a record type.|  
 |[remove](./remove.md)|Defines a custom event accessor that is invoked when client code unsubscribes from the event.|  
 |[set](./set.md)|Defines an accessor method for a property or an indexer.|  
 |[value](./value.md)|Used to set accessors and to add or remove event handlers.|  

--- a/docs/csharp/language-reference/keywords/index.md
+++ b/docs/csharp/language-reference/keywords/index.md
@@ -19,26 +19,26 @@ Keywords are predefined, reserved identifiers that have special meanings to the 
   
 |||||  
 |---|---|---|---|  
-|[abstract](abstract.md)|[as](../operators/type-testing-and-cast.md#as-operator)|[base](base.md)|[bool](../builtin-types/bool.md)|  
-|[break](break.md)|[byte](../builtin-types/integral-numeric-types.md)|[case](switch.md)|[catch](try-catch.md)|  
-|[char](../builtin-types/char.md)|[checked](checked.md)|[class](class.md)|[const](const.md)|  
-|[continue](continue.md)|[decimal](../builtin-types/floating-point-numeric-types.md)|[default](default.md)|[delegate](../builtin-types/reference-types.md)|  
-|[do](do.md)|[double](../builtin-types/floating-point-numeric-types.md)|[else](if-else.md)|[enum](../builtin-types/enum.md)|  
-|[event](event.md)|[explicit](../operators/user-defined-conversion-operators.md)|[extern](extern.md)|[false](../builtin-types/bool.md)|  
-|[finally](try-finally.md)|[fixed](fixed-statement.md)|[float](../builtin-types/floating-point-numeric-types.md)|[for](for.md)|  
-|[foreach](foreach-in.md)|[goto](goto.md)|[if](if-else.md)|[implicit](../operators/user-defined-conversion-operators.md)|  
+|[abstract](abstract.md)|[as](../operators/type-testing-and-cast.md#as-operator)|[base](base.md)|[bool](../builtin-types/bool.md)|
+|[break](break.md)|[byte](../builtin-types/integral-numeric-types.md)|[case](switch.md)|[catch](try-catch.md)|
+|[char](../builtin-types/char.md)|[checked](checked.md)|[class](class.md)|[const](const.md)|
+|[continue](continue.md)|[decimal](../builtin-types/floating-point-numeric-types.md)|[default](default.md)|[delegate](../builtin-types/reference-types.md)|
+|[do](do.md)|[double](../builtin-types/floating-point-numeric-types.md)|[else](if-else.md)|[enum](../builtin-types/enum.md)|
+|[event](event.md)|[explicit](../operators/user-defined-conversion-operators.md)|[extern](extern.md)|[false](../builtin-types/bool.md)|
+|[finally](try-finally.md)|[fixed](fixed-statement.md)|[float](../builtin-types/floating-point-numeric-types.md)|[for](for.md)|
+|[foreach](foreach-in.md)|[goto](goto.md)|[if](if-else.md)|[implicit](../operators/user-defined-conversion-operators.md)|
 |[in](in.md)|[int](../builtin-types/integral-numeric-types.md)|[interface](interface.md)|[internal](internal.md)|
 |[is](is.md)|[lock](lock-statement.md)|[long](../builtin-types/integral-numeric-types.md)|[namespace](namespace.md)|
 |[new](../operators/new-operator.md)|[null](null.md)|[object](../builtin-types/reference-types.md)|[operator](../operators/operator-overloading.md)|
 |[out](out.md)|[override](override.md)|[params](params.md)|[private](private.md)|
-|[protected](protected.md)|[public](public.md)|[readonly](readonly.md)|[record](../../programming-guide/classes-and-structs/records.md)|
-|[ref](ref.md)|[return](return.md)|[sbyte](../builtin-types/integral-numeric-types.md)|[sealed](sealed.md)|
-|[short](../builtin-types/integral-numeric-types.md)|[sizeof](../operators/sizeof.md)|[stackalloc](../operators/stackalloc.md)|[static](static.md)|
-|[string](../builtin-types/reference-types.md)|[struct](../builtin-types/struct.md)|[switch](switch.md)|[this](this.md)|
-|[throw](throw.md)|[true](../builtin-types/bool.md)|[try](try-catch.md)|[typeof](../operators/type-testing-and-cast.md#typeof-operator)|
-|[uint](../builtin-types/integral-numeric-types.md)|[ulong](../builtin-types/integral-numeric-types.md)|[unchecked](unchecked.md)|[unsafe](unsafe.md)|
-|[ushort](../builtin-types/integral-numeric-types.md)|[using](using.md)|[virtual](virtual.md)|[void](../builtin-types/void.md)|
-|[volatile](volatile.md)|[while](while.md)|
+|[protected](protected.md)|[public](public.md)|[readonly](readonly.md)|[ref](ref.md)|
+|[return](return.md)|[sbyte](../builtin-types/integral-numeric-types.md)|[sealed](sealed.md)|[short](../builtin-types/integral-numeric-types.md)|
+|[sizeof](../operators/sizeof.md)|[stackalloc](../operators/stackalloc.md)|[static](static.md)|[string](../builtin-types/reference-types.md)|
+|[struct](../builtin-types/struct.md)|[switch](switch.md)|[this](this.md)|[throw](throw.md)|
+|[true](../builtin-types/bool.md)|[try](try-catch.md)|[typeof](../operators/type-testing-and-cast.md#typeof-operator)|[uint](../builtin-types/integral-numeric-types.md)|
+|[ulong](../builtin-types/integral-numeric-types.md)|[unchecked](unchecked.md)|[unsafe](unsafe.md)|[ushort](../builtin-types/integral-numeric-types.md)|
+|[using](using.md)|[virtual](virtual.md)|[void](../builtin-types/void.md)|[volatile](volatile.md)|
+|[while](while.md)||||
 
 ## Contextual keywords
 
@@ -55,10 +55,11 @@ Keywords are predefined, reserved identifiers that have special meanings to the 
 |[nameof](../operators/nameof.md)|[nint](../builtin-types/nint-nuint.md)|[not](../operators/patterns.md#logical-patterns)|
 |[notnull](../../programming-guide/generics/constraints-on-type-parameters.md#notnull-constraint)|[nuint](../builtin-types/nint-nuint.md)|[on](on.md)|
 |[or](../operators/patterns.md#logical-patterns)|[orderby](orderby-clause.md)|[partial (type)](partial-type.md)|
-|[partial (method)](partial-method.md)|[remove](remove.md)|[select](select-clause.md)|
-|[set](set.md)|[unmanaged (generic type constraint)](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint)|[value](value.md)|
-|[var](var.md)|[when (filter condition)](when.md)|[where (generic type constraint)](where-generic-type-constraint.md)|
-|[where (query clause)](where-clause.md)|[with](../operators/with-expression.md)|[yield](yield.md)|
+|[partial (method)](partial-method.md)|[record](../../programming-guide/classes-and-structs/records.md)|[remove](remove.md)|
+|[select](select-clause.md)|[set](set.md)|[unmanaged (generic type constraint)](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint)|
+|[value](value.md)|[var](var.md)|[when (filter condition)](when.md)|
+|[where (generic type constraint)](where-generic-type-constraint.md)|[where (query clause)](where-clause.md)|[with](../operators/with-expression.md)|
+|[yield](yield.md)|||
 
 ## See also
 


### PR DESCRIPTION
The following code compiles:
```csharp
public static class Program
{
    public record A;

    public static void Main()
    {
        var record = new A();
    }
}
```

So, `record` can be a variable's name and it's not a reserved keyword, but contextual.
