### PR TITLE
Conditional operator: moved the example to the beginning of the article

### DIFF
--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -13,9 +13,11 @@ ms.assetid: e83a17f1-7500-48ba-8bee-2fbc4c847af4
 ---
 # ?: operator (C# reference)
 
-The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`.
+The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`, as the following example shows:
 
-The syntax for the conditional operator is as follows:
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ConditionalOperator.cs" id="BasicExample":::
+
+As the preceding example shows, the syntax for the conditional operator is as follows:
 
 ```csharp
 condition ? consequent : alternative
@@ -49,10 +51,6 @@ a ? b : (c ? d : e)
 > ```text
 > is this condition true ? yes : no
 > ```
-
-The following example demonstrates the usage of the conditional operator:
-
-[!code-csharp-interactive[non ref conditional](snippets/shared/ConditionalOperator.cs#ConditionalValue)]
 
 ## Conditional ref expression
 

--- a/docs/csharp/language-reference/operators/snippets/shared/ConditionalOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/ConditionalOperator.cs
@@ -7,11 +7,21 @@ namespace operators
     {
         public static void Examples()
         {
+            BasicExample();
             ConditionalRefExpressions();
-            ConditionalValueExpressions();
             ComparisonWithIf();
             TargetTyped();
             NotTargetTyped();
+        }
+
+        private static void BasicExample()
+        {
+            // <BasicExample>
+            string GetWeatherDisplay(double tempInCelcius) => tempInCelcius < 20.0 ? "Cold." : "Perfect!";
+            
+            Console.WriteLine(GetWeatherDisplay(15));  // output: Cold.
+            Console.WriteLine(GetWeatherDisplay(27));  // output: Perfect!
+            // </BasicExample>
         }
 
         private static void ConditionalRefExpressions()
@@ -33,19 +43,6 @@ namespace operators
             // 1 2 100 4 5
             // 10 20 0 40 50
             // </SnippetConditionalRef>
-        }
-
-        private static void ConditionalValueExpressions()
-        {
-            // <SnippetConditionalValue>
-            double sinc(double x) => x != 0.0 ? Math.Sin(x) / x : 1;
-
-            Console.WriteLine(sinc(0.1));
-            Console.WriteLine(sinc(0.0));
-            // Output:
-            // 0.998334166468282
-            // 1
-            // </SnippetConditionalValue>
         }
 
         private static void TargetTyped()


### PR DESCRIPTION
This PR has a story behind.

Once, a colleague of mine was confused with some C# doc article and very emotionally expressed that confusion to me. I asked to show the article and explain what was wrong. Turned out that the article about the conditional operator (and it was revised by me long time ago, so I was confused too :)) is not very beginner-friendly. Looks like providing a simple example  at the very beginning of the article would make it clearer for the readers who for the first time learn about the conditional operator. So, this PR does that: moves the example usage from the middle of the article to its beginning. Also, I've tried to simplify the example itself.
