### PR TITLE
Fix typo in prepare-libraries-for-trimming.md

### DIFF
--- a/docs/core/deploying/prepare-libraries-for-trimming.md
+++ b/docs/core/deploying/prepare-libraries-for-trimming.md
@@ -201,7 +201,7 @@ If the intent of your code can't be expressed with the annotations, but you know
 ```csharp
 class TypeCollection
 {
-    Type[] types;u
+    Type[] types;
 
     // Ensure that only types with ctors are stored in the array
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]


### PR DESCRIPTION
## Summary

There was a hanging `u` in the code sample. Removing it.
