### PR TITLE
Added details about `IServiceScopeFactory` and scoped service lifetimes within `IHostedService`

### DIFF
--- a/docs/core/extensions/access-by-line.txt
+++ b/docs/core/extensions/access-by-line.txt
@@ -23,6 +23,7 @@ snippets/configuration/options-configparam/ServiceCollectionExtensions.cs: ~/doc
 snippets/configuration/options-noparams/ServiceCollectionExtensions.cs: ~/docs/core/extensions/options-library-authors.md
 snippets/configuration/options-object/ServiceCollectionExtensions.cs: ~/docs/core/extensions/options-library-authors.md
 snippets/configuration/options-postconfig/ServiceCollectionExtensions.cs: ~/docs/core/extensions/options-library-authors.md
+snippets/configuration/worker-scope/Worker.cs: ~/docs/core/extensions/dependency-injection.md
 snippets/configuration/worker-service-options/Worker.cs: ~/docs/core/extensions/high-performance-logging.md
 snippets/configuration/worker-service/appsettings.IncludeScopes.json: ~/docs/core/extensions/logging.md
 snippets/configuration/worker-service/Worker.cs: ~/docs/core/extensions/logging.md

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -3,7 +3,7 @@ title: Use dependency injection in .NET
 description: Learn how to use dependency injection in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/13/2020
+ms.date: 04/12/2021
 ms.topic: tutorial
 no-loc: [Transient, Scoped, Singleton, Example]
 ---
@@ -80,10 +80,10 @@ Update *Program.cs* with the following code:
 
 :::code language="csharp" source="snippets/configuration/console-di/Program.cs" range="1-18,35-60" highlight="22-26":::
 
-> Each `services.Add{SERVICE_NAME}` extension method adds, and potentially configures, services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
->
-> - Allows them to be displayed in [IntelliSense](/visualstudio/ide/using-intellisense) without adding additional `using` blocks.
-> - Prevents excessive `using` statements in the `Program` or `Startup` classes where these extension methods are typically called.
+Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
+
+- Allows them to be displayed in [IntelliSense](/visualstudio/ide/using-intellisense) without adding additional `using` blocks.
+- Prevents excessive `using` statements in the `Program` or `Startup` classes where these extension methods are typically called.
 
 The app:
 

--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -3,7 +3,7 @@ title: Dependency injection in .NET
 description: Learn how .NET implements dependency injection and how to use it.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/28/2020
+ms.date: 04/12/2021
 ms.topic: overview
 ---
 
@@ -132,16 +132,17 @@ The `ConfigureServices` method registers services that the app uses, including p
 
 The following table lists a small sample of these framework-registered services:
 
-| Service Type                                                                       | Lifetime  |
-|------------------------------------------------------------------------------------|-----------|
-| <xref:Microsoft.Extensions.Hosting.IHostApplicationLifetime>                       | Singleton |
-| <xref:Microsoft.Extensions.Logging.ILogger%601?displayProperty=fullName>           | Singleton |
-| <xref:Microsoft.Extensions.Logging.ILoggerFactory?displayProperty=fullName>        | Singleton |
-| <xref:Microsoft.Extensions.ObjectPool.ObjectPoolProvider?displayProperty=fullName> | Singleton |
-| <xref:Microsoft.Extensions.Options.IConfigureOptions%601?displayProperty=fullName> | Transient |
-| <xref:Microsoft.Extensions.Options.IOptions%601?displayProperty=fullName>          | Singleton |
-| <xref:System.Diagnostics.DiagnosticListener?displayProperty=fullName>              | Singleton |
-| <xref:System.Diagnostics.DiagnosticSource?displayProperty=fullName>                | Singleton |
+| Service Type                                                                                  | Lifetime  |
+|-----------------------------------------------------------------------------------------------|-----------|
+| <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory?displayProperty=fullName> | Singleton |
+| <xref:Microsoft.Extensions.Hosting.IHostApplicationLifetime>                                  | Singleton |
+| <xref:Microsoft.Extensions.Logging.ILogger%601?displayProperty=fullName>                      | Singleton |
+| <xref:Microsoft.Extensions.Logging.ILoggerFactory?displayProperty=fullName>                   | Singleton |
+| <xref:Microsoft.Extensions.ObjectPool.ObjectPoolProvider?displayProperty=fullName>            | Singleton |
+| <xref:Microsoft.Extensions.Options.IConfigureOptions%601?displayProperty=fullName>            | Transient |
+| <xref:Microsoft.Extensions.Options.IOptions%601?displayProperty=fullName>                     | Singleton |
+| <xref:System.Diagnostics.DiagnosticListener?displayProperty=fullName>                         | Singleton |
+| <xref:System.Diagnostics.DiagnosticSource?displayProperty=fullName>                           | Singleton |
 
 ## Service lifetimes
 

--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -305,6 +305,23 @@ The root service provider is created when <xref:Microsoft.Extensions.DependencyI
 
 Scoped services are disposed by the container that created them. If a scoped service is created in the root container, the service's lifetime is effectively promoted to singleton because it's only disposed by the root container when the app shuts down. Validating service scopes catches these situations when `BuildServiceProvider` is called.
 
+## Scope scenarios
+
+The <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory> is always registered as a singleton but the <xref:System.IServiceProvider> can vary based on the lifetime of the containing class. For example, if you're to create, and resolve services from a scope, and any of those services take an <xref:System.IServiceProvider>, it'll be a scoped instance.
+
+To achieve scoping services within implementations of <xref:Microsoft.Extensions.Hosting.IHostedService>, such as the <xref:Microsoft.Extensions.Hosting.BackgroundService>, do *not* inject the service dependencies via constructor injection. Instead, inject <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>, create a scope, then resolve dependencies from the scope to use the appropriate service lifetime.
+
+:::code language="csharp" source="snippets/configuration/worker-scope/Worker.cs" highlight="13,15-16,22":::
+
+In the preceding code, while the app is running the background service:
+
+- Depends on the <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>.
+- Creates an <xref:Microsoft.Extensions.DependencyInjection.IServiceScope> for resolving additional services.
+- Resolves scoped services for consumption.
+- Works on processing objects and then relaying them, and finally marks them as processed.
+
+From the sample source code, you can see how implementations of <xref:Microsoft.Extensions.Hosting.IHostedService> can benefit from scoped service lifetimes.
+
 ## See also
 
 - [Use dependency injection in .NET](dependency-injection-usage.md)

--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -307,13 +307,13 @@ Scoped services are disposed by the container that created them. If a scoped ser
 
 ## Scope scenarios
 
-The <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory> is always registered as a singleton but the <xref:System.IServiceProvider> can vary based on the lifetime of the containing class. For example, if you're to create, and resolve services from a scope, and any of those services take an <xref:System.IServiceProvider>, it'll be a scoped instance.
+The <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory> is always registered as a singleton, but the <xref:System.IServiceProvider> can vary based on the lifetime of the containing class. For example, if you resolve services from a scope, and any of those services take an <xref:System.IServiceProvider>, it'll be a scoped instance.
 
 To achieve scoping services within implementations of <xref:Microsoft.Extensions.Hosting.IHostedService>, such as the <xref:Microsoft.Extensions.Hosting.BackgroundService>, do *not* inject the service dependencies via constructor injection. Instead, inject <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>, create a scope, then resolve dependencies from the scope to use the appropriate service lifetime.
 
 :::code language="csharp" source="snippets/configuration/worker-scope/Worker.cs" highlight="13,15-16,22":::
 
-In the preceding code, while the app is running the background service:
+In the preceding code, while the app is running, the background service:
 
 - Depends on the <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>.
 - Creates an <xref:Microsoft.Extensions.DependencyInjection.IServiceScope> for resolving additional services.

--- a/docs/core/extensions/snippets/configuration/worker-scope/AutoIncrementingIdProvider.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/AutoIncrementingIdProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace WorkerScope.Example
+{
+    class AutoIncrementingIdProvider : IObjectIdProvider
+    {
+        static int s_id;
+
+        int IObjectIdProvider.GetNextId() => ++ s_id;
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectIdProvider.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectIdProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace WorkerScope.Example
+{
+    interface IObjectIdProvider
+    {
+        int GetNextId();
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectProcessor.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectProcessor.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace WorkerScope.Example
+{
+    interface IObjectProcessor
+    {
+        Task ProcessAsync(ObjectGraph obj);
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectRelay.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectRelay.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace WorkerScope.Example
+{
+    interface IObjectRelay
+    {
+        Task RelayAsync(ObjectGraph obj);
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectStore.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectStore.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace WorkerScope.Example
+{
+    interface IObjectStore
+    {
+        Task<ObjectGraph> GetNextAsync();
+
+        Task<ObjectGraph> MarkAsync(ObjectGraph graph);
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/ObjectGraph.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/ObjectGraph.cs
@@ -1,0 +1,4 @@
+﻿namespace WorkerScope.Example
+{
+    record ObjectGraph(int Id, string Name, bool IsProcessed = false);
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/ObjectWorkerService.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/ObjectWorkerService.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace WorkerScope.Example
+{
+    internal class ObjectWorkerService :
+        IObjectProcessor,
+        IObjectRelay,
+        IObjectStore
+    {
+        static readonly Random s_random = new((int)DateTime.Now.Ticks);
+        static readonly ConcurrentDictionary<int, ObjectGraph> s_objects = new();
+
+        static int NextRandomDelay => s_random.Next(250, 3000);
+
+        readonly IObjectIdProvider _objectIdProvider;
+
+        public ObjectWorkerService(ILogger<ObjectWorkerService> logger, IServiceProvider serviceProvider)
+        {
+            _objectIdProvider = serviceProvider.GetRequiredService<IObjectIdProvider>();
+            
+            logger.LogInformation(
+                "ObjectWorkerService's provider hash: {hash}",
+                serviceProvider.GetHashCode());
+        }
+
+        public async Task<ObjectGraph> GetNextAsync()
+        {
+            await Task.Delay(NextRandomDelay);
+
+            var id = _objectIdProvider.GetNextId();
+
+            return s_objects.GetOrAdd(id, _ => new(id, $"Object #{id}"));
+        }
+
+        public int GetNextId() => s_objects.Count + 1;
+
+        public async Task<ObjectGraph> MarkAsync(ObjectGraph obj)
+        {
+            await Task.Delay(NextRandomDelay);
+
+            return s_objects.TryUpdate(obj.Id, obj with { IsProcessed = true }, obj) &&
+                s_objects.TryGetValue(obj.Id, out ObjectGraph updatedObject)
+                ? updatedObject
+                : obj;
+        }
+
+        public Task ProcessAsync(ObjectGraph obj) => Task.Delay(NextRandomDelay);
+
+        public Task RelayAsync(ObjectGraph obj) => Task.Delay(NextRandomDelay);
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/Program.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/Program.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using WorkerScope.Example;
+
+using var host =
+    Host.CreateDefaultBuilder(args)
+        .ConfigureServices(
+            (_, services) =>
+                services.AddHostedService<Worker>()
+                    .AddScoped<IObjectIdProvider, AutoIncrementingIdProvider>()
+                    .AddScoped<IObjectRelay, ObjectWorkerService>()
+                    .AddScoped<IObjectStore, ObjectWorkerService>()
+                    .AddScoped<IObjectProcessor, ObjectWorkerService>())
+        .Build();
+
+await host.RunAsync();

--- a/docs/core/extensions/snippets/configuration/worker-scope/Worker.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/Worker.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace WorkerScope.Example
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public Worker(ILogger<Worker> logger, IServiceScopeFactory serviceScopeFactory) =>
+            (_logger, _serviceScopeFactory) = (logger, serviceScopeFactory);
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                using (IServiceScope scope = _serviceScopeFactory.CreateScope())
+                {
+                    try
+                    {
+                        _logger.LogInformation(
+                            "Starting scoped work, provider hash: {hash}.",
+                            scope.ServiceProvider.GetHashCode());
+
+                        var store = scope.ServiceProvider.GetRequiredService<IObjectStore>();
+                        var next = await store.GetNextAsync();
+                        _logger.LogInformation("{next}", next);
+
+                        var processor = scope.ServiceProvider.GetRequiredService<IObjectProcessor>();
+                        await processor.ProcessAsync(next);
+                        _logger.LogInformation("Processing {name}.", next.Name);
+
+                        var relay = scope.ServiceProvider.GetRequiredService<IObjectRelay>();
+                        await relay.RelayAsync(next);
+                        _logger.LogInformation("Processed results have been relayed.");
+
+                        var marked = await store.MarkAsync(next);
+                        _logger.LogInformation("Marked as processed: {next}", marked);
+                    }
+                    finally
+                    {
+                        _logger.LogInformation(
+                            "Finished scoped work, provider hash: {hash}.{nl}",
+                            scope.ServiceProvider.GetHashCode(), Environment.NewLine);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/core/extensions/snippets/configuration/worker-scope/worker-scope.csproj
+++ b/docs/core/extensions/snippets/configuration/worker-scope/worker-scope.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>WorkerScope.Example</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Added details about `IServiceScopeFactory` as it relates to DI, service lifetime, and one-off `IServiceProvider`
- Added code samples to show `IHostedService` scoped dependency resolution with `IServiceScopeFactory`
- Added `IServiceScopeFactory` to framework services table with Singleton specification
- Minor peripheral doc clean-up

Fixes #23624

### Internal preview

✔️ [Dependency injection in .NET: Scope screnarios](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-23775#scope-scenarios)
✔️ [Dependency injection in .NET: Framework-provided services](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-23775#framework-provided-services)