### PR TITLE
MVC buffering breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -22,6 +22,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 - [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md)
 - [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md)
 - [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md)
+- [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md)
 - [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md)
 - [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md)
 - [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md)

--- a/docs/core/compatibility/aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md
+++ b/docs/core/compatibility/aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md
@@ -1,0 +1,58 @@
+---
+title: "Breaking change: MVC no longer buffers IAsyncEnumerable types when using System.Text.Json"
+description: "Learn about the breaking change in ASP.NET Core 6.0 where MVC no longer buffers IAsyncEnumerable return types when formatting using System.Text.Json."
+ms.date: 05/17/2021
+---
+# MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json
+
+In ASP.NET Core 5, MVC added support for output formatting <xref:System.Collections.Generic.IAsyncEnumerable%601> types by buffering the sequence in memory and formatting the buffered collection. In ASP.NET Core 6, when formatting using <xref:System.Text.Json?displayProperty=fullName>, MVC no longer buffers <xref:System.Collections.Generic.IAsyncEnumerable%601> instances. Instead, MVC relies on the support that <xref:System.Text.Json?displayProperty=fullName> added for these types.
+
+In most cases, the absence of buffering would not be observable by the application. However, some scenarios may have inadvertently relied on the buffering semantics to correctly serialize. For example, returning an <xref:System.Collections.Generic.IAsyncEnumerable%601> that's backed by an Entity Framework query on a type with lazy-loaded properties can result in concurrent query execution, which might not be supported by the provider.
+
+This change does not affect output formatting using Newtonsoft.Json or with XML-based formatters.
+
+## Version introduced
+
+ASP.NET Core 6.0 Preview 4
+
+## Old behavior
+
+<xref:System.Collections.Generic.IAsyncEnumerable%601> instances returned from an MVC action as a value to be formatted using <xref:System.Data.Objects.ObjectResult> or a <xref:System.Web.Mvc.JsonResult> are buffered before being serialized as a synchronous collection.
+
+## New behavior
+
+When formatting using <xref:System.Text.Json?displayProperty=fullName>, MVC no longer buffers <xref:System.Collections.Generic.IAsyncEnumerable%601> instances.
+
+## Reason for change
+
+<xref:System.Text.Json?displayProperty=fullName> added support for streaming <xref:System.Collections.Generic.IAsyncEnumerable%601> types. This allows for a smaller memory footprint during serialization.
+
+## Recommended action
+
+If your application requires buffering, consider manually buffering the <xref:System.Collections.Generic.IAsyncEnumerable%601> object:
+
+```csharp
+// Before
+public IActionResult Get()
+{
+    return Ok(dbContext.Blogs);
+}
+
+// After
+public async Task<IActionResult> Get()
+{
+    return Ok(await dbContext.Blogs.ToListAsync());
+}
+```
+
+<!--
+
+## Category
+
+ASP.NET Core
+
+## Affected APIs
+
+Not detectable via API analysis
+
+-->

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -41,6 +41,8 @@ items:
           href: aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md
         - name: "Middleware: New Use overload"
           href: aspnet-core/6.0/middleware-new-use-overload.md
+        - name: MVC doesn't buffer IAsyncEnumerable types
+          href: aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md
         - name: Nullable reference type annotations changed
           href: aspnet-core/6.0/nullable-reference-type-annotations-changed.md
         - name: Obsoleted and removed APIs
@@ -373,6 +375,8 @@ items:
           href: aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md
         - name: "Middleware: New Use overload"
           href: aspnet-core/6.0/middleware-new-use-overload.md
+        - name: MVC doesn't buffer IAsyncEnumerable types
+          href: aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md
         - name: Nullable reference type annotations changed
           href: aspnet-core/6.0/nullable-reference-type-annotations-changed.md
         - name: Obsoleted and removed APIs


### PR DESCRIPTION
Fixes https://github.com/aspnet/Announcements/issues/463 - please label as documented.

[Internal preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc?branch=pr-en-us-24264).