### PR TITLE
Clean up learning links on main F# docs page

### DIFF
--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -9,15 +9,17 @@ metadata:
   ms.topic: landing-page # Required
   author: cartermp
   ms.author: phcart
-  ms.date: 08/29/2020
+  ms.date: 07/28/2021
 
 landingContent:
   - title: "Learn to program in F#"
     linkLists:
       - linkListType: get-started
         links:
-          - text: "What is F#?"
-            url: what-is-fsharp.md
+          - text: "Hello World tutorial"
+            url: https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial
+          - text: "Learn F#"
+            url: https://dotnet.microsoft.com/learn/fsharp
           - text: "Install F#"
             url: get-started/install-fsharp.md
           - text: "Get started with F# in Visual Studio"
@@ -28,10 +30,6 @@ landingContent:
         links:
           - text: Download the .NET Core SDK
             url: https://dotnet.microsoft.com/download
-      - linkListType: get-started
-        links:
-          - text: F# on Q&A
-            url: /answers/topics/dotnet-fsharp.html
   - title: "F# fundamentals"
     linkLists:
       - linkListType: overview

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -22,8 +22,6 @@ landingContent:
             url: get-started/install-fsharp.md
           - text: "Learn F#"
             url: https://dotnet.microsoft.com/learn/fsharp
-          - text: "Learn F#"
-            url: https://dotnet.microsoft.com/learn/fsharp
           - text: "Get started with F# in Visual Studio"
             url: get-started/get-started-visual-studio.md
           - text: "Get started with F# in Visual Studio Code"

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -59,7 +59,7 @@ landingContent:
           - text: "Async programming in F#"
             url: tutorials/asynchronous-and-concurrent-programming/async.md
           - text: "Type providers"
-            url: tutorials/type-providers/
+            url: tutorials/type-providers/index.md
 
   - title: "New features in F#"
     linkLists:

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -31,7 +31,7 @@ landingContent:
       - linkListType: video
         links:
           - text: "Beginning F# video series"
-            url: https://aka.ms/beginning-fsharp-videos
+            url: https://aka.ms/BeginnersSeriesFSharp
       - linkListType: download
         links:
           - text: Download the .NET Core SDK

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -16,16 +16,22 @@ landingContent:
     linkLists:
       - linkListType: get-started
         links:
-          - text: "Hello World tutorial"
-            url: https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial
-          - text: "Learn F#"
-            url: https://dotnet.microsoft.com/learn/fsharp
+          - text: "First steps in F#"
+            url: /learn/modules/fsharp-first-steps/
           - text: "Install F#"
             url: get-started/install-fsharp.md
+          - text: "Learn F#"
+            url: https://dotnet.microsoft.com/learn/fsharp
+          - text: "Learn F#"
+            url: https://dotnet.microsoft.com/learn/fsharp
           - text: "Get started with F# in Visual Studio"
             url: get-started/get-started-visual-studio.md
           - text: "Get started with F# in Visual Studio Code"
             url: get-started/get-started-vscode.md
+      - linkListType: video
+        links:
+          - text: "Beginning F# video series"
+            url: https://aka.ms/beginning-fsharp-videos
       - linkListType: download
         links:
           - text: Download the .NET Core SDK

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -16,16 +16,18 @@ landingContent:
     linkLists:
       - linkListType: get-started
         links:
+          - text: "What is F#?"
+            url: what-is-fsharp.md
           - text: "First steps in F#"
             url: /learn/modules/fsharp-first-steps/
           - text: "Install F#"
             url: get-started/install-fsharp.md
-          - text: "Learn F#"
-            url: https://dotnet.microsoft.com/learn/fsharp
           - text: "Get started with F# in Visual Studio"
             url: get-started/get-started-visual-studio.md
           - text: "Get started with F# in Visual Studio Code"
             url: get-started/get-started-vscode.md
+          - text: "Further learning"
+            url: https://dotnet.microsoft.com/learn/fsharp
       - linkListType: video
         links:
           - text: "Beginning F# video series"

--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -42,10 +42,6 @@ landingContent:
         links:
           - text: "Tour of F#"
             url: tour.md
-          - text: "Introduction to Functional Programming in F#"
-            url: introduction-to-functional-programming/index.md
-          - text: "First-class functions"
-            url: introduction-to-functional-programming/first-class-functions.md
       - linkListType: concept
         links:
           - text: "F# style guide"
@@ -56,8 +52,14 @@ landingContent:
             url: style-guide/conventions.md
       - linkListType: tutorial
         links:
+          - text: "Introduction to Functional Programming in F#"
+            url: introduction-to-functional-programming/index.md
+          - text: "First-class functions"
+            url: introduction-to-functional-programming/first-class-functions.md
           - text: "Async programming in F#"
             url: tutorials/asynchronous-and-concurrent-programming/async.md
+          - text: "Type providers"
+            url: tutorials/type-providers/
 
   - title: "New features in F#"
     linkLists:


### PR DESCRIPTION

We've been reviewing the various paths into F# learning

1. We'd like to highlight https://dotnet.microsoft.com/learn/fsharp as the curated learning page for F#. It needs work but Beth Massi is improving it and it is the primary learning link we should use

2. We need one "get started immediately" link.  Currently the best we have is https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial/intro and indeed this is what's linked from the main F# landing page https://dotnet.microsoft.com/languages/fsharp.  So  let's use this here.

3. The Q&A forums are not yet appropriate to link due to low volume. We can revist this later. But suggest removing that for now