### PR TITLE
Update .ghal.rules.json for new labeler

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -24,7 +24,7 @@
         "type": "query",
         "value": "length(Issue.labels[?name == ':checkered_flag: Release .NET 6']) != `0`",
         "actions": {
-          "projects-add": ["132"]
+          "projects-add": [ "132" ]
         }
       }
     },
@@ -35,7 +35,8 @@
       "processor-meta-custom": {
         "issuetype": {
           "(?i)breaking-change$": {
-            "labels-add": [ "breaking-change", "doc-idea" ]
+            "labels-add": [ "breaking-change", "doc-idea" ],
+            "projects-add": [ "135" ]
           }
         }
       }
@@ -324,7 +325,7 @@
         "type": "query",
         "value": "length(PullRequest.labels[?name == ':checkered_flag: Release .NET 6']) != `0`",
         "actions": {
-          "projects-add": ["132"]
+          "projects-add": [ "132" ]
         }
       }
     }

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -265,15 +265,6 @@
               "(?i).*docs\/framework\/windows-workflow-foundation.*": {
                 "labels-add": [ "dotnet-framework/prod", "dotnet-wf/tech" ]
               },
-              "(?i).*docs\/framework\/winforms.*": {
-                "labels-add": [ "dotnet-framework/prod", "dotnet-winforms/tech" ]
-              },
-              "(?i).*docs\/framework\/wpf.*": {
-                "labels-add": [ "dotnet-framework/prod", "dotnet-wpf/tech" ]
-              },
-              "(?i).*docs\/framework\/xaml-services.*": {
-                "labels-add": [ "dotnet-framework/prod", "dotnet-wpf/tech" ]
-              },
               
               "(?i).*docs\/fsharp.*": {
                 "labels-add": "dotnet-fsharp/prod"
@@ -331,7 +322,7 @@
     "labeled": {
       "processor-conditional-release6": {
         "type": "query",
-        "value": "length(Issue.labels[?name == ':checkered_flag: Release .NET 6']) != `0`",
+        "value": "length(PullRequest.labels[?name == ':checkered_flag: Release .NET 6']) != `0`",
         "actions": {
           "projects-add": ["132"]
         }

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -1,10 +1,10 @@
 {
   "version": 3,
-  "configRevision": 3,
+  "configRevision": 4,
 
   "issue": {
     "labeled": {
-      "processor-conditional": {
+      "processor-conditional-techprodlabels": {
         "type": "query",
         "value": "length(Issue.labels[?contains(name, '/prod') || contains(name, '/tech')]) != `0`",
         "processors": {
@@ -18,6 +18,13 @@
               "labels-add": ":watch: Not Triaged"
             }
           }
+        }
+      },
+      "processor-conditional-release6": {
+        "type": "query",
+        "value": "length(Issue.labels[?name == ':checkered_flag: Release .NET 6']) != `0`",
+        "actions": {
+          "projects-add": ["132"]
         }
       }
     },
@@ -318,6 +325,15 @@
               
             }
           }
+        }
+      }
+    },
+    "labeled": {
+      "processor-conditional-release6": {
+        "type": "query",
+        "value": "length(Issue.labels[?name == ':checkered_flag: Release .NET 6']) != `0`",
+        "actions": {
+          "projects-add": ["132"]
         }
       }
     }


### PR DESCRIPTION
## Summary

Depends on the new labeler version.

- [x] New labeler version is deployed
- New rule for **Issue** which detects the `:checkered_flag: Release .NET 6` label and adds it to [.NET 6 documentation plan (132)](https://github.com/dotnet/docs/projects/132)
- New rule for **PR** which detects the `:checkered_flag: Release .NET 6` label and adds it to [.NET 6 documentation plan (132)](https://github.com/dotnet/docs/projects/132)
- Remove WinForms/WPF file detection paths