### PR TITLE
Removed confusing sample input

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/interface-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/interface-properties.md
@@ -36,8 +36,6 @@ implements the `Name` property on the `ICitizen` interface.
 [!code-csharp[Example](~/samples/snippets/csharp/interfaces/properties.cs#PropertyExample)]
 [!code-csharp[Example](~/samples/snippets/csharp/interfaces/properties.cs#UseProperty)]
 
-**`210 Hazem Abolrous`**
-
 ## Sample output
 
 ```console


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/24344.

This line is confusing and unnecessary (the same input is repeated with context in the sample output section), so I think it should be removed.