### PR TITLE
Fix small typo in name of Elsa Workflows

### DIFF
--- a/docs/core/dotnet-five.md
+++ b/docs/core/dotnet-five.md
@@ -44,7 +44,7 @@ There are no plans to port the following technologies from .NET Framework to .NE
 | Technology            | Recommended alternative                                                                         |
 |-----------------------|-------------------------------------------------------------------------------------------------|
 | Web Forms             | ASP.NET Core [Blazor](/aspnet/core/blazor) or [Razor Pages](/aspnet/core/tutorials/razor-pages) |
-| Windows Workflow (WF) | [Open-source CoreWF](https://github.com/UiPath-Open/corewf) or [Elsa-Workflow](https://github.com/elsa-workflows/elsa-core) |
+| Windows Workflow (WF) | [Open-source CoreWF](https://github.com/UiPath-Open/corewf) or [Elsa-Workflows](https://github.com/elsa-workflows/elsa-core) |
 
 ### Windows Communication Foundation
 


### PR DESCRIPTION
## Summary

Fixed small typo in name of Elsa Workflows (Elsa Workflow -> Elsa Workflows).
