### PR TITLE
updated reverseName and structReverseName examples to return expected…

### DIFF
--- a/docs/fsharp/style-guide/conventions.md
+++ b/docs/fsharp/style-guide/conventions.md
@@ -513,13 +513,15 @@ The previous observations about performance with struct tuples and records also 
     let reverseName (Name s) =
         s.ToCharArray()
         |> Array.rev
-        |> string
+        |> Array.map Char.ToString
+        |> String.concat ""
         |> Name
 
     let structReverseName (SName s) =
         s.ToCharArray()
         |> Array.rev
-        |> string
+        |> Array.map Char.ToString
+        |> String.concat ""
         |> SName
 ```
 

--- a/docs/fsharp/style-guide/conventions.md
+++ b/docs/fsharp/style-guide/conventions.md
@@ -513,15 +513,13 @@ The previous observations about performance with struct tuples and records also 
     let reverseName (Name s) =
         s.ToCharArray()
         |> Array.rev
-        |> Array.map Char.ToString
-        |> String.concat ""
+        |> System.String
         |> Name
 
     let structReverseName (SName s) =
         s.ToCharArray()
         |> Array.rev
-        |> Array.map Char.ToString
-        |> String.concat ""
+        |> System.String
         |> SName
 ```
 


### PR DESCRIPTION
… values.

## Summary

Describe your changes here.

Working through the examples in the 'Performance' section of the coding conventions docs. I noticed that both examples `reverseName` and `structReverseName` returned `val it : Name = Name "System.String[]"` and `val it : SName = SName "System.String[]"`, respectively, rather than the reversed string.  
  
With the updated code, each function returns a reversed Name/SName string value. 

Still very new to F#, so apologies if I missed the point of the example.



