### PR TITLE
Mention the unit option for While

### DIFF
--- a/docs/fsharp/language-reference/computation-expressions.md
+++ b/docs/fsharp/language-reference/computation-expressions.md
@@ -240,7 +240,7 @@ The following table describes methods that can be used in a workflow builder cla
 |`TryFinally`|`M<'T> * (unit -> unit) -> M<'T>`|Called for `try...finally` expressions in computation expressions.|
 |`TryWith`|`M<'T> * (exn -> M<'T>) -> M<'T>`|Called for `try...with` expressions in computation expressions.|
 |`Using`|`'T * ('T -> M<'U>) -> M<'U> when 'T :> IDisposable`|Called for `use` bindings in computation expressions.|
-|`While`|`(unit -> bool) * M<'T> -> M<'T>`|Called for `while...do` expressions in computation expressions.|
+|`While`|`(unit -> bool) * M<'T> -> M<'T>`or<br /><br />`(unit -> bool) * M<unit> -> M<unit>`|Called for `while...do` expressions in computation expressions.|
 |`Yield`|`'T -> M<'T>`|Called for `yield` expressions in computation expressions.|
 |`YieldFrom`|`M<'T> -> M<'T>`|Called for `yield!` expressions in computation expressions.|
 |`Zero`|`unit -> M<'T>`|Called for empty `else` branches of `if...then` expressions in computation expressions.|


### PR DESCRIPTION
## Summary

Mention that the `While` construct in computation expressions can have another form.

Other expressions, like Combine, already mention that there are alternate forms allowed.

According to Expert F# 4.0, 4th edition, page 473, Table 16-2:

> Used to de-sugar `while ... do ...` within computation expressions. `M<'T>` may optionally be `M<unit>`
