### PR TITLE
If message is not null, get to the CustomMethod execution

### DIFF
--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -26,7 +26,7 @@ namespace Console.ExampleFormatters.Custom
             IExternalScopeProvider scopeProvider,
             TextWriter textWriter)
         {
-            if (logEntry.Exception is null)
+            if (logEntry.Exception == null && message == null)
             {
                 return;
             }
@@ -34,11 +34,6 @@ namespace Console.ExampleFormatters.Custom
             string message =
                 logEntry.Formatter(
                     logEntry.State, logEntry.Exception);
-            
-            if (message == null)
-            {
-                return;
-            }
             
             CustomLogicGoesHere(textWriter);
             textWriter.WriteLine(message);

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -26,7 +26,7 @@ namespace Console.ExampleFormatters.Custom
             IExternalScopeProvider scopeProvider,
             TextWriter textWriter)
         {
-            if (logEntry.Exception == null && message == null)
+            if (logEntry.Exception is null && message is null)
             {
                 return;
             }


### PR DESCRIPTION

## Summary

If the logEntry.Exception is null, the method will simply exist without logging anything. Given that the normal case would be to have no exception, but to have a log message, I think it would be more valuable as a code sample if the execution could get to the "CustomLogicGoesHere" method. 
A similar code snippet is also present in the SystemdConsoleFormatter implementation (https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Logging.Console/src/SystemdConsoleFormatter.cs).


Fixes #Issue_Number (if available)
