### PR TITLE
Upgrade Assistant telemetry article: `ms.date`, add to TOC, and add set env var

### DIFF
--- a/docs/core/porting/upgrade-assistant-telemetry.md
+++ b/docs/core/porting/upgrade-assistant-telemetry.md
@@ -2,7 +2,7 @@
 title: Upgrade Assistant Telemetry
 description: Learn about telemetry collected by the Upgrade Assistant.
 author: tasou
-ms.date: 06/03/2021
+ms.date: 06/21/2021
 ---
 # Upgrade Assistant telemetry
 
@@ -11,6 +11,59 @@ The [Upgrade Assistant](./upgrade-assistant-overview.md) includes a telemetry fe
 ## How to opt out
 
 The Upgrade Assistant telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
+
+### [Command Line](#tab/command-line)
+
+Create and assign persisted environment variable, given the value.
+
+```CMD
+:: Assigns the env var to the value
+setx DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT="1"
+```
+
+In a new instance of the **Command Prompt**, read the environment variable.
+
+```CMD
+:: Prints the env var value
+echo %DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT%
+```
+
+### [PowerShell](#tab/powershell)
+
+Create and assign persisted environment variable, given the value.
+
+```powershell
+# Assigns the env var to the value
+[System.Environment]::SetEnvironmentVariable('DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT', '1', 'User')
+```
+
+In a new instance of the **Windows PowerShell**, read the environment variable.
+
+```powershell
+# Prints the env var value
+[System.Environment]::GetEnvironmentVariable('DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT')
+```
+
+### [Bash](#tab/bash)
+
+Create and assign persisted environment variable, given the value.
+
+```Bash
+# Assigns the env var to the value
+echo export DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT="1" >> /etc/environment && source /etc/environment
+```
+
+In a new instance of the **Bash**, read the environment variable.
+
+```Bash
+# Prints the env var value
+echo "${DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT}"
+
+# Or use printenv:
+# printenv DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT
+```
+
+---
 
 ## Disclosure
 

--- a/docs/core/porting/upgrade-assistant-telemetry.md
+++ b/docs/core/porting/upgrade-assistant-telemetry.md
@@ -72,7 +72,10 @@ The Upgrade Assistant displays text similar to the following when you first run 
 ```console
 Telemetry
 ---------
-The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The .NET tools collect usage data in order to help us improve your experience.
+It is collected by Microsoft and shared with the community. You can opt-out of
+telemetry by setting the DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT environment
+variable to '1' or 'true' using your favorite shell.
 ```
 
 To suppress the "first run" experience text, set the `DOTNET_UPGRADEASSISTANT_SKIP_FIRST_TIME_EXPERIENCE` environment variable to `1` or `true`.

--- a/docs/core/porting/upgrade-assistant-telemetry.md
+++ b/docs/core/porting/upgrade-assistant-telemetry.md
@@ -12,18 +12,18 @@ The [Upgrade Assistant](./upgrade-assistant-overview.md) includes a telemetry fe
 
 The Upgrade Assistant telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
 
-### [Command Line](#tab/command-line)
+### [Console](#tab/console)
 
 Create and assign persisted environment variable, given the value.
 
-```CMD
+```console
 :: Assigns the env var to the value
 setx DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT="1"
 ```
 
 In a new instance of the **Command Prompt**, read the environment variable.
 
-```CMD
+```console
 :: Prints the env var value
 echo %DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT%
 ```

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2460,6 +2460,8 @@ items:
     items:
     - name: Overview
       href: ../core/porting/upgrade-assistant-overview.md
+    - name: Telemetry
+      href: ../core/porting/upgrade-assistant-telemetry.md
     - name: ASP.NET Core
       href: ../core/porting/upgrade-assistant-aspnetmvc.md
     - name: Windows Presentation Foundation


### PR DESCRIPTION
## Summary

- Update `ms.date` to reflect date of article
- Add article to TOC
- Add set env var example to make it easier for people to opt out

Related to #24758 -- attention @twsouthwick see the [internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/porting/upgrade-assistant-telemetry?branch=pr-en-us-24762)