### PR TITLE
Ignore PowerShell files for repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,5 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+*.ps1 linguist-vendored


### PR DESCRIPTION
Hopefully this will correct the language stats for this repo - currently 95% PowerShell.

![image](https://user-images.githubusercontent.com/24882762/123342517-c2387f00-d504-11eb-8372-2fd1c8cd0c23.png)
