### PR TITLE
Update version text

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -68,7 +68,7 @@ The following options are for `dotnet` by itself. For example, `dotnet --info`. 
 
 - **`--version`**
 
-  Prints out the version of the .NET SDK in use.
+ Prints out the version of the .NET SDK used by dotnet commands. Includes the effects of any global.json
 
 - **`--list-runtimes`**
 


### PR DESCRIPTION
Commit message details:

> This clarifies that --version displays the SDK version, not the muxur version (the muxor is the actual dotnet.exe) after discovering that some very smart people were confused about this.

