### PR TITLE
Unity 2021.2 will support .NET Standard 2.1

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -8,7 +8,7 @@
 | Xamarin.Mac                | 3.0    | 3.0    | 3.0   | 3.0   | 3.0   | 3.0                | 3.0                | 3.8                 | 5.16 |
 | Xamarin.Android            | 7.0    | 7.0    | 7.0   | 7.0   | 7.0   | 7.0                | 7.0                | 8.0                 | 10.0 |
 | Universal Windows Platform | 10.0   | 10.0   | 10.0  | 10.0  | 10.0  | 10.0.16299         | 10.0.16299         | 10.0.16299          | TBD |
-| Unity                      | 2018.1 | 2018.1 | 2018.1| 2018.1| 2018.1| 2018.1             |  2018.1            | 2018.1              | TBD |
+| Unity                      | 2018.1 | 2018.1 | 2018.1| 2018.1| 2018.1| 2018.1             |  2018.1            | 2018.1              | 2021.2 (not yet released) |
 
 <sup>1 The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/main/release-notes/download-archive.md) if you cannot upgrade to Visual Studio 2017 or a later version.</sup>
 

--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -8,7 +8,7 @@
 | Xamarin.Mac                | 3.0    | 3.0    | 3.0   | 3.0   | 3.0   | 3.0                | 3.0                | 3.8                 | 5.16 |
 | Xamarin.Android            | 7.0    | 7.0    | 7.0   | 7.0   | 7.0   | 7.0                | 7.0                | 8.0                 | 10.0 |
 | Universal Windows Platform | 10.0   | 10.0   | 10.0  | 10.0  | 10.0  | 10.0.16299         | 10.0.16299         | 10.0.16299          | TBD |
-| Unity                      | 2018.1 | 2018.1 | 2018.1| 2018.1| 2018.1| 2018.1             |  2018.1            | 2018.1              | 2021.2 (not yet released) |
+| Unity                      | 2018.1 | 2018.1 | 2018.1| 2018.1| 2018.1| 2018.1             |  2018.1            | 2018.1              | 2021.2.0b6 |
 
 <sup>1 The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/main/release-notes/download-archive.md) if you cannot upgrade to Visual Studio 2017 or a later version.</sup>
 


### PR DESCRIPTION
## Summary

As shown in https://unity3d.com/unity/beta/2021.2.0b6, Unity 2021.2 Beta 6 added support for .NET Standard 2.1. This PR changes the .NET Standard support table.

https://dotnet.microsoft.com/platform/dotnet-standard#versions will also have to be updated.