### PR TITLE
Fix missing command argument

### DIFF
--- a/docs/core/porting/upgrade-assistant-winforms-framework.md
+++ b/docs/core/porting/upgrade-assistant-winforms-framework.md
@@ -34,7 +34,7 @@ Review the created project and its files, especially its project file(s).
 Open a terminal and navigate to the folder where the target project or solution is located. Run the `upgrade-assistant` command, passing in the name of the project you're targeting (you can run the command from anywhere, as long as the path to the project file is valid).
 
 ```console
-upgrade-assistant .\WinformsTest.csproj
+upgrade-assistant upgrade .\WinformsTest.csproj
 ```
 
 The tool runs and shows you a list of the steps it will do.


### PR DESCRIPTION
## Summary

The docs are missing the argument that tells it to try to upgrade.

Without this, it returns 

```
Required command was not provided.
Unrecognized command or argument '.\whateverproject.csproj'
```