### PR TITLE
CA2016 correct category

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -21,7 +21,7 @@ dev_langs:
 |-|-|
 | **Type name** |ForwardCancellationTokenToInvocations|
 | **Rule ID** |CA2016|
-| **Category** |[Performance](performance-warnings.md)|
+| **Category** |[Reliability](reliability-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause


### PR DESCRIPTION
## Summary

Small change to fix Category of CA2016 which seems to be incorrectly set to Performance instead of Reliability.
