### PR TITLE
change range to ID

### DIFF
--- a/docs/csharp/fundamentals/types/namespaces.md
+++ b/docs/csharp/fundamentals/types/namespaces.md
@@ -10,19 +10,19 @@ helpviewer_keywords:
 
 Namespaces are heavily used in C# programming in two ways. First, .NET uses namespaces to organize its many classes, as follows:  
 
-:::code language="csharp" source="snippets/namespaces/Program.cs" range="Snippet22":::
+:::code language="csharp" source="snippets/namespaces/Program.cs" ID="Snippet22":::
 
 <xref:System> is a namespace and <xref:System.Console> is a class in that namespace. The `using` keyword can be used so that the complete name isn't required, as in the following example:
 
-:::code language="csharp" source="snippets/namespaces/Program.cs" range="Snippet1":::
+:::code language="csharp" source="snippets/namespaces/Program.cs" ID="Snippet1":::
 
-:::code language="csharp" source="snippets/namespaces/Program.cs" range="Snippet22":::
+:::code language="csharp" source="snippets/namespaces/Program.cs" ID="Snippet22":::
 
 For more information, see the [using Directive](../../language-reference/keywords/using-directive.md).
 
 Second, declaring your own namespaces can help you control the scope of class and method names in larger programming projects. Use the [namespace](../../language-reference/keywords/namespace.md) keyword to declare a namespace, as in the following example:
 
-:::code language="csharp" source="snippets/namespaces/Program.cs" range="Snippet6":::
+:::code language="csharp" source="snippets/namespaces/Program.cs" ID="Snippet6":::
 
 The name of the namespace must be a valid C# [identifier name](../coding-style/identifier-names.md).
 


### PR DESCRIPTION
Fixes #24456

The snippet tags incorrectly used the "range" argument instead of the "ID" argument.

[Internal preview link](https://review.docs.microsoft.com/en-us/dotnet/csharp/fundamentals/types/namespaces?branch=pr-en-us-24494)

