### PR TITLE
Update ms.topic for fundamentals folder

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -211,6 +211,10 @@
         "docs/framework/wcf/diagnostics/tracing/**.md": "reference",
         "docs/framework/wcf/diagnostics/wmi/**.md": "reference",
         "docs/fsharp/language-reference/**/**.md": "language-reference",
+        "docs/fundamentals/code-analysis/**.md": "reference",
+        "docs/fundamentals/code-analysis/quality-rules/**.md": "reference",
+        "docs/fundamentals/code-analysis/style-rules/**.md": "reference",
+        "docs/fundamentals/code-analysis/diagnostics/**.md": "reference",
         "docs/standard/**/*how-to*.md": "how-to",
         "docs/standard/base-types/*.md": "how-to"
       },

--- a/docs/fundamentals/code-analysis/code-quality-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-quality-rule-options.md
@@ -2,7 +2,6 @@
 title: Code quality rule configuration options
 description: Learn how to specify additional configuration options for code quality rules.
 ms.date: 09/24/2020
-ms.topic: conceptual
 no-loc: ["EditorConfig"]
 ---
 # Code quality rule configuration options

--- a/docs/fundamentals/code-analysis/code-style-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-style-rule-options.md
@@ -2,7 +2,6 @@
 title: .NET code style rule options
 description: Learn how to specify .NET code style options.
 ms.date: 09/25/2020
-ms.topic: conceptual
 author: gewarren
 ms.author: gewarren
 ---

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -2,7 +2,6 @@
 title: Configure code analysis rules
 description: Learn how to configure code analysis rules in an analyzer configuration file.
 ms.date: 09/24/2020
-ms.topic: conceptual
 no-loc: ["EditorConfig"]
 ---
 # Configuration options for code analysis

--- a/docs/fundamentals/code-analysis/suppress-warnings.md
+++ b/docs/fundamentals/code-analysis/suppress-warnings.md
@@ -2,6 +2,7 @@
 title: Suppress code analysis warnings
 description: Learn the different ways you can suppress .NET code analysis violations.
 ms.date: 01/28/2021
+ms-topic: how-to
 dev_langs:
   - CSharp
   - VB


### PR DESCRIPTION
Contributes to #23694

Makes reference the default topic type for subfolders under fundamentals, changes a few articles from conceptual to reference and one to how-to.