### PR TITLE
Address issue defined in #23717

### DIFF
--- a/docs/core/extensions/options-library-authors.md
+++ b/docs/core/extensions/options-library-authors.md
@@ -52,7 +52,7 @@ In the preceding code, the `AddMyLibraryService`:
 
 - Extends an instance of <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>
 - Defines an <xref:Microsoft.Extensions.Configuration.IConfiguration> parameter `namedConfigurationSection`
-- Calls <xref:Microsoft.Extensions.Options.ConfigureOptions%601.Configure%2A> passing the generic type parameter of `LibraryOptions` and the `namedConfigurationSection` instance to configure
+- Calls <xref:Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure%60%601(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,Microsoft.Extensions.Configuration.IConfiguration)> passing the generic type parameter of `LibraryOptions` and the `namedConfigurationSection` instance to configure
 
 Consumers in this pattern provide the scoped `IConfiguration` instance of the named section:
 

--- a/docs/core/extensions/options-library-authors.md
+++ b/docs/core/extensions/options-library-authors.md
@@ -52,7 +52,7 @@ In the preceding code, the `AddMyLibraryService`:
 
 - Extends an instance of <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>
 - Defines an <xref:Microsoft.Extensions.Configuration.IConfiguration> parameter `namedConfigurationSection`
-- Calls <xref:Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure%60%601(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,Microsoft.Extensions.Configuration.IConfiguration)> passing the generic type parameter of `LibraryOptions` and the `namedConfigurationSection` instance to configure
+- Calls <xref:Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure%60%601(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration)> passing the generic type parameter of `LibraryOptions` and the `namedConfigurationSection` instance to configure
 
 Consumers in this pattern provide the scoped `IConfiguration` instance of the named section:
 

--- a/docs/core/extensions/options-library-authors.md
+++ b/docs/core/extensions/options-library-authors.md
@@ -3,7 +3,7 @@ title: Options pattern guidance for .NET library authors
 author: IEvangelist
 description: Learn how to expose the options pattern as a library author in .NET.
 ms.author: dapine
-ms.date: 01/28/2021
+ms.date: 04/12/2021
 ---
 
 # Options pattern guidance for .NET library authors
@@ -46,13 +46,13 @@ In the preceding code, the `AddMyLibraryService`:
 
 When you author a library that exposes many options to consumers, you may want to consider requiring an `IConfiguration` parameter extension method. The expected `IConfiguration` instance should be scoped to a named section of the configuration by using the <xref:Microsoft.Extensions.Configuration.IConfiguration.GetSection%2A?displayProperty=nameWithType> function.
 
-:::code language="csharp" source="snippets/configuration/options-configparam/ServiceCollectionExtensions.cs" highlight="10,12-16":::
+:::code language="csharp" source="snippets/configuration/options-configparam/ServiceCollectionExtensions.cs" highlight="10,12-14":::
 
 In the preceding code, the `AddMyLibraryService`:
 
 - Extends an instance of <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>
 - Defines an <xref:Microsoft.Extensions.Configuration.IConfiguration> parameter `namedConfigurationSection`
-- Calls <xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration,System.Object)> passing an options instance that the configuration binds to
+- Calls <xref:Microsoft.Extensions.Options.ConfigureOptions%601.Configure%2A> passing the generic type parameter of `LibraryOptions` and the `namedConfigurationSection` instance to configure
 
 Consumers in this pattern provide the scoped `IConfiguration` instance of the named section:
 

--- a/docs/core/extensions/snippets/configuration/options-configparam/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-configparam/ServiceCollectionExtensions.cs
@@ -9,11 +9,9 @@ namespace ExampleLibrary.Extensions.DependencyInjection
           this IServiceCollection services,
           IConfiguration namedConfigurationSection)
         {
-            namedConfigurationSection.Bind(new LibraryOptions
-            {
-                // Default library options are overridden
-                // by bound configuration values.
-            });
+            // Default library options are overridden
+            // by bound configuration values.
+            services.Configure<LibraryOptions>(namedConfigurationSection);
 
             // Register lib services here...
             // services.AddScoped<ILibraryService, DefaultLibraryService>();


### PR DESCRIPTION
## Summary

Fix code example, there was a call to `.Bind` that was incorrect. It should have been `.Configure`.

Fixes #23717 

### Internal preview

✔️ [Options pattern guidance for .NET library authors](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/options-library-authors?branch=pr-en-us-23758)