### PR TITLE
Add workaround for syslib0009 warning

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/includes/suppress-syslib-warning.md
+++ b/docs/fundamentals/syslib-diagnostics/includes/suppress-syslib-warning.md
@@ -1,6 +1,6 @@
 ## Suppress warnings
 
-It's recommended that you use one of the workarounds when possible. However, if you cannot change your code, you can suppress warnings through a `#pragma` directive or a `<NoWarn>` project setting. If you must use the obsolete APIs and the `SYSLIB0XXX` diagnostic does not surface as an error, you can suppress the warning in code or in your project file.
+It's recommended that you use an available workaround whenever possible. However, if you cannot change your code, you can suppress warnings through a `#pragma` directive or a `<NoWarn>` project setting. If you must use the obsolete APIs and the `SYSLIB0XXX` diagnostic does not surface as an error, you can suppress the warning in code or in your project file.
 
 To suppress the warnings in code:
 

--- a/docs/fundamentals/syslib-diagnostics/syslib0009.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0009.md
@@ -11,5 +11,9 @@ The following APIs are marked obsolete, starting in .NET 5. Use of these APIs ge
 - <xref:System.Net.AuthenticationManager.Authenticate%2A?displayProperty=nameWithType>
 - <xref:System.Net.AuthenticationManager.PreAuthenticate%2A?displayProperty=nameWithType>
 
+## Workarounds
+
+Implement <xref:System.Net.IAuthenticationModule>, which was previously called by <xref:System.Net.AuthenticationManager.Authenticate%2A?displayProperty=nameWithType>, instead.
+
 <!-- Include adds ## Suppress warnings (H2 heading) -->
 [!INCLUDE [suppress-syslib-warning](includes/suppress-syslib-warning.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib0009.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0009.md
@@ -13,7 +13,7 @@ The following APIs are marked obsolete, starting in .NET 5. Use of these APIs ge
 
 ## Workarounds
 
-Implement <xref:System.Net.IAuthenticationModule>, which was previously called by <xref:System.Net.AuthenticationManager.Authenticate%2A?displayProperty=nameWithType>, instead.
+Implement <xref:System.Net.IAuthenticationModule>, which has methods that were previously called by <xref:System.Net.AuthenticationManager.Authenticate%2A?displayProperty=nameWithType>.
 
 <!-- Include adds ## Suppress warnings (H2 heading) -->
 [!INCLUDE [suppress-syslib-warning](includes/suppress-syslib-warning.md)]


### PR DESCRIPTION
## Summary

- A workaround was added to the syslib0009 warning documentation.
- SYSLIB warning suppression documentation was generalized for warnings that may not have workarounds.

Fixes #25121