### PR TITLE
Proposed modification to colon formatting guide based on discussion

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -248,30 +248,40 @@ This is a way to avoid too long lines (in case return type might have long name)
 
 ### Type annotations
 
-#### Right-pad function argument type annotations
+#### Right-pad value and function argument type annotations
 
-When defining arguments with type annotations, use white space after the `:` symbol:
+When defining values or arguments with type annotations, use white space after the `:` symbol, but not before:
 
 ```fsharp
 // OK
 let complexFunction (a: int) (b: int) c = a + b + c
+let expensiveToCompute: int = 0 // Type annotation for let-bound value
+
+type C() =
+    member _.Property: int = 1
 
 // Bad
 let complexFunctionBad (a :int) (b :int) (c:int) = a + b + c
+let expensiveToComputeBad1:int = 1
+let expensiveToComputeBad2 :int = 2
 ```
 
 #### Surround return type annotations with white space
 
-In a let-bound function or value type annotation (return type in the case of a function), use white space before and after the `:` symbol:
+In function or member return type annotations, use white space before and after the `:` symbol:
 
 ```fsharp
 // OK
-let expensiveToCompute : int = 0 // Type annotation for let-bound value
 let myFun (a: decimal) b c : decimal = a + b + c // Type annotation for the return type of a function
+let anotherFun (arg: int) : unit = () // Type annotation for return type of a function
+type C() =
+    member _.SomeMethod(x: int) : int = 1 // Type annotation for return type of a member
+
 // Bad
-let expensiveToComputeBad1:int = 1
-let expensiveToComputeBad2 :int = 2
 let myFunBad (a: decimal) b c:decimal = a + b + c
+let anotherFunBad (arg: int): unit = ()
+type C() =
+    member _.SomeMethod(x: int): int = 1
 ```
 
 ### Formatting bindings
@@ -1302,7 +1312,7 @@ The guidelines below apply to both functions, members, and type definitions.
 Keep generic type arguments and constraints on a single line if it’s not too long:
 
 ```fsharp
-let f<'a, 'b when 'a : equality and 'b : comparison> param =
+let f<'a, 'b when 'a: equality and 'b: comparison> param =
     // function body
 ```
 


### PR DESCRIPTION

The discussion here made me realise that we are documenting value annotations as having a space after them.  This addresses that.

https://github.com/dotnet/docs/pull/12076#issuecomment-858384813

cc @auduchinok @cartermp 
