### PR TITLE
Recovery Singleton service disposed ahead of time in exception

### DIFF
--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -7,7 +7,7 @@ namespace ConsoleDisposable.Example
 {
     class Program
     {
-        static Task Main(string[] args)
+        static async Task Main(string[] args)
         {
             using IHost host = CreateHostBuilder(args).Build();
 
@@ -17,7 +17,7 @@ namespace ConsoleDisposable.Example
             ExemplifyDisposableScoping(host.Services, "Scope 2");
             Console.WriteLine();
 
-            return host.RunAsync();
+            await host.RunAsync();
         }
         // Sample output:
         //     Scope 1...


### PR DESCRIPTION
## Summary

Use doc's code can't achieve the correct output. Use `await` for `RunAsync()` method so that Singleton service will not be disposed ahead of time. Additionally, `Main` method also need to be tagged with `async` modifier.

Fixes #Issue_Number (if available)
