### PR TITLE
Update branches-and-loops.yml

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
@@ -113,7 +113,7 @@ items:
     else
     {
         Console.WriteLine("The answer is not greater than 10");
-        Console.WriteLine("Or the first number is not equal to the second");
+        Console.WriteLine("And the first number is not equal to the second");
     }
     ```
 


### PR DESCRIPTION
Proposed grammatical change in the else conditional Console.WriteLine string for the && operator.

## Summary

Change the string in the Console.Writeline for the && operator instruction in order to use the word "And" instead of "Or". This ensures that there are no confusions as to how the forementioned operator work. 
