### PR TITLE
Fix wrong detected method

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -41,7 +41,7 @@ The rule only works when the method is preceded by the `await` keyword.
 |<xref:System.IO.Stream.ReadAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken)>|
 |<xref:System.IO.Stream.ReadAsync(System.Byte[],System.Int32,System.Int32)>|<xref:System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken)> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
 |<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte},System.Threading.CancellationToken)>|
-|<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte},System.Threading.CancellationToken)> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
+|<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte})> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
 
 > [!IMPORTANT]
 > Make sure to pass the `offset` and `count` integer arguments to the created `Memory` or `ReadOnlyMemory` instances.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -41,7 +41,7 @@ The rule only works when the method is preceded by the `await` keyword.
 |<xref:System.IO.Stream.ReadAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken)>|
 |<xref:System.IO.Stream.ReadAsync(System.Byte[],System.Int32,System.Int32)>|<xref:System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken)> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
 |<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte},System.Threading.CancellationToken)>|
-|<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte})> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
+|<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte},System.Threading.CancellationToken)> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
 
 > [!IMPORTANT]
 > Make sure to pass the `offset` and `count` integer arguments to the created `Memory` or `ReadOnlyMemory` instances.


### PR DESCRIPTION
## Summary

[CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835)

`WriteAsync(Byte[], Int32, Int32, CancellationToken)` is mentioned twice. The second instance should be `WriteAsync(Byte[], Int32, Int32)`.