### PR TITLE
Provide "Marshaling data" main article with explanation of how to call native code in C#

### DIFF
--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -59,3 +59,15 @@ The following code defines the library functions provided by Pinvoke.dll. Many s
 [!code-cpp[PInvokeLib#1](../../../samples/snippets/cpp/VS_Snippets_CLR/pinvokelib/cpp/pinvokelib.cpp#1)]
 
 [!code-cpp[PInvokeLib#2](../../../samples/snippets/cpp/VS_Snippets_CLR/pinvokelib/cpp/pinvokelib.h#2)]
+
+To call this in a managed code (on the C# side) you should first implement the managed prototypes for all functions and methods which are to be invoked on the C# side.
+If an unmanaged code uses a class or struct (or any custom type) this type has to be declared also in a managed code.  
+Please see the <xref:System.Runtime.InteropServices.DllImportAttribute> which the prototype should be marked with.
+
+The example of such a prototype would look like:
+```cs
+// Declares a managed prototype for TestStructInStruct declared and defined in unmanaged library
+[DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
+internal static extern int TestStructInStruct(ref MyPerson2 person2);
+```
+For more examples and comprehensive explanation please see other documents in this section related to marshaling.

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -65,11 +65,13 @@ If an unmanaged code uses a class or struct (or any custom type) this type has t
 Please see the <xref:System.Runtime.InteropServices.DllImportAttribute> which the prototype should be marked with.
 
 The example of such a prototype would look like:
+
 ```cs
 // Declares a managed prototype for TestStructInStruct declared and defined in unmanaged library
 [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
 internal static extern int TestStructInStruct(ref MyPerson2 person2);
 ```
+
 For more examples and comprehensive explanation please see other documents in this section related to marshaling.
 
 ## See also

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -66,7 +66,7 @@ Decorate the prototype with the <xref:System.Runtime.InteropServices.DllImportAt
 
 The following code shows an example prototype:
 
-```cs
+```csharp
 // Managed prototype for TestingStructInStruct, which is declared and defined in an unmanaged library.
 [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
 internal static extern int TestStructInStruct(ref MyPerson2 person2);

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -71,3 +71,9 @@ The example of such a prototype would look like:
 internal static extern int TestStructInStruct(ref MyPerson2 person2);
 ```
 For more examples and comprehensive explanation please see other documents in this section related to marshaling.
+
+## See also
+
+- [Marshaling Classes, Structures, and Unions](marshaling-classes-structures-and-unions.md)
+- [Marshaling Strings](marshaling-strings.md)
+- [Marshaling Different Types of Arrays](marshaling-different-types-of-arrays.md)

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -60,21 +60,19 @@ The following code defines the library functions provided by Pinvoke.dll. Many s
 
 [!code-cpp[PInvokeLib#2](../../../samples/snippets/cpp/VS_Snippets_CLR/pinvokelib/cpp/pinvokelib.h#2)]
 
-To call this in a managed code (on the C# side) you should first implement the managed prototypes for all functions and methods which are to be invoked on the C# side.
-If an unmanaged code uses a class or struct (or any custom type) this type has to be declared also in a managed code.  
-Please see the <xref:System.Runtime.InteropServices.DllImportAttribute> which the prototype should be marked with.
+To call the library functions from managed code, first implement the managed prototypes for each function you want to invoke.
+If the unmanaged code uses any any custom types, you must also declare those types in your managed code.  
+Decorate the prototype with the <xref:System.Runtime.InteropServices.DllImportAttribute> attribute.
 
-The example of such a prototype would look like:
+The following code shows an example prototype:
 
 ```cs
-// Declares a managed prototype for TestStructInStruct declared and defined in unmanaged library
+// Managed prototype for TestingStructInStruct, which is declared and defined in an unmanaged library.
 [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
 internal static extern int TestStructInStruct(ref MyPerson2 person2);
 ```
 
-For more examples and comprehensive explanation please see other documents in this section related to marshaling.
-
-## See also
+For more information and examples, see the following articles:
 
 - [Marshaling Classes, Structures, and Unions](marshaling-classes-structures-and-unions.md)
 - [Marshaling Strings](marshaling-strings.md)


### PR DESCRIPTION
This pull request fixes #10308

It adds the brief explanation of how to call the native, unmanaged library code in C#.

---

Full explanation of how to utilize the library created in the native language is placed in other documents of the marshaling documentation like [Platform Invoke (P/Invoke)](https://docs.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke) and [Marshaling Classes, Structures and Unions](https://docs.microsoft.com/en-us/dotnet/framework/interop/marshaling-classes-structures-and-unions) documents.
That's why the explanation delivered in this pull request acts only as a brief summary or just a introduction to this.

There is also the *See also* section added, so the developer/reader knows where to search for more examples and knowledge.

Please check the commit message for more details.