### PR TITLE
Remove confusing sentence

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/data-types/structures-and-classes.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/structures-and-classes.md
@@ -25,7 +25,7 @@ Visual Basic unifies the syntax for structures and classes, with the result that
   
 - Both are *container* types, meaning that they contain other types as members.  
   
-- Both have members, which can include constructors, methods, properties, fields, constants, enumerations, events, and event handlers. However, do not confuse these members with the declared *elements* of a structure.  
+- Both have members, which can include constructors, methods, properties, fields, constants, enumerations, events, and event handlers.
   
 - Members of both can have individualized access levels. For example, one member can be declared `Public` and another `Private`.  
   


### PR DESCRIPTION
Fixes #23921

Neither Kathleen nor I could figure out what difference was supposedly highlight between members and elements. It added confusion without adding any information.
