### PR TITLE
Update ca5393.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -23,6 +23,7 @@ Using one of the unsafe values of <xref:System.Runtime.InteropServices.DllImport
 - `AssemblyDirectory`
 - `UseDllDirectoryForDependencies`
 - `ApplicationDirectory`
+- `LegacyBehavior`
 
 ## Rule description
 
@@ -34,7 +35,6 @@ For more information, see [Load Library Safely](https://msrc-blog.microsoft.com/
 
 Use safe values of <xref:System.Runtime.InteropServices.DllImportSearchPath> to specify an explicit search path instea:
 
-- `LegacyBehavior`
 - `SafeDirectories`
 - `System32`
 - `UserDirectories`

--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -33,7 +33,7 @@ For more information, see [Load Library Safely](https://msrc-blog.microsoft.com/
 
 ## How to fix violations
 
-Use safe values of <xref:System.Runtime.InteropServices.DllImportSearchPath> to specify an explicit search path instea:
+Use safe values of <xref:System.Runtime.InteropServices.DllImportSearchPath> to specify an explicit search path instead:
 
 - `SafeDirectories`
 - `System32`


### PR DESCRIPTION
LegacyBehavior triggers this warning.
`warning CA5393: Use of unsafe DllImportSearchPath value LegacyBehavior`

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
