### PR TITLE
Add constant interpolated strings

### DIFF
--- a/docs/csharp/how-to/concatenate-multiple-strings.md
+++ b/docs/csharp/how-to/concatenate-multiple-strings.md
@@ -1,7 +1,7 @@
 ---
 title: "How to concatenate multiple strings (C# Guide)"
 description: There are multiple ways to concatenate strings in C#. Learn the options and the reasons behind different choices.
-ms.date: 04/19/2021
+ms.date: 06/30/2021
 helpviewer_keywords: 
   - "joining strings [C#]"
   - "concatenating strings [C#]"
@@ -34,6 +34,8 @@ In some expressions, it's easier to concatenate strings using string interpolati
 
 > [!NOTE]
 > In string concatenation operations, the C# compiler treats a null string the same as an empty string.
+
+Beginning with C# 10, you can use string interpolation to initialize a constant string when all the expressions used for placeholders are also constant strings.
 
 ## `String.Format`
 

--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -39,9 +39,14 @@ The `Obsolete` attribute marks a code element as no longer recommended for use. 
 
 In the following example the `Obsolete` attribute is applied to class `A` and to method `B.OldMethod`. Because the second argument of the attribute constructor applied to `B.OldMethod` is set to `true`, this method will cause a compiler error, whereas using class `A` will just produce a warning. Calling `B.NewMethod`, however, produces no warning or error. For example, when you use it with the previous definitions, the following code generates two warnings and one error:
 
-:::code language="csharp" source="snippets/ObsoleteExample.cs" interactive="try-dotnet" :::
+:::code language="csharp" source="snippets/ObsoleteExample.cs" id="Snippet1" interactive="try-dotnet" :::
 
 The string provided as the first argument to the attribute constructor will be displayed as part of the warning or error. Two warnings for class `A` are generated: one for the declaration of the class reference, and one for the class constructor. The `Obsolete` attribute can be used without arguments, but including an explanation what to use instead is recommended.
+
+In C# 10, you can use constant string interpolation and the `nameof` operator to ensure the names match:
+
+:::code language="csharp" source="snippets/ObsoleteExample.cs" id="Snippet2" :::
+
 
 ## `AttributeUsage` attribute
 

--- a/docs/csharp/language-reference/attributes/snippets/ObsoleteExample.cs
+++ b/docs/csharp/language-reference/attributes/snippets/ObsoleteExample.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// <Snippet1>
+using System;
 
 namespace AttributeExamples
 {
@@ -31,5 +32,20 @@ namespace AttributeExamples
             // b.OldMethod();
         }
     }
+}
+// </Snippet1>
+
+namespace ExampleConstantInterpolation
+{
+    // <Snippet2>
+    public class B
+    {
+        [Obsolete($"use {nameof(NewMethod)} instead", true)]
+        public void OldMethod() { }
+
+        public void NewMethod() { }
+    }
+    // </Snippet2>
+
 }
 

--- a/docs/csharp/language-reference/attributes/snippets/attributes.csproj
+++ b/docs/csharp/language-reference/attributes/snippets/attributes.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <StartupObject>AttributeExamples.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/keywords/const.md
+++ b/docs/csharp/language-reference/keywords/const.md
@@ -1,7 +1,7 @@
 ---
 description: "const keyword - C# Reference"
 title: "const keyword - C# Reference"
-ms.date: 07/20/2015
+ms.date: 06/20/2021
 f1_keywords: 
   - "const_CSharpKeyword"
   - "const"
@@ -17,6 +17,15 @@ You use the `const` keyword to declare a constant field or a constant local. Con
 const int X = 0;
 public const double GravitationalConstant = 6.673e-11;
 private const string ProductName = "Visual C#";
+```
+
+Beginning with C# 10, [interpolated strings](../tokens/interpolated.md) may be constants, if all expressions used are also constant strings. This feature can improve the code that builds constant strings:
+
+```csharp
+const string Language = "C#";
+const string Platform = ".NET";
+const string Version = "10.0";
+const string FullProductName = $"{Platform} - Language: {Language} Version: {Version}";
 ```
 
 ## Remarks

--- a/docs/csharp/language-reference/keywords/const.md
+++ b/docs/csharp/language-reference/keywords/const.md
@@ -52,11 +52,9 @@ public const int C2 = C1 + 100;
 > [!NOTE]
 > The [readonly](./readonly.md) keyword differs from the `const` keyword. A `const` field can only be initialized at the declaration of the field. A `readonly` field can be initialized either at the declaration or in a constructor. Therefore, `readonly` fields can have different values depending on the constructor used. Also, although a `const` field is a compile-time constant, the `readonly` field can be used for run-time constants, as in this line: `public static readonly uint l1 = (uint)DateTime.Now.Ticks;`
 
-## Example
+## Examples
 
 [!code-csharp[csrefKeywordsModifiers#5](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#5)]
-
-## Example
 
 This example demonstrates how to use constants as local variables.
 

--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -1,7 +1,7 @@
 ---
 title: "+ and += operators - C# reference"
 description: "Learn about the C# addition operator and how it works with operands of numeric, string, or delegate types."
-ms.date: 04/23/2020
+ms.date: 06/30/2021
 f1_keywords: 
   - "+_CSharpKeyword"
   - "+=_CSharpKeyword"
@@ -30,6 +30,8 @@ When one or both operands are of type [string](../builtin-types/reference-types.
 Beginning with C# 6, [string interpolation](../tokens/interpolated.md) provides a more convenient way to format strings:
 
 [!code-csharp-interactive[string interpolation](snippets/shared/AdditionOperator.cs#UseStringInterpolation)]
+
+Beginning with C# 10, you can use string interpolation to initialize a constant string when all the expressions used for placeholders are also constant strings.
 
 ## Delegate combination
 

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -1,7 +1,7 @@
 ---
 title: "$ - string interpolation - C# reference"
 description: String interpolation provides a more readable and convenient syntax to format string output than traditional string composite formatting.
-ms.date: 09/02/2019
+ms.date: 06/30/2021
 f1_keywords: 
   - "$_CSharpKeyword"
   - "$"
@@ -40,6 +40,8 @@ Elements in square brackets are optional. The following table describes each ele
 The following example uses optional formatting components described above:
 
 [!code-csharp-interactive[specify alignment and format string](~/samples/snippets/csharp/language-reference/tokens/string-interpolation.cs#2)]
+
+Beginning with C# 10, you can use string interpolation to initialize a constant string when all the expressions used for placeholders are also constant strings. In other words, every *interpolationexpression* must be a string, and it must be a compile time constant.
 
 ## Special characters
 

--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Strings - C# Programming Guide"
 description: Learn about strings in C# programming. See information on declaring and initializing strings, the immutability of string objects, and string escape sequences.
-ms.date: 06/27/2019
+ms.date: 06/30/2021
 helpviewer_keywords: 
   - "C# language, strings"
   - "strings [C#]"
@@ -83,6 +83,8 @@ Available in C# 6.0 and later, [*interpolated strings*](../../language-reference
 Use string interpolation to improve the readability and maintainability of your code. String interpolation achieves the same results as the `String.Format` method, but improves ease of use and inline clarity.
 
 [!code-csharp[csProgGuideFormatStrings](~/samples/snippets/csharp/programming-guide/strings/Strings_1.cs#StringInterpolation)]
+
+Beginning with C# 10, you can use string interpolation to initialize a constant string when all the expressions used for placeholders are also constant strings.
 
 ### Composite Formatting
 


### PR DESCRIPTION
Fixes #24076

In C# 10, interpolated string expressions may be used to declare string constants. In that case, all interpolation expressions must be constant strings.

I checked for all references to `const` or *interpolated strings* in the C# guide, and made any necessary updates.
