### PR TITLE
Rename to Main

### DIFF
--- a/docs/standard/parallel-programming/snippets/vb/asyncculture1.vb
+++ b/docs/standard/parallel-programming/snippets/vb/asyncculture1.vb
@@ -7,7 +7,7 @@ Imports System.Globalization
 Imports System.Threading
 
 Module Example
-    Public Sub Main1()
+    Public Sub Main()
         Dim values() As Decimal = {163025412.32D, 18905365.59D}
         Dim formatString As String = "C2"
         Dim formatDelegate As Func(Of String) = Function()

--- a/docs/standard/parallel-programming/snippets/vb/snippets.vbproj
+++ b/docs/standard/parallel-programming/snippets/vb/snippets.vbproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>snippets</RootNamespace>
     <TargetFramework>net5.0</TargetFramework>
-    <StartupObject>Sub Main</StartupObject>
+    <StartupObject>snippets.Snippets</StartupObject>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/parallel-programming/snippets/vb/unwrap.vb
+++ b/docs/standard/parallel-programming/snippets/vb/unwrap.vb
@@ -1,7 +1,7 @@
 ﻿Imports System.Threading
 
 Module UnwrapExample
-    Sub Main2()
+    Sub Main()
         Dim taskOne As Task(Of Integer) = RemoteIncrement(0)
         Console.WriteLine("Started RemoteIncrement(0)")
 


### PR DESCRIPTION
Since these names are visible in the doc page, I think it's better to keep them as `Main`.