### PR TITLE
Swap param order when using ArgumentException

### DIFF
--- a/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
@@ -31,7 +31,7 @@ namespace patterns
                Operation.Start => StartSystem(),
                Operation.Stop => StopSystem(),
                Operation.Reset => ResetToReady(),
-               _ => throw new ArgumentException(nameof(command), "Invalid enum value for command"),
+               _ => throw new ArgumentException("Invalid enum value for command", nameof(command)),
            };
         // </PerformOperation>
 
@@ -43,7 +43,7 @@ namespace patterns
                "Start" => StartSystem(),
                "Stop" => StopSystem(),
                "Reset" => ResetToReady(),
-               _ => throw new ArgumentException(nameof(command), "Invalid string value for command"),
+               _ => throw new ArgumentException("Invalid string value for command", nameof(command)),
            };
         // </PerformStringOperation>
 


### PR DESCRIPTION
## Summary

The order of the parameters is wrong for the use of `ArgumentException` . The message should be first, followed by the name of the parameter, [as documented here](https://docs.microsoft.com/en-us/dotnet/api/system.argumentexception.-ctor?view=net-5.0#System_ArgumentException__ctor_System_String_System_String_).

Oddly enough, [the order used for the constructor](https://docs.microsoft.com/en-us/dotnet/api/system.argumentnullexception.-ctor?view=net-5.0#System_ArgumentNullException__ctor_System_String_System_String_) for `ArgumentNullException` is the opposite of `ArgumentException`!
