### PR TITLE
Modify doc titles in ToC

### DIFF
--- a/docs/azure/TOC.yml
+++ b/docs/azure/TOC.yml
@@ -43,9 +43,9 @@
       href: ./sdk/thread-safety.md      
     - name: Logging
       href: ./sdk/logging.md
-    - name: Configuring a proxy server
+    - name: Configure a proxy server
       href: ./sdk/azure-sdk-configure-proxy.md
-    - name: Package List
+    - name: Packages list
       href: ./sdk/packages.md
     - name: SDK example
       href: /samples/dotnet/samples/azure-identity-resource-management-storage/


### PR DESCRIPTION
Use sentence casing and avoid gerunds
