### PR TITLE
Update blob-storage.fsx

### DIFF
--- a/samples/snippets/fsharp/azure/blob-storage.fsx
+++ b/samples/snippets/fsharp/azure/blob-storage.fsx
@@ -1,8 +1,8 @@
 open System
 open System.IO
 open Microsoft.Azure // Namespace for CloudConfigurationManager
-open Microsoft.Azure.Storage // Namespace for CloudStorageAccount
-open Microsoft.Azure.Storage.Blob // Namespace for Blob storage types
+open Microsoft.WindowsAzure.Storage // Namespace for CloudStorageAccount
+open Microsoft.WindowsAzure.Storage.Blob // Namespace for Blob storage types
 
 //
 // Get your connection string.


### PR DESCRIPTION
Currently, the Package DLL refers to Microsoft.WindowsAzure.Storage instead of Microsoft.Azure.Storage.

## Summary
I change the DLL Reference from Microsoft.Azure.Storage to Microsoft.WindowsAzure.Storage in FSharp Azure Storage Snippets.

Fixes #Issue_Number (if available)
