### PR TITLE
Enable CA2208 as error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -77,6 +77,9 @@ dotnet_style_prefer_auto_properties = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
 dotnet_style_prefer_conditional_expression_over_return = true:refactoring
 
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = error
+
 # C# files
 [*.cs]
 # New line preferences

--- a/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
@@ -31,7 +31,7 @@ namespace patterns
                Operation.Start => StartSystem(),
                Operation.Stop => StopSystem(),
                Operation.Reset => ResetToReady(),
-               _ => throw new ArgumentException(nameof(command), "Invalid enum value for command")
+               _ => throw new ArgumentException(nameof(command), "Invalid enum value for command"),
            };
         // </PerformOperation>
 

--- a/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
@@ -31,7 +31,7 @@ namespace patterns
                Operation.Start => StartSystem(),
                Operation.Stop => StopSystem(),
                Operation.Reset => ResetToReady(),
-               _ => throw new ArgumentException(nameof(command), "Invalid enum value for command"),
+               _ => throw new ArgumentException(nameof(command), "Invalid enum value for command")
            };
         // </PerformOperation>
 


### PR DESCRIPTION
This should prevent mistakes like the one fixed in https://github.com/dotnet/docs/pull/24786 when a sample is being edited.