### PR TITLE
fix next steps link in distributed tracing concepts doc

### DIFF
--- a/docs/core/diagnostics/distributed-tracing-concepts.md
+++ b/docs/core/diagnostics/distributed-tracing-concepts.md
@@ -134,5 +134,5 @@ recorded.
 
 ## Next steps
 
-See the [Distributed Tracing Overview](distributed-tracing.md) for example code to get started
+See the [Distributed Tracing Instrumentation](distributed-tracing-instrumentation-walkthroughs.md) for example code to get started
 using distributed tracing in .NET applications.


### PR DESCRIPTION
## Summary

Fix the "next steps" link in distributed tracing concepts doc to link to distributed tracing instrumentation doc.
Fixes #23917 
