### PR TITLE
Update tour.md for Code Sample Line Numbers

### DIFF
--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -55,7 +55,7 @@ It's important to note that because `struct` tuples are value types, they cannot
 
 Pipe operators such as `|>` are used extensively when processing data in F#. These operators are functions that allow you to establish "pipelines" of functions in a flexible manner. The following example walks through how you can take advantage of these operators to build a simple functional pipeline:
 
-[!code-fsharp[Pipelines](~/samples/snippets/fsharp/tour.fs#L227-L282)]
+[!code-fsharp[Pipelines](~/samples/snippets/fsharp/tour.fs#L227-L302)]
 
 The previous sample made use of many features of F#, including list processing functions, first-class functions, and [partial application](./language-reference/functions/index.md#partial-application-of-arguments). Although a deep understanding of each of those concepts can become somewhat advanced, it should be clear how easily functions can be used to process data when building pipelines.
 
@@ -65,15 +65,15 @@ Lists, Arrays, and Sequences are three primary collection types in the F# core l
 
 [Lists](./language-reference/lists.md) are ordered, immutable collections of elements of the same type.  They are singly-linked lists, which means they are meant for enumeration, but a poor choice for random access and concatenation if they're large.  This in contrast to Lists in other popular languages, which typically do not use a singly-linked list to represent Lists.
 
-[!code-fsharp[Lists](~/samples/snippets/fsharp/tour.fs#L309-L359)]
+[!code-fsharp[Lists](~/samples/snippets/fsharp/tour.fs#L311-L363)]
 
 [Arrays](./language-reference/arrays.md) are fixed-size, *mutable* collections of elements of the same type.  They support fast random access of elements, and are faster than F# lists because they are just contiguous blocks of memory.
 
-[!code-fsharp[Arrays](~/samples/snippets/fsharp/tour.fs#L368-L407)]
+[!code-fsharp[Arrays](~/samples/snippets/fsharp/tour.fs#L372-L413)]
 
 [Sequences](./language-reference/sequences.md) are a logical series of elements, all of the same type.  These are a more general type than Lists and Arrays, capable of being your "view" into any logical series of elements.  They also stand out because they can be ***lazy***, which means that elements can be computed only when they are needed.
 
-[!code-fsharp[Sequences](~/samples/snippets/fsharp/tour.fs#L418-L452)]
+[!code-fsharp[Sequences](~/samples/snippets/fsharp/tour.fs#L424-L458)]
 
 ## Recursive Functions
 
@@ -82,7 +82,7 @@ Processing collections or sequences of elements is typically done with [recursio
 > [!NOTE]
 > The following example makes use of the pattern matching via the `match` expression.  This fundamental construct is covered later in this article.
 
-[!code-fsharp[RecursiveFunctions](~/samples/snippets/fsharp/tour.fs#L461-L500)]
+[!code-fsharp[RecursiveFunctions](~/samples/snippets/fsharp/tour.fs#L467-L509)]
 
 F# also has full support for Tail Call Optimization, which is a way to optimize recursive calls so that they are just as fast as a loop construct.
 
@@ -92,31 +92,31 @@ Record and Union types are two fundamental data types used in F# code, and are g
 
 [Records](./language-reference/records.md) are an aggregate of named values, with optional members (such as methods).  If you're familiar with C# or Java, then these should feel similar to POCOs or POJOs - just with structural equality and less ceremony.
 
-[!code-fsharp[Records](~/samples/snippets/fsharp/tour.fs#L507-L559)]
+[!code-fsharp[Records](~/samples/snippets/fsharp/tour.fs#L516-L568)]
 
 You can also represent Records as structs. This is done with the `[<Struct>]` attribute:
 
-[!code-fsharp[Records](~/samples/snippets/fsharp/tour.fs#L561-L568)]
+[!code-fsharp[Records](~/samples/snippets/fsharp/tour.fs#L573-L577)]
 
 [Discriminated Unions (DUs)](./language-reference/discriminated-unions.md) are values which could be a number of named forms or cases.  Data stored in the type can be one of several distinct values.
 
-[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L575-L631)]
+[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L584-L640)]
 
 You can also use DUs as *Single-Case Discriminated Unions*, to help with domain modeling over primitive types.  Often times, strings and other primitive types are used to represent something, and are thus given a particular meaning.  However, using only the primitive representation of the data can result in mistakenly assigning an incorrect value!  Representing each type of information as a distinct single-case union can enforce correctness in this scenario.
 
-[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L633-L654)]
+[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L642-L663)]
 
 As the above sample demonstrates, to get the underlying value in a single-case Discriminated Union, you must explicitly unwrap it.
 
 Additionally, DUs also support recursive definitions, allowing you to easily represent trees and inherently recursive data.  For example, here's how you can represent a Binary Search Tree with `exists` and `insert` functions.
 
-[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L656-L683)]
+[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L665-L695)]
 
 Because DUs allow you to represent the recursive structure of the tree in the data type, operating on this recursive structure is straightforward and guarantees correctness.  It is also supported in pattern matching, as shown below.
 
 Additionally, you can represent DUs as `struct`s with the `[<Struct>]` attribute:
 
-[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L685-L696)]
+[!code-fsharp[Unions](~/samples/snippets/fsharp/tour.fs#L704-L708)]
 
 However, there are two key things to keep in mind when doing so:
 
@@ -129,17 +129,17 @@ Failure to follow the above will result in a compilation error.
 
 [Pattern Matching](./language-reference/pattern-matching.md) is the F# language feature which enables correctness for operating on F# types.  In the above samples, you probably noticed quite a bit of `match x with ...` syntax.  This construct allows the compiler, which can understand the "shape" of data types, to force you to account for all possible cases when using a data type through what is known as Exhaustive Pattern Matching.  This is incredibly powerful for correctness, and can be cleverly used to "lift" what would normally be a runtime concern into compile-time.
 
-[!code-fsharp[PatternMatching](~/samples/snippets/fsharp/tour.fs#L705-L742)]
+[!code-fsharp[PatternMatching](~/samples/snippets/fsharp/tour.fs#L717-L743)]
 
 Something you may have noticed is the use of the `_` pattern.  This is known as the [Wildcard Pattern](./language-reference/pattern-matching.md#wildcard-pattern), which is a way of saying "I don't care what something is".  Although convenient, you can accidentally bypass Exhaustive Pattern Matching and no longer benefit from compile-time enforcements if you aren't careful in using `_`.  It is best used when you don't care about certain pieces of a decomposed type when pattern matching, or the final clause when you have enumerated all meaningful cases in a pattern matching expression.
 
 In the following example, the `_` case is used when a parse operation fails.
 
-[!code-fsharp[PatternMatching](~/samples/snippets/fsharp/tour.fs#L744-L762)]
+[!code-fsharp[PatternMatching](~/samples/snippets/fsharp/tour.fs#L745-L771)]
 
 [Active Patterns](./language-reference/active-patterns.md) are another powerful construct to use with pattern matching.  They allow you to partition input data into custom forms, decomposing them at the pattern match call site.  They can also be parameterized, thus allowing to define the partition as a function.  Expanding the previous example to support Active Patterns looks something like this:
 
-[!code-fsharp[ActivePatterns](~/samples/snippets/fsharp/tour.fs#L764-L786)]
+[!code-fsharp[ActivePatterns](~/samples/snippets/fsharp/tour.fs#L777-L795)]
 
 ## Optional Types
 
@@ -147,7 +147,7 @@ One special case of Discriminated Union types is the Option Type, which is so us
 
 [The Option Type](./language-reference/options.md) is a type which represents one of two cases: a value, or nothing at all.  It is used in any scenario where a value may or may not result from a particular operation.  This then forces you to account for both cases, making it a compile-time concern rather than a runtime concern.  These are often used in APIs where `null` is used to represent "nothing" instead, thus eliminating the need to worry about `NullReferenceException` in many circumstances.
 
-[!code-fsharp[Options](~/samples/snippets/fsharp/tour.fs#L789-L814)]
+[!code-fsharp[Options](~/samples/snippets/fsharp/tour.fs#L803-L823)]
 
 ## Units of Measure
 
@@ -155,7 +155,7 @@ One unique feature of F#'s type system is the ability to provide context for num
 
 [Units of Measure](./language-reference/units-of-measure.md) allow you to associate a numeric type to a unit, such as Meters, and have functions perform work on units rather than numeric literals.  This enables the compiler to verify that the types of numeric literals passed in make sense under a certain context, thus eliminating runtime errors associated with that kind of work.
 
-[!code-fsharp[UnitsOfMeasure](~/samples/snippets/fsharp/tour.fs#L817-L842)]
+[!code-fsharp[UnitsOfMeasure](~/samples/snippets/fsharp/tour.fs#L830-L851)]
 
 The F# Core library defines many SI unit types and unit conversions.  To learn more, check out the [FSharp.Data.UnitSystems.SI.UnitSymbols Namespace](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-data-unitsystems-si-unitsymbols.html).
 
@@ -165,15 +165,15 @@ F# also has full support for .NET classes, [Interfaces](./language-reference/int
 
 [Classes](./language-reference/classes.md) are types that represent .NET objects, which can have properties, methods, and events as its [Members](./language-reference/members/index.md).
 
-[!code-fsharp[Classes](~/samples/snippets/fsharp/tour.fs#L845-L880)]
+[!code-fsharp[Classes](~/samples/snippets/fsharp/tour.fs#L860-L889)]
 
 Defining generic classes is also very straightforward.
 
-[!code-fsharp[Classes](~/samples/snippets/fsharp/tour.fs#L883-L908)]
+[!code-fsharp[Classes](~/samples/snippets/fsharp/tour.fs#L896-L917)]
 
 To implement an Interface, you can use either `interface ... with` syntax or an [Object Expression](./language-reference/object-expressions.md).
 
-[!code-fsharp[Classes](~/samples/snippets/fsharp/tour.fs#L911-L934)]
+[!code-fsharp[Classes](~/samples/snippets/fsharp/tour.fs#L924-L943)]
 
 ## Which Types to Use
 


### PR DESCRIPTION
## Summary

The code samples in this document do not appear to line up with the content.

Based on the content found in the referenced code samples located here: [tour.fs](https://github.com/dotnet/docs/blob/main/samples/snippets/fsharp/tour.fs), I believe that these changes to the code sample line number references should align closer to the intended content, or at least provide a possible suggestion for changes.
