### PR TITLE
fix(code-samples): visible non-constant fields

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -58,9 +58,9 @@ You can use this class as a type in any entity or value object, as for the follo
 public class CardType
     : Enumeration
 {
-    public static CardType Amex = new CardType(1, nameof(Amex));
-    public static CardType Visa = new CardType(2, nameof(Visa));
-    public static CardType MasterCard = new CardType(3, nameof(MasterCard));
+    public static CardType Amex => new(1, nameof(Amex));
+    public static CardType Visa => new(2, nameof(Visa));
+    public static CardType MasterCard => new(3, nameof(MasterCard));
 
     public CardType(int id, string name)
         : base(id, name)


### PR DESCRIPTION
Non-constant fields should not be visible.

## Summary

Proposes a fix in accordance with .NET code analysis usage rule: [https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2211](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2211)

### Cause

A public or protected static field is not constant nor is it read-only.

### Rule description

Static fields that are neither constants nor read-only are not thread-safe. Access to such a field must be carefully controlled and requires advanced programming techniques for synchronizing access to the class object. Because these are difficult skills to learn and master, and testing such an object poses its own challenges, static fields are best used to store data that does not change. This rule applies to libraries; applications should not expose any fields.