### PR TITLE
Update how-to-display-milliseconds-in-date-and-time-values.md

### DIFF
--- a/docs/standard/base-types/how-to-display-milliseconds-in-date-and-time-values.md
+++ b/docs/standard/base-types/how-to-display-milliseconds-in-date-and-time-values.md
@@ -44,9 +44,9 @@ The default date and time formatting methods, such as <xref:System.DateTime.ToSt
   
 > [!NOTE]
 > It is possible to display very small fractional units of a second, such as ten thousandths of a second or hundred-thousandths of a second. However, these values may not be meaningful. The precision of a date and time value depends on the resolution of the operating system clock. For more information, see the API your operating system uses:
->   - Windows 7: [GetSystemTimeAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-GetSystemTimeAsFileTime)
->   - Windows 8 and above: [GetSystemTimePreciseAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime)
->   - Linux: [clock_gettime](https://linux.die.net/man/3/clock_gettime)
+> - Windows 7: [GetSystemTimeAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-GetSystemTimeAsFileTime)
+> - Windows 8 and above: [GetSystemTimePreciseAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime)
+> - Linux and macOS: [clock_gettime](https://linux.die.net/man/3/clock_gettime)
   
 ## See also
 

--- a/docs/standard/base-types/how-to-display-milliseconds-in-date-and-time-values.md
+++ b/docs/standard/base-types/how-to-display-milliseconds-in-date-and-time-values.md
@@ -44,6 +44,7 @@ The default date and time formatting methods, such as <xref:System.DateTime.ToSt
   
 > [!NOTE]
 > It is possible to display very small fractional units of a second, such as ten thousandths of a second or hundred-thousandths of a second. However, these values may not be meaningful. The precision of a date and time value depends on the resolution of the operating system clock. For more information, see the API your operating system uses:
+>
 > - Windows 7: [GetSystemTimeAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-GetSystemTimeAsFileTime)
 > - Windows 8 and above: [GetSystemTimePreciseAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime)
 > - Linux and macOS: [clock_gettime](https://linux.die.net/man/3/clock_gettime)

--- a/docs/standard/base-types/how-to-display-milliseconds-in-date-and-time-values.md
+++ b/docs/standard/base-types/how-to-display-milliseconds-in-date-and-time-values.md
@@ -43,7 +43,10 @@ The default date and time formatting methods, such as <xref:System.DateTime.ToSt
  [!code-vb[Formatting.HowTo.Millisecond#3](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.HowTo.Millisecond/vb/Millisecond.vb#3)]  
   
 > [!NOTE]
-> It is possible to display very small fractional units of a second, such as ten thousandths of a second or hundred-thousandths of a second. However, these values may not be meaningful. The precision of date and time values depends on the resolution of the system clock. On Windows NT 3.5 and later, and Windows Vista operating systems, the clock's resolution is approximately 10-15 milliseconds.  
+> It is possible to display very small fractional units of a second, such as ten thousandths of a second or hundred-thousandths of a second. However, these values may not be meaningful. The precision of a date and time value depends on the resolution of the operating system clock. For more information, see the API your operating system uses:
+>   - Windows 7: [GetSystemTimeAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-GetSystemTimeAsFileTime)
+>   - Windows 8 and above: [GetSystemTimePreciseAsFileTime](https://docs.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime)
+>   - Linux: [clock_gettime](https://linux.die.net/man/3/clock_gettime)
   
 ## See also
 


### PR DESCRIPTION
## Summary

Adjusted the note to remove the delay info and leave that up to the API articles themselves, since they're the source of truth.

@tarekgh what about macOS? Does that fall under Linux? If so, I'll amend that.

Fixes #25167
