### PR TITLE
Fixed Broken Link to 'What is Infrastructure as Code'

### DIFF
--- a/docs/architecture/cloud-native/infrastructure-as-code.md
+++ b/docs/architecture/cloud-native/infrastructure-as-code.md
@@ -119,7 +119,7 @@ Figure 10-17 shows a YAML snippet that lists the version of Azure CLI and the de
 
 **Figure 10-17** - Azure CLI script
 
-In the article, [What is Infrastructure as Code](/azure/devops/learn/what-is-infrastructure-as-code), Author Sam Guckenheimer describes how, "Teams who implement IaC can deliver stable environments rapidly and at scale. Teams avoid manual configuration of environments and enforce consistency by representing the desired state of their environments via code. Infrastructure deployments with IaC are repeatable and prevent runtime issues caused by configuration drift or missing dependencies. DevOps teams can work together with a unified set of practices and tools to deliver applications and their supporting infrastructure rapidly, reliably, and at scale."
+In the article, [What is Infrastructure as Code](https://docs.microsoft.com/en-us/devops/deliver/what-is-infrastructure-as-code), Author Sam Guckenheimer describes how, "Teams who implement IaC can deliver stable environments rapidly and at scale. Teams avoid manual configuration of environments and enforce consistency by representing the desired state of their environments via code. Infrastructure deployments with IaC are repeatable and prevent runtime issues caused by configuration drift or missing dependencies. DevOps teams can work together with a unified set of practices and tools to deliver applications and their supporting infrastructure rapidly, reliably, and at scale."
 
 >[!div class="step-by-step"]
 >[Previous](feature-flags.md)


### PR DESCRIPTION
## Summary

Describe your changes here.
Note that this fix is a little weird since the source mentions the author (Sam Guckenheimer) by name, but the destination is just documentation that doesn't have an author attributed. The quoted text is in the destination location so I'm sure this is the correct destination.

Fixes #24380