### PR TITLE
Make affected apis not required

### DIFF
--- a/.github/ISSUE_TEMPLATE/breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/breaking-change.yml
@@ -98,9 +98,6 @@ body:
     attributes:
       label: Affected APIs
       description: List all the APIs affected by this change. For methods, clarify if it's all overloads or specific overloads.
-      placeholder: None.
-    validations:
-      required: true
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
There was an unfortunate bug where if you submitted an issue without adding any text other than whitespace in affected apis, the issue submission failed and you lost all your inputs.