### PR TITLE
Remove irrelevant section from trimming docs

### DIFF
--- a/docs/core/deploying/trim-self-contained.md
+++ b/docs/core/deploying/trim-self-contained.md
@@ -36,39 +36,6 @@ When the code is indirectly referencing an assembly through reflection, you can 
 </ItemGroup>
 ```
 
-### Support for SSL certificates
-
-If your app loads SSL certificates, such as in an ASP.NET Core app, you'll want to ensure that when trimming you prevent trimming assemblies that will help with loading SSL certificates.
-
-We can update our project file to include the following for ASP.NET Core 3.1:
-
-```xml
-<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>...</PropertyGroup>
-  <!--Include the following for .aspnetcore 3.1-->
-  <ItemGroup>
-    <TrimmerRootAssembly Include="System.Net" />
-    <TrimmerRootAssembly Include="System.Net.Security" />
-    <TrimmerRootAssembly Include="System.Security" />
-  </ItemGroup>
-  ...
-</Project>
-```
-
-If we're using .Net 5.0, we can update our project file to include the following:
-
-```xml
-<Project Sdk="Microsoft.NET.Sdk.Web">
- <PropertyGroup>...</PropertyGroup>
- <!--Include the following for .net 5.0-->
- <ItemGroup>
-    <TrimmerRootAssembly Include="System.Net.Security" />
-    <TrimmerRootAssembly Include="System.Security" />
-  </ItemGroup>
-  ...
-</Project>
-```
-
 ## Trim your app - CLI
 
 Trim your application using the [dotnet publish](../tools/dotnet-publish.md) command. When you publish your app, set the following properties:


### PR DESCRIPTION
This looks like someone was documenting a workaround for trimming issues
they encountered in previous versions: https://github.com/dotnet/runtime/issues/44260

It doesn't belong in these docs, and the analysis warnings
should prevent such issues going forward.

Thanks to @eerhardt for noticing this!