### PR TITLE
Typo in "ASP.NET Core gRPC for WCF developers" -> Channel credentials

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/channel-credentials.md
+++ b/docs/architecture/grpc-for-wcf-developers/channel-credentials.md
@@ -152,7 +152,7 @@ class Program
 ```
 
 > [!NOTE]
-> Due to an internal Windows bug as [documented here](https://github.com/dotnet/runtime/issues/23749#issuecomment-388231655), you'll need to apply the following a workaround if the certificate is created from certificate and private key PEM data.
+> Due to an internal Windows bug as [documented here](https://github.com/dotnet/runtime/issues/23749#issuecomment-388231655), you'll need to apply the following workaround if the certificate is created from a certificate and private key PEM data.
 >
 > ```csharp
 > X509Certificate2 cert = X509Certificate2.CreateFromPem(certificatePem, rsaPrivateKeyPem);


### PR DESCRIPTION
## Summary
Looks like the sentence was re-written and the "a" not moved to its new place.