### PR TITLE
Updated async-in-depth with HttpClient best practice.

### DIFF
--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -32,7 +32,8 @@ The following section describes a 10,000 foot view of what happens with a typica
 The first example method `GetHtmlAsync()` calls an async method and returns an active task, likely yet to complete. The second example method `GetFirstCharactersCountAsync()` adds the use of the `async` and `await` keywords to operate on the task.
 
 ```csharp
-class DotnetFoundationClient {
+class DotNetFoundationClient
+{
     // HttpClient is intended to be instantiated once per application, rather than per-use.
     private static readonly HttpClient client = new HttpClient();
 

--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -42,7 +42,7 @@ class DotNetFoundationClient
         // Execution is synchronous here
         var uri = new Uri("https://www.dotnetfoundation.org");
 
-        return client.GetStringAsync(uri);
+        return s_client.GetStringAsync(uri);
     }
     
     public async Task<string> GetFirstCharactersCountAsync(int count)

--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -35,7 +35,7 @@ The first example method `GetHtmlAsync()` calls an async method and returns an a
 class DotNetFoundationClient
 {
     // HttpClient is intended to be instantiated once per application, rather than per-use.
-    private static readonly HttpClient client = new HttpClient();
+    private static readonly HttpClient s_client = new HttpClient();
 
     public Task<string> GetHtmlAsync()
     {

--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -52,7 +52,7 @@ class DotNetFoundationClient
 
         // Execution of GetFirstCharactersCountAsync() is yielded to the caller here
         // GetStringAsync returns a Task<string>, which is *awaited*
-        var page = await client.GetStringAsync(uri);
+        var page = await s_client.GetStringAsync(uri);
 
         // Execution resumes when the client.GetStringAsync task completes,
         // becoming synchronous again.


### PR DESCRIPTION
## Summary

Updated async-in-depth with HttpClient best practice.

- Updated the example code with class-level scoping. 
- Made the `HttpClient` `static` and `readonly` as it goes with the line's comment. The methods and the class could have been `static` as well, but I thought it would be noise that don't contribute to the example. I'm open to changing that.
- Removed `string url` from the method's arguments since it is unused.

Fixes #23783
