### PR TITLE
Update example in how-to-write-a-simple-parallel-for-loop.md

### DIFF
--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Write a Simple Parallel.For Loop"
 description: Learn to write Parallel.For loops in .NET in which you don't need to cancel the loop, break out of loop iterations, or maintain any thread-local state.
-ms.date: "03/30/2017"
+ms.date: "07/16/2021"
 dev_langs:
   - "csharp"
   - "vb"

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.parallel.for/cs/for1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.parallel.for/cs/for1.cs
@@ -6,11 +6,10 @@ using System.Threading.Tasks;
 
 public class Example
 {
-   public static void Main()
+   public static void Main(string[] args)
    {
       long totalSize = 0;
 
-      String[] args = Environment.GetCommandLineArgs();
       if (args.Length == 1) {
          Console.WriteLine("There are no command line arguments.");
          return;


### PR DESCRIPTION
Changing Environment.GetCommandLineArgs() to Main(string[] args)

Fixes #25087
