### PR TITLE
Update F# formatting for exception patterns

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1012,21 +1012,22 @@ with
     printfn "A second that was a multiple of 3"
 ```
 
-Always add a `|` for each clause, even when only having a single clause.
+Add a `|` for each clause, except when there is only a single clause consisting of a simple value pattern:
 
 ```fsharp
 // OK
+try
+    persistState currentState
+with ex ->
+    printfn "Something went wrong: %A" ex
+
+// Not OK
 try
     persistState currentState
 with
 | ex ->
     printfn "Something went wrong: %A" ex
 
-// Not OK
-try
-    persistState currentState
-with ex ->
-    printfn "Something went wrong: %A" ex
 ```
 
 ## Formatting function parameter application

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1012,13 +1012,19 @@ with
     printfn "A second that was a multiple of 3"
 ```
 
-Add a `|` for each clause, except when there is only a single clause consisting of a simple value pattern:
+Add a `|` for each clause, except when there is only a single clause:
 
 ```fsharp
 // OK
 try
     persistState currentState
 with ex ->
+    printfn "Something went wrong: %A" ex
+
+// OK
+try
+    persistState currentState
+with :? System.ApplicationException as ex ->
     printfn "Something went wrong: %A" ex
 
 // Not OK
@@ -1028,6 +1034,12 @@ with
 | ex ->
     printfn "Something went wrong: %A" ex
 
+// Not OK
+try
+    persistState currentState
+with
+| :? System.ApplicationException as ex ->
+    printfn "Something went wrong: %A" ex
 ```
 
 ## Formatting function parameter application


### PR DESCRIPTION
This relates to  https://github.com/fsprojects/fantomas/issues/1854#issuecomment-894324296 and will need some discussion with @nojaf (since it messes the Fantomas formatting tool around to change these rules)

I don't understand why we would be recommending changing this code:
```fsharp
try
    persistState currentState
with ex ->
    printfn "Something went wrong: %A" ex
```
to
```fsharp
try
    persistState currentState
with
| ex ->
    printfn "Something went wrong: %A" ex
```

The second is surely harder to read.

For non-simple solitary clauses I don't mind using `|` in this case - it can help disambiguate the `:?` and allow further exception types to be added - but the simplest rule is "one clause, no bar".  So not this:
```fsharp
try
    persistState currentState
with
| :? SomeException as ex ->
    printfn "Something went wrong: %A" ex
```
but rather this:
```fsharp
try
    persistState currentState
with :? SomeException as ex ->
    printfn "Something went wrong: %A" ex
```
