### PR TITLE
Corrected runtime to run-time

### DIFF
--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -65,7 +65,7 @@ That is a case-sensitive ordinal comparison. For more information about string c
 
 ### Delegate equality
 
-Two [delegate](../../programming-guide/delegates/index.md) operands of the same runtime type are equal when both of them are `null` or their invocation lists are of the same length and have equal entries in each position:
+Two [delegate](../../programming-guide/delegates/index.md) operands of the same run-time type are equal when both of them are `null` or their invocation lists are of the same length and have equal entries in each position:
 
 [!code-csharp-interactive[delegate equality](snippets/shared/EqualityOperators.cs#DelegateEquality)]
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -22,8 +22,8 @@ C# introduced pattern matching in C# 7.0. Since then, each major C# version exte
 
 In those constructs, you can match an input expression against any of the following patterns:
 
-- [Declaration pattern](#declaration-and-type-patterns): to check the runtime type of an expression and, if a match succeeds, assign an expression result to a declared variable. Introduced in C# 7.0.
-- [Type pattern](#declaration-and-type-patterns): to check the runtime type of an expression. Introduced in C# 9.0.
+- [Declaration pattern](#declaration-and-type-patterns): to check the run-time type of an expression and, if a match succeeds, assign an expression result to a declared variable. Introduced in C# 7.0.
+- [Type pattern](#declaration-and-type-patterns): to check the run-time type of an expression. Introduced in C# 9.0.
 - [Constant pattern](#constant-pattern): to test if an expression result equals a specified constant. Introduced in C# 7.0.
 - [Relational patterns](#relational-patterns): to compare an expression result with a specified constant. Introduced in C# 9.0.
 - [Logical patterns](#logical-patterns): to test if an expression matches a logical combination of patterns. Introduced in C# 9.0.
@@ -38,23 +38,23 @@ For the example of how to use those patterns to build a data-driven algorithm, s
 
 ## Declaration and type patterns
 
-You use declaration and type patterns to check if the runtime type of an expression is compatible with a given type. With a declaration pattern, you can also declare a new local variable. When a declaration pattern matches an expression, that variable is assigned a converted expression result, as the following example shows:
+You use declaration and type patterns to check if the run-time type of an expression is compatible with a given type. With a declaration pattern, you can also declare a new local variable. When a declaration pattern matches an expression, that variable is assigned a converted expression result, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/DeclarationAndTypePatterns.cs" id="BasicExample":::
 
 Beginning with C# 7.0, a *declaration pattern* with type `T` matches an expression when an expression result is non-null and any of the following conditions are true:
 
-- The runtime type of an expression result is `T`.
+- The run-time type of an expression result is `T`.
 
-- The runtime type of an expression result derives from type `T` or implements interface `T` or another [implicit reference conversion](~/_csharplang/spec/conversions.md#implicit-reference-conversions) exists from it to `T`. The following example demonstrates two cases when this condition is true:
+- The run-time type of an expression result derives from type `T`, implements interface `T`, or another [implicit reference conversion](~/_csharplang/spec/conversions.md#implicit-reference-conversions) exists from it to `T`. The following example demonstrates two cases when this condition is true:
 
   :::code language="csharp" source="snippets/patterns/DeclarationAndTypePatterns.cs" id="ReferenceConversion":::
 
-  In the preceding example, at the first call to the `GetSourceLabel` method, the first pattern matches an argument value because the argument's runtime type `int[]` derives from the <xref:System.Array> type. At the second call to the `GetSourceLabel` method, the argument's runtime type <xref:System.Collections.Generic.List%601> doesn't derive from the <xref:System.Array> type but implements the <xref:System.Collections.Generic.ICollection%601> interface.
+  In the preceding example, at the first call to the `GetSourceLabel` method, the first pattern matches an argument value because the argument's run-time type `int[]` derives from the <xref:System.Array> type. At the second call to the `GetSourceLabel` method, the argument's run-time type <xref:System.Collections.Generic.List%601> doesn't derive from the <xref:System.Array> type but implements the <xref:System.Collections.Generic.ICollection%601> interface.
 
-- The runtime type of an expression result is a [nullable value type](../builtin-types/nullable-value-types.md) with the underlying type `T`.
+- The run-time type of an expression result is a [nullable value type](../builtin-types/nullable-value-types.md) with the underlying type `T`.
 
-- A [boxing](../../programming-guide/types/boxing-and-unboxing.md#boxing) or [unboxing](../../programming-guide/types/boxing-and-unboxing.md#unboxing) conversion exists from the runtime type of an expression result to type `T`.
+- A [boxing](../../programming-guide/types/boxing-and-unboxing.md#boxing) or [unboxing](../../programming-guide/types/boxing-and-unboxing.md#unboxing) conversion exists from the run-time type of an expression result to type `T`.
 
 The following example demonstrates the last two conditions:
 
@@ -68,7 +68,7 @@ Beginning with C# 9.0, for that purpose you can use a *type pattern*, as the fol
 
 :::code language="csharp" source="snippets/patterns/DeclarationAndTypePatterns.cs" id="TypePattern":::
 
-Like a declaration pattern, a type pattern matches an expression when an expression result is non-null and its runtime type satisfies any of the conditions listed above.
+Like a declaration pattern, a type pattern matches an expression when an expression result is non-null and its run-time type satisfies any of the conditions listed above.
 
 For more information, see the [Declaration pattern](~/_csharplang/proposals/csharp-8.0/patterns.md#declaration-pattern) and [Type pattern](~/_csharplang/proposals/csharp-9.0/patterns3.md#type-patterns) sections of the feature proposal notes.
 
@@ -150,7 +150,7 @@ Beginning with C# 8.0, you use a *property pattern* to match an expression's pro
 
 A property pattern matches an expression when an expression result is non-null and every nested pattern matches the corresponding property or field of the expression result.
 
-You can also add a runtime type check and a variable declaration to a property pattern, as the following example shows:
+You can also add a run-time type check and a variable declaration to a property pattern, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="WithTypeCheck":::
 
@@ -180,7 +180,7 @@ You can use the names of tuple elements and `Deconstruct` parameters in a positi
 
 You can also extend a positional pattern in any of the following ways:
 
-- Add a runtime type check and a variable declaration, as the following example shows:
+- Add a run-time type check and a variable declaration, as the following example shows:
 
   :::code language="csharp" source="snippets/patterns/PositionalPattern.cs" id="WithTypeCheck":::
 

--- a/docs/csharp/language-reference/operators/type-testing-and-cast.md
+++ b/docs/csharp/language-reference/operators/type-testing-and-cast.md
@@ -25,14 +25,14 @@ helpviewer_keywords:
 
 You can use the following operators and expressions to perform type checking or type conversion:
 
-- [is operator](#is-operator): to check if the runtime type of an expression is compatible with a given type
-- [as operator](#as-operator): to explicitly convert an expression to a given type if its runtime type is compatible with that type
+- [is operator](#is-operator): to check if the run-time type of an expression is compatible with a given type
+- [as operator](#as-operator): to explicitly convert an expression to a given type if its run-time type is compatible with that type
 - [cast expression](#cast-expression): to perform an explicit conversion
 - [typeof operator](#typeof-operator): to obtain the <xref:System.Type?displayProperty=nameWithType> instance for a type
 
 ## is operator
 
-The `is` operator checks if the runtime type of an expression result is compatible with a given type. Beginning with C# 7.0, the `is` operator also tests an expression result against a pattern.
+The `is` operator checks if the run-time type of an expression result is compatible with a given type. Beginning with C# 7.0, the `is` operator also tests an expression result against a pattern.
 
 The expression with the type-testing `is` operator has the following form
 
@@ -66,7 +66,7 @@ For information about C# conversions, see the [Conversions](~/_csharplang/spec/c
 
 ### Type testing with pattern matching
 
-Beginning with C# 7.0, the `is` operator also tests an expression result against a pattern. The following example shows how to use a [declaration pattern](patterns.md#declaration-and-type-patterns) to check the runtime type of an expression:
+Beginning with C# 7.0, the `is` operator also tests an expression result against a pattern. The following example shows how to use a [declaration pattern](patterns.md#declaration-and-type-patterns) to check the run-time type of an expression:
 
 [!code-csharp-interactive[is with declaration pattern](snippets/shared/TypeTestingAndConversionOperators.cs#IsDeclarationPattern)]
 
@@ -125,11 +125,11 @@ You can also use the `typeof` operator with unbound generic types. The name of a
 
 [!code-csharp-interactive[typeof unbound generic](snippets/shared/TypeTestingAndConversionOperators.cs#TypeOfUnboundGeneric)]
 
-An expression cannot be an argument of the `typeof` operator. To get the <xref:System.Type?displayProperty=nameWithType> instance for the runtime type of an expression result, use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method.
+An expression cannot be an argument of the `typeof` operator. To get the <xref:System.Type?displayProperty=nameWithType> instance for the run-time type of an expression result, use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method.
 
 ### Type testing with the `typeof` operator
 
-Use the `typeof` operator to check if the runtime type of the expression result exactly matches a given type. The following example demonstrates the difference between type checking performed with the `typeof` operator and the [is operator](#is-operator):
+Use the `typeof` operator to check if the run-time type of the expression result exactly matches a given type. The following example demonstrates the difference between type checking performed with the `typeof` operator and the [is operator](#is-operator):
 
 [!code-csharp[typeof vs is](snippets/shared/TypeTestingAndConversionOperators.cs#TypeCheckWithTypeOf)]
 

--- a/docs/csharp/language-reference/operators/with-expression.md
+++ b/docs/csharp/language-reference/operators/with-expression.md
@@ -16,7 +16,7 @@ Available in C# 9.0 and later, a `with` expression produces a copy of its [recor
 
 As the preceding example shows, you use [object initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md) syntax to specify what members to modify and their new values. In a `with` expression, a left-hand operand must be of a record type.
 
-The result of a `with` expression has the same runtime type as the expression's operand, as the following example shows:
+The result of a `with` expression has the same run-time type as the expression's operand, as the following example shows:
 
 :::code language="csharp" source="snippets/with-expression/InheritanceExample.cs" :::
 


### PR DESCRIPTION
Thanks to @gewarren for the review of #23884 - I've checked all the articles in the operators folder and changed "runtime" to "run-time" where the adjective is used.
