### PR TITLE
Windows SDK version override

### DIFF
--- a/docs/core/compatibility/5.0.md
+++ b/docs/core/compatibility/5.0.md
@@ -125,6 +125,7 @@ If you're migrating an app to .NET 5, the breaking changes listed here might aff
 
 - [Directory.Packages.props files imported by default](sdk/5.0/directory-packages-props-imported-by-default.md)
 - [Error generated when executable project references mismatched executable](sdk/5.0/referencing-executable-generates-error.md)
+- [FrameworkReference replaced with WindowsSdkPackageVersion for Windows SDK](sdk/5.0/override-windows-sdk-package-version.md)
 - [NETCOREAPP3_1 preprocessor symbol not defined](sdk/5.0/netcoreapp3_1-preprocessor-symbol-not-defined.md)
 - [OutputType set to WinExe](sdk/5.0/automatically-infer-winexe-output-type.md)
 - [PublishDepsFilePath behavior change](sdk/5.0/publishdepsfilepath-behavior-change.md)

--- a/docs/core/compatibility/sdk/5.0/override-windows-sdk-package-version.md
+++ b/docs/core/compatibility/sdk/5.0/override-windows-sdk-package-version.md
@@ -8,7 +8,7 @@ ms.date: 08/04/2021
 Starting in .NET 5.0.8 (which includes .NET SDK 5.0.302 and .NET SDK 5.0.205), developers targeting Windows can't use the `FrameworkReference` item to override their version of the Windows SDK targeting package. The `WindowsSdkPackageVersion` property replaces this functionality.
 
 > [!NOTE]
-> We don't recommend overriding the Windows SDK version, because the Windows SDK targeting packages are included with the .NET 5+ SDK. Instead, to reference the latest Windows SDK package, update your version of the .NET SDK. This property should only be used in rare cases such as using preview packages or needing to override the version of C#/WinRT.
+> We don't recommend overriding the Windows SDK version, because the Windows SDK targeting packages are included with the .NET 5+ SDK. Instead, to reference the latest Windows SDK package, update your version of the .NET SDK.
 
 ## Version introduced
 

--- a/docs/core/compatibility/sdk/5.0/override-windows-sdk-package-version.md
+++ b/docs/core/compatibility/sdk/5.0/override-windows-sdk-package-version.md
@@ -1,0 +1,49 @@
+---
+title: "Breaking change: Use WindowsSdkPackageVersion to override Windows SDK version"
+description: Learn about the breaking change in .NET 5 where the WindowsSdkPackageVersion property replaces the FrameworkReference item for overriding the version of the Windows SDK targeting package.
+ms.date: 08/04/2021
+---
+# FrameworkReference replaced with WindowsSdkPackageVersion for Windows SDK
+
+Starting in .NET 5.0.8 (which includes .NET SDK 5.0.302 and .NET SDK 5.0.205), developers targeting Windows can't use the `FrameworkReference` item to override their version of the Windows SDK targeting package. The `WindowsSdkPackageVersion` property replaces this functionality.
+
+## Version introduced
+
+.NET SDK 5.0.302, .NET SDK 5.0.205
+
+## Previous behavior
+
+Developers could use the `FrameworkReference` item to override the Windows SDK package version in .NET 5 applications. For example:
+
+```xml
+<ItemGroup>
+  <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.18" />
+  <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.18" />
+</ItemGroup>
+```
+
+## New behavior
+
+The [`WindowsSdkPackageVersion`](../../../project-sdk/msbuild-props.md#windowssdkpackageversion) property replaces the behavior of the `FrameworkReference` override. For example:
+
+```xml
+<PropertyGroup>
+  <WindowsSdkPackageVersion>10.0.19041.18</WindowsSdkPackageVersion>
+</PropertyGroup>
+```
+
+## Category of change
+
+This change might affect [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change was introduced to simplify the package override behavior for targeting the Windows SDK packages produced by C#/WinRT.
+
+## Recommended action
+
+Remove any use of `FrameworkReference` in your .NET 5+ app's project file when targeting the Windows SDK.
+
+## Affected APIs
+
+Windows APIs in .NET 5 and later versions that are provided by the [Windows SDK targeting package](https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref).

--- a/docs/core/compatibility/sdk/5.0/override-windows-sdk-package-version.md
+++ b/docs/core/compatibility/sdk/5.0/override-windows-sdk-package-version.md
@@ -7,6 +7,9 @@ ms.date: 08/04/2021
 
 Starting in .NET 5.0.8 (which includes .NET SDK 5.0.302 and .NET SDK 5.0.205), developers targeting Windows can't use the `FrameworkReference` item to override their version of the Windows SDK targeting package. The `WindowsSdkPackageVersion` property replaces this functionality.
 
+> [!NOTE]
+> We don't recommend overriding the Windows SDK version, because the Windows SDK targeting packages are included with the .NET 5+ SDK. Instead, to reference the latest Windows SDK package, update your version of the .NET SDK. This property should only be used in rare cases such as using preview packages or needing to override the version of C#/WinRT.
+
 ## Version introduced
 
 .NET SDK 5.0.302, .NET SDK 5.0.205

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -340,7 +340,7 @@ items:
         - name: TargetFramework change from netcoreapp to net
           href: sdk/5.0/targetframework-name-change.md
         - name: Use WindowsSdkPackageVersion for Windows SDK
-          href: sdk/5.0/override-windows-sdk-package-versions.md
+          href: sdk/5.0/override-windows-sdk-package-version.md
       - name: Security
         items:
         - name: Code access security APIs are obsolete
@@ -730,7 +730,7 @@ items:
         - name: TargetFramework change from netcoreapp to net
           href: sdk/5.0/targetframework-name-change.md
         - name: Use WindowsSdkPackageVersion for Windows SDK
-          href: sdk/5.0/override-windows-sdk-package-versions.md
+          href: sdk/5.0/override-windows-sdk-package-version.md
         - name: WinForms and WPF apps use Microsoft.NET.Sdk
           href: sdk/5.0/sdk-and-target-framework-change.md
       - name: .NET Core 2.1 - 3.1

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -339,6 +339,8 @@ items:
           href: sdk/5.0/publishdepsfilepath-behavior-change.md
         - name: TargetFramework change from netcoreapp to net
           href: sdk/5.0/targetframework-name-change.md
+        - name: Use WindowsSdkPackageVersion for Windows SDK
+          href: sdk/5.0/override-windows-sdk-package-versions.md
       - name: Security
         items:
         - name: Code access security APIs are obsolete
@@ -727,6 +729,8 @@ items:
           href: sdk/5.0/publishdepsfilepath-behavior-change.md
         - name: TargetFramework change from netcoreapp to net
           href: sdk/5.0/targetframework-name-change.md
+        - name: Use WindowsSdkPackageVersion for Windows SDK
+          href: sdk/5.0/override-windows-sdk-package-versions.md
         - name: WinForms and WPF apps use Microsoft.NET.Sdk
           href: sdk/5.0/sdk-and-target-framework-change.md
       - name: .NET Core 2.1 - 3.1

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -785,6 +785,19 @@ The `ValidateExecutableReferencesMatchSelfContained` property can be used to dis
 </PropertyGroup>
 ```
 
+### WindowsSdkPackageVersion
+
+The `WindowsSdkPackageVersion` property can be used to override the version of the [Windows SDK targeting package](https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref). This property was introduced in .NET 5, and replaces the use of the `FrameworkReference` item for this purpose.
+
+```xml
+<PropertyGroup>
+  <WindowsSdkPackageVersion>10.0.19041.18</WindowsSdkPackageVersion>
+</PropertyGroup>
+```
+
+> [!NOTE]
+> We don't recommend overriding the Windows SDK version, because the Windows SDK targeting packages are included with the .NET 5+ SDK. Instead, to reference the latest Windows SDK package, update your version of the .NET SDK. This property should only be used in rare cases such as using preview packages or needing to override the version of C#/WinRT.
+
 ## Run-related properties
 
 The following properties are used for launching an app with the [`dotnet run`](../tools/dotnet-run.md) command:


### PR DESCRIPTION
Fixes #25396.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/5.0/override-windows-sdk-package-version?branch=pr-en-us-25466).