### PR TITLE
Fix Dapr Getting Started tutorial

### DIFF
--- a/docs/architecture/dapr-for-net-developers/getting-started.md
+++ b/docs/architecture/dapr-for-net-developers/getting-started.md
@@ -224,6 +224,9 @@ Additionally, you'll need complete this sample using [Visual Studio 2019](https:
 
 1. Add a ASP.NET Core Web API project to the same solution and call it _DaprBackEnd_. Select **API** as the project type. By default, a Dapr sidecar relies on the network boundary to limit access to its public API. So, clear the checkbox for **Configure for HTTPS**.
 
+    > [!IMPORTANT]
+    > If you leave the **Configure for HTTPS** checkbox checked, the generated ASP.NET Core API project includes middleware to redirect client requests to the HTTPS endpoint. This breaks communication between the Dapr sidecar and your application, unless you explicitly configure the use of HTTPS when running your Dapr application. To enable the Dapr sidecar to communicate over HTTPS, include the `--app-ssl` flag in the Dapr command to start the application. Also specify the HTTPS port using the `--app-port` parameter. The remainder of this walkthrough uses plain HTTP communication between the sidecar and the application, and requires you to clear the **Configure for HTTPS** checkbox.
+
     :::image type="content" source="./media/getting-started/multicontainer-createwebapi.png" alt-text="Screenshot of creating the web API":::
 
 ### Add Dapr service invocation
@@ -416,7 +419,6 @@ In the final part of this example, you'll add container support and run the solu
     FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
     WORKDIR /app
     EXPOSE 80
-    EXPOSE 443
 
     FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
     WORKDIR /src
@@ -470,7 +472,7 @@ In the final part of this example, you'll add container support and run the solu
 
       daprfrontend-dapr:
         image: "daprio/daprd:latest"
-        command: [ "./daprd", "-app-id", "daprfrontend", "-app-port", "443", "-app-ssl" ]
+        command: [ "./daprd", "-app-id", "daprfrontend", "-app-port", "80" ]
         depends_on:
           - daprfrontend
         network_mode: "service:daprfrontend"
@@ -485,7 +487,7 @@ In the final part of this example, you'll add container support and run the solu
 
       daprbackend-dapr:
         image: "daprio/daprd:latest"
-        command: [ "./daprd", "-app-id", "daprbackend", "-app-port", "443", "-app-ssl" ]
+        command: [ "./daprd", "-app-id", "daprbackend", "-app-port", "80" ]
         depends_on:
           - daprbackend
         network_mode: "service:daprbackend"


### PR DESCRIPTION
## Summary

PR #24360 introduced a bug in the Getting Started sample/tutorial. See issue #24491 for full background info.

This PR fixes the bug and adds some additional clarification text.
PR #24360 also fixed the `depends_on` for the `daprbackend-dapr` service in the Docker Compose file, that's kept in.

Fixes #24491

