### PR TITLE
Add SDK category for breaking changes

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -408,6 +408,16 @@
             "redirect_document_id": true
         },
         {
+            "source_path": "docs/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type.md",
+            "redirect_url": "/dotnet/core/compatibility/sdk/5.0/automatically-infer-winexe-output-type",
+            "redirect_document_id": true
+        },
+        {
+            "source_path": "docs/core/compatibility/windows-forms/5.0/sdk-and-target-framework-change.md",
+            "redirect_url": "/dotnet/core/compatibility/sdk/5.0/sdk-and-target-framework-change",
+            "redirect_document_id": true
+        },
+        {
             "source_path": "docs/core/compatibility/wpf.md",
             "redirect_url": "/dotnet/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type"
         },

--- a/docs/core/compatibility/5.0.md
+++ b/docs/core/compatibility/5.0.md
@@ -128,6 +128,11 @@ If you're migrating an app to .NET 5, the breaking changes listed here might aff
 - [Streams allow successive Begin operations](networking/5.0/negotiatestream-sslstream-dont-fail-on-successive-begin-calls.md)
 - [WinHttpHandler removed from .NET runtime](networking/5.0/winhttphandler-removed-from-runtime.md)
 
+## SDK
+
+- [OutputType set to WinExe](sdk/5.0/automatically-infer-winexe-output-type.md)
+- [WinForms and WPF apps use Microsoft.NET.Sdk](sdk/5.0/sdk-and-target-framework-change.md)
+
 ## Security
 
 - [Code access security APIs are obsolete](core-libraries/5.0/code-access-security-apis-obsolete.md)

--- a/docs/core/compatibility/5.0.md
+++ b/docs/core/compatibility/5.0.md
@@ -151,17 +151,17 @@ If you're migrating an app to .NET 5, the breaking changes listed here might aff
 ## Windows Forms
 
 - [Native code can't access Windows Forms objects](windows-forms/5.0/winforms-objects-not-accessible-from-native-code.md)
-- [OutputType set to WinExe](windows-forms/5.0/automatically-infer-winexe-output-type.md)
+- [OutputType set to WinExe](sdk/5.0/automatically-infer-winexe-output-type.md)
 - [DataGridView doesn't reset custom fonts](windows-forms/5.0/datagridview-doesnt-reset-custom-font-settings.md)
 - [Methods throw ArgumentException](windows-forms/5.0/invalid-args-cause-argumentexception.md)
 - [Methods throw ArgumentNullException](windows-forms/5.0/null-args-cause-argumentnullexception.md)
 - [Properties throw ArgumentOutOfRangeException](windows-forms/5.0/invalid-args-cause-argumentoutofrangeexception.md)
 - [TextFormatFlags.ModifyString is obsolete](windows-forms/5.0/modifystring-field-of-textformatflags-obsolete.md)
 - [DataGridView APIs throw InvalidOperationException](windows-forms/5.0/null-owner-causes-invalidoperationexception.md)
-- [WinForms apps use Microsoft.NET.Sdk](windows-forms/5.0/sdk-and-target-framework-change.md)
+- [WinForms apps use Microsoft.NET.Sdk](sdk/5.0/sdk-and-target-framework-change.md)
 - [Removed status bar controls](windows-forms/5.0/winforms-deprecated-controls.md)
 
 ## WPF
 
-- [OutputType set to WinExe](windows-forms/5.0/automatically-infer-winexe-output-type.md)
-- [WPF apps use Microsoft.NET.Sdk](windows-forms/5.0/sdk-and-target-framework-change.md)
+- [OutputType set to WinExe](sdk/5.0/automatically-infer-winexe-output-type.md)
+- [WPF apps use Microsoft.NET.Sdk](sdk/5.0/sdk-and-target-framework-change.md)

--- a/docs/core/compatibility/sdk/5.0/automatically-infer-winexe-output-type.md
+++ b/docs/core/compatibility/sdk/5.0/automatically-infer-winexe-output-type.md
@@ -25,7 +25,7 @@ Starting in the 5.0.100 version of the .NET SDK, when `OutputType` is set to `Ex
 </PropertyGroup>
 ```
 
- If `OutputType` is not specified in the project file, it defaults to `Library` and that value doesn't change.
+If `OutputType` is not specified in the project file, it defaults to `Library` and that value doesn't change.
 
 ## Reason for change
 
@@ -33,7 +33,7 @@ It's assumed that most users don't want a console window to open when a WPF or W
 
 ## Version introduced
 
-.NET 5.0.100
+.NET SDK 5.0.100
 
 ## Recommended action
 
@@ -55,6 +55,7 @@ Not detectable via API analysis.
 
 ### Category
 
+- SDK
 - Windows Forms
 - Windows Presentation Framework (WPF)
 

--- a/docs/core/compatibility/sdk/5.0/sdk-and-target-framework-change.md
+++ b/docs/core/compatibility/sdk/5.0/sdk-and-target-framework-change.md
@@ -62,6 +62,7 @@ Not detectable via API analysis.
 
 ### Category
 
+- SDK
 - Windows Forms
 - Windows Presentation Framework (WPF)
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -651,6 +651,14 @@ items:
           href: networking/5.0/winhttphandler-removed-from-runtime.md
       - name: .NET Core 2.0-3.0
         href: networking.md
+    - name: SDK
+      items:
+      - name: .NET 5
+        items:
+        - name: OutputType set to WinExe
+          href: sdk/5.0/automatically-infer-winexe-output-type.md
+        - name: WinForms and WPF apps use Microsoft.NET.Sdk
+          href: sdk/5.0/sdk-and-target-framework-change.md
     - name: Security
       items:
       - name: .NET 5

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -297,6 +297,12 @@ items:
           href: networking/5.0/negotiatestream-sslstream-dont-fail-on-successive-begin-calls.md
         - name: WinHttpHandler removed from .NET runtime
           href: networking/5.0/winhttphandler-removed-from-runtime.md
+      - name: SDK
+        items:
+        - name: OutputType set to WinExe
+          href: sdk/5.0/automatically-infer-winexe-output-type.md
+        - name: WinForms and WPF apps use Microsoft.NET.Sdk
+          href: sdk/5.0/sdk-and-target-framework-change.md
       - name: Security
         items:
         - name: Code access security APIs are obsolete


### PR DESCRIPTION
This PR adds the SDK category to the TOC and to the overview page ([internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/5.0?branch=pr-en-us-24364#sdk)). I thought this might be useful since SDK changes affect apps that might still be targeting an older version of .NET too.

Please let me know your thoughts on this @dsplaisted @PriyaPurkayastha.

Also, I'm leaning towards moving the existing "code analysis" category breaking changes into the SDK category, since you see the CA warnings based on the SDK you're using. Along those lines, should the MSBuild category breaking changes be moved into the SDK category as well?

(#24363 adds the SDK category to the new issue template for breaking changes.)