### PR TITLE
Update nullable-operators.md

### DIFF
--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -136,7 +136,7 @@ The following table describes symbols related to reference cells and provides a 
 
 |Symbol or operator|Links|Description|
 |------------------|-----|-----------|
-|`!`|[Reference Cells](../reference-cells.md)<br /><br />[Computation Expressions](../computation-expressions.md)|<ul><li>Dereferences a reference cell.<br /></li><li>After a keyword, indicates a modified version of the keyword's behavior as controlled by a workflow.<br /></li></ul>|
+|`!`|[Reference Cells](../reference-cells.md)|<ul><li>Dereferences a reference cell.<br /></li></ul>|
 |`:=`|[Reference Cells](../reference-cells.md)|<ul><li>Assigns a value to a reference cell.<br /></li></ul>|
 
 ## Symbols used in quotations
@@ -163,6 +163,7 @@ The following table describes additional symbols used in expressions
 |`? ... <- ...`||<ul><li>Used as an operator for setting dynamic properties. You must provide your own implementation.<br /></li></ul>|
 |`;`|[Verbose Syntax](../verbose-syntax.md)<br /><br />[Lists](../lists.md)<br /><br />[Records](../records.md)|<ul><li>Separates expressions (used mostly in verbose syntax).<br /></li><li>Separates elements of a list.<br /></li><li>Separates fields of a record.<br /></li></ul>|
 |`->`|[Sequences](../sequences.md)|<ul><li>Yields an expression (in sequence expressions); equivalent to the `do yield` keywords.<br /></li></ul>|
+|`!`|[Computation Expressions](../computation-expressions.md)|<ul><li>After a keyword, indicates a modified version of the keyword's behavior as controlled by a workflow.<br /></li></ul>|
 
 ## Additional symbols used in match patterns
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -1,7 +1,7 @@
 ---
 title: Symbol and Operator Reference
 description: Learn about the symbols and operators that are used in the F# programming language.
-ms.date: 08/15/2020
+ms.date: 07/26/2021
 fl_keywords:
  - "|>_FS"
 ---

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -7,105 +7,203 @@ fl_keywords:
 ---
 # Symbol and operator reference
 
-This article includes a table of symbols and operators that are used in the F# language.
+This article includes tables describing the symbols and operators that are used in the F# language. Some symbols
+and operators have two entries.
 
-## Table of symbols and operators
+## Comment, compiler directive and attribute symbols
 
-The following table describes symbols used in the F# language and provides a brief description of some of the uses of the symbol and links for more information. Symbols are ordered according to the ASCII character set ordering.
+The following table describes symbols related to comments, compiler directives and attributes and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`(*...*)`||<ul><li>Delimits a comment that could span multiple lines.<br /></li></ul>|
+|`//`||<ul><li>Indicates the beginning of a single-line comment.<br /></li></ul>|
+|`///`|[XML Documentation](../xml-documentation.md)|<ul><li>Indicates an XML comment.<br /></li></ul>|
+|`#`|[Compiler Directives](../compiler-directives.md)|<ul><li>Prefixes a preprocessor or compiler directive, such as `#light`.<br /></li></ul>|
+|`[<...>]`|[Attributes](../attributes.md)|<ul><li>Delimits an attribute.<br /></li></ul>|
+
+## String and identifier symbols
+
+The following table describes symbols related to strings and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`"`|[Literals](../literals.md)<br /><br />[Strings](../strings.md)|<ul><li>Delimits a text string.<br /></li></ul>|
+|`"""`|[Strings](../strings.md)|Delimits a verbatim text string. Differs from `@"..."` in that a you can indicate a quotation mark character by using a single quote in the string.|
+|`$"`|[Strings](../strings.md)|Starts an interpolated string.|
+|`'`|[Literals](../literals.md)|<ul><li>Delimits a single-character literal.<br /></li></ul>|
+|<code>&#96;&#96;...&#96;&#96;</code>||<ul><li>Delimits an identifier that would otherwise not be a legal identifier, such as a language keyword.<br /></li></ul>|
+|`\`|[Strings](../strings.md)|<ul><li>Escapes the next character; used in character and string literals.<br /></li></ul>|
+
+## Arithmetic operators
+
+The following table describes the arithmetic operators in the F# language and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`+`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>When used as a binary operator, adds the left and right sides.<br /></li><li>When used as a unary operator, indicates a positive quantity. (Formally, it produces the same value with the sign unchanged.)<br /></li></ul>|
+|`-`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>When used as a binary operator, subtracts the right side from the left side.<br /></li><li>When used as a unary operator, performs a negation operation.<br /></li></ul>|
+|`*`|[Arithmetic Operators](arithmetic-operators.md)<br /><br />[Tuples](../tuples.md)<br /><br />[Units of Measure](../units-of-measure.md)|<ul><li>When used as a binary operator, multiplies the left and right sides.<br /></li><li>In types, indicates pairing in a tuple.<br /></li><li>Used in units of measure types.<br /></li></ul>|
+|`/`|[Arithmetic Operators](arithmetic-operators.md)<br /><br />[Units of Measure](../units-of-measure.md)|<ul><li>Divides the left side (numerator) by the right side (denominator).<br /></li><li>Used in units of measure types.<br /></li></ul>|
+|`%`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Computes the integer remainder.<br /></li></ul>|
+|`**`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Computes the exponentiation operation (`x ** y` means `x` to the power of `y`).<br /></li></ul>|
+
+## Comparison operators
+
+The following table describes the comparison operators in the F# language and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`<`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Computes the less-than operation.<br /></li></ul>|
+|`<>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is not equal to the right side; otherwise, returns false.<br /></li></ul>|
+|`<=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is less than or equal to the right side; otherwise, returns `false`.<br /></li></ul>|
+|`=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is equal to the right side; otherwise, returns `false`.<br /></li></ul>|
+|`>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than the right side; otherwise, returns `false`.<br /></li></ul>|r /></li></ul>|
+|`>=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than or equal to the right side; otherwise, returns `false`.<br 
+
+## Boolean operators
+
+The following table describes the arithmetic and boolean operators symbols used in the F# language and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`&&`|[Boolean Operators](boolean-operators.md)|<ul><li>Computes the Boolean AND operation.<br /></li></ul>|
+|<code>&#124;&#124;</code>|[Boolean Operators](boolean-operators.md)|<ul><li>Computes the Boolean OR operation.<br /></li></ul>|
+
+## Bitwise operators
+
+The following table describes bitwise operators used in the F# language and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`&&&`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise AND operation.<br /></li></ul>|
+|`<<<`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Shifts bits in the quantity on the left side to the left by the number of bits specified on the right side.<br /></li></ul>|
+|`>>>`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Shifts bits in the quantity on the left side to the right by the number of places specified on the right side.<br /></li></ul>|
+|`^^^`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise exclusive OR operation.<br /></li></ul>|
+|<code>&#124;&#124;&#124;</code>|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise OR operation.<br /></li></ul>|
+|`~~~`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise NOT operation.<br /></li></ul>|
+
+## Function symbols and operators
+
+The following table describes the operators and symbols related to functions used in the F# language and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`->`|[Functions](../functions/index.md)|<ul><li>In function expressions, separates the input pattern from the output expression.<br /></ul>|
+|<code>&#124;></code>|[Functions](../functions/index.md)|<ul><li>Passes the result of the left side to the function on the right side (forward pipe operator).<br /></li></ul>|
+|<code>&#124;&#124;></code>|[&#40; &#124;&#124;&#62; &#41;&#60;'T1,'T2,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%7C%7C%3E%20))|<ul><li>Passes the tuple of two arguments on the left side to the function on the right side.<br /></li></ul>|
+|<code>&#124;&#124;&#124;></code>|[&#40; &#124;&#124;&#124;&#62; &#41;&#60;'T1,'T2,'T3,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%7C%7C%7C%3E%20))|<ul><li>Passes the tuple of three arguments on the left side to the function on the right side.<br /></li></ul>|
+|`>>`|[Functions](../functions/index.md)|<ul><li>Composes two functions (forward composition operator).<br /></li></ul>|
+|`<<`|[Functions](../functions/index.md)|<ul><li>Composes two functions in reverse order; the second one is executed first (backward composition operator).<br /></li></ul>|
+|<code>&lt;&#124;</code>|[Functions](../functions/index.md)|<ul><li>Passes the result of the expression on the right side to the function on left side (backward pipe operator).<br /></li></ul>|
+|<code>&lt;&#124;&#124;</code>|[&#40; &#60;&#124;&#124; &#41;&#60;'T1,'T2,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%3C%7C%7C%20))|<ul><li>Passes the tuple of two arguments on the right side to the function on left side.<br /></li></ul>|
+|<code>&lt;&#124;&#124;&#124;</code>|[&#40; &#60;&#124;&#124;&#124; &#41;&#60;'T1,'T2,'T3,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%3C%7C%7C%7C%20))|<ul><li>Passes the tuple of three arguments on the right side to the function on left side.<br /></li></ul>|
+
+## Type symbols and operators
+
+The following table describes symbols related to type annotation and type tests used in the F# language and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`->`|[Functions](../functions/index.md)|<ul><li>In function types, delimits arguments and return values, also yields a result in sequence expressions.<br /></li></ul>|
+|`:`|[Functions](../functions/index.md)|<ul><li>In a type annotation, separates a parameter or member name from its type.<br /></li></ul>|
+|`:>`|[Casting and Conversions](../casting-and-conversions.md)|<ul><li>Converts a type to type that is higher in the hierarchy.<br /></li></ul>|
+|`:?`|[Match Expressions](../match-expressions.md)|<ul><li>Returns `true` if the value matches the specified type (including if it is a subtype); otherwise, returns `false` (type test operator).<br /></li></ul>|
+|`:?>`|[Casting and Conversions](../casting-and-conversions.md)|<ul><li>Converts a type to a type that is lower in the hierarchy.<br /></li></ul>|
+|`#`|[Flexible Types](../flexible-types.md)|<ul><li>When used with a type, indicates a *flexible type*, which refers to a type or any one of its derived types.<br /></li></ul>|
+|`'`|[Automatic Generalization](../generics/automatic-generalization.md)|<ul><li>Indicates a generic type parameter.<br /></li></ul>|
+|`<...>`|[Automatic Generalization](../generics/automatic-generalization.md)|<ul><li>Delimits type parameters.<br /></li></ul>|
+|`^`|[Statically Resolved Type Parameters](../generics/statically-resolved-type-parameters.md)<br /><br />[Strings](../strings.md)|<ul><li>Specifies type parameters that must be resolved at compile time, not at runtime.<br /></li><li>Concatenates strings.<br /></li></ul>|
+
+## Tuple, list, array, unit value symbols and operators
+
+The following table describes symbols related to tuples, lists, unit values and arrays and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`( )`|[Unit Type](../unit-type.md)|<ul><li>Represents the single value of the unit type.<br /></li></ul>|
+|`(...)`|[Tuples](../tuples.md)<br /><br />[Operator Overloading](../operator-overloading.md)|<ul><li>Indicates the order in which expressions are evaluated.<br /></li><li>Delimits a tuple.<br /></li><li>Used in operator definitions.<br /></li></ul>|
+|<code>(&#124;...&#124;)</code>|[Active Patterns](../active-patterns.md)|<ul><li>Delimits an active pattern name. Also called *banana clips*.<br /></li></ul>|
+|`,`|[Tuples](../tuples.md)|<ul><li>Separates the elements of a tuple, or type parameters.<br /></li></ul>|
+|`::`|[Lists](../lists.md)<br /><br />[Match Expressions](../match-expressions.md)|<ul><li>Creates a list. The element on the left side is prepended to the list on the right side.<br /></li><li>Used in pattern matching to separate the parts of a list.<br /></li></ul>|
+|`@`|[Lists](../lists.md)<br /><br />[Strings](../strings.md)|<ul><li>Concatenates two lists.<br /></li><li>When placed before a string literal, indicates that the string is to be interpreted verbatim, with no interpretation of escape characters.<br /></li></ul>|
+|`[...]`|[Lists](../lists.md)|<ul><li>Delimits the elements of a list.<br /></li></ul>|
+|<code>[&#124;...&#124;]</code>|[Arrays](../arrays.md)|<ul><li>Delimits the elements of an array.<br /></li></ul>|
+
+## Reference cell operators
+
+The following table describes symbols related to reference cells and provides a brief description of each.
 
 |Symbol or operator|Links|Description|
 |------------------|-----|-----------|
 |`!`|[Reference Cells](../reference-cells.md)<br /><br />[Computation Expressions](../computation-expressions.md)|<ul><li>Dereferences a reference cell.<br /></li><li>After a keyword, indicates a modified version of the keyword's behavior as controlled by a workflow.<br /></li></ul>|
-|`!=`||<ul><li>Not used in F#. Use `<>` for inequality operations.<br /></li></ul>|
-|`"`|[Literals](../literals.md)<br /><br />[Strings](../strings.md)|<ul><li>Delimits a text string.<br /></li></ul>|
-|`"""`|[Strings](../strings.md)|Delimits a verbatim text string. Differs from `@"..."` in that a you can indicate a quotation mark character by using a single quote in the string.|
-|`#`|[Compiler Directives](../compiler-directives.md)<br /><br />[Flexible Types](../flexible-types.md)|<ul><li>Prefixes a preprocessor or compiler directive, such as `#light`.<br /></li><li>When used with a type, indicates a *flexible type*, which refers to a type or any one of its derived types.<br /></li></ul>|
-|`$`||<ul><li>Used internally for certain compiler-generated variable and function names.<br /></li></ul>|
-|`%`|[Arithmetic Operators](arithmetic-operators.md)<br /><br />[Code Quotations](../code-quotations.md)|<ul><li>Computes the integer remainder.<br /></li><li>Used for splicing expressions into typed code quotations.<br /></li></ul>|
-|`%%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into untyped code quotations.<br /></li></ul>|
-|`%?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the integer remainder, when the right side is a nullable type.<br /></li></ul>|
-|`&`|[Match Expressions](../match-expressions.md)|<ul><li>Computes the address of a mutable value, for use when interoperating with other languages.<br /></li><li>Used in AND patterns.<br /></li></ul>|
-|`&&`|[Boolean Operators](boolean-operators.md)|<ul><li>Computes the Boolean AND operation.<br /></li></ul>|
-|`&&&`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise AND operation.<br /></li></ul>|
-|`'`|[Literals](../literals.md)<br /><br />[Automatic Generalization](../generics/automatic-generalization.md)|<ul><li>Delimits a single-character literal.<br /></li><li>Indicates a generic type parameter.<br /></li></ul>|
-|<code>&#96;&#96;...&#96;&#96;</code>||<ul><li>Delimits an identifier that would otherwise not be a legal identifier, such as a language keyword.<br /></li></ul>|
-|`( )`|[Unit Type](../unit-type.md)|<ul><li>Represents the single value of the unit type.<br /></li></ul>|
-|`(...)`|[Tuples](../tuples.md)<br /><br />[Operator Overloading](../operator-overloading.md)|<ul><li>Indicates the order in which expressions are evaluated.<br /></li><li>Delimits a tuple.<br /></li><li>Used in operator definitions.<br /></li></ul>|
-|`(*...*)`||<ul><li>Delimits a comment that could span multiple lines.<br /></li></ul>|
-|<code>(&#124;...&#124;)</code>|[Active Patterns](../active-patterns.md)|<ul><li>Delimits an active pattern. Also called *banana clips*.<br /></li></ul>|
-|`*`|[Arithmetic Operators](arithmetic-operators.md)<br /><br />[Tuples](../tuples.md)<br /><br />[Units of Measure](../units-of-measure.md)|<ul><li>When used as a binary operator, multiplies the left and right sides.<br /></li><li>In types, indicates pairing in a tuple.<br /></li><li>Used in units of measure types.<br /></li></ul>|
-|`*?`|[Nullable Operators](nullable-operators.md)|<ul><li>Multiplies the left and right sides, when the right side is a nullable type.<br /></li></ul>|
-|`**`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Computes the exponentiation operation (`x ** y` means `x` to the power of `y`).<br /></li></ul>|
-|`+`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>When used as a binary operator, adds the left and right sides.<br /></li><li>When used as a unary operator, indicates a positive quantity. (Formally, it produces the same value with the sign unchanged.)<br /></li></ul>|
-|`+?`|[Nullable Operators](nullable-operators.md)|<ul><li>Adds the left and right sides, when the right side is a nullable type.<br /></li></ul>|
-|`,`|[Tuples](../tuples.md)|<ul><li>Separates the elements of a tuple, or type parameters.<br /></li></ul>|
-|`-`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>When used as a binary operator, subtracts the right side from the left side.<br /></li><li>When used as a unary operator, performs a negation operation.<br /></li></ul>|
-|`-?`|[Nullable Operators](nullable-operators.md)|<ul><li>Subtracts the right side from the left side, when the right side is a nullable type.<br /></li></ul>|
-|`->`|[Functions](../functions/index.md)<br /><br />[Match Expressions](../match-expressions.md)|<ul><li>In function types, delimits arguments and return values.<br /></li><li>Yields an expression (in sequence expressions); equivalent to the `yield` keyword.<br /></li><li>Used in match expressions<br /></li></ul>|
-|`.`|[Members](../members/index.md)<br /><br />[Primitive Types](../basic-types.md)|<ul><li>Accesses a member, and separates individual names in a fully qualified name.<br /></li><li>Specifies a decimal point in floating point numbers.<br /></li></ul>|
-|`..`|[Loops: `for...in` Expression](../loops-for-in-expression.md)|<ul><li>Specifies a range.<br /></li></ul>|
-|`.. ..`|[Loops: `for...in` Expression](../loops-for-in-expression.md)|<ul><li>Specifies a range together with an increment.<br /></li></ul>|
-|`.[...]`|[Arrays](../arrays.md)|<ul><li>Accesses an array element.<br /></li></ul>|
-|`/`|[Arithmetic Operators](arithmetic-operators.md)<br /><br />[Units of Measure](../units-of-measure.md)|<ul><li>Divides the left side (numerator) by the right side (denominator).<br /></li><li>Used in units of measure types.<br /></li></ul>|
-|`/?`|[Nullable Operators](nullable-operators.md)|<ul><li>Divides the left side by the right side, when the right side is a nullable type.<br /></li></ul>|
-|`//`||<ul><li>Indicates the beginning of a single-line comment.<br /></li></ul>|
-|`///`|[XML Documentation](../xml-documentation.md)|<ul><li>Indicates an XML comment.<br /></li></ul>|
-|`:`|[Functions](../functions/index.md)|<ul><li>In a type annotation, separates a parameter or member name from its type.<br /></li></ul>|
-|`::`|[Lists](../lists.md)<br /><br />[Match Expressions](../match-expressions.md)|<ul><li>Creates a list. The element on the left side is prepended to the list on the right side.<br /></li><li>Used in pattern matching to separate the parts of a list.<br /></li></ul>|
 |`:=`|[Reference Cells](../reference-cells.md)|<ul><li>Assigns a value to a reference cell.<br /></li></ul>|
-|`:>`|[Casting and Conversions](../casting-and-conversions.md)|<ul><li>Converts a type to type that is higher in the hierarchy.<br /></li></ul>|
-|`:?`|[Match Expressions](../match-expressions.md)|<ul><li>Returns `true` if the value matches the specified type (including if it is a subtype); otherwise, returns `false` (type test operator).<br /></li></ul>|
-|`:?>`|[Casting and Conversions](../casting-and-conversions.md)|<ul><li>Converts a type to a type that is lower in the hierarchy.<br /></li></ul>|
-|`;`|[Verbose Syntax](../verbose-syntax.md)<br /><br />[Lists](../lists.md)<br /><br />[Records](../records.md)|<ul><li>Separates expressions (used mostly in verbose syntax).<br /></li><li>Separates elements of a list.<br /></li><li>Separates fields of a record.<br /></li></ul>|
-|`<`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Computes the less-than operation.<br /></li></ul>|
-|`<?`|[Nullable Operators](nullable-operators.md)|Computes the less than operation, when the right side is a nullable type.|
-|`<<`|[Functions](../functions/index.md)|<ul><li>Composes two functions in reverse order; the second one is executed first (backward composition operator).<br /></li></ul>|
-|`<<<`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Shifts bits in the quantity on the left side to the left by the number of bits specified on the right side.<br /></li></ul>|
+
+## Symbols used in expressions
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`.`|[Members](../members/index.md)<br /><br />[Primitive Types](../basic-types.md)|<ul><li>Accesses a member, and separates individual names in a fully qualified name.<br /></li><li>Specifies a decimal point in floating point numbers.<br /></li></ul>|
+|`.[...]`|[Arrays](../arrays.md)|<ul><li>Accesses an array element.<br /></li></ul>|
 |`<-`|[Values](../values/index.md)|<ul><li>Assigns a value to a variable.<br /></li></ul>|
-|`<...>`|[Automatic Generalization](../generics/automatic-generalization.md)|<ul><li>Delimits type parameters.<br /></li></ul>|
-|`<>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is not equal to the right side; otherwise, returns false.<br /></li></ul>|
-|`<>?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "not equal" operation when the right side is a nullable type.<br /></li></ul>|
-|`<=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is less than or equal to the right side; otherwise, returns `false`.<br /></li></ul>|
-|`<=?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "less than or equal to" operation when the right side is a nullable type.<br /></li></ul>|
-|<code>&#124;></code>|[Functions](../functions/index.md)|<ul><li>Passes the result of the left side to the function on the right side (forward pipe operator).<br /></li></ul>|
-|<code>&#124;&#124;></code>|[&#40; &#124;&#124;&#62; &#41;&#60;'T1,'T2,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%7C%7C%3E%20))|<ul><li>Passes the tuple of two arguments on the left side to the function on the right side.<br /></li></ul>|
-|<code>&#124;&#124;&#124;></code>|[&#40; &#124;&#124;&#124;&#62; &#41;&#60;'T1,'T2,'T3,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%7C%7C%7C%3E%20))|<ul><li>Passes the tuple of three arguments on the left side to the function on the right side.<br /></li></ul>|
-|<code>&lt;&#124;</code>|[Functions](../functions/index.md)|<ul><li>Passes the result of the expression on the right side to the function on left side (backward pipe operator).<br /></li></ul>|
-|<code>&lt;&#124;&#124;</code>|[&#40; &#60;&#124;&#124; &#41;&#60;'T1,'T2,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%3C%7C%7C%20))|<ul><li>Passes the tuple of two arguments on the right side to the function on left side.<br /></li></ul>|
-|<code>&lt;&#124;&#124;&#124;</code>|[&#40; &#60;&#124;&#124;&#124; &#41;&#60;'T1,'T2,'T3,'U&#62; Function](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20%3C%7C%7C%7C%20))|<ul><li>Passes the tuple of three arguments on the right side to the function on left side.<br /></li></ul>|
+|`?`||<ul><li>Used as an operator for dynamic method and property calls. You must provide your own implementation.<br /></li></ul>|
+|`? ... <- ...`||<ul><li>Used as an operator for setting dynamic properties. You must provide your own implementation.<br /></li></ul>|
+|`;`|[Verbose Syntax](../verbose-syntax.md)<br /><br />[Lists](../lists.md)<br /><br />[Records](../records.md)|<ul><li>Separates expressions (used mostly in verbose syntax).<br /></li><li>Separates elements of a list.<br /></li><li>Separates fields of a record.<br /></li></ul>|
+|`->`|[Sequences](../sequences.md)|<ul><li>Yields an expression (in sequence expressions); equivalent to the `do yield` keywords.<br /></li></ul>|
+
+## Symbols used in match expressions and patterns
+
+The following table describes symbols related to pattern matching and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`->`|[Match Expressions](../match-expressions.md)|<ul><li>Used in match expressions<br /></li></ul>|
+|`&`|[Match Expressions](../match-expressions.md)|<ul><li>Computes the address of a mutable value, for use when interoperating with other languages.<br /></li><li>Used in AND patterns.<br /></li></ul>|
+|`_`|[Match Expressions](../match-expressions.md)<br /><br />[Generics](../generics/index.md)|<ul><li>Indicates a wildcard pattern.<br /></li><li>Specifies an anonymous generic parameter.<br /></li></ul>|
+|<code>&#124;</code>|[Match Expressions](../match-expressions.md)|<ul><li>Delimits individual match cases, individual discriminated union cases, and enumeration values.<br /></li></ul>|
+
+## Symbols used in declarations
+
+The following table describes symbols related to declarations:
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`?`|[Parameters and Arguments](../parameters-and-arguments.md)|<ul><li>Specifies an optional argument.<br /></li></ul>|
+|`~~`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary negation operator.<br /></li></ul>|
+|`~-`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary minus operator.<br /></li></ul>|
+|`~+`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary plus operator.<br /></li></ul>|
+
+## Symbols used in quotations
+
+The following table describes symbols related to quotations and provides a brief description of each.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
 |`<@...@>`|[Code Quotations](../code-quotations.md)|<ul><li>Delimits a typed code quotation.<br /></li></ul>|
 |`<@@...@@>`|[Code Quotations](../code-quotations.md)|<ul><li>Delimits an untyped code quotation.<br /></li></ul>|
-|`=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is equal to the right side; otherwise, returns `false`.<br /></li></ul>|
+|`%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into typed code quotations.<br /></li></ul>|
+|`%%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into untyped code quotations.<br /></li></ul>|
+
+## Nullable operators
+
+[Nullable Operators](nullable-operators.md) are defined for use in F# queries. The following table shows these operators:
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`%?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the integer remainder, when the right side is a nullable type.<br /></li></ul>|
+|`*?`|[Nullable Operators](nullable-operators.md)|<ul><li>Multiplies the left and right sides, when the right side is a nullable type.<br /></li></ul>|
+|`+?`|[Nullable Operators](nullable-operators.md)|<ul><li>Adds the left and right sides, when the right side is a nullable type.<br /></li></ul>|
+|`-?`|[Nullable Operators](nullable-operators.md)|<ul><li>Subtracts the right side from the left side, when the right side is a nullable type.<br /></li></ul>|
+|`/?`|[Nullable Operators](nullable-operators.md)|<ul><li>Divides the left side by the right side, when the right side is a nullable type.<br /></li></ul>|
+|`<?`|[Nullable Operators](nullable-operators.md)|Computes the less than operation, when the right side is a nullable type.|
+|`<>?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "not equal" operation when the right side is a nullable type.<br /></li></ul>|
+|`<=?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "less than or equal to" operation when the right side is a nullable type.<br /></li></ul>|
 |`=?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "equal" operation when the right side is a nullable type.<br /></li></ul>|
-|`==`||<ul><li>Not used in F#. Use `=` for equality operations.<br /></li></ul>|
-|`>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than the right side; otherwise, returns `false`.<br /></li></ul>|
 |`>?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "greater than" operation when the right side is a nullable type.<br /></li></ul>|
-|`>>`|[Functions](../functions/index.md)|<ul><li>Composes two functions (forward composition operator).<br /></li></ul>|
-|`>>>`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Shifts bits in the quantity on the left side to the right by the number of places specified on the right side.<br /></li></ul>|
-|`>=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than or equal to the right side; otherwise, returns `false`.<br /></li></ul>|
 |`>=?`|[Nullable Operators](nullable-operators.md)|<ul><li>Computes the "greater than or equal" operation when the right side is a nullable type.<br /></li></ul>|
-|`?`|[Parameters and Arguments](../parameters-and-arguments.md)|<ul><li>Specifies an optional argument.<br /></li><li>Used as an operator for dynamic method and property calls. You must provide your own implementation.<br /></li></ul>|
-|`? ... <- ...`||<ul><li>Used as an operator for setting dynamic properties. You must provide your own implementation.<br /></li></ul>|
 |`?>=`, `?>`, `?<=`, `?<`, `?=`, `?<>`, `?+`, `?-`, `?*`, `?/`|[Nullable Operators](nullable-operators.md)|<ul><li>Equivalent to the corresponding operators without the ? prefix, where a nullable type is on the left.<br /></li></ul>|
 |`>=?`, `>?`, `<=?`, `<?`, `=?`, `<>?`, `+?`, `-?`, `*?`, `/?`|[Nullable Operators](nullable-operators.md)|<ul><li>Equivalent to the corresponding operators without the ? suffix, where a nullable type is on the right.<br /></li></ul>|
 |`?>=?`, `?>?`, `?<=?`, `?<?`, `?=?`, `?<>?`, `?+?`, `?-?`, `?*?`, `?/?`|[Nullable Operators](nullable-operators.md)|<ul><li>Equivalent to the corresponding operators without the surrounding question marks, where both sides are nullable types.<br /></li></ul>|
-|`@`|[Lists](../lists.md)<br /><br />[Strings](../strings.md)|<ul><li>Concatenates two lists.<br /></li><li>When placed before a string literal, indicates that the string is to be interpreted verbatim, with no interpretation of escape characters.<br /></li></ul>|
-|`[...]`|[Lists](../lists.md)|<ul><li>Delimits the elements of a list.<br /></li></ul>|
-|<code>[&#124;...&#124;]</code>|[Arrays](../arrays.md)|<ul><li>Delimits the elements of an array.<br /></li></ul>|
-|`[<...>]`|[Attributes](../attributes.md)|<ul><li>Delimits an attribute.<br /></li></ul>|
-|`\`|[Strings](../strings.md)|<ul><li>Escapes the next character; used in character and string literals.<br /></li></ul>|
-|`^`|[Statically Resolved Type Parameters](../generics/statically-resolved-type-parameters.md)<br /><br />[Strings](../strings.md)|<ul><li>Specifies type parameters that must be resolved at compile time, not at runtime.<br /></li><li>Concatenates strings.<br /></li></ul>|
-|`^^^`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise exclusive OR operation.<br /></li></ul>|
-|`_`|[Match Expressions](../match-expressions.md)<br /><br />[Generics](../generics/index.md)|<ul><li>Indicates a wildcard pattern.<br /></li><li>Specifies an anonymous generic parameter.<br /></li></ul>|
-|<code>&#96;</code>|[Automatic Generalization](../generics/automatic-generalization.md)|<ul><li>Used internally to indicate a generic type parameter.<br /></li></ul>|
-|`{...}`|[Sequences](../sequences.md)<br /><br />[Records](../records.md)|<ul><li>Delimits sequence expressions and computation expressions.<br /></li><li>Used in record definitions.<br /></li></ul>|
-|<code>&#124;</code>|[Match Expressions](../match-expressions.md)|<ul><li>Delimits individual match cases, individual discriminated union cases, and enumeration values.<br /></li></ul>|
-|<code>&#124;&#124;</code>|[Boolean Operators](boolean-operators.md)|<ul><li>Computes the Boolean OR operation.<br /></li></ul>|
-|<code>&#124;&#124;&#124;</code>|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise OR operation.<br /></li></ul>|
-|`~~`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary negation operator.<br /></li></ul>|
-|`~~~`|[Bitwise Operators](bitwise-operators.md)|<ul><li>Computes the bitwise NOT operation.<br /></li></ul>|
-|`~-`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary minus operator.<br /></li></ul>|
-|`~+`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary plus operator.<br /></li></ul>|
 
 ## Operator precedence
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -30,7 +30,7 @@ The following table describes symbols related to strings and provides a brief de
 |------------------|-----|-----------|
 |`"`|[Literals](../literals.md)<br /><br />[Strings](../strings.md)|<ul><li>Delimits a text string.<br /></li></ul>|
 |`"""`|[Strings](../strings.md)|Delimits a verbatim text string. Differs from `@"..."` in that a you can indicate a quotation mark character by using a single quote in the string.|
-|`$"`|[Strings](../strings.md)|Starts an interpolated string.|
+|`$"`|[Interpolated Strings](../interpolated-strings.md)|Starts an interpolated string.|
 |`'`|[Literals](../literals.md)|<ul><li>Delimits a single-character literal.<br /></li></ul>|
 |<code>&#96;&#96;...&#96;&#96;</code>||<ul><li>Delimits an identifier that would otherwise not be a legal identifier, such as a language keyword.<br /></li></ul>|
 |`\`|[Strings](../strings.md)|<ul><li>Escapes the next character; used in character and string literals.<br /></li></ul>|

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -58,8 +58,8 @@ The following table describes the comparison operators in the F# language and pr
 |`<>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is not equal to the right side; otherwise, returns false.<br /></li></ul>|
 |`<=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is less than or equal to the right side; otherwise, returns `false`.<br /></li></ul>|
 |`=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is equal to the right side; otherwise, returns `false`.<br /></li></ul>|
-|`>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than the right side; otherwise, returns `false`.<br /></li></ul>|r /></li></ul>|
-|`>=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than or equal to the right side; otherwise, returns `false`.<br 
+|`>`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than the right side; otherwise, returns `false`.<br /></li></ul>|
+|`>=`|[Arithmetic Operators](arithmetic-operators.md)|<ul><li>Returns `true` if the left side is greater than or equal to the right side; otherwise, returns `false`.<br /></li></ul>|
 
 ## Boolean operators
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -150,7 +150,7 @@ The following table describes symbols related to quotations.
 |`%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into typed code quotations.<br /></li></ul>|
 |`%%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into untyped code quotations.<br /></li></ul>|
 
-## Additional symbols used in expressions 
+## Additional symbols used in expressions
 
 The following table describes additional symbols used in expressions
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -8,7 +8,7 @@ fl_keywords:
 # Symbol and operator reference
 
 This article includes tables describing the symbols and operators that are used in the F# language. Some symbols
-and operators have two entries.
+and operators have two or more entries when used in multiple roles.
 
 ## Comment, compiler directive and attribute symbols
 
@@ -139,7 +139,20 @@ The following table describes symbols related to reference cells and provides a 
 |`!`|[Reference Cells](../reference-cells.md)<br /><br />[Computation Expressions](../computation-expressions.md)|<ul><li>Dereferences a reference cell.<br /></li><li>After a keyword, indicates a modified version of the keyword's behavior as controlled by a workflow.<br /></li></ul>|
 |`:=`|[Reference Cells](../reference-cells.md)|<ul><li>Assigns a value to a reference cell.<br /></li></ul>|
 
-## Symbols used in expressions
+## Symbols used in quotations
+
+The following table describes symbols related to quotations.
+
+|Symbol or operator|Links|Description|
+|------------------|-----|-----------|
+|`<@...@>`|[Code Quotations](../code-quotations.md)|<ul><li>Delimits a typed code quotation.<br /></li></ul>|
+|`<@@...@@>`|[Code Quotations](../code-quotations.md)|<ul><li>Delimits an untyped code quotation.<br /></li></ul>|
+|`%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into typed code quotations.<br /></li></ul>|
+|`%%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into untyped code quotations.<br /></li></ul>|
+
+## Additional symbols used in expressions 
+
+The following table describes additional symbols used in expressions
 
 |Symbol or operator|Links|Description|
 |------------------|-----|-----------|
@@ -151,7 +164,7 @@ The following table describes symbols related to reference cells and provides a 
 |`;`|[Verbose Syntax](../verbose-syntax.md)<br /><br />[Lists](../lists.md)<br /><br />[Records](../records.md)|<ul><li>Separates expressions (used mostly in verbose syntax).<br /></li><li>Separates elements of a list.<br /></li><li>Separates fields of a record.<br /></li></ul>|
 |`->`|[Sequences](../sequences.md)|<ul><li>Yields an expression (in sequence expressions); equivalent to the `do yield` keywords.<br /></li></ul>|
 
-## Symbols used in match expressions and patterns
+## Additional symbols used in match patterns
 
 The following table describes symbols related to pattern matching and provides a brief description of each.
 
@@ -162,9 +175,9 @@ The following table describes symbols related to pattern matching and provides a
 |`_`|[Match Expressions](../match-expressions.md)<br /><br />[Generics](../generics/index.md)|<ul><li>Indicates a wildcard pattern.<br /></li><li>Specifies an anonymous generic parameter.<br /></li></ul>|
 |<code>&#124;</code>|[Match Expressions](../match-expressions.md)|<ul><li>Delimits individual match cases, individual discriminated union cases, and enumeration values.<br /></li></ul>|
 
-## Symbols used in declarations
+## Additional symbols used in declarations
 
-The following table describes symbols related to declarations:
+The following table describes symbols related to declarations.
 
 |Symbol or operator|Links|Description|
 |------------------|-----|-----------|
@@ -173,20 +186,9 @@ The following table describes symbols related to declarations:
 |`~-`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary minus operator.<br /></li></ul>|
 |`~+`|[Operator Overloading](../operator-overloading.md)|<ul><li>Used to declare an overload for the unary plus operator.<br /></li></ul>|
 
-## Symbols used in quotations
-
-The following table describes symbols related to quotations and provides a brief description of each.
-
-|Symbol or operator|Links|Description|
-|------------------|-----|-----------|
-|`<@...@>`|[Code Quotations](../code-quotations.md)|<ul><li>Delimits a typed code quotation.<br /></li></ul>|
-|`<@@...@@>`|[Code Quotations](../code-quotations.md)|<ul><li>Delimits an untyped code quotation.<br /></li></ul>|
-|`%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into typed code quotations.<br /></li></ul>|
-|`%%`|[Code Quotations](../code-quotations.md)|<ul><li>Used for splicing expressions into untyped code quotations.<br /></li></ul>|
-
 ## Nullable operators
 
-[Nullable Operators](nullable-operators.md) are defined for use in F# queries. The following table shows these operators:
+[Nullable Operators](nullable-operators.md) are defined for use in F# queries. The following table shows these operators.
 
 |Symbol or operator|Links|Description|
 |------------------|-----|-----------|

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -1,6 +1,6 @@
 ---
-title: Nullable Operators
-description: Learn about the nullable operators that are available in the F# programming language.
+title: Nullable Operators (Queries)
+description: Learn about the nullable operators that are available in the F# programming language, for use in query expressions.
 ms.date: 05/16/2016
 ---
 # Nullable Operators
@@ -8,7 +8,7 @@ ms.date: 05/16/2016
 Nullable operators are binary arithmetic or comparison operators that work with nullable arithmetic types on one or both sides. Nullable types arise frequently when you work with data from sources such as databases that allow nulls in place of actual values. Nullable operators are used frequently in query expressions. In addition to nullable operators for arithmetic and comparison, conversion operators can be used to convert between nullable types. There are also nullable versions of certain query operators.
 
 > [!NOTE]
-> Nullable operators are generally only used in [query expressions](../query-expressions.md). If you do not use query expressions, you do not need to
+> Nullable operators are only used in [query expressions](../query-expressions.md). If you do not use query expressions, you do not need to
 > know or use these operators.
 
 ## Table of Nullable Operators

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -7,6 +7,10 @@ ms.date: 05/16/2016
 
 Nullable operators are binary arithmetic or comparison operators that work with nullable arithmetic types on one or both sides. Nullable types arise frequently when you work with data from sources such as databases that allow nulls in place of actual values. Nullable operators are used frequently in query expressions. In addition to nullable operators for arithmetic and comparison, conversion operators can be used to convert between nullable types. There are also nullable versions of certain query operators.
 
+> [!NOTE]
+> Nullable operators are generally only used in [query expressions](../query-expressions.md). If you do not use query expressions, you do not need to
+> know or use these operators.
+
 ## Table of Nullable Operators
 
 The following table lists nullable operators supported in the F# language.

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -8,7 +8,7 @@ ms.date: 05/16/2016
 Nullable operators are binary arithmetic or comparison operators that work with nullable arithmetic types on one or both sides. Nullable types arise frequently when you work with data from sources such as databases that allow nulls in place of actual values. Nullable operators are used frequently in query expressions. In addition to nullable operators for arithmetic and comparison, conversion operators can be used to convert between nullable types. There are also nullable versions of certain query operators.
 
 > [!NOTE]
-> Nullable operators are only used in [query expressions](../query-expressions.md). If you do not use query expressions, you do not need to
+> Nullable operators are only used in [query expressions](../query-expressions.md). If you don't use query expressions, you don't need to
 > know or use these operators.
 
 ## Table of Nullable Operators

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -5,10 +5,10 @@ ms.date: 05/16/2016
 ---
 # Nullable Operators in Queries
 
-Nullable operators are binary arithmetic or comparison operators that work with nullable arithmetic types on one or both sides. Nullable types arise frequently when you work with data from sources such as databases that allow nulls in place of actual values. Nullable operators are used frequently in query expressions. In addition to nullable operators for arithmetic and comparison, conversion operators can be used to convert between nullable types. There are also nullable versions of certain query operators.
+Nullable operators are binary arithmetic or comparison operators that work with nullable arithmetic types on one or both sides. Nullable types arise when you work with data from sources such as databases that allow nulls in place of actual values. Nullable operators are used in query expressions. In addition to nullable operators for arithmetic and comparison, conversion operators can be used to convert between nullable types. There are also nullable versions of certain query operators.
 
 > [!NOTE]
-> Nullable operators are only used in [query expressions](../query-expressions.md). If you don't use query expressions, you don't need to
+> Nullable operators are generally only used in [query expressions](../query-expressions.md). If you don't use query expressions, you don't need to
 > know or use these operators.
 
 ## Table of Nullable Operators

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -1,7 +1,7 @@
 ---
 title: Nullable Operators in Queries
 description: Learn about the nullable operators that are available in the F# programming language, for use in query expressions.
-ms.date: 05/16/2016
+ms.date: 07/26/2021
 ---
 # Nullable Operators in Queries
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -1,9 +1,9 @@
 ---
-title: Nullable Operators (Queries)
+title: Nullable Operators in Queries
 description: Learn about the nullable operators that are available in the F# programming language, for use in query expressions.
 ms.date: 05/16/2016
 ---
-# Nullable Operators
+# Nullable Operators in Queries
 
 Nullable operators are binary arithmetic or comparison operators that work with nullable arithmetic types on one or both sides. Nullable types arise frequently when you work with data from sources such as databases that allow nulls in place of actual values. Nullable operators are used frequently in query expressions. In addition to nullable operators for arithmetic and comparison, conversion operators can be used to convert between nullable types. There are also nullable versions of certain query operators.
 


### PR DESCRIPTION
We've had commentary that F# has "too many operators"

In practice, users need to know very few of them, the reset are corner case, see https://github.com/dsyme/fsharp-presentations/blob/master/design-notes/on-teaching-operators.md

This is one of a number of edits I'll be making to help clarify when certain operators come into play.

