### PR TITLE
deconstruction allows assignment and initialization

### DIFF
--- a/docs/csharp/fundamentals/functional/deconstruct.md
+++ b/docs/csharp/fundamentals/functional/deconstruct.md
@@ -1,7 +1,7 @@
 ---
 title: Deconstructing tuples and other types
 description: Learn how to deconstruct tuples and other types.
-ms.date: 03/22/2021
+ms.date: 06/30/2021
 ---
 # Deconstructing tuples and other types
 
@@ -41,12 +41,14 @@ There are three ways to deconstruct a tuple:
 
     :::code language="csharp" source="./snippets/deconstructing-tuples/deconstruct-tuple5.cs" ID="Snippet1":::
 
+- Beginning in C# 10, you can mix variable declaration and assignment in a deconstruction.
+
+    :::code language="csharp" source="./snippets/deconstructing-tuples/deconstruct-tuple6.cs" ID="Snippet1":::
+
 You can't specify a specific type outside the parentheses even if every field in the tuple has the
 same type. Doing so generates compiler error CS8136, "Deconstruction 'var (...)' form disallows a specific type for 'var'.".
 
 You must assign each element of the tuple to a variable. If you omit any elements, the compiler generates error CS8132, "Can't deconstruct a tuple of 'x' elements into 'y' variables."
-
-You can't mix declarations and assignments to existing variables on the left-hand side of a deconstruction. The compiler generates error CS8184, "a deconstruction can't mix declarations and expressions on the left-hand-side." when the members include newly declared and existing variables.
 
 ## Tuple elements with discards
 

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-tuple6.cs
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-tuple6.cs
@@ -1,4 +1,4 @@
-﻿public class Example5
+﻿public class Example6
 {
     // <Snippet1>
     public static void Main()

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-tuple6.cs
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-tuple6.cs
@@ -1,0 +1,22 @@
+﻿public class Example5
+{
+    // <Snippet1>
+    public static void Main()
+    {
+        string city = "Raleigh";
+        int population = 458880;
+
+        (city, population, double area) = QueryCityData("New York City");
+
+        // Do something with the data.
+    }
+    // </Snippet1>
+
+    private static (string, int, double) QueryCityData(string name)
+    {
+        if (name == "New York City")
+            return (name, 8175133, 468.48);
+
+        return ("", 0, 0);
+    }
+}

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruction.csproj
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruction.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <StartupObject>deconstruction.Program</StartupObject>
   </PropertyGroup>

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruction.csproj
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruction.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <StartupObject>deconstruction.Program</StartupObject>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #24116

Beginning with C# 10, the left side of a deconstruction can mix variable assignment and variable initialization.

With this PR, I searched for all instances of "deconstruct" to see if they referenced the previous restriction. Only one instance made that declaration.

Update the "deconstruct" article to add a new samples that shows the new syntax.
