### PR TITLE
Update standard-numeric-format-strings.md

### DIFF
--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -50,6 +50,8 @@ Standard numeric format strings are supported by:
 
 The following table describes the standard numeric format specifiers and displays sample output produced by each format specifier. See the [Notes](#notes) section for additional information about using standard numeric format strings, and the [Code example](#code-example) section for a comprehensive illustration of their use.
 
+> The result of a formatted string for a specific culture might differ from the following examples. Operating system settings, user settings, environment variables, and the .NET version you're using can all affect the format. For example, starting with .NET 5, .NET tries to unify cultural formats across platforms. For more information, see [.NET globalization and ICU](../globalization-localization/globalization-icu.md).
+
 |Format specifier|Name|Description|Examples|
 |----------------------|----------|-----------------|--------------|
 |"C" or "c"|Currency|Result: A currency value.<br /><br /> Supported by: All numeric types.<br /><br /> Precision specifier: Number of decimal digits.<br /><br /> Default precision specifier: Defined by <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits%2A?displayProperty=nameWithType>.<br /><br /> More information: [The Currency ("C") Format Specifier](#CFormatString).|123.456 ("C", en-US)<br />-> \\$123.46<br /><br /> 123.456 ("C", fr-FR)<br />-> 123,46 &euro;<br /><br /> 123.456 ("C", ja-JP)<br />-> ¥123<br /><br /> -123.456 ("C3", en-US)<br />-> (\\$123.456)<br /><br /> -123.456 ("C3", fr-FR)<br />-> -123,456 &euro;<br /><br /> -123.456 ("C3", ja-JP)<br />-> -¥123.456|
@@ -251,9 +253,6 @@ The following example formats assorted floating-point values with the number for
 [!code-cpp[Formatting.Numeric.Standard#6](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/Standard.cpp#6)]
 [!code-csharp[Formatting.Numeric.Standard#6](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#6)]
 [!code-vb[Formatting.Numeric.Standard#6](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#6)]
-
-> [!IMPORTANT]
-> The format for a specific culture may change over time. Operating system settings, user settings, environment variables, and changes to .NET itself, may affect the format of a specific culture. Starting with .NET 5.0, .NET tries to unify cultural formats across platforms. For more information, see [.NET globalization and ICU](../globalization-localization/globalization-icu.md).
 
 <a name="PFormatString"></a>
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -1,7 +1,7 @@
 ---
 title: Standard numeric format strings
 description: In this article, learn to use standard numeric format strings to format common numeric types into text representations in .NET.
-ms.date: 02/26/2021
+ms.date: 04/08/2021
 ms.topic: reference
 dev_langs:
   - "csharp"
@@ -251,6 +251,9 @@ The following example formats assorted floating-point values with the number for
 [!code-cpp[Formatting.Numeric.Standard#6](../../../samples/snippets/cpp/VS_Snippets_CLR/Formatting.Numeric.Standard/cpp/Standard.cpp#6)]
 [!code-csharp[Formatting.Numeric.Standard#6](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#6)]
 [!code-vb[Formatting.Numeric.Standard#6](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#6)]
+
+> [!IMPORTANT]
+> The format for a specific culture may change over time. Operating system settings, user settings, environment variables, and changes to .NET itself, may affect the format of a specific culture. Starting with .NET 5.0, .NET tries to unify cultural formats across platforms. For more information, see [.NET globalization and ICU](../globalization-localization/globalization-icu.md).
 
 <a name="PFormatString"></a>
 


### PR DESCRIPTION
## Summary

- Added a note detailing how cultural formats may differ.

Fixes #21884

@gewarren according to the linked issue in the runtime repo, the team was unable to reproduce the problem. I too cannot reproduce it natively unless I start tweaking cultural settings, than the results may be different between versions. Hopefully this note will clarify this scenario. I linked to the ICU article too.

What do you think I should do with the note? Move it near the top of the article or put it within each section? I think it should be at the top, but people may just be looking at specific format strings instead of the article overall.
