### PR TITLE
Documented TimeSpan marshalling

### DIFF
--- a/docs/standard/native-interop/type-marshaling.md
+++ b/docs/standard/native-interop/type-marshaling.md
@@ -42,6 +42,7 @@ This first table describes the mappings for various types for whom the marshalin
 | `decimal` | COM `DECIMAL` struct |
 | .NET Delegate | Native function pointer |
 | `System.DateTime` | Win32 `DATE` type |
+| `System.TimeSpan` | `int64_t` |
 | `System.Guid` | Win32 `GUID` type |
 
 A few categories of marshaling have different defaults if you're marshaling as a parameter or structure.


### PR DESCRIPTION
Tested in .NET 5 on Win64. Not sure about other platforms, please specify.