### PR TITLE
Add documentation for dotnet nuget trust command

### DIFF
--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -1,0 +1,200 @@
+---
+title: dotnet nuget trust command
+description: The dotnet nuget trust command gets or sets trusted signers to the NuGet configuration.
+author: erdembayar
+ms.date: 06/02/2021
+---
+# dotnet nuget trust
+
+**This article applies to:** ✔️ .NET 5.0.300 SDK, 6.0.100-preview.4 SDK and later versions
+
+## Name
+
+`dotnet nuget trust` - Gets or sets trusted signers to the NuGet configuration.
+
+## Synopsis
+
+```dotnetcli
+dotnet nuget trust [list|author|repository|source|certificate|remove|sync] [OPTIONS]
+
+if none of list|add|remove|sync is specified, the command will default to list.
+
+dotnet nuget trust -h|--help
+```
+
+## Description
+
+The `dotnet nuget trust` gets or sets trusted signers to the NuGet configuration. For additional usage, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md). For details on how the nuget.config schema looks like, refer to the [NuGet config file reference](../nuget-config-file.md).
+
+## Arguments
+
+- `<list|author|repository|source|certificate|remove|sync>`
+
+  Specifies the command for gets or sets trusted signers to the NuGet configuration. 
+
+#### `> dotnet nuget trust list`
+
+```
+Lists all the trusted signers in the configuration. This option will include all the certificates (with fingerprint and fingerprint algorithm) each signer has. If a certificate has a preceding [U], it means that certificate entry has allowUntrustedRoot set as true.
+
+USAGE:
+    dotnet nuget trust list [OPTIONS]
+
+OPTIONS:
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+#### `> dotnet nuget trust sync`
+
+```
+Deletes the current list of certificates and replaces them with an up-to-date list from the repository.
+
+USAGE:
+    dotnet nuget trust sync [OPTIONS] <name>
+
+OPTIONS:
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+#### `> dotnet nuget trust remove`
+
+```
+Removes any trusted signers that match the given name.
+
+USAGE:
+    dotnet nuget trust remove [OPTIONS] <name>
+
+OPTIONS:
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+#### `> dotnet nuget trust author`
+
+```
+Adds a trusted signer with the given name, based on the author signature(s) of one or more packages. If <name> already exists in the configuration, the signature(s) will be appended. The given a <package> should be local paths to signed .nupkg files.
+
+USAGE:
+    dotnet nuget trust author [OPTIONS] <name> <package>...
+
+EXAMPLE:
+    dotnet nuget trust author Contoso ./contoso.library.nupkg
+
+OPTIONS:
+        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+#### `> dotnet nuget trust repository`
+
+```
+Adds a trusted signer with the given name, based on the repository signature(s) or countersignature(s) of one or more packages. If <name> already exists in the configuration, the signature(s) will be appended. The given a <package> should be local paths to signed .nupkg files.
+
+USAGE:
+    dotnet nuget trust repository [OPTIONS] <name> <package>...
+
+OPTIONS:
+        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
+        --owners                        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+#### `> dotnet nuget trust certificate`
+
+```
+Adds a trusted signer with the given name, based on a certificate fingerprint.
+
+If a trusted signer with the given name already exists, the certificate item will be added to that signer. Otherwise a trusted author will be created with a certificate item from given certificate information.
+
+USAGE:
+    dotnet nuget trust certificate [OPTIONS] <name> <fingerprint>
+
+OPTIONS:
+        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
+        --algorithm                     Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+#### `> dotnet nuget trust source`
+
+```
+Adds a trusted signer based on a given package source.
+
+If only `<name>` is provided without `<source-url>`, the package source from your NuGet configuration files with the same name will be added to the trusted list.
+
+If a `<source-url>` is provided, it MUST be a v3 package source URL (like https://api.nuget.org/v3/index.json). Other package source types are not supported.
+
+If <name> already exists in the configuration, the package source will be appended to it.
+
+USAGE:
+    dotnet nuget trust source <name> [source-url]
+
+OPTIONS:
+        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
+        --owners                        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
+    -h, --help                          Prints out a short help for the command.
+    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+    -i, --interactive                   Allows command to stop and wait for user input or action.
+        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```
+
+## Examples
+
+- List trusted signers:
+
+  ```dotnetcli
+  dotnet nuget trust list
+  ```
+
+- Trust source *NuGet* in specified *nuget.config* file:
+
+  ```dotnetcli
+  dotnet nuget trust source NuGet --configfile ..\nuget.config
+  ```
+
+- Trust an author from signed nupkg package file *foo.nupkg* with *--allow-untrusted-root* option:
+
+  ```dotnetcli
+  dotnet nuget trust author PackageAuthor .\foo.nupkg --allow-untrusted-root
+  ```
+
+- Trust a repository from signed nupkg package file *foo.nupkg*:
+
+  ```dotnetcli
+  dotnet nuget trust repository PackageRepository .\foo.nupkg
+  ```
+
+- Trust a package signing certificate using it's SHA256 fingerprint:
+
+  ```dotnetcli
+    dotnet nuget trust certificate MyCert  F99EC8CDCE5642B380296A19E22FA8EB3AEF1C70079541A2B3D6E4A93F5E1AFD --algorithm SHA256
+  ```
+
+- Trust owners *Nuget* and *Microsoft* from the repository *https://api.nuget.org/v3/index.json*:
+
+  ```dotnetcli
+    dotnet nuget trust source NuGetTrust https://api.nuget.org/v3/index.json --owners "Nuget;Microsoft"
+  ```
+
+- Removes trusted signer named *NuGet* from  specified *nuget.config* file:
+
+  ```dotnetcli
+    dotnet nuget trust remove NuGet --configfile ..\nuget.config
+  ```

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -22,7 +22,7 @@ dotnet nuget trust -h|--help
 
 ## Description
 
-The `dotnet nuget trust` manage the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For additional usage, see [Common NuGet configurations](../../../nuget/consume-packages/configuring-nuget-behavior.md). For details on how the nuget.config schema looks like, refer to the [NuGet config file reference](../../../nuget/reference/nuget-config-file.md).
+The `dotnet nuget trust` manage the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For additional usage, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior). For details on how the nuget.config schema looks like, refer to the [NuGet config file reference](/nuget/reference/nuget-config-file).
 
 ## Options
 
@@ -210,7 +210,7 @@ dotnet nuget trust certificate <name> <fingerprint> [OPTIONS]
 
   The name of existing trusted signer going be added. If a trusted signer with the given name already exists, the certificate item will be added to that signer. Otherwise a trusted author will be created with a certificate item from given certificate information.
 
-- **`<fingerprint>`**
+- **`fingerprint`**
 
   The fingerprint of the certificate.
 

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -6,7 +6,7 @@ ms.date: 06/02/2021
 ---
 # dotnet nuget trust
 
-**This article applies to:** ✔️ .NET 5.0.300 SDK, 6.0.100-preview.4 SDK and later versions
+**This article applies to:** ✔️ .NET 5.0.300 SDK and later versions
 
 ## Name
 
@@ -15,138 +15,264 @@ ms.date: 06/02/2021
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget trust [list|author|repository|source|certificate|remove|sync] [OPTIONS]
-
-if none of list|add|remove|sync is specified, the command will default to list.
+dotnet nuget trust [command] [OPTIONS]
 
 dotnet nuget trust -h|--help
 ```
 
 ## Description
 
-The `dotnet nuget trust` gets or sets trusted signers to the NuGet configuration. For additional usage, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md). For details on how the nuget.config schema looks like, refer to the [NuGet config file reference](../nuget-config-file.md).
+The `dotnet nuget trust` manage the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For additional usage, see [Common NuGet configurations](../../../nuget/consume-packages/configuring-nuget-behavior.md). For details on how the nuget.config schema looks like, refer to the [NuGet config file reference](../../../nuget/reference/nuget-config-file.md).
 
-## Arguments
+## Options
 
-- `<list|author|repository|source|certificate|remove|sync>`
+- **`-h|--help`**
 
-  Specifies the command for gets or sets trusted signers to the NuGet configuration. 
+  Prints out a description of how to use the command.
 
-#### `> dotnet nuget trust list`
+## Commands
 
-```
+If no command is specified, the command will default to `list`.
+
+### `list`
+
 Lists all the trusted signers in the configuration. This option will include all the certificates (with fingerprint and fingerprint algorithm) each signer has. If a certificate has a preceding [U], it means that certificate entry has allowUntrustedRoot set as true.
 
-USAGE:
-    dotnet nuget trust list [OPTIONS]
+#### Synopsis:
 
-OPTIONS:
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```dotnetcli
+dotnet nuget trust list [OPTIONS]
 ```
 
-#### `> dotnet nuget trust sync`
+#### OPTIONS:
 
-```
+- **`-h|--help`**
+
+  Prints out a description of how to use the command.
+
+- **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file that should be used instead of the standard hierarchy.
+
+### `sync`
+
 Deletes the current list of certificates and replaces them with an up-to-date list from the repository.
 
-USAGE:
-    dotnet nuget trust sync [OPTIONS] <name>
+#### Synopsis
 
-OPTIONS:
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```dotnetcli
+dotnet nuget trust sync <name> [OPTIONS]
 ```
 
-#### `> dotnet nuget trust remove`
+#### Arguments
 
-```
+- **`name`**
+
+  The name of existing trusted signer going be synced.
+
+#### OPTIONS:
+
+- **`-h|--help`**
+
+  Prints out a description of how to use the command.
+
+- **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file that should be used instead of the standard hierarchy.
+
+### `remove`
+
 Removes any trusted signers that match the given name.
 
-USAGE:
-    dotnet nuget trust remove [OPTIONS] <name>
+#### Synopsis
 
-OPTIONS:
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```dotnetcli
+dotnet nuget trust remove <name> [OPTIONS]
 ```
 
-#### `> dotnet nuget trust author`
+#### Arguments
 
-```
-Adds a trusted signer with the given name, based on the author signature(s) of one or more packages. If <name> already exists in the configuration, the signature(s) will be appended. The given a <package> should be local paths to signed .nupkg files.
+- **`name`**
 
-USAGE:
-    dotnet nuget trust author [OPTIONS] <name> <package>...
+  The name of existing trusted signer going be removed.
+  
+#### OPTIONS:
 
-EXAMPLE:
-    dotnet nuget trust author Contoso ./contoso.library.nupkg
+- **`-h|--help`**
 
-OPTIONS:
-        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
-```
+  Prints out a description of how to use the command.
 
-#### `> dotnet nuget trust repository`
+- **`-v, --verbosity <LEVEL>`**
 
-```
-Adds a trusted signer with the given name, based on the repository signature(s) or countersignature(s) of one or more packages. If <name> already exists in the configuration, the signature(s) will be appended. The given a <package> should be local paths to signed .nupkg files.
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
-USAGE:
-    dotnet nuget trust repository [OPTIONS] <name> <package>...
+- **`--configfile <PATH>`**
 
-OPTIONS:
-        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
-        --owners                        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+  Specific NuGet file that should be used instead of the standard hierarchy.
+
+### `author`
+
+Adds a trusted signer with the given name, based on the author signature of the package.
+
+#### Synopsis
+
+```dotnetcli
+dotnet nuget trust author <name> <package> [OPTIONS]
 ```
 
-#### `> dotnet nuget trust certificate`
+#### Arguments
 
+- **`name`**
+
+  The name of existing trusted signer going be added. If `name` already exists in the configuration, the signature will be appended.
+
+- **`package`**
+
+  The given `package` should be local path to the signed .nupkg file.
+  
+#### OPTIONS:
+
+- **`--allow-untrusted-root`**
+
+  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
+
+- **`-h|--help`**
+
+  Prints out a description of how to use the command.
+
+- **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file that should be used instead of the standard hierarchy.
+
+### `repository`
+
+Adds a trusted signer with the given name, based on the repository signature or countersignature of a signed package.
+
+#### Synopsis
+
+```dotnetcli
+dotnet nuget trust repository <name> <package> [OPTIONS]
 ```
+
+#### Arguments
+
+- **`name`**
+
+  The name of existing trusted signer going be added. If `name` already exists in the configuration, the signature will be appended.
+
+- **`package`**
+
+  The given `package` should be local path to the signed .nupkg file.
+
+#### OPTIONS:
+
+- **`--allow-untrusted-root`**
+
+  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
+
+- **`-h|--help`**
+
+  Prints out a description of how to use the command.
+
+- **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file that should be used instead of the standard hierarchy.
+
+### `certificate`
+
 Adds a trusted signer with the given name, based on a certificate fingerprint.
 
-If a trusted signer with the given name already exists, the certificate item will be added to that signer. Otherwise a trusted author will be created with a certificate item from given certificate information.
+#### Synopsis
 
-USAGE:
-    dotnet nuget trust certificate [OPTIONS] <name> <fingerprint>
-
-OPTIONS:
-        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
-        --algorithm                     Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```dotnetcli
+dotnet nuget trust certificate <name> <fingerprint> [OPTIONS]
 ```
 
-#### `> dotnet nuget trust source`
+#### Arguments
 
-```
+- **`name`**
+
+  The name of existing trusted signer going be added. If a trusted signer with the given name already exists, the certificate item will be added to that signer. Otherwise a trusted author will be created with a certificate item from given certificate information.
+
+- **`<fingerprint>`**
+
+  The fingerprint of the certificate.
+
+#### OPTIONS:
+
+- **`--allow-untrusted-root`**
+
+  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
+
+- **`--algorithm <ALGORITHM>`**
+
+  Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512.
+  
+- **`-h|--help`**
+
+  Prints out a description of how to use the command.
+
+- **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file that should be used instead of the standard hierarchy.
+
+### `source`
+
 Adds a trusted signer based on a given package source.
 
-If only `<name>` is provided without `<source-url>`, the package source from your NuGet configuration files with the same name will be added to the trusted list.
+#### Synopsis
 
-If a `<source-url>` is provided, it MUST be a v3 package source URL (like https://api.nuget.org/v3/index.json). Other package source types are not supported.
-
-If <name> already exists in the configuration, the package source will be appended to it.
-
-USAGE:
-    dotnet nuget trust source <name> [source-url]
-
-OPTIONS:
-        --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
-        --owners                        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
-    -h, --help                          Prints out a short help for the command.
-    -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-        --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
+```dotnetcli
+dotnet nuget trust source <name> [source-url] [--owners <List>] [OPTIONS]
 ```
+
+#### Arguments
+
+- **`name`**
+
+  The name of existing trusted signer going be added. If only `<name>` is provided without `<source-url>`, the package source from your NuGet configuration files with the same name will be added to the trusted list. If `<name>` already exists in the configuration, the package source will be appended to it.
+
+#### OPTIONS:
+
+- **`--owners <List>`**
+
+  Semi-colon separated list of trusted owners to further restrict the trust of a repository.
+
+- **`source-url`**
+
+  If a `source-url` is provided, it MUST be a v3 package source URL (like <https://api.nuget.org/v3/index.json>). Other package source types are not supported.
+
+- **`-h|--help`**
+
+  Prints out a description of how to use the command.
+
+- **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+
+- **`--configfile`**
+
+  Specific NuGet file that should be used instead of the standard hierarchy.
 
 ## Examples
 
@@ -180,7 +306,7 @@ OPTIONS:
     dotnet nuget trust certificate MyCert  F99EC8CDCE5642B380296A19E22FA8EB3AEF1C70079541A2B3D6E4A93F5E1AFD --algorithm SHA256
   ```
 
-- Trust owners *Nuget* and *Microsoft* from the repository *https://api.nuget.org/v3/index.json*:
+- Trust owners *Nuget* and *Microsoft* from the repository <https://api.nuget.org/v3/index.json>:
 
   ```dotnetcli
     dotnet nuget trust source NuGetTrust https://api.nuget.org/v3/index.json --owners "Nuget;Microsoft"

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -41,10 +41,14 @@ Lists all the trusted signers in the configuration. This option will include all
 #### Synopsis:
 
 ```dotnetcli
-dotnet nuget trust list [OPTIONS]
+dotnet nuget trust list [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### OPTIONS:
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file to use instead of the standard hierarchy.
 
 - **`-h|--help`**
 
@@ -52,11 +56,7 @@ dotnet nuget trust list [OPTIONS]
 
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile <PATH>`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ### `sync`
 
@@ -65,16 +65,20 @@ Deletes the current list of certificates and replaces them with an up-to-date li
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust sync <name> [OPTIONS]
+dotnet nuget trust sync <name> [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
 - **`name`**
 
-  The name of existing trusted signer going be synced.
+  The name of the existing trusted signer to sync.
 
 #### OPTIONS:
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file to use instead of the standard hierarchy.
 
 - **`-h|--help`**
 
@@ -82,11 +86,7 @@ dotnet nuget trust sync <name> [OPTIONS]
 
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile <PATH>`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ### `remove`
 
@@ -95,16 +95,20 @@ Removes any trusted signers that match the given name.
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust remove <name> [OPTIONS]
+dotnet nuget trust remove <name> [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
 - **`name`**
 
-  The name of existing trusted signer going be removed.
+  The name of the existing trusted signer to remove.
   
 #### OPTIONS:
+
+- **`--configfile <PATH>`**
+
+  Specific NuGet file to use instead of the standard hierarchy.
 
 - **`-h|--help`**
 
@@ -112,11 +116,7 @@ dotnet nuget trust remove <name> [OPTIONS]
 
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile <PATH>`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ### `author`
 
@@ -125,18 +125,18 @@ Adds a trusted signer with the given name, based on the author signature of the 
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust author <name> <package> [OPTIONS]
+dotnet nuget trust author <name> <package> [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
 - **`name`**
 
-  The name of existing trusted signer going be added. If `name` already exists in the configuration, the signature will be appended.
+  The name of the trusted signer to add. If `name` already exists in the configuration, the signature is appended.
 
 - **`package`**
 
-  The given `package` should be local path to the signed .nupkg file.
+  The given `package` should be a local path to the signed *.nupkg* file.
   
 #### OPTIONS:
 
@@ -144,17 +144,17 @@ dotnet nuget trust author <name> <package> [OPTIONS]
 
   Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
 
+- **`--configfile <PATH>`**
+
+  Specific NuGet file to use instead of the standard hierarchy.
+
 - **`-h|--help`**
 
   Prints out a description of how to use the command.
 
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile <PATH>`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ### `repository`
 
@@ -163,18 +163,18 @@ Adds a trusted signer with the given name, based on the repository signature or 
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust repository <name> <package> [OPTIONS]
+dotnet nuget trust repository <name> <package> [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
 - **`name`**
 
-  The name of existing trusted signer going be added. If `name` already exists in the configuration, the signature will be appended.
+  The name of the trusted signer to add. If `name` already exists in the configuration, the signature is appended.
 
 - **`package`**
 
-  The given `package` should be local path to the signed .nupkg file.
+  The given `package` should be a local path to the signed *.nupkg* file.
 
 #### OPTIONS:
 
@@ -182,17 +182,17 @@ dotnet nuget trust repository <name> <package> [OPTIONS]
 
   Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
 
+- **`--configfile <PATH>`**
+
+  Specific NuGet file to use instead of the standard hierarchy.
+
 - **`-h|--help`**
 
   Prints out a description of how to use the command.
 
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile <PATH>`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ### `certificate`
 
@@ -201,14 +201,14 @@ Adds a trusted signer with the given name, based on a certificate fingerprint.
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust certificate <name> <fingerprint> [OPTIONS]
+dotnet nuget trust certificate <name> <fingerprint> [--algorithm <ALGORITHM>] [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
 - **`name`**
 
-  The name of existing trusted signer going be added. If a trusted signer with the given name already exists, the certificate item will be added to that signer. Otherwise a trusted author will be created with a certificate item from given certificate information.
+  The name of the trusted signer to add. If a trusted signer with the given name already exists, the certificate item is added to that signer. Otherwise a trusted author is created with a certificate item from the given certificate information.
 
 - **`fingerprint`**
 
@@ -216,25 +216,25 @@ dotnet nuget trust certificate <name> <fingerprint> [OPTIONS]
 
 #### OPTIONS:
 
+- **`--algorithm <ALGORITHM>`**
+
+  Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512.
+
 - **`--allow-untrusted-root`**
 
   Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
 
-- **`--algorithm <ALGORITHM>`**
+- **`--configfile <PATH>`**
 
-  Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512.
-  
+  Specific NuGet file to use instead of the standard hierarchy.
+
 - **`-h|--help`**
 
   Prints out a description of how to use the command.
 
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile <PATH>`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ### `source`
 
@@ -243,36 +243,36 @@ Adds a trusted signer based on a given package source.
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust source <name> [source-url] [--owners <List>] [OPTIONS]
+dotnet nuget trust source <name> [--configfile <PATH>] [-h|--help] [--owners <List>] [--source-url] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
 - **`name`**
 
-  The name of existing trusted signer going be added. If only `<name>` is provided without `<source-url>`, the package source from your NuGet configuration files with the same name will be added to the trusted list. If `<name>` already exists in the configuration, the package source will be appended to it.
+  The name of the trusted signer to add. If only `<name>` is provided without `--<source-url>`, the package source from your NuGet configuration files with the same name is added to the trusted list. If `<name>` already exists in the configuration, the package source is appended to it.
 
 #### OPTIONS:
 
-- **`--owners <List>`**
+- **`--configfile <PATH>`**
 
-  Semi-colon separated list of trusted owners to further restrict the trust of a repository.
-
-- **`source-url`**
-
-  If a `source-url` is provided, it MUST be a v3 package source URL (like <https://api.nuget.org/v3/index.json>). Other package source types are not supported.
+  Specific NuGet file to use instead of the standard hierarchy.
 
 - **`-h|--help`**
 
   Prints out a description of how to use the command.
 
+- **`--owners <List>`**
+
+  Semicolon-separated list of trusted owners to further restrict the trust of a repository.
+
+- **`--source-url`**
+
+  If a `source-url` is provided, it must be a v3 package source URL (like `https://api.nuget.org/v3/index.json`). Other package source types are not supported.
+
 - **`-v, --verbosity <LEVEL>`**
 
-  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-- **`--configfile`**
-
-  Specific NuGet file that should be used instead of the standard hierarchy.
+  Set the verbosity level. Defaults to m[inimal]. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ## Examples
 
@@ -288,10 +288,10 @@ dotnet nuget trust source <name> [source-url] [--owners <List>] [OPTIONS]
   dotnet nuget trust source NuGet --configfile ..\nuget.config
   ```
 
-- Trust an author from signed nupkg package file *foo.nupkg* with *--allow-untrusted-root* option:
+- Trust an author from signed nupkg package file *foo.nupkg*:
 
   ```dotnetcli
-  dotnet nuget trust author PackageAuthor .\foo.nupkg --allow-untrusted-root
+  dotnet nuget trust author PackageAuthor .\foo.nupkg
   ```
 
 - Trust a repository from signed nupkg package file *foo.nupkg*:
@@ -300,19 +300,19 @@ dotnet nuget trust source <name> [source-url] [--owners <List>] [OPTIONS]
   dotnet nuget trust repository PackageRepository .\foo.nupkg
   ```
 
-- Trust a package signing certificate using it's SHA256 fingerprint:
+- Trust a package signing certificate using its SHA256 fingerprint:
 
   ```dotnetcli
     dotnet nuget trust certificate MyCert  F99EC8CDCE5642B380296A19E22FA8EB3AEF1C70079541A2B3D6E4A93F5E1AFD --algorithm SHA256
   ```
 
-- Trust owners *Nuget* and *Microsoft* from the repository <https://api.nuget.org/v3/index.json>:
+- Trust owners *Nuget* and *Microsoft* from the repository `https://api.nuget.org/v3/index.json`:
 
   ```dotnetcli
     dotnet nuget trust source NuGetTrust https://api.nuget.org/v3/index.json --owners "Nuget;Microsoft"
   ```
 
-- Removes trusted signer named *NuGet* from  specified *nuget.config* file:
+- Remove trusted signer named *NuGet* from  specified *nuget.config* file:
 
   ```dotnetcli
     dotnet nuget trust remove NuGet --configfile ..\nuget.config

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -43,7 +43,6 @@ USAGE:
 OPTIONS:
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 
@@ -58,7 +57,6 @@ USAGE:
 OPTIONS:
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 
@@ -73,7 +71,6 @@ USAGE:
 OPTIONS:
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 
@@ -92,7 +89,6 @@ OPTIONS:
         --allow-untrusted-root          Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 
@@ -109,7 +105,6 @@ OPTIONS:
         --owners                        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 
@@ -128,7 +123,6 @@ OPTIONS:
         --algorithm                     Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 
@@ -151,7 +145,6 @@ OPTIONS:
         --owners                        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
     -h, --help                          Prints out a short help for the command.
     -v, --verbosity <LEVEL>             Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-    -i, --interactive                   Allows command to stop and wait for user input or action.
         --configfile                    Specific NuGet file that should be used instead of the standard hierarchy.
 ```
 

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -15,14 +15,14 @@ ms.date: 06/02/2021
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget trust [command] [OPTIONS]
+dotnet nuget trust [command] [Options]
 
 dotnet nuget trust -h|--help
 ```
 
 ## Description
 
-The `dotnet nuget trust` manage the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For additional usage, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior). For details on how the nuget.config schema looks like, refer to the [NuGet config file reference](/nuget/reference/nuget-config-file).
+The `dotnet nuget trust` command manages the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For more information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior). For details on what the nuget.config schema looks like, refer to the [NuGet config file reference](/nuget/reference/nuget-config-file).
 
 ## Options
 
@@ -44,7 +44,7 @@ Lists all the trusted signers in the configuration. This option will include all
 dotnet nuget trust list [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
-#### OPTIONS:
+#### Options:
 
 - **`--configfile <PATH>`**
 
@@ -65,16 +65,16 @@ Deletes the current list of certificates and replaces them with an up-to-date li
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust sync <name> [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
+dotnet nuget trust sync <NAME> [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
-- **`name`**
+- **`NAME`**
 
   The name of the existing trusted signer to sync.
 
-#### OPTIONS:
+#### Options:
 
 - **`--configfile <PATH>`**
 
@@ -95,16 +95,16 @@ Removes any trusted signers that match the given name.
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust remove <name> [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
+dotnet nuget trust remove <NAME> [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
-- **`name`**
+- **`NAME`**
 
   The name of the existing trusted signer to remove.
   
-#### OPTIONS:
+#### Options:
 
 - **`--configfile <PATH>`**
 
@@ -125,20 +125,20 @@ Adds a trusted signer with the given name, based on the author signature of the 
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust author <name> <package> [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
+dotnet nuget trust author <NAME> <PACKAGE> [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
-- **`name`**
+- **`NAME`**
 
-  The name of the trusted signer to add. If `name` already exists in the configuration, the signature is appended.
+  The name of the trusted signer to add. If `NAME` already exists in the configuration, the signature is appended.
 
-- **`package`**
+- **`PACKAGE`**
 
-  The given `package` should be a local path to the signed *.nupkg* file.
+  The given `PACKAGE` should be a local path to the signed *.nupkg* file.
   
-#### OPTIONS:
+#### Options:
 
 - **`--allow-untrusted-root`**
 
@@ -163,20 +163,20 @@ Adds a trusted signer with the given name, based on the repository signature or 
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust repository <name> <package> [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
+dotnet nuget trust repository <NAME> <PACKAGE> [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
-- **`name`**
+- **`NAME`**
 
-  The name of the trusted signer to add. If `name` already exists in the configuration, the signature is appended.
+  The name of the trusted signer to add. If `NAME` already exists in the configuration, the signature is appended.
 
-- **`package`**
+- **`PACKAGE`**
 
-  The given `package` should be a local path to the signed *.nupkg* file.
+  The given `PACKAGE` should be a local path to the signed *.nupkg* file.
 
-#### OPTIONS:
+#### Options:
 
 - **`--allow-untrusted-root`**
 
@@ -201,20 +201,20 @@ Adds a trusted signer with the given name, based on a certificate fingerprint.
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust certificate <name> <fingerprint> [--algorithm <ALGORITHM>] [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
+dotnet nuget trust certificate <NAME> <FINGERPRINT> [--algorithm <ALGORITHM>] [--allow-untrusted-root] [--configfile <PATH>] [-h|--help] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
-- **`name`**
+- **`NAME`**
 
   The name of the trusted signer to add. If a trusted signer with the given name already exists, the certificate item is added to that signer. Otherwise a trusted author is created with a certificate item from the given certificate information.
 
-- **`fingerprint`**
+- **`FINGERPRINT`**
 
   The fingerprint of the certificate.
 
-#### OPTIONS:
+#### Options:
 
 - **`--algorithm <ALGORITHM>`**
 
@@ -243,16 +243,16 @@ Adds a trusted signer based on a given package source.
 #### Synopsis
 
 ```dotnetcli
-dotnet nuget trust source <name> [--configfile <PATH>] [-h|--help] [--owners <List>] [--source-url] [-v, --verbosity <LEVEL>]
+dotnet nuget trust source <NAME> [--configfile <PATH>] [-h|--help] [--owners <List>] [--source-url] [-v, --verbosity <LEVEL>]
 ```
 
 #### Arguments
 
-- **`name`**
+- **`NAME`**
 
-  The name of the trusted signer to add. If only `<name>` is provided without `--<source-url>`, the package source from your NuGet configuration files with the same name is added to the trusted list. If `<name>` already exists in the configuration, the package source is appended to it.
+  The name of the trusted signer to add. If only `<NAME>` is provided without `--<source-url>`, the package source from your NuGet configuration files with the same name is added to the trusted list. If `<NAME>` already exists in the configuration, the package source is appended to it.
 
-#### OPTIONS:
+#### Options:
 
 - **`--configfile <PATH>`**
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -269,6 +269,8 @@ items:
           href: ../core/tools/dotnet-nuget-update-source.md
         - name: dotnet nuget verify
           href: ../core/tools/dotnet-nuget-verify.md
+        - name: dotnet nuget trust
+          href: ../core/tools/dotnet-nuget-trust.md          
       - name: dotnet pack
         href: ../core/tools/dotnet-pack.md
       - name: dotnet publish


### PR DESCRIPTION
## Summary

Describe your changes here:
dotnet 5.0.300 SDK has added `dotnet nuget trust` command. Spec for command is here: Spec is [here](https://github.com/NuGet/Home/blob/b30a8ff077272045224829c6772327b724ebed35/proposed/2021/DotnetNugetTrustedSigners.md). NuGet.Client PR is [here](https://github.com/NuGet/NuGet.Client/pull/3989).

Happy to iterate to make the doc better based on feedback.

Fixes https://github.com/dotnet/docs/issues/24502
