### PR TITLE
Add "Object Initializers with collection read-only property initialization" section

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -103,6 +103,34 @@ The preceding sample generates code that calls the <xref:System.Collections.Gene
 
 This initializer example calls <xref:System.Collections.Generic.Dictionary%602.Add(%600,%601)> to add the three items into the dictionary. These two different ways to initialize associative collections have slightly different behavior because of the method calls the compiler generates. Both variants work with the `Dictionary` class. Other types may only support one or the other based on their public API.
 
+## Object Initializers with collection read-only property initialization
+
+Some classes may have collection properties where the property is read-only, like the `Cats` property of `CatOwner` in the following case:
+
+[!code-csharp[ObjectInitializer1](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs#CatOwnerDeclaration)]
+
+You will not be able to use collection initializer syntax discussed so far since the property cannot be assigned a new list:
+
+```csharp
+CatOwner owner = new CatOwner
+{
+    Cats = new List<Cat>
+    {
+        new Cat{ Name = "Sylvester", Age=8 },
+        new Cat{ Name = "Whiskers", Age=2 },
+        new Cat{ Name = "Sasha", Age=14 }
+    }
+};
+```
+
+However, new entries can be added to `Cats` nonetheless using the initialization syntax by omitting the list creation (`new List<Cat>`), as shown next:
+
+[!code-csharp[ListInitializer](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs#ReadOnlyPropertyCollectionInitializer)]
+
+The set of entries to be added simply appear surrounded by braces. The above is identical to writing:
+
+[!code-csharp[ListInitializer](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs#ReadOnlyPropertyCollectionInitializerTranslation)]
+
 ## Examples
 
 The following example combines the concepts of object and collection initializers.

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
@@ -26,6 +26,13 @@ namespace object_collection_initializers
         }
         // </SnippetCatDeclaration>
 
+        // <SnippetCatOwnerDeclaration>
+        public class CatOwner
+        {
+            public IList<Cat> Cats { get; } = new List<Cat>();
+        }
+        // </SnippetCatOwnerDeclaration>
+
         // <SnippetMatrixDeclaration>
         public class Matrix
         {
@@ -113,6 +120,29 @@ namespace object_collection_initializers
                 {42, "forty-two" }
             };
             // </SnippetDictionaryAddInitializer>
+
+            {
+                // <SnippetReadOnlyPropertyCollectionInitializer>
+                CatOwner owner = new CatOwner
+                {
+                    Cats =
+                    {
+                        new Cat{ Name = "Sylvester", Age=8 },
+                        new Cat{ Name = "Whiskers", Age=2 },
+                        new Cat{ Name = "Sasha", Age=14 }
+                    }
+                };
+                // </SnippetReadOnlyPropertyCollectionInitializer>
+            }
+
+            {
+                // <SnippetReadOnlyPropertyCollectionInitializerTranslation>
+                CatOwner owner = new CatOwner();
+                owner.Cats.Add(new Cat{ Name = "Sylvester", Age=8 });
+                owner.Cats.Add(new Cat{ Name = "Whiskers", Age=2 });
+                owner.Cats.Add(new Cat{ Name = "Sasha", Age=14 });
+                // <SnippetReadOnlyPropertyCollectionInitializerTranslation>
+            }
 
             InitializationSample.Main();
             FullExample.Main();


### PR DESCRIPTION
## Summary

Adds a new section titled **Object Initializers with collection read-only property initialization** that demonstrates exactly what the title reads and highlighted as an omission in issue #24612.

Fixes #24612
