### PR TITLE
Added an include for logging articles regarding samples browser

### DIFF
--- a/docs/core/extensions/console-log-formatter.md
+++ b/docs/core/extensions/console-log-formatter.md
@@ -22,6 +22,8 @@ In this article, you will learn about console log formatters. The sample source 
   - Update configuration via <xref:Microsoft.Extensions.Options.IOptionsMonitor%601>
   - Enable custom color formatting
 
+[!INCLUDE [logging-samples-browser](includes/logging-samples-browser.md)]
+
 ## Register formatter
 
 The [`Console` logging provider](logging-providers.md#console) has several predefined formatters, and exposes the ability to author your own custom formatter. To register any of the available formatters, use the corresponding `Add{Type}Console` extension method:

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -3,13 +3,15 @@ title: Implement a custom logging provider in .NET
 description: Learn how to implement a custom logging provider in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 06/22/2021
+ms.date: 07/30/2021
 ms.topic: how-to
 ---
 
 # Implement a custom logging provider in .NET
 
 There are many [logging providers](logging-providers.md) available for common logging needs. You may need to implement a custom <xref:Microsoft.Extensions.Logging.ILoggerProvider> when one of the available providers doesn't suit your application needs. In this article, you'll learn how to implement a custom logging provider that can be used to colorize logs in the console.
+
+[!INCLUDE [logging-samples-browser](includes/logging-samples-browser.md)]
 
 ### Sample custom logger configuration
 

--- a/docs/core/extensions/high-performance-logging.md
+++ b/docs/core/extensions/high-performance-logging.md
@@ -3,7 +3,7 @@ title: High-performance logging in .NET
 author: IEvangelist
 description: Learn how to use LoggerMessage to create cacheable delegates that require fewer object allocations for high-performance logging scenarios.
 ms.author: dapine
-ms.date: 01/04/2021
+ms.date: 07/30/2021
 ---
 
 # High-performance logging in .NET
@@ -16,6 +16,8 @@ The <xref:Microsoft.Extensions.Logging.LoggerMessage> class exposes functionalit
 - Logger extension methods must parse the message template (named format string) every time a log message is written. <xref:Microsoft.Extensions.Logging.LoggerMessage> only requires parsing a template once when the message is defined.
 
 The sample app demonstrates <xref:Microsoft.Extensions.Logging.LoggerMessage> features with a priority queue processing worker service. The app processes work items in priority order. As these operations occur, log messages are generated using the <xref:Microsoft.Extensions.Logging.LoggerMessage> pattern.
+
+[!INCLUDE [logging-samples-browser](includes/logging-samples-browser.md)]
 
 ## Define a logger message
 

--- a/docs/core/extensions/includes/logging-samples-browser.md
+++ b/docs/core/extensions/includes/logging-samples-browser.md
@@ -1,0 +1,9 @@
+---
+author: IEvangelist
+ms.author: dapine
+ms.date: 07/30/2021
+ms.topic: include
+---
+
+> [!TIP]
+> All of the logging example source code is available in the **Samples Browser** for download. For more information, see [Browse code samples: Logging in .NET](/samples/dotnet/samples/csharp-logging-fundamentals).

--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -3,7 +3,7 @@ title: Compile-time logging source generation
 description: Learn how to use the LoggerMessageAttribute and compile-time source generation for logging in .NET.
 author: maryamariyan
 ms.author: maariyan
-ms.date: 05/18/2021
+ms.date: 07/30/2021
 ---
 
 # Compile-time logging source generation
@@ -17,6 +17,8 @@ ms.date: 05/18/2021
 .NET 6 introduces the `LoggerMessageAttribute` type. This attribute is part of the `Microsoft.Extensions.Logging` namespace, and when used, it source-generates performant logging APIs. The source-generation logging support is designed to deliver a highly usable and highly performant logging solution for modern .NET applications. The auto-generated source code relies on the <xref:Microsoft.Extensions.Logging.ILogger> interface in conjunction with <xref:Microsoft.Extensions.Logging.LoggerMessage.Define%2A?displayProperty=nameWithType> functionality.
 
 The source generator is triggered when `LoggerMessageAttribute` is used on `partial` logging methods. When triggered, it is either able to autogenerate the implementation of the `partial` methods it's decorating, or produce compile-time diagnostics with hints about proper usage. The compile-time logging solution is typically considerably faster at run time than existing logging approaches. It achieves this by eliminating boxing, temporary allocations, and copies to the maximum extent possible.
+
+[!INCLUDE [logging-samples-browser](includes/logging-samples-browser.md)]
 
 ## Basic usage
 

--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -3,12 +3,14 @@ title: Logging in .NET
 author: IEvangelist
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
 ms.author: dapine
-ms.date: 02/19/2021
+ms.date: 07/30/2021
 ---
 
 # Logging in .NET
 
 .NET supports a logging API that works with a variety of built-in and third-party logging providers. This article shows how to use the logging API with built-in providers. Most of the code examples shown in this article apply to any .NET app that uses the [Generic Host](generic-host.md). For apps that don't use the Generic Host, see [Non-host console app](#non-host-console-app).
+
+[!INCLUDE [logging-samples-browser](includes/logging-samples-browser.md)]
 
 ## Create logs
 


### PR DESCRIPTION
## Summary

Added an include that can be plugged into logging articles with samples browser snippets

Fixes #25314, relies on https://github.com/dotnet/samples/pull/4719

Internal preview

✔️ [Logging in .NET](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/logging?branch=pr-en-us-25402&tabs=command-line)