### PR TITLE
Use 'T1 etc for type variables in F#

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1312,14 +1312,14 @@ The guidelines below apply to both functions, members, and type definitions.
 Keep generic type arguments and constraints on a single line if it’s not too long:
 
 ```fsharp
-let f<'a, 'b when 'a: equality and 'b: comparison> param =
+let f<'T1, 'T2 when 'T1: equality and 'T2: comparison> param =
     // function body
 ```
 
 If both generic type arguments/constraints and function parameters don’t fit, but the type parameters/constraints alone do, place the parameters on new lines:
 
 ```fsharp
-let f<'a, 'b when 'a : equality and 'b : comparison>
+let f<'T1, 'T2 when 'T1 : equality and 'T2 : comparison>
     param
     =
     // function body
@@ -1328,10 +1328,10 @@ let f<'a, 'b when 'a : equality and 'b : comparison>
 If the type parameters or constraints are too long, break and align them as shown below. Keep the list of type parameters on the same line as the function, regardless of its length. For constraints, place `when` on the first line, and keep each constraint on a single line regardless of its length. Place `>` at the end of the last line. Indent the constraints by one level.
 
 ```fsharp
-let inline f< ^a, ^b
-    when ^a : (static member Foo1: unit -> ^b)
-    and ^b : (member Foo2: unit -> int)
-    and ^b : (member Foo3: string -> ^a option)>
+let inline f< ^T1, ^T2
+    when ^T1 : (static member Foo1: unit -> ^T2)
+    and ^T2 : (member Foo2: unit -> int)
+    and ^T2 : (member Foo3: string -> ^T1 option)>
     arg1
     arg2
     =
@@ -1341,10 +1341,10 @@ let inline f< ^a, ^b
 If the type parameters/constraints are broken up, but there are no normal function parameters, place the `=` on a new line regardless:
 
 ```f#
-let inline f<^a, ^b
-    when ^a : (static member Foo1: unit -> ^b)
-    and ^b : (member Foo2: unit -> int)
-    and ^b : (member Foo3: string -> ^a option)>
+let inline f<^T1, ^T2
+    when ^T1 : (static member Foo1: unit -> ^T2)
+    and ^T2 : (member Foo2: unit -> int)
+    and ^T2 : (member Foo3: string -> ^T1 option)>
     =
     // function body
 ```


### PR DESCRIPTION
F# style guidelines prefer the use of `'T1` etc for type variables.

Pointed out on twitter https://twitter.com/jordan_n_marr/status/1420043164535173125