### PR TITLE
IdentityServer4 - licensing information updates

### DIFF
--- a/docs/architecture/cloud-native/identity-server.md
+++ b/docs/architecture/cloud-native/identity-server.md
@@ -6,7 +6,7 @@ ms.date: 05/13/2020
 
 # IdentityServer for cloud-native applications
 
-IdentityServer is an open-source authentication server that implements OpenID Connect (OIDC) and OAuth 2.0 standards for ASP.NET Core. It's designed to provide a common way to authenticate requests to all of your applications, whether they're web, native, mobile, or API endpoints. IdentityServer can be used to implement Single Sign-On (SSO) for multiple applications and application types. It can be used to authenticate actual users via sign-in forms and similar user interfaces as well as service-based authentication that typically involves token issuance, verification, and renewal without any user interface. IdentityServer is designed to be a customizable solution. Each instance is typically customized to suit an individual organization and/or set of applications' needs.
+IdentityServer is an authentication server that implements OpenID Connect (OIDC) and OAuth 2.0 standards for ASP.NET Core. It's designed to provide a common way to authenticate requests to all of your applications, whether they're web, native, mobile, or API endpoints. IdentityServer can be used to implement Single Sign-On (SSO) for multiple applications and application types. It can be used to authenticate actual users via sign-in forms and similar user interfaces as well as service-based authentication that typically involves token issuance, verification, and renewal without any user interface. IdentityServer is designed to be a customizable solution. Each instance is typically customized to suit an individual organization and/or set of applications' needs.
 
 ## Common web app scenarios
 

--- a/docs/architecture/cloud-native/identity-server.md
+++ b/docs/architecture/cloud-native/identity-server.md
@@ -37,7 +37,14 @@ IdentityServer provides middleware that runs within an ASP.NET Core application 
 
 ## Getting started
 
-IdentityServer4 is open-source and free to use. You can add it to your applications using its NuGet packages. The main package is [IdentityServer4](https://www.nuget.org/packages/IdentityServer4/) that has been downloaded over four million times. The base package doesn't include any user interface code and only supports in memory configuration. To use it with a database, you'll also want a data provider like [IdentityServer4.EntityFramework](https://www.nuget.org/packages/IdentityServer4.EntityFramework) that uses Entity Framework Core to store configuration and operational data for IdentityServer. For user interface, you can copy files from the [Quickstart UI repository](https://github.com/IdentityServer/IdentityServer4.Quickstart.UI) into your ASP.NET Core MVC application to add support for sign in and sign out using IdentityServer middleware.
+IdentityServer4 is available under dual license:  
+
+* RPL - let's you use the IdentityServer4 free if used in open source work
+* Paid - let's you use the IdentityServer4 in a commercial scenario
+
+Please reach out to official [Product's pricing](https://duendesoftware.com/products/identityserver) page.
+
+You can add it to your applications using its NuGet packages. The main package is [IdentityServer4](https://www.nuget.org/packages/IdentityServer4/) that has been downloaded over four million times. The base package doesn't include any user interface code and only supports in memory configuration. To use it with a database, you'll also want a data provider like [IdentityServer4.EntityFramework](https://www.nuget.org/packages/IdentityServer4.EntityFramework) that uses Entity Framework Core to store configuration and operational data for IdentityServer. For user interface, you can copy files from the [Quickstart UI repository](https://github.com/IdentityServer/IdentityServer4.Quickstart.UI) into your ASP.NET Core MVC application to add support for sign in and sign out using IdentityServer middleware.
 
 ## Configuration
 


### PR DESCRIPTION
This pull request fixes #23551 

It updates all the information about IdentityServer4 regarding it's open-source nature and it's licensing.

---

the changes include:
* Remove any "open-source" mention from the general IdentityServer4 description
* Update the "*Getting started*" section regarding the licenses which can be used when utilizing the IdentityServer4 tool
This change adds brief descriptions of both paid and unpaid scenarios, and also links the product's pricing page just in case there are more details needed.

