### PR TITLE
Removed extra space and fixed grammar mistake

### DIFF
--- a/docs/architecture/dapr-for-net-developers/dapr-at-20000-feet.md
+++ b/docs/architecture/dapr-for-net-developers/dapr-at-20000-feet.md
@@ -30,7 +30,7 @@ Figure 2-1 shows Dapr from 20,000 feet.
 ![Dapr at 20,000 feet](./media/dapr-at-20000-feet/dapr-high-level.png)
 **Figure 2-1**. Dapr at 20,000 feet.
 
-In the top row of the figure, note how Dapr provides language-specific SDKs for popular development platforms. Dapr v 1.0 includes supports Go, Node.js, Python, .NET, Java, and JavaScript. This book focuses on the Dapr .NET SDK, which also provides direct support for ASP.NET Core integration.
+In the top row of the figure, note how Dapr provides language-specific SDKs for popular development platforms. Dapr v1.0 includes support for Go, Node.js, Python, .NET, Java, and JavaScript. This book focuses on the Dapr .NET SDK, which also provides direct support for ASP.NET Core integration.
 
 While language-specific SDKs enhance the developer experience, Dapr is platform agnostic. Under the hood, Dapr's programming model exposes capabilities through standard HTTP/gRPC communication protocols. Any programming platform can call Dapr via its native HTTP and gRPC APIs.  
 


### PR DESCRIPTION
## Summary

Describe your changes here.
Removed extra space in `Dapr v 1.0` to `Dapr v1.0` and fixed grammar mistake with `includes supports Go` to `includes support for Go`

Fixes #Issue_Number (if available)
N/A