### PR TITLE
Add notes to clarify `EventId` bits

### DIFF
--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -34,6 +34,9 @@ The preceding code:
 
 The logger is instantiated with the `name` and a `Func<ColorConsoleLoggerConfiguration>` which will return the current config &mdash; this handles updates to the config values as monitored through the <xref:Microsoft.Extensions.Options.IOptionsMonitor%601.OnChange%2A?displayProperty=nameWithType> callback.
 
+> [!IMPORTANT]
+> The <xref:Microsoft.Extensions.Logging.ILogger.Log%2A?displayProperty=nameWithType> implementation checks if the `config.EventId` value is set, when it's not or when it matches the exact `logEntry.EventId` it logs in color.
+
 ## Custom logger provider
 
 The `ILoggerProvider` object is responsible for creating logger instances. It's not necessary to create a logger instance per category, but it makes sense for some loggers, like NLog or log4net. This strategy allows you to choose different logging output targets per category, as in the following example:

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -32,10 +32,10 @@ The preceding code:
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/ColorConsoleLogger.cs" range="16-17":::
 
-The logger is instantiated with the `name` and a `Func<ColorConsoleLoggerConfiguration>` which will return the current config &mdash; this handles updates to the config values as monitored through the <xref:Microsoft.Extensions.Options.IOptionsMonitor%601.OnChange%2A?displayProperty=nameWithType> callback.
+The logger is instantiated with the `name` and a `Func<ColorConsoleLoggerConfiguration>`, which returns the current config &mdash; this handles updates to the config values as monitored through the <xref:Microsoft.Extensions.Options.IOptionsMonitor%601.OnChange%2A?displayProperty=nameWithType> callback.
 
 > [!IMPORTANT]
-> The <xref:Microsoft.Extensions.Logging.ILogger.Log%2A?displayProperty=nameWithType> implementation checks if the `config.EventId` value is set, when it's not or when it matches the exact `logEntry.EventId` it logs in color.
+> The <xref:Microsoft.Extensions.Logging.ILogger.Log%2A?displayProperty=nameWithType> implementation checks if the `config.EventId` value is set. When `config.EventId` is not set or when it matches the exact `logEntry.EventId`, the logger logs in color.
 
 ## Custom logger provider
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
@@ -12,10 +12,10 @@ class Program
 
         var logger = host.Services.GetRequiredService<ILogger<Program>>();
 
-        logger.LogDebug(1, "Does this line get hit?");
-        logger.LogInformation(3, "Nothing to see here.");
-        logger.LogWarning(5, "Warning... that was odd.");
-        logger.LogError(7, "Oops, there was an error.");
+        logger.LogDebug(1, "Does this line get hit?");    // Not logged
+        logger.LogInformation(3, "Nothing to see here."); // Logs in ConsoleColor.Green
+        logger.LogWarning(5, "Warning... that was odd."); // Logs in ConsoleColor.DarkMagenta
+        logger.LogError(7, "Oops, there was an error.");  // Logs in ConsoleColor.Red
 
         await host.RunAsync();
     }


### PR DESCRIPTION
## Summary

The code is valid as is, but we're adding a bit of clarification.

Fixes #24746

[Internal review](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/custom-logging-provider?branch=pr-en-us-24778)