### PR TITLE
Match description with code snippet

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md
@@ -123,7 +123,7 @@ If you are writing a class with some operations that may incur noticeable delays
   
 4. Create a collection for managing lifetimes of pending asynchronous operations. The client needs a way to track operations as they are executed and completed, and this tracking is done by requiring the client to pass a unique token, or task ID, when the client makes the call to the asynchronous method. The `PrimeNumberCalculator` component must keep track of each call by associating the task ID with its corresponding invocation. If the client passes a task ID that is not unique, the `PrimeNumberCalculator` component must raise an exception.  
   
-     The `PrimeNumberCalculator` component keeps track of task ID by using a special collection class called a <xref:System.Collections.Specialized.HybridDictionary>. In the class definition, create a <xref:System.Collections.Specialized.HybridDictionary> called `userTokenToLifetime`.  
+     The `PrimeNumberCalculator` component keeps track of task ID by using a special collection class called a <xref:System.Collections.Specialized.HybridDictionary>. In the class definition, create a <xref:System.Collections.Specialized.HybridDictionary> called `userStateToLifetime`.  
   
      [!code-csharp[System.ComponentModel.AsyncOperationManager#23](snippets/component-that-supports-the-event-based-asynchronous-pattern/csharp/primenumbercalculatormain.cs#23)]
      [!code-vb[System.ComponentModel.AsyncOperationManager#23](snippets/component-that-supports-the-event-based-asynchronous-pattern/vb/primenumbercalculatormain.vb#23)]  


### PR DESCRIPTION
## Summary

The description of the code snippet uses wrong variable name. It is corrected in this PR.

Fixes #Issue_Number (if available)
