### PR TITLE
Fixed a Incomplete method call.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/methods.md
@@ -85,7 +85,7 @@ Using a local variable, in this case, `result`, to store a value is optional. It
 To use a value returned by reference from a method, you must declare a [ref local](ref-returns.md#ref-locals) variable if you intend to modify its value. For example, if the `Planet.GetEstimatedDistance` method returns a <xref:System.Double> value by reference, you can define it as a ref local variable with code like the following:
 
 ```csharp
-ref int distance = plant
+ref int distance = Planet.GetEstimatedDistance();
 ```
 
 Returning a multi-dimensional array from a method, `M`, that modifies the array's contents is not necessary if the calling function passed the array into `M`.  You may return the resulting array from `M` for good style or functional flow of values, but it is not necessary because C# passes all reference types by value, and the value of an array reference is the pointer to the array. In the method `M`, any changes to the array's contents are observable by any code that has a reference to the array, as shown in the following example:


### PR DESCRIPTION
## Summary

Fixed Incomplete method name on line 88.
Intially
`ref int distance = plant`
changed to 
`ref int distance = Planet.GetEstimatedDistance();`
because the intent was demonstrating return a value by reference.

