### PR TITLE
First parameter of `ThrowWhenNull` is nullable marked with the `[NotN…

### DIFF
--- a/docs/csharp/language-reference/attributes/snippets/NullableAttributes.cs
+++ b/docs/csharp/language-reference/attributes/snippets/NullableAttributes.cs
@@ -110,12 +110,12 @@ namespace attributes
         }
 
         // <NotNullThrowHelper>
-        public static void ThrowWhenNull([NotNull] object value, string valueExpression = "") =>
+        public static void ThrowWhenNull([NotNull] object? value, string valueExpression = "") =>
             _ = value ?? throw new ArgumentNullException(valueExpression);
         // </NotNullThrowHelper>
 
         // <TestThrowHelper>
-        public static void LogMessage(string message)
+        public static void LogMessage(string? message)
         {
             ThrowWhenNull(message, nameof(message));
 


### PR DESCRIPTION
## Summary

- First parameter of `ThrowWhenNull` is now nullable and annotated with the `[NotNull]` to indicate that after calling `ThrowWhenNull` the `value` isn't null anymore.
- The `message` parameter of  `LogMessage` is now nullable to illustrate that after calling `ThrowWhenNull` the `message` parameter is now considered non nullable by the compiler.

Fixes #24548 
