### PR TITLE
MessagePack breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -1,7 +1,7 @@
 ---
 title: Breaking changes in .NET 6
 description: Navigate to the breaking changes in .NET 6.
-ms.date: 04/02/2021
+ms.date: 04/07/2021
 no-loc: [Blazor]
 ---
 # Breaking changes in .NET 6
@@ -14,6 +14,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 ## ASP.NET Core
 
 - [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md)
+- [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md)
 - [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md)
 - [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md)
 - [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md)

--- a/docs/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework.md
+++ b/docs/core/compatibility/aspnet-core/6.0/assemblies-removed-from-shared-framework.md
@@ -19,7 +19,7 @@ In addition, the following assemblies were removed from the ASP.NET Core runtime
 
 ## Version introduced
 
-6.0
+ASP.NET Core 6.0
 
 ## Old behavior
 
@@ -28,6 +28,8 @@ Applications could use APIs provided by these libraries by referencing the [Micr
 ## New behavior
 
 If you use APIs from the affected assemblies without having a [PackageReference](../../../project-sdk/msbuild-props.md#packagereference) in your project file, you might see run-time errors. For example, an application that uses reflection to access APIs from one of these assemblies without adding an explicit reference to the package will have run-time errors. The `PackageReference` ensures that the assemblies are present as part of the application output.
+
+For discussion, see <https://github.com/dotnet/aspnetcore/issues/31007>.
 
 ## Reason for change
 

--- a/docs/core/compatibility/aspnet-core/6.0/blazor-eventargstype-property-replaced.md
+++ b/docs/core/compatibility/aspnet-core/6.0/blazor-eventargstype-property-replaced.md
@@ -13,7 +13,7 @@ Starting in ASP.NET Core 6.0, the <xref:Microsoft.AspNetCore.Components.RenderTr
 
 ## Version introduced
 
-6.0
+ASP.NET Core 6.0
 
 ## Old behavior
 

--- a/docs/core/compatibility/aspnet-core/6.0/blazor-parameter-name-changed-in-method.md
+++ b/docs/core/compatibility/aspnet-core/6.0/blazor-parameter-name-changed-in-method.md
@@ -10,7 +10,7 @@ The `RequestImageFileAsync` method's `maxWith` parameter was renamed from `maxWi
 
 ## Version introduced
 
-6.0 Preview 1
+ASP.NET Core 6.0 Preview 1
 
 ## Old behavior
 

--- a/docs/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed.md
+++ b/docs/core/compatibility/aspnet-core/6.0/kestrel-log-message-attributes-changed.md
@@ -10,7 +10,7 @@ Kestrel log messages have associated IDs and names. These attributes uniquely id
 
 ## Version introduced
 
-6.0
+ASP.NET Core 6.0
 
 ## Old behavior
 

--- a/docs/core/compatibility/aspnet-core/6.0/messagepack-library-change.md
+++ b/docs/core/compatibility/aspnet-core/6.0/messagepack-library-change.md
@@ -1,0 +1,64 @@
+---
+title: "Breaking change: Changed MessagePack library in signalr-protocol-msgpack package"
+description: "Learn about the breaking change in ASP.NET Core 6.0 where the MessagePack library was changed and two options were removed in the @microsoft/signalr-protocol-msgpack package."
+ms.date: 04/07/2021
+---
+# Changed MessagePack library in @microsoft/signalr-protocol-msgpack
+
+The [@microsoft/signalr-protocol-msgpack](https://www.npmjs.com/package/@microsoft/signalr-protocol-msgpack) npm package now references `@msgpack/msgpack` instead of `msgpack5`. Additionally, the available options that can optionally be passed into the `MessagePackHubProtocol` have changed. The `MessagePackOptions.disableTimestampEncoding` and `MessagePackOptions.forceFloat64` properties were removed, and some new options were added.
+
+For discussion, see <https://github.com/dotnet/aspnetcore/issues/30471>.
+
+## Version introduced
+
+ASP.NET Core 6.0
+
+## Old behavior
+
+In previous versions, you must include three script references to use the [MessagePack Hub Protocol](/aspnet/core/signalr/messagepackhubprotocol) in the browser:
+
+```html
+<script src="~/lib/signalr/signalr.js"></script>
+<script src="~/lib/msgpack5/msgpack5.js"></script>
+<script src="~/lib/signalr/signalr-protocol-msgpack.js"></script>
+```
+
+## New behavior
+
+Starting in ASP.NET Core 6, you only need two script references to use the [MessagePack Hub Protocol](/aspnet/core/signalr/messagepackhubprotocol) in the browser:
+
+```html
+<script src="~/lib/signalr/signalr.js"></script>
+<script src="~/lib/signalr/signalr-protocol-msgpack.js"></script>
+```
+
+Instead of the `msgpack5` package, the `@msgpack/msgpack` package is downloaded to your *node_modules* directory if you want to use it directly in your app.
+
+Finally, `MessagePackOptions` has new, additional properties, and the `disableTimestampEncoding` and `forceFloat64` properties are removed.
+
+## Reason for change
+
+This change was made to reduce asset size, make it simpler to consume the package, and add more customizability.
+
+## Recommended action
+
+If you were previously using `msgpack5` in your app, you'll need to add a direct reference to the library in your *package.json* file.
+
+## Affected APIs
+
+The following APIs were removed:
+
+- `MessagePackOptions.disableTimestampEncoding`
+- `MessagePackOptions.forceFloat64`
+
+<!--
+
+## Category
+
+ASP.NET Core
+
+## Affected APIs
+
+Not detectable via API analysis.
+
+-->

--- a/docs/core/compatibility/aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md
+++ b/docs/core/compatibility/aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md
@@ -12,7 +12,7 @@ For discussion, see GitHub issue [dotnet/aspnetcore#29222](https://github.com/do
 
 ## Version introduced
 
-6.0
+ASP.NET Core 6.0
 
 ## Old behavior
 

--- a/docs/core/compatibility/aspnet-core/6.0/nullable-reference-type-annotations-changed.md
+++ b/docs/core/compatibility/aspnet-core/6.0/nullable-reference-type-annotations-changed.md
@@ -14,7 +14,7 @@ For discussion, see GitHub issue [dotnet/aspnetcore#27564](https://github.com/do
 
 ## Version introduced
 
-6.0
+ASP.NET Core 6.0
 
 ## Old behavior
 

--- a/docs/core/compatibility/aspnet-core/6.0/obsolete-removed-apis.md
+++ b/docs/core/compatibility/aspnet-core/6.0/obsolete-removed-apis.md
@@ -10,7 +10,7 @@ In ASP.NET Core 6.0 Preview 1, several APIs were either removed or marked as obs
 
 ## Version introduced
 
-6.0 Preview 1
+ASP.NET Core 6.0 Preview 1
 
 ## Old behavior
 

--- a/docs/core/compatibility/aspnet-core/6.0/razor-engine-apis-obsolete.md
+++ b/docs/core/compatibility/aspnet-core/6.0/razor-engine-apis-obsolete.md
@@ -10,7 +10,7 @@ Types related to the <xref:Microsoft.AspNetCore.Razor.Language.RazorEngine> type
 
 ## Version introduced
 
-6.0 Preview 1
+ASP.NET Core 6.0 Preview 1
 
 ## Old behavior
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -37,6 +37,8 @@ items:
           href: aspnet-core/6.0/blazor-eventargstype-property-replaced.md
         - name: "Kestrel: Log message attributes changed"
           href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
+        - name: "MessagePack: Library changed in @microsoft/signalr-protocol-msgpack"
+          href: aspnet-core/6.0/messagepack-library-change.md
         - name: "Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports"
           href: aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md
         - name: "Razor: RazorEngine APIs marked obsolete"
@@ -345,6 +347,8 @@ items:
           href: aspnet-core/6.0/blazor-eventargstype-property-replaced.md
         - name: "Kestrel: Log message attributes changed"
           href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
+        - name: "MessagePack: Library changed in @microsoft/signalr-protocol-msgpack"
+          href: aspnet-core/6.0/messagepack-library-change.md
         - name: "Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports"
           href: aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md
         - name: "Razor: RazorEngine APIs marked obsolete"


### PR DESCRIPTION
Contributes to https://github.com/aspnet/Announcements/issues/454.

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/6.0/messagepack-library-change?branch=pr-en-us-23700).

https://docs.microsoft.com/en-us/aspnet/core/signalr/messagepackhubprotocol?view=aspnetcore-6.0#javascript-client should also be updated accordingly. @Rick-Anderson Can you do that or should I?