### PR TITLE
Remove redundant content in formatting-rules.md

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
@@ -396,9 +396,6 @@ csharp_indent_case_contents_when_block = true
 | **Introduced version** | Visual Studio 2017 version 15.3 |
 | **Option values** | `true` - Indent `switch` case contents<br /><br />`false` - Do not indent `switch` case contents |
 
-- When this rule is set to **true**, i.
-- When this rule is set to **false**, d.
-
 Code examples:
 
 ```csharp


### PR DESCRIPTION
The *i* and *d* at the end of the two removed sentences are likely just the words *indent* and *do*, i.e., the start of the two sentences above for "Option values".

Seems like leftover text when porting this doc from an older format, so I removed them.