### PR TITLE
Fix typo

### DIFF
--- a/docs/csharp/language-reference/keywords/private-protected.md
+++ b/docs/csharp/language-reference/keywords/private-protected.md
@@ -58,7 +58,7 @@ The first file contains a public base class, `BaseClass`, and a type derived fro
 
 In the second file, an attempt to access `myValue` as an inherited member of `DerivedClass2` will produce an error, as it is only accessible by derived types in Assembly1.
 
-If `Assembly1.cs` contains an <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> that names `Assembly2`, the derived class `DerivedClass1` will have access to `private protected` members declared in `BaseClass`. `InternalsVisibleTo` makes `private protected` members visible to derived classes in other assemblies.
+If `Assembly1.cs` contains an <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> that names `Assembly2`, the derived class `DerivedClass2` will have access to `private protected` members declared in `BaseClass`. `InternalsVisibleTo` makes `private protected` members visible to derived classes in other assemblies.
 
 Struct members cannot be `private protected` because the struct cannot be inherited.
 


### PR DESCRIPTION
Fixes #25153 

The sentence should have `DerivedClass2` which is in a different assembly, rather than `DerivedClass1`, which is in the same assembly as the base class.
