### PR TITLE
Fix reportgenerator usage example.

### DIFF
--- a/docs/core/testing/unit-testing-code-coverage.md
+++ b/docs/core/testing/unit-testing-code-coverage.md
@@ -282,8 +282,8 @@ Run the tool and provide the desired options, given the output *coverage.cobertu
 
 ```console
 reportgenerator
-"-reports:Path\To\TestProject\TestResults\{guid}\coverage.cobertura.xml"
-"-targetdir:coveragereport"
+-reports:"Path\To\TestProject\TestResults\{guid}\coverage.cobertura.xml"
+-targetdir:"coveragereport"
 -reporttypes:Html
 ```
 


### PR DESCRIPTION
Just used this example a minute ago and noticed a wrong formatting on the parameters.