### PR TITLE
Edit pass on REST tutorial

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -1,12 +1,12 @@
 ---
-title: "Tutorial: Make HTTP requests in a .NET console application using C#"
+title: "Tutorial: Make HTTP requests in a .NET console app using C#"
 description: Learn how to make HTTP requests to a REST web service and deserialize JSON responses. This tutorial creates a .NET console and uses C#.
 ms.date: 04/21/2021
 ---
 
-# Tutorial: Make HTTP requests in a .NET console application using C\#
+# Tutorial: Make HTTP requests in a .NET console app using C\#
 
-This tutorial builds an application that issues HTTP requests to a REST service on GitHub. The application reads information in JSON format and converts the JSON into C# objects. Converting from JSON to C# objects is known as *deserialization*.
+This tutorial builds an app that issues HTTP requests to a REST service on GitHub. The app reads information in JSON format and converts the JSON into C# objects. Converting from JSON to C# objects is known as *deserialization*.
 
 The tutorial shows how to:
 
@@ -22,11 +22,11 @@ If you prefer to follow along with the [final sample](https://github.com/dotnet/
 
 * [.NET SDK 5.0 or later](https://dotnet.microsoft.com/download/dotnet/5.0)
 * A code editor such as [Visual Studio Code](https://code.visualstudio.com/), which is an open
-source, cross platform editor. You can run the sample application on Windows, Linux, or macOS, or in a Docker container.
+source, cross platform editor. You can run the sample app on Windows, Linux, or macOS, or in a Docker container.
 
-## Create the client application
+## Create the client app
 
-1. Open a command prompt and create a new directory for your application. Make that the current
+1. Open a command prompt and create a new directory for your app. Make that the current
 directory.
 
 1. Enter the following command in a console window:
@@ -35,9 +35,9 @@ directory.
    dotnet new console --name WebAPIClient
    ```
 
-   This command creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient".
+   This command creates the starter files for a basic "Hello World" app. The project name is "WebAPIClient".
 
-1. Navigate into the "WebAPIClient" directory, and run the application.
+1. Navigate into the "WebAPIClient" directory, and run the app.
 
    ```dotnetcli
    cd WebAPIClient
@@ -47,11 +47,11 @@ directory.
    dotnet run
    ```
 
-   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md) to restore any dependencies that the application needs. It also runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
+   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md) to restore any dependencies that the app needs. It also runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
 
 ## Make HTTP requests
 
-This application calls the [GitHub API](https://developer.github.com/v3/) to get information about the projects under the
+This app calls the [GitHub API](https://developer.github.com/v3/) to get information about the projects under the
 [.NET Foundation](https://www.dotnetfoundation.org/) umbrella. The endpoint is <https://api.github.com/orgs/dotnet/repos>. To retrieve information, it makes an HTTP GET request. Browsers also make HTTP GET requests, so you can paste that URL into your browser address bar to see what information you'll be receiving and processing.
 
 Use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs. So the following steps create an async method and call it from the Main method.
@@ -133,7 +133,7 @@ Use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:Sys
    using System.Net.Http.Headers;
    ```
 
-1. Build the application and run it.
+1. Build the app and run it.
 
    ```dotnetcli
    dotnet run
@@ -202,7 +202,7 @@ The following steps convert the JSON response into C# objects. You use the <xref
    using System.Text.Json;
    ```
 
-1. Run the application.
+1. Run the app.
 
    ```dotnetcli
    dotnet run
@@ -231,7 +231,7 @@ The following steps convert the JSON response into C# objects. You use the <xref
    Console.WriteLine(repo.Name);
    ```
 
-1. Run the application.
+1. Run the app.
 
    The output is the same.
 
@@ -267,7 +267,7 @@ The `ProcessRepositories` method can do the async work and return a collection o
    }
    ```
 
-1. Run the application.
+1. Run the app.
 
    The output is the same.
 
@@ -307,7 +307,7 @@ The following steps add code to process a few more of the properties in the JSON
    }
    ```
 
-1. Run the application.
+1. Run the app.
 
    The list now includes the additional properties.
 
@@ -341,13 +341,13 @@ again:
    Console.WriteLine(repo.LastPush);
    ```
 
-1. Run the application.
+1. Run the app.
 
    The output includes the date and time of the last push to each repository.
 
 ## Next steps
 
-Your version of the application should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
+Your version of the app should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
 
 This tutorial showed you how to make web requests, parse the results, and display properties of those results. You've seen some of the features of the C# language that support object-oriented techniques.
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -212,9 +212,9 @@ At this point, the code retrieves a response from a web server and displays the 
 
    The output is a list of the names of the repositories that are part of the .NET Foundation.
 
-## Controlling Serialization
+## Controll serialization
 
-1. In *repo.cs*, change the `name` property to `Name` and add a `[JsonPropertyName]` attribute to specify how this pproperty appears in the JSON.
+1. In *repo.cs*, change the `name` property to `Name` and add a `[JsonPropertyName]` attribute to specify how this property appears in the JSON.
 
    ```csharp
    [JsonPropertyName("name")]
@@ -229,49 +229,51 @@ At this point, the code retrieves a response from a web server and displays the 
 
 1. In *Program.cs*, update the code to use the new capitalization of the `Name` property:
 
-```csharp
-Console.WriteLine(repo.Name);
-```
+   ```csharp
+   Console.WriteLine(repo.Name);
+   ```
 
-Execute `dotnet run` to make sure you've got the mappings correct. You should
-see the same output as before.
+1. Compile and run the application.
 
-Let's make one more change before adding new features. The `ProcessRepositories` method can do the async
-work and return a collection of the repositories. Let's return the `List<Repository>` from that method,
-and move the code that writes the information into the `Main` method.
+   ```dotnetcli
+   dotnet run
+   ```
 
-Change the signature of `ProcessRepositories` to return a task whose result is a list of `Repository`
-objects:
+## Simplify some code
 
-```csharp
-private static async Task<List<Repository>> ProcessRepositories()
-```
+The `ProcessRepositories` method can do the async work and return a collection of the repositories. Change that method to return `List<Repository>`, and move the code that writes the information into the `Main` method.
 
-Then, just return the repositories after processing the JSON response:
+1. Change the signature of `ProcessRepositories` to return a task whose result is a list of `Repository` objects:
 
-```csharp
-var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
-var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
-return repositories;
-```
+   ```csharp
+   private static async Task<List<Repository>> ProcessRepositories()
+   ```
 
-The compiler generates the `Task<T>` object for the return because you've marked this method as `async`.
-Then, let's modify the `Main` method so that it captures those results and writes each repository name
-to the console. Your `Main` method now looks like this:
+1. Return the repositories after processing the JSON response:
 
-```csharp
-public static async Task Main(string[] args)
-{
-    var repositories = await ProcessRepositories();
+   ```csharp
+   var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
+   var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
+   return repositories;
+   ```
 
-    foreach (var repo in repositories)
-        Console.WriteLine(repo.Name);
-}
-```
+   The compiler generates the `Task<T>` object for the return because you've marked this method as `async`.
 
-## Reading More Information
+1. Modify the `Main` method so that it captures those results and writes each repository name to the console. Your `Main` method now looks like this:
 
-Let's finish this by processing a few more of the properties in the JSON packet that gets sent from the
+   ```csharp
+   public static async Task Main(string[] args)
+   {
+       var repositories = await ProcessRepositories();
+   
+       foreach (var repo in repositories)
+           Console.WriteLine(repo.Name);
+   }
+   ```
+
+## Read more information
+
+Process  a few more of the properties in the JSON packet that gets sent from the
 GitHub API. You won't want to grab everything, but adding a few properties will demonstrate a few more
 features of the C# language.
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -168,7 +168,7 @@ The following steps convert the JSON response into C# objects. You use the <xref
 
    The JSON for a repository object contains dozens of properties,but only the `name` property will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the target class. This feature makes it easier to create types that work with only a subset of fields in a large JSON packet.
 
-   The C# convention is to capitalize the first letter of property names, but the `name` property here starts with a lowercase letter because that matches exactly what's in the JSON. Later you'll see how to use C# property names that don't match the JSON property names.
+   The C# convention is to [capitalize the first letter of property names](../../standard/design-guidelines/capitalization-conventions.md), but the `name` property here starts with a lowercase letter because that matches exactly what's in the JSON. Later you'll see how to use C# property names that don't match the JSON property names.
 
 1. Use the serializer to convert JSON into C# objects. Replace the call to
 <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)> in the `ProcessRepositories` method with the following lines:

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -1,251 +1,216 @@
 ---
-title: Create a REST client using .NET Core
-description: This tutorial teaches you about some features in .NET Core and the C# language.
-ms.date: 01/09/2020
-ms.assetid: 51033ce2-7a53-4cdd-966d-9da15c8204d2
+title: "Tutorial: Make HTTP requests from a .NET console application using C#"
+description: Learn how to make HTTP requests from a .NET console application to a REST web service using C#.
+ms.date: 04/21/2021
 ---
 
-# REST client
+# Tutorial: Make HTTP requests from a .NET console application using C\#
 
-This tutorial teaches you a number of features in .NET Core and the C# language. You'll learn:
+In this tutorial you learn how to:
 
-* The basics of the .NET Core CLI.
-* An overview of C# Language features.
-* Managing dependencies with NuGet
-* HTTP Communications
-* Processing JSON information
-* Managing configuration with Attributes.
+> [!div class="checklist"]
+>
+> * Do HTTP Communications.
+> * Process JSON information.
+> * Manage configuration with Attributes.
 
-You'll build an application that issues HTTP Requests to a REST
-service on GitHub. You'll read information in JSON format, and convert
-that JSON packet into C# objects. Finally, you'll see how to work with
-C# objects.
-
-There are many features in this tutorial. Let's build them one by one.
+You'll build an application that issues HTTP requests to a REST
+service on GitHub. You'll read information in JSON format and convert
+the JSON into C# objects.
 
 If you prefer to follow along with the [final sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient) for this article, you can download it. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#view-and-download-samples).
 
 ## Prerequisites
 
-You'll need to set up your machine to run .NET core. You can find the
-installation instructions on the [.NET Core Downloads](https://dotnet.microsoft.com/download)
-page. You can run this
-application on Windows, Linux, or macOS, or in a Docker container.
-You'll need to install your favorite code editor. The descriptions below
-use [Visual Studio Code](https://code.visualstudio.com/), which is an open
-source, cross platform editor. However, you can use whatever tools you are
-comfortable with.
+* [.NET SDK 5.0 or later](https://dotnet.microsoft.com/download/dotnet/5.0)
+* A code editor. The tutorial instructions refer to [Visual Studio Code](https://code.visualstudio.com/), which is an open
+source, cross platform editor. You can run this application on Windows, Linux, or macOS, or in a Docker container.
 
-## Create the Application
+## Create the client application
 
-The first step is to create a new application. Open a command prompt and
-create a new directory for your application. Make that the current
+1. Open a command prompt and create a new directory for your application. Make that the current
 directory. Enter the following command in a console window:
 
-```dotnetcli
-dotnet new console --name WebAPIClient
-```
+   ```dotnetcli
+   dotnet new console --name WebAPIClient
+   ```
 
-This creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient". As this is a new project, none of the dependencies are in place. The first run will download the .NET Core framework, install a development certificate, and run the NuGet package manager to restore missing dependencies.
+   This creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient". As this is a new project, none of the dependencies are in place.
 
-Before you start making modifications, `cd` into the "WebAPIClient" directory and type
-`dotnet run` ([see note](#dotnet-restore-note)) at the command prompt to
-run your application. `dotnet run` automatically performs `dotnet restore`
-if your environment is missing dependencies. It also performs `dotnet build` if your application needs to be rebuilt.
-After your initial setup, you will only need to run `dotnet restore` or `dotnet build`
-when it makes sense for your project.
+1. Navigate into the "WebAPIClient" directory and type `dotnet run` at the command prompt to run the application.
 
-## Adding New Dependencies
+   ```dotnetcli
+   cd WebAPIClient
+   dotnet run
+   ```
 
-One of the key design goals for .NET Core is to minimize the size of
-the .NET installation. If an application
-needs additional libraries for some of its features, you add those
-dependencies into your C# project (\*.csproj) file. For our example, you'll need to add the `System.Runtime.Serialization.Json` package,
-so your application can process JSON responses.
+   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md) and runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
 
-You'll need the `System.Runtime.Serialization.Json` package for this application. Add it to your project by running the following [.NET CLI](../../core/tools/dotnet-add-package.md) command:
+## Make HTTP requests
 
-```dotnetcli
-dotnet add package System.Text.Json
-```
+This application will call the [GitHub API](https://developer.github.com/v3/) to get information about the projects under the
+[.NET Foundation](https://www.dotnetfoundation.org/) umbrella. The endpoint is: <https://api.github.com/orgs/dotnet/repos>. To retrieve information, it makes an HTTP GET request. Browsers also make HTTP GET requests, so you can paste that URL into your browser address bar to see what information you'll be receiving and processing.
 
-## Making Web Requests
+You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs.
 
-Now you're ready to start retrieving data from the web. In this
-application, you'll read information from the
-[GitHub API](https://developer.github.com/v3/). Let's read information
-about the projects under the
-[.NET Foundation](https://www.dotnetfoundation.org/) umbrella. You'll
-start by making the request to the GitHub API to retrieve information
-on the projects. The endpoint you'll use is: <https://api.github.com/orgs/dotnet/repos>. You want to retrieve all the
-information about these projects, so you'll use an HTTP GET request.
-Your browser also uses HTTP GET requests, so you can paste that URL into
-your browser to see what information you'll be receiving and processing.
+1. Open the `Program.cs` file in your project directory and add the following async method to the `Program` class:
 
-You use the <xref:System.Net.Http.HttpClient> class to make web requests. Like all modern .NET
-APIs, <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs.
-Start by making an async method. You'll fill in the implementation as you
-build the functionality of the application. Start by opening the `program.cs` file in your project directory and adding the following method to the `Program` class:
+   ```csharp
+   private static async Task ProcessRepositories()
+   {
+   }
+   ```
 
-```csharp
-private static async Task ProcessRepositories()
-{
-}
-```
-
-You'll need to add a `using` directive at the top of your `Main` method so
+1. Add a `using` directive at the top of the program.cs file so
 that the C# compiler recognizes the <xref:System.Threading.Tasks.Task> type:
 
-```csharp
-using System.Threading.Tasks;
-```
+   ```csharp
+   using System.Threading.Tasks;
+   ```
 
-If you build your project at this point, you'll get a warning generated
-for this method, because it does not contain any `await` operators and
-will run synchronously. Ignore that for now; you'll add `await` operators
-as you fill in the method.
+If you build the project at this point, you get a warning generated for this method, because it doesn't contain any `await` operators and
+runs synchronously. Ignore that for now; you'll add `await` operators as you fill in the method.
 
-Next, update the `Main` method to call the `ProcessRepositories` method. The
-`ProcessRepositories` method returns a task, and you shouldn't exit the
-program before that task finishes. Therefore, you must change the signature of `Main`. Add the `async` modifier, and change the return type to `Task`. Then, in the body of the method, add a call to `ProcessRepositories`. Add the `await` keyword to that method call:
+1. Replace the `Main` method with the following code:
 
-```csharp
-static async Task Main(string[] args)
-{
-    await ProcessRepositories();
-}
-```
+   ```csharp
+   static async Task Main(string[] args)
+   {
+       await ProcessRepositories();
+   }
+   ```
 
-Now, you have a program that does nothing, but does it asynchronously. Let's improve it.
+   These changes:
 
-First you need an object that is capable to retrieve data from the web; you can use
- a <xref:System.Net.Http.HttpClient> to do that. This object handles the request and the responses. Instantiate a single instance of that type in the `Program` class inside the *Program.cs* file.
+   * Change the signature of `Main` by adding the `async` modifier and changing the return type to `Task`.
+   * Replace the `Console.WriteLine` statement with a call to `ProcessRepositories` that uses the `await` keyword.
 
-```csharp
-namespace WebAPIClient
-{
-    class Program
-    {
-        private static readonly HttpClient client = new HttpClient();
+1. In the Program class, create a static instance of <xref:System.Net.Http.HttpClient> to handle requests and responses.
 
-        static async Task Main(string[] args)
-        {
-            //...
-        }
-    }
-}
-```
+   ```csharp
+   namespace WebAPIClient
+   {
+       class Program
+       {
+           private static readonly HttpClient client = new HttpClient();
 
-Let's go back to the `ProcessRepositories` method and fill in a first version of it:
+           static async Task Main(string[] args)
+           {
+               //...
+           }
+       }
+   }
+   ```
 
-```csharp
-private static async Task ProcessRepositories()
-{
-    client.DefaultRequestHeaders.Accept.Clear();
-    client.DefaultRequestHeaders.Accept.Add(
-        new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
-    client.DefaultRequestHeaders.Add("User-Agent", ".NET Foundation Repository Reporter");
+1. Add code to the `ProcessRepositories` method to call the GitHub endpoint and display the result.
 
-    var stringTask = client.GetStringAsync("https://api.github.com/orgs/dotnet/repos");
+   ```csharp
+   private static async Task ProcessRepositories()
+   {
+       client.DefaultRequestHeaders.Accept.Clear();
+       client.DefaultRequestHeaders.Accept.Add(
+           new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
+       client.DefaultRequestHeaders.Add("User-Agent", ".NET Foundation Repository Reporter");
+   
+       var stringTask = client.GetStringAsync("https://api.github.com/orgs/dotnet/repos");
+   
+       var msg = await stringTask;
+       Console.Write(msg);
+   }
+   ```
 
-    var msg = await stringTask;
-    Console.Write(msg);
-}
-```
+1. Add two `using` directives at the top of the file:
 
-You'll need to also add two new `using` directives at the top of the file for this to compile:
+   ```csharp
+   using System.Net.Http;
+   using System.Net.Http.Headers;
+   ```
 
-```csharp
-using System.Net.Http;
-using System.Net.Http.Headers;
-```
+The code in `ProcessRepositories` makes a web request to read the list of all repositories under the .NET foundation organization. (The GitHub ID for the .NET Foundation is `dotnet`.)
 
-This first version makes a web request to read the list of all repositories under the dotnet
-foundation organization. (The GitHub ID for the .NET Foundation is `dotnet`.) The first few lines set up
-the <xref:System.Net.Http.HttpClient> for this request. First, it is configured to accept the GitHub JSON responses.
-This format is simply JSON. The next line adds a User Agent header to all requests from this
-object. These two headers are checked by the GitHub server code, and are necessary to retrieve
-information from GitHub.
+The first few lines set up HTTP headers that will be included in all requests:
+  
+* An `Accept` header to accept the GitHub JSON responses.
+* A `User-Agent` header.
 
-After you've configured the <xref:System.Net.Http.HttpClient>, you make a web request and retrieve the response. In
-this first version, you use the <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> convenience method. This convenience method
-starts a task that makes the web request, and then when the request returns, it reads the
-response stream and extracts the content from the stream. The body of the response is returned
-as a <xref:System.String>. The string is available when the task completes.
+These two headers are checked by the GitHub server code, and are necessary to retrieve information from GitHub.
 
-The final two lines of this method await that task, and then print the response to the console.
-Build the app, and run it. The build warning is gone now, because the `ProcessRepositories` now
-does contain an `await` operator. You'll see a long display of JSON formatted text.
+After the headers are configured, <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> is called to make a web request and retrieve the response. This method starts a task that makes the web request, and then when the request returns, it reads the response stream and extracts the content from the stream. The body of the response is returned as a <xref:System.String>. The string is available when the task completes.
+
+The final two lines of this method await that task and then print the response to the console.
+
+1. Build the app and run it.
+
+   ```dotnetcli
+   dotnet run
+   ```
+
+   The build warning is gone, because the `ProcessRepositories` now does contain an `await` operator. The output is a long display of JSON formatted text.
 
 ## Processing the JSON Result
 
-At this point, you've written the code to retrieve a response from a web server, and display
-the text that is contained in that response. Next, let's convert that JSON response into C#
-objects.
+At this point, the code retrieves a response from a web server and displays the text that is contained in that response. In the following steps, you convert that JSON response into C# objects. You'll use the <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class to serializes objects to JSON and deserializes JSON into objects.
 
-The <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class serializes objects to JSON and deserializes JSON into objects. Start by defining a class to represent the `repo` JSON object returned from the GitHub API:
+1. Create a file named "repo.cs" and put the following code in it. This code defines a class to represent the `repo` JSON object returned from the GitHub API:
 
-```csharp
-using System;
+   ```csharp
+   using System;
+   
+   namespace WebAPIClient
+   {
+       public class Repository
+       {
+           public string name { get; set; }
+       }
+   }
+   ```
 
-namespace WebAPIClient
-{
-    public class Repository
-    {
-        public string name { get; set; }
-    }
-}
-```
+   You'll use this class to display a list of repository names. When you deserialize a repository object from the JSON, only the name proprey will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the class that is the target of deserialization. This feature makes it easier to create types that work with only a subset of the fields in the JSON packet.
 
-Put the above code in a new file called 'repo.cs'. This version of the class represents the
-simplest path to process JSON data. The class name and the member name match the names used
-in the JSON packet, instead of following C# conventions. You'll fix that by providing some
-configuration attributes later. This class demonstrates another important feature of JSON
-serialization and deserialization: Not all the fields in the JSON packet are part of this class.
-The JSON serializer will ignore information that is not included in the class type being used.
-This feature makes it easier to create types that work with only a subset of the fields in
-the JSON packet.
+    The name property is in lowercase letters because that matches exactly what's in the JSON. Later you'll see how to follow the C# convention of capitalizing the first letter of property names.
 
-Now that you've created the type, let's deserialize it.
+1. Use the serializer to convert JSON into C# objects. Replace the call to
+<xref:System.Net.Http.HttpClient.GetStringAsync(System.String)> in the `ProcessRepositories` method with the following lines:
 
-Next, you'll use the serializer to convert JSON into C# objects. Replace the call to
-<xref:System.Net.Http.HttpClient.GetStringAsync(System.String)> in your `ProcessRepositories` method with the following lines:
+   ```csharp
+   var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
+   var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
+   ```
 
-```csharp
-var streamTask = client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
-var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
-```
+1. Add the following `using` directives at the top of the file:
 
-You're using new namespaces, so you'll need to add it at the top of the file as well:
+   ```csharp
+   using System.Collections.Generic;
+   using System.Text.Json;
+   ```
 
-```csharp
-using System.Collections.Generic;
-using System.Text.Json;
-```
+   Notice that you're now using <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. The serializer uses a stream instead of a string as its source.
 
-Notice that you're now using <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. The serializer
-uses a stream instead of a string as its source. Let's explain a couple features of the C#
-language that are being used in the second line of the preceding code snippet. The first argument to <xref:System.Text.Json.JsonSerializer.DeserializeAsync%60%601(System.IO.Stream,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken)?displayProperty=nameWithType> is an
-`await` expression. (The other two parameters are optional and are omitted in the code snippet.) Await expressions can appear almost anywhere in your code, even though
-up to now, you've only seen them as part of an assignment statement. The `Deserialize` method is *generic*, which means you must supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, the <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<>`. The JSON text represents a collection of repo objects, so the type argument is `Repository`.
+   The first argument to <xref:System.Text.Json.JsonSerializer.DeserializeAsync%60%601(System.IO.Stream,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken)?displayProperty=nameWithType> is an `await` expression. (The other two parameters are optional and are omitted in the code snippet.) `await` expressions can appear almost anywhere in your code, even though up to now, you've only seen them as part of an assignment statement.
 
-You're almost done with this section. Now that you've converted the JSON to C# objects, let's display
-the name of each repository. Replace the lines that read:
+   The `Deserialize` method is *generic*, which means you must supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, the <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The JSON text represents a collection of repository objects, so the type argument is `Repository`.
 
-```csharp
-var msg = await stringTask;   //**Deleted this
-Console.Write(msg);
-```
+1. Add code to display the name of each repository. Replace the lines that read:
 
-with the following:
+   ```csharp
+   var msg = await stringTask;   //**Deleted this
+   Console.Write(msg);
+   ```
 
-```csharp
-foreach (var repo in repositories)
-    Console.WriteLine(repo.name);
-```
+   with the following:
 
-Compile and run the application. It will print the names of the repositories that are part of the
-.NET Foundation.
+   ```csharp
+   foreach (var repo in repositories)
+       Console.WriteLine(repo.name);
+   ```
+
+1. Compile and run the application.
+
+   ```dotnetcli
+   dotnet run
+   ```
+
+   The output is a list of the names of the repositories that are part of the .NET Foundation.
 
 ## Controlling Serialization
 
@@ -382,7 +347,3 @@ Your version should now match the [finished sample](https://github.com/dotnet/sa
 This tutorial showed you how to make web requests, parse the result, and display properties of
 those results. You've also added new packages as dependencies in your project. You've seen some of
 the features of the C# language that support object-oriented techniques.
-
-<a name="dotnet-restore-note"></a>
-
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -122,7 +122,10 @@ Use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:Sys
 
    This code:
 
-   * Sets up HTTP headers for all requests: an `Accept` header to accept JSON responses, and a `User-Agent` header. These headers are checked by the GitHub server code and are necessary to retrieve information from GitHub.
+   * Sets up HTTP headers for all requests:
+     * An [`Accept`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept) header to accept JSON responses
+     * A [`User-Agent`](https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent) header.
+     These headers are checked by the GitHub server code and are necessary to retrieve information from GitHub.
    * Calls <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> to make a web request and retrieve the response. This method starts a task that makes the web request. When the request returns, the task reads the response stream and extracts the content from the stream. The body of the response is returned as a <xref:System.String>, which is available when the task completes.
    * Awaits the task for the response string and prints the response to the console.
 
@@ -139,7 +142,7 @@ Use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:Sys
    dotnet run
    ```
 
-   There is no build warning, because the `ProcessRepositories` now does contain an `await` operator.
+   There is no build warning because the `ProcessRepositories` now contains an `await` operator.
 
    The output is a long display of JSON text.
 
@@ -147,7 +150,7 @@ Use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:Sys
 
 The following steps convert the JSON response into C# objects. You use the <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class to deserialize JSON into objects.
 
-1. Create a file named *repo.cs* and put the following code in it. This code defines a class to represent the JSON object returned from the GitHub API:
+1. Create a file named *repo.cs* and add the following code:
 
    ```csharp
    using System;
@@ -161,7 +164,7 @@ The following steps convert the JSON response into C# objects. You use the <xref
    }
    ```
 
-   You'll use this class to display a list of repository names.
+   The preceding code defines a class to represent the JSON object returned from the GitHub API. You'll use this class to display a list of repository names.
 
    The JSON for a repository object contains dozens of properties,but only the `name` property will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the target class. This feature makes it easier to create types that work with only a subset of fields in a large JSON packet.
 
@@ -175,11 +178,11 @@ The following steps convert the JSON response into C# objects. You use the <xref
    var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
    ```
 
-   The new code calls <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. This serializer method uses a stream instead of a string as its source.
+   The updated code replaces <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)> with <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)>. This serializer method uses a stream instead of a string as its source.
 
-   The first argument to <xref:System.Text.Json.JsonSerializer.DeserializeAsync%60%601(System.IO.Stream,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken)?displayProperty=nameWithType> is an `await` expression. (The other two parameters are optional and are omitted in the code snippet.) `await` expressions can appear almost anywhere in your code, even though up to now, you've only seen them as part of an assignment statement.
+   The first argument to <xref:System.Text.Json.JsonSerializer.DeserializeAsync%60%601(System.IO.Stream,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken)?displayProperty=nameWithType> is an `await` expression. `await` expressions can appear almost anywhere in your code, even though up to now, you've only seen them as part of an assignment statement. The other two parameters, `JsonSerializerOptions` and `CancellationToken`, are optional and are omitted in the code snippet.
 
-   The `DeserializeAsync` method is *generic*, which means you supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, a <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The type argument is your `Repository` class, because the JSON text represents a collection of repository objects.
+   The `DeserializeAsync` method is [*generic*](../programming-guide/generics/index.md), which means you supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, a <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The type argument is your `Repository` class, because the JSON text represents a collection of repository objects.
 
 1. Add code to display the name of each repository. Replace the lines that read:
 
@@ -273,7 +276,7 @@ The `ProcessRepositories` method can do the async work and return a collection o
 
 ## Deserialize more properties
 
-The following steps add code to process a few more of the properties in the JSON packet that is received. You won't want to grab everything, but adding a few properties demonstrates more features of the C# language.
+The following steps add code to process more of the properties in the  received JSON packet. You probably won't want to process every property, but adding a few more demonstrates other features of C#.
 
 1. Add the following properties to the `Repository` class definition:
 
@@ -291,7 +294,7 @@ The following steps add code to process a few more of the properties in the JSON
    public int Watchers { get; set; }
    ```
 
-   The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. So no extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.
+   The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. No extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.
 
 1. Update the `Main` method to display the property values:
 
@@ -347,8 +350,6 @@ again:
 
 ## Next steps
 
-Your version of the app should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
-
-This tutorial showed you how to make web requests, parse the results, and display properties of those results. You've seen some of the features of the C# language that support object-oriented techniques.
+In this tutorial, you created an app that makes web requests and parses the results. Your version of the app should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
 
 Learn more about how to configure JSON serialization in [How to serialize and deserialize (marshal and unmarshal) JSON in .NET](../../standard/serialization/system-text-json-how-to.md).

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -10,48 +10,49 @@ In this tutorial you learn how to:
 
 > [!div class="checklist"]
 >
-> * Do HTTP Communications.
-> * Process JSON information.
-> * Manage configuration with Attributes.
+> * Send HTTP requests.
+> * Process HTTP JSON responses.
+> * Configure JSON processing with Attributes.
 
-You'll build an application that issues HTTP requests to a REST
-service on GitHub. You'll read information in JSON format and convert
+You'll build an application that issues HTTP requests to a REST service on GitHub. The application reads information in JSON format and converts
 the JSON into C# objects.
 
-If you prefer to follow along with the [final sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient) for this article, you can download it. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#view-and-download-samples).
+If you prefer to follow along with the [final sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient) for this tutorial, you can download it. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#view-and-download-samples).
 
 ## Prerequisites
 
 * [.NET SDK 5.0 or later](https://dotnet.microsoft.com/download/dotnet/5.0)
-* A code editor. The tutorial instructions refer to [Visual Studio Code](https://code.visualstudio.com/), which is an open
+* A code editor such as [Visual Studio Code](https://code.visualstudio.com/), which is an open
 source, cross platform editor. You can run this application on Windows, Linux, or macOS, or in a Docker container.
 
 ## Create the client application
 
 1. Open a command prompt and create a new directory for your application. Make that the current
-directory. Enter the following command in a console window:
+directory.
+
+1. Enter the following command in a console window:
 
    ```dotnetcli
    dotnet new console --name WebAPIClient
    ```
 
-   This creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient". As this is a new project, none of the dependencies are in place.
+   This command creates the starter files for a basic "Hello World" application. The project name is "WebAPIClient".
 
-1. Navigate into the "WebAPIClient" directory and type `dotnet run` at the command prompt to run the application.
+1. Navigate into the "WebAPIClient" directory, and run the application.
 
    ```dotnetcli
    cd WebAPIClient
    dotnet run
    ```
 
-   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md) and runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
+   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md), and it runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
 
 ## Make HTTP requests
 
 This application will call the [GitHub API](https://developer.github.com/v3/) to get information about the projects under the
 [.NET Foundation](https://www.dotnetfoundation.org/) umbrella. The endpoint is: <https://api.github.com/orgs/dotnet/repos>. To retrieve information, it makes an HTTP GET request. Browsers also make HTTP GET requests, so you can paste that URL into your browser address bar to see what information you'll be receiving and processing.
 
-You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs.
+You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs. So the following steps create an async method and call it from the Main method.
 
 1. Open the `Program.cs` file in your project directory and add the following async method to the `Program` class:
 
@@ -61,15 +62,13 @@ You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <x
    }
    ```
 
-1. Add a `using` directive at the top of the program.cs file so
-that the C# compiler recognizes the <xref:System.Threading.Tasks.Task> type:
+1. Add a `using` directive at the top of the *Program.cs* file so that the C# compiler recognizes the <xref:System.Threading.Tasks.Task> type:
 
    ```csharp
    using System.Threading.Tasks;
    ```
 
-If you build the project at this point, you get a warning generated for this method, because it doesn't contain any `await` operators and
-runs synchronously. Ignore that for now; you'll add `await` operators as you fill in the method.
+  If you run `dotnet build` at this point, the compile succeeds but you get a warning that this method doesn't contain any `await` operators and runs synchronously. You'll add `await` operators later as you fill in the method.
 
 1. Replace the `Main` method with the following code:
 
@@ -80,12 +79,12 @@ runs synchronously. Ignore that for now; you'll add `await` operators as you fil
    }
    ```
 
-   These changes:
+   This code:
 
-   * Change the signature of `Main` by adding the `async` modifier and changing the return type to `Task`.
-   * Replace the `Console.WriteLine` statement with a call to `ProcessRepositories` that uses the `await` keyword.
+   * Changes the signature of `Main` by adding the `async` modifier and changing the return type to `Task`.
+   * Replaces the `Console.WriteLine` statement with a call to `ProcessRepositories` that uses the `await` keyword.
 
-1. In the Program class, create a static instance of <xref:System.Net.Http.HttpClient> to handle requests and responses.
+1. In the `Program` class, create a static instance of <xref:System.Net.Http.HttpClient> to handle requests and responses.
 
    ```csharp
    namespace WebAPIClient
@@ -102,7 +101,7 @@ runs synchronously. Ignore that for now; you'll add `await` operators as you fil
    }
    ```
 
-1. Add code to the `ProcessRepositories` method to call the GitHub endpoint and display the result.
+1. In the `ProcessRepositories` method, call the GitHub endpoint that returns a list of all repositories under the .NET foundation organization:
 
    ```csharp
    private static async Task ProcessRepositories()
@@ -119,6 +118,12 @@ runs synchronously. Ignore that for now; you'll add `await` operators as you fil
    }
    ```
 
+   This code:
+
+   * Sets up HTTP headers for all requests: an `Accept` header to accept JSON responses, and a `User-Agent` header. These headers are checked by the GitHub server code and are necessary to retrieve information from GitHub.
+   * Calls <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> to make a web request and retrieve the response. This method starts a task that makes the web request, and then when the request returns, it reads the response stream and extracts the content from the stream. The body of the response is returned as a <xref:System.String>. The string is available when the task completes.
+   * Awaits the async task for the response string and prints the response to the console.
+
 1. Add two `using` directives at the top of the file:
 
    ```csharp
@@ -126,32 +131,21 @@ runs synchronously. Ignore that for now; you'll add `await` operators as you fil
    using System.Net.Http.Headers;
    ```
 
-The code in `ProcessRepositories` makes a web request to read the list of all repositories under the .NET foundation organization. (The GitHub ID for the .NET Foundation is `dotnet`.)
-
-The first few lines set up HTTP headers that will be included in all requests:
-  
-* An `Accept` header to accept the GitHub JSON responses.
-* A `User-Agent` header.
-
-These two headers are checked by the GitHub server code, and are necessary to retrieve information from GitHub.
-
-After the headers are configured, <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> is called to make a web request and retrieve the response. This method starts a task that makes the web request, and then when the request returns, it reads the response stream and extracts the content from the stream. The body of the response is returned as a <xref:System.String>. The string is available when the task completes.
-
-The final two lines of this method await that task and then print the response to the console.
-
 1. Build the app and run it.
 
    ```dotnetcli
    dotnet run
    ```
 
-   The build warning is gone, because the `ProcessRepositories` now does contain an `await` operator. The output is a long display of JSON formatted text.
+   There is no build warning, because the `ProcessRepositories` now does contain an `await` operator.
 
-## Processing the JSON Result
+   The output is a long display of JSON text.
 
-At this point, the code retrieves a response from a web server and displays the text that is contained in that response. In the following steps, you convert that JSON response into C# objects. You'll use the <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class to serializes objects to JSON and deserializes JSON into objects.
+## Deserialize the JSON Result
 
-1. Create a file named "repo.cs" and put the following code in it. This code defines a class to represent the `repo` JSON object returned from the GitHub API:
+The following steps convert the JSON response into C# objects. You'll use the <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class to deserialize JSON into objects.
+
+1. Create a file named *repo.cs* and put the following code in it. This code defines a class to represent the repository JSON object returned from the GitHub API:
 
    ```csharp
    using System;
@@ -165,9 +159,9 @@ At this point, the code retrieves a response from a web server and displays the 
    }
    ```
 
-   You'll use this class to display a list of repository names. When you deserialize a repository object from the JSON, only the name proprey will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the class that is the target of deserialization. This feature makes it easier to create types that work with only a subset of the fields in the JSON packet.
+   You'll use this class to display a list of repository names. When you deserialize a repository object from the JSON, only the `name` property will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the class that is the target of deserialization. This feature makes it easier to create types that work with only a subset of fields in a large JSON packet.
 
-    The name property is in lowercase letters because that matches exactly what's in the JSON. Later you'll see how to follow the C# convention of capitalizing the first letter of property names.
+   The C# convention is to capitalize the first letter of property names, but the `name` property is in lowercase letters because that matches exactly what's in the JSON. Later you'll see how to use C# property names that don't match the JSON property names.
 
 1. Use the serializer to convert JSON into C# objects. Replace the call to
 <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)> in the `ProcessRepositories` method with the following lines:
@@ -177,23 +171,16 @@ At this point, the code retrieves a response from a web server and displays the 
    var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
    ```
 
-1. Add the following `using` directives at the top of the file:
-
-   ```csharp
-   using System.Collections.Generic;
-   using System.Text.Json;
-   ```
-
-   Notice that you're now using <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. The serializer uses a stream instead of a string as its source.
+   Notice that you're now using <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. This serializer method uses a stream instead of a string as its source.
 
    The first argument to <xref:System.Text.Json.JsonSerializer.DeserializeAsync%60%601(System.IO.Stream,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken)?displayProperty=nameWithType> is an `await` expression. (The other two parameters are optional and are omitted in the code snippet.) `await` expressions can appear almost anywhere in your code, even though up to now, you've only seen them as part of an assignment statement.
 
-   The `Deserialize` method is *generic*, which means you must supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, the <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The JSON text represents a collection of repository objects, so the type argument is `Repository`.
+   The `DeserializeAsync` method is *generic*, which means you supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, a <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The JSON text represents a collection of repository objects, which you created the `Repository` type for. So the type argument is `Repository`.
 
 1. Add code to display the name of each repository. Replace the lines that read:
 
    ```csharp
-   var msg = await stringTask;   //**Deleted this
+   var msg = await stringTask;
    Console.Write(msg);
    ```
 
@@ -204,7 +191,14 @@ At this point, the code retrieves a response from a web server and displays the 
        Console.WriteLine(repo.name);
    ```
 
-1. Compile and run the application.
+1. Add the following `using` directives at the top of the file:
+
+   ```csharp
+   using System.Collections.Generic;
+   using System.Text.Json;
+   ```
+
+1. Run the application.
 
    ```dotnetcli
    dotnet run
@@ -212,7 +206,7 @@ At this point, the code retrieves a response from a web server and displays the 
 
    The output is a list of the names of the repositories that are part of the .NET Foundation.
 
-## Controll serialization
+## Configure serialization
 
 1. In *repo.cs*, change the `name` property to `Name` and add a `[JsonPropertyName]` attribute to specify how this property appears in the JSON.
 
@@ -233,13 +227,9 @@ At this point, the code retrieves a response from a web server and displays the 
    Console.WriteLine(repo.Name);
    ```
 
-1. Compile and run the application.
+1. Run the application.
 
-   ```dotnetcli
-   dotnet run
-   ```
-
-## Simplify some code
+## Simplify the code
 
 The `ProcessRepositories` method can do the async work and return a collection of the repositories. Change that method to return `List<Repository>`, and move the code that writes the information into the `Main` method.
 
@@ -257,9 +247,9 @@ The `ProcessRepositories` method can do the async work and return a collection o
    return repositories;
    ```
 
-   The compiler generates the `Task<T>` object for the return because you've marked this method as `async`.
+   The compiler generates the `Task<T>` object for the return value because you've marked this method as `async`.
 
-1. Modify the `Main` method so that it captures those results and writes each repository name to the console. Your `Main` method now looks like this:
+1. Modify the `Main` method to capture those results and write each repository name to the console. The `Main` method now looks like this:
 
    ```csharp
    public static async Task Main(string[] args)
@@ -271,80 +261,95 @@ The `ProcessRepositories` method can do the async work and return a collection o
    }
    ```
 
-## Read more information
+1. Run the application.
 
-Process  a few more of the properties in the JSON packet that gets sent from the
-GitHub API. You won't want to grab everything, but adding a few properties will demonstrate a few more
-features of the C# language.
+   The output is the same.
 
-Let's start by adding a few more simple types to the `Repository` class definition. Add these properties
-to that class:
+## Deserialize more properties
 
-```csharp
-[JsonPropertyName("description")]
-public string Description { get; set; }
+The following steps add code to process a few more of the properties in the JSON packet that gets sent from the GitHub API. You won't want to grab everything, but adding a few properties will demonstrate a few more features of the C# language.
 
-[JsonPropertyName("html_url")]
-public Uri GitHubHomeUrl { get; set; }
+1. Add the following properties to the `Repository` class definition:
 
-[JsonPropertyName("homepage")]
-public Uri Homepage { get; set; }
+   ```csharp
+   [JsonPropertyName("description")]
+   public string Description { get; set; }
+   
+   [JsonPropertyName("html_url")]
+   public Uri GitHubHomeUrl { get; set; }
+   
+   [JsonPropertyName("homepage")]
+   public Uri Homepage { get; set; }
+   
+   [JsonPropertyName("watchers")]
+   public int Watchers { get; set; }
+   ```
 
-[JsonPropertyName("watchers")]
-public int Watchers { get; set; }
-```
+   The types of these properties have built-in conversions from the string type (which is what the JSON packets contain) to the target type.
 
-These properties have built-in conversions from the string type (which is what the JSON packets contain) to
-the target type. The <xref:System.Uri> type may be new to you. It represents a URI, or in this case, a URL. In the case
-of the `Uri` and `int` types, if the JSON packet contains data that does not convert to the target type,
-the serialization action will throw an exception.
+   The <xref:System.Uri> type represents a URI, or in this case, a URL. In the case of the `Uri` and `int` types, if the JSON packet contains data that does not convert to the target type, the serialization action will throw an exception.
 
-Once you've added these, update the `Main` method to display those elements:
+1. Update the `Main` method to display the property values:
 
-```csharp
-foreach (var repo in repositories)
-{
-    Console.WriteLine(repo.Name);
-    Console.WriteLine(repo.Description);
-    Console.WriteLine(repo.GitHubHomeUrl);
-    Console.WriteLine(repo.Homepage);
-    Console.WriteLine(repo.Watchers);
-    Console.WriteLine();
-}
-```
+   ```csharp
+   foreach (var repo in repositories)
+   {
+       Console.WriteLine(repo.Name);
+       Console.WriteLine(repo.Description);
+       Console.WriteLine(repo.GitHubHomeUrl);
+       Console.WriteLine(repo.Homepage);
+       Console.WriteLine(repo.Watchers);
+       Console.WriteLine();
+   }
+   ```
 
-As a final step, let's add the information for the last push operation. This information is formatted in
-this fashion in the JSON response:
+1. Run the application.
+
+   The list now includes the additional properties.
+
+## Add a date property
+
+The date of the last push operation is formatted in this fashion in the JSON response:
 
 ```json
 2016-02-08T21:27:00Z
 ```
 
-That format is in Coordinated Universal Time (UTC) so you'll get a <xref:System.DateTime> value whose <xref:System.DateTime.Kind%2A> property is <xref:System.DateTimeKind.Utc>. If you prefer a date represented in your time zone, you'll need to write
-a custom conversion method. First, define a `public` property that will hold the
-UTC representation of the date and time in your `Repository` class and a `LastPush` `readonly` property that returns the date converted to local time:
+This format is for Coordinated Universal Time (UTC), so you'll get a <xref:System.DateTime> value whose <xref:System.DateTime.Kind%2A> property is <xref:System.DateTimeKind.Utc>.
 
-```csharp
-[JsonPropertyName("pushed_at")]
-public DateTime LastPushUtc { get; set; }
+To get a date and time represented in your time zone, you have to write a custom conversion method.
 
-public DateTime LastPush => LastPushUtc.ToLocalTime();
-```
+1. In *repo.cs*, add a `public` property for the UTC representation of the date and time and a `LastPush` `readonly` property that returns the date converted to local time:
 
-Let's go over the new constructs we just defined. The `LastPush` property is defined using an *expression-bodied member* for the `get` accessor. There is no `set` accessor. Omitting the `set` accessor is how you define a *read-only* property in C#. (Yes,
-you can create *write-only* properties in C#, but their value is limited.)
+   ```csharp
+   [JsonPropertyName("pushed_at")]
+   public DateTime LastPushUtc { get; set; }
 
-Finally, add one more output statement in the console, and you're ready to build and run this app
+   public DateTime LastPush => LastPushUtc.ToLocalTime();
+   ```
+
+   The `LastPush` property is defined using an *expression-bodied member* for the `get` accessor. There is no `set` accessor. Omitting the `set`  accessor is how you define a *read-only* property in C#. (Yes, you can create *write-only* properties in C#, but their value is limited.)
+
+1. Add one more output statement in *Program.cs*:
 again:
 
-```csharp
-Console.WriteLine(repo.LastPush);
-```
+   ```csharp
+   Console.WriteLine(repo.LastPush);
+   ```
 
-Your version should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
+1. Run the application.
 
-## Conclusion
+   The output includes the date of the last push to each repository.
 
-This tutorial showed you how to make web requests, parse the result, and display properties of
-those results. You've also added new packages as dependencies in your project. You've seen some of
+## Next steps
+
+Your version of the application should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
+
+This tutorial showed you how to make web requests, parse the results, and display properties of those results. You've seen some of
 the features of the C# language that support object-oriented techniques.
+
+Learn more about C# language features in other tutorials, such as:
+
+* [Inheritance in C# and .NET](inheritance.md)
+* [Work with Language-Integrated Query (LINQ)](working-with-linq.md)
+* [Use Attributes in C#](attributes.md)

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -349,11 +349,6 @@ again:
 
 Your version of the application should now match the [finished sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient).
 
-This tutorial showed you how to make web requests, parse the results, and display properties of those results. You've seen some of
-the features of the C# language that support object-oriented techniques.
+This tutorial showed you how to make web requests, parse the results, and display properties of those results. You've seen some of the features of the C# language that support object-oriented techniques.
 
-Learn more about C# language features in other tutorials, such as:
-
-* [Inheritance in C# and .NET](inheritance.md)
-* [Work with Language-Integrated Query (LINQ)](working-with-linq.md)
-* [Use Attributes in C#](attributes.md)
+Learn more about how to configure JSON serialization in [How to serialize and deserialize (marshal and unmarshal) JSON in .NET](../../standard/serialization/system-text-json-how-to.md).

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -1,21 +1,20 @@
 ---
-title: "Tutorial: Make HTTP requests from a .NET console application using C#"
-description: Learn how to make HTTP requests from a .NET console application to a REST web service using C#.
+title: "Tutorial: Make HTTP requests in a .NET console application using C#"
+description: Learn how to make HTTP requests to a REST web service and deserialize JSON responses. This tutorial creates a .NET console and uses C#.
 ms.date: 04/21/2021
 ---
 
-# Tutorial: Make HTTP requests from a .NET console application using C\#
+# Tutorial: Make HTTP requests in a .NET console application using C\#
 
-In this tutorial you learn how to:
+This tutorial builds an application that issues HTTP requests to a REST service on GitHub. The application reads information in JSON format and converts the JSON into C# objects. Converting from JSON to C# objects is known as *deserialization*.
+
+The tutorial shows how to:
 
 > [!div class="checklist"]
 >
 > * Send HTTP requests.
-> * Process HTTP JSON responses.
-> * Configure JSON processing with Attributes.
-
-You'll build an application that issues HTTP requests to a REST service on GitHub. The application reads information in JSON format and converts
-the JSON into C# objects.
+> * Deserialize JSON responses.
+> * Configure deserialization with attributes.
 
 If you prefer to follow along with the [final sample](https://github.com/dotnet/samples/tree/main/csharp/getting-started/console-webapiclient) for this tutorial, you can download it. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#view-and-download-samples).
 
@@ -23,7 +22,7 @@ If you prefer to follow along with the [final sample](https://github.com/dotnet/
 
 * [.NET SDK 5.0 or later](https://dotnet.microsoft.com/download/dotnet/5.0)
 * A code editor such as [Visual Studio Code](https://code.visualstudio.com/), which is an open
-source, cross platform editor. You can run this application on Windows, Linux, or macOS, or in a Docker container.
+source, cross platform editor. You can run the sample application on Windows, Linux, or macOS, or in a Docker container.
 
 ## Create the client application
 
@@ -42,17 +41,20 @@ directory.
 
    ```dotnetcli
    cd WebAPIClient
+   ```
+
+   ```dotnetcli
    dotnet run
    ```
 
-   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md), and it runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
+   [`dotnet run`](../../core/tools/dotnet-run.md) automatically runs [`dotnet restore`](../../core/tools/dotnet-restore.md) to restore any dependencies that the application needs. It also runs [`dotnet build`](../../core/tools/dotnet-build.md) if needed.
 
 ## Make HTTP requests
 
-This application will call the [GitHub API](https://developer.github.com/v3/) to get information about the projects under the
-[.NET Foundation](https://www.dotnetfoundation.org/) umbrella. The endpoint is: <https://api.github.com/orgs/dotnet/repos>. To retrieve information, it makes an HTTP GET request. Browsers also make HTTP GET requests, so you can paste that URL into your browser address bar to see what information you'll be receiving and processing.
+This application calls the [GitHub API](https://developer.github.com/v3/) to get information about the projects under the
+[.NET Foundation](https://www.dotnetfoundation.org/) umbrella. The endpoint is <https://api.github.com/orgs/dotnet/repos>. To retrieve information, it makes an HTTP GET request. Browsers also make HTTP GET requests, so you can paste that URL into your browser address bar to see what information you'll be receiving and processing.
 
-You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs. So the following steps create an async method and call it from the Main method.
+Use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <xref:System.Net.Http.HttpClient> supports only async methods for its long-running APIs. So the following steps create an async method and call it from the Main method.
 
 1. Open the `Program.cs` file in your project directory and add the following async method to the `Program` class:
 
@@ -68,7 +70,7 @@ You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <x
    using System.Threading.Tasks;
    ```
 
-  If you run `dotnet build` at this point, the compile succeeds but you get a warning that this method doesn't contain any `await` operators and runs synchronously. You'll add `await` operators later as you fill in the method.
+   If you run `dotnet build` at this point, the compile succeeds but warns that this method doesn't contain any `await` operators and so runs synchronously. You'll add `await` operators later as you fill in the method.
 
 1. Replace the `Main` method with the following code:
 
@@ -121,8 +123,8 @@ You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <x
    This code:
 
    * Sets up HTTP headers for all requests: an `Accept` header to accept JSON responses, and a `User-Agent` header. These headers are checked by the GitHub server code and are necessary to retrieve information from GitHub.
-   * Calls <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> to make a web request and retrieve the response. This method starts a task that makes the web request, and then when the request returns, it reads the response stream and extracts the content from the stream. The body of the response is returned as a <xref:System.String>. The string is available when the task completes.
-   * Awaits the async task for the response string and prints the response to the console.
+   * Calls <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)?displayProperty=nameWithType> to make a web request and retrieve the response. This method starts a task that makes the web request. When the request returns, the task reads the response stream and extracts the content from the stream. The body of the response is returned as a <xref:System.String>, which is available when the task completes.
+   * Awaits the task for the response string and prints the response to the console.
 
 1. Add two `using` directives at the top of the file:
 
@@ -131,7 +133,7 @@ You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <x
    using System.Net.Http.Headers;
    ```
 
-1. Build the app and run it.
+1. Build the application and run it.
 
    ```dotnetcli
    dotnet run
@@ -143,9 +145,9 @@ You'll use the <xref:System.Net.Http.HttpClient> class to make HTTP requests. <x
 
 ## Deserialize the JSON Result
 
-The following steps convert the JSON response into C# objects. You'll use the <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class to deserialize JSON into objects.
+The following steps convert the JSON response into C# objects. You use the <xref:System.Text.Json.JsonSerializer?displayProperty=nameWithType> class to deserialize JSON into objects.
 
-1. Create a file named *repo.cs* and put the following code in it. This code defines a class to represent the repository JSON object returned from the GitHub API:
+1. Create a file named *repo.cs* and put the following code in it. This code defines a class to represent the JSON object returned from the GitHub API:
 
    ```csharp
    using System;
@@ -159,9 +161,11 @@ The following steps convert the JSON response into C# objects. You'll use the <x
    }
    ```
 
-   You'll use this class to display a list of repository names. When you deserialize a repository object from the JSON, only the `name` property will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the class that is the target of deserialization. This feature makes it easier to create types that work with only a subset of fields in a large JSON packet.
+   You'll use this class to display a list of repository names.
 
-   The C# convention is to capitalize the first letter of property names, but the `name` property is in lowercase letters because that matches exactly what's in the JSON. Later you'll see how to use C# property names that don't match the JSON property names.
+   The JSON for a repository object contains dozens of properties,but only the `name` property will be deserialized. The serializer automatically ignores JSON properties for which there is no match in the target class. This feature makes it easier to create types that work with only a subset of fields in a large JSON packet.
+
+   The C# convention is to capitalize the first letter of property names, but the `name` property here starts with a lowercase letter because that matches exactly what's in the JSON. Later you'll see how to use C# property names that don't match the JSON property names.
 
 1. Use the serializer to convert JSON into C# objects. Replace the call to
 <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)> in the `ProcessRepositories` method with the following lines:
@@ -171,11 +175,11 @@ The following steps convert the JSON response into C# objects. You'll use the <x
    var repositories = await JsonSerializer.DeserializeAsync<List<Repository>>(await streamTask);
    ```
 
-   Notice that you're now using <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. This serializer method uses a stream instead of a string as its source.
+   The new code calls <xref:System.Net.Http.HttpClient.GetStreamAsync(System.String)> instead of <xref:System.Net.Http.HttpClient.GetStringAsync(System.String)>. This serializer method uses a stream instead of a string as its source.
 
    The first argument to <xref:System.Text.Json.JsonSerializer.DeserializeAsync%60%601(System.IO.Stream,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken)?displayProperty=nameWithType> is an `await` expression. (The other two parameters are optional and are omitted in the code snippet.) `await` expressions can appear almost anywhere in your code, even though up to now, you've only seen them as part of an assignment statement.
 
-   The `DeserializeAsync` method is *generic*, which means you supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, a <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The JSON text represents a collection of repository objects, which you created the `Repository` type for. So the type argument is `Repository`.
+   The `DeserializeAsync` method is *generic*, which means you supply type arguments for what kind of objects should be created from the JSON text. In this example, you're deserializing to a `List<Repository>`, which is another generic object, a <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. The `List<T>` class stores a collection of objects. The type argument declares the type of objects stored in the `List<T>`. The type argument is your `Repository` class, because the JSON text represents a collection of repository objects.
 
 1. Add code to display the name of each repository. Replace the lines that read:
 
@@ -184,7 +188,7 @@ The following steps convert the JSON response into C# objects. You'll use the <x
    Console.Write(msg);
    ```
 
-   with the following:
+   with the following code:
 
    ```csharp
    foreach (var repo in repositories)
@@ -206,7 +210,7 @@ The following steps convert the JSON response into C# objects. You'll use the <x
 
    The output is a list of the names of the repositories that are part of the .NET Foundation.
 
-## Configure serialization
+## Configure deserialization
 
 1. In *repo.cs*, change the `name` property to `Name` and add a `[JsonPropertyName]` attribute to specify how this property appears in the JSON.
 
@@ -229,7 +233,9 @@ The following steps convert the JSON response into C# objects. You'll use the <x
 
 1. Run the application.
 
-## Simplify the code
+   The output is the same.
+
+## Refactor the code
 
 The `ProcessRepositories` method can do the async work and return a collection of the repositories. Change that method to return `List<Repository>`, and move the code that writes the information into the `Main` method.
 
@@ -249,7 +255,7 @@ The `ProcessRepositories` method can do the async work and return a collection o
 
    The compiler generates the `Task<T>` object for the return value because you've marked this method as `async`.
 
-1. Modify the `Main` method to capture those results and write each repository name to the console. The `Main` method now looks like this:
+1. Modify the `Main` method to capture the results and write each repository name to the console. The `Main` method now looks like this:
 
    ```csharp
    public static async Task Main(string[] args)
@@ -267,7 +273,7 @@ The `ProcessRepositories` method can do the async work and return a collection o
 
 ## Deserialize more properties
 
-The following steps add code to process a few more of the properties in the JSON packet that gets sent from the GitHub API. You won't want to grab everything, but adding a few properties will demonstrate a few more features of the C# language.
+The following steps add code to process a few more of the properties in the JSON packet that is received. You won't want to grab everything, but adding a few properties demonstrates more features of the C# language.
 
 1. Add the following properties to the `Repository` class definition:
 
@@ -285,9 +291,7 @@ The following steps add code to process a few more of the properties in the JSON
    public int Watchers { get; set; }
    ```
 
-   The types of these properties have built-in conversions from the string type (which is what the JSON packets contain) to the target type.
-
-   The <xref:System.Uri> type represents a URI, or in this case, a URL. In the case of the `Uri` and `int` types, if the JSON packet contains data that does not convert to the target type, the serialization action will throw an exception.
+   The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. So no extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.
 
 1. Update the `Main` method to display the property values:
 
@@ -315,7 +319,7 @@ The date of the last push operation is formatted in this fashion in the JSON res
 2016-02-08T21:27:00Z
 ```
 
-This format is for Coordinated Universal Time (UTC), so you'll get a <xref:System.DateTime> value whose <xref:System.DateTime.Kind%2A> property is <xref:System.DateTimeKind.Utc>.
+This format is for Coordinated Universal Time (UTC), so the result of deserialization is a <xref:System.DateTime> value whose <xref:System.DateTime.Kind%2A> property is <xref:System.DateTimeKind.Utc>.
 
 To get a date and time represented in your time zone, you have to write a custom conversion method.
 
@@ -328,9 +332,9 @@ To get a date and time represented in your time zone, you have to write a custom
    public DateTime LastPush => LastPushUtc.ToLocalTime();
    ```
 
-   The `LastPush` property is defined using an *expression-bodied member* for the `get` accessor. There is no `set` accessor. Omitting the `set`  accessor is how you define a *read-only* property in C#. (Yes, you can create *write-only* properties in C#, but their value is limited.)
+   The `LastPush` property is defined using an *expression-bodied member* for the `get` accessor. There's no `set` accessor. Omitting the `set`  accessor is one way to define a *read-only* property in C#. (Yes, you can create *write-only* properties in C#, but their value is limited.)
 
-1. Add one more output statement in *Program.cs*:
+1. Add another output statement in *Program.cs*:
 again:
 
    ```csharp
@@ -339,7 +343,7 @@ again:
 
 1. Run the application.
 
-   The output includes the date of the last push to each repository.
+   The output includes the date and time of the last push to each repository.
 
 ## Next steps
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -214,21 +214,20 @@ At this point, the code retrieves a response from a web server and displays the 
 
 ## Controlling Serialization
 
-Before you add more features, let's address the `name` property by using the `[JsonPropertyName]` attribute. Make
-the following changes to the declaration of the `name` field in repo.cs:
+1. In *repo.cs*, change the `name` property to `Name` and add a `[JsonPropertyName]` attribute to specify how this pproperty appears in the JSON.
 
-```csharp
-[JsonPropertyName("name")]
-public string Name { get; set; }
-```
+   ```csharp
+   [JsonPropertyName("name")]
+   public string Name { get; set; }
+   ```
 
-To use `[JsonPropertyName]` attribute, you will need to add the <xref:System.Text.Json.Serialization> namespace to the `using` directives:
+1. Add the <xref:System.Text.Json.Serialization> namespace to the `using` directives:
 
-```csharp
-using System.Text.Json.Serialization;
-```
+   ```csharp
+   using System.Text.Json.Serialization;
+   ```
 
-This change means you need to change the code that writes the name of each repository in program.cs:
+1. In *Program.cs*, update the code to use the new capitalization of the `Name` property:
 
 ```csharp
 Console.WriteLine(repo.Name);


### PR DESCRIPTION
Fixes #23518

Implements the suggestions in #23518 except doesn't add `// requires using ...` comments in code snippets. As this tutorial is aimed at beginners, I kept explicit steps for adding `using` directives, so `requires using` comments in the code aren't needed.

This PR is mostly wording and formatting changes. The only substantive change is to refer to .NET 5 in Prereqs and remove the unnecessary STJ package installation.

To be followed by a PR in the samples repo to remove unnecessary PackageReference and target net5.0.