### PR TITLE
update guidance on finalizers

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/destructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/destructors.md
@@ -9,9 +9,7 @@ helpviewer_keywords:
 ---
 # Finalizers (C# Programming Guide)
 
-Finalizers (historically referred to as **destructors**) are used to perform any necessary final clean-up when a class instance is being collected by the garbage collector.
-
-In most cases, you can avoid writing a finalizer by using the  <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=fullName> or derived classes to wrap any unmanaged handle.
+Finalizers (historically referred to as **destructors**) are used to perform any necessary final clean-up when a class instance is being collected by the garbage collector. In most cases, you can avoid writing a finalizer by using the  <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=fullName> or derived classes to wrap any unmanaged handle.
 
 ## Remarks  
 
@@ -57,7 +55,7 @@ Whether or not finalizers are run as part of application termination is implemen
 > [!NOTE]
 > The .NET Framework implementation makes every reasonable effort to call finalizers for all of its objects that have not yet been garbage collected, unless such cleanup has been suppressed (by a call to the library method `GC.SuppressFinalize`, for example).
   
- If you need to perform cleanup reliably when an application exist, register a handler for the <xref:System.AppDomain.ProcessExit?displayProperty=fullName> event. That handler would ensure <xref:System.IDisposable.Dispose?displayProperty=nameWithType> has been called for all objects that require cleanup before application exit. Because you can't call *Finalize* directly, and you can't guarantee the garbage collector calls all finalizers before exit, you must use `Dispose` to ensure resources are freed.
+ If you need to perform cleanup reliably when an application exist, register a handler for the <xref:System.AppDomain.ProcessExit?displayProperty=fullName> event. That handler would ensure <xref:System.IDisposable.Dispose?displayProperty=nameWithType> (or, <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType>) has been called for all objects that require cleanup before application exit. Because you can't call *Finalize* directly, and you can't guarantee the garbage collector calls all finalizers before exit, you must use `Dispose` or `DisposeAsync` to ensure resources are freed.
 
 ## Using finalizers to release resources
 
@@ -71,6 +69,7 @@ For more information about cleaning up resources, see the following articles:
 
 - [Cleaning Up Unmanaged Resources](../../../standard/garbage-collection/unmanaged.md)
 - [Implementing a Dispose Method](../../../standard/garbage-collection/implementing-dispose.md)
+- [Implementing a Dispose Method](../../../standard/garbage-collection/implementing-disposeasync.md)
 - [using Statement](../../language-reference/keywords/using-statement.md)
 
 ## Example

--- a/docs/csharp/programming-guide/classes-and-structs/destructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/destructors.md
@@ -1,85 +1,83 @@
 ---
 title: "Finalizers - C# Programming Guide"
-description: Finalizers in C#, which are also called destructors, perform any necessary final clean-up when a class instance is being collected by the garbage collector.
-ms.date: 10/08/2018
+description: Finalizers in C# perform any necessary final clean-up when a class instance is being collected by the garbage collector.
+ms.date: 06/09/2021
 helpviewer_keywords: 
   - "~ [C#], in finalizers"
   - "C# language, finalizers"
   - "finalizers [C#]"
-ms.assetid: 1ae6e46d-a4b1-4a49-abe5-b97f53d9e049
 ---
 # Finalizers (C# Programming Guide)
 
-Finalizers (which are also called **destructors**) are used to perform any necessary final clean-up when a class instance is being collected by the garbage collector.  
-  
+Finalizers (historically referred to as **destructors**) are used to perform any necessary final clean-up when a class instance is being collected by the garbage collector.
+
+In most cases, you can avoid writing a finalizer by using the  <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=fullName> or derived classes to wrap any unmanaged handle.
+
 ## Remarks  
-  
-- Finalizers cannot be defined in structs. They are only used with classes.  
-  
-- A class can only have one finalizer.  
-  
-- Finalizers cannot be inherited or overloaded.  
-  
-- Finalizers cannot be called. They are invoked automatically.  
-  
-- A finalizer does not take modifiers or have parameters.  
-  
- For example, the following is a declaration of a finalizer for the `Car` class.
-  
- [!code-csharp[csProgGuideObjects#86](snippets/destructors/Program.cs#2)]
+
+- Finalizers cannot be defined in structs. They are only used with classes.
+- A class can only have one finalizer.
+- Finalizers cannot be inherited or overloaded.
+- Finalizers cannot be called. They are invoked automatically.
+- A finalizer does not take modifiers or have parameters.
+
+For example, the following is a declaration of a finalizer for the `Car` class.
+
+:::code language="csharp" source="snippets/destructors/Program.cs" ID="Snippet2":::
 
 A finalizer can also be implemented as an expression body definition, as the following example shows.
 
-[!code-csharp[expression-bodied-finalizer](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-destructor.cs#1)]  
-  
- The finalizer implicitly calls <xref:System.Object.Finalize%2A> on the base class of the object. Therefore, a call to a finalizer is implicitly translated to the following code:  
-  
-```csharp  
-protected override void Finalize()  
-{  
-    try  
-    {  
-        // Cleanup statements...  
-    }  
-    finally  
-    {  
-        base.Finalize();  
-    }  
-}  
-```  
-  
- This design means that the `Finalize` method is called recursively for all instances in the inheritance chain, from the most-derived to the least-derived.  
-  
+:::code language="csharp" source="snippets/destructors/expr-bodied-destructor.cs" ID="Snippet1":::
+
+The finalizer implicitly calls <xref:System.Object.Finalize%2A> on the base class of the object. Therefore, a call to a finalizer is implicitly translated to the following code:
+
+```csharp
+protected override void Finalize()
+{
+    try
+    { 
+        // Cleanup statements...
+    }
+    finally
+    {
+        base.Finalize();
+    }
+}
+```
+
+This design means that the `Finalize` method is called recursively for all instances in the inheritance chain, from the most-derived to the least-derived.
+
 > [!NOTE]
-> Empty finalizers should not be used. When a class contains a finalizer, an entry is created in the `Finalize` queue. When the finalizer is called, the garbage collector is invoked to process the queue. An empty finalizer just causes a needless loss of performance.  
-  
- The programmer has no control over when the finalizer is called; the garbage collector decides when to call it. The garbage collector checks for objects that are no longer being used by the application. If it considers an object eligible for finalization, it calls the finalizer (if any) and reclaims the memory used to store the object.
+> Empty finalizers should not be used. When a class contains a finalizer, an entry is created in the `Finalize` queue. When the finalizer is called, the garbage collector is invoked to process the queue. An empty finalizer just causes a needless loss of performance.
 
- In .NET Framework applications (but not in .NET Core applications), finalizers are also called when the program exits.
-  
- It's possible to force garbage collection by calling <xref:System.GC.Collect%2A>, but most of the time, this call should be avoided because it may create performance issues.  
-  
-## Using finalizers to release resources  
+The programmer has no control over when the finalizer is called; the garbage collector decides when to call it. The garbage collector checks for objects that are no longer being used by the application. If it considers an object eligible for finalization, it calls the finalizer (if any) and reclaims the memory used to store the object. It's possible to force garbage collection by calling <xref:System.GC.Collect%2A>, but most of the time, this call should be avoided because it may create performance issues.
 
- In general, C# does not require as much memory management on the part of the developer as languages that don't target a runtime with garbage collection. This is because the .NET garbage collector implicitly manages the allocation and release of memory for your objects. However, when your application encapsulates unmanaged resources, such as windows, files, and network connections, you should use finalizers to free those resources. When the object is eligible for finalization, the garbage collector runs the `Finalize` method of the object.
-  
-## Explicit release of resources  
+Whether or not finalizers are run as part of application termination is implementation-specific.
 
- If your application is using an expensive external resource, we also recommend that you provide a way to explicitly release the resource before the garbage collector frees the object. To release the resource, implement a `Dispose` method from the <xref:System.IDisposable> interface that performs the necessary cleanup for the object. This can considerably improve the performance of the application. Even with this explicit control over resources, the finalizer becomes a safeguard to clean up resources if the call to the `Dispose` method fails.  
+> [!NOTE]
+> The .NET Framework implementation makes every reasonable effort to call finalizers for all of its objects that have not yet been garbage collected, unless such cleanup has been suppressed (by a call to the library method `GC.SuppressFinalize`, for example).
   
- For more information about cleaning up resources, see the following articles:  
-  
-- [Cleaning Up Unmanaged Resources](../../../standard/garbage-collection/unmanaged.md)  
-  
-- [Implementing a Dispose Method](../../../standard/garbage-collection/implementing-dispose.md)  
-  
-- [using Statement](../../language-reference/keywords/using-statement.md)  
-  
-## Example  
+ If you need to perform cleanup reliably when an application exist, register a handler for the <xref:System.AppDomain.ProcessExit?displayProperty=fullName> event. That handler would ensure <xref:System.IDisposable.Dispose?displayProperty=nameWithType> has been called for all objects that require cleanup before application exit. Because you can't call *Finalize* directly, and you can't guarantee the garbage collector calls all finalizers before exit, you must use `Dispose` to ensure resources are freed.
 
- The following example creates three classes that make a chain of inheritance. The class `First` is the base class, `Second` is derived from `First`, and `Third` is derived from `Second`. All three have finalizers. In `Main`, an instance of the most-derived class is created. When the program runs, notice that the finalizers for the three classes are called automatically, and in order, from the most-derived to the least-derived.  
-  
- [!code-csharp[Destructors#1](snippets/destructors/Program.cs#1)]
+## Using finalizers to release resources
+
+In general, C# does not require as much memory management on the part of the developer as languages that don't target a runtime with garbage collection. This is because the .NET garbage collector implicitly manages the allocation and release of memory for your objects. However, when your application encapsulates unmanaged resources, such as windows, files, and network connections, you should use finalizers to free those resources. When the object is eligible for finalization, the garbage collector runs the `Finalize` method of the object.
+
+## Explicit release of resources
+
+If your application is using an expensive external resource, we also recommend that you provide a way to explicitly release the resource before the garbage collector frees the object. To release the resource, implement a `Dispose` method from the <xref:System.IDisposable> interface that performs the necessary cleanup for the object. This can considerably improve the performance of the application. Even with this explicit control over resources, the finalizer becomes a safeguard to clean up resources if the call to the `Dispose` method fails.
+
+For more information about cleaning up resources, see the following articles:  
+
+- [Cleaning Up Unmanaged Resources](../../../standard/garbage-collection/unmanaged.md)
+- [Implementing a Dispose Method](../../../standard/garbage-collection/implementing-dispose.md)
+- [using Statement](../../language-reference/keywords/using-statement.md)
+
+## Example
+
+The following example creates three classes that make a chain of inheritance. The class `First` is the base class, `Second` is derived from `First`, and `Third` is derived from `Second`. All three have finalizers. In `Main`, an instance of the most-derived class is created. When the program runs, notice that the finalizers for the three classes are called automatically, and in order, from the most-derived to the least-derived.
+
+:::code language="csharp" source="snippets/destructors/Program.cs" ID="Snippet1":::
   
 ## C# language specification  
 

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/destructors/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/destructors/Program.cs
@@ -23,17 +23,15 @@ class Third : Second
     }
 }
 
-class TestDestructors
-{
-    static void Main()
-    {
-        Third t = new Third();
-    }
-}
-/* Output (to VS Output Window):
-    Third's finalizer is called.
-    Second's finalizer is called.
-    First's finalizer is called.
+/* 
+Test with code like the following:
+    Third t = new Third();
+    t = null;
+
+When oejcts are finalized, the output would be:
+Third's finalizer is called.
+Second's finalizer is called.
+First's finalizer is called.
 */
 //</Snippet1>
 

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/destructors/expr-bodied-destructor.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/destructors/expr-bodied-destructor.cs
@@ -13,9 +13,10 @@ class Program
 {
    static void Main()
    {
-      var destroyer = new Destroyer();
-      destroyer = null;
-      GC.Collect();
-      Console.WriteLine("Exiting...");
-   }
+        var destroyer = new Destroyer();
+        destroyer = null;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        Console.WriteLine("Exiting...");
+    }
 }

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/destructors/expr-bodied-destructor.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/destructors/expr-bodied-destructor.cs
@@ -15,8 +15,7 @@ class Program
    {
         var destroyer = new Destroyer();
         destroyer = null;
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
+        GC.GetTotalMemory(forceFullCollection: true);
         Console.WriteLine("Exiting...");
     }
 }

--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -75,7 +75,7 @@ An expression body definition for a finalizer typically contains cleanup stateme
 
 The following example defines a finalizer that uses an expression body definition to indicate that the finalizer has been called.
 
-[!code-csharp[expression-bodied-finalizer](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-destructor.cs#1)]  
+[!code-csharp[expression-bodied-finalizer](../classes-and-structs/snippets/destructors/expr-bodied-destructor.cs#1)]  
 
 For more information, see [Finalizers (C# Programming Guide)](../classes-and-structs/destructors.md).
 


### PR DESCRIPTION
Fixes #17463

This PR does the following:

- Uses the language from the C# standard to define if finalizers are called.
- copy edit the article. Mostly removing any use of "destructor" which is no longer the preferred term.
- Update samples so they don't show the practice of calling `GC.Collect()` and `GC.WaitForPendingFinalizers()`, which won't guarantee finalizers are called on .NET Core and .NET 5 and later.
- Link to `System.AppDomain.ProcessExit` as a way to be notified of app shutdown so cleanup can be performed.
