### PR TITLE
Corrected the parameter order for GetPosition(Int64, SequencePosition) in example

### DIFF
--- a/docs/standard/io/buffers.md
+++ b/docs/standard/io/buffers.md
@@ -138,7 +138,7 @@ The preceding code creates a `ReadOnlySequence<byte>` with empty segments and sh
 There are several unusual outcomes when dealing with a `ReadOnlySequence<T>`/`SequencePosition` vs. a normal `ReadOnlySpan<T>`/`ReadOnlyMemory<T>`/`T[]`/`int`:
 
 - `SequencePosition` is a position marker for a specific `ReadOnlySequence<T>`, not an absolute position. Because it's relative to a specific `ReadOnlySequence<T>`, it doesn't have meaning if used outside of the `ReadOnlySequence<T>` where it originated.
-- Arithmetic can't be performed on `SequencePosition` without the `ReadOnlySequence<T>`. That means doing basic things like `position++` is written `ReadOnlySequence<T>.GetPosition(1, position)`.
+- Arithmetic can't be performed on `SequencePosition` without the `ReadOnlySequence<T>`. That means doing basic things like `position++` is written `position = ReadOnlySequence<T>.GetPosition(1, position)`.
 - `GetPosition(long)` does **not** support negative indexes. That means it's impossible to get the second to last character without walking all segments.
 - Two `SequencePosition` can't be compared, making it difficult to:
   - Know if one position is greater than or less than another position.

--- a/docs/standard/io/buffers.md
+++ b/docs/standard/io/buffers.md
@@ -2,7 +2,7 @@
 description: "Learn more about: Work with Buffers in .NET"
 title: "System.Buffers - .NET"
 ms.date: 12/05/2019
-helpviewer_keywords: 
+helpviewer_keywords:
   - "buffers [.NET]"
   - "I/O [.NET], buffers"
 author: rick-anderson
@@ -138,7 +138,7 @@ The preceding code creates a `ReadOnlySequence<byte>` with empty segments and sh
 There are several unusual outcomes when dealing with a `ReadOnlySequence<T>`/`SequencePosition` vs. a normal `ReadOnlySpan<T>`/`ReadOnlyMemory<T>`/`T[]`/`int`:
 
 - `SequencePosition` is a position marker for a specific `ReadOnlySequence<T>`, not an absolute position. Because it's relative to a specific `ReadOnlySequence<T>`, it doesn't have meaning if used outside of the `ReadOnlySequence<T>` where it originated.
-- Arithmetic can't be performed on `SequencePosition` without the `ReadOnlySequence<T>`. That means doing basic things like `position++` is written `ReadOnlySequence<T>.GetPosition(position, 1)`.
+- Arithmetic can't be performed on `SequencePosition` without the `ReadOnlySequence<T>`. That means doing basic things like `position++` is written `ReadOnlySequence<T>.GetPosition(1, position)`.
 - `GetPosition(long)` does **not** support negative indexes. That means it's impossible to get the second to last character without walking all segments.
 - Two `SequencePosition` can't be compared, making it difficult to:
   - Know if one position is greater than or less than another position.


### PR DESCRIPTION
## Summary

The article, "Work with Buffers in .NET" has the arguments for `ReadOnlySequence<T>.GetPosition` in the wrong order in the example. This PR corrects the order of arguments.

See API documentation for [ReadOnlySequence<T>.GetPosition(Int64, SequencePosition)](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.readonlysequence-1.getposition?view=net-5.0#System_Buffers_ReadOnlySequence_1_GetPosition_System_Int64_System_SequencePosition_)
