### PR TITLE
Fix confusion and lack of clarity in various documents

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/index.md
+++ b/docs/csharp/fundamentals/object-oriented/index.md
@@ -76,7 +76,7 @@ You can define part of a class, struct, or method in one code file and another p
   
 ## Object Initializers  
 
-You can instantiate and initialize class or struct objects, and collections of objects, without explicitly calling their constructor.
+You can instantiate and initialize class or struct objects, and collections of objects, without explicitly calling their constructor with an ending `()` after the type.
   
 ## Anonymous Types  
 

--- a/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
+++ b/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
@@ -23,7 +23,7 @@ root.GetDirectories("*.*", System.IO.SearchOption.AllDirectories);
   
  The weakness in this approach is that if any one of the subdirectories under the specified root causes a <xref:System.IO.DirectoryNotFoundException> or <xref:System.UnauthorizedAccessException>, the whole method fails and returns no directories. The same is true when you use the <xref:System.IO.DirectoryInfo.GetFiles%2A> method. If you have to handle these exceptions on specific subfolders, you must manually walk the directory tree, as shown in the following examples.  
   
- When you manually walk a directory tree, you can handle the subdirectories first (*pre-order traversal*), or the files first (*post-order traversal*). If you perform a pre-order traversal, you walk the whole tree under the current folder before iterating through the files that are directly in that folder itself. The examples later in this document perform post-order traversal, but you can easily modify them to perform pre-order traversal.  
+ When you manually walk a directory tree, you can handle the files first (*pre-order traversal*), or the subdirectories first (*post-order traversal*). If you perform a pre-order traversal, you visit files directly under that folder itself, and then walk the whole tree under the current folder. Post-order traversal is the other way around, walking the whole tree beneath before getting to the current folder's files. The examples later in this document perform pre-order traversal, but you can easily modify them to perform post-order traversal.  
   
  Another option is whether to use recursion or a stack-based traversal. The examples later in this document show both approaches.  
   


### PR DESCRIPTION
## Summary

### Edits to how-to-iterate-through-a-directory-tree.md (issue #23822)

Line 26 fixes the confusion between pre-order and post-order traversal.

### Edits to index.md (issue #24882)

Line 79 fixes the lack of clarity concerning the meaning of "explicitly calling a constructor".

Fixes #23822
Fixes #24882