### PR TITLE
Update dotnet-new.md - wrong exampe shown

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -133,10 +133,10 @@ Each template may have additional options defined. For more information, see [.N
   dotnet new console --language "F#"
   ```
 
-- Create a .NET Standard class library project in the specified directory:
+- Create a .NET Standard 2.0 class library project in the specified directory:
 
   ```dotnetcli
-  dotnet new classlib --language VB -o MyLibrary
+  dotnet new classlib --framework "netstandard2.0" -o MyLibrary
   ```
 
 - Create a new ASP.NET Core C# MVC project in the current directory with no authentication:


### PR DESCRIPTION
The example showed how to create a VB-project. But the headline described how to create a netstandard project.
