### PR TITLE
Fix RegexOptions.IgnorePatternWhitespace # to EOL

### DIFF
--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -251,7 +251,7 @@ The <xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace?di
 
 - Unescaped white space in the regular expression pattern is ignored. To be part of a regular expression pattern, white-space characters must be escaped (for example, as `\s` or "`\` ").
 
-- The number sign (#) is interpreted as the beginning of a comment, rather than as a literal character. All text in the regular expression pattern from the # character to the next `\n` character, or to the end of the string, is interpreted as a comment.
+- The number sign (#) is interpreted as the beginning of a comment, rather than as a literal character. All text in the regular expression pattern from the `#` character to either the next `\n` character or to the end of the string, is interpreted as a comment.
 
 However, in the following cases, white-space characters in a regular expression aren't ignored, even if you use the <xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace?displayProperty=nameWithType> option:
 

--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -251,7 +251,7 @@ The <xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace?di
 
 - Unescaped white space in the regular expression pattern is ignored. To be part of a regular expression pattern, white-space characters must be escaped (for example, as `\s` or "`\` ").
 
-- The number sign (#) is interpreted as the beginning of a comment, rather than as a literal character. All text in the regular expression pattern from the # character to the end of the string is interpreted as a comment.
+- The number sign (#) is interpreted as the beginning of a comment, rather than as a literal character. All text in the regular expression pattern from the # character to the next `\n` character, or to the end of the string, is interpreted as a comment.
 
 However, in the following cases, white-space characters in a regular expression aren't ignored, even if you use the <xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace?displayProperty=nameWithType> option:
 


### PR DESCRIPTION
The [Regular Expression Options](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options#ignore-white-space) documentation currently states that

> All text in the regular expression pattern from the # character to the end of the string is interpreted as a comment.

when `RegexOptions.IgnorePatternWhitespace` is in effect.  This omits the fact that `#` behaves as a line comment when the pattern contains multiple lines.  It causes the text from `#` to the end of the line, denoted by `\n`, to be interpreted as a comment.  For example:

```csharp
using System.Text.RegularExpressions;

Console.WriteLine(Regex.Match(
    "Hello World",
    "Hello # Line Comment\n\\sWorld",
    RegexOptions.IgnorePatternWhitespace));
```

Prints "Hello World", rather than "Hello" as it does if `\n` is removed or replaced by `\r`.

This PR adds this behavior to the documentation.

Thanks for considering,
Kevin

---
#### Document Details

⚠ *Do not edit this section. It is required for docs.microsoft.com ➟ GitHub issue linking.*

* ID: bf9b6611-d08f-2fe9-216b-e0658d7f1553
* Version Independent ID: 3d3be892-b9b5-ca0b-1193-9fa49716decb
* Content: [Regular Expression Options](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options)
* Content Source: [docs/standard/base-types/regular-expression-options.md](https://github.com/dotnet/docs/blob/main/docs/standard/base-types/regular-expression-options.md)
* Product: **dotnet-fundamentals**
* GitHub Login: @adegeo
* Microsoft Alias: **adegeo**