### PR TITLE
Fix libomp install on macos

### DIFF
--- a/docs/machine-learning/how-to-guides/install-extra-dependencies.md
+++ b/docs/machine-learning/how-to-guides/install-extra-dependencies.md
@@ -90,5 +90,5 @@ No extra installation steps required. The library is installed when the NuGet pa
 1. Install the library with `Homebrew`
 
     ```bash
-    brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link libomp --force
+    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install ./libomp.rb && brew link libomp --force
     ```

--- a/docs/machine-learning/how-to-guides/install-extra-dependencies.md
+++ b/docs/machine-learning/how-to-guides/install-extra-dependencies.md
@@ -90,5 +90,5 @@ No extra installation steps required. The library is installed when the NuGet pa
 1. Install the library with `Homebrew`
 
     ```bash
-    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install ./libomp.rb && brew link libomp --force
+    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb && brew install ./libomp.rb && brew link libomp --force
     ```


### PR DESCRIPTION
## Summary
Brew no longer supports installing from github (https://github.com/Homebrew/brew/issues/8791), so we must use a work-around to install libomp on macos.

Describe your changes here.
This PR uses the common workaround to the new limitation of not being able to install straight from github.

Also, the current hash gives 404 (for libmp 7.0.0), this new hash is for a working version of libomp (11.1.0).

Fixes #21225 
