### PR TITLE
Fix bug, modernize C# and VB, use `HttpClient` rather than `WebClient`.

### DIFF
--- a/docs/standard/parallel-programming/how-to-create-pre-computed-tasks.md
+++ b/docs/standard/parallel-programming/how-to-create-pre-computed-tasks.md
@@ -1,27 +1,28 @@
 ---
-description: "Learn more about: How to: Create Pre-Computed Tasks"
-title: "How to: Create Pre-Computed Tasks"
-ms.date: "03/30/2017"
-dev_langs: 
+title: "Create pre-computed Task objects"
+description: "In this article you'll learn how to create pre-computed tasks."
+ms.date: 05/04/2021
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "tasks, creating pre-computed"
 ms.assetid: a73eafa2-1f49-4106-a19e-997186029b58
 ---
-# How to: Create Pre-Computed Tasks
 
-This document describes how to use the <xref:System.Threading.Tasks.Task.FromResult%2A?displayProperty=nameWithType> method to retrieve the results of asynchronous download operations that are held in a cache. The <xref:System.Threading.Tasks.Task.FromResult%2A> method returns a finished <xref:System.Threading.Tasks.Task%601> object that holds the provided value as its <xref:System.Threading.Tasks.Task%601.Result%2A> property. This method is useful when you perform an asynchronous operation that returns a <xref:System.Threading.Tasks.Task%601> object, and the result of that <xref:System.Threading.Tasks.Task%601> object is already computed.  
-  
-## Example  
+# Create pre-computed tasks
 
- The following example downloads strings from the web. It defines the `DownloadStringAsync` method. This method downloads strings from the web asynchronously. This example also uses a <xref:System.Collections.Concurrent.ConcurrentDictionary%602> object to cache the results of previous operations. If the input address is held in this cache, `DownloadStringAsync` uses the <xref:System.Threading.Tasks.Task.FromResult%2A> method to produce a <xref:System.Threading.Tasks.Task%601> object that holds the content at that address. Otherwise, `DownloadStringAsync` downloads the file from the web and adds the result to the cache.  
-  
- [!code-csharp[TPL_CachedDownloads#1](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_cacheddownloads/cs/cacheddownloads.cs#1)]
- [!code-vb[TPL_CachedDownloads#1](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_cacheddownloads/vb/cacheddownloads.vb#1)]  
-  
- This example computes the time that is required to download multiple strings two times. The second set of download operations should take less time than the first set because the results are held in the cache. The <xref:System.Threading.Tasks.Task.FromResult%2A> method enables the `DownloadStringAsync` method to create <xref:System.Threading.Tasks.Task%601> objects that hold these pre-computed results.  
-  
+In this article, you'll learn how to use the <xref:System.Threading.Tasks.Task.FromResult%2A?displayProperty=nameWithType> method to retrieve the results of asynchronous download operations that are held in a cache. The <xref:System.Threading.Tasks.Task.FromResult%2A> method returns a finished <xref:System.Threading.Tasks.Task%601> object that holds the provided value as its <xref:System.Threading.Tasks.Task%601.Result%2A> property. This method is useful when you perform an asynchronous operation that returns a <xref:System.Threading.Tasks.Task%601> object, and the result of that <xref:System.Threading.Tasks.Task%601> object is already computed.
+
+## Example
+
+The following example downloads strings from the web. It defines the `DownloadStringAsync` method. This method downloads strings from the web asynchronously. This example also uses a <xref:System.Collections.Concurrent.ConcurrentDictionary%602> object to cache the results of previous operations. If the input address is held in this cache, `DownloadStringAsync` uses the <xref:System.Threading.Tasks.Task.FromResult%2A> method to produce a <xref:System.Threading.Tasks.Task%601> object that holds the content at that address. Otherwise, `DownloadStringAsync` downloads the file from the web and adds the result to the cache.
+
+:::code language="csharp" source="snippets/cs/DownloadCache.cs":::
+:::code language="vb" source="snippets/vb/DownloadCache.vb":::
+
+In the preceding example, the first time each url is downloaded and its value is stored in the cache. The <xref:System.Threading.Tasks.Task.FromResult%2A> method enables the `DownloadStringAsync` method to create <xref:System.Threading.Tasks.Task%601> objects that hold these pre-computed results. Subsequent calls to download the string return the cached values, and is much faster.
+
 ## See also
 
-- [Task-based Asynchronous Programming](task-based-asynchronous-programming.md)
+- [Task-based asynchronous programming](task-based-asynchronous-programming.md)

--- a/docs/standard/parallel-programming/how-to-create-pre-computed-tasks.md
+++ b/docs/standard/parallel-programming/how-to-create-pre-computed-tasks.md
@@ -1,6 +1,6 @@
 ---
 title: "Create pre-computed Task objects"
-description: "In this article you'll learn how to create pre-computed tasks."
+description: "In this article, you'll learn how to create pre-computed tasks."
 ms.date: 05/04/2021
 dev_langs:
   - "csharp"
@@ -21,7 +21,7 @@ The following example downloads strings from the web. It defines the `DownloadSt
 :::code language="csharp" source="snippets/cs/DownloadCache.cs":::
 :::code language="vb" source="snippets/vb/DownloadCache.vb":::
 
-In the preceding example, the first time each url is downloaded and its value is stored in the cache. The <xref:System.Threading.Tasks.Task.FromResult%2A> method enables the `DownloadStringAsync` method to create <xref:System.Threading.Tasks.Task%601> objects that hold these pre-computed results. Subsequent calls to download the string return the cached values, and is much faster.
+In the preceding example, the first time each url is downloaded, its value is stored in the cache. The <xref:System.Threading.Tasks.Task.FromResult%2A> method enables the `DownloadStringAsync` method to create <xref:System.Threading.Tasks.Task%601> objects that hold these pre-computed results. Subsequent calls to download the string return the cached values, and is much faster.
 
 ## See also
 

--- a/docs/standard/parallel-programming/snippets/cs/DownloadCache.cs
+++ b/docs/standard/parallel-programming/snippets/cs/DownloadCache.cs
@@ -15,7 +15,7 @@ public static class DownloadCache
     {
         if (s_cachedDownloads.TryGetValue(address, out string content))
         {
-            return Task.FromResult<string>(content);
+            return Task.FromResult(content);
         }
 
         return Task.Run(async () =>
@@ -27,7 +27,7 @@ public static class DownloadCache
         });
     }
 
-    public static async Task Main(string[] args)
+    public static async Task Main()
     {
         string[] urls = new[]
         {

--- a/docs/standard/parallel-programming/snippets/cs/DownloadCache.cs
+++ b/docs/standard/parallel-programming/snippets/cs/DownloadCache.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public static class DownloadCache
+{
+    private static readonly ConcurrentDictionary<string, string> s_cachedDownloads = new();
+    private static readonly HttpClient s_httpClient = new();
+
+    public static Task<string> DownloadStringAsync(string address)
+    {
+        if (s_cachedDownloads.TryGetValue(address, out string content))
+        {
+            return Task.FromResult<string>(content);
+        }
+
+        return Task.Run(async () =>
+        {
+            content = await s_httpClient.GetStringAsync(address);
+            s_cachedDownloads.TryAdd(address, content);
+
+            return content;
+        });
+    }
+
+    public static async Task Main(string[] args)
+    {
+        string[] urls = new[]
+        {
+            "https://docs.microsoft.com/aspnet/core",
+            "https://docs.microsoft.com/dotnet",
+            "https://docs.microsoft.com/dotnet/architecture/dapr-for-net-developers",
+            "https://docs.microsoft.com/dotnet/azure",
+            "https://docs.microsoft.com/dotnet/desktop/wpf",
+            "https://docs.microsoft.com/dotnet/devops/create-dotnet-github-action",
+            "https://docs.microsoft.com/dotnet/machine-learning",
+            "https://docs.microsoft.com/xamarin",
+            "https://dotnet.microsoft.com/",
+            "https://www.microsoft.com"
+        };
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        IEnumerable<Task<string>> downloads = urls.Select(DownloadStringAsync);
+
+        static void StopAndLogElapsedTime(
+            int attemptNumber, Stopwatch stopwatch, Task<string[]> downloadTasks)
+        {
+            stopwatch.Stop();
+
+            int charCount = downloadTasks.Result.Sum(result => result.Length);
+            long elapsedMs = stopwatch.ElapsedMilliseconds;
+
+            Console.WriteLine(
+                $"Attempt number: {attemptNumber}\n" +
+                $"Retrieved characters: {charCount:#,0}\n" +
+                $"Elapsed retrieval time: {elapsedMs:#,0} milliseconds.\n");
+        }
+
+        await Task.WhenAll(downloads).ContinueWith(
+            downloadTasks => StopAndLogElapsedTime(1, stopwatch, downloadTasks));
+
+        // Perform the same operation a second time. The time required
+        // should be shorter because the results are held in the cache.
+        stopwatch.Restart();
+
+        downloads = urls.Select(DownloadStringAsync);
+
+        await Task.WhenAll(downloads).ContinueWith(
+            downloadTasks => StopAndLogElapsedTime(2, stopwatch, downloadTasks));
+    }
+    // Sample output:
+    //     Attempt number: 1
+    //     Retrieved characters: 754,585
+    //     Elapsed retrieval time: 2,857 milliseconds.
+
+    //     Attempt number: 2
+    //     Retrieved characters: 754,585
+    //     Elapsed retrieval time: 1 milliseconds.
+}

--- a/docs/standard/parallel-programming/snippets/cs/snippets.csproj
+++ b/docs/standard/parallel-programming/snippets/cs/snippets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <StartupObject>SimpleExample</StartupObject>
+    <StartupObject>DownloadCache</StartupObject>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/parallel-programming/snippets/vb/DownloadCache.vb
+++ b/docs/standard/parallel-programming/snippets/vb/DownloadCache.vb
@@ -1,0 +1,79 @@
+﻿Imports System.Collections.Concurrent
+Imports System.Net.Http
+
+Module Snippets
+    Class DownloadCache
+        Private Shared ReadOnly s_cachedDownloads As ConcurrentDictionary(Of String, String) =
+            New ConcurrentDictionary(Of String, String)()
+        Private Shared ReadOnly s_httpClient As HttpClient = New HttpClient()
+
+        Public Function DownloadStringAsync(ByVal address As String) As Task(Of String)
+            Dim content As String = Nothing
+
+            If s_cachedDownloads.TryGetValue(address, content) Then
+                Return Task.FromResult(Of String)(content)
+            End If
+
+            Return Task.Run(
+                Async Function()
+                    content = Await s_httpClient.GetStringAsync(address)
+                    s_cachedDownloads.TryAdd(address, content)
+                    Return content
+                End Function)
+        End Function
+    End Class
+
+    Public Sub StopAndLogElapsedTime(
+            ByVal attemptNumber As Integer,
+            ByVal stopwatch As Stopwatch,
+            ByVal downloadTasks As Task(Of String()))
+
+        stopwatch.Stop()
+
+        Dim charCount As Integer = downloadTasks.Result.Sum(Function(result) result.Length)
+        Dim elapsedMs As Long = stopwatch.ElapsedMilliseconds
+
+        Console.WriteLine(
+            $"Attempt number: {attemptNumber}{vbCrLf}" &
+            $"Retrieved characters: {charCount:#,0}{vbCrLf}" &
+            $"Elapsed retrieval time: {elapsedMs:#,0} milliseconds.{vbCrLf}")
+    End Sub
+
+    Sub Main()
+        Dim cache As DownloadCache = New DownloadCache()
+        Dim urls As String() = {
+                "https://docs.microsoft.com/aspnet/core",
+                "https://docs.microsoft.com/dotnet",
+                "https://docs.microsoft.com/dotnet/architecture/dapr-for-net-developers",
+                "https://docs.microsoft.com/dotnet/azure",
+                "https://docs.microsoft.com/dotnet/desktop/wpf",
+                "https://docs.microsoft.com/dotnet/devops/create-dotnet-github-action",
+                "https://docs.microsoft.com/dotnet/machine-learning",
+                "https://docs.microsoft.com/xamarin",
+                "https://dotnet.microsoft.com/",
+                "https://www.microsoft.com"
+            }
+        Dim stopwatch As Stopwatch = Stopwatch.StartNew()
+        Dim downloads As IEnumerable(Of Task(Of String)) =
+                urls.Select(AddressOf cache.DownloadStringAsync)
+        Task.WhenAll(downloads).ContinueWith(
+                Sub(downloadTasks)
+                    StopAndLogElapsedTime(1, stopwatch, downloadTasks)
+                End Sub).Wait()
+
+        stopwatch.Restart()
+        downloads = urls.Select(AddressOf cache.DownloadStringAsync)
+        Task.WhenAll(downloads).ContinueWith(
+                Sub(downloadTasks)
+                    StopAndLogElapsedTime(2, stopwatch, downloadTasks)
+                End Sub).Wait()
+    End Sub
+    ' Sample output:
+    '     Attempt number 1
+    '     Retrieved characters: 754,585
+    '     Elapsed retrieval time: 2,857 milliseconds.
+    '
+    '     Attempt number 2
+    '     Retrieved characters: 754,585
+    '     Elapsed retrieval time: 1 milliseconds.
+End Module

--- a/docs/standard/parallel-programming/snippets/vb/DownloadCache.vb
+++ b/docs/standard/parallel-programming/snippets/vb/DownloadCache.vb
@@ -7,7 +7,7 @@ Module Snippets
             New ConcurrentDictionary(Of String, String)()
         Private Shared ReadOnly s_httpClient As HttpClient = New HttpClient()
 
-        Public Function DownloadStringAsync(ByVal address As String) As Task(Of String)
+        Public Function DownloadStringAsync(address As String) As Task(Of String)
             Dim content As String = Nothing
 
             If s_cachedDownloads.TryGetValue(address, content) Then
@@ -24,9 +24,9 @@ Module Snippets
     End Class
 
     Public Sub StopAndLogElapsedTime(
-            ByVal attemptNumber As Integer,
-            ByVal stopwatch As Stopwatch,
-            ByVal downloadTasks As Task(Of String()))
+            attemptNumber As Integer,
+            stopwatch As Stopwatch,
+            downloadTasks As Task(Of String()))
 
         stopwatch.Stop()
 

--- a/docs/standard/parallel-programming/snippets/vb/My Project/launchSettings.json
+++ b/docs/standard/parallel-programming/snippets/vb/My Project/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "snippets": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/docs/standard/parallel-programming/snippets/vb/snippets.vbproj
+++ b/docs/standard/parallel-programming/snippets/vb/snippets.vbproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>snippets</RootNamespace>
     <TargetFramework>net5.0</TargetFramework>
+    <StartupObject>Sub Main</StartupObject>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/parallel-programming/snippets/vb/unwrap.vb
+++ b/docs/standard/parallel-programming/snippets/vb/unwrap.vb
@@ -1,7 +1,7 @@
 ﻿Imports System.Threading
 
 Module UnwrapExample
-    Sub Main()
+    Sub Main2()
         Dim taskOne As Task(Of Integer) = RemoteIncrement(0)
         Console.WriteLine("Started RemoteIncrement(0)")
 


### PR DESCRIPTION
## Summary

- Clean up article
- Update `ms.date`
- Modernize C# and VB code
- Use `HttpClient` rather than `WebClient`
- Use latest `:::` syntax

Fixes #23707

### Preview

✔️ [Create pre-computed tasks](https://review.docs.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-create-pre-computed-tasks?branch=pr-en-us-24028)