### PR TITLE
Added reference to Attribute parameter types

### DIFF
--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -50,6 +50,8 @@ Many attributes have parameters, which can be positional, unnamed, or named. Any
 
 The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Positional parameters correspond to the parameters of the attribute constructor. Named or optional parameters correspond to either properties or fields of the attribute. Refer to the individual attribute's documentation for information on default parameter values.
 
+For more information on allowed parameter types refer to [Attributes](../../../_csharplang/spec/attributes.md#attribute-parameter-types) page in [C# Language Specification](../../../_csharplang/spec/introduction.md)
+
 ### Attribute targets
 
 The *target* of an attribute is the entity which the attribute applies to. For example, an attribute may apply to a class, a particular method, or an entire assembly. By default, an attribute applies to the element that follows it. But you can also explicitly identify, for example, whether an attribute is applied to a method, or to its parameter, or to its return value.

--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -50,7 +50,7 @@ Many attributes have parameters, which can be positional, unnamed, or named. Any
 
 The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Positional parameters correspond to the parameters of the attribute constructor. Named or optional parameters correspond to either properties or fields of the attribute. Refer to the individual attribute's documentation for information on default parameter values.
 
-For more information on allowed parameter types refer to [Attributes](../../../../../_csharplang/spec/attributes.md#attribute-parameter-types) page in [C# Language Specification](../../../../../_csharplang/spec/introduction.md)
+For more information on allowed parameter types, see the [Attributes](~/_csharplang/spec/attributes.md#attribute-parameter-types) section of the [C# language specification](~/_csharplang/spec/introduction.md)
 
 ### Attribute targets
 

--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -50,7 +50,7 @@ Many attributes have parameters, which can be positional, unnamed, or named. Any
 
 The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Positional parameters correspond to the parameters of the attribute constructor. Named or optional parameters correspond to either properties or fields of the attribute. Refer to the individual attribute's documentation for information on default parameter values.
 
-For more information on allowed parameter types refer to [Attributes](../../../_csharplang/spec/attributes.md#attribute-parameter-types) page in [C# Language Specification](../../../_csharplang/spec/introduction.md)
+For more information on allowed parameter types refer to [Attributes](../../../../../_csharplang/spec/attributes.md#attribute-parameter-types) page in [C# Language Specification](../../../../../_csharplang/spec/introduction.md)
 
 ### Attribute targets
 

--- a/docs/standard/attributes/writing-custom-attributes.md
+++ b/docs/standard/attributes/writing-custom-attributes.md
@@ -31,7 +31,7 @@ To design your own custom attributes, you do not need to master many new concept
   
 - [Declaring properties](#declaring-properties)  
   
- This section describes each of these steps and concludes with a [custom attribute example](#custom-attribute-example).  
+ This section describes each of these steps and concludes with a [custom attribute example](#custom-attribute-example). 
   
 ## Applying the AttributeUsageAttribute  
 
@@ -154,3 +154,4 @@ To design your own custom attributes, you do not need to master many new concept
 - <xref:System.Attribute?displayProperty=nameWithType>
 - <xref:System.AttributeUsageAttribute?displayProperty=nameWithType>
 - [Attributes](index.md)
+- [Attribute parameter types](../../../_csharplang/spec/attributes.md#attribute-parameter-types)

--- a/docs/standard/attributes/writing-custom-attributes.md
+++ b/docs/standard/attributes/writing-custom-attributes.md
@@ -31,7 +31,7 @@ To design your own custom attributes, you do not need to master many new concept
   
 - [Declaring properties](#declaring-properties)  
   
- This section describes each of these steps and concludes with a [custom attribute example](#custom-attribute-example). 
+ This section describes each of these steps and concludes with a [custom attribute example](#custom-attribute-example).
   
 ## Applying the AttributeUsageAttribute  
 

--- a/docs/standard/attributes/writing-custom-attributes.md
+++ b/docs/standard/attributes/writing-custom-attributes.md
@@ -154,4 +154,4 @@ To design your own custom attributes, you do not need to master many new concept
 - <xref:System.Attribute?displayProperty=nameWithType>
 - <xref:System.AttributeUsageAttribute?displayProperty=nameWithType>
 - [Attributes](index.md)
-- [Attribute parameter types](../../../_csharplang/spec/attributes.md#attribute-parameter-types)
+- [Attribute parameter types](~/_csharplang/spec/attributes.md#attribute-parameter-types)


### PR DESCRIPTION
## Summary

Added reference to "Attribute Parameter types section" (https://github.com/dotnet/csharplang/blob/main/spec/attributes.md#attribute-parameter-types) to the following pages:

Attributes: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/attributes/#attribute-parameters
Writing Custom Attributes:  https://docs.microsoft.com/en-us/dotnet/standard/attributes/writing-custom-attributes#see-also

Fixes #22699 