### PR TITLE
Add missing semicolon

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -358,7 +358,7 @@ public void Test(string id)
     {
         _logger.LogWarning(
             AppLogEvents.Error, ex,
-            "Failed to process iteration: {Id}", id)
+            "Failed to process iteration: {Id}", id);
     }
 }
 ```


### PR DESCRIPTION
I'm also wondering, can't the code be simplified from:

```csharp
public void Test(string id)
{
    try
    {
        if (id == "none")
        {
            throw new Exception("Default Id detected.");
        }
    }
    catch (Exception ex)
    {
        _logger.LogWarning(
            AppLogEvents.Error, ex,
            "Failed to process iteration: {Id}", id);
    }
}
```

to:

```csharp
public void Test(string id)
{
    if (id == "none")
    {
        _logger.LogWarning(
            AppLogEvents.Error, new Exception("Default Id detected."),
            "Failed to process iteration: {Id}", id);
    }
}
```