### PR TITLE
Explain how to apply attributes to positional records

### DIFF
--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -90,7 +90,7 @@ If <xref:System.AttributeUsageAttribute.Inherited> is `false`, then the attribut
 
 In this case `NonInheritedAttribute` isn't applied to `DClass` via inheritance.
 
-You can also use these keywords to specify where an attribute should be applied. For example, you can use the `field:` specifier to add an attribute to the backing field of an [auto-implemented property]../../programming-guide/classes-and-structs/properties.md#auto-implemented-properties). Or you can use the `field:`, `property:` or `param:` specifier to apply an attribute to any of the elements generated from a [positional record](../builtin-types/record.md#positional-syntax-for-property-definition).
+You can also use these keywords to specify where an attribute should be applied. For example, you can use the `field:` specifier to add an attribute to the backing field of an [auto-implemented property](../../programming-guide/classes-and-structs/properties.md#auto-implemented-properties). Or you can use the `field:`, `property:` or `param:` specifier to apply an attribute to any of the elements generated from a positional record. For an example, see [Positional syntax for property definition](../builtin-types/record.md#positional-syntax-for-property-definition).
 
 ## `ModuleInitializer` attribute
 

--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -90,6 +90,8 @@ If <xref:System.AttributeUsageAttribute.Inherited> is `false`, then the attribut
 
 In this case `NonInheritedAttribute` isn't applied to `DClass` via inheritance.
 
+You can also use these keywords to specify where an attribute should be applied. For example, you can use the `field:` specifier to add an attribute to the backing field of an [auto-implemented property]../../programming-guide/classes-and-structs/properties.md#auto-implemented-properties). Or you can use the `field:`, `property:` or `param:` specifier to apply an attribute to any of the elements generated from a [positional record](../builtin-types/record.md#positional-syntax-for-property-definition).
+
 ## `ModuleInitializer` attribute
 
 Starting with C# 9, the `ModuleInitializer` attribute marks a method that the runtime calls when the assembly loads. `ModuleInitializer` is an alias for <xref:System.Runtime.CompilerServices.ModuleInitializerAttribute>.

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -46,6 +46,12 @@ When you use the positional syntax for property definition, the compiler creates
 * A primary constructor whose parameters match the positional parameters on the record declaration.
 * A `Deconstruct` method with an `out` parameter for each positional parameter provided in the record declaration. This method is provided only if there are two or more positional parameters. The method deconstructs properties defined by using positional syntax; it ignores properties that are defined by using standard property syntax.
 
+You may want to add attributes to any of these elements the compiler creates from the record definition. You can add a *target* to any atribute you apply to the positional record's properties. The following example applies the <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute?displayProperty=nameWithType> to each property of the `Person` record. The `property:` target indicates that the attribute is applied to the compiler generated property. Other values are `field:` to apply the attribute to the field, and `param:` to apply the attribute to the parameter.
+
+:::code language="csharp" source="snippets/shared/RecordType.cs" id="PositionalAttributes":::
+
+The preceding example also shows how to create XML documentation comments for the record. You can add the `<param>` tag to add documentation for the primary constructor's parameters.
+
 If the generated auto-implemented property definition isn't what you want, you can define your own property of the same name. If you do that, the generated constructor and deconstructor will use your property definition. For instance, the following example makes the `FirstName` positional property `internal` instead of `public`.
 
 :::code language="csharp" source="snippets/shared/RecordType.cs" id="PositionalWithManualProperty":::

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -46,7 +46,7 @@ When you use the positional syntax for property definition, the compiler creates
 * A primary constructor whose parameters match the positional parameters on the record declaration.
 * A `Deconstruct` method with an `out` parameter for each positional parameter provided in the record declaration. This method is provided only if there are two or more positional parameters. The method deconstructs properties defined by using positional syntax; it ignores properties that are defined by using standard property syntax.
 
-You may want to add attributes to any of these elements the compiler creates from the record definition. You can add a *target* to any atribute you apply to the positional record's properties. The following example applies the <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute?displayProperty=nameWithType> to each property of the `Person` record. The `property:` target indicates that the attribute is applied to the compiler generated property. Other values are `field:` to apply the attribute to the field, and `param:` to apply the attribute to the parameter.
+You may want to add attributes to any of these elements the compiler creates from the record definition. You can add a *target* to any attribute you apply to the positional record's properties. The following example applies the <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute?displayProperty=nameWithType> to each property of the `Person` record. The `property:` target indicates that the attribute is applied to the compiler generated property. Other values are `field:` to apply the attribute to the field, and `param:` to apply the attribute to the parameter.
 
 :::code language="csharp" source="snippets/shared/RecordType.cs" id="PositionalAttributes":::
 

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace builtin_types
 {
@@ -57,6 +58,26 @@ namespace builtin_types
             public string[] PhoneNumbers { get; init; }
         };
         // </MixedSyntax>
+    }
+
+    public static class PositionalAttributes
+    {
+        // <PositionalAttributes>
+        /// <summary>
+        /// Person record type
+        /// </summary>
+        /// <param name="FirstName">First Name</param>
+        /// <param name="LastName">Last Name</param>
+        /// <remarks>
+        /// The person type is a positional record containing the
+        /// properties for the first and last name. Those properties
+        /// map to the JSON elements "firstName" and "lastName" when
+        /// serialized or deserialized.
+        /// </remarks>
+        public record Person([property: JsonPropertyName("firstName")]string FirstName, 
+            [property: JsonPropertyName("lastName")]string LastName);
+        // </PositionalAttributes>
+
     }
 
     namespace instantiatepositional

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
@@ -9,4 +9,8 @@
     <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile></DocumentationFile>
+  </PropertyGroup>
+
 </Project>

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -42,7 +42,7 @@ Records in C# 9 are also supported, as shown in the following example:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/Records.cs":::
 
-You can apply any of the attributes to the property names, using the `property:` target on the attribute. For more information on positional records, see the article on [records](../../csharp/language-reference/builtin-types/record.md#positional-syntax-for-property-definition)
+You can apply any of the attributes to the property names, using the `property:` target on the attribute. For more information on positional records, see the article on [records](../../csharp/language-reference/builtin-types/record.md#positional-syntax-for-property-definition) in the C# language reference.
 
 For types that are immutable because all their property setters are non-public, see the following section.
 ::: zone-end

--- a/docs/standard/serialization/system-text-json-immutability.md
+++ b/docs/standard/serialization/system-text-json-immutability.md
@@ -42,6 +42,8 @@ Records in C# 9 are also supported, as shown in the following example:
 
 :::code language="csharp" source="snippets/system-text-json-how-to-5-0/csharp/Records.cs":::
 
+You can apply any of the attributes to the property names, using the `property:` target on the attribute. For more information on positional records, see the article on [records](../../csharp/language-reference/builtin-types/record.md#positional-syntax-for-property-definition)
+
 For types that are immutable because all their property setters are non-public, see the following section.
 ::: zone-end
 


### PR DESCRIPTION
Fixes #24037 

Add a description and example for how to apply attributes to the field or property generated from the primary constructor on positional records. 

Then, link to that description from the locations where readers are mostly likely to need to add attributes to records, or where they are likely to look for that information.