### PR TITLE
#22968: Use null-conditional operator to simplify snippet

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/eventsoverview/cs/programnodata.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/eventsoverview/cs/programnodata.cs
@@ -40,16 +40,7 @@ namespace ConsoleApplication1
             total += x;
             if (total >= threshold)
             {
-                OnThresholdReached(EventArgs.Empty);
-            }
-        }
-
-        protected virtual void OnThresholdReached(EventArgs e)
-        {
-            EventHandler handler = ThresholdReached;
-            if (handler != null)
-            {
-                handler(this, e);
+                ThresholdReached?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/eventsoverview/vb/module1nodata.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/eventsoverview/vb/module1nodata.vb
@@ -1,4 +1,4 @@
-﻿'<snippet5>
+'<snippet5>
 Module Module1
 
     Sub Main()
@@ -29,12 +29,8 @@ Class Counter
     Public Sub Add(x As Integer)
         total = total + x
         If (total >= threshold) Then
-            OnThresholdReached(EventArgs.Empty)
+            ThresholdReached?.Invoke(this. EventArgs.Empty)
         End If
-    End Sub
-
-    Protected Overridable Sub OnThresholdReached(e As EventArgs)
-        RaiseEvent ThresholdReached(Me, e)
     End Sub
 
     Public Event ThresholdReached As EventHandler


### PR DESCRIPTION
## Summary

Replace archaic code for raising an event with a simplified version that uses the null-conditional operator.

Fixes #22968