### PR TITLE
Improve How to determine if a file is an assembly

### DIFF
--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -39,13 +39,13 @@ The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the te
 
 1. Install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package.
 
-2. Create a <xref:System.IO.FileStream?displayProperty=nameWithType> instance to read data from the file you are testing.
+2. Create a <xref:System.IO.FileStream?displayProperty=nameWithType> instance to read data from the file you're testing.
 
 3. Create a <xref:System.Reflection.PortableExecutable.PEReader?displayProperty=nameWithType> instance, passing your file stream into the constructor.
 
 4. Check the value of the <xref:System.Reflection.PortableExecutable.PEReader.HasMetadata> property. If the value is `false`, the file is not an assembly.
 
-5. Call the <xref:System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader%2A> method on your PE reader instance to create a metadata reader.
+5. Call the <xref:System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader%2A> method on the PE reader instance to create a metadata reader.
 
 6. Check the value of the <xref:System.Reflection.Metadata.MetadataReader.IsAssembly> property. If the value is `true`, the file is an assembly.
 

--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -43,7 +43,7 @@ The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the te
 
 3. Create a <xref:System.Reflection.PortableExecutable.PEReader?displayProperty=nameWithType> instance, passing your file stream into the constructor.
 
-4. Check the value of the <xref:System.Reflection.PortableExecutable.PEReader.HasMetadata> property. If the value is `false`, the file is not an assembly. 
+4. Check the value of the <xref:System.Reflection.PortableExecutable.PEReader.HasMetadata> property. If the value is `false`, the file is not an assembly.
 
 5. Call the <xref:System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader%2A> method on your PE reader instance to create a metadata reader.
 

--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Determine if a file is an assembly"
 description: This article shows you how determine whether a file is a .NET assembly, both manually and programmatically.
-ms.date: 08/19/2019
+ms.date: 07/24/2021
 ms.topic: how-to
 dev_langs: 
   - "csharp"
@@ -20,73 +20,43 @@ A file is an assembly if and only if it is managed, and contains an assembly ent
 3. If **ILDASM** reports that the file is not a portable executable (PE) file, then it is not an assembly. For more information, see the topic [How to: View assembly contents](view-contents.md).  
   
 ## How to programmatically determine if a file is an assembly  
-  
+
+### Using the AssemblyName class
+
 1. Call the <xref:System.Reflection.AssemblyName.GetAssemblyName%2A?displayProperty=nameWithType> method, passing the full file path and name of the file you are testing.  
   
 2. If a <xref:System.BadImageFormatException> exception is thrown, the file is not an assembly.  
-  
-## Example  
 
 This example tests a DLL to see if it is an assembly.  
 
-```csharp
-class TestAssembly  
-{  
-    static void Main()  
-    {  
-  
-        try  
-        {  
-            System.Reflection.AssemblyName testAssembly =  
-                System.Reflection.AssemblyName.GetAssemblyName(@"C:\Windows\Microsoft.NET\Framework\v3.5\System.Net.dll");  
-  
-            System.Console.WriteLine("Yes, the file is an assembly.");  
-        }  
-  
-        catch (System.IO.FileNotFoundException)  
-        {  
-            System.Console.WriteLine("The file cannot be found.");  
-        }  
-  
-        catch (System.BadImageFormatException)  
-        {  
-            System.Console.WriteLine("The file is not an assembly.");  
-        }  
-  
-        catch (System.IO.FileLoadException)  
-        {  
-            System.Console.WriteLine("The assembly has already been loaded.");  
-        }  
-    }  
-}  
-/* Output (with .NET Framework 3.5 installed):  
-    Yes, the file is an assembly.  
-*/  
-```  
+[!code-csharp[](snippets/identify/csharp/ExampleAssemblyName.cs#AssemblyName)]
 
-```vb  
-Module Module1  
-    Sub Main()  
-        Try  
-            Dim testAssembly As Reflection.AssemblyName =  
-                                Reflection.AssemblyName.GetAssemblyName("C:\Windows\Microsoft.NET\Framework\v3.5\System.Net.dll")  
-            Console.WriteLine("Yes, the file is an Assembly.")  
-        Catch ex As System.IO.FileNotFoundException  
-            Console.WriteLine("The file cannot be found.")  
-        Catch ex As System.BadImageFormatException  
-            Console.WriteLine("The file is not an Assembly.")  
-        Catch ex As System.IO.FileLoadException  
-            Console.WriteLine("The Assembly has already been loaded.")  
-        End Try  
-        Console.ReadLine()  
-    End Sub  
-End Module  
-' Output (with .NET Framework 3.5 installed):  
-'        Yes, the file is an Assembly.  
-```
+[!code-vb[](snippets/identify/visual-basic/ExampleAssemblyName.vb#AssemblyName)]
 
 The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the test file, and then releases it once the information is read.  
-  
+
+### Using the PEReader class
+
+1. Install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package.
+
+2. Create a <xref:System.IO.FileStream?displayProperty=nameWithType> instance to read data from the file you are testing.
+
+3. Create a <xref:System.Reflection.PortableExecutable.PEReader?displayProperty=nameWithType> instance, passing your file stream into the constructor.
+
+4. Check the value of the <xref:System.Reflection.PortableExecutable.PEReader.HasMetadata> property. If the value is `false`, the file is not an assembly. 
+
+5. Call the <xref:System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader%2A> method on your PE reader instance to create a metadata reader.
+
+6. Check the value of the <xref:System.Reflection.Metadata.MetadataReader.IsAssembly> property. If the value is `true`, the file is an assembly.
+
+Unlike the <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method, the <xref:System.Reflection.PortableExecutable.PEReader> class does not throw an exception on native Portable Executable (PE) files. This enables you to avoid the extra performance cost caused by exceptions when you need to check such files. You still need to handle exceptions in case the file does not exist or is not a PE file.
+
+This example shows how to determine if a file is an assembly using the <xref:System.Reflection.PortableExecutable.PEReader> class.
+
+[!code-csharp[](snippets/identify/csharp/ExamplePeReader.cs#PeReader)]
+
+[!code-vb[](snippets/identify/visual-basic/ExamplePeReader.vb#PeReader)]
+
 ## See also
 
 - <xref:System.Reflection.AssemblyName>

--- a/docs/standard/assembly/snippets/identify/csharp/AssemblySnippets.csproj
+++ b/docs/standard/assembly/snippets/identify/csharp/AssemblySnippets.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/docs/standard/assembly/snippets/identify/csharp/ExampleAssemblyName.cs
+++ b/docs/standard/assembly/snippets/identify/csharp/ExampleAssemblyName.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 static class ExampleAssemblyName
 {
@@ -10,7 +11,7 @@ static class ExampleAssemblyName
         try
         {
             string path = Path.Combine(
-                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                RuntimeEnvironment.GetRuntimeDirectory(),
                 "System.Net.dll");
 
             AssemblyName testAssembly = AssemblyName.GetAssemblyName(path);

--- a/docs/standard/assembly/snippets/identify/csharp/ExampleAssemblyName.cs
+++ b/docs/standard/assembly/snippets/identify/csharp/ExampleAssemblyName.cs
@@ -1,0 +1,37 @@
+﻿//<SnippetAssemblyName>
+using System;
+using System.IO;
+using System.Reflection;
+
+static class ExampleAssemblyName
+{
+    public static void CheckAssembly()
+    {
+        try
+        {
+            string path = Path.Combine(
+                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                "System.Net.dll");
+
+            AssemblyName testAssembly = AssemblyName.GetAssemblyName(path);
+            Console.WriteLine("Yes, the file is an assembly.");
+        }
+        catch (FileNotFoundException)
+        {
+            Console.WriteLine("The file cannot be found.");
+        }
+        catch (BadImageFormatException)
+        {
+            Console.WriteLine("The file is not an assembly.");
+        }
+        catch (FileLoadException)
+        {
+            Console.WriteLine("The assembly has already been loaded.");
+        }
+    }
+
+    /* Output: 
+    Yes, the file is an assembly.  
+    */
+}
+//</SnippetAssemblyName>

--- a/docs/standard/assembly/snippets/identify/csharp/ExamplePeReader.cs
+++ b/docs/standard/assembly/snippets/identify/csharp/ExamplePeReader.cs
@@ -4,12 +4,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 
 static class ExamplePeReader
 {
     static bool IsAssembly(string path)
     {
-        var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
         // Try to read CLI metadata from the PE file.
         using var peReader = new PEReader(fs);
@@ -26,8 +27,8 @@ static class ExamplePeReader
 
     public static void CheckAssembly()
     {
-        string path = System.IO.Path.Combine(
-                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+        string path = Path.Combine(
+                RuntimeEnvironment.GetRuntimeDirectory(),
                 "System.Net.dll");
 
         try

--- a/docs/standard/assembly/snippets/identify/csharp/ExamplePeReader.cs
+++ b/docs/standard/assembly/snippets/identify/csharp/ExamplePeReader.cs
@@ -1,0 +1,58 @@
+﻿//<SnippetPeReader>
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+static class ExamplePeReader
+{
+    static bool IsAssembly(string path)
+    {
+        var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+        // Try to read CLI metadata from the PE file.
+        using var peReader = new PEReader(fs);
+
+        if (!peReader.HasMetadata)
+        {
+            return false; // File does not have CLI metadata.
+        }
+
+        // Check that file has an assembly manifest.
+        MetadataReader reader = peReader.GetMetadataReader();
+        return reader.IsAssembly;
+    }
+
+    public static void CheckAssembly()
+    {
+        string path = System.IO.Path.Combine(
+                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                "System.Net.dll");
+
+        try
+        {
+            if (IsAssembly(path))
+            {
+                Console.WriteLine("Yes, the file is an assembly.");
+            }
+            else
+            {
+                Console.WriteLine("The file is not an assembly.");
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            Console.WriteLine("The file is not an executable.");
+        }
+        catch (FileNotFoundException)
+        {
+            Console.WriteLine("The file cannot be found.");
+        }
+    }
+
+    /* Output: 
+    Yes, the file is an assembly.  
+    */
+}
+//</SnippetPeReader>

--- a/docs/standard/assembly/snippets/identify/csharp/Program.cs
+++ b/docs/standard/assembly/snippets/identify/csharp/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace AssemblySnippets
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            ExampleAssemblyName.CheckAssembly();
+            ExamplePeReader.CheckAssembly();
+        }
+    }
+}

--- a/docs/standard/assembly/snippets/identify/visual-basic/AssemblySnippets.vbproj
+++ b/docs/standard/assembly/snippets/identify/visual-basic/AssemblySnippets.vbproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>AssemblySnippets</RootNamespace>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/docs/standard/assembly/snippets/identify/visual-basic/ExampleAssemblyName.vb
+++ b/docs/standard/assembly/snippets/identify/visual-basic/ExampleAssemblyName.vb
@@ -2,12 +2,13 @@
 Imports System
 Imports System.IO
 Imports System.Reflection
+Imports System.Runtime.InteropServices
 
 Module ExampleAssemblyName
     Sub CheckAssembly()
         Try
             Dim filePath As String = Path.Combine(
-                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                RuntimeEnvironment.GetRuntimeDirectory(),
                 "System.Net.dll")
 
             Dim testAssembly As AssemblyName =

--- a/docs/standard/assembly/snippets/identify/visual-basic/ExampleAssemblyName.vb
+++ b/docs/standard/assembly/snippets/identify/visual-basic/ExampleAssemblyName.vb
@@ -1,0 +1,27 @@
+﻿'<SnippetAssemblyName>
+Imports System
+Imports System.IO
+Imports System.Reflection
+
+Module ExampleAssemblyName
+    Sub CheckAssembly()
+        Try
+            Dim filePath As String = Path.Combine(
+                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                "System.Net.dll")
+
+            Dim testAssembly As AssemblyName =
+                                AssemblyName.GetAssemblyName(filePath)
+            Console.WriteLine("Yes, the file is an Assembly.")
+        Catch ex As FileNotFoundException
+            Console.WriteLine("The file cannot be found.")
+        Catch ex As BadImageFormatException
+            Console.WriteLine("The file is not an Assembly.")
+        Catch ex As FileLoadException
+            Console.WriteLine("The Assembly has already been loaded.")
+        End Try
+    End Sub
+End Module
+' Output:  
+' Yes, the file is an Assembly.  
+'</SnippetAssemblyName>

--- a/docs/standard/assembly/snippets/identify/visual-basic/ExamplePeReader.vb
+++ b/docs/standard/assembly/snippets/identify/visual-basic/ExamplePeReader.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Generic
 Imports System.IO
 Imports System.Reflection.Metadata
 Imports System.Reflection.PortableExecutable
+Imports System.Runtime.InteropServices
 
 Module ExamplePeReader
     Function IsAssembly(path As String) As Boolean
@@ -25,7 +26,7 @@ Module ExamplePeReader
 
     Sub CheckAssembly()
         Dim filePath As String = Path.Combine(
-                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                RuntimeEnvironment.GetRuntimeDirectory(),
                 "System.Net.dll")
 
         Try

--- a/docs/standard/assembly/snippets/identify/visual-basic/ExamplePeReader.vb
+++ b/docs/standard/assembly/snippets/identify/visual-basic/ExamplePeReader.vb
@@ -1,0 +1,46 @@
+﻿'<SnippetPeReader>
+Imports System
+Imports System.Collections.Generic
+Imports System.IO
+Imports System.Reflection.Metadata
+Imports System.Reflection.PortableExecutable
+
+Module ExamplePeReader
+    Function IsAssembly(path As String) As Boolean
+
+        Dim fs As FileStream = New FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
+
+        ' Try to read CLI metadata from the PE file.
+        Dim peReader As PEReader = New PEReader(fs)
+        Using (peReader)
+            If Not peReader.HasMetadata Then
+                Return False ' File does Not have CLI metadata.
+            End If
+
+            ' Check that file has an assembly manifest.
+            Dim reader As MetadataReader = peReader.GetMetadataReader()
+            Return reader.IsAssembly
+        End Using
+    End Function
+
+    Sub CheckAssembly()
+        Dim filePath As String = Path.Combine(
+                System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                "System.Net.dll")
+
+        Try
+            If IsAssembly(filePath) Then
+                Console.WriteLine("Yes, the file is an assembly.")
+            Else
+                Console.WriteLine("The file is not an assembly.")
+            End If
+        Catch ex As BadImageFormatException
+            Console.WriteLine("The file is not an executable.")
+        Catch ex As FileNotFoundException
+            Console.WriteLine("The file cannot be found.")
+        End Try
+    End Sub
+End Module
+' Output:  
+' Yes, the file is an Assembly.
+'</SnippetPeReader>

--- a/docs/standard/assembly/snippets/identify/visual-basic/Program.vb
+++ b/docs/standard/assembly/snippets/identify/visual-basic/Program.vb
@@ -1,0 +1,6 @@
+Module Program
+    Sub Main(args As String())
+        ExampleAssemblyName.CheckAssembly()
+        ExamplePeReader.CheckAssembly()
+    End Sub
+End Module


### PR DESCRIPTION
- Convert snippets to buildable projects
- Update existing example to remove mentions of .NET Framework 3.5
- Add new example that uses PEReader class

Compared to example in the linked issue, i added a check for MetadataReader.IsAssembly, it is needed for corner case of .netmodule file (which has CLI metadata but is not an assembly).

Fixes #24361

@IEvangelist for review


