### PR TITLE
Typo "NuGet.config files"→"NuGet.Config files"

### DIFF
--- a/docs/core/tools/dotnet-nuget-list-source.md
+++ b/docs/core/tools/dotnet-nuget-list-source.md
@@ -43,6 +43,6 @@ The `dotnet nuget list source` command lists all existing sources from your NuGe
 
 ## See also
 
-- [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
+- [Package source sections in NuGet.Config files](/nuget/reference/nuget-config-file#package-source-sections)
 
 - [sources command (nuget.exe)](/nuget/reference/cli-reference/cli-ref-sources)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-list-source
#PingMSFTDocs

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
