### PR TITLE
Update publish-subscribe.md

### DIFF
--- a/docs/architecture/dapr-for-net-developers/publish-subscribe.md
+++ b/docs/architecture/dapr-for-net-developers/publish-subscribe.md
@@ -302,7 +302,7 @@ public interface IEventBus
     void Publish(IntegrationEvent integrationEvent);
 
     void Subscribe<T, THandler>()
-        where TEvent : IntegrationEvent
+        where T : IntegrationEvent
         where THandler : IIntegrationEventHandler<T>;
 }
 ```


### PR DESCRIPTION
Corrected typo in the IEventBus interface.

## Summary

TEvent was not used in the definition of the Subscribe method. Based on the code TEvent was supposed to be T. You could also change the other to T's to TEvent as well.

Fixes #Issue_Number (if available)
