### PR TITLE
Update configuration named section and option class binding

### DIFF
--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -3,7 +3,7 @@ title: Options pattern in .NET
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine
-ms.date: 06/21/2021
+ms.date: 07/06/2021
 ---
 
 # Options pattern in .NET
@@ -272,7 +272,7 @@ Consider the following *appsettings.json* file:
 
 ```json
 {
-  "Settings": {
+  "MyCustomSettingsSection": {
     "SiteTitle": "Amazing docs from Awesome people!",
     "Scale": 10,
     "VerbosityLevel": 32
@@ -280,9 +280,14 @@ Consider the following *appsettings.json* file:
 }
 ```
 
-The following class binds to the `"Settings"` configuration section and applies a couple of `DataAnnotations` rules:
+The following class binds to the `"MyCustomSettingsSection"` configuration section and applies a couple of `DataAnnotations` rules:
 
 :::code language="csharp" source="snippets/configuration/console-json/SettingsOptions.cs":::
+
+In the preceding `SettingsOptions` class, the `ConfigurationSectionName` property contains the name of the configuration section to bind to. In this scenario, the options object provides the name of its configuration section.
+
+> [!TIP]
+> The configuration section name is independent of the configuration object that it's binding to. In other words, a configuration section named `"FooBarOptions"` can be bound to an options object named `ZedOptions`. Although it might be common to name them the same, it's *not* necessary and can actually cause name conflicts.
 
 The following code:
 
@@ -291,7 +296,7 @@ The following code:
 
 ```csharp
 services.AddOptions<SettingsOptions>()
-    .Bind(Configuration.GetSection(SettingsOptions.Settings))
+    .Bind(Configuration.GetSection(SettingsOptions.ConfigurationSectionName))
     .ValidateDataAnnotations();
 ```
 
@@ -305,7 +310,7 @@ The following code applies a more complex validation rule using a delegate:
 
 ```csharp
 services.AddOptions<SettingsOptions>()
-    .Bind(Configuration.GetSection(SettingsOptions.Settings))
+    .Bind(Configuration.GetSection(SettingsOptions.ConfigurationSectionName))
     .ValidateDataAnnotations()
     .Validate(config =>
     {
@@ -331,7 +336,7 @@ Using the preceding code, validation is enabled in `ConfigureServices` with the 
 ```csharp
 services.Configure<SettingsOptions>(
     Configuration.GetSection(
-        SettingsOptions.Settings));
+        SettingsOptions.ConfigurationSectionName));
 services.TryAddEnumerable(
     ServiceDescriptor.Singleton
         <IValidateOptions<SettingsOptions>, ValidateSettingsOptions>());

--- a/docs/core/extensions/snippets/configuration/console-json/SettingsOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/SettingsOptions.cs
@@ -5,7 +5,7 @@ namespace ConsoleJson.Example
 {
     public class SettingsOptions
     {
-        public const string Settings = nameof(Settings);
+        public const string ConfigurationSectionName = "MyCustomSettingsSection";
 
         [RegularExpression(@"^[a-zA-Z''-'\s]{1,40}$")]
         public string SiteTitle { get; set; }

--- a/docs/core/extensions/snippets/configuration/console-json/ValidateSettingsOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/ValidateSettingsOptions.cs
@@ -9,7 +9,7 @@ namespace ConsoleJson.Example
         public SettingsOptions _settings { get; private set; }
 
         public ValidateSettingsOptions(IConfiguration config) =>
-            _settings = config.GetSection(SettingsOptions.Settings)
+            _settings = config.GetSection(SettingsOptions.ConfigurationSectionName)
                               .Get<SettingsOptions>();
 
         public ValidateOptionsResult Validate(string name, SettingsOptions options)


### PR DESCRIPTION
## Summary

Address feedback about named configuration section concerns as it relates to binding to an options class.

Fixes #24991

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/options?branch=pr-en-us-24998#options-validation)