### PR TITLE
Update Override and Method Selection section

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
@@ -65,7 +65,7 @@ The C# language is designed so that versioning between [base](../../language-ref
   
  [!code-csharp[csProgGuideInheritance#32](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInheritance/CS/Inheritance.cs#32)]  
   
- When `DoWork` is called on an instance of `Derived`, the C# compiler will first try to make the call compatible with the versions of `DoWork` declared originally on `Derived`. Override methods are not considered as declared on a class, they are new implementations of a method declared on a base class. Only if the C# compiler cannot match the method call to an original method on `Derived` will it try to match the call to an overridden method with the same name and compatible parameters. For example:  
+ When `DoWork` is called on an instance of `Derived`, the C# compiler will first try to make the call compatible with the versions of `DoWork` declared originally on `Derived`. Override methods are not considered as declared on a class, they are new implementations of a method declared on a base class. Only if the C# compiler cannot match the method call to an original method on `Derived`, it will try to match the call to an overridden method with the same name and compatible parameters. For example:  
   
  [!code-csharp[csProgGuideInheritance#33](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInheritance/CS/Inheritance.cs#33)]  
   


### PR DESCRIPTION
Fixed a small typo on the second paragraph of Override and Method Selection section.

## Summary
The original text had the following:
"Only if the C# compiler cannot match the method call to an original method on **Derived** will it try to match the call to an overridden method with the same name and compatible parameters"

In here, replaced "**Derived** will it try to match..." to "**Derived**, it will try to match..." because the change looks better in readability and grammar.

Fixes #23923
