### PR TITLE
Update getting-started.md to use .NET 5

### DIFF
--- a/docs/architecture/dapr-for-net-developers/getting-started.md
+++ b/docs/architecture/dapr-for-net-developers/getting-started.md
@@ -392,9 +392,9 @@ In the final part of this example, you'll add container support and run the solu
     COPY --from=publish /app/publish .
     ENTRYPOINT ["dotnet", "DaprFrontEnd.dll"]
     ```
-    
+
     The preceding *Dockerfile* sequentially performs the following steps when invoked:
-    
+
     1. Pulls the `mcr.microsoft.com/dotnet/aspnet:5.0` image and names it `base`.
     1. Sets the working directory to */app*.
     1. Exposes port `80` and `443`.
@@ -413,7 +413,7 @@ In the final part of this example, you'll add container support and run the solu
     1. Sets the working directory to */app*.
     1. Copies the `/app/publish` directory from the `publish` image into the root of the `final` image.
     1. Sets the entry point as the image to `dotnet` and passes the `DaprFrontEnd.dll` as an arg.
-    
+
 1. In the `DaprBackEnd` web API project, right-click on the project node, and choose **Add** > **Container Orchestrator Support**. Choose **Docker Compose**, and then select **Linux** again as the target OS.
 
     In the root of the _DaprBackEnd_ project directory, a new *Dockerfile* was created. The *Dockerfile* contains the following YAML:

--- a/docs/architecture/dapr-for-net-developers/getting-started.md
+++ b/docs/architecture/dapr-for-net-developers/getting-started.md
@@ -374,6 +374,7 @@ In the final part of this example, you'll add container support and run the solu
     FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
     WORKDIR /app
     EXPOSE 80
+    EXPOSE 443
     
     FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
     WORKDIR /src
@@ -396,7 +397,7 @@ In the final part of this example, you'll add container support and run the solu
     
     1. Pulls the `mcr.microsoft.com/dotnet/aspnet:5.0` image and names it `base`.
     1. Sets the working directory to */app*.
-    1. Exposes port `80`.
+    1. Exposes port `80` and `443`.
     1. Pulls the `mcr.microsoft.com/dotnet/sdk:5.0` image and names it `build`.
     1. Sets the working directory to */src*.
     1. Copies the _DaprFrontEnd/DaprFrontEnd.csproj_ to a new directory named *DaprFrontEnd/*.

--- a/docs/architecture/dapr-for-net-developers/getting-started.md
+++ b/docs/architecture/dapr-for-net-developers/getting-started.md
@@ -22,7 +22,7 @@ You'll start by installing Dapr on your development computer. Once complete, you
 
 1. [Initialize Dapr](https://docs.dapr.io/getting-started/install-dapr/). This step sets up your development environment by installing the latest Dapr binaries and container images.
 
-1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet/3.1).
+1. Install the [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0).
 
 Now that Dapr is installed, it's time to build your first Dapr application!
 
@@ -38,7 +38,7 @@ You'll start by building a simple .NET Console application that consumes the [Da
     dotnet new console -o DaprCounter
     ```
 
-    The command scaffolds a simple "Hello World" .NET Core application.
+    The command scaffolds a simple "Hello World" .NET application.
 
 1. Then, navigate into the new directory created by the previous command:
 
@@ -104,7 +104,7 @@ You can invoke Dapr APIs across any development platform using Dapr's native sup
     - From the state store, `DaprClient.GetStateAsync` fetches the value for the `counter` key. If the key doesn't exist, the default `int` value (which is `0`) is returned.
     - The code then iterates, writing the `counter` value to the console and saving an incremented value to the state store.
 
-1. The Dapr CLI `run` command starts the application. It invokes the underlying Dapr runtime and enables both the application and Dapr sidecar to run together. If you omit the `app-id`, Dapr will generate a unique name for the application. The final segment of the command, `dotnet run`, instructs the Dapr runtime to run the .NET core application.
+1. The Dapr CLI `run` command starts the application. It invokes the underlying Dapr runtime and enables both the application and Dapr sidecar to run together. If you omit the `app-id`, Dapr will generate a unique name for the application. The final segment of the command, `dotnet run`, instructs the Dapr runtime to run the .NET application.
 
     > [!IMPORTANT]
     > Care must be taken to always pass an explicit `app-id` parameter when consuming the state management building block. The block uses the application id value as a *prefix* for its state key for each key/value pair. If the application id changes, you can no longer access the previously stored state.
@@ -204,9 +204,9 @@ In the first example, you created a simple .NET console application that ran sid
 
 In the next example, you'll create a multi-container application. You'll also use the [Dapr service invocation](service-invocation.md) building block to communicate between services. The solution will consist of a web application that retrieves weather forecasts from a web API. They will each run in a Docker container. You'll use Docker Compose to run the container locally and enable debugging capabilities.
 
-Make sure you've configured your local environment for Dapr and installed the [.NET Core 3.1 Development Tools](https://dotnet.microsoft.com/download/dotnet-core/3.1) (instructions are available at the beginning of this chapter).
+Make sure you've configured your local environment for Dapr and installed the [.NET 5 Development Tools](https://dotnet.microsoft.com/download/dotnet-core/5.0) (instructions are available at the beginning of this chapter).
 
-Additionally, you'll need complete this sample using [Visual Studio 2019](https://visualstudio.microsoft.com/downloads) with the **.NET Core cross-platform development** workload installed.
+Additionally, you'll need complete this sample using [Visual Studio 2019](https://visualstudio.microsoft.com/downloads) with the **.NET cross-platform development** workload installed.
 
 ### Create the application
 
@@ -322,7 +322,7 @@ Now, you'll configure communication between the services using Dapr [service inv
     @{
         ViewData["Title"] = "Home page";
     }
-
+    
     <div class="text-center">
         <h1 class="display-4">Welcome</h1>
         <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
@@ -355,7 +355,7 @@ In the final part of this example, you'll add container support and run the solu
 
     ```yaml
     version: "3.4"
-
+    
     services:
       daprfrontend:
         image: ${DOCKER_REGISTRY-}daprfrontend
@@ -371,34 +371,33 @@ In the final part of this example, you'll add container support and run the solu
     The *Dockerfile* contains the YAML:
 
     ```yml
-    FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
+    FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
     WORKDIR /app
     EXPOSE 80
-    EXPOSE 443
-
-    FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
+    
+    FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
     WORKDIR /src
     COPY ["DaprFrontEnd/DaprFrontEnd.csproj", "DaprFrontEnd/"]
     RUN dotnet restore "DaprFrontEnd/DaprFrontEnd.csproj"
     COPY . .
     WORKDIR "/src/DaprFrontEnd"
     RUN dotnet build "DaprFrontEnd.csproj" -c Release -o /app/build
-
+    
     FROM build AS publish
     RUN dotnet publish "DaprFrontEnd.csproj" -c Release -o /app/publish
-
+    
     FROM base AS final
     WORKDIR /app
     COPY --from=publish /app/publish .
     ENTRYPOINT ["dotnet", "DaprFrontEnd.dll"]
     ```
-
+    
     The preceding *Dockerfile* sequentially performs the following steps when invoked:
-
-    1. Pulls the `mcr.microsoft.com/dotnet/aspnet:3.1` image and names it `base`.
+    
+    1. Pulls the `mcr.microsoft.com/dotnet/aspnet:5.0` image and names it `base`.
     1. Sets the working directory to */app*.
-    1. Exposes port `80` and `443`.
-    1. Pulls the `mcr.microsoft.com/dotnet/sdk:3.1` image and names it `build`.
+    1. Exposes port `80`.
+    1. Pulls the `mcr.microsoft.com/dotnet/sdk:5.0` image and names it `build`.
     1. Sets the working directory to */src*.
     1. Copies the _DaprFrontEnd/DaprFrontEnd.csproj_ to a new directory named *DaprFrontEnd/*.
     1. Calls [`dotnet restore`](../../core/tools/dotnet-restore.md) on the project.
@@ -413,17 +412,17 @@ In the final part of this example, you'll add container support and run the solu
     1. Sets the working directory to */app*.
     1. Copies the `/app/publish` directory from the `publish` image into the root of the `final` image.
     1. Sets the entry point as the image to `dotnet` and passes the `DaprFrontEnd.dll` as an arg.
-
+    
 1. In the `DaprBackEnd` web API project, right-click on the project node, and choose **Add** > **Container Orchestrator Support**. Choose **Docker Compose**, and then select **Linux** again as the target OS.
 
     In the root of the _DaprBackEnd_ project directory, a new *Dockerfile* was created. The *Dockerfile* contains the following YAML:
 
     ```yml
-    FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
+    FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
     WORKDIR /app
     EXPOSE 80
 
-    FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
+    FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
     WORKDIR /src
     COPY ["DaprBackEnd/DaprBackEnd.csproj", "DaprBackEnd/"]
     RUN dotnet restore "DaprBackEnd/DaprBackEnd.csproj"


### PR DESCRIPTION
Removed EXPOSE 443 in yaml that was unneccessary.
Used .NET 5 links

Update descriptions as .NET Core now is .NET(also the visual studio workload)

## Summary

Describe your changes here.

Fixes #25098
