### PR TITLE
Update MinimalEventCounterSource.cs

### DIFF
--- a/docs/core/diagnostics/snippets/EventCounters/MinimalEventCounterSource.cs
+++ b/docs/core/diagnostics/snippets/EventCounters/MinimalEventCounterSource.cs
@@ -14,7 +14,7 @@ public sealed class MinimalEventCounterSource : EventSource
             DisplayUnits = "ms"
         };
 
-    public void Request(string url, float elapsedMilliseconds)
+    public void Request(string url, long elapsedMilliseconds)
     {
         WriteEvent(1, url, elapsedMilliseconds);
         _requestCounter?.WriteMetric(elapsedMilliseconds);


### PR DESCRIPTION

## Summary
`StopWatch.TotalMiliseconds` outputs a long - Which is what you would typically use in this case.
Also `WriteEvent` has a specific overload for `(int, int64, string)`, which is significantly faster than the `(int, Params Object[])` args one that was used in this snippet.
