### PR TITLE
Replaced "solution folder" with "project folder"

### DIFF
--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -94,7 +94,7 @@ dotnet sln add [-h|--help]
 
 - **`--in-root`**
 
-  Places the projects in the root of the solution, rather than creating a solution folder. Available since .NET Core 3.0 SDK.
+  Places the projects in the root of the solution, rather than creating a project folder. Available since .NET Core 3.0 SDK.
 
 - **`-s|--solution-folder <PATH>`**
 


### PR DESCRIPTION
## Summary

Replaced "_solution folder_" with "_project folder_", because projects are placed in project folders, not solution folders, by default.