### PR TITLE
Add docs about changes between 3.x and 5.0

### DIFF
--- a/docs/core/deploying/single-file.md
+++ b/docs/core/deploying/single-file.md
@@ -13,7 +13,7 @@ Single File deployment is available for both the [framework-dependent deployment
 
 ## Output differences from .NET 3.x
 
-In .NET 3.x, publishing as a single file produced exactly one file, with all files next to the app bundled and extracted at startup. In .NET 5.0 there is no extraction by default. For Windows this can result in multiple files in the output: the app file, and the core runtime DLLs alongside. To embed those files for extraction, like in .NET 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. See [Other considerations](#other-considerations) for more details about extraction.
+In .NET Core 3.x, publishing as a single file produced exactly one file, with all files next to the app bundled and extracted at startup. In .NET 5+, there is no extraction by default. On Windows, this can result in multiple files in the output: the app file, and the core runtime DLLs alongside. To embed those files for extraction, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Other considerations](#other-considerations).
 
 ## API incompatibility
 

--- a/docs/core/deploying/single-file.md
+++ b/docs/core/deploying/single-file.md
@@ -11,6 +11,10 @@ Bundling all application-dependent files into a single binary provides an applic
 
 Single File deployment is available for both the [framework-dependent deployment model](index.md#publish-framework-dependent) and [self-contained applications](index.md#publish-self-contained). The size of the single file in a self-contained application will be large since it will include the runtime and the framework libraries. The single file deployment option can be combined with [ReadyToRun](ready-to-run.md) and [Trim (an experimental feature in .NET 5.0)](trim-self-contained.md) publish options.
 
+## Output differences from .NET 3.x
+
+In .NET 3.x, publishing as a single file produced exactly one file, with all files next to the app bundled and extracted at startup. In .NET 5.0 there is no extraction by default. For Windows this can result in multiple files in the output: the app file, and the core runtime DLLs alongside. To embed those files for extraction, like in .NET 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. See [Other considerations](#other-considerations) for more details about extraction.
+
 ## API incompatibility
 
 Some APIs are not compatible with single-file deployment and applications may require modification if they use these APIs. If you use a third-party framework or package, it's possible that they may also use one of these APIs and need modification. The most common cause of problems is dependence on file paths for files or DLLs shipped with the application.

--- a/docs/core/deploying/single-file.md
+++ b/docs/core/deploying/single-file.md
@@ -13,7 +13,7 @@ Single File deployment is available for both the [framework-dependent deployment
 
 ## Output differences from .NET 3.x
 
-In .NET Core 3.x, publishing as a single file produced exactly one file, with all files next to the app bundled and extracted at startup. In .NET 5+, all managed DLLs are loaded from memory and there is no extraction by default. On Windows, this means that the managed binaries are embedded in the single-file bundle, but the native binaries of the core runtime itself are seperate files. To embed those files for extraction and get exactly one output file, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Other considerations](#other-considerations).
+In .NET Core 3.x, publishing as a single file produced exactly one file, consisting of the app itself, dependencies, and any other files in the folder during publish. When the app starts, the single file app was extracted to a temporary folder and run from there. Starting with .NET 5, only managed DLLs are bundled with the app into a single executable. When the app starts, the managed DLLs are extracted and loaded in memory, avoiding the extraction to a temporary folder. On Windows, this means that the managed binaries are embedded in the single-file bundle, but the native binaries of the core runtime itself are separate files. To embed those files for extraction and get exactly one output file, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Other considerations](#other-considerations).
 
 ## API incompatibility
 

--- a/docs/core/deploying/single-file.md
+++ b/docs/core/deploying/single-file.md
@@ -13,7 +13,7 @@ Single File deployment is available for both the [framework-dependent deployment
 
 ## Output differences from .NET 3.x
 
-In .NET Core 3.x, publishing as a single file produced exactly one file, with all files next to the app bundled and extracted at startup. In .NET 5+, there is no extraction by default. On Windows, this can result in multiple files in the output: the app file, and the core runtime DLLs alongside. To embed those files for extraction, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Other considerations](#other-considerations).
+In .NET Core 3.x, publishing as a single file produced exactly one file, with all files next to the app bundled and extracted at startup. In .NET 5+, all managed DLLs are loaded from memory and there is no extraction by default. On Windows, this means that the managed binaries are embedded in the single-file bundle, but the native binaries of the core runtime itself are seperate files. To embed those files for extraction and get exactly one output file, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Other considerations](#other-considerations).
 
 ## API incompatibility
 


### PR DESCRIPTION
## Summary

Single-file had some behavioral changes between 3.x and 5.0 which were underspecified. This explains the differences and how to reproduce the 3.x output layout.
