### PR TITLE
Add Windows 10 version 20H2 as a .NET Framework supported OS

### DIFF
--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -2,7 +2,7 @@
 title: ".NET Framework system requirements"
 description: "Find out what are the hardware, operating system and software requirements to install .NET Framework 4.5 and later versions."
 ms.date: "04/18/2019"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "software requirements"
   - ".NET Framework, system requirements"
   - "system requirements"
@@ -47,6 +47,7 @@ For information on the support lifecycle of .NET Framework versions, see [Micros
 
 | Operating system | Supported editions | Preinstalled with the OS | Installable separately |
 | ---------------- | ------------------ | ------------------------ | ---------------------- |
+| Windows 10 November 2020 Update<br/> (version 20H2) | 32-bit and 64-bit | .NET Framework 4.8 | -- |
 | Windows 10 May 2020 Update<br/> (version 2004) | 32-bit and 64-bit | .NET Framework 4.8 | -- |
 | Windows 10 November 2019 Update<br/> (version 1909) | 32-bit and 64-bit | .NET Framework 4.8 | -- |
 | Windows 10 May 2019 Update<br/> (version 1903) | 32-bit and 64-bit | .NET Framework 4.8 | -- |


### PR DESCRIPTION
## Summary

Add Windows 10 version 20H2 as a .NET Framework supported OS

Fixes #19321
