### PR TITLE
CA1032 documentation does not reflect analyzer behavior.

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1032.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1032.md
@@ -44,7 +44,7 @@ To fix a violation of this rule, add the missing constructors to the exception, 
 
 ## When to suppress warnings
 
-It's safe to suppress a warning from this rule when the violation is caused by using a different access level for the public constructors. Additionally, it's okay to suppress the warning for the `NewException(SerializationInfo, StreamingContext)` constructor if you're building a Portable Class Library (PCL).
+It's safe to suppress a warning from this rule when the violation is caused by using a different access level for the public constructors.
 
 [!INCLUDE [suppress-warning](../../../../includes/code-analysis/suppress-warning.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1032.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1032.cs
@@ -31,12 +31,6 @@ namespace ca1032
         {
             // Add any type-specific logic for inner exceptions.
         }
-
-        protected GoodException(SerializationInfo info,
-           StreamingContext context) : base(info, context)
-        {
-            // Implement type-specific serialization constructor logic.
-        }
     }
     //</snippet1>
 }


### PR DESCRIPTION
Previously analyzer was checking if Exception(SerializationInfo, StreamingContext) ctor is implemented.
Currently the analyzer is not raising a warning when this constructor is missing.

I think that to be fair about how analyzer works it would be beneficial to delete Exception(SerializationInfo, StreamingContext) ctor info.