### PR TITLE
memory-t-usage-guidelines.md: reference to MemoryPool.Dispose should be IMemoryOwner.Dispose

### DIFF
--- a/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
+++ b/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
@@ -222,9 +222,9 @@ class Person
 
 **Rule #7: If you have an IMemoryOwner\<T> reference, you must at some point dispose of it or transfer its ownership (but not both).**
 
-Since a <xref:System.Memory%601> instance may be backed by either managed or unmanaged memory, the owner must call <xref:System.Buffers.MemoryPool%601.Dispose%2A?displayProperty=nameWithType> when work performed on the <xref:System.Memory%601> instance is complete. Alternatively, the owner may transfer ownership of the <xref:System.Buffers.IMemoryOwner%601> instance to a different component, at which point the acquiring component becomes responsible for calling <xref:System.Buffers.MemoryPool%601.Dispose%2A?displayProperty=nameWithType> at the appropriate time (more on this later).
+Since a <xref:System.Memory%601> instance may be backed by either managed or unmanaged memory, the owner must call `Dispose` on <xref:System.Buffers.IMemoryOwner%601> when work performed on the <xref:System.Memory%601> instance is complete. Alternatively, the owner may transfer ownership of the <xref:System.Buffers.IMemoryOwner%601> instance to a different component, at which point the acquiring component becomes responsible for calling `Dispose` at the appropriate time (more on this later).
 
-Failure to call the <xref:System.Buffers.MemoryPool%601.Dispose%2A> method may lead to unmanaged memory leaks or other performance degradation.
+Failure to call the `Dispose` on an <xref:System.Buffers.IMemoryOwner%601> instance may lead to unmanaged memory leaks or other performance degradation.
 
 This rule also applies to code that calls factory methods like <xref:System.Buffers.MemoryPool%601.Rent%2A?displayProperty=nameWithType>. The caller becomes the owner of the returned <xref:System.Buffers.IMemoryOwner%601> and is responsible for disposing of the instance when finished.
 
@@ -235,7 +235,7 @@ Accepting an instance of this type signals that your component intends to take o
 Any component that transfers ownership of the <xref:System.Buffers.IMemoryOwner%601> instance to a different component should no longer use that instance after the method call completes.
 
 > [!IMPORTANT]
-> If your constructor accepts <xref:System.Buffers.IMemoryOwner%601> as a parameter, its type should implement <xref:System.IDisposable>, and your <xref:System.IDisposable.Dispose%2A> method should call <xref:System.Buffers.IMemoryOwner%601.Dispose%2A?displayProperty=nameWithType>.
+> If your constructor accepts <xref:System.Buffers.IMemoryOwner%601> as a parameter, its type should implement <xref:System.IDisposable>, and your <xref:System.IDisposable.Dispose%2A> method should call `Dispose` on the <xref:System.Buffers.IMemoryOwner%601> object.
 
 **Rule #9: If you're wrapping a synchronous p/invoke method, your API should accept Span\<T> as a parameter.**
 

--- a/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
+++ b/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
@@ -224,7 +224,7 @@ class Person
 
 Since a <xref:System.Memory%601> instance may be backed by either managed or unmanaged memory, the owner must call `Dispose` on <xref:System.Buffers.IMemoryOwner%601> when work performed on the <xref:System.Memory%601> instance is complete. Alternatively, the owner may transfer ownership of the <xref:System.Buffers.IMemoryOwner%601> instance to a different component, at which point the acquiring component becomes responsible for calling `Dispose` at the appropriate time (more on this later).
 
-Failure to call the `Dispose` on an <xref:System.Buffers.IMemoryOwner%601> instance may lead to unmanaged memory leaks or other performance degradation.
+Failure to call the `Dispose` method on an <xref:System.Buffers.IMemoryOwner%601> instance may lead to unmanaged memory leaks or other performance degradation.
 
 This rule also applies to code that calls factory methods like <xref:System.Buffers.MemoryPool%601.Rent%2A?displayProperty=nameWithType>. The caller becomes the owner of the returned <xref:System.Buffers.IMemoryOwner%601> and is responsible for disposing of the instance when finished.
 

--- a/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
+++ b/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
@@ -235,7 +235,7 @@ Accepting an instance of this type signals that your component intends to take o
 Any component that transfers ownership of the <xref:System.Buffers.IMemoryOwner%601> instance to a different component should no longer use that instance after the method call completes.
 
 > [!IMPORTANT]
-> If your constructor accepts <xref:System.Buffers.IMemoryOwner%601> as a parameter, its type should implement <xref:System.IDisposable>, and your <xref:System.IDisposable.Dispose%2A> method should call <xref:System.Buffers.MemoryPool%601.Dispose%2A?displayProperty=nameWithType>.
+> If your constructor accepts <xref:System.Buffers.IMemoryOwner%601> as a parameter, its type should implement <xref:System.IDisposable>, and your <xref:System.IDisposable.Dispose%2A> method should call <xref:System.Buffers.IMemoryOwner%601.Dispose%2A?displayProperty=nameWithType>.
 
 **Rule #9: If you're wrapping a synchronous p/invoke method, your API should accept Span\<T> as a parameter.**
 


### PR DESCRIPTION
Owners of `IMemoryOwner` should call `IMemoryOwner.Dispose`, reference to `MemoryPool` is a typo here. /cc @GrabYourPitchforks 