### PR TITLE
Clarify code analysis rules default API surface

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -27,7 +27,7 @@ dev_langs:
 
 A method has a name that starts with `Get`, takes no parameters, and returns a value that's not an array.
 
-By default, this rule only looks at `public` and `protected` methods, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible methods, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -24,7 +24,7 @@ ms.author: gewarren
 
 The values of an enumeration are powers of two or are combinations of other values that are defined in the enumeration, and the <xref:System.FlagsAttribute?displayProperty=fullName> attribute is not present. To reduce false positives, this rule does not report a violation for enumerations that have contiguous values.
 
-By default, this rule only looks at public enumerations, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible enumerations, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -27,7 +27,7 @@ dev_langs:
 
 The underlying type of an enumeration is not <xref:System.Int32?displayProperty=fullName>.
 
-By default, this rule only looks at public enumerations, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible enumerations, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -24,7 +24,7 @@ ms.author: gewarren
 
 A type implements the <xref:System.IComparable?displayProperty=fullName> interface and does not override <xref:System.Object.Equals%2A?displayProperty=fullName> or does not overload the language-specific operator for equality, inequality, less-than, or greater-than. The rule does not report a violation if the type inherits only an implementation of the interface.
 
-By default, this rule only looks at public and protected types, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible types, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -27,7 +27,7 @@ dev_langs:
 
 A type contains an indexer that uses an index type other than <xref:System.Int32?displayProperty=fullName>, <xref:System.Int64?displayProperty=fullName>, <xref:System.Object?displayProperty=fullName>, or <xref:System.String?displayProperty=fullName>.
 
-By default, this rule only looks at public and protected types, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible types, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1044.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1044.md
@@ -27,7 +27,7 @@ dev_langs:
 
 A property has a set accessor but not a get accessor.
 
-By default, this rule only looks at public types, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible types, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -27,7 +27,7 @@ dev_langs:
 
 The name of a method contains "uri", "Uri", "urn", "Urn", "url", or "Url", and the method returns a string.
 
-By default, this rule only looks at public methods, but this is [configurable](#configure-code-to-analyze).
+By default, this rule only looks at externally visible methods, but this is [configurable](#configure-code-to-analyze).
 
 ## Rule description
 


### PR DESCRIPTION
Update sentence to be consistent across rules.

public → externally visible
public and protected → externally visible

> `SymbolVisibility` is actually computed by walking the containing symbol chain and computing overall visibility. So, a protected method within an internal type will have `SymbolVisibility.Internal`, while protected member within a public type will have `SymbolVisibility.Public`. It is basically effective member visibility.

_Originally posted by @mavasani in https://github.com/dotnet/roslyn-analyzers/pull/3500#discussion_r413409558_