### PR TITLE
dotnet run doesn't respect /property arguments

### DIFF
--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -27,6 +27,9 @@ dotnet run -h|--help
 
 The `dotnet run` command provides a convenient option to run your application from the source code with one command. It's useful for fast iterative development from the command line. The command depends on the [`dotnet build`](dotnet-build.md) command to build the code. Any requirements for the build, such as that the project must be restored first, apply to `dotnet run` as well.
 
+> [!NOTE]
+> Although `dotnet run` depends on `dotnet build`, `dotnet run` doesn't respect arguments like `/property:property=value`, which are respected by `dotnet build`.
+
 Output files are written into the default location, which is `bin/<configuration>/<target>`. For example if you have a `netcoreapp2.1` application and you run `dotnet run`, the output is placed in `bin/Debug/netcoreapp2.1`. Files are overwritten as needed. Temporary files are placed in the `obj` directory.
 
 If the project specifies multiple frameworks, executing `dotnet run` results in an error unless the `-f|--framework <FRAMEWORK>` option is used to specify the framework.

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -28,7 +28,7 @@ dotnet run -h|--help
 The `dotnet run` command provides a convenient option to run your application from the source code with one command. It's useful for fast iterative development from the command line. The command depends on the [`dotnet build`](dotnet-build.md) command to build the code. Any requirements for the build, such as that the project must be restored first, apply to `dotnet run` as well.
 
 > [!NOTE]
-> Although `dotnet run` depends on `dotnet build`, `dotnet run` doesn't respect arguments like `/property:property=value`, which are respected by `dotnet build`.
+> `dotnet run` doesn't respect arguments like `/property:property=value`, which are respected by `dotnet build`.
 
 Output files are written into the default location, which is `bin/<configuration>/<target>`. For example if you have a `netcoreapp2.1` application and you run `dotnet run`, the output is placed in `bin/Debug/netcoreapp2.1`. Files are overwritten as needed. Temporary files are placed in the `obj` directory.
 


### PR DESCRIPTION
Fixes #23889 
