### PR TITLE
Fix end tag of one basic object initializers snippet

### DIFF
--- a/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
@@ -141,7 +141,7 @@ namespace object_collection_initializers
                 owner.Cats.Add(new Cat{ Name = "Sylvester", Age=8 });
                 owner.Cats.Add(new Cat{ Name = "Whiskers", Age=2 });
                 owner.Cats.Add(new Cat{ Name = "Sasha", Age=14 });
-                // <SnippetReadOnlyPropertyCollectionInitializerTranslation>
+                // </SnippetReadOnlyPropertyCollectionInitializerTranslation>
             }
 
             InitializationSample.Main();


### PR DESCRIPTION
## Summary

One of the snippets added in PR #24639 that addresses issue #24612 had a typo in the _end tag_. As a result, the snippet (last in [the section added by the PR](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization)) appears blank.