### PR TITLE
Change event to pull_request_target

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -1,7 +1,7 @@
 name: 'Status checker'
 
 on: 
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
This attempts to fix the error "Resource not accessible by integration" when trying to insert a new status check. See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target.