### PR TITLE
Use HYPHEN-MINUS instead of EN DASH in dotnet nuget command example

### DIFF
--- a/docs/core/tools/dotnet-nuget-locals.md
+++ b/docs/core/tools/dotnet-nuget-locals.md
@@ -58,7 +58,7 @@ The `dotnet nuget locals` command clears or lists local NuGet resources in the h
 - Displays the paths of all the local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
 
   ```dotnetcli
-  dotnet nuget locals all –l
+  dotnet nuget locals all -l
   ```
 
 - Displays the path for the local http-cache directory:


### PR DESCRIPTION
Use `-` (U+002D HYPHEN-MINUS) instead of `–` (U+2013 EN DASH) in the `dotnet nuget locals all -l` example to be copy/paste friendly.