### PR TITLE
Add a doc to help troubleshoot package mixups

### DIFF
--- a/docs/core/install/linux-centos.md
+++ b/docs/core/install/linux-centos.md
@@ -71,9 +71,9 @@ This section provides information on common errors you may get while using the p
 
 [!INCLUDE [package-manager-failed-to-fetch-rpm](includes/package-manager-failed-to-fetch-rpm.md)]
 
-### Errors about missing `fxr`, `libhostfxr.so` or `FrameworkList.xml`
+### Errors related to missing `fxr`, `libhostfxr.so`, or `FrameworkList.xml`
 
-See how to [Troubleshoot Package Mixups](linux-package-mixup.md)
+For more information about solving these problems, see [Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors](linux-package-mixup.md).
 
 ## Dependencies
 

--- a/docs/core/install/linux-centos.md
+++ b/docs/core/install/linux-centos.md
@@ -71,6 +71,10 @@ This section provides information on common errors you may get while using the p
 
 [!INCLUDE [package-manager-failed-to-fetch-rpm](includes/package-manager-failed-to-fetch-rpm.md)]
 
+### Errors about missing `fxr`, `libhostfxr.so` or `FrameworkList.xml`
+
+See how to [Troubleshoot Package Mixups](linux-package-mixup.md)
+
 ## Dependencies
 
 [!INCLUDE [linux-rpm-install-dependencies](includes/linux-rpm-install-dependencies.md)]

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -102,6 +102,10 @@ For more information on installing .NET without a package manager, see one of th
 
 [!INCLUDE [package-manager-failed-to-fetch-rpm](includes/package-manager-failed-to-fetch-rpm.md)]
 
+### Errors about missing `fxr`, `libhostfxr.so` or `FrameworkList.xml`
+
+See how to [Troubleshoot Package Mixups](linux-package-mixup.md)
+
 ## Next steps
 
 - [How to enable TAB completion for the .NET CLI](../tools/enable-tab-autocomplete.md)

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -102,9 +102,9 @@ For more information on installing .NET without a package manager, see one of th
 
 [!INCLUDE [package-manager-failed-to-fetch-rpm](includes/package-manager-failed-to-fetch-rpm.md)]
 
-### Errors about missing `fxr`, `libhostfxr.so` or `FrameworkList.xml`
+### Errors related to missing `fxr`, `libhostfxr.so`, or `FrameworkList.xml`
 
-See how to [Troubleshoot Package Mixups](linux-package-mixup.md)
+For more information about solving these problems, see [Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors](linux-package-mixup.md).
 
 ## Next steps
 

--- a/docs/core/install/linux-package-mixup.md
+++ b/docs/core/install/linux-package-mixup.md
@@ -3,14 +3,14 @@ title: Troubleshoot .NET Package Mix ups on Linux
 description: Learn about how to troubleshoot strange .NET package errors on Linux.
 author: omajid
 ms.date: 05/12/2021
-no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FIleNoteFoundException']
+no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FileNotFoundException']
 ---
 
 # Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors
 
 When you try to use .NET 5+ (and .NET Core), commands such as `dotnet new` and `dotnet run` may fail with a message related to something not being found. Some of the error messages may be similar to the following:
 
-- **System.IO.FIleNoteFoundException**
+- **System.IO.FileNotFoundException**
 
   > System.IO.FileNotFoundException: Could not find file '/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml'.
 

--- a/docs/core/install/linux-package-mixup.md
+++ b/docs/core/install/linux-package-mixup.md
@@ -3,7 +3,7 @@ title: Troubleshoot .NET Package Mix ups on Linux
 description: Learn about how to troubleshoot strange .NET package errors on Linux.
 author: omajid
 ms.date: 05/12/2021
-no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FIleNoteFoundException', 'mdatp', 'powershell', 'mssql']
+no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FIleNoteFoundException']
 ---
 
 # Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors
@@ -51,7 +51,7 @@ If your distribution provides .NET packages, it's recommended that you use that 
 
 01. **I only use .NET and no other packages from the Microsoft repository, and my distribution provides .NET packages.**
 
-    If you only use the Microsoft repository for .NET packages and not for any other Microsoft package such as **mdatp**, **powershell**, or **mssql**, then:
+    If you only use the Microsoft repository for .NET packages and not for any other Microsoft package such as `mdatp`, `powershell`, or `mssql`, then:
 
     01. Remove the Microsoft repository
     01. Remove the .NET related packages from your OS
@@ -67,7 +67,7 @@ If your distribution provides .NET packages, it's recommended that you use that 
 
 02. **I want to use the distribution provided .NET packages, but I also use the Microsoft repository for other packages.**
 
-    If you use the Microsoft repository for Microsoft packages such as **mdatp**, **powershell**, or **mssql**, but you don't want to use the repository for .NET, then:
+    If you use the Microsoft repository for Microsoft packages such as `mdatp`, `powershell`, or `mssql`, but you don't want to use the repository for .NET, then:
 
     01. Configure the Microsoft repository to exclude any .NET package
     01. Remove the .NET related packages from your OS

--- a/docs/core/install/linux-package-mixup.md
+++ b/docs/core/install/linux-package-mixup.md
@@ -3,7 +3,7 @@ title: Troubleshoot .NET Package Mix ups on Linux
 description: Learn about how to troubleshoot strange .NET package errors on Linux.
 author: omajid
 ms.date: 05/12/2021
-no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FileNotFoundException']
+no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrameworkList.xml', 'System.IO.FileNotFoundException']
 ---
 
 # Troubleshoot _fxr_, _libhostfxr.so_, and _FrameworkList.xml_ errors

--- a/docs/core/install/linux-package-mixup.md
+++ b/docs/core/install/linux-package-mixup.md
@@ -6,7 +6,7 @@ ms.date: 05/12/2021
 no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FileNotFoundException']
 ---
 
-# Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors
+# Troubleshoot _fxr_, _libhostfxr.so_, and _FrameworkList.xml_ errors
 
 When you try to use .NET 5+ (and .NET Core), commands such as `dotnet new` and `dotnet run` may fail with a message related to something not being found. Some of the error messages may be similar to the following:
 

--- a/docs/core/install/linux-package-mixup.md
+++ b/docs/core/install/linux-package-mixup.md
@@ -1,99 +1,136 @@
 ---
-title: Troubleshoot Package Mixup
-description: Learn about how to troubleshoot strange .NET packae errors on Linux.
+title: Troubleshoot .NET Package Mix ups on Linux
+description: Learn about how to troubleshoot strange .NET package errors on Linux.
 author: omajid
 ms.date: 05/12/2021
+no-loc: ['usr','lib64','share','dotnet','libhostfxr.so', 'fxr', 'FrmaeworkList.xml', 'System.IO.FIleNoteFoundException', 'mdatp', 'powershell', 'mssql']
 ---
 
-# Troubleshoot `fxr`, `libhostfxr.so` or `FrameworkList.xml` errors
+# Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors
 
-Users trying to use .NET and .NET Core may run into .NET commands (`dotnet new`, `dotnet build`, `dotnet run`) failing. The exact error messages can vary. Some example error messages:
+When you try to use .NET 5+ (and .NET Core), commands such as `dotnet new` and `dotnet run` may fail with a message related to something not being found. Some of the error messages may be similar to the following:
 
-- [SDK #12075](https://github.com/dotnet/sdk/issues/12075), [SDK #15785](https://github.com/dotnet/sdk/issues/15785), [SDK #15863](https://github.com/dotnet/sdk/issues/15863) and [SDK #17411](https://github.com/dotnet/sdk/issues/17411):
+- **System.IO.FIleNoteFoundException**
 
-  ```
-  System.IO.FileNotFoundException: Could not find file '/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml'.`
-  ```
+  > System.IO.FileNotFoundException: Could not find file '/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml'.
 
-- [SDK #17570](https://github.com/dotnet/sdk/issues/17570):
+- **A fatal error occurred.**
 
-  ```
-  A fatal error occurred. The required library libhostfxr.so could not be found.
-  ```
+  > A fatal error occurred. The required library _libhostfxr.so_ could not be found.
 
-- [Core #5746](https://github.com/dotnet/core/issues/5746) and [SDK #15476](https://github.com/dotnet/sdk/issues/15476):
+  or
 
-  ```
-  A fatal error occurred. The folder [/usr/share/dotnet/host/fxr] does not exist
-  ```
+  > A fatal error occurred. The folder [/usr/share/dotnet/host/fxr] does not exist.
 
-- [Installer #9254](https://github.com/dotnet/installer/issues/9254) and [StackOverflow](https://stackoverflow.com/questions/65422998/):
+  or
 
-  ```
-  A fatal error occurred, the folder [/usr/share/dotnet/host/fxr] does not contain any version-numbered child folders
-  ```
+  > A fatal error occurred, the folder [/usr/share/dotnet/host/fxr] does not contain any version-numbered child folders.
 
-And some symptoms without clear error messages:
+- **Generic messages about dotnet not found**
 
-- [Core #4605](https://github.com/dotnet/core/issues/4605), [Core #4644](https://github.com/dotnet/core/issues/4655) and [Runtime #49375](https://github.com/dotnet/runtime/issues/49375):
+  A general message may appear that indicates the SDK isn't found, or that the package has already been installed.
 
-  SDK is installed, but `dotnet` complains it isn't.
+One symptom of these problems is that both the `/usr/lib64/dotnet` and `/usr/share/dotnet` folders are on your system.
 
-Another common symptom of this problem is that you have both `/usr/lib64/dotnet` and `/usr/share/dotnet` on your machine.
+## What's going on
 
-## What's going on?
+This generally happens when two Linux package repositories provide .NET packages. While Microsoft provides a Linux package repository to source .NET packages, some Linux distributions also provide .NET packages, such as:
 
-This generally happens when two Linux package repositories provide .NET packages. Often .NET packages are provided by the Linux distribution (eg, Arch, CentOS, Fedora, RHEL), in addition to Microsoft.
+- Arch
+- CentOS
+- Fedora
+- RHEL
 
-Mixing .NET packages from two different sources will most likely lead to issues since they packages may place things at different paths, and may be compiled differently.
+Mixing .NET packages from two different sources will most likely lead to issues since the packages may place things at different paths, and may be compiled differently.
 
-## Some fixes
+## Solutions
 
-The fix is to use .NET from one package repository only. Which repository to pick and how to do it varies by use-case and the Linux distribution.
+The solution to these problems is to use .NET from one package repository. Which repository to pick, and how to do it, varies by use-case and the Linux distribution.
 
-The first fix is probably the simplest (and best in the very long term) but there are some known issues that may lead to better outcomes for the user right now if they pick another option.
+If your distribution provides .NET packages, it's recommended that you use that package repository instead of Microsoft's.
 
-**Use case 1**: I only want to install/use .NET. I dont want to use any other packages - such as `mdatp`, `powershell` and `mssql` - from the Microsoft repository.
+01. **I only use .NET and no other packages from the Microsoft repository, and my distribution provides .NET packages.**
 
-In this case, remove the Microsoft repository, the .NET packages and then re-install the .NET packages from the Linux distribution repository.
+    If you only use the Microsoft repository for .NET packages and not for any other Microsoft package such as **mdatp**, **powershell**, or **mssql**, then:
 
-For Fedora, CentOS >= 8, and RHEL >=8:
+    01. Remove the Microsoft repository
+    01. Remove the .NET related packages from your OS
+    01. Install the .NET packages from the distribution repository
 
-```bash
-sudo dnf remove package-microsoft-prod
-sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
-sudo dnf install dotnet-sdk-5.0
-```
+    For Fedora, CentOS 8+, RHEL 8+, use the following bash commands:
 
-**Use case 2**: I want to install and use .NET but also need other packages from Microsoft's repository, such as `mdatp`, `powershell` or `mssql`.
+    ```bash
+    sudo dnf remove package-microsoft-prod
+    sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
+    sudo dnf install dotnet-sdk-5.0
+    ```
 
-In this case, keep the Microsoft repository, but configure it so that it doesn't provide any the .NET packages, remove the already-installed .NET packages and then re-install the .NET packages from the Linux distribution repository.
+02. **I want to use the distribution provided .NET packages, but I also use the Microsoft repository for other packages.**
 
-For Fedora, CentOS >= 8, and RHEL >=8:
+    If you use the Microsoft repository for Microsoft packages such as **mdatp**, **powershell**, or **mssql**, but you don't want to use the repository for .NET, then:
 
-```bash
-echo 'excludepkgs=dotnet*,aspnet*,netstandard*' | sudo tee -a /etc/yum.repos.d/microsoft-prod.repo
-sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
-sudo dnf install dotnet-sdk-5.0
-```
+    01. Configure the Microsoft repository to exclude any .NET package
+    01. Remove the .NET related packages from your OS
+    01. Install the .NET packages from the distribution repository
 
-**Use case 3**: I need a recent version of .NET that's not available if I go with option 1 or 2.
+    For Fedora, CentOS 8+, RHEL 8+, use the following bash commands:
 
-In this case, keep the Microsoft repository, and configure it so .NET packages from the Microsoft repository are considered a higher priority. Then remove the already-installed .NET packages and then re-install the .NET packages from the Microsoft repository.
+    ```bash
+    echo 'excludepkgs=dotnet*,aspnet*,netstandard*' | sudo tee -a /etc/yum.repos.d/microsoft-prod.repo
+    sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
+    sudo dnf install dotnet-sdk-5.0
+    ```
 
-For Fedora, CentOS >= 8, and RHEL >=8:
+03. **I need a recent version of .NET that's not provided by the Linux distribution repositories.**
 
-```bash
-echo 'priority=50' | sudo tee -a /etc/yum.repos.d/microsoft-prod.repo
-sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
-sudo dnf install dotnet-sdk-5.0
-```
+    In this case, keep the Microsoft repository, but configure it so .NET packages from the Microsoft repository are considered a higher priority. Then, remove the already-installed .NET packages and then re-install the .NET packages from the Microsoft repository.
+  
+    For Fedora, CentOS 8+, RHEL 8+, use the following bash commands:
 
-**Use case 4** I dont care about the vendor of .NET but the version of .NET from the Linux distribution has bugs that are showstoppers for me and those bugs are fixed in the Microsoft packages.
+    ```bash
+    echo 'priority=50' | sudo tee -a /etc/yum.repos.d/microsoft-prod.repo
+    sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
+    sudo dnf install dotnet-sdk-5.0
+    ```
 
-Follow the same steps as Use case 3.
+04. **I've encountered a bug in the Linux distribution version of .NET, I need the latest Microsoft version.**
+
+    Use solution 3 to solve this problem.
+
+## Online references
+
+Many of these problems have been reported by users such as yourself. The following is a list of those issues. You can read through them for insights on what may be happening:
+
+- System.IO.FileNotFoundException and '/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml'
+
+  - [SDK #15785: unable to build brand new project after upgrading to 5.0.3](https://github.com/dotnet/sdk/issues/15785)
+  - [SDK #15863: "MSB4018 ResolveTargetingPackAssets task failed unexpectedly" after updating to 5.0.103](https://github.com/dotnet/sdk/issues/15863)
+  - [SDK #17411: dotnet build always throwing error](https://github.com/dotnet/sdk/issues/17411)
+  - [SDK #12075: dotnet 3.1.301 on Fedora 32 unable to find FrameworkList.xml because it doesn't exist](https://github.com/dotnet/sdk/issues/12075)
+
+- Fatal error: _libhostfxr.so_ couldn't be found
+
+  - [SDK #17570: After updating Fedora 33 to 34 and dotnet 5.0.5 to 5.0.6 I get error regarding libhostfxr.so](https://github.com/dotnet/sdk/issues/17570):
+
+- Fatal error: folder _/host/fxr_ doesn't exist
+
+  - [Core #5746: The folder does not exist when installing 3.1 on CentOS 8 with packages.microsoft.com repo enabled](https://github.com/dotnet/core/issues/5746)
+  - [SDK #15476: A fatal error occurred. The folder [/usr/share/dotnet/host/fxr] does not exist](https://github.com/dotnet/sdk/issues/15476):
+
+- Fatal error: folder _/host/fxr_ doesn't contain any version-numbered child folders
+
+  - [Installer #9254: Error when install dotnet/core/aspnet:3.1 on CentOS 8 - Folder does not contain any version-numbered child folders](https://github.com/dotnet/installer/issues/9254)
+  - [StackOverflow: Error when install dotnet/core/aspnet:3.1 on CentOS 8 - Folder does not contain any version-numbered child folders](https://stackoverflow.com/questions/65422998/)
+
+- Generic errors without clear messages
+
+  - [Core #4605: cannot run "dotnet new console"](https://github.com/dotnet/core/issues/4605)
+  - [Core #4644: Cannot install .NET Core SDK 2.1 on Fedora 32](https://github.com/dotnet/core/issues/4655)
+  - [Runtime #49375: After updating to 5.0.200-1 using package manager, it appears that no sdks are installed](https://github.com/dotnet/runtime/issues/49375)
 
 ## Next steps
 
+- [Install .NET on Linux](linux.md)
+- [How to remove the .NET Runtime and SDK](remove-runtime-sdk-versions.md?pivots=os-linux)
 - [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.md).
 - [Tutorial: Containerize a .NET app](../docker/build-container.md).

--- a/docs/core/install/linux-package-mixup.md
+++ b/docs/core/install/linux-package-mixup.md
@@ -1,0 +1,99 @@
+---
+title: Troubleshoot Package Mixup
+description: Learn about how to troubleshoot strange .NET packae errors on Linux.
+author: omajid
+ms.date: 05/12/2021
+---
+
+# Troubleshoot `fxr`, `libhostfxr.so` or `FrameworkList.xml` errors
+
+Users trying to use .NET and .NET Core may run into .NET commands (`dotnet new`, `dotnet build`, `dotnet run`) failing. The exact error messages can vary. Some example error messages:
+
+- [SDK #12075](https://github.com/dotnet/sdk/issues/12075), [SDK #15785](https://github.com/dotnet/sdk/issues/15785), [SDK #15863](https://github.com/dotnet/sdk/issues/15863) and [SDK #17411](https://github.com/dotnet/sdk/issues/17411):
+
+  ```
+  System.IO.FileNotFoundException: Could not find file '/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml'.`
+  ```
+
+- [SDK #17570](https://github.com/dotnet/sdk/issues/17570):
+
+  ```
+  A fatal error occurred. The required library libhostfxr.so could not be found.
+  ```
+
+- [Core #5746](https://github.com/dotnet/core/issues/5746) and [SDK #15476](https://github.com/dotnet/sdk/issues/15476):
+
+  ```
+  A fatal error occurred. The folder [/usr/share/dotnet/host/fxr] does not exist
+  ```
+
+- [Installer #9254](https://github.com/dotnet/installer/issues/9254) and [StackOverflow](https://stackoverflow.com/questions/65422998/):
+
+  ```
+  A fatal error occurred, the folder [/usr/share/dotnet/host/fxr] does not contain any version-numbered child folders
+  ```
+
+And some symptoms without clear error messages:
+
+- [Core #4605](https://github.com/dotnet/core/issues/4605), [Core #4644](https://github.com/dotnet/core/issues/4655) and [Runtime #49375](https://github.com/dotnet/runtime/issues/49375):
+
+  SDK is installed, but `dotnet` complains it isn't.
+
+Another common symptom of this problem is that you have both `/usr/lib64/dotnet` and `/usr/share/dotnet` on your machine.
+
+## What's going on?
+
+This generally happens when two Linux package repositories provide .NET packages. Often .NET packages are provided by the Linux distribution (eg, Arch, CentOS, Fedora, RHEL), in addition to Microsoft.
+
+Mixing .NET packages from two different sources will most likely lead to issues since they packages may place things at different paths, and may be compiled differently.
+
+## Some fixes
+
+The fix is to use .NET from one package repository only. Which repository to pick and how to do it varies by use-case and the Linux distribution.
+
+The first fix is probably the simplest (and best in the very long term) but there are some known issues that may lead to better outcomes for the user right now if they pick another option.
+
+**Use case 1**: I only want to install/use .NET. I dont want to use any other packages - such as `mdatp`, `powershell` and `mssql` - from the Microsoft repository.
+
+In this case, remove the Microsoft repository, the .NET packages and then re-install the .NET packages from the Linux distribution repository.
+
+For Fedora, CentOS >= 8, and RHEL >=8:
+
+```bash
+sudo dnf remove package-microsoft-prod
+sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
+sudo dnf install dotnet-sdk-5.0
+```
+
+**Use case 2**: I want to install and use .NET but also need other packages from Microsoft's repository, such as `mdatp`, `powershell` or `mssql`.
+
+In this case, keep the Microsoft repository, but configure it so that it doesn't provide any the .NET packages, remove the already-installed .NET packages and then re-install the .NET packages from the Linux distribution repository.
+
+For Fedora, CentOS >= 8, and RHEL >=8:
+
+```bash
+echo 'excludepkgs=dotnet*,aspnet*,netstandard*' | sudo tee -a /etc/yum.repos.d/microsoft-prod.repo
+sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
+sudo dnf install dotnet-sdk-5.0
+```
+
+**Use case 3**: I need a recent version of .NET that's not available if I go with option 1 or 2.
+
+In this case, keep the Microsoft repository, and configure it so .NET packages from the Microsoft repository are considered a higher priority. Then remove the already-installed .NET packages and then re-install the .NET packages from the Microsoft repository.
+
+For Fedora, CentOS >= 8, and RHEL >=8:
+
+```bash
+echo 'priority=50' | sudo tee -a /etc/yum.repos.d/microsoft-prod.repo
+sudo dnf remove 'dotnet*' 'aspnet*' 'netstandard*'
+sudo dnf install dotnet-sdk-5.0
+```
+
+**Use case 4** I dont care about the vendor of .NET but the version of .NET from the Linux distribution has bugs that are showstoppers for me and those bugs are fixed in the Microsoft packages.
+
+Follow the same steps as Use case 3.
+
+## Next steps
+
+- [Tutorial: Create a new app with Visual Studio Code](../tutorials/with-visual-studio-code.md).
+- [Tutorial: Containerize a .NET app](../docker/build-container.md).

--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -139,6 +139,14 @@ As an alternative to the ASP.NET Core Runtime, you can install the .NET Core Run
 
 Consult the [Red Hat documentation for .NET](https://access.redhat.com/documentation/net/5.0/) on the steps required to install other releases of .NET.
 
+## Troubleshoot the package manager
+
+This section provides information on common errors you may get while using the package manager to install .NET or .NET Core.
+
+### Errors about missing `fxr`, `libhostfxr.so` or `FrameworkList.xml`
+
+See how to [Troubleshoot Package Mixups](linux-package-mixup.md)
+
 ## Next steps
 
 - [How to enable TAB completion for the .NET CLI](../tools/enable-tab-autocomplete.md)

--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -143,9 +143,9 @@ Consult the [Red Hat documentation for .NET](https://access.redhat.com/documenta
 
 This section provides information on common errors you may get while using the package manager to install .NET or .NET Core.
 
-### Errors about missing `fxr`, `libhostfxr.so` or `FrameworkList.xml`
+### Errors related to missing `fxr`, `libhostfxr.so`, or `FrameworkList.xml`
 
-See how to [Troubleshoot Package Mixups](linux-package-mixup.md)
+For more information about solving these problems, see [Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors](linux-package-mixup.md).
 
 ## Next steps
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -48,6 +48,8 @@ items:
       href: ../core/install/templates.md
     - name: macOS Notarization issues
       href: ../core/install/macos-notarization-issues.md
+    - name: Troubleshoot .NET Package mix ups on Linux
+      href: ../core/install/linux-package-mixup.md 
     - name: How to check .NET versions
       href: ../core/install/how-to-detect-installed-versions.md
     - name: Install localized IntelliSense


### PR DESCRIPTION
Now that source-built .NET Core is becoming more widespread, people are hitting issues when some packages on their machines come from the Microsoft repos and others from the distro archive. They don't mix well: they have different dotnet roots, /usr/share/dotnet vs. /usr/lib64/dotnet.

Document some ways to identify this problem as well as some solutions based on what the user's goal is.

Fixes: #18347

cc @dagood @NikolaMilosavljevic @dleeapho @MichaelSimons @leecow @adegeo 