### PR TITLE
Nameof: added section about instance member names

### DIFF
--- a/docs/fsharp/language-reference/nameof.md
+++ b/docs/fsharp/language-reference/nameof.md
@@ -88,3 +88,18 @@ let f (str: string) =
 f "str" // matches
 f "asdf" // does not match
 ```
+
+## Nameof with instance members
+
+F# requries an instance in order to extract the name of an instance member with `nameof`.  If an instance is not easily available, then one can be obtained using `Unchecked.defaultof`.
+
+```fsharp
+type MyRecord = { MyField: int }
+type MyClass() =
+    member _.MyProperty = ()
+    member _.MyMethod () = ()
+    
+nameof Unchecked.defaultof<MyRecord>.MyField   // MyField
+nameof Unchecked.defaultof<MyClass>.MyProperty // MyProperty
+nameof Unchecked.defaultof<MyClass>.MyMethod   // MyMethod
+```


### PR DESCRIPTION
## Summary

Added a section to the [Nameof documentation](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/nameof) about obtaining the names of instance members.

Fixes #24258 (if it were still open)