### PR TITLE
Fix variable names in 'Viewing Type Information' article

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.types.viewinfo/cpp/source2.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.types.viewinfo/cpp/source2.cpp
@@ -3,28 +3,28 @@ using namespace System;
 using namespace System::IO;
 using namespace System::Reflection;
 
-public ref class Mymemberinfo
+public ref class MyMemberInfo
 {
 public:
     static void Main()
     {
         Console::WriteLine ("\nReflection.MemberInfo");
         // Gets the Type and MemberInfo.
-        Type^ MyType = Type::GetType("System.IO.File");
-        array<MemberInfo^>^ Mymemberinfoarray = MyType->GetMembers();
+        Type^ myType = Type::GetType("System.IO.File");
+        array<MemberInfo^>^ myMemberInfoArray = myType->GetMembers();
         // Gets and displays the DeclaringType method.
         Console::WriteLine("\nThere are {0} members in {1}.",
-            Mymemberinfoarray->Length, MyType->FullName);
-        Console::WriteLine("{0}.", MyType->FullName);
-        if (MyType->IsPublic)
+            myMemberInfoArray->Length, myType->FullName);
+        Console::WriteLine("{0}.", myType->FullName);
+        if (myType->IsPublic)
         {
-            Console::WriteLine("{0} is public.", MyType->FullName);
+            Console::WriteLine("{0} is public.", myType->FullName);
         }
     }
 };
 
 int main()
 {
-    Mymemberinfo::Main();
+    MyMemberInfo::Main();
 }
 // </snippet2>

--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.types.viewinfo/cpp/source3.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.types.viewinfo/cpp/source3.cpp
@@ -10,37 +10,37 @@ public:
     {
         Console::WriteLine("Reflection.MethodInfo");
         // Gets and displays the Type.
-        Type^ MyType = Type::GetType("System.Reflection.FieldInfo");
+        Type^ myType = Type::GetType("System.Reflection.FieldInfo");
         // Specifies the member for which you want type information.
-        MethodInfo^ Mymethodinfo = MyType->GetMethod("GetValue");
-        Console::WriteLine(MyType->FullName + "." + Mymethodinfo->Name);
+        MethodInfo^ myMethodInfo = myType->GetMethod("GetValue");
+        Console::WriteLine(myType->FullName + "." + myMethodInfo->Name);
         // Gets and displays the MemberType property.
-        MemberTypes Mymembertypes = Mymethodinfo->MemberType;
-        if (MemberTypes::Constructor == Mymembertypes)
+        MemberTypes myMemberTypes = myMethodInfo->MemberType;
+        if (MemberTypes::Constructor == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type All");
         }
-        else if (MemberTypes::Custom == Mymembertypes)
+        else if (MemberTypes::Custom == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type Custom");
         }
-        else if (MemberTypes::Event == Mymembertypes)
+        else if (MemberTypes::Event == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type Event");
         }
-        else if (MemberTypes::Field == Mymembertypes)
+        else if (MemberTypes::Field == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type Field");
         }
-        else if (MemberTypes::Method == Mymembertypes)
+        else if (MemberTypes::Method == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type Method");
         }
-        else if (MemberTypes::Property == Mymembertypes)
+        else if (MemberTypes::Property == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type Property");
         }
-        else if (MemberTypes::TypeInfo == Mymembertypes)
+        else if (MemberTypes::TypeInfo == myMemberTypes)
         {
             Console::WriteLine("MemberType is of type TypeInfo");
         }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.types.viewinfo/cs/source2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.types.viewinfo/cs/source2.cs
@@ -3,21 +3,21 @@ using System;
 using System.IO;
 using System.Reflection;
 
-class Mymemberinfo
+class MyMemberInfo
 {
     public static void Main()
     {
         Console.WriteLine ("\nReflection.MemberInfo");
         // Gets the Type and MemberInfo.
-        Type MyType = Type.GetType("System.IO.File");
-        MemberInfo[] Mymemberinfoarray = MyType.GetMembers();
+        Type myType = Type.GetType("System.IO.File");
+        MemberInfo[] myMemberInfoArray = myType.GetMembers();
         // Gets and displays the DeclaringType method.
         Console.WriteLine("\nThere are {0} members in {1}.",
-            Mymemberinfoarray.Length, MyType.FullName);
-        Console.WriteLine("{0}.", MyType.FullName);
-        if (MyType.IsPublic)
+            myMemberInfoArray.Length, myType.FullName);
+        Console.WriteLine("{0}.", myType.FullName);
+        if (myType.IsPublic)
         {
-            Console.WriteLine("{0} is public.", MyType.FullName);
+            Console.WriteLine("{0} is public.", myType.FullName);
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.types.viewinfo/cs/source3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.types.viewinfo/cs/source3.cs
@@ -9,37 +9,37 @@ class MyMethodInfo
     {
         Console.WriteLine("Reflection.MethodInfo");
         // Gets and displays the Type.
-        Type MyType = Type.GetType("System.Reflection.FieldInfo");
+        Type myType = Type.GetType("System.Reflection.FieldInfo");
         // Specifies the member for which you want type information.
-        MethodInfo Mymethodinfo = MyType.GetMethod("GetValue");
-        Console.WriteLine(MyType.FullName + "." + Mymethodinfo.Name);
+        MethodInfo myMethodInfo = myType.GetMethod("GetValue");
+        Console.WriteLine(myType.FullName + "." + myMethodInfo.Name);
         // Gets and displays the MemberType property.
-        MemberTypes Mymembertypes = Mymethodinfo.MemberType;
-        if (MemberTypes.Constructor == Mymembertypes)
+        MemberTypes myMemberTypes = myMethodInfo.MemberType;
+        if (MemberTypes.Constructor == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type All");
         }
-        else if (MemberTypes.Custom == Mymembertypes)
+        else if (MemberTypes.Custom == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type Custom");
         }
-        else if (MemberTypes.Event == Mymembertypes)
+        else if (MemberTypes.Event == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type Event");
         }
-        else if (MemberTypes.Field == Mymembertypes)
+        else if (MemberTypes.Field == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type Field");
         }
-        else if (MemberTypes.Method == Mymembertypes)
+        else if (MemberTypes.Method == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type Method");
         }
-        else if (MemberTypes.Property == Mymembertypes)
+        else if (MemberTypes.Property == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type Property");
         }
-        else if (MemberTypes.TypeInfo == Mymembertypes)
+        else if (MemberTypes.TypeInfo == myMemberTypes)
         {
             Console.WriteLine("MemberType is of type TypeInfo");
         }

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.types.viewinfo/vb/source2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.types.viewinfo/vb/source2.vb
@@ -2,18 +2,18 @@
 Imports System.IO
 Imports System.Reflection
 
-Class Mymemberinfo
+Class MyMemberInfo
     Public Shared Sub Main()
         Console.WriteLine("\nReflection.MemberInfo")
         ' Gets the Type and MemberInfo.
-        Dim MyType As Type = Type.GetType("System.IO.File")
-        Dim Mymemberinfoarray() As MemberInfo = MyType.GetMembers()
+        Dim myType As Type = Type.GetType("System.IO.File")
+        Dim myMemberInfoArray() As MemberInfo = myType.GetMembers()
         ' Gets and displays the DeclaringType method.
         Console.WriteLine("\nThere are {0} members in {1}.",
-            Mymemberinfoarray.Length, MyType.FullName)
-        Console.WriteLine("{0}.", MyType.FullName)
-        If MyType.IsPublic
-            Console.WriteLine("{0} is public.", MyType.FullName)
+            myMemberInfoArray.Length, myType.FullName)
+        Console.WriteLine("{0}.", myType.FullName)
+        If myType.IsPublic
+            Console.WriteLine("{0} is public.", myType.FullName)
         End If
     End Sub
 End Class

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.types.viewinfo/vb/source3.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.types.viewinfo/vb/source3.vb
@@ -5,25 +5,25 @@ Class MyMethodInfo
     Public Shared Sub Main()
         Console.WriteLine("Reflection.MethodInfo")
         ' Gets and displays the Type.
-        Dim MyType As Type = Type.GetType("System.Reflection.FieldInfo")
+        Dim myType As Type = Type.GetType("System.Reflection.FieldInfo")
         ' Specifies the member for which you want type information.
-        Dim Mymethodinfo As MethodInfo = MyType.GetMethod("GetValue")
-        Console.WriteLine((MyType.FullName & "." & Mymethodinfo.Name))
+        Dim myMethodInfo As MethodInfo = myType.GetMethod("GetValue")
+        Console.WriteLine((myType.FullName & "." & myMethodInfo.Name))
         ' Gets and displays the MemberType property.
-        Dim Mymembertypes As MemberTypes = Mymethodinfo.MemberType
-        If MemberTypes.Constructor = Mymembertypes Then
+        Dim myMemberTypes As MemberTypes = myMethodInfo.MemberType
+        If MemberTypes.Constructor = myMemberTypes Then
             Console.WriteLine("MemberType is of type All")
-        ElseIf MemberTypes.Custom = Mymembertypes Then
+        ElseIf MemberTypes.Custom = myMemberTypes Then
             Console.WriteLine("MemberType is of type Custom")
-        ElseIf MemberTypes.Event = Mymembertypes Then
+        ElseIf MemberTypes.Event = myMemberTypes Then
             Console.WriteLine("MemberType is of type Event")
-        ElseIf MemberTypes.Field = Mymembertypes Then
+        ElseIf MemberTypes.Field = myMemberTypes Then
             Console.WriteLine("MemberType is of type Field")
-        ElseIf MemberTypes.Method = Mymembertypes Then
+        ElseIf MemberTypes.Method = myMemberTypes Then
             Console.WriteLine("MemberType is of type Method")
-        ElseIf MemberTypes.Property = Mymembertypes Then
+        ElseIf MemberTypes.Property = myMemberTypes Then
             Console.WriteLine("MemberType is of type Property")
-        ElseIf MemberTypes.TypeInfo = Mymembertypes Then
+        ElseIf MemberTypes.TypeInfo = myMemberTypes Then
             Console.WriteLine("MemberType is of type TypeInfo")
         End If
         Return


### PR DESCRIPTION
## Summary

Fix variable names in [Viewing Type Information](https://docs.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/viewing-type-information) article.

Fixes #23868
