### PR TITLE
Extra 1 character (typo)

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-use-svcutil-exe-to-export-metadata-from-compiled-service-code.md
+++ b/docs/framework/wcf/feature-details/how-to-use-svcutil-exe-to-export-metadata-from-compiled-service-code.md
@@ -19,7 +19,7 @@ Svcutil.exe can export metadata for services, contracts, and data types in compi
   
 ### To export metadata for compiled service contracts  
   
-1. Compile your service contract implementations into one or more class libraries.1  
+1. Compile your service contract implementations into one or more class libraries.
   
 2. Run Svcutil.exe on the compiled assemblies.  
   


### PR DESCRIPTION
## Summary

There was an extra one (1) on the end of the line (typo). It might be a broken reference, but I didn't see anywhere below that it might have been linking to.