### PR TITLE
dotnet new article - updates for 5.0.3xx SDK

### DIFF
--- a/docs/core/testing/unit-testing-code-coverage.md
+++ b/docs/core/testing/unit-testing-code-coverage.md
@@ -22,7 +22,7 @@ The "system under test" refers to the code that you're writing unit tests agains
 
 ### Create a class library
 
-From a command prompt in a new directory named `UnitTestingCodeCoverage`, create a new .NET standard class library using the [`dotnet new classlib`](../tools/dotnet-new.md#classlib) command:
+From a command prompt in a new directory named `UnitTestingCodeCoverage`, create a new .NET standard class library using the [`dotnet new classlib`](../tools/dotnet-new-sdk-templates.md#classlib) command:
 
 ```dotnetcli
 dotnet new classlib -n Numbers
@@ -60,7 +60,7 @@ namespace System.Numbers
 
 ### Create test projects
 
-Create two new **xUnit Test Project (.NET Core)** templates from the same command prompt using the [`dotnet new xunit`](../tools/dotnet-new.md#test) command:
+Create two new **xUnit Test Project (.NET Core)** templates from the same command prompt using the [`dotnet new xunit`](../tools/dotnet-new-sdk-templates.md#test) command:
 
 ```dotnetcli
 dotnet new xunit -n XUnit.Coverlet.Collector

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -32,7 +32,8 @@ The `dotnet new --install` command installs a template package from the `PATH` o
 
 - **`--nuget-source <SOURCE>`**
   
-  Specifies an additional NuGet source to use during installation.
+  By default, `dotnet new --install` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
+  To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
 
 ## Examples
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet new --install option
-description: The dotnet new --install option installs a template package provided.
+description: The dotnet new --install option installs a template package.
 ms.date: 04/29/2021
 ---
 # dotnet new --install option
@@ -9,19 +9,17 @@ ms.date: 04/29/2021
 
 ## Name
 
-`dotnet new --install` - installs a template package provided.
+`dotnet new --install` - installs a template package.
 
 ## Synopsis
 
 ```dotnetcli
-
 dotnet new --install <PATH|NUGET_ID>  [--interactive] [--nuget-source <SOURCE>]
-
 ```
 
 ## Description
 
-The `dotnet new --install` installs a template package from the `PATH` or `NUGET_ID` provided. If you want to install a prerelease version of a template package, you need to specify the version in the format of `<package-name>::<package-version>`. By default, `dotnet new` passes \* for the version, which represents the latest stable package version. See an example in the [Examples](#examples) section.
+The `dotnet new --install` command installs a template package from the `PATH` or `NUGET_ID` provided. If you want to install a prerelease version of a template package, specify the version in the format `<package-name>::<package-version>`. By default, `dotnet new` passes \* for the version, which represents the latest stable package version. For more information, see the [Examples](#examples) section.
   
   If a version of the template was already installed when you run this command, the template will be updated to the specified version, or to the latest stable version if no version was specified.
   For information on creating custom templates, see [Custom templates for dotnet new](custom-templates.md).
@@ -50,7 +48,7 @@ The `dotnet new --install` installs a template package from the `PATH` or `NUGET
   dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0
   ```
 
-- Install version 2.0 of the SPA templates for ASP.NET Core from custom NuGet source using interactive mode:
+- Install version 2.0 of the SPA templates for ASP.NET Core from a custom NuGet source using interactive mode:
 
   ```dotnetcli
   dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0 --nuget-source "https://api.my-custom-nuget.com/v3/index.json" --interactive

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -1,0 +1,63 @@
+---
+title: dotnet new --install option
+description: The dotnet new --install option installs a template package provided.
+ms.date: 04/29/2021
+---
+# dotnet new --install option
+
+**This article applies to:** ✔️ .NET Core 2.0 SDK and later versions
+
+## Name
+
+`dotnet new --install` - installs a template package provided.
+
+## Synopsis
+
+```dotnetcli
+
+dotnet new --install <PATH|NUGET_ID>  [--interactive] [--nuget-source <SOURCE>]
+
+```
+
+## Description
+
+The `dotnet new --install` installs a template package from the `PATH` or `NUGET_ID` provided. If you want to install a prerelease version of a template package, you need to specify the version in the format of `<package-name>::<package-version>`. By default, `dotnet new` passes \* for the version, which represents the latest stable package version. See an example in the [Examples](#examples) section.
+  
+  If a version of the template was already installed when you run this command, the template will be updated to the specified version, or to the latest stable version if no version was specified.
+  For information on creating custom templates, see [Custom templates for dotnet new](custom-templates.md).
+
+## Options
+
+- **`--interactive`**
+  
+  Allows the command to stop and wait for user input or action (for example to complete authentication). Available since .NET Core 5.0 SDK.
+
+- **`--nuget-source <SOURCE>`**
+  
+  Specifies an additional NuGet source to use during installation.
+
+## Examples
+
+- Install the latest version of SPA templates for ASP.NET Core:
+
+  ```dotnetcli
+  dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates
+  ```
+
+- Install version 2.0 of the SPA templates for ASP.NET Core:
+
+  ```dotnetcli
+  dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0
+  ```
+
+- Install version 2.0 of the SPA templates for ASP.NET Core from custom NuGet source using interactive mode:
+
+  ```dotnetcli
+  dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0 --nuget-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
+  ```
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new --search option](dotnet-new-search.md)
+- [Custom templates for dotnet new](custom-templates.md)

--- a/docs/core/tools/dotnet-new-list.md
+++ b/docs/core/tools/dotnet-new-list.md
@@ -78,13 +78,13 @@ The `dotnet new --list` option lists available templates to use with `dotnet new
   dotnet new spa --list
   ```
 
-- List all templates matching the *we* substring. No exact match is found, so substring matching runs against both the short name and name columns.
+- List all templates matching the *we* substring.
 
   ```dotnetcli
   dotnet new we --list
   ```
 
-- List all templates matching the *we* substring that supports F# language. No exact match is found, so substring matching runs against both the short name and name columns.
+- List all templates matching the *we* substring that support the F# language.
 
   ```dotnetcli
   dotnet new we --list --language "F#"

--- a/docs/core/tools/dotnet-new-list.md
+++ b/docs/core/tools/dotnet-new-list.md
@@ -1,0 +1,111 @@
+---
+title: dotnet new --list option
+description: The dotnet new --list option lists available templates.
+ms.date: 04/29/2021
+---
+# dotnet new --list option
+
+**This article applies to:** ✔️ .NET Core 2.0 SDK and later versions
+
+## Name
+
+`dotnet new --list` -  Lists available templates to be run using `dotnet new`.
+
+## Synopsis
+
+```dotnetcli
+
+dotnet new [<TEMPLATE_NAME>] -l|--list [--author <AUTHOR>] [-lang|--language {"C#"|"F#"|VB}] [--tag <TAG>] [--type <TYPE>]
+    [--columns <COLUMNS>] [--columns-all]
+
+```
+
+## Description
+
+The `dotnet new --list` option lists available templates to be run using `dotnet new`. If the <TEMPLATE_NAME> is specified, lists templates containing the specified name.
+
+## Arguments
+
+- **`TEMPLATE_NAME`**
+
+If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in template name or short name will be shown.
+
+## Options
+
+- **`--author <AUTHOR>`**
+
+  Filters templates based on template author. Partial match is supported. Available since .NET Core 5.0.300 SDK.
+
+- **`--columns <COLUMNS>`**
+
+  Comma-separated list of columns to display in the output. The supported columns are:
+  - `language` - A comma-separated list of languages supported by the template.
+  - `tags` - The list of template tags.
+  - `author` - The template author.
+  - `type` - The template type: project or item.
+  
+  The template name and short name are always shown. The default list of columns is template name, short name, language and tags. This list is equivalent to specifying `--columns=language,tags`.
+  Available since .NET Core 5.0.300 SDK.
+
+- **`--columns-all`**
+
+  Displays all columns in the output. Available since .NET Core 5.0.300 SDK.
+
+- **`-lang|--language {C#|F#|VB}`**
+
+  Filters templates based on language supported by the template. The language accepted varies by the template. Not valid for some templates.
+
+  > [!NOTE]
+  > Some shells interpret `#` as a special character. In those cases, enclose the language parameter value in quotes. For example, `dotnet new --list --language "F#"`.
+
+- **`--tag <TAG>`**
+
+  Filters templates based on template tags. To be selected, a template must have at least one tag that exactly matches the criteria. Available since .NET Core 5.0.300 SDK.
+
+- **`--type <TYPE>`**
+
+  Filters templates based on template type. Predefined values are `project` and `item`.
+
+## Examples
+
+- List all templates
+
+  ```dotnetcli
+  dotnet new --list
+  ```
+
+- List all templates available for Single Page Application (SPA) templates:
+
+  ```dotnetcli
+  dotnet new spa --list
+  ```
+
+- List all templates matching the *we* substring. No exact match is found, so substring matching runs against both the short name and name columns.
+
+  ```dotnetcli
+  dotnet new we --list
+  ```
+
+- List all templates matching the *we* substring that supports F# language. No exact match is found, so substring matching runs against both the short name and name columns.
+
+  ```dotnetcli
+  dotnet new we --list --language "F#"
+  ```
+
+- List all item templates.
+
+  ```dotnetcli
+  dotnet new --list --type item
+  ```
+
+- List all C# templates specifying the author and the type in the output.
+
+  ```dotnetcli
+  dotnet new --list --language "C#" --columns "author,type"
+  ```
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new --search option](dotnet-new-search.md)
+- [Custom templates for dotnet new](custom-templates.md)

--- a/docs/core/tools/dotnet-new-list.md
+++ b/docs/core/tools/dotnet-new-list.md
@@ -14,21 +14,19 @@ ms.date: 04/29/2021
 ## Synopsis
 
 ```dotnetcli
-
-dotnet new [<TEMPLATE_NAME>] -l|--list [--author <AUTHOR>] [-lang|--language {"C#"|"F#"|VB}] [--tag <TAG>] [--type <TYPE>]
-    [--columns <COLUMNS>] [--columns-all]
-
+dotnet new [<TEMPLATE_NAME>] -l|--list [--author <AUTHOR>] [-lang|--language {"C#"|"F#"|VB}]
+    [--tag <TAG>] [--type <TYPE>] [--columns <COLUMNS>] [--columns-all]
 ```
 
 ## Description
 
-The `dotnet new --list` option lists available templates to be run using `dotnet new`. If the <TEMPLATE_NAME> is specified, lists templates containing the specified name.
+The `dotnet new --list` option lists available templates to use with `dotnet new`. If the <TEMPLATE_NAME> is specified, lists templates containing the specified name. This option lists only default and installed templates. To find templates in NuGet that you can install locally, use the [`--search`](dotnet-new-search.md) option.
 
 ## Arguments
 
 - **`TEMPLATE_NAME`**
 
-If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in template name or short name will be shown.
+  If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in template name or short name will be shown.
 
 ## Options
 
@@ -44,7 +42,7 @@ If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in
   - `author` - The template author.
   - `type` - The template type: project or item.
   
-  The template name and short name are always shown. The default list of columns is template name, short name, language and tags. This list is equivalent to specifying `--columns=language,tags`.
+  The template name and short name are always shown. The default list of columns is template name, short name, language, and tags. This list is equivalent to specifying `--columns=language,tags`.
   Available since .NET Core 5.0.300 SDK.
 
 - **`--columns-all`**
@@ -74,7 +72,7 @@ If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in
   dotnet new --list
   ```
 
-- List all templates available for Single Page Application (SPA) templates:
+- List all Single Page Application (SPA) templates:
 
   ```dotnetcli
   dotnet new spa --list
@@ -98,7 +96,7 @@ If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in
   dotnet new --list --type item
   ```
 
-- List all C# templates specifying the author and the type in the output.
+- List all C# templates, showing the author and the type in the output.
 
   ```dotnetcli
   dotnet new --list --language "C#" --columns "author,type"

--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -1,0 +1,680 @@
+---
+title: .NET default templates for dotnet new
+description: The information about dotnet new templates shipped with dotnet SDK.
+no-loc: [Blazor, WebAssembly]
+ms.date: 04/29/2021
+---
+# .NET default templates for dotnet new
+
+When you install the [.NET SDK](https://dotnet.microsoft.com/download), you receive over a dozen built-in templates for creating projects and files, including console apps, class libraries, unit test projects, ASP.NET Core apps (including [Angular](https://angular.io/) and [React](https://reactjs.org/) projects), and configuration files. To list the built-in templates, run the `dotnet new` command with the `-l|--list` option:
+
+```dotnetcli
+dotnet new --list
+```
+
+  The following table shows the templates that come pre-installed with the .NET SDK. The default language for the template is shown inside the brackets. Click on the short name link to see the specific template options.
+
+| Templates                                    | Short name                        | Language     | Tags                                  | Introduced |
+|----------------------------------------------|-----------------------------------|--------------|---------------------------------------|------------|
+| Console Application                          | [`console`](#console)             | [C#], F#, VB | Common/Console                        | 1.0        |
+| Class library                                | [`classlib`](#classlib)           | [C#], F#, VB | Common/Library                        | 1.0        |
+| WPF Application                              | [`wpf`](#wpf)                     | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| WPF Class library                            | [`wpflib`](#wpf)                  | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| WPF Custom Control Library                   | [`wpfcustomcontrollib`](#wpf)     | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| WPF User Control Library                     | [`wpfusercontrollib`](#wpf)       | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| Windows Forms (WinForms) Application         | [`winforms`](#winforms)           | [C#], VB     | Common/WinForms                       | 3.0 (5.0 for VB)|
+| Windows Forms (WinForms) Class library       | [`winformslib`](#winforms)        | [C#], VB     | Common/WinForms                       | 3.0 (5.0 for VB)|
+| Worker Service                               | [`worker`](#web-others)           | [C#]         | Common/Worker/Web                     | 3.0        |
+| Unit Test Project                            | [`mstest`](#test)                 | [C#], F#, VB | Test/MSTest                           | 1.0        |
+| NUnit 3 Test Project                         | [`nunit`](#nunit)                 | [C#], F#, VB | Test/NUnit                            | 2.1.400    |
+| NUnit 3 Test Item                            | `nunit-test`                      | [C#], F#, VB | Test/NUnit                            | 2.2        |
+| xUnit Test Project                           | [`xunit`](#test)                  | [C#], F#, VB | Test/xUnit                            | 1.0        |
+| Razor Component                              | `razorcomponent`                  | [C#]         | Web/ASP.NET                           | 3.0        |
+| Razor Page                                   | [`page`](#page)                   | [C#]         | Web/ASP.NET                           | 2.0        |
+| MVC ViewImports                              | [`viewimports`](#namespace)       | [C#]         | Web/ASP.NET                           | 2.0        |
+| MVC ViewStart                                | `viewstart`                       | [C#]         | Web/ASP.NET                           | 2.0        |
+| Blazor Server App                            | [`blazorserver`](#blazorserver)   | [C#]         | Web/Blazor                            | 3.0        |
+| Blazor WebAssembly App                       | [`blazorwasm`](#blazorwasm)       | [C#]         | Web/Blazor/WebAssembly                | 3.1.300    |
+| ASP.NET Core Empty                           | [`web`](#web)                     | [C#], F#     | Web/Empty                             | 1.0        |
+| ASP.NET Core Web App (Model-View-Controller) | [`mvc`](#web-options)             | [C#], F#     | Web/MVC                               | 1.0        |
+| ASP.NET Core Web App                         | [`webapp, razor`](#web-options)   | [C#]         | Web/MVC/Razor Pages                   | 2.2, 2.0   |
+| ASP.NET Core with Angular                    | [`angular`](#spa)                 | [C#]         | Web/MVC/SPA                           | 2.0        |
+| ASP.NET Core with React.js                   | [`react`](#spa)                   | [C#]         | Web/MVC/SPA                           | 2.0        |
+| ASP.NET Core with React.js and Redux         | [`reactredux`](#reactredux)       | [C#]         | Web/MVC/SPA                           | 2.0        |
+| Razor Class Library                          | [`razorclasslib`](#razorclasslib) | [C#]         | Web/Razor/Library/Razor Class Library | 2.1        |
+| ASP.NET Core Web API                         | [`webapi`](#webapi)               | [C#], F#     | Web/WebAPI                            | 1.0        |
+| ASP.NET Core gRPC Service                    | [`grpc`](#web-others)             | [C#]         | Web/gRPC                              | 3.0        |
+| dotnet gitignore file                        | `gitignore`                       |              | Config                                | 3.0        |
+| global.json file                             | [`globaljson`](#globaljson)       |              | Config                                | 2.0        |
+| NuGet Config                                 | `nugetconfig`                     |              | Config                                | 1.0        |
+| Dotnet local tool manifest file              | `tool-manifest`                   |              | Config                                | 3.0        |
+| Web Config                                   | `webconfig`                       |              | Config                                | 1.0        |
+| Solution File                                | `sln`                             |              | Solution                              | 1.0        |
+| Protocol Buffer File                         | [`proto`](#namespace)             |              | Web/gRPC                              | 3.0        |
+
+## Template options
+
+Each template may have additional options available. The core templates have the following additional options:
+
+### `console`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Available since .NET Core 3.0 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+
+- **`--langVersion <VERSION_NUMBER>`**
+
+  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3. Not supported for F#. Available since .NET Core 2.2 SDK.
+
+  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
+
+- **`--no-restore`**
+
+  If specified, doesn't execute an implicit restore during project creation. Available since .NET Core 2.2 SDK.
+
+***
+
+### `classlib`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Values: `net5.0` or `netcoreapp<version>` to create a .NET Class Library or `netstandard<version>` to create a .NET Standard Class Library. The default value for .NET 5.0 SDK is `net5.0`.
+
+- **`--langVersion <VERSION_NUMBER>`**
+
+  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3. Not supported for F#. Available since .NET Core 2.2 SDK.
+
+  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### <a name="wpf"></a> `wpf`, `wpflib`, `wpfcustomcontrollib`, `wpfusercontrollib`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `net5.0`. Available since .NET Core 3.1 SDK.
+
+- **`--langVersion <VERSION_NUMBER>`**
+
+  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3.
+
+  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### <a name="winforms"></a> `winforms`, `winformslib`
+
+- **`--langVersion <VERSION_NUMBER>`**
+
+  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3.
+
+  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### <a name="web-others"></a> `worker`, `grpc`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK.
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### <a name="test"></a> `mstest`, `xunit`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Option available since .NET Core 3.0 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+
+- **`-p|--enable-pack`**
+
+  Enables packaging for the project using [dotnet pack](dotnet-pack.md).
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### `nunit`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+  | 2.2         | `netcoreapp2.2` |
+  | 2.1         | `netcoreapp2.1` |
+
+- **`-p|--enable-pack`**
+
+  Enables packaging for the project using [dotnet pack](dotnet-pack.md).
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### `page`
+
+- **`-na|--namespace <NAMESPACE_NAME>`**
+
+  Namespace for the generated code. The default value is `MyApp.Namespace`.
+
+- **`-np|--no-pagemodel`**
+
+  Creates the page without a PageModel.
+
+***
+
+### <a name="namespace"></a> `viewimports`, `proto`
+
+- **`-na|--namespace <NAMESPACE_NAME>`**
+
+  Namespace for the generated code. The default value is `MyApp.Namespace`.
+
+***
+
+### `blazorserver`
+
+- **`-au|--auth <AUTHENTICATION_TYPE>`**
+
+  The type of authentication to use. The possible values are:
+
+  - `None` - No authentication (Default).
+  - `Individual` - Individual authentication.
+  - `IndividualB2C` - Individual authentication with Azure AD B2C.
+  - `SingleOrg` - Organizational authentication for a single tenant.
+  - `MultiOrg` - Organizational authentication for multiple tenants.
+  - `Windows` - Windows authentication.
+
+- **`--aad-b2c-instance <INSTANCE>`**
+
+  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://login.microsoftonline.com/tfp/`.
+
+- **`-ssp|--susi-policy-id <ID>`**
+
+  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`-rp|--reset-password-policy-id <ID>`**
+
+  The reset password policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`-ep|--edit-profile-policy-id <ID>`**
+
+  The edit profile policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`--aad-instance <INSTANCE>`**
+
+  The Azure Active Directory instance to connect to. Use with `SingleOrg` or `MultiOrg` authentication. The default value is `https://login.microsoftonline.com/`.
+
+- **`--client-id <ID>`**
+
+  The Client ID for this project. Use with `IndividualB2C`, `SingleOrg`, or `MultiOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
+
+- **`--domain <DOMAIN>`**
+
+  The domain for the directory tenant. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `qualified.domain.name`.
+
+- **`--tenant-id <ID>`**
+
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+
+- **`--callback-path <PATH>`**
+
+  The request path within the application's base path of the redirect URI. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `/signin-oidc`.
+
+- **`-r|--org-read-access`**
+
+  Allows this application read-access to the directory. Only applies to `SingleOrg` or `MultiOrg` authentication.
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`--no-https`**
+
+  Turns off HTTPS. This option only applies if `Individual`, `IndividualB2C`, `SingleOrg`, or `MultiOrg` aren't being used for `--auth`.
+
+- **`-uld|--use-local-db`**
+
+  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication.
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### `blazorwasm`
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+- **`-ho|--hosted`**
+
+  Includes an ASP.NET Core host for the Blazor WebAssembly app.
+
+- **`-au|--auth <AUTHENTICATION_TYPE>`**
+
+  The type of authentication to use. The possible values are:
+
+  - `None` - No authentication (Default).
+  - `Individual` - Individual authentication.
+  - `IndividualB2C` - Individual authentication with Azure AD B2C.
+  - `SingleOrg` - Organizational authentication for a single tenant.
+
+- **`--authority <AUTHORITY>`**
+
+  The authority of the OIDC provider. Use with `Individual` authentication. The default value is `https://login.microsoftonline.com/`.
+
+- **`--aad-b2c-instance <INSTANCE>`**
+
+  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://aadB2CInstance.b2clogin.com/`.
+
+- **`-ssp|--susi-policy-id <ID>`**
+
+  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`--aad-instance <INSTANCE>`**
+
+  The Azure Active Directory instance to connect to. Use with `SingleOrg` authentication. The default value is `https://login.microsoftonline.com/`.
+
+- **`--client-id <ID>`**
+
+  The Client ID for this project. Use with `IndividualB2C`, `SingleOrg`, or `Individual` authentication in standalone scenarios. The default value is `33333333-3333-3333-33333333333333333`.
+
+- **`--domain <DOMAIN>`**
+
+  The domain for the directory tenant. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `qualified.domain.name`.
+
+- **`--app-id-uri <URI>`**
+
+  The App ID Uri for the server API you want to call. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `api.id.uri`.
+
+- **`--api-client-id <ID>`**
+
+  The Client ID for the API that the server hosts. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `11111111-1111-1111-11111111111111111`.
+
+- **`-s|--default-scope <SCOPE>`**
+
+  The API scope the client needs to request to provision an access token. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `user_impersonation`.
+
+- **`--tenant-id <ID>`**
+
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+
+- **`-r|--org-read-access`**
+
+  Allows this application read-access to the directory. Only applies to `SingleOrg` authentication.
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`-p|--pwa`**
+
+  produces a Progressive Web Application (PWA) supporting installation and offline use.
+
+- **`--no-https`**
+
+  Turns off HTTPS. This option only applies if `Individual`, `IndividualB2C`, or `SingleOrg` aren't being used for `--auth`.
+
+- **`-uld|--use-local-db`**
+
+  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication.
+
+- **`--called-api-url <URL>`**
+
+  URL of the API to call from the web app. Only applies to `SingleOrg` or `IndividualB2C` authentication without an ASP.NET Core host specified. The default value is `https://graph.microsoft.com/v1.0/me`.
+
+- **`--calls-graph`**
+
+  Specifies if the web app calls Microsoft Graph. Only applies to `SingleOrg` authentication.
+
+- **`--called-api-scopes <SCOPES>`**
+
+  Scopes to request to call the API from the web app. Only applies to `SingleOrg` or `IndividualB2C` authentication without an ASP.NET Core host specified. The default is `user.read`.
+
+***
+
+### `web`
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+  | 2.1         | `netcoreapp2.1` |
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+- **`--no-https`**
+
+  Turns off HTTPS.
+
+***
+
+### <a name="web-options"></a> `mvc`, `webapp`
+
+- **`-au|--auth <AUTHENTICATION_TYPE>`**
+
+  The type of authentication to use. The possible values are:
+
+  - `None` - No authentication (Default).
+  - `Individual` - Individual authentication.
+  - `IndividualB2C` - Individual authentication with Azure AD B2C.
+  - `SingleOrg` - Organizational authentication for a single tenant.
+  - `MultiOrg` - Organizational authentication for multiple tenants.
+  - `Windows` - Windows authentication.
+
+- **`--aad-b2c-instance <INSTANCE>`**
+
+  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://login.microsoftonline.com/tfp/`.
+
+- **`-ssp|--susi-policy-id <ID>`**
+
+  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`-rp|--reset-password-policy-id <ID>`**
+
+  The reset password policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`-ep|--edit-profile-policy-id <ID>`**
+
+  The edit profile policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`--aad-instance <INSTANCE>`**
+
+  The Azure Active Directory instance to connect to. Use with `SingleOrg` or `MultiOrg` authentication. The default value is `https://login.microsoftonline.com/`.
+
+- **`--client-id <ID>`**
+
+  The Client ID for this project. Use with `IndividualB2C`, `SingleOrg`, or `MultiOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
+
+- **`--domain <DOMAIN>`**
+
+  The domain for the directory tenant. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `qualified.domain.name`.
+
+- **`--tenant-id <ID>`**
+
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+
+- **`--callback-path <PATH>`**
+
+  The request path within the application's base path of the redirect URI. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `/signin-oidc`.
+
+- **`-r|--org-read-access`**
+
+  Allows this application read-access to the directory. Only applies to `SingleOrg` or `MultiOrg` authentication.
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`--no-https`**
+
+  Turns off HTTPS. This option only applies if `Individual`, `IndividualB2C`, `SingleOrg`, or `MultiOrg` aren't being used.
+
+- **`-uld|--use-local-db`**
+
+  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication.
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Option available since .NET Core 3.0 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+- **`--use-browserlink`**
+
+  Includes BrowserLink in the project. Option not available in .NET Core 2.2 and 3.1 SDK.
+
+- **`-rrc|--razor-runtime-compilation`**
+
+  Determines if the project is configured to use [Razor runtime compilation](/aspnet/core/mvc/views/view-compilation#runtime-compilation) in Debug builds. Option available since .NET Core 3.1.201 SDK.
+
+***
+
+### <a name="spa"></a> `angular`, `react`
+
+- **`-au|--auth <AUTHENTICATION_TYPE>`**
+
+  The type of authentication to use. Available since .NET Core 3.0 SDK.
+  
+  The possible values are:
+
+  - `None` - No authentication (Default).
+  - `Individual` - Individual authentication.
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+- **`--no-https`**
+
+  Turns off HTTPS. This option only applies if authentication is `None`.
+
+- **`-uld|--use-local-db`**
+
+  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication. Available since .NET Core 3.0 SDK.
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+  | 2.1         | `netcoreapp2.0` |
+
+***
+
+### `reactredux`
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+  | 2.1         | `netcoreapp2.0` |
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+- **`--no-https`**
+
+  Turns off HTTPS.
+
+***
+
+### `razorclasslib`
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+- **`-s|--support-pages-and-views`**
+
+  Supports adding traditional Razor pages and Views in addition to components to this library. Available since .NET Core 3.0 SDK.
+
+***
+  
+### `webapi`
+
+- **`-au|--auth <AUTHENTICATION_TYPE>`**
+
+  The type of authentication to use. The possible values are:
+
+  - `None` - No authentication (Default).
+  - `IndividualB2C` - Individual authentication with Azure AD B2C.
+  - `SingleOrg` - Organizational authentication for a single tenant.
+  - `Windows` - Windows authentication.
+
+- **`--aad-b2c-instance <INSTANCE>`**
+
+  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://login.microsoftonline.com/tfp/`.
+
+- **`-ssp|--susi-policy-id <ID>`**
+
+  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
+
+- **`--aad-instance <INSTANCE>`**
+
+  The Azure Active Directory instance to connect to. Use with `SingleOrg` authentication. The default value is `https://login.microsoftonline.com/`.
+
+- **`--client-id <ID>`**
+
+  The Client ID for this project. Use with `IndividualB2C` or `SingleOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
+
+- **`--domain <DOMAIN>`**
+
+  The domain for the directory tenant. Use with `IndividualB2C` or `SingleOrg` authentication. The default value is `qualified.domain.name`.
+
+- **`--tenant-id <ID>`**
+
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+
+- **`-r|--org-read-access`**
+
+  Allows this application read-access to the directory. Only applies to `SingleOrg` authentication.
+
+- **`--exclude-launch-settings`**
+
+  Excludes *launchSettings.json* from the generated template.
+
+- **`--no-https`**
+
+  Turns off HTTPS. `app.UseHsts` and `app.UseHttpsRedirection` aren't added to `Startup.Configure`. This option only applies if `IndividualB2C` or `SingleOrg` aren't being used for authentication.
+
+- **`-uld|--use-local-db`**
+
+  Specifies LocalDB should be used instead of SQLite. Only applies to `IndividualB2C` authentication.
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
+
+  The following table lists the default values according to the SDK version number you're using:
+
+  | SDK version | Default value   |
+  |-------------|-----------------|
+  | 5.0         | `net5.0`        |
+  | 3.1         | `netcoreapp3.1` |
+  | 3.0         | `netcoreapp3.0` |
+  | 2.1         | `netcoreapp2.1` |
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore during project creation.
+
+***
+
+### `globaljson`
+
+- **`--sdk-version <VERSION_NUMBER>`**
+
+  Specifies the version of the .NET SDK to use in the *global.json* file.
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new --list option](dotnet-new-list.md)
+- [Custom templates for dotnet new](custom-templates.md)
+- [Create a custom template for dotnet new](../tutorials/cli-templates-create-item-template.md)

--- a/docs/core/tools/dotnet-new-search.md
+++ b/docs/core/tools/dotnet-new-search.md
@@ -1,0 +1,107 @@
+---
+title: dotnet new --search option
+description: The dotnet new --search option searches for the templates on NuGet.org.
+ms.date: 04/29/2021
+---
+# dotnet new --search option
+
+**This article applies to:** ✔️ .NET Core 5.0.300 SDK and later versions
+
+## Name
+
+`dotnet new --search` - searches for the templates supported by `dotnet new` on NuGet.org.
+
+## Synopsis
+
+```dotnetcli
+
+dotnet new <TEMPLATE_NAME> --search
+
+dotnet new [<TEMPLATE_NAME>] --search [--author <AUTHOR>] [-lang|--language {"C#"|"F#"|VB}] 
+    [--package <PACKAGE>] [--tag <TAG>] [--type <TYPE>]
+    [--columns <COLUMNS>] [--columns-all]
+
+```
+
+## Description
+
+The `dotnet new --search` option searches for the templates supported by `dotnet new` on NuGet.org. When the <TEMPLATE_NAME> is specified, searches for the templates containing the specified name.
+The option is available since .NET Core 5.0.300 SDK.
+
+## Arguments
+
+- **`TEMPLATE_NAME`**
+
+If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in template name or short name will be shown.
+The argument is mandatory when `--author`, `--language`, `--package`, `--tag` or `--type` options are not specified.
+
+## Options
+
+- **`--author <AUTHOR>`**
+
+  Filters templates based on template author. Partial match is supported.
+
+- **`--columns <COLUMNS>`**
+
+  Comma-separated list of columns to display in the output. The supported columns are:
+  - `language` - A comma-separated list of languages supported by the template.
+  - `tags` - The list of template tags.
+  - `author` - The template author.
+  - `type` - The template type: project or item.
+  
+  The template name, short name, package name and total downloads count are always shown. The default list of columns is template name, short name, author, language, package, and total downloads. This list is equivalent to specifying `--columns=author,language`.
+
+- **`--columns-all`**
+
+  Displays all columns in the output.
+
+- **`-lang|--language {C#|F#|VB}`**
+
+  Filters templates based on language supported by the template. The language accepted varies by the template. Not valid for some templates.
+
+  > [!NOTE]
+  > Some shells interpret `#` as a special character. In those cases, enclose the language parameter value in quotes. For example, `dotnet new --search --language "F#"`.
+
+- **`--package <PACKAGE>`**
+
+  Filters templates based on NuGet package ID. Partial match is supported.
+
+- **`--tag <TAG>`**
+
+  Filters templates based on template tags. To be selected, a template must have at least one tag that exactly matches the criteria.
+
+- **`--type <TYPE>`**
+
+  Filters templates based on template type. Predefined values are `project` and `item`.
+
+## Examples
+
+- Search for all templates available on NuGet.org matching the *spa* substring.
+
+  ```dotnetcli
+  dotnet new spa --search
+  ```
+
+- Search for all templates available on NuGet.org matching the *we* substring and supporting F# language.
+
+  ```dotnetcli
+  dotnet new we --search --lang "F#"
+  ```
+
+- Search for item templates.
+
+  ```dotnetcli
+  dotnet new --search --type item
+  ```
+
+- Search for all C# templates specifying the type and tags in the output.
+
+  ```dotnetcli
+  dotnet new -l -lang "C#" --columns "type,tags"
+  ```
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new --list option](dotnet-new-list.md)
+- [Custom templates for dotnet new](custom-templates.md)

--- a/docs/core/tools/dotnet-new-search.md
+++ b/docs/core/tools/dotnet-new-search.md
@@ -82,7 +82,7 @@ The `dotnet new --search` option searches for templates supported by `dotnet new
 - Search for all templates available on NuGet.org matching the *we* substring and supporting the F# language.
 
   ```dotnetcli
-  dotnet new we --search --lang "F#"
+  dotnet new we --search --language "F#"
   ```
 
 - Search for item templates.
@@ -94,7 +94,7 @@ The `dotnet new --search` option searches for templates supported by `dotnet new
 - Search for all C# templates, showing the type and tags in the output.
 
   ```dotnetcli
-  dotnet new --search -lang "C#" --columns "type,tags"
+  dotnet new --search --language "C#" --columns "type,tags"
   ```
 
 ## See also

--- a/docs/core/tools/dotnet-new-search.md
+++ b/docs/core/tools/dotnet-new-search.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet new --search option
-description: The dotnet new --search option searches for the templates on NuGet.org.
+description: The dotnet new --search option searches for templates on NuGet.org.
 ms.date: 04/29/2021
 ---
 # dotnet new --search option
@@ -14,26 +14,23 @@ ms.date: 04/29/2021
 ## Synopsis
 
 ```dotnetcli
-
 dotnet new <TEMPLATE_NAME> --search
 
 dotnet new [<TEMPLATE_NAME>] --search [--author <AUTHOR>] [-lang|--language {"C#"|"F#"|VB}] 
     [--package <PACKAGE>] [--tag <TAG>] [--type <TYPE>]
     [--columns <COLUMNS>] [--columns-all]
-
 ```
 
 ## Description
 
-The `dotnet new --search` option searches for the templates supported by `dotnet new` on NuGet.org. When the <TEMPLATE_NAME> is specified, searches for the templates containing the specified name.
-The option is available since .NET Core 5.0.300 SDK.
+The `dotnet new --search` option searches for templates supported by `dotnet new` on NuGet.org. When the <TEMPLATE_NAME> is specified, searches for templates containing the specified name.
 
 ## Arguments
 
 - **`TEMPLATE_NAME`**
 
-If the argument is specified, only the templates containing `<TEMPLATE_NAME>` in template name or short name will be shown.
-The argument is mandatory when `--author`, `--language`, `--package`, `--tag` or `--type` options are not specified.
+  If the argument is specified, only templates containing `<TEMPLATE_NAME>` in the template name or short name will be shown.
+  The argument is mandatory when `--author`, `--language`, `--package`, `--tag` or `--type` options are not specified.
 
 ## Options
 
@@ -82,7 +79,7 @@ The argument is mandatory when `--author`, `--language`, `--package`, `--tag` or
   dotnet new spa --search
   ```
 
-- Search for all templates available on NuGet.org matching the *we* substring and supporting F# language.
+- Search for all templates available on NuGet.org matching the *we* substring and supporting the F# language.
 
   ```dotnetcli
   dotnet new we --search --lang "F#"
@@ -94,10 +91,10 @@ The argument is mandatory when `--author`, `--language`, `--package`, `--tag` or
   dotnet new --search --type item
   ```
 
-- Search for all C# templates specifying the type and tags in the output.
+- Search for all C# templates, showing the type and tags in the output.
 
   ```dotnetcli
-  dotnet new -l -lang "C#" --columns "type,tags"
+  dotnet new --search -lang "C#" --columns "type,tags"
   ```
 
 ## See also

--- a/docs/core/tools/dotnet-new-uninstall.md
+++ b/docs/core/tools/dotnet-new-uninstall.md
@@ -1,0 +1,49 @@
+---
+title: dotnet new --uninstall option
+description: The dotnet new --uninstall option uninstalls a template package.
+ms.date: 04/29/2021
+---
+# dotnet new --uninstall option
+
+**This article applies to:** ✔️ .NET Core 2.0 SDK and later versions
+
+## Name
+
+`dotnet new --uninstall` - uninstalls a template package.
+
+## Synopsis
+
+```dotnetcli
+
+dotnet new --uninstall <PATH|NUGET_ID>
+
+```
+
+## Description
+
+The `dotnet new --install` uninstalls a template package at the `PATH` or `NUGET_ID` provided. When the `<PATH|NUGET_ID>` value isn't specified, all currently installed template packages and their associated templates are displayed. When specifying `NUGET_ID`, don't include the version number.
+  If you don't specify a parameter to this option, the command lists the installed templates and details about them.
+  > [!NOTE]
+  > To uninstall a template using a `PATH`, you need to fully qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.
+  > Don't include a final terminating directory slash on your template path.
+
+## Examples
+
+- List the installed templates and details about them, including how to uninstall them:
+
+  ```dotnetcli
+  dotnet new -u
+  ```
+
+- Uninstall the SPA templates for ASP.NET Core:
+
+  ```dotnetcli
+  dotnet new -u Microsoft.DotNet.Web.Spa.ProjectTemplates
+  ```
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new --list option](dotnet-new-list.md)
+- [dotnet new --search option](dotnet-new-search.md)
+- [Custom templates for dotnet new](custom-templates.md)

--- a/docs/core/tools/dotnet-new-update.md
+++ b/docs/core/tools/dotnet-new-update.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet new --update-* options
-description: The dotnet new --update-* options checks and apply updates to installed template packages.
+description: The dotnet new --update-* options check for and apply updates to installed template packages.
 ms.date: 04/29/2021
 ---
 # dotnet new --update-check and --update-apply options
@@ -9,22 +9,22 @@ ms.date: 04/29/2021
 
 ## Name
 
-`dotnet new --update-check` and `dotnet new --update-apply` options allow to check and apply updates to installed template packages for `dotnet new`.
+`dotnet new --update-check` checks for available updates for installed template packages.
+
+`dotnet new --update-apply` applies updates to installed template packages.
 
 ## Synopsis
 
 ```dotnetcli
-
 dotnet new --update-check
 
 dotnet new --update-apply
-
 ```
 
 ## Description
 
-The `dotnet new --update-check` checks if there are updates available for the template packs that are currently installed.
-The `dotnet new --update-apply` checks if there are updates available for the template packages that are currently installed and installs them.
+The `dotnet new --update-check` option checks if there are updates available for the template packs that are currently installed.
+The `dotnet new --update-apply` option checks if there are updates available for the template packages that are currently installed and installs them.
 
 ## See also
 

--- a/docs/core/tools/dotnet-new-update.md
+++ b/docs/core/tools/dotnet-new-update.md
@@ -1,0 +1,34 @@
+---
+title: dotnet new --update-* options
+description: The dotnet new --update-* options checks and apply updates to installed template packages.
+ms.date: 04/29/2021
+---
+# dotnet new --update-check and --update-apply options
+
+**This article applies to:** ✔️ .NET Core 3.0 SDK and later versions
+
+## Name
+
+`dotnet new --update-check` and `dotnet new --update-apply` options allow to check and apply updates to installed template packages for `dotnet new`.
+
+## Synopsis
+
+```dotnetcli
+
+dotnet new --update-check
+
+dotnet new --update-apply
+
+```
+
+## Description
+
+The `dotnet new --update-check` checks if there are updates available for the template packs that are currently installed.
+The `dotnet new --update-apply` checks if there are updates available for the template packages that are currently installed and installs them.
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new --search option](dotnet-new-search.md)
+- [dotnet new --install option](dotnet-new-install.md)
+- [Custom templates for dotnet new](custom-templates.md)

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -15,12 +15,8 @@ ms.date: 09/04/2020
 ## Synopsis
 
 ```dotnetcli
-dotnet new <TEMPLATE> [--dry-run] [--force] [-i|--install {PATH|NUGET_ID}]
-    [-lang|--language {"C#"|"F#"|VB}] [-n|--name <OUTPUT_NAME>]
-    [--nuget-source <SOURCE>] [-o|--output <OUTPUT_DIRECTORY>]
-    [-u|--uninstall] [--update-apply] [--update-check] [Template options]
-
-dotnet new <TEMPLATE> [-l|--list] [--type <TYPE>]
+dotnet new <TEMPLATE> [--dry-run] [--force] [-lang|--language {"C#"|"F#"|VB}] 
+    [-n|--name <OUTPUT_NAME>] [-o|--output <OUTPUT_DIRECTORY>] [Template options]
 
 dotnet new -h|--help
 ```
@@ -41,52 +37,54 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
   The template to instantiate when the command is invoked. Each template might have specific options you can pass. For more information, see [Template options](#template-options).
 
-  You can run `dotnet new --list` or `dotnet new -l` to see a list of all installed templates. If the `TEMPLATE` value isn't an exact match on text in the **Templates** or **Short Name** column from the returned table, a substring match is performed on those two columns.
+  You can run [`dotnet new --list` option](dotnet-new-list.md) to see a list of all installed templates. If the `TEMPLATE` value isn't an exact match on text in the **Templates** or **Short Name** column from the returned table, a substring match is performed on those two columns.
 
-  Starting with .NET Core 3.0 SDK, the CLI searches for templates in NuGet.org when you invoke the `dotnet new` command in the following conditions:
+  Starting with .NET Core 3.0 SDK and ending with .NET Core 5.0.300 SDK, the CLI searches for templates in NuGet.org when you invoke the `dotnet new` command in the following conditions:
 
   - If the CLI can't find a template match when invoking `dotnet new`, not even partial.
   - If there's a newer version of the template available. In this case, the project or artifact is created but the CLI warns you about an updated version of the template.
 
+  Starting with .NET Core 5.0.300 SDK, the [`--search` option](dotnet-new-search.md) should be used to search for templates in NuGet.org..
+
   The following table shows the templates that come pre-installed with the .NET SDK. The default language for the template is shown inside the brackets. Click on the short name link to see the specific template options.
 
-| Templates                                    | Short name                        | Language     | Tags                                  | Introduced |
-|----------------------------------------------|-----------------------------------|--------------|---------------------------------------|------------|
-| Console Application                          | [`console`](#console)             | [C#], F#, VB | Common/Console                        | 1.0        |
-| Class library                                | [`classlib`](#classlib)           | [C#], F#, VB | Common/Library                        | 1.0        |
-| WPF Application                              | [`wpf`](#wpf)                     | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
-| WPF Class library                            | [`wpflib`](#wpf)                  | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
-| WPF Custom Control Library                   | [`wpfcustomcontrollib`](#wpf)     | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
-| WPF User Control Library                     | [`wpfusercontrollib`](#wpf)       | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
-| Windows Forms (WinForms) Application         | [`winforms`](#winforms)           | [C#], VB     | Common/WinForms                       | 3.0 (5.0 for VB)|
-| Windows Forms (WinForms) Class library       | [`winformslib`](#winforms)        | [C#], VB     | Common/WinForms                       | 3.0 (5.0 for VB)|
-| Worker Service                               | [`worker`](#web-others)           | [C#]         | Common/Worker/Web                     | 3.0        |
-| Unit Test Project                            | [`mstest`](#test)                 | [C#], F#, VB | Test/MSTest                           | 1.0        |
-| NUnit 3 Test Project                         | [`nunit`](#nunit)                 | [C#], F#, VB | Test/NUnit                            | 2.1.400    |
-| NUnit 3 Test Item                            | `nunit-test`                      | [C#], F#, VB | Test/NUnit                            | 2.2        |
-| xUnit Test Project                           | [`xunit`](#test)                  | [C#], F#, VB | Test/xUnit                            | 1.0        |
-| Razor Component                              | `razorcomponent`                  | [C#]         | Web/ASP.NET                           | 3.0        |
-| Razor Page                                   | [`page`](#page)                   | [C#]         | Web/ASP.NET                           | 2.0        |
-| MVC ViewImports                              | [`viewimports`](#namespace)       | [C#]         | Web/ASP.NET                           | 2.0        |
-| MVC ViewStart                                | `viewstart`                       | [C#]         | Web/ASP.NET                           | 2.0        |
-| Blazor Server App                            | [`blazorserver`](#blazorserver)   | [C#]         | Web/Blazor                            | 3.0        |
-| Blazor WebAssembly App                       | [`blazorwasm`](#blazorwasm)       | [C#]         | Web/Blazor/WebAssembly                | 3.1.300    |
-| ASP.NET Core Empty                           | [`web`](#web)                     | [C#], F#     | Web/Empty                             | 1.0        |
-| ASP.NET Core Web App (Model-View-Controller) | [`mvc`](#web-options)             | [C#], F#     | Web/MVC                               | 1.0        |
-| ASP.NET Core Web App                         | [`webapp, razor`](#web-options)   | [C#]         | Web/MVC/Razor Pages                   | 2.2, 2.0   |
-| ASP.NET Core with Angular                    | [`angular`](#spa)                 | [C#]         | Web/MVC/SPA                           | 2.0        |
-| ASP.NET Core with React.js                   | [`react`](#spa)                   | [C#]         | Web/MVC/SPA                           | 2.0        |
-| ASP.NET Core with React.js and Redux         | [`reactredux`](#reactredux)       | [C#]         | Web/MVC/SPA                           | 2.0        |
-| Razor Class Library                          | [`razorclasslib`](#razorclasslib) | [C#]         | Web/Razor/Library/Razor Class Library | 2.1        |
-| ASP.NET Core Web API                         | [`webapi`](#webapi)               | [C#], F#     | Web/WebAPI                            | 1.0        |
-| ASP.NET Core gRPC Service                    | [`grpc`](#web-others)             | [C#]         | Web/gRPC                              | 3.0        |
-| dotnet gitignore file                        | `gitignore`                       |              | Config                                | 3.0        |
-| global.json file                             | [`globaljson`](#globaljson)       |              | Config                                | 2.0        |
-| NuGet Config                                 | `nugetconfig`                     |              | Config                                | 1.0        |
-| Dotnet local tool manifest file              | `tool-manifest`                   |              | Config                                | 3.0        |
-| Web Config                                   | `webconfig`                       |              | Config                                | 1.0        |
-| Solution File                                | `sln`                             |              | Solution                              | 1.0        |
-| Protocol Buffer File                         | [`proto`](#namespace)             |              | Web/gRPC                              | 3.0        |
+| Templates                                    | Short name                                                   | Language     | Tags                                  | Introduced |
+|----------------------------------------------|--------------------------------------------------------------|--------------|---------------------------------------|------------|
+| Console Application                          | [`console`](dotnet-new-sdk-templates.md#console)             | [C#], F#, VB | Common/Console                        | 1.0        |
+| Class library                                | [`classlib`](dotnet-new-sdk-templates.md#classlib)           | [C#], F#, VB | Common/Library                        | 1.0        |
+| WPF Application                              | [`wpf`](dotnet-new-sdk-templates.md#wpf)                     | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| WPF Class library                            | [`wpflib`](dotnet-new-sdk-templates.md#wpf)                  | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| WPF Custom Control Library                   | [`wpfcustomcontrollib`](dotnet-new-sdk-templates.md#wpf)     | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| WPF User Control Library                     | [`wpfusercontrollib`](dotnet-new-sdk-templates.md#wpf)       | [C#], VB     | Common/WPF                            | 3.0 (5.0 for VB)|
+| Windows Forms (WinForms) Application         | [`winforms`](dotnet-new-sdk-templates.md#winforms)           | [C#], VB     | Common/WinForms                       | 3.0 (5.0 for VB)|
+| Windows Forms (WinForms) Class library       | [`winformslib`](dotnet-new-sdk-templates.md#winforms)        | [C#], VB     | Common/WinForms                       | 3.0 (5.0 for VB)|
+| Worker Service                               | [`worker`](dotnet-new-sdk-templates.md#web-others)           | [C#]         | Common/Worker/Web                     | 3.0        |
+| Unit Test Project                            | [`mstest`](dotnet-new-sdk-templates.md#test)                 | [C#], F#, VB | Test/MSTest                           | 1.0        |
+| NUnit 3 Test Project                         | [`nunit`](dotnet-new-sdk-templates.md#nunit)                 | [C#], F#, VB | Test/NUnit                            | 2.1.400    |
+| NUnit 3 Test Item                            | `nunit-test`                                                 | [C#], F#, VB | Test/NUnit                            | 2.2        |
+| xUnit Test Project                           | [`xunit`](dotnet-new-sdk-templates.md#test)                  | [C#], F#, VB | Test/xUnit                            | 1.0        |
+| Razor Component                              | `razorcomponent`                                             | [C#]         | Web/ASP.NET                           | 3.0        |
+| Razor Page                                   | [`page`](dotnet-new-sdk-templates.md#page)                   | [C#]         | Web/ASP.NET                           | 2.0        |
+| MVC ViewImports                              | [`viewimports`](dotnet-new-sdk-templates.md#namespace)       | [C#]         | Web/ASP.NET                           | 2.0        |
+| MVC ViewStart                                | `viewstart`                                                  | [C#]         | Web/ASP.NET                           | 2.0        |
+| Blazor Server App                            | [`blazorserver`](dotnet-new-sdk-templates.md#blazorserver)   | [C#]         | Web/Blazor                            | 3.0        |
+| Blazor WebAssembly App                       | [`blazorwasm`](dotnet-new-sdk-templates.md#blazorwasm)       | [C#]         | Web/Blazor/WebAssembly                | 3.1.300    |
+| ASP.NET Core Empty                           | [`web`](dotnet-new-sdk-templates.md#web)                     | [C#], F#     | Web/Empty                             | 1.0        |
+| ASP.NET Core Web App (Model-View-Controller) | [`mvc`](dotnet-new-sdk-templates.md#web-options)             | [C#], F#     | Web/MVC                               | 1.0        |
+| ASP.NET Core Web App                         | [`webapp, razor`](dotnet-new-sdk-templates.md#web-options)   | [C#]         | Web/MVC/Razor Pages                   | 2.2, 2.0   |
+| ASP.NET Core with Angular                    | [`angular`](dotnet-new-sdk-templates.md#spa)                 | [C#]         | Web/MVC/SPA                           | 2.0        |
+| ASP.NET Core with React.js                   | [`react`](dotnet-new-sdk-templates.md#spa)                   | [C#]         | Web/MVC/SPA                           | 2.0        |
+| ASP.NET Core with React.js and Redux         | [`reactredux`](dotnet-new-sdk-templates.md#reactredux)       | [C#]         | Web/MVC/SPA                           | 2.0        |
+| Razor Class Library                          | [`razorclasslib`](dotnet-new-sdk-templates.md#razorclasslib) | [C#]         | Web/Razor/Library/Razor Class Library | 2.1        |
+| ASP.NET Core Web API                         | [`webapi`](dotnet-new-sdk-templates.md#webapi)               | [C#], F#     | Web/WebAPI                            | 1.0        |
+| ASP.NET Core gRPC Service                    | [`grpc`](dotnet-new-sdk-templates.md#web-others)             | [C#]         | Web/gRPC                              | 3.0        |
+| dotnet gitignore file                        | `gitignore`                                                  |              | Config                                | 3.0        |
+| global.json file                             | [`globaljson`](dotnet-new-sdk-templates.md#globaljson)       |              | Config                                | 2.0        |
+| NuGet Config                                 | `nugetconfig`                                                |              | Config                                | 1.0        |
+| Dotnet local tool manifest file              | `tool-manifest`                                              |              | Config                                | 3.0        |
+| Web Config                                   | `webconfig`                                                  |              | Config                                | 1.0        |
+| Solution File                                | `sln`                                                        |              | Solution                              | 1.0        |
+| Protocol Buffer File                         | [`proto`](dotnet-new-sdk-templates.md#namespace)             |              | Web/gRPC                              | 3.0        |
 
 ## Options
 
@@ -102,18 +100,6 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
   Prints out help for the command. It can be invoked for the `dotnet new` command itself or for any template. For example, `dotnet new mvc --help`.
 
-- **`-i|--install <PATH|NUGET_ID>`**
-
-  Installs a template pack from the `PATH` or `NUGET_ID` provided. If you want to install a prerelease version of a template package, you need to specify the version in the format of `<package-name>::<package-version>`. By default, `dotnet new` passes \* for the version, which represents the latest stable package version. See an example in the [Examples](#examples) section.
-  
-  If a version of the template was already installed when you run this command, the template will be updated to the specified version, or to the latest stable version if no version was specified.
-
-  For information on creating custom templates, see [Custom templates for dotnet new](custom-templates.md).
-
-- **`-l|--list`**
-
-  Lists templates containing the specified name. If no name is specified, lists all templates.
-
 - **`-lang|--language {C#|F#|VB}`**
 
   The language of the template to create. The language accepted varies by the template (see defaults in the [arguments](#arguments) section). Not valid for some templates.
@@ -125,676 +111,32 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
   The name for the created output. If no name is specified, the name of the current directory is used.
 
-- **`--nuget-source <SOURCE>`**
-
-  Specifies a NuGet source to use during install.
-
 - **`-o|--output <OUTPUT_DIRECTORY>`**
 
   Location to place the generated output. The default is the current directory.
 
-- **`--type <TYPE>`**
-
-  Filters templates based on available types. Predefined values are `project` and `item`.
-
-- **`-u|--uninstall [PATH|NUGET_ID]`**
-
-  Uninstalls a template pack at the `PATH` or `NUGET_ID` provided. When the `<PATH|NUGET_ID>` value isn't specified, all currently installed template packs and their associated templates are displayed. When specifying `NUGET_ID`, don't include the version number.
-
-  If you don't specify a parameter to this option, the command lists the installed templates and details about them.
-
-  > [!NOTE]
-  > To uninstall a template using a `PATH`, you need to fully qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.
-  > Don't include a final terminating directory slash on your template path.
-
-- **`--update-apply`**
-
-  Checks if there are updates available for the template packs that are currently installed and installs them. Available since .NET Core 3.0 SDK.
-
-- **`--update-check`**
-
-  Checks if there are updates available for the template packs that are currently installed. Available since .NET Core 3.0 SDK.
-
 ## Template options
 
-Each project template may have additional options available. The core templates have the following additional options:
-
-### `console`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Available since .NET Core 3.0 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-
-- **`--langVersion <VERSION_NUMBER>`**
-
-  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3. Not supported for F#. Available since .NET Core 2.2 SDK.
-
-  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
-
-- **`--no-restore`**
-
-  If specified, doesn't execute an implicit restore during project creation. Available since .NET Core 2.2 SDK.
-
-***
-
-### `classlib`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Values: `net5.0` or `netcoreapp<version>` to create a .NET Class Library or `netstandard<version>` to create a .NET Standard Class Library. The default value for .NET 5.0 SDK is `net5.0`.
-
-- **`--langVersion <VERSION_NUMBER>`**
-
-  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3. Not supported for F#. Available since .NET Core 2.2 SDK.
-
-  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### <a name="wpf"></a> `wpf`, `wpflib`, `wpfcustomcontrollib`, `wpfusercontrollib`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `net5.0`. Available since .NET Core 3.1 SDK.
-
-- **`--langVersion <VERSION_NUMBER>`**
-
-  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3.
-
-  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### <a name="winforms"></a> `winforms`, `winformslib`
-
-- **`--langVersion <VERSION_NUMBER>`**
-
-  Sets the `LangVersion` property in the created project file. For example, use `--langVersion 7.3` to use C# 7.3.
-
-  For a list of default C# versions, see [Defaults](../../csharp/language-reference/configure-language-version.md#defaults).
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### <a name="web-others"></a> `worker`, `grpc`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. The default value is `netcoreapp3.1`. Available since .NET Core 3.1 SDK.
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### <a name="test"></a> `mstest`, `xunit`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Option available since .NET Core 3.0 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-
-- **`-p|--enable-pack`**
-
-  Enables packaging for the project using [dotnet pack](dotnet-pack.md).
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### `nunit`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-  | 2.2         | `netcoreapp2.2` |
-  | 2.1         | `netcoreapp2.1` |
-
-- **`-p|--enable-pack`**
-
-  Enables packaging for the project using [dotnet pack](dotnet-pack.md).
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### `page`
-
-- **`-na|--namespace <NAMESPACE_NAME>`**
-
-  Namespace for the generated code. The default value is `MyApp.Namespace`.
-
-- **`-np|--no-pagemodel`**
-
-  Creates the page without a PageModel.
-
-***
-
-### <a name="namespace"></a> `viewimports`, `proto`
-
-- **`-na|--namespace <NAMESPACE_NAME>`**
-
-  Namespace for the generated code. The default value is `MyApp.Namespace`.
-
-***
-
-### `blazorserver`
-
-- **`-au|--auth <AUTHENTICATION_TYPE>`**
-
-  The type of authentication to use. The possible values are:
-
-  - `None` - No authentication (Default).
-  - `Individual` - Individual authentication.
-  - `IndividualB2C` - Individual authentication with Azure AD B2C.
-  - `SingleOrg` - Organizational authentication for a single tenant.
-  - `MultiOrg` - Organizational authentication for multiple tenants.
-  - `Windows` - Windows authentication.
-
-- **`--aad-b2c-instance <INSTANCE>`**
-
-  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://login.microsoftonline.com/tfp/`.
-
-- **`-ssp|--susi-policy-id <ID>`**
-
-  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`-rp|--reset-password-policy-id <ID>`**
-
-  The reset password policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`-ep|--edit-profile-policy-id <ID>`**
-
-  The edit profile policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`--aad-instance <INSTANCE>`**
-
-  The Azure Active Directory instance to connect to. Use with `SingleOrg` or `MultiOrg` authentication. The default value is `https://login.microsoftonline.com/`.
-
-- **`--client-id <ID>`**
-
-  The Client ID for this project. Use with `IndividualB2C`, `SingleOrg`, or `MultiOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
-
-- **`--domain <DOMAIN>`**
-
-  The domain for the directory tenant. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `qualified.domain.name`.
-
-- **`--tenant-id <ID>`**
-
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
-
-- **`--callback-path <PATH>`**
-
-  The request path within the application's base path of the redirect URI. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `/signin-oidc`.
-
-- **`-r|--org-read-access`**
-
-  Allows this application read-access to the directory. Only applies to `SingleOrg` or `MultiOrg` authentication.
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`--no-https`**
-
-  Turns off HTTPS. This option only applies if `Individual`, `IndividualB2C`, `SingleOrg`, or `MultiOrg` aren't being used for `--auth`.
-
-- **`-uld|--use-local-db`**
-
-  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication.
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### `blazorwasm`
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-- **`-ho|--hosted`**
-
-  Includes an ASP.NET Core host for the Blazor WebAssembly app.
-
-- **`-au|--auth <AUTHENTICATION_TYPE>`**
-
-  The type of authentication to use. The possible values are:
-
-  - `None` - No authentication (Default).
-  - `Individual` - Individual authentication.
-  - `IndividualB2C` - Individual authentication with Azure AD B2C.
-  - `SingleOrg` - Organizational authentication for a single tenant.
-
-- **`--authority <AUTHORITY>`**
-
-  The authority of the OIDC provider. Use with `Individual` authentication. The default value is `https://login.microsoftonline.com/`.
-
-- **`--aad-b2c-instance <INSTANCE>`**
-
-  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://aadB2CInstance.b2clogin.com/`.
-
-- **`-ssp|--susi-policy-id <ID>`**
-
-  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`--aad-instance <INSTANCE>`**
-
-  The Azure Active Directory instance to connect to. Use with `SingleOrg` authentication. The default value is `https://login.microsoftonline.com/`.
-
-- **`--client-id <ID>`**
-
-  The Client ID for this project. Use with `IndividualB2C`, `SingleOrg`, or `Individual` authentication in standalone scenarios. The default value is `33333333-3333-3333-33333333333333333`.
-
-- **`--domain <DOMAIN>`**
-
-  The domain for the directory tenant. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `qualified.domain.name`.
-
-- **`--app-id-uri <URI>`**
-
-  The App ID Uri for the server API you want to call. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `api.id.uri`.
-
-- **`--api-client-id <ID>`**
-
-  The Client ID for the API that the server hosts. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `11111111-1111-1111-11111111111111111`.
-
-- **`-s|--default-scope <SCOPE>`**
-
-  The API scope the client needs to request to provision an access token. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `user_impersonation`.
-
-- **`--tenant-id <ID>`**
-
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
-
-- **`-r|--org-read-access`**
-
-  Allows this application read-access to the directory. Only applies to `SingleOrg` authentication.
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`-p|--pwa`**
-
-  produces a Progressive Web Application (PWA) supporting installation and offline use.
-
-- **`--no-https`**
-
-  Turns off HTTPS. This option only applies if `Individual`, `IndividualB2C`, or `SingleOrg` aren't being used for `--auth`.
-
-- **`-uld|--use-local-db`**
-
-  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication.
-
-- **`--called-api-url <URL>`**
-
-  URL of the API to call from the web app. Only applies to `SingleOrg` or `IndividualB2C` authentication without an ASP.NET Core host specified. The default value is `https://graph.microsoft.com/v1.0/me`.
-
-- **`--calls-graph`**
-
-  Specifies if the web app calls Microsoft Graph. Only applies to `SingleOrg` authentication.
-
-- **`--called-api-scopes <SCOPES>`**
-
-  Scopes to request to call the API from the web app. Only applies to `SingleOrg` or `IndividualB2C` authentication without an ASP.NET Core host specified. The default is `user.read`.
-
-***
-
-### `web`
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-  | 2.1         | `netcoreapp2.1` |
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-- **`--no-https`**
-
-  Turns off HTTPS.
-
-***
-
-### <a name="web-options"></a> `mvc`, `webapp`
-
-- **`-au|--auth <AUTHENTICATION_TYPE>`**
-
-  The type of authentication to use. The possible values are:
-
-  - `None` - No authentication (Default).
-  - `Individual` - Individual authentication.
-  - `IndividualB2C` - Individual authentication with Azure AD B2C.
-  - `SingleOrg` - Organizational authentication for a single tenant.
-  - `MultiOrg` - Organizational authentication for multiple tenants.
-  - `Windows` - Windows authentication.
-
-- **`--aad-b2c-instance <INSTANCE>`**
-
-  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://login.microsoftonline.com/tfp/`.
-
-- **`-ssp|--susi-policy-id <ID>`**
-
-  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`-rp|--reset-password-policy-id <ID>`**
-
-  The reset password policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`-ep|--edit-profile-policy-id <ID>`**
-
-  The edit profile policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`--aad-instance <INSTANCE>`**
-
-  The Azure Active Directory instance to connect to. Use with `SingleOrg` or `MultiOrg` authentication. The default value is `https://login.microsoftonline.com/`.
-
-- **`--client-id <ID>`**
-
-  The Client ID for this project. Use with `IndividualB2C`, `SingleOrg`, or `MultiOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
-
-- **`--domain <DOMAIN>`**
-
-  The domain for the directory tenant. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `qualified.domain.name`.
-
-- **`--tenant-id <ID>`**
-
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
-
-- **`--callback-path <PATH>`**
-
-  The request path within the application's base path of the redirect URI. Use with `SingleOrg` or `IndividualB2C` authentication. The default value is `/signin-oidc`.
-
-- **`-r|--org-read-access`**
-
-  Allows this application read-access to the directory. Only applies to `SingleOrg` or `MultiOrg` authentication.
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`--no-https`**
-
-  Turns off HTTPS. This option only applies if `Individual`, `IndividualB2C`, `SingleOrg`, or `MultiOrg` aren't being used.
-
-- **`-uld|--use-local-db`**
-
-  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication.
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Option available since .NET Core 3.0 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-- **`--use-browserlink`**
-
-  Includes BrowserLink in the project. Option not available in .NET Core 2.2 and 3.1 SDK.
-
-- **`-rrc|--razor-runtime-compilation`**
-
-  Determines if the project is configured to use [Razor runtime compilation](/aspnet/core/mvc/views/view-compilation#runtime-compilation) in Debug builds. Option available since .NET Core 3.1.201 SDK.
-
-***
-
-### <a name="spa"></a> `angular`, `react`
-
-- **`-au|--auth <AUTHENTICATION_TYPE>`**
-
-  The type of authentication to use. Available since .NET Core 3.0 SDK.
-  
-  The possible values are:
-
-  - `None` - No authentication (Default).
-  - `Individual` - Individual authentication.
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-- **`--no-https`**
-
-  Turns off HTTPS. This option only applies if authentication is `None`.
-
-- **`-uld|--use-local-db`**
-
-  Specifies LocalDB should be used instead of SQLite. Only applies to `Individual` or `IndividualB2C` authentication. Available since .NET Core 3.0 SDK.
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-  | 2.1         | `netcoreapp2.0` |
-
-***
-
-### `reactredux`
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-  | 2.1         | `netcoreapp2.0` |
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-- **`--no-https`**
-
-  Turns off HTTPS.
-
-***
-
-### `razorclasslib`
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-- **`-s|--support-pages-and-views`**
-
-  Supports adding traditional Razor pages and Views in addition to components to this library. Available since .NET Core 3.0 SDK.
-
-***
-  
-### `webapi`
-
-- **`-au|--auth <AUTHENTICATION_TYPE>`**
-
-  The type of authentication to use. The possible values are:
-
-  - `None` - No authentication (Default).
-  - `IndividualB2C` - Individual authentication with Azure AD B2C.
-  - `SingleOrg` - Organizational authentication for a single tenant.
-  - `Windows` - Windows authentication.
-
-- **`--aad-b2c-instance <INSTANCE>`**
-
-  The Azure Active Directory B2C instance to connect to. Use with `IndividualB2C` authentication. The default value is `https://login.microsoftonline.com/tfp/`.
-
-- **`-ssp|--susi-policy-id <ID>`**
-
-  The sign-in and sign-up policy ID for this project. Use with `IndividualB2C` authentication.
-
-- **`--aad-instance <INSTANCE>`**
-
-  The Azure Active Directory instance to connect to. Use with `SingleOrg` authentication. The default value is `https://login.microsoftonline.com/`.
-
-- **`--client-id <ID>`**
-
-  The Client ID for this project. Use with `IndividualB2C` or `SingleOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
-
-- **`--domain <DOMAIN>`**
-
-  The domain for the directory tenant. Use with `IndividualB2C` or `SingleOrg` authentication. The default value is `qualified.domain.name`.
-
-- **`--tenant-id <ID>`**
-
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
-
-- **`-r|--org-read-access`**
-
-  Allows this application read-access to the directory. Only applies to `SingleOrg` authentication.
-
-- **`--exclude-launch-settings`**
-
-  Excludes *launchSettings.json* from the generated template.
-
-- **`--no-https`**
-
-  Turns off HTTPS. `app.UseHsts` and `app.UseHttpsRedirection` aren't added to `Startup.Configure`. This option only applies if `IndividualB2C` or `SingleOrg` aren't being used for authentication.
-
-- **`-uld|--use-local-db`**
-
-  Specifies LocalDB should be used instead of SQLite. Only applies to `IndividualB2C` authentication.
-
-- **`-f|--framework <FRAMEWORK>`**
-
-  Specifies the [framework](../../standard/frameworks.md) to target. Option not available in .NET Core 2.2 SDK.
-
-  The following table lists the default values according to the SDK version number you're using:
-
-  | SDK version | Default value   |
-  |-------------|-----------------|
-  | 5.0         | `net5.0`        |
-  | 3.1         | `netcoreapp3.1` |
-  | 3.0         | `netcoreapp3.0` |
-  | 2.1         | `netcoreapp2.1` |
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore during project creation.
-
-***
-
-### `globaljson`
-
-- **`--sdk-version <VERSION_NUMBER>`**
-
-  Specifies the version of the .NET SDK to use in the *global.json* file.
-
-***
+Each template may have additional options defined. The template options defined in .NET default templates are explained [here](dotnet-new-sdk-templates.md).
 
 ## Examples
 
-- Create a C# console application project by specifying the template name:
+- Create a C# console application project:
 
   ```dotnetcli
-  dotnet new "Console Application"
+  dotnet new console
   ```
 
 - Create an F# console application project in the current directory:
 
   ```dotnetcli
-  dotnet new console -lang "F#"
+  dotnet new console --language "F#"
   ```
 
 - Create a .NET Standard class library project in the specified directory:
 
   ```dotnetcli
-  dotnet new classlib -lang VB -o MyLibrary
+  dotnet new classlib --language VB -o MyLibrary
   ```
 
 - Create a new ASP.NET Core C# MVC project in the current directory with no authentication:
@@ -809,36 +151,6 @@ Each project template may have additional options available. The core templates 
   dotnet new xunit
   ```
 
-- List all templates available for Single Page Application (SPA) templates:
-
-  ```dotnetcli
-  dotnet new spa -l
-  ```
-
-- List all templates matching the *we* substring. No exact match is found, so substring matching runs against both the short name and name columns.
-
-  ```dotnetcli
-  dotnet new we -l
-  ```
-
-- Attempt to invoke the template matching *ng*. If a single match can't be determined, list the templates that are partial matches.
-
-  ```dotnetcli
-  dotnet new ng
-  ```
-
-- Install version 2.0 of the SPA templates for ASP.NET Core:
-
-  ```dotnetcli
-  dotnet new -i Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0
-  ```
-
-- List the installed templates and details about them, including how to uninstall them:
-
-  ```dotnetcli
-  dotnet new -u
-  ```
-
 - Create a *global.json* in the current directory setting the SDK version to 3.1.101:
 
   ```dotnetcli
@@ -847,7 +159,10 @@ Each project template may have additional options available. The core templates 
 
 ## See also
 
+- [dotnet new --list option](dotnet-new-list.md)
+- [dotnet new --search option](dotnet-new-search.md)
+- [dotnet new --install option](dotnet-new-install.md)
+- [.NET default templates](dotnet-new-sdk-templates.md)
 - [Custom templates for dotnet new](custom-templates.md)
 - [Create a custom template for dotnet new](../tutorials/cli-templates-create-item-template.md)
 - [dotnet/dotnet-template-samples GitHub repo](https://github.com/dotnet/dotnet-template-samples)
-- [Available templates for dotnet new](https://github.com/dotnet/templating/wiki/Available-templates-for-dotnet-new)

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -37,7 +37,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
   The template to instantiate when the command is invoked. Each template might have specific options you can pass. For more information, see [Template options](#template-options).
 
-  You can run [`dotnet new --list` option](dotnet-new-list.md) to see a list of all installed templates. If the `TEMPLATE` value isn't an exact match on text in the **Templates** or **Short Name** column from the returned table, a substring match is performed on those two columns.
+  You can run [`dotnet new --list`](dotnet-new-list.md) to see a list of all installed templates.
 
   Starting with .NET Core 3.0 SDK and ending with .NET Core 5.0.300 SDK, the CLI searches for templates in NuGet.org when you invoke the `dotnet new` command in the following conditions:
 

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -117,7 +117,7 @@ The command calls the [template engine](https://github.com/dotnet/templating) to
 
 ## Template options
 
-Each template may have additional options defined. The template options defined in .NET default templates are explained [here](dotnet-new-sdk-templates.md).
+Each template may have additional options defined. For more information, see [.NET default templates for `dotnet new`](dotnet-new-sdk-templates.md).
 
 ## Examples
 
@@ -162,7 +162,7 @@ Each template may have additional options defined. The template options defined 
 - [dotnet new --list option](dotnet-new-list.md)
 - [dotnet new --search option](dotnet-new-search.md)
 - [dotnet new --install option](dotnet-new-install.md)
-- [.NET default templates](dotnet-new-sdk-templates.md)
+- [.NET default templates for dotnet new](dotnet-new-sdk-templates.md)
 - [Custom templates for dotnet new](custom-templates.md)
 - [Create a custom template for dotnet new](../tutorials/cli-templates-create-item-template.md)
 - [dotnet/dotnet-template-samples GitHub repo](https://github.com/dotnet/dotnet-template-samples)

--- a/docs/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks.md
+++ b/docs/csharp/programming-guide/concepts/async/cancel-an-async-task-or-a-list-of-tasks.md
@@ -28,7 +28,7 @@ This tutorial requires the following:
 
 ### Create example application
 
-Create a new .NET Core console application. You can create one by using the [`dotnet new console`](../../../../core/tools/dotnet-new.md#console) command or from [Visual Studio](/visualstudio/install/install-visual-studio). Open the *Program.cs* file in your favorite code editor.
+Create a new .NET Core console application. You can create one by using the [`dotnet new console`](../../../../core/tools/dotnet-new-sdk-templates.md#console) command or from [Visual Studio](/visualstudio/install/install-visual-studio). Open the *Program.cs* file in your favorite code editor.
 
 ### Replace using statements
 

--- a/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -14,7 +14,7 @@ The following example uses a query to create a collection of tasks. Each task do
 
 ## Create example application
 
-Create a new .NET Core console application. You can create one by using the [dotnet new console](../../../../core/tools/dotnet-new.md#console) command or from [Visual Studio](/visualstudio/install/install-visual-studio). Open the *Program.cs* file in your favorite code editor.
+Create a new .NET Core console application. You can create one by using the [dotnet new console](../../../../core/tools/dotnet-new-sdk-templates.md#console) command or from [Visual Studio](/visualstudio/install/install-visual-studio). Open the *Program.cs* file in your favorite code editor.
 
 ### Replace using statements
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -227,6 +227,21 @@ items:
         href: ../core/tools/dotnet-msbuild.md
       - name: dotnet new
         href: ../core/tools/dotnet-new.md
+        items:
+        - name: dotnet new --list
+          href: ../core/tools/dotnet-new-list.md
+        - name: dotnet new --search
+          href: ../core/tools/dotnet-new-search.md
+        - name: dotnet new --install
+          href: ../core/tools/dotnet-new-install.md
+        - name: dotnet new --uninstall
+          href: ../core/tools/dotnet-new-uninstall.md
+        - name: dotnet new --update-*
+          href: ../core/tools/dotnet-new-update.md
+        - name: .NET default templates
+          href: ../core/tools/dotnet-new-sdk-templates.md
+        - name: Custom templates
+          href: ../core/tools/custom-templates.md
       - name: dotnet nuget
         items:
         - name: dotnet nuget delete

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -226,8 +226,9 @@ items:
       - name: dotnet msbuild
         href: ../core/tools/dotnet-msbuild.md
       - name: dotnet new
-        href: ../core/tools/dotnet-new.md
         items:
+        - name: dotnet new
+          href: ../core/tools/dotnet-new.md
         - name: dotnet new --list
           href: ../core/tools/dotnet-new-list.md
         - name: dotnet new --search

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -329,8 +329,6 @@ items:
       href: ../core/tutorials/libraries.md
     - name: Create templates for the CLI
       items:
-      - name: Custom templates
-        href: ../core/tools/custom-templates.md
       - name: 1 - Create an item template
         href: ../core/tutorials/cli-templates-create-item-template.md
         displayName: tutorials, cli


### PR DESCRIPTION
## Summary

We introduced new options in `dotnet new` in 5.0.3xx SDK. PR documents them.
Also PR splits `dotnet new` article to several articles based on sub features.
fixes https://github.com/dotnet/templating/issues/2896

Do not merge until 5.0.3xx is released.
