### PR TITLE
Match code and text

### DIFF
--- a/docs/csharp/whats-new/csharp-7.md
+++ b/docs/csharp/whats-new/csharp-7.md
@@ -103,7 +103,7 @@ Discards are supported in the following scenarios:
 - In a pattern matching operation with the [is](../language-reference/operators/is.md) and [switch](../language-reference/keywords/switch.md) statements.
 - As a standalone identifier when you want to explicitly identify the value of an assignment as a discard.
 
-The following example defines a `QueryCityDataForYears` method that returns a 6-tuple that contains data for a city for two different years. The method call in the example is concerned only with the two population values returned by the method and so treats the remaining values in the tuple as discards when it deconstructs the tuple.
+The following example defines a `QueryCityData` method that returns a 3-tuple that contains data for a city for two different years. The method call in the example is concerned only with the two population values returned by the method and so treats the remaining values in the tuple as discards when it deconstructs the tuple.
 
 ```csharp
 using System;


### PR DESCRIPTION
Fixes #24847

The code on the discards example and the text did not match.
