### PR TITLE
Fixes #24673 doc conflates GetType(TypeName), Type.GetType, and Object.GetType

### DIFF
--- a/docs/visual-basic/language-reference/operators/gettype-operator.md
+++ b/docs/visual-basic/language-reference/operators/gettype-operator.md
@@ -41,13 +41,12 @@ GetType(typename)
   
 - Any enumeration defined by Visual Basic, the .NET Framework, or your application.  
   
- If you want to get the type object of an object variable, use the <xref:System.Type.GetType%2A?displayProperty=nameWithType> method.  
+ If you want to get the type object of an object variable, use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method.  
   
- The `GetType` operator can be useful in the following circumstances:  
+ The `GetType` operator can be useful in the following circumstance:  
   
-- You must access the metadata for a type at run time. The <xref:System.Type> object supplies metadata such as type members and deployment information. You need this, for example, to reflect over an assembly. For more information, see <xref:System.Reflection?displayProperty=nameWithType>.  
-  
-- You want to compare two object references to see if they refer to instances of the same type. If they do, `GetType` returns references to the same <xref:System.Type> object.  
+- You must access the metadata for a type at run time. The <xref:System.Type> object supplies metadata such as type members and deployment information. You need this, for example, to reflect over an assembly. For more information, see also <xref:System.Reflection?displayProperty=nameWithType>.  
+
   
 ## Example  
 
@@ -60,3 +59,5 @@ GetType(typename)
 - [Operator Precedence in Visual Basic](operator-precedence.md)
 - [Operators Listed by Functionality](operators-listed-by-functionality.md)
 - [Operators and Expressions](../../programming-guide/language-features/operators-and-expressions/index.md)
+- <xref:System.Object.GetType%2A?displayProperty=nameWithType>
+- <xref:System.Type.GetType%2A?displayProperty=nameWithType>

--- a/docs/visual-basic/language-reference/operators/gettype-operator.md
+++ b/docs/visual-basic/language-reference/operators/gettype-operator.md
@@ -46,7 +46,6 @@ GetType(typename)
  The `GetType` operator can be useful in the following circumstance:  
   
 - You must access the metadata for a type at run time. The <xref:System.Type> object supplies metadata such as type members and deployment information. You need this, for example, to reflect over an assembly. For more information, see also <xref:System.Reflection?displayProperty=nameWithType>.  
-
   
 ## Example  
 


### PR DESCRIPTION

## Summary

This PR update the doc based on the suggestion in the issue.

Fixes #24673
