### PR TITLE
Add async enumerables

### DIFF
--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -82,7 +82,7 @@ await foreach (string element in elements)
 }
 ```
 
-On an iteration of the `await foreach` loop, the <xref:System.Collections.IAsyncEnumerator.MoveNextAsync%2A> method is called for `elements`. The <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> return by `MoveNext` completes when the next `yield return` is reached.
+On an iteration of the `await foreach` loop, the <xref:System.Collections.Generic.IAsyncEnumerator%601.MoveNextAsync%2A?displayProperty=nameWithType> method is called for `elements`. The <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> return by `MoveNext` completes when the next `yield return` is reached.
 
 On each subsequent iteration of the `await foreach` loop, the execution of the iterator body continues from where it left off, again stopping when it reaches a `yield return` statement. The `await foreach` loop completes when the end of the iterator method or a `yield break` statement is reached.
 

--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -36,7 +36,12 @@ For more information about iterators, see [Iterators](../../iterators.md).
 
 The declaration of an iterator must meet the following requirements:
 
-- The return type must be <xref:System.Collections.Generic.IAsyncEnumerable%601>, <xref:System.Collections.Generic.IEnumerable%601>, <xref:System.Collections.IEnumerable>, <xref:System.Collections.Generic.IEnumerator%601>, or <xref:System.Collections.IEnumerator>.
+- The return type must be one of the following types:
+  - <xref:System.Collections.Generic.IAsyncEnumerable%601>
+  - <xref:System.Collections.Generic.IEnumerable%601>
+  - <xref:System.Collections.IEnumerable>
+  - <xref:System.Collections.Generic.IEnumerator%601>
+  - <xref:System.Collections.IEnumerator>
 - The declaration can't have any [in](in-parameter-modifier.md), [ref](ref.md), or [out](out-parameter-modifier.md) parameters.
 
 The `yield` type of an iterator that returns <xref:System.Collections.IEnumerable> or <xref:System.Collections.IEnumerator> is `object`.  If the iterator returns <xref:System.Collections.Generic.IEnumerable%601> or <xref:System.Collections.Generic.IEnumerator%601>, there must be an implicit conversion from the type of the expression in the `yield return` statement to the generic type parameter.

--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -26,6 +26,8 @@ You use a `yield return` statement to return each element one at a time.
 
 The sequence returned from an iterator method can be consumed by using a [foreach](../statements/iteration-statements.md#the-foreach-statement) statement or LINQ query. Each iteration of the `foreach` loop calls the iterator method. When a `yield return` statement is reached in the iterator method, `expression` is returned, and the current location in code is retained. Execution is restarted from that location the next time that the iterator function is called.
 
+When the iterator returns an <xref:System.Collections.Generic.IAsyncEnumerable%601?displayProperty=nameWithType>, that sequence can be consumed asynchronously using an [await foreach](../statements/iteration-statements.md#await-foreach) statement. The iteration of the loop is analogous to the `foreach` statement. The difference os that each iteration may be suspended for an asynchronous operation before returning the expression for the next element.
+
 You can use a `yield break` statement to end the iteration.
 
 For more information about iterators, see [Iterators](../../iterators.md).
@@ -34,16 +36,14 @@ For more information about iterators, see [Iterators](../../iterators.md).
 
 The declaration of an iterator must meet the following requirements:
 
-- The return type must be <xref:System.Collections.IEnumerable>, <xref:System.Collections.Generic.IEnumerable%601>, <xref:System.Collections.IEnumerator>, or <xref:System.Collections.Generic.IEnumerator%601>.
-
+- The return type must be <xref:System.Collections.Generic.IAsyncEnumerable%601>, <xref:System.Collections.Generic.IEnumerable%601>, <xref:System.Collections.IEnumerable>, <xref:System.Collections.Generic.IEnumerator%601>, or <xref:System.Collections.IEnumerator>.
 - The declaration can't have any [in](in-parameter-modifier.md), [ref](ref.md), or [out](out-parameter-modifier.md) parameters.
 
-The `yield` type of an iterator that returns <xref:System.Collections.IEnumerable> or <xref:System.Collections.IEnumerator> is `object`.  If the iterator returns <xref:System.Collections.Generic.IEnumerable%601> or <xref:System.Collections.Generic.IEnumerator%601>, there must be an implicit conversion from the type of the expression in the `yield return` statement to the generic type parameter .
+The `yield` type of an iterator that returns <xref:System.Collections.IEnumerable> or <xref:System.Collections.IEnumerator> is `object`.  If the iterator returns <xref:System.Collections.Generic.IEnumerable%601> or <xref:System.Collections.Generic.IEnumerator%601>, there must be an implicit conversion from the type of the expression in the `yield return` statement to the generic type parameter.
 
 You can't include a `yield return` or `yield break` statement in:
 
 - [Lambda expressions](../operators/lambda-expressions.md) and [anonymous methods](../operators/delegate-operator.md).
-
 - Methods that contain unsafe blocks. For more information, see [unsafe](unsafe.md).
 
 ## Exception handling
@@ -52,7 +52,7 @@ A `yield return` statement can't be located in a try-catch block. A `yield retur
 
 A `yield break` statement can be located in a try block or a catch block but not a finally block.
 
-If the `foreach` body (outside of the iterator method) throws an exception, a `finally` block in the iterator method is executed.
+If the `foreach` or `await foreach` body (outside of the iterator method) throws an exception, a `finally` block in the iterator method is executed.
 
 ## Technical implementation
 
@@ -72,15 +72,27 @@ On an iteration of the `foreach` loop, the <xref:System.Collections.IEnumerator.
 
 On each subsequent iteration of the `foreach` loop, the execution of the iterator body continues from where it left off, again stopping when it reaches a `yield return` statement. The `foreach` loop completes when the end of the iterator method or a `yield break` statement is reached.
 
-## Example 1
+The following code returns an `IAsyncEnumerable<string>` from an iterator method and then iterates through its elements.
+
+```csharp
+IAsyncEnumerable<string> elements = MyAsyncIteratorMethod();
+await foreach (string element in elements)
+{
+   ...
+}
+```
+
+On an iteration of the `await foreach` loop, the <xref:System.Collections.IAsyncEnumerator.MoveNextAsync%2A> method is called for `elements`. The <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> return by `MoveNext` completes when the next `yield return` is reached.
+
+On each subsequent iteration of the `await foreach` loop, the execution of the iterator body continues from where it left off, again stopping when it reaches a `yield return` statement. The `await foreach` loop completes when the end of the iterator method or a `yield break` statement is reached.
+
+## Examples
 
 The following example has a `yield return` statement that's inside a `for` loop. Each iteration of the `foreach` statement body in the `Main` method creates a call to the `Power` iterator function. Each call to the iterator function proceeds to the next execution of the `yield return` statement, which occurs during the next iteration of the `for` loop.
 
 The return type of the iterator method is <xref:System.Collections.IEnumerable>, which is an iterator interface type. When the iterator method is called, it returns an enumerable object that contains the powers of a number.
 
 [!code-csharp[csrefKeywordsContextual#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsContextual/CS/csrefKeywordsContextual.cs#5)]
-
-## Example 2
 
 The following example demonstrates a `get` accessor that is an iterator. In the example, each `yield return` statement returns an instance of a user-defined class.
 

--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -78,7 +78,7 @@ The following code returns an `IAsyncEnumerable<string>` from an iterator method
 IAsyncEnumerable<string> elements = MyAsyncIteratorMethod();
 await foreach (string element in elements)
 {
-   ...
+   // ...
 }
 ```
 

--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -26,7 +26,7 @@ You use a `yield return` statement to return each element one at a time.
 
 The sequence returned from an iterator method can be consumed by using a [foreach](../statements/iteration-statements.md#the-foreach-statement) statement or LINQ query. Each iteration of the `foreach` loop calls the iterator method. When a `yield return` statement is reached in the iterator method, `expression` is returned, and the current location in code is retained. Execution is restarted from that location the next time that the iterator function is called.
 
-When the iterator returns an <xref:System.Collections.Generic.IAsyncEnumerable%601?displayProperty=nameWithType>, that sequence can be consumed asynchronously using an [await foreach](../statements/iteration-statements.md#await-foreach) statement. The iteration of the loop is analogous to the `foreach` statement. The difference os that each iteration may be suspended for an asynchronous operation before returning the expression for the next element.
+When the iterator returns an <xref:System.Collections.Generic.IAsyncEnumerable%601?displayProperty=nameWithType>, that sequence can be consumed asynchronously using an [await foreach](../statements/iteration-statements.md#await-foreach) statement. The iteration of the loop is analogous to the `foreach` statement. The difference is that each iteration may be suspended for an asynchronous operation before returning the expression for the next element.
 
 You can use a `yield break` statement to end the iteration.
 


### PR DESCRIPTION
Fixes #23409

The language reference for the `yield` statement did not cover async enumerables. This PR adds those.

