### PR TITLE
Fix example of CA1034

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1034.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1034.md
@@ -50,7 +50,7 @@ Do not suppress a warning from this rule.
 The following example shows a type that violates the rule.
 
 ```csharp
-internal class ParentType
+public class ParentType
 {
     public class NestedType
     {


### PR DESCRIPTION
No warning is reported when the enclosing type is not externally visible

## Summary

Changed the _accessibility level_ of the enclosing type from `internal` to `public` in order to match the *Cause* of rule _CA1034_:
> An externally visible type contains an externally visible type declaration. . . .

With the current version of the example, _warning CA1034_ is not reported using _.NET SDK 5.0.201_.

See also [Stack Overflow](https://stackoverflow.com/q/67021887/10167996), where this issue was also discussed.
