### PR TITLE
Fix typo in command description

### DIFF
--- a/docs/core/tools/dotnet-new-uninstall.md
+++ b/docs/core/tools/dotnet-new-uninstall.md
@@ -21,7 +21,7 @@ dotnet new --uninstall <PATH|NUGET_ID>
 
 ## Description
 
-The `dotnet new --uninstall` uninstalls a template package at the `PATH` or `NUGET_ID` provided. When the `<PATH|NUGET_ID>` value isn't specified, all currently installed template packages and their associated templates are displayed. When specifying `NUGET_ID`, don't include the version number.
+The `dotnet new --uninstall` command uninstalls a template package at the `PATH` or `NUGET_ID` provided. When the `<PATH|NUGET_ID>` value isn't specified, all currently installed template packages and their associated templates are displayed. When specifying `NUGET_ID`, don't include the version number.
   If you don't specify a parameter to this option, the command lists the installed templates and details about them.
   > [!NOTE]
   > To uninstall a template using a `PATH`, you need to fully qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.

--- a/docs/core/tools/dotnet-new-uninstall.md
+++ b/docs/core/tools/dotnet-new-uninstall.md
@@ -21,7 +21,7 @@ dotnet new --uninstall <PATH|NUGET_ID>
 
 ## Description
 
-The `dotnet new --install` uninstalls a template package at the `PATH` or `NUGET_ID` provided. When the `<PATH|NUGET_ID>` value isn't specified, all currently installed template packages and their associated templates are displayed. When specifying `NUGET_ID`, don't include the version number.
+The `dotnet new --uninstall` uninstalls a template package at the `PATH` or `NUGET_ID` provided. When the `<PATH|NUGET_ID>` value isn't specified, all currently installed template packages and their associated templates are displayed. When specifying `NUGET_ID`, don't include the version number.
   If you don't specify a parameter to this option, the command lists the installed templates and details about them.
   > [!NOTE]
   > To uninstall a template using a `PATH`, you need to fully qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.


### PR DESCRIPTION
This page is about the `uninstall` command, so it should probably be this command.