### PR TITLE
Added an include file detailing `Dispose` and `DisposeAsync` lifetime bits

### DIFF
--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -1,7 +1,7 @@
 ---
 title: "Implement a Dispose method"
 description: In this article, learn to implement the Dispose method, which releases unmanaged resources used by your code in .NET.
-ms.date: 09/08/2020
+ms.date: 04/07/2021
 dev_langs:
   - "csharp"
   - "vb"
@@ -20,6 +20,8 @@ The [.NET garbage collector](index.md) does not allocate or release unmanaged me
 To help ensure that resources are always cleaned up appropriately, a <xref:System.IDisposable.Dispose%2A> method should be idempotent, such that it is callable multiple times without throwing an exception. Furthermore, subsequent invocations of <xref:System.IDisposable.Dispose%2A> should do nothing.
 
 The code example provided for the <xref:System.GC.KeepAlive%2A?displayProperty=nameWithType> method shows how garbage collection can cause a finalizer to run, while an unmanaged reference to the object or its members is still in use. It may make sense to utilize <xref:System.GC.KeepAlive%2A?displayProperty=nameWithType> to make the object ineligible for garbage collection from the start of the current routine to the point where this method is called.
+
+[!INCLUDE [disposables-and-dependency-injection](includes/disposables-and-dependency-injection.md)]
 
 ## Safe handles
 
@@ -145,6 +147,7 @@ The following example illustrates the dispose pattern for a derived class, `Disp
 
 ## See also
 
+- [Disposal of services](../../core/extensions/dependency-injection-guidelines.md#disposal-of-services)
 - <xref:System.GC.SuppressFinalize%2A>
 - <xref:System.IDisposable>
 - <xref:System.IDisposable.Dispose%2A?displayProperty=nameWithType>

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -3,7 +3,7 @@ title: Implement a DisposeAsync method
 description: Learn how to implement DisposeAsync and DisposeAsyncCore methods to perform asynchronous resource cleanup.
 author: IEvangelist
 ms.author: dapine
-ms.date: 03/17/2021
+ms.date: 04/07/2021
 dev_langs:
   - "csharp"
 helpviewer_keywords:
@@ -16,6 +16,8 @@ helpviewer_keywords:
 The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> that represents the asynchronous dispose operation.
 
 It is typical when implementing the <xref:System.IAsyncDisposable> interface that classes will also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous or asynchronous dispose. All of the guidance for implementing the dispose pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
+
+[!INCLUDE [disposables-and-dependency-injection](includes/disposables-and-dependency-injection.md)]
 
 ## DisposeAsync() and DisposeAsyncCore()
 
@@ -129,6 +131,7 @@ The highlighted lines in the following code show what it means to have "stacked 
 
 For a dual implementation example of `IDisposable` and `IAsyncDisposable`, see the <xref:System.Text.Json.Utf8JsonWriter> source code [on GitHub](https://github.com/dotnet/runtime/blob/035b729d829368c2790d825bd02db14f0c0fd2ea/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs#L297-L345).
 
+- [Disposal of services](../../core/extensions/dependency-injection-guidelines.md#disposal-of-services)
 - <xref:System.IAsyncDisposable>
 - <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType>
 - <xref:System.Threading.Tasks.TaskAsyncEnumerableExtensions.ConfigureAwait(System.IAsyncDisposable,System.Boolean)>

--- a/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
+++ b/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
@@ -7,6 +7,6 @@ ms.custom: include
 ---
 
 > [!TIP]
-> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](../../../core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource cleanup. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
+> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](/dotnet/core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource cleanup. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
 >
 > For more information, see [Dependency injection in .NET](../../../core/extensions/dependency-injection.md).

--- a/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
+++ b/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
@@ -1,0 +1,12 @@
+---
+author: IEvangelist
+ms.topic: include
+ms.date: 04/07/2021
+ms.author: dapine
+ms.custom: include
+---
+
+> [!TIP]
+> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](../../../core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource clean up. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
+>
+> For more information, see [Dependency injection in .NET](../../../core/extensions/dependency-injection.md).

--- a/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
+++ b/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
@@ -7,6 +7,6 @@ ms.custom: include
 ---
 
 > [!TIP]
-> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](../../../core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource clean up. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
+> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](../../../core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource cleanup. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
 >
 > For more information, see [Dependency injection in .NET](../../../core/extensions/dependency-injection.md).

--- a/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
+++ b/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
@@ -7,6 +7,6 @@ ms.custom: include
 ---
 
 > [!TIP]
-> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](/dotnet/core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource cleanup. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
+> With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](/dotnet/core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider> and corresponding <xref:Microsoft.Extensions.Hosting.IHost> orchestrate resource cleanup. Specifically, implementations of <xref:System.IDisposable> and <xref:System.IAsyncDisposable> are properly disposed at the end of their specified lifetime.
 >
 > For more information, see [Dependency injection in .NET](/dotnet/core/extensions/dependency-injection.md).

--- a/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
+++ b/docs/standard/garbage-collection/includes/disposables-and-dependency-injection.md
@@ -9,4 +9,4 @@ ms.custom: include
 > [!TIP]
 > With regard to dependency injection, when registering services in an <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>, the [service lifetime](/dotnet/core/extensions/dependency-injection.md#service-lifetimes) is managed implicitly on your behalf. The <xref:System.IServiceProvider?displayProperty=nameWithType> and corresponding <xref:Microsoft.Extensions.Hosting.IHost?displayProperty=nameWithType> orchestrate resource cleanup. Specifically, implementations of <xref:System.IDisposable?displayProperty=nameWithType> and <xref:System.IAsyncDisposable?displayProperty=nameWithType> are properly disposed at the end of their specified lifetime.
 >
-> For more information, see [Dependency injection in .NET](../../../core/extensions/dependency-injection.md).
+> For more information, see [Dependency injection in .NET](/dotnet/core/extensions/dependency-injection.md).


### PR DESCRIPTION
## Summary

- Added an include file detailing `Dispose` and `DisposeAsync` lifetime management bits
- Update both dispose/async articles
  - Added new include after intro paragraph
  - Added **See also** link back to DI article

Fixes #23307

## Preview

✔️ [Implement a Dispose method](https://review.docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose?branch=pr-en-us-23692)
✔️ [Implement a DisposeAsync method](https://review.docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync?branch=pr-en-us-23692)