### PR TITLE
Omit first arguement in Lambda Expression

### DIFF
--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -7,7 +7,7 @@ namespace ConsoleDisposable.Example
 {
     class Program
     {
-        static Task Main(string[] args)
+        static void Main(string[] args)
         {
             using IHost host = CreateHostBuilder(args).Build();
 
@@ -17,7 +17,7 @@ namespace ConsoleDisposable.Example
             ExemplifyDisposableScoping(host.Services, "Scope 2");
             Console.WriteLine();
 
-            return host.RunAsync();
+            host.Run();
         }
         // Sample output:
         //     Scope 1...

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -41,7 +41,7 @@ namespace ConsoleDisposable.Example
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
+                .ConfigureServices((services) =>
                     services.AddTransient<TransientDisposable>()
                             .AddScoped<ScopedDisposable>()
                             .AddSingleton<SingletonDisposable>());


### PR DESCRIPTION


## Summary

There is a new extension method in class "HostingHostBuilderExtensions" within nuget package "Microsoft.Extension.Hosting", so that first arguement can be omitted.

Fixes #Issue_Number (if available)

Null
