### PR TITLE
Add missing null-conditional operator

### DIFF
--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
@@ -48,7 +48,7 @@ class ExampleConjunctiveDisposableusing : IDisposable, IAsyncDisposable
         }
         else
         {
-            _disposableResource.Dispose();
+            _disposableResource?.Dispose();
         }
 
         _asyncDisposableResource = null;


### PR DESCRIPTION
## Summary

Example of `IAsyncDisposable` implementation has missing null-conditional operator. The `DisposeAsync` method may fail, when called 2 times. Also other methods in example use null-conditional operator, when calling `Dispose`.
