### PR TITLE
Argument coercion breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -43,7 +43,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 
 ## JIT compiler
 
-- [Coerce call arguments according to ECMA-33](jit/6.0/coerce-call-arguments-ecma-335.md)
+- [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md)
 
 ## Networking
 

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -41,6 +41,10 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 - [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md)
 - [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md)
 
+## JIT compiler
+
+- [Coerce call arguments according to ECMA-33](jit/6.0/coerce-call-arguments-ecma-335.md)
+
 ## Networking
 
 - [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md)

--- a/docs/core/compatibility/jit/6.0/coerce-call-arguments-ecma-335.md
+++ b/docs/core/compatibility/jit/6.0/coerce-call-arguments-ecma-335.md
@@ -1,0 +1,41 @@
+---
+title: "Breaking change: Coerce call arguments according to ECMA-33"
+description: Learn about the breaking change in .NET 6.0 where call arguments are coerced according to ECMA-33.
+ms.date: 06/22/2021
+---
+# Coerce call arguments according to ECMA-33
+
+[ECMA-335](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) (Table III.9: Signature Matching) describes which implicit conversions are supported for call arguments. This change adds checking for the supported conversions.
+
+## Version introduced
+
+6.0
+
+## Change description
+
+In previous .NET versions, the just-in-time (JIT) compiler does not coerce call arguments according to ECMA-335. This leads to undefined behavior on some platforms. For example, on x86, passing a `long` value as an `int` register leaves the register undefined.
+
+Starting in .NET 6, if implicit conversion is not allowed, then the JIT compiler throws an <xref:System.InvalidProgramException>. There are two conversion cases that are still allowed:
+
+- `int8` -> `nint` on 64-bit platform (because it's used often and doesn't lead to bad code)
+- `byref` -> `nint`
+
+## Reason for change
+
+The previous behavior caused silent, bad code generation on some platforms, including ARM64 Apple.
+
+## Recommended action
+
+If you updated to .NET 6 and your app throws <xref:System.InvalidProgramException> exceptions because of this change, use an explicit conversion for the affected argument or fix the callee declaration.
+
+## Affected APIs
+
+None.
+
+<!--
+
+### Category
+
+Just-in-time (JIT) compiler
+
+-->

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -75,7 +75,7 @@ items:
           href: core-libraries/6.0/hosting-exception-handling.md
       - name: JIT compiler
         items:
-        - name: Coerce call arguments according to ECMA-33
+        - name: Call argument coercion
           href: jit/6.0/coerce-call-arguments-ecma-335.md
       - name: Networking
         items:
@@ -631,7 +631,7 @@ items:
       items:
       - name: .NET 6
         items:
-        - name: Coerce call arguments according to ECMA-33
+        - name: Call argument coercion
           href: jit/6.0/coerce-call-arguments-ecma-335.md
     - name: MSBuild
       items:

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -276,7 +276,7 @@ items:
         - name: Casting RCW to InterfaceIsIInspectable throws exception
           href: interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
         - name: No A/W suffix probing on non-Windows platforms
-          href: interop/5.0/function-suffix-pinvoke.
+          href: interop/5.0/function-suffix-pinvoke.md
       - name: JIT compiler
         items:
         - name: Coerce call arguments according to ECMA-33

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -276,7 +276,11 @@ items:
         - name: Casting RCW to InterfaceIsIInspectable throws exception
           href: interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
         - name: No A/W suffix probing on non-Windows platforms
-          href: interop/5.0/function-suffix-pinvoke.md
+          href: interop/5.0/function-suffix-pinvoke.
+      - name: JIT compiler
+        items:
+        - name: Coerce call arguments according to ECMA-33
+          href: jit/6.0/coerce-call-arguments-ecma-335.md
       - name: MSBuild
         items:
         - name: Directory.Packages.props files imported by default
@@ -623,6 +627,12 @@ items:
           href: interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
         - name: No A/W suffix probing on non-Windows platforms
           href: interop/5.0/function-suffix-pinvoke.md
+    - name: JIT compiler
+      items:
+      - name: .NET 6
+        items:
+        - name: Coerce call arguments according to ECMA-33
+          href: jit/6.0/coerce-call-arguments-ecma-335.md
     - name: MSBuild
       items:
       - name: .NET 5

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -73,6 +73,10 @@ items:
           href: core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
+      - name: JIT compiler
+        items:
+        - name: Coerce call arguments according to ECMA-33
+          href: jit/6.0/coerce-call-arguments-ecma-335.md
       - name: Networking
         items:
         - name: WebRequest, WebClient, and ServicePoint are obsolete
@@ -277,10 +281,6 @@ items:
           href: interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
         - name: No A/W suffix probing on non-Windows platforms
           href: interop/5.0/function-suffix-pinvoke.md
-      - name: JIT compiler
-        items:
-        - name: Coerce call arguments according to ECMA-33
-          href: jit/6.0/coerce-call-arguments-ecma-335.md
       - name: MSBuild
         items:
         - name: Directory.Packages.props files imported by default


### PR DESCRIPTION
Fixes #24342.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/jit/6.0/coerce-call-arguments-ecma-335?branch=pr-en-us-24799).