### PR TITLE
Turn off recommendations for tutorials

### DIFF
--- a/docs/machine-learning/how-to-guides/matchup-app-infer-net.md
+++ b/docs/machine-learning/how-to-guides/matchup-app-infer-net.md
@@ -3,6 +3,7 @@ title: Infer.NET game match-up app - probabilistic programming
 description: Discover how to use probabilistic programming with Infer.NET to create a game match-up list app based on a simplified version of TrueSkill.
 ms.date: 01/30/2020
 ms.custom: mvc,how-to
+recommendations: false
 #Customer intent: As a developer, I want to use probabilistic programming with Infer.NET to create a game matchup list app based on a simplified version of TrueSkill.
 ---
 

--- a/docs/machine-learning/tutorials/github-issue-classification.md
+++ b/docs/machine-learning/tutorials/github-issue-classification.md
@@ -4,6 +4,7 @@ description: Discover how to use ML.NET in a multiclass classification scenario 
 ms.date: 06/30/2020
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0516
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET to apply a multiclass classification learning algorithm so that I can understand how to categorize support issues to assign them to a given area.
 ---
 # Tutorial: Categorize support issues using multiclass classification with ML.NET

--- a/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md
+++ b/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md
@@ -6,6 +6,7 @@ ms.author: luquinta
 ms.date: 04/13/2021
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET so that I can use transfer learning in an image classification scenario to classify images using a pretrained TensorFlow model and ML.NET's Image Classification API.
 ---
 

--- a/docs/machine-learning/tutorials/image-classification.md
+++ b/docs/machine-learning/tutorials/image-classification.md
@@ -4,6 +4,7 @@ description: Learn how to train a classification model to categorize images usin
 ms.date: 04/13/2021
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0612
+recommendations: false
 #Customer intent: As a developer, I want to train a classification model with ML.NET to categorize images using a pre-trained TensorFlow model to process images.
 ---
 # Tutorial: Train an ML.NET classification model to categorize images

--- a/docs/machine-learning/tutorials/iris-clustering.md
+++ b/docs/machine-learning/tutorials/iris-clustering.md
@@ -5,6 +5,7 @@ author: pkulikov
 ms.date: 06/30/2020
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0516
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET so that I can build a k-means clustering model to categorize iris flowers based on its parameters.
 ---
 # Tutorial: Categorize iris flowers using k-means clustering with ML.NET

--- a/docs/machine-learning/tutorials/movie-recommendation.md
+++ b/docs/machine-learning/tutorials/movie-recommendation.md
@@ -5,6 +5,7 @@ author: briacht
 ms.date: 06/30/2020
 ms.custom: mvc, title-hack-0516
 ms.topic: tutorial
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET to apply a recommendation learning algorithm so that I can understand how to recommend items based on a user's history.
 ---
 

--- a/docs/machine-learning/tutorials/object-detection-onnx.md
+++ b/docs/machine-learning/tutorials/object-detection-onnx.md
@@ -6,6 +6,7 @@ ms.author: luquinta
 ms.date: 04/13/2021
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET so that I can use a pre-trained model in an object detection scenario to detect objects in images using ONNX.
 ---
 

--- a/docs/machine-learning/tutorials/phone-calls-anomaly-detection.md
+++ b/docs/machine-learning/tutorials/phone-calls-anomaly-detection.md
@@ -4,6 +4,7 @@ description: Learn how to build an anomaly detection application for time series
 ms.date: 12/04/2020
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET in a time-series anomaly detection for number of phone calls so that I can analyze the data for anomaly points to take the appropriate action.
 ---
 # Tutorial: Detect anomalies in time series with ML.NET

--- a/docs/machine-learning/tutorials/predict-prices.md
+++ b/docs/machine-learning/tutorials/predict-prices.md
@@ -4,6 +4,7 @@ description: This tutorial illustrates how to build a regression model using ML.
 ms.date: 06/30/2020
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0516
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET so that I can train and build a model in a regression scenario to predict prices.
 ---
 # Tutorial: Predict prices using regression with ML.NET

--- a/docs/machine-learning/tutorials/sales-anomaly-detection.md
+++ b/docs/machine-learning/tutorials/sales-anomaly-detection.md
@@ -4,6 +4,7 @@ description: Learn how to build an anomaly detection application for product sal
 ms.date: 06/30/2020
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0612
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET in a product sales anomaly detection scenario so that I can analyze the data for anomaly spikes and change points to take the appropriate action.
 ---
 # Tutorial: Detect anomalies in product sales with ML.NET

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -4,6 +4,7 @@ description: This tutorial shows you how to create a .NET Core console applicati
 ms.date: 06/30/2020
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to use ML.NET to apply a binary classification task so that I can understand how to use sentiment prediction to take appropriate action.
 ---
 # Tutorial: Analyze sentiment of website comments with binary classification in ML.NET

--- a/docs/spark/tutorials/amazon-emr-spark-deployment.md
+++ b/docs/spark/tutorials/amazon-emr-spark-deployment.md
@@ -4,6 +4,7 @@ description: Discover how to deploy a .NET for Apache Spark application to Amazo
 ms.date: 10/09/2020
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to deployment .NET for Apache Spark application to Amazon EMR Spark.
 ---
 

--- a/docs/spark/tutorials/batch-processing.md
+++ b/docs/spark/tutorials/batch-processing.md
@@ -5,6 +5,7 @@ author: mamccrea
 ms.author: mamccrea
 ms.date: 10/09/2020
 ms.topic: tutorial
+recommendations: false
 ---
 
 # Tutorial: Do batch processing with .NET for Apache Spark

--- a/docs/spark/tutorials/databricks-deployment.md
+++ b/docs/spark/tutorials/databricks-deployment.md
@@ -4,6 +4,7 @@ description: Discover how to deploy a .NET for Apache Spark application to Datab
 ms.date: 10/09/2020
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to deployment .NET for Apache Spark application to Databricks.
 ---
 

--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -6,6 +6,7 @@ ms.topic: tutorial
 ms.custom: mvc
 ms.author: luquinta
 author: luisquintanilla
+recommendations: false
 # Customer intent: As a developer, I want to write a simple custom application using .NET for Apache Spark.
 ---
 

--- a/docs/spark/tutorials/hdinsight-deployment.md
+++ b/docs/spark/tutorials/hdinsight-deployment.md
@@ -4,6 +4,7 @@ description: Discover how to deploy a .NET for Apache Spark application to HDIns
 ms.date: 10/09/2020
 ms.topic: tutorial
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want to deployment .NET for Apache Spark application to HDInsight.
 ---
 

--- a/docs/spark/tutorials/ml-sentiment-analysis.md
+++ b/docs/spark/tutorials/ml-sentiment-analysis.md
@@ -5,6 +5,7 @@ author: mamccrea
 ms.author: mamccrea
 ms.date: 10/09/2020
 ms.topic: tutorial
+recommendations: false
 ---
 
 # Tutorial: Sentiment analysis with .NET for Apache Spark and ML.NET

--- a/docs/spark/tutorials/streaming.md
+++ b/docs/spark/tutorials/streaming.md
@@ -5,6 +5,7 @@ author: mamccrea
 ms.author: mamccrea
 ms.date: 10/09/2020
 ms.topic: tutorial
+recommendations: false
 ---
 
 # Tutorial: Structured Streaming with .NET for Apache Spark

--- a/docs/spark/what-is-apache-spark-dotnet.md
+++ b/docs/spark/what-is-apache-spark-dotnet.md
@@ -4,6 +4,7 @@ description: Learn about .NET for Apache Spark, a free, open-source, and cross-p
 author: mamccrea
 ms.topic: overview
 ms.date: 10/09/2020
+recommendations: false
 ---
 
 # What is .NET for Apache Spark?

--- a/docs/spark/what-is-spark.md
+++ b/docs/spark/what-is-spark.md
@@ -4,6 +4,7 @@ description: Learn about Apache Spark and big data scenarios.
 ms.date: 10/15/2019
 ms.topic: conceptual
 ms.custom: mvc
+recommendations: false
 #Customer intent: As a developer, I want an introduction to Apache Spark.
 ---
 


### PR DESCRIPTION
Based on internal conversations, turn off recommendations for ML.NET and Spark.NET tutorials and how-to's that have a clear "next step" defined at the end of the article.
