### PR TITLE
Add .NET MAUI to hub page

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -209,6 +209,8 @@ additionalContent:
             text: Xamarin.Android
           - url: /azure/developer/mobile-apps
             text: Develop Xamarin apps with Azure
+          - url: .NET Multi-platform App UI (MAUI)
+            text: /dotnet/maui
       # Card
       - title: Desktop
         links:
@@ -224,6 +226,8 @@ additionalContent:
             text: Windows Forms (.NET Framework)
           - url: /xamarin/mac
             text: Xamarin for macOS
+          - url: .NET Multi-platform App UI (MAUI)
+            text: /dotnet/maui            
       # Card
       - title: Microservices
         links:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -209,8 +209,8 @@ additionalContent:
             text: Xamarin.Android
           - url: /azure/developer/mobile-apps
             text: Develop Xamarin apps with Azure
-          - url: .NET Multi-platform App UI (MAUI)
-            text: /dotnet/maui
+          - url: /dotnet/maui
+            text: .NET Multi-platform App UI (MAUI)
       # Card
       - title: Desktop
         links:
@@ -226,8 +226,8 @@ additionalContent:
             text: Windows Forms (.NET Framework)
           - url: /xamarin/mac
             text: Xamarin for macOS
-          - url: .NET Multi-platform App UI (MAUI)
-            text: /dotnet/maui            
+          - url: /dotnet/maui
+            text: .NET Multi-platform App UI (MAUI)          
       # Card
       - title: Microservices
         links:


### PR DESCRIPTION
## Summary

Add .NET MAUI to the mobile and desktop cards on the hub page.

As .NET MAUI is still a preview, I've added it to the end of each card.
