### PR TITLE
Executable ref breaking change

### DIFF
--- a/docs/core/compatibility/5.0.md
+++ b/docs/core/compatibility/5.0.md
@@ -130,6 +130,7 @@ If you're migrating an app to .NET 5, the breaking changes listed here might aff
 
 ## SDK
 
+- [Error generated when executable project references mismatched executable](sdk/5.0/referencing-executable-generates-error.md)
 - [OutputType set to WinExe](sdk/5.0/automatically-infer-winexe-output-type.md)
 - [WinForms and WPF apps use Microsoft.NET.Sdk](sdk/5.0/sdk-and-target-framework-change.md)
 

--- a/docs/core/compatibility/sdk/5.0/referencing-executable-generates-error.md
+++ b/docs/core/compatibility/sdk/5.0/referencing-executable-generates-error.md
@@ -1,0 +1,46 @@
+---
+title: "Breaking change: Error generated when executable references executable"
+description: Learn about the breaking change in .NET 5 where compile-time errors are generated when an executable references an executable whose SelfContained value is different.
+ms.date: 05/26/2021
+---
+# Error generated when executable project references mismatched executable
+
+Generally, an executable project references library projects, not other executable projects. An executable project can also reference another executable project to use APIs that are defined in it. Some customers want to reference an executable project from another executable project so that both apps are placed in and are runnable from the same output folder. However, this scenario does not work if a self-contained executable references a non-self-contained executable, or vice versa. Because of how the application host works, neither app is launchable. To prevent situations where apps can't be launched, .NET SDK 5 produces compile-time errors NETSDK1150 and NETSDK1151 when it detects mismatched executable references.
+
+## Change description
+
+In previous .NET SDK versions, you could reference a self-contained executable project from a non-self-contained executable project without a build error. However, both apps would not be runnable. Starting in .NET SDK 5, an error is generated if an executable project references another executable project and the `SelfContained` values don't match.
+
+## Version introduced
+
+.NET SDK 5.0.300
+
+## Reason for change
+
+The errors were introduced to prevent situations where you expect to be able to launch both applications but cannot.
+
+## Recommended action
+
+If the referenced project doesn't need to be runnable from the output folder, you can set a property to avoid this error check:
+
+```xml
+<ValidateExecutableReferencesMatchSelfContained>false<ValidateExecutableReferencesMatchSelfContained>
+```
+
+For more information, see [ValidateExecutableReferencesMatchSelfContained](../../../project-sdk/msbuild-props.md#validateexecutablereferencesmatchselfcontained).
+
+## Affected APIs
+
+None.
+
+<!--
+
+### Affected APIs
+
+Not detectable via API analysis.
+
+### Category
+
+- SDK
+
+-->

--- a/docs/core/compatibility/sdk/5.0/referencing-executable-generates-error.md
+++ b/docs/core/compatibility/sdk/5.0/referencing-executable-generates-error.md
@@ -5,7 +5,7 @@ ms.date: 05/26/2021
 ---
 # Error generated when executable project references mismatched executable
 
-Generally, an executable project references library projects, not other executable projects. An executable project can also reference another executable project to use APIs that are defined in it. Some customers want to reference an executable project from another executable project so that both apps are placed in and are runnable from the same output folder. However, this scenario does not work if a self-contained executable references a non-self-contained executable, or vice versa. Because of how the application host works, neither app is launchable. To prevent situations where apps can't be launched, .NET SDK 5 produces compile-time errors NETSDK1150 and NETSDK1151 when it detects mismatched executable references.
+Generally, an executable project references library projects, not other executable projects. An executable project can also reference another executable project to use APIs that are defined in it. Some developers want to reference an executable project from another executable project so that both apps are placed in and are runnable from the same output folder. However, this scenario does not work if a self-contained executable references a non-self-contained executable, or vice versa. Because of how the application host works, neither app can be launched. To prevent situations where apps aren't runnable, .NET SDK 5+ produces compile-time errors NETSDK1150 and NETSDK1151 when it detects mismatched executable references.
 
 ## Change description
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -299,6 +299,8 @@ items:
           href: networking/5.0/winhttphandler-removed-from-runtime.md
       - name: SDK
         items:
+        - name: Error when referencing mismatched executable
+          href: sdk/5.0/referencing-executable-generates-error.md
         - name: OutputType set to WinExe
           href: sdk/5.0/automatically-infer-winexe-output-type.md
         - name: WinForms and WPF apps use Microsoft.NET.Sdk
@@ -655,6 +657,8 @@ items:
       items:
       - name: .NET 5
         items:
+        - name: Error when referencing mismatched executable
+          href: sdk/5.0/referencing-executable-generates-error.md
         - name: OutputType set to WinExe
           href: sdk/5.0/automatically-infer-winexe-output-type.md
         - name: WinForms and WPF apps use Microsoft.NET.Sdk

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -683,6 +683,7 @@ The following MSBuild properties are documented in this section:
 - [AssetTargetFallback](#assettargetfallback)
 - [DisableImplicitFrameworkReferences](#disableimplicitframeworkreferences)
 - [Restore-related properties](#restore-related-properties)
+- [ValidateExecutableReferencesMatchSelfContained](#validateexecutablereferencesmatchselfcontained)
 
 ### AssetTargetFallback
 
@@ -715,6 +716,16 @@ Restoring a referenced package installs all of its direct dependencies and all t
 ```xml
 <PropertyGroup>
   <RestoreIgnoreFailedSource>true</RestoreIgnoreFailedSource>
+</PropertyGroup>
+```
+
+### ValidateExecutableReferencesMatchSelfContained
+
+The `ValidateExecutableReferencesMatchSelfContained` property can be used to disable errors related to executable project references. If .NET detects that a self-contained executable project references a framework-dependent executable project, or vice versa, it generates errors NETSDK1150 and NETSDK1151, respectively. To avoid these errors when the reference is intentional, set the `ValidateExecutableReferencesMatchSelfContained` property to `false`.
+
+```xml
+<PropertyGroup>
+  <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
Fixes #24231

[Internal preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/5.0/referencing-executable-generates-error?branch=pr-en-us-24418).