### PR TITLE
Fixed typo with Allocation Size in line 298

### DIFF
--- a/docs/standard/garbage-collection/large-object-heap.md
+++ b/docs/standard/garbage-collection/large-object-heap.md
@@ -295,7 +295,7 @@ Because the LOH is not compacted, sometimes the LOH is thought to be the source 
 
 It’s more common to see VM fragmentation caused by temporary large objects that require the garbage collector to frequently acquire new managed heap segments from the OS and to release empty ones back to the OS.
 
-To verify whether the LOH is causing VM fragmentation, you can set a breakpoint on [VirtualAlloc](/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc) and [VirtualFree](/windows/desktop/api/memoryapi/nf-memoryapi-virtualfree) to see who call them. For example, to see who tried to allocate virtual memory chunks larger than 8MB from the OS, you can set a breakpoint like this:
+To verify whether the LOH is causing VM fragmentation, you can set a breakpoint on [VirtualAlloc](/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc) and [VirtualFree](/windows/desktop/api/memoryapi/nf-memoryapi-virtualfree) to see who called them. For example, to see who tried to allocate virtual memory chunks larger than 8 MB from the OS, you can set a breakpoint like this:
 
 ```console
 bp kernel32!virtualalloc "j (dwo(@esp+8)>800000) 'kb';'g'"

--- a/docs/standard/garbage-collection/large-object-heap.md
+++ b/docs/standard/garbage-collection/large-object-heap.md
@@ -295,7 +295,7 @@ Because the LOH is not compacted, sometimes the LOH is thought to be the source 
 
 It’s more common to see VM fragmentation caused by temporary large objects that require the garbage collector to frequently acquire new managed heap segments from the OS and to release empty ones back to the OS.
 
-To verify whether the LOH is causing VM fragmentation, you can set a breakpoint on [VirtualAlloc](/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc) and [VirtualFree](/windows/desktop/api/memoryapi/nf-memoryapi-virtualfree) to see who call them. For example, to see who tried to allocate virtual memory chunks larger than 8MBB from the OS, you can set a breakpoint like this:
+To verify whether the LOH is causing VM fragmentation, you can set a breakpoint on [VirtualAlloc](/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc) and [VirtualFree](/windows/desktop/api/memoryapi/nf-memoryapi-virtualfree) to see who call them. For example, to see who tried to allocate virtual memory chunks larger than 8MB from the OS, you can set a breakpoint like this:
 
 ```console
 bp kernel32!virtualalloc "j (dwo(@esp+8)>800000) 'kb';'g'"


### PR DESCRIPTION
## Summary

In line 298 ("... allocate virtual memory chunks larger than 8MBB from the OS"), 8MB is written as 8MBB. I believe it is a typo. So fixed it.

