### PR TITLE
Fixing a content issue in hello-world.yml

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -57,7 +57,7 @@ items:
     prints out the name.
 
     You can assign different values to any variable you declare. You can change
-    the name to one of your friends. Add these two lines in the interactive window
+    the name to one of your friends. Add these three lines in the interactive window
     following the code you've already added:
 
     ```csharp

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -60,7 +60,6 @@ items:
     the name to one of your friends. Add these two lines in the interactive window
     following the code you've already added.  Make sure you keep the declaration
     of the `aFriend` variable and its initial assignment.
-    following the code you've already added:
 
     ```csharp
     aFriend = "Maira";

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -61,6 +61,7 @@ items:
     following the code you've already added:
 
     ```csharp
+    string aFriend;
     aFriend = "Maira";
     Console.WriteLine(aFriend);
     ```

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -57,7 +57,9 @@ items:
     prints out the name.
 
     You can assign different values to any variable you declare. You can change
-    the name to one of your friends. Add these three lines in the interactive window
+    the name to one of your friends. Add these two lines in the interactive window
+    following the code you've already added.  Make sure you keep the declaration
+    of the `aFriend` variable and its initial assignment.
     following the code you've already added:
 
     ```csharp

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -63,7 +63,6 @@ items:
     following the code you've already added:
 
     ```csharp
-    string aFriend;
     aFriend = "Maira";
     Console.WriteLine(aFriend);
     ```


### PR DESCRIPTION
In the explanation of this document about assigning values, variables were given to that value without defining a variable.


Wrong ❌
```
aFriend = "Maira";
Console.WriteLine(aFriend);
```

correct ✔
```
string aFriend;
aFriend = "Maira";
Console.WriteLine(aFriend);
```


