### PR TITLE
If message not null, execute CustomMethod

### DIFF
--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -29,12 +29,12 @@ namespace Console.ExampleFormatters.Custom
             string message =
                 logEntry.Formatter(
                     logEntry.State, logEntry.Exception);
-    
+
             if (message == null)
             {
                 return;
             }
-            
+
             CustomLogicGoesHere(textWriter);
             textWriter.WriteLine(message);
         }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -25,9 +25,12 @@ namespace Console.ExampleFormatters.Custom
             in LogEntry<TState> logEntry,
             IExternalScopeProvider scopeProvider,
             TextWriter textWriter)
-        {   
-            string message = logEntry.Formatter(logEntry.State, logEntry.Exception);
-            if (logEntry.Exception == null && message == null)
+        {
+            string message =
+                logEntry.Formatter(
+                    logEntry.State, logEntry.Exception);
+    
+            if (message == null)
             {
                 return;
             }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -25,17 +25,9 @@ namespace Console.ExampleFormatters.Custom
             in LogEntry<TState> logEntry,
             IExternalScopeProvider scopeProvider,
             TextWriter textWriter)
-        {
-            if (logEntry.Exception is null)
-            {
-                return;
-            }
-
-            string message =
-                logEntry.Formatter(
-                    logEntry.State, logEntry.Exception);
-            
-            if (message == null)
+        {   
+            string message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+            if (logEntry.Exception == null && message == null)
             {
                 return;
             }


### PR DESCRIPTION
If the logEntry.Exception is null, the method will simply exit without logging anything. Given that the normal case would be to have no exception, but to have a log message, I think it would be more valuable as a code sample if the execution could get to the "CustomLogicGoesHere" method.
A similar code snippet is also present in the SystemdConsoleFormatter implementation (https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Logging.Console/src/SystemdConsoleFormatter.cs).

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
