### PR TITLE
Correct interface implemented name

### DIFF
--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md
@@ -53,7 +53,7 @@ class Program
   
 ## Comparing Generic Collections  
 
- The following example illustrates the benefits of contravariance support in the <xref:System.Collections.Generic.IComparer%601> interface. The `PersonComparer` class implements the `IEqualityComparer<Person>` interface. However, you can reuse this class to compare a sequence of objects of the `Employee` type because `Employee` inherits `Person`.  
+ The following example illustrates the benefits of contravariance support in the <xref:System.Collections.Generic.IEqualityComparer%601> interface. The `PersonComparer` class implements the `IEqualityComparer<Person>` interface. However, you can reuse this class to compare a sequence of objects of the `Employee` type because `Employee` inherits `Person`.  
   
 ```csharp  
 // Simple hierarchy of classes.  

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-in-interfaces-for-generic-collections.md
@@ -53,7 +53,7 @@ class Program
   
 ## Comparing Generic Collections  
 
- The following example illustrates the benefits of contravariance support in the <xref:System.Collections.Generic.IComparer%601> interface. The `PersonComparer` class implements the `IComparer<Person>` interface. However, you can reuse this class to compare a sequence of objects of the `Employee` type because `Employee` inherits `Person`.  
+ The following example illustrates the benefits of contravariance support in the <xref:System.Collections.Generic.IComparer%601> interface. The `PersonComparer` class implements the `IEqualityComparer<Person>` interface. However, you can reuse this class to compare a sequence of objects of the `Employee` type because `Employee` inherits `Person`.  
   
 ```csharp  
 // Simple hierarchy of classes.  


### PR DESCRIPTION
## Summary

As spotted by @shao130, the `PersonComparer` class implements `IEqualityComparer<T>` interface, not `IComparer<T>`.

Fixes #23579 
