### PR TITLE
Fix a bug in the encrypt sample, that was causing the decrypt to fail

### DIFF
--- a/docs/standard/security/decrypting-data.md
+++ b/docs/standard/security/decrypting-data.md
@@ -1,7 +1,7 @@
 ---
 title: "Decrypting data"
 description: Learn how to decrypt data in .NET, using a symmetric algorithm or an asymmetric algorithm.
-ms.date: 04/16/2021
+ms.date: 04/19/2021
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/security/decrypting-data.md
+++ b/docs/standard/security/decrypting-data.md
@@ -21,18 +21,18 @@ Decryption is the reverse operation of encryption. For secret-key encryption, yo
 
 The decryption of data encrypted with symmetric algorithms is similar to the process used to encrypt data with symmetric algorithms. The <xref:System.Security.Cryptography.CryptoStream> class is used with symmetric cryptography classes provided by .NET to decrypt data read from any managed stream object.
 
-The following example illustrates how to create a new instance of the default implementation class for the <xref:System.Security.Cryptography.Aes> algorithm. The instance is used to perform decryption on a <xref:System.Security.Cryptography.CryptoStream> object. This example first creates a new instance of the <xref:System.Security.Cryptography.Aes> implementation class. It reads the initialization vector (IV) value from a managed stream variable, `myStream`. Next it instantiates a <xref:System.Security.Cryptography.CryptoStream> object and initializes it to the value of the `myStream` instance. The <xref:System.Security.Cryptography.SymmetricAlgorithm.CreateDecryptor%2A?displayProperty=nameWithType> method from the <xref:System.Security.Cryptography.Aes> instance is passed the IV value and the same key that was used for encryption.
+The following example illustrates how to create a new instance of the default implementation class for the <xref:System.Security.Cryptography.Aes> algorithm. The instance is used to perform decryption on a <xref:System.Security.Cryptography.CryptoStream> object. This example first creates a new instance of the <xref:System.Security.Cryptography.Aes> implementation class. It reads the initialization vector (IV) value from a managed stream variable, `fileStream`. Next it instantiates a <xref:System.Security.Cryptography.CryptoStream> object and initializes it to the value of the `fileStream` instance. The <xref:System.Security.Cryptography.SymmetricAlgorithm.CreateDecryptor%2A?displayProperty=nameWithType> method from the <xref:System.Security.Cryptography.Aes> instance is passed the IV value and the same key that was used for encryption.
 
 ```vb
 Dim aes As Aes = Aes.Create()
 Dim cryptStream As New CryptoStream(
-    myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read)
+    fileStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read)
 ```
 
 ```csharp
 Aes aes = Aes.Create();
 CryptoStream cryptStream = new CryptoStream(
-    myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read);
+    fileStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read);
 ```
 
 The following example shows the entire process of creating a stream, decrypting the stream, reading from the stream, and closing the streams. A file stream object is created that reads a file named *TestData.txt*. The file stream is then decrypted using the **CryptoStream** class and the **Aes** class. This example specifies key value that is used in the symmetric encryption example for [Encrypting Data](encrypting-data.md). It does not show the code needed to encrypt and transfer these values.

--- a/docs/standard/security/decrypting-data.md
+++ b/docs/standard/security/decrypting-data.md
@@ -1,7 +1,7 @@
 ---
 title: "Decrypting data"
 description: Learn how to decrypt data in .NET, using a symmetric algorithm or an asymmetric algorithm.
-ms.date: 03/22/2021
+ms.date: 04/16/2021
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/security/encrypting-data.md
+++ b/docs/standard/security/encrypting-data.md
@@ -21,18 +21,18 @@ Symmetric encryption and asymmetric encryption are performed using different pro
 
 The managed symmetric cryptography classes are used with a special stream class called a <xref:System.Security.Cryptography.CryptoStream> that encrypts data read into the stream. The **CryptoStream** class is initialized with a managed stream class, a class that implements the <xref:System.Security.Cryptography.ICryptoTransform> interface (created from a class that implements a cryptographic algorithm), and a <xref:System.Security.Cryptography.CryptoStreamMode> enumeration that describes the type of access permitted to the **CryptoStream**. The **CryptoStream** class can be initialized using any class that derives from the <xref:System.IO.Stream> class, including <xref:System.IO.FileStream>, <xref:System.IO.MemoryStream>, and <xref:System.Net.Sockets.NetworkStream>. Using these classes, you can perform symmetric encryption on a variety of stream objects.
 
-The following example illustrates how to create a new instance of the default implementation class for the <xref:System.Security.Cryptography.Aes> algorithm. The instance is used to perform encryption on a **CryptoStream** class. In this example, the **CryptoStream** is initialized with a stream object called `myStream` that can be any type of managed stream. The **CreateEncryptor** method from the **Aes** class is passed the key and IV that are used for encryption. In this case, the default key and IV generated from `aes` are used.
+The following example illustrates how to create a new instance of the default implementation class for the <xref:System.Security.Cryptography.Aes> algorithm. The instance is used to perform encryption on a **CryptoStream** class. In this example, the **CryptoStream** is initialized with a stream object called `fileStream` that can be any type of managed stream. The **CreateEncryptor** method from the **Aes** class is passed the key and IV that are used for encryption. In this case, the default key and IV generated from `aes` are used.
 
 ```vb
 Dim aes As Aes = Aes.Create()
 Dim cryptStream As New CryptoStream(
-    myStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write)
+    fileStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write)
 ```
 
 ```csharp
 Aes aes = Aes.Create();
 CryptoStream cryptStream = new CryptoStream(
-    myStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write);
+    fileStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write);
 ```
 
 After this code is executed, any data written to the **CryptoStream** object is encrypted using the AES algorithm.

--- a/docs/standard/security/encrypting-data.md
+++ b/docs/standard/security/encrypting-data.md
@@ -1,7 +1,7 @@
 ---
 title: "Encrypting data"
 description: Learn how to encrypt data in .NET, using a symmetric algorithm or an asymmetric algorithm.
-ms.date: 03/22/2021
+ms.date: 04/16/2021
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
@@ -35,8 +35,7 @@ try
 
     Console.WriteLine($"The decrypted original message: {decryptedMessage}");
 }
-catch (Execption ex)
+catch (Exception ex)
 {
     Console.WriteLine($"The decryption failed. {ex}");
-    throw;
 }

--- a/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System;
 using System.IO;
 using System.Security.Cryptography;
 
@@ -21,8 +22,8 @@ try
         0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
     };
 
-    //Create a CryptoStream, pass it the file stream, and decrypt
-    //it with the Aes class using the key and IV.
+    // Create a CryptoStream, pass it the file stream, and decrypt
+    // it with the Aes class using the key and IV.
     using CryptoStream cryptoStream = new(
        fileStream,
        aes.CreateDecryptor(key, iv),
@@ -35,8 +36,8 @@ try
 
     Console.WriteLine($"The decrypted original message: {decryptedMessage}");
 }
-catch
+catch (Execption ex)
 {
-    Console.WriteLine("The decryption failed.");
+    Console.WriteLine($"The decryption failed. {ex}");
     throw;
 }

--- a/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System;
 using System.IO;
 using System.Security.Cryptography;
 

--- a/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
@@ -2,43 +2,41 @@
 using System.IO;
 using System.Security.Cryptography;
 
-public class DecryptExample
+try
 {
-    public static void Main(string[] args)
+    using FileStream fileStream = new("TestData.txt", FileMode.Open);
+
+    // Create a new instance of the default Aes implementation class
+    using Aes aes = Aes.Create();
+
+    // Reads IV value from beginning of the file.
+    byte[] iv = new byte[aes.IV.Length];
+    fileStream.Read(iv, 0, iv.Length);
+
+    // Decryption key must be the same value that was used
+    // to encrypt the stream.
+    byte[] key =
     {
-        //Decryption key must be the same value that was used
-        //to encrypt the stream.
-        byte[] key = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
+    };
 
-        try
-        {
-            //Create a file stream.
-            using FileStream myStream = new FileStream("TestData.txt", FileMode.Open);
+    //Create a CryptoStream, pass it the file stream, and decrypt
+    //it with the Aes class using the key and IV.
+    using CryptoStream cryptoStream = new(
+       fileStream,
+       aes.CreateDecryptor(key, iv),
+       CryptoStreamMode.Read);
 
-            //Create a new instance of the default Aes implementation class
-            using Aes aes = Aes.Create();
+    // Read the stream.
+    using StreamReader decryptReader = new(cryptoStream);
 
-            //Reads IV value from beginning of the file.
-            byte[] iv = new byte[aes.IV.Length];
-            myStream.Read(iv, 0, iv.Length);
+    var decryptedMessage = await decryptReader.ReadToEndAsync();
 
-            //Create a CryptoStream, pass it the file stream, and decrypt
-            //it with the Aes class using the key and IV.
-            using CryptoStream cryptStream = new CryptoStream(
-               myStream,
-               aes.CreateDecryptor(key, iv),
-               CryptoStreamMode.Read);
-
-            //Read the stream.
-            using StreamReader sReader = new StreamReader(cryptStream);
-
-            //Display the message.
-            Console.WriteLine("The decrypted original message: {0}", sReader.ReadToEnd());
-        }
-        catch
-        {
-            Console.WriteLine("The decryption failed.");
-            throw;
-        }
-    }
+    Console.WriteLine($"The decrypted original message: {decryptedMessage}");
+}
+catch
+{
+    Console.WriteLine("The decryption failed.");
+    throw;
 }

--- a/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
@@ -11,7 +11,18 @@ try
 
     // Reads IV value from beginning of the file.
     byte[] iv = new byte[aes.IV.Length];
-    fileStream.Read(iv, 0, iv.Length);
+    int numBytesToRead = aes.IV.Length;
+    int numBytesRead = 0;
+    while (numBytesToRead > 0)
+    {
+        int n = fileStream.Read(iv, numBytesRead, numBytesToRead);
+
+        // Break when the end of the file is reached.
+        if (n == 0) break;
+
+        numBytesRead += n;
+        numBytesToRead -= n;
+    }
 
     // Decryption key must be the same value that was used
     // to encrypt the stream.
@@ -31,7 +42,7 @@ try
     // Read the stream.
     using StreamReader decryptReader = new(cryptoStream);
 
-    var decryptedMessage = await decryptReader.ReadToEndAsync();
+    string decryptedMessage = await decryptReader.ReadToEndAsync();
 
     Console.WriteLine($"The decrypted original message: {decryptedMessage}");
 }

--- a/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aes-decrypt.cs
@@ -4,47 +4,41 @@ using System.Security.Cryptography;
 
 try
 {
-    using FileStream fileStream = new("TestData.txt", FileMode.Open);
-
-    // Create a new instance of the default Aes implementation class
-    using Aes aes = Aes.Create();
-
-    // Reads IV value from beginning of the file.
-    byte[] iv = new byte[aes.IV.Length];
-    int numBytesToRead = aes.IV.Length;
-    int numBytesRead = 0;
-    while (numBytesToRead > 0)
+    using (FileStream fileStream = new("TestData.txt", FileMode.Open))
     {
-        int n = fileStream.Read(iv, numBytesRead, numBytesToRead);
+        using (Aes aes = Aes.Create())
+        {
+            byte[] iv = new byte[aes.IV.Length];
+            int numBytesToRead = aes.IV.Length;
+            int numBytesRead = 0;
+            while (numBytesToRead > 0)
+            {
+                int n = fileStream.Read(iv, numBytesRead, numBytesToRead);
+                if (n == 0) break;
 
-        // Break when the end of the file is reached.
-        if (n == 0) break;
+                numBytesRead += n;
+                numBytesToRead -= n;
+            }
 
-        numBytesRead += n;
-        numBytesToRead -= n;
+            byte[] key =
+            {
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
+            };
+
+            using (CryptoStream cryptoStream = new(
+               fileStream,
+               aes.CreateDecryptor(key, iv),
+               CryptoStreamMode.Read))
+            {
+                using (StreamReader decryptReader = new(cryptoStream))
+                {
+                    string decryptedMessage = await decryptReader.ReadToEndAsync();
+                    Console.WriteLine($"The decrypted original message: {decryptedMessage}");
+                }
+            }
+        }
     }
-
-    // Decryption key must be the same value that was used
-    // to encrypt the stream.
-    byte[] key =
-    {
-        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-        0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
-    };
-
-    // Create a CryptoStream, pass it the file stream, and decrypt
-    // it with the Aes class using the key and IV.
-    using CryptoStream cryptoStream = new(
-       fileStream,
-       aes.CreateDecryptor(key, iv),
-       CryptoStreamMode.Read);
-
-    // Read the stream.
-    using StreamReader decryptReader = new(cryptoStream);
-
-    string decryptedMessage = await decryptReader.ReadToEndAsync();
-
-    Console.WriteLine($"The decrypted original message: {decryptedMessage}");
 }
 catch (Exception ex)
 {

--- a/docs/standard/security/snippets/decrypting-data/csharp/aesdecrypt.csproj
+++ b/docs/standard/security/snippets/decrypting-data/csharp/aesdecrypt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/security/snippets/decrypting-data/vb/aes-decrypt.vb
+++ b/docs/standard/security/snippets/decrypting-data/vb/aes-decrypt.vb
@@ -17,7 +17,17 @@ Module Module1
 
                     ' Reads IV value from beginning of the file.
                     Dim iv As Byte() = New Byte(aes.IV.Length - 1) {}
-                    fileStream.Read(iv, 0, iv.Length)
+                    Dim numBytesToRead As Integer = CType(aes.IV.Length, Integer)
+                    Dim numBytesRead As Integer = 0
+
+                    While (numBytesToRead > 0)
+                        Dim n As Integer = fileStream.Read(iv, numBytesRead, numBytesToRead)
+                        If n = 0 Then
+                            Exit While
+                        End If
+                        numBytesRead += n
+                        numBytesToRead -= n
+                    End While
 
                     ' Create an instance of the CryptoStream class, pass it the file stream, and decrypt
                     ' it with the Rijndael class using the key and IV.

--- a/docs/standard/security/snippets/decrypting-data/vb/aes-decrypt.vb
+++ b/docs/standard/security/snippets/decrypting-data/vb/aes-decrypt.vb
@@ -10,7 +10,7 @@ Module Module1
 
         Try
             ' Create a file stream.
-            Using fileStream As FileStream = New FileStream("TestData.txt", FileMode.Open)
+            Using fileStream As New FileStream("TestData.txt", FileMode.Open)
 
                 ' Create a new instance of the default Aes implementation class
                 Using aes As Aes = Aes.Create()

--- a/docs/standard/security/snippets/decrypting-data/vb/aes-decrypt.vb
+++ b/docs/standard/security/snippets/decrypting-data/vb/aes-decrypt.vb
@@ -4,30 +4,30 @@ Imports System.Security.Cryptography
 
 Module Module1
     Sub Main()
-        'Decryption key must be the same value that was used
-        'to encrypt the stream.
+        ' Decryption key must be the same value that was used
+        ' to encrypt the stream.
         Dim key As Byte() = {&H1, &H2, &H3, &H4, &H5, &H6, &H7, &H8, &H9, &H10, &H11, &H12, &H13, &H14, &H15, &H16}
 
         Try
-            'Create a file stream.
-            Using myStream As FileStream = New FileStream("TestData.txt", FileMode.Open)
+            ' Create a file stream.
+            Using fileStream As FileStream = New FileStream("TestData.txt", FileMode.Open)
 
-                'Create a new instance of the default Aes implementation class
+                ' Create a new instance of the default Aes implementation class
                 Using aes As Aes = Aes.Create()
 
-                    'Reads IV value from beginning of the file.
+                    ' Reads IV value from beginning of the file.
                     Dim iv As Byte() = New Byte(aes.IV.Length - 1) {}
-                    myStream.Read(iv, 0, iv.Length)
+                    fileStream.Read(iv, 0, iv.Length)
 
-                    'Create an instance of the CryptoStream class, pass it the file stream, and decrypt
-                    'it with the Rijndael class using the key and IV.
-                    Using cryptStream As New CryptoStream(myStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read)
+                    ' Create an instance of the CryptoStream class, pass it the file stream, and decrypt
+                    ' it with the Rijndael class using the key and IV.
+                    Using cryptoStream As New CryptoStream(fileStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Read)
 
-                        'Read the stream.
-                        Using sReader As New StreamReader(cryptStream)
+                        ' Read the stream.
+                        Using decryptReader As New StreamReader(cryptoStream)
 
-                            'Display the message.
-                            Console.WriteLine("The decrypted original message: {0}", sReader.ReadToEnd())
+                            ' Display the message.
+                            Console.WriteLine($"The decrypted original message: {decryptReader.ReadToEnd()}")
                         End Using
                     End Using
                 End Using

--- a/docs/standard/security/snippets/decrypting-data/vb/aesdecrypt.vbproj
+++ b/docs/standard/security/snippets/decrypting-data/vb/aesdecrypt.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
+++ b/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System;
 using System.IO;
 using System.Security.Cryptography;
 

--- a/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
+++ b/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
@@ -6,35 +6,27 @@ try
 {
     using (FileStream fileStream = new("TestData.txt", FileMode.OpenOrCreate))
     {
-
-        // Create an instance of the default Aes implementation class
-        // and configure the encryption key.
-        using Aes aes = Aes.Create();
-
-        // Encryption key used to encrypt the stream.
-        // The same value must be used to encrypt and decrypt the stream.
-        byte[] key =
+        using (Aes aes = Aes.Create())
         {
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-            0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
-        };
-        aes.Key = key;
-
-        // Stores IV at the beginning of the file.
-        // This information will be used for decryption.
-        byte[] iv = aes.IV;
-        fileStream.Write(iv, 0, iv.Length);
-
-        // Create a CryptoStream, pass it the FileStream, and encrypt
-        // it with the Aes class.
-        using (CryptoStream cryptoStream = new(
-            fileStream,
-            aes.CreateEncryptor(),
-            CryptoStreamMode.Write))
-        {
-            using (StreamWriter encryptWriter = new(cryptoStream))
+            byte[] key =
             {
-                encryptWriter.WriteLine("Hello World!");
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
+            };
+            aes.Key = key;
+
+            byte[] iv = aes.IV;
+            fileStream.Write(iv, 0, iv.Length);
+
+            using (CryptoStream cryptoStream = new(
+                fileStream,
+                aes.CreateEncryptor(),
+                CryptoStreamMode.Write))
+            {
+                using (StreamWriter encryptWriter = new(cryptoStream))
+                {
+                    encryptWriter.WriteLine("Hello World!");
+                }
             }
         }
     }

--- a/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
+++ b/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
@@ -2,54 +2,48 @@
 using System.IO;
 using System.Security.Cryptography;
 
-public class EncryptExample
+try
 {
-    public static void Main(string[] args)
+    using (FileStream fileStream = new("TestData.txt", FileMode.OpenOrCreate))
     {
-        //Encryption key used to encrypt the stream.
-        //The same value must be used to encrypt and decrypt the stream.
-        byte[] key = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
 
-        try
+        // Create an instance of the default Aes implementation class
+        // and configure the encryption key.
+        using Aes aes = Aes.Create();
+
+        // Encryption key used to encrypt the stream.
+        // The same value must be used to encrypt and decrypt the stream.
+        byte[] key =
         {
-            //Create a file stream
-            using FileStream myStream = new FileStream("TestData.txt", FileMode.OpenOrCreate);
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
+        };
+        aes.Key = key;
 
-            //Create a new instance of the default Aes implementation class  
-            // and configure encryption key.  
-            using Aes aes = Aes.Create();
-            aes.Key = key;
+        // Stores IV at the beginning of the file.
+        // This information will be used for decryption.
+        byte[] iv = aes.IV;
+        fileStream.Write(iv, 0, iv.Length);
 
-            //Stores IV at the beginning of the file.
-            //This information will be used for decryption.
-            byte[] iv = aes.IV;
-            myStream.Write(iv, 0, iv.Length);
-
-            //Create a CryptoStream, pass it the FileStream, and encrypt
-            //it with the Aes class.  
-            using CryptoStream cryptStream = new CryptoStream(
-                myStream, 
-                aes.CreateEncryptor(),
-                CryptoStreamMode.Write);
-
-            //Create a StreamWriter for easy writing to the
-            //file stream.  
-            using StreamWriter sWriter = new StreamWriter(cryptStream);
-
-            //Write to the stream.  
-            sWriter.WriteLine("Hello World!");
-
-            cryptStream.FlushFinalBlock();
-
-            //Inform the user that the message was written  
-            //to the stream.  
-            Console.WriteLine("The file was encrypted.");
-        }
-        catch
+        // Create a CryptoStream, pass it the FileStream, and encrypt
+        // it with the Aes class.
+        using (CryptoStream cryptoStream = new(
+            fileStream,
+            aes.CreateEncryptor(),
+            CryptoStreamMode.Write))
         {
-            //Inform the user that an exception was raised.  
-            Console.WriteLine("The encryption failed.");
-            throw;
+            using (StreamWriter encryptWriter = new(cryptoStream))
+            {
+                encryptWriter.WriteLine("Hello World!");
+            }
         }
     }
+
+    Console.WriteLine("The file was encrypted.");
+}
+catch
+{
+    //Inform the user that an exception was raised.
+    Console.WriteLine("The encryption failed.");
+    throw;
 }

--- a/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
+++ b/docs/standard/security/snippets/encrypting-data/csharp/aes-encrypt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System;
 using System.IO;
 using System.Security.Cryptography;
 
@@ -41,9 +42,7 @@ try
 
     Console.WriteLine("The file was encrypted.");
 }
-catch
+catch (Exception ex)
 {
-    //Inform the user that an exception was raised.
-    Console.WriteLine("The encryption failed.");
-    throw;
+    Console.WriteLine($"The encryption failed. {ex}");
 }

--- a/docs/standard/security/snippets/encrypting-data/csharp/aesencrypt.csproj
+++ b/docs/standard/security/snippets/encrypting-data/csharp/aesencrypt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/security/snippets/encrypting-data/vb/aes-encrypt.vb
+++ b/docs/standard/security/snippets/encrypting-data/vb/aes-encrypt.vb
@@ -4,33 +4,36 @@ Imports System.Security.Cryptography
 
 Module Module1
     Sub Main()
-        'Encryption key used to encrypt the stream.
-        'The same value must be used to encrypt and decrypt the stream.
-        Dim key As Byte() = {&H1, &H2, &H3, &H4, &H5, &H6, &H7, &H8, &H9, &H10, &H11, &H12, &H13, &H14, &H15, &H16}
-
         Try
-            'Create a file stream
-            Using myStream As FileStream = New FileStream("TestData.txt", FileMode.OpenOrCreate)
+            ' Create a file stream
+            Using fileStream As FileStream = New FileStream("TestData.txt", FileMode.OpenOrCreate)
 
-                'Create a new instance of the default Aes implementation class  
-                ' and configure encryption key.  
+                ' Create a new instance of the default Aes implementation class  
+                ' and configure encryption key.
                 Using aes As Aes = Aes.Create()
+                    'Encryption key used to encrypt the stream.
+                    'The same value must be used to encrypt and decrypt the stream.
+                    Dim key As Byte() = {
+                        &H1, &H2, &H3, &H4, &H5, &H6, &H7, &H8,
+                        &H9, &H10, &H11, &H12, &H13, &H14, &H15, &H16
+                    }
+
                     aes.Key = key
 
-                    'Stores IV at the beginning of the file.
-                    'This information will be used for decryption.
+                    ' Stores IV at the beginning of the file.
+                    ' This information will be used for decryption.
                     Dim iv As Byte() = aes.IV
-                    myStream.Write(iv, 0, iv.Length)
+                    fileStream.Write(iv, 0, iv.Length)
 
-                    'Create a CryptoStream, pass it the FileStream, and encrypt
-                    'it with the Aes class.  
-                    Using cryptStream As New CryptoStream(myStream, aes.CreateEncryptor(), CryptoStreamMode.Write)
+                    ' Create a CryptoStream, pass it the FileStream, and encrypt
+                    ' it with the Aes class.
+                    Using cryptoStream As New CryptoStream(fileStream, aes.CreateEncryptor(), CryptoStreamMode.Write)
 
-                        'Create a StreamWriter for easy writing to the
-                        'file stream.  
-                        Using sWriter As New StreamWriter(cryptStream)
+                        ' Create a StreamWriter for easy writing to the
+                        ' file stream.
+                        Using sWriter As New StreamWriter(cryptoStream)
 
-                            'Write to the stream.  
+                            'Write to the stream.
                             sWriter.WriteLine("Hello World!")
                         End Using
                     End Using

--- a/docs/standard/security/snippets/encrypting-data/vb/aes-encrypt.vb
+++ b/docs/standard/security/snippets/encrypting-data/vb/aes-encrypt.vb
@@ -6,7 +6,7 @@ Module Module1
     Sub Main()
         Try
             ' Create a file stream
-            Using fileStream As FileStream = New FileStream("TestData.txt", FileMode.OpenOrCreate)
+            Using fileStream As New FileStream("TestData.txt", FileMode.OpenOrCreate)
 
                 ' Create a new instance of the default Aes implementation class  
                 ' and configure encryption key.

--- a/docs/standard/security/snippets/encrypting-data/vb/aesencrypt.vbproj
+++ b/docs/standard/security/snippets/encrypting-data/vb/aesencrypt.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Upgrade encrypt / decrypt snippets to .NET 5
- Use top-level statements
- Use target-type new expressions
- Use explicitly scoped `using` to avoid encryption errors

Fixes #23814

### Internal preview

✔️ [Encrypting data](https://review.docs.microsoft.com/en-us/dotnet/standard/security/encrypting-data?branch=pr-en-us-23816)
✔️ [Decrypting data](https://review.docs.microsoft.com/en-us/dotnet/standard/security/decrypting-data?branch=pr-en-us-23816)