### PR TITLE
F# docs - add info about capitalization of modules implied by script names

### DIFF
--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -188,7 +188,8 @@ dotnet fsi Script2.fsx
 
 You can specify as many `#load` directives as you like in a script.
 
-> Note that the `open Script1` declaration is required. This is because constructs in an F# script are compiled into a top-level module that is the name of the script file it is in. If the script file has a lowercase name such as `script3.fsx` then the implied module name is automatically capitalized, and you will need to use `open Script3`.  If you would like a loadable-script to define constructs in a specific namespace of module you can include a namespace of module declaration, for example:
+> [!NOTE]
+> The `open Script1` declaration is required. This is because constructs in an F# script are compiled into a top-level module that is the name of the script file it is in. If the script file has a lowercase name such as `script3.fsx` then the implied module name is automatically capitalized, and you will need to use `open Script3`. If you would like a loadable-script to define constructs in a specific namespace of module you can include a namespace of module declaration, for example:
 >
 > ```fsharp
 > module MyScriptLibrary

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -179,16 +179,20 @@ open Script1
 printfn $"%d{square 12}"
 ```
 
-Note that the `open Script1` declaration is required. This is because constructs in an F# script are compiled into a top-level module that is the name of the script file it is in.
-
 You can evaluate `Script2.fsx` like so:
 
 ```console
 dotnet fsi Script2.fsx
 144
 ```
-
 You can specify as many `#load` directives as you like in a script.
+
+> Note that the `open Script1` declaration is required. This is because constructs in an F# script are compiled into a top-level module that is the name of the script file it is in. If the script file has a lowercase name such as `script3.fsx` then the implied module name is automatically capitalized, and you will need to use `open Script3`.  If you would like a loadable-script to define constructs in a specific namespace of module you can include a namespace of module declaration, for example:
+>
+> ```fsharp
+> module MyScriptLibrary
+> ```
+
 
 ## Using the `fsi` object in F# code
 

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -185,6 +185,7 @@ You can evaluate `Script2.fsx` like so:
 dotnet fsi Script2.fsx
 144
 ```
+
 You can specify as many `#load` directives as you like in a script.
 
 > Note that the `open Script1` declaration is required. This is because constructs in an F# script are compiled into a top-level module that is the name of the script file it is in. If the script file has a lowercase name such as `script3.fsx` then the implied module name is automatically capitalized, and you will need to use `open Script3`.  If you would like a loadable-script to define constructs in a specific namespace of module you can include a namespace of module declaration, for example:
@@ -192,7 +193,6 @@ You can specify as many `#load` directives as you like in a script.
 > ```fsharp
 > module MyScriptLibrary
 > ```
-
 
 ## Using the `fsi` object in F# code
 


### PR DESCRIPTION
## Summary

Clarifies implied capitalization of script names

Fixes https://github.com/dotnet/fsharp/issues/8760#issuecomment-884903600

