### PR TITLE
Update ide0073.md

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0073.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0073.md
@@ -37,7 +37,7 @@ This style rule concerns providing a file header at top of source code files. Th
 |Property|Value|
 |-|-|
 | **Option name** | file_header_template
-| **Option values** | non-empty string - Prefer the string as required file header, replacing `{fileName}` placeholders (if any) with the actual file.<br /><br /> `unset` or empty string - Do not require file header. |
+| **Option values** | non-empty string, optionally containing a `{fileName}` placeholder - Prefer the string as required file header.<br /><br /> `unset` or empty string - Do not require file header. |
 | **Default option value** | `unset` |
 
 ### Example

--- a/docs/fundamentals/code-analysis/style-rules/ide0073.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0073.md
@@ -40,12 +40,15 @@ This style rule concerns providing a file header at top of source code files. Th
 | **Option values** | non-empty string - Prefer the string as required file header.<br /><br /> `unset` or empty string - Do not require file header. |
 | **Default option value** | `unset` |
 
+You can include `{fileName}` as a placeholder for the file name.
+
 ### Example
 
 ```csharp
 // file_header_template = Copyright (c) SomeCorp. All rights reserved.\nLicensed under the xyz license.
 
-// Copyright (c) SomeCorp. All rights reserved.\nLicensed under the xyz license.
+// Copyright (c) SomeCorp. All rights reserved.
+// Licensed under the xyz license.
 namespace N1
 {
     class C1 { }
@@ -63,7 +66,8 @@ namespace N2
 ```vb
 ' file_header_template = Copyright (c) SomeCorp. All rights reserved.\nLicensed under the xyz license.
 
-' Copyright (c) SomeCorp. All rights reserved.\nLicensed under the xyz license.
+' Copyright (c) SomeCorp. All rights reserved.
+' Licensed under the xyz license.
 Namespace N1
     Class C1
     End Class

--- a/docs/fundamentals/code-analysis/style-rules/ide0073.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0073.md
@@ -37,10 +37,8 @@ This style rule concerns providing a file header at top of source code files. Th
 |Property|Value|
 |-|-|
 | **Option name** | file_header_template
-| **Option values** | non-empty string - Prefer the string as required file header.<br /><br /> `unset` or empty string - Do not require file header. |
+| **Option values** | non-empty string - Prefer the string as required file header, replacing `{fileName}` placeholders (if any) with the actual file.<br /><br /> `unset` or empty string - Do not require file header. |
 | **Default option value** | `unset` |
-
-You can include `{fileName}` as a placeholder for the file name.
 
 ### Example
 


### PR DESCRIPTION
- Add small note about the existence of `{fileName}` placeholder.
- Fix the literal `\n` when it's used incorrectly instead of an actual new line.

Fixes #22519