### PR TITLE
Use proper DI within example - fixes #23303

### DIFF
--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom logging provider in .NET
 description: Learn how to implement a custom logging provider in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/25/2020
+ms.date: 04/07/2021
 ms.topic: how-to
 ---
 
@@ -28,7 +28,7 @@ The `ILogger` implementation category name is typically the logging source. For 
 The preceding code:
 
 - Creates a logger instance per category name.
-- Checks `logLevel == _config.LogLevel` in `IsEnabled`, so each `logLevel` has a unique logger. Loggers should also be enabled for all higher log levels:
+- Checks `_config.LogLevels.ContainsKey(logLevel)` in `IsEnabled`, so each `logLevel` has a unique logger. Loggers should also be enabled for all higher log levels:
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/ColorConsoleLogger.cs" range="16-17":::
 
@@ -38,21 +38,21 @@ The `ILoggerProvider` object is responsible for creating logger instances. Maybe
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/ColorConsoleLoggerProvider.cs":::
 
-In the preceding code, <xref:Microsoft.Build.Logging.LoggerDescription.CreateLogger%2A> creates a single instance of the `ColorConsoleLogger` per category name and stores it in the [`ConcurrentDictionary<TKey,TValue>`](/dotnet/api/system.collections.concurrent.concurrentdictionary-2).
+In the preceding code, <xref:Microsoft.Build.Logging.LoggerDescription.CreateLogger%2A> creates a single instance of the `ColorConsoleLogger` per category name and stores it in the [`ConcurrentDictionary<TKey,TValue>`](/dotnet/api/system.collections.concurrent.concurrentdictionary-2). Additionally, the <xref:Microsoft.Extensions.Options.IOptionsMonitor%601> interface is required to update changes to the underlying `ColorConsoleLoggerConfiguration` object.
 
 ## Usage and registration of the custom logger
 
 To add the custom logging provider and corresponding logger, add an <xref:Microsoft.Extensions.Logging.ILoggerProvider> with <xref:Microsoft.Extensions.Logging.ILoggingBuilder> from the <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.ConfigureLogging(Microsoft.Extensions.Hosting.IHostBuilder,System.Action{Microsoft.Extensions.Logging.ILoggingBuilder})?displayProperty=nameWithType>:
 
-:::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" range="23-39":::
+:::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" range="23-33":::
 
 The `ILoggingBuilder` creates one or more `ILogger` instances. The `ILogger` instances are used by the framework to log the information.
 
-For the preceding code, provide at least one extension method for the `ILoggerFactory`:
+By convention, extension methods on `ILoggingBuilder` are used to register the custom provider:
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/Extensions/ColorConsoleLoggerExtensions.cs":::
 
-Running this simple application will render similar to the following console window:
+Running this simple application will render similar color output to the console window:
 
 :::image type="content" source="media/color-console-logger.png" alt-text="Color console logger sample output":::
 

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -52,7 +52,7 @@ By convention, extension methods on `ILoggingBuilder` are used to register the c
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/Extensions/ColorConsoleLoggerExtensions.cs":::
 
-Running this simple application will render similar color output to the console window:
+Running this simple application will render color output to the console window similar to the following image:
 
 :::image type="content" source="media/color-console-logger.png" alt-text="Color console logger sample output":::
 

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -60,4 +60,5 @@ Running this simple application will render similar color output to the console 
 
 - [Logging in .NET](logging.md).
 - [Logging providers in .NET](logging-providers.md).
+- [Dependency injection in .NET](dependency-injection.md).
 - [High-performance logging in .NET](high-performance-logging.md).

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -58,7 +58,7 @@ Running this simple application will render similar color output to the console 
 
 ## See also
 
-- [Logging in .NET](logging.md).
-- [Logging providers in .NET](logging-providers.md).
-- [Dependency injection in .NET](dependency-injection.md).
-- [High-performance logging in .NET](high-performance-logging.md).
+- [Logging in .NET](logging.md)
+- [Logging providers in .NET](logging-providers.md)
+- [Dependency injection in .NET](dependency-injection.md)
+- [High-performance logging in .NET](high-performance-logging.md)

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
@@ -14,7 +14,7 @@ public class ColorConsoleLogger : ILogger
     public IDisposable BeginScope<TState>(TState state) => default;
 
     public bool IsEnabled(LogLevel logLevel) =>
-        logLevel == _config.LogLevel;
+        _config.LogLevels.ContainsKey(logLevel);
 
     public void Log<TState>(
         LogLevel logLevel,
@@ -32,7 +32,7 @@ public class ColorConsoleLogger : ILogger
         {
             ConsoleColor originalColor = Console.ForegroundColor;
 
-            Console.ForegroundColor = _config.Color;
+            Console.ForegroundColor = _config.LogLevels[logLevel];
             Console.WriteLine($"[{eventId.Id,2}: {logLevel,-12}]");
             
             Console.ForegroundColor = originalColor;

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerConfiguration.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerConfiguration.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 public class ColorConsoleLoggerConfiguration
 {
     public int EventId { get; set; }
-    public LogLevel LogLevel { get; set; } = LogLevel.Information;
-    public ConsoleColor Color { get; set; } = ConsoleColor.Green;
+
+    public Dictionary<LogLevel, ConsoleColor> LogLevels { get; set; } = new()
+    {
+        [LogLevel.Information] = ConsoleColor.Green
+    };
 }

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerProvider.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerProvider.cs
@@ -1,17 +1,27 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 public sealed class ColorConsoleLoggerProvider : ILoggerProvider
 {
-    private readonly ColorConsoleLoggerConfiguration _config;
-    private readonly ConcurrentDictionary<string, ColorConsoleLogger> _loggers =
-        new ConcurrentDictionary<string, ColorConsoleLogger>();
+    private readonly IDisposable _onChangeToken;
+    private ColorConsoleLoggerConfiguration _currentConfig;
+    private readonly ConcurrentDictionary<string, ColorConsoleLogger> _loggers = new();
 
-    public ColorConsoleLoggerProvider(ColorConsoleLoggerConfiguration config) =>
-        _config = config;
+    public ColorConsoleLoggerProvider(
+        IOptionsMonitor<ColorConsoleLoggerConfiguration> config)
+    {
+        _currentConfig = config.CurrentValue;
+        _onChangeToken = config.OnChange(updatedConfig => _currentConfig = updatedConfig);
+    }
 
     public ILogger CreateLogger(string categoryName) =>
-        _loggers.GetOrAdd(categoryName, name => new ColorConsoleLogger(name, _config));
+        _loggers.GetOrAdd(categoryName, name => new ColorConsoleLogger(name, _currentConfig));
 
-    public void Dispose() => _loggers.Clear();
+    public void Dispose()
+    {
+        _loggers.Clear();
+        _onChangeToken.Dispose();
+    }
 }

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Extensions/ColorConsoleLoggerExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Extensions/ColorConsoleLoggerExtensions.cs
@@ -1,28 +1,32 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
 
 public static class ColorConsoleLoggerExtensions
 {
     public static ILoggingBuilder AddColorConsoleLogger(
-        this ILoggingBuilder builder) =>
-        builder.AddColorConsoleLogger(
-            new ColorConsoleLoggerConfiguration());
+        this ILoggingBuilder builder)
+    {
+        builder.AddConfiguration();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ILoggerProvider, ColorConsoleLoggerProvider>());
+
+        LoggerProviderOptions.RegisterProviderOptions
+            <ColorConsoleLoggerConfiguration, ColorConsoleLoggerProvider>(builder.Services);
+
+        return builder;
+    }
 
     public static ILoggingBuilder AddColorConsoleLogger(
         this ILoggingBuilder builder,
         Action<ColorConsoleLoggerConfiguration> configure)
     {
-        var config = new ColorConsoleLoggerConfiguration();
-        configure(config);
+        builder.AddColorConsoleLogger();
+        builder.Services.Configure(configure);
 
-        return builder.AddColorConsoleLogger(config);
-    }
-
-    public static ILoggingBuilder AddColorConsoleLogger(
-        this ILoggingBuilder builder,
-        ColorConsoleLoggerConfiguration config)
-    {
-        builder.AddProvider(new ColorConsoleLoggerProvider(config));
         return builder;
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 class Program
 {
-    static Task Main(string[] args)
+    static async Task Main(string[] args)
     {
         using IHost host = CreateHostBuilder(args).Build();
 
@@ -17,24 +17,18 @@ class Program
         logger.LogWarning(5, "Warning... that was odd.");
         logger.LogError(7, "Oops, there was an error.");
 
-        return host.RunAsync();
+        await host.RunAsync();
     }
 
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureLogging(builder =>
                 builder.ClearProviders()
-                    .AddProvider(
-                        new ColorConsoleLoggerProvider(
-                            new ColorConsoleLoggerConfiguration
-                            {
-                                LogLevel = LogLevel.Error,
-                                Color = ConsoleColor.Red
-                            }))
-                    .AddColorConsoleLogger()
                     .AddColorConsoleLogger(configuration =>
                     {
-                        configuration.LogLevel = LogLevel.Warning;
-                        configuration.Color = ConsoleColor.DarkMagenta;
+                        configuration.LogLevels.Add(
+                            LogLevel.Warning, ConsoleColor.DarkMagenta);
+                        configuration.LogLevels.Add(
+                            LogLevel.Error, ConsoleColor.Red);
                     }));
 }


### PR DESCRIPTION
## Summary

- Update the example app to use proper DI instead of manually instantiating providers and configs
- Use `IOptionsMonitor<>` to exemplify customer ask
- Update article accordingly

Fixes #23303

## Internal preview

✔️ [Implement a custom logging provider in .NET](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/custom-logging-provider?branch=pr-en-us-23695)