### PR TITLE
Correction to code sample

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs
@@ -3,7 +3,7 @@
     // To detect redundant calls
     bool _disposed = false;
 
-    ~DerivedClassWithFinalizer() => this.Dispose(true);
+    ~DerivedClassWithFinalizer() => this.Dispose(false);
 
     // Protected implementation of Dispose pattern.
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
## Summary

Should this none-deterministic call from Finalizer use Dispose(false) as it does for base class and none-derived classes?


