### PR TITLE
Remove description in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/breaking-change.yml
@@ -44,7 +44,6 @@ body:
     id: change-type
     attributes:
       label: Type of breaking change
-      description: Does this change affect binary or source compatibility?
       options:
         - label: Binary incompatible (code must be recompiled to use the newer API version)
         - label: Source incompatible (code must be changed and recompiled to use the newer API version)


### PR DESCRIPTION
One more change to remove the description so we don't have to try and align the exact wording with the checkboxes.