### PR TITLE
Add publish GHA to landing page

### DIFF
--- a/docs/fundamentals/index.yml
+++ b/docs/fundamentals/index.yml
@@ -102,6 +102,8 @@ landingContent:
         links:
           - text: App publishing
             url: ../core/deploying/index.md
+          - text: GitHub Actions: publish .NET apps
+            url: ../devops/dotnet-publish-github-action.md
 
   # Card
   - title: Use .NET Core from the command line

--- a/docs/fundamentals/index.yml
+++ b/docs/fundamentals/index.yml
@@ -102,7 +102,7 @@ landingContent:
         links:
           - text: App publishing
             url: ../core/deploying/index.md
-          - text: GitHub Actions: publish .NET apps
+          - text: Publish .NET apps with GitHub Actions
             url: ../devops/dotnet-publish-github-action.md
 
   # Card


### PR DESCRIPTION
## Summary

Add GHA to .NET fundamentals landing page


[Internal preview: .NET Fundamentals landing page](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/?branch=pr-en-us-25472)