### PR TITLE
Display the entire Program.cs file, and just highlight the registration

### DIFF
--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -42,6 +42,8 @@ In the preceding code, <xref:Microsoft.Build.Logging.LoggerDescription.CreateLog
 
 ## Usage and registration of the custom logger
 
+By convention, registering services for dependency injection happens as part of the startup routine of an application. The registration occurs in the `Program` class, or could be delegated to a `Startup` class. In this example, you'll register directly from the _Program.cs_.
+
 To add the custom logging provider and corresponding logger, add an <xref:Microsoft.Extensions.Logging.ILoggerProvider> with <xref:Microsoft.Extensions.Logging.ILoggingBuilder> from the <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.ConfigureLogging(Microsoft.Extensions.Hosting.IHostBuilder,System.Action{Microsoft.Extensions.Logging.ILoggingBuilder})?displayProperty=nameWithType>:
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" highlight="23-33":::

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom logging provider in .NET
 description: Learn how to implement a custom logging provider in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 04/07/2021
+ms.date: 05/06/2021
 ms.topic: how-to
 ---
 
@@ -44,7 +44,7 @@ In the preceding code, <xref:Microsoft.Build.Logging.LoggerDescription.CreateLog
 
 To add the custom logging provider and corresponding logger, add an <xref:Microsoft.Extensions.Logging.ILoggerProvider> with <xref:Microsoft.Extensions.Logging.ILoggingBuilder> from the <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.ConfigureLogging(Microsoft.Extensions.Hosting.IHostBuilder,System.Action{Microsoft.Extensions.Logging.ILoggingBuilder})?displayProperty=nameWithType>:
 
-:::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" range="23-33":::
+:::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" highlight="23-33":::
 
 The `ILoggingBuilder` creates one or more `ILogger` instances. The `ILogger` instances are used by the framework to log the information.
 


### PR DESCRIPTION
## Summary

Display the entire _Program.cs_ file, and just highlight the registration. This will show the additional context of where the registration bits are called from.

Fixes #23333

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/custom-logging-provider?branch=pr-en-us-24066)