### PR TITLE
Discussion from runtime/issues/12506

### DIFF
--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -16,7 +16,7 @@ Starting with .NET 5.0, the runtime can emit events through `EventPipe` with det
 
 ## Collect a trace with assembly loading events
 
-### Tracing an existing process
+### Trace an existing process
 
 To enable assembly loading events in the runtime and collect a trace of them, use `dotnet-trace` with the following command:
 

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -38,7 +38,8 @@ dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe 
 You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd> key. Doing this will also exit hello.exe.
 
 > [!NOTE]
-> * Launching hello.exe via dotnet-trace will redirect its input/output and you will not be able to interact with it on the console by default. Use the `--show-child-io` switch to interact with its stdin/stdout.
+>
+> * Launching hello.exe via dotnet-trace will redirect its input and output, and you won't be able to interact with it on the console by default. Use the `--show-child-io` switch to interact with its `stdin` and `stdout`.
 > * Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process.
 > * If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable.
 

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -26,7 +26,7 @@ dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 --process-id 
 
 This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader` events in the `Microsoft-Windows-DotNETRuntime` provider. The result is a `.nettrace` file.
 
-### Using dotnet-trace to launch a child process and trace it from startup
+### Use dotnet-trace to launch a child process and trace it from startup
 
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use dotnet-trace to do this.
 

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -19,7 +19,6 @@ Starting with .NET 5.0, the runtime can emit events through `EventPipe` with det
 
 ## Collect a trace with assembly loading events
 
-
 You can use `dotnet-trace` to trace an existing process or to launch a child process and trace it from startup.
 
 ### Trace an existing process

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -16,6 +16,7 @@ Starting with .NET 5.0, the runtime can emit events through `EventPipe` with det
 
 ## Collect a trace with assembly loading events
 
+### Tracing an existing process
 To enable assembly loading events in the runtime and collect a trace of them, use `dotnet-trace` with the following command:
 
 ```console
@@ -23,6 +24,21 @@ dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 --process-id 
 ```
 
 This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader` events in the `Microsoft-Windows-DotNETRuntime` provider. The result is a `.nettrace` file.
+
+### Using dotnet-trace to launch a child process and trace it from startup
+Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace.
+
+This will launch hello.exe with arg1 and arg2 as its command line arguments and collect a trace from its runtime startup:
+```console
+dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe arg1 arg2
+```
+
+You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd> key. Doing this will also exit hello.exe.
+
+> [!NOTE]
+> * Launching hello.exe via dotnet-trace will redirect its input/output and you will not be able to interact with it on the console by default. Use the `--show-child-io` switch to interact with its stdin/stdout.
+> * Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process.
+> * If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable.
 
 ## View a trace
 

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -12,7 +12,11 @@ Starting with .NET 5.0, the runtime can emit events through `EventPipe` with det
 ## Prerequisites
 
 - [.NET 5.0 SDK](https://dotnet.microsoft.com/download) or later versions
-- [dotnet-trace](../diagnostics/dotnet-trace.md) tool.
+- [`dotnet-trace`](../diagnostics/dotnet-trace.md) tool.
+
+> [!NOTE]
+>
+> For more details on usage of `dotnet-trace` please refer to [`dotnet-trace`](../diagnostics/dotnet-trace.md) tool documentation.  The scope of `dotnet-trace` capabilities is greater than collecting detailed assembly loading information.
 
 ## Collect a trace with assembly loading events
 

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -36,7 +36,7 @@ The following command launches hello.exe with `arg1` and `arg2` as its command l
 dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe arg1 arg2
 ```
 
-You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>. This also closes hello.exe.
+You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>. This also closes _hello.exe_.
 
 > [!NOTE]
 >

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -30,7 +30,7 @@ This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader
 
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use dotnet-trace to do this.
 
-This will launch hello.exe with arg1 and arg2 as its command line arguments and collect a trace from its runtime startup:
+The following command launches hello.exe with `arg1` and `arg2` as its command line arguments and collects a trace from its runtime startup:
 
 ```console
 dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe arg1 arg2

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -28,7 +28,7 @@ This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader
 
 ### Use dotnet-trace to launch a child process and trace it from startup
 
-Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use dotnet-trace to do this.
+Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use `dotnet-trace` to do this.
 
 The following command launches hello.exe with `arg1` and `arg2` as its command line arguments and collects a trace from its runtime startup:
 

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -28,7 +28,7 @@ This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader
 
 ### Using dotnet-trace to launch a child process and trace it from startup
 
-Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace.
+Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use dotnet-trace to do this.
 
 This will launch hello.exe with arg1 and arg2 as its command line arguments and collect a trace from its runtime startup:
 ```console

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -35,7 +35,7 @@ This will launch hello.exe with arg1 and arg2 as its command line arguments and 
 dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe arg1 arg2
 ```
 
-You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd> key. Doing this will also exit hello.exe.
+You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>. This also closes hello.exe.
 
 > [!NOTE]
 >

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -17,6 +17,7 @@ Starting with .NET 5.0, the runtime can emit events through `EventPipe` with det
 ## Collect a trace with assembly loading events
 
 ### Tracing an existing process
+
 To enable assembly loading events in the runtime and collect a trace of them, use `dotnet-trace` with the following command:
 
 ```console
@@ -26,6 +27,7 @@ dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 --process-id 
 This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader` events in the `Microsoft-Windows-DotNETRuntime` provider. The result is a `.nettrace` file.
 
 ### Using dotnet-trace to launch a child process and trace it from startup
+
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, it is possible to do this by using dotnet-trace.
 
 This will launch hello.exe with arg1 and arg2 as its command line arguments and collect a trace from its runtime startup:

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -31,6 +31,7 @@ This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use dotnet-trace to do this.
 
 This will launch hello.exe with arg1 and arg2 as its command line arguments and collect a trace from its runtime startup:
+
 ```console
 dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe arg1 arg2
 ```

--- a/docs/core/dependency-loading/collect-details.md
+++ b/docs/core/dependency-loading/collect-details.md
@@ -12,13 +12,15 @@ Starting with .NET 5.0, the runtime can emit events through `EventPipe` with det
 ## Prerequisites
 
 - [.NET 5.0 SDK](https://dotnet.microsoft.com/download) or later versions
-- [`dotnet-trace`](../diagnostics/dotnet-trace.md) tool.
+- [`dotnet-trace`](../diagnostics/dotnet-trace.md) tool
 
 > [!NOTE]
->
-> For more details on usage of `dotnet-trace` please refer to [`dotnet-trace`](../diagnostics/dotnet-trace.md) tool documentation.  The scope of `dotnet-trace` capabilities is greater than collecting detailed assembly loading information.
+> The scope of `dotnet-trace` capabilities is greater than collecting detailed assembly loading information. For more information on the usage of `dotnet-trace`, see [`dotnet-trace`](../diagnostics/dotnet-trace.md).
 
 ## Collect a trace with assembly loading events
+
+
+You can use `dotnet-trace` to trace an existing process or to launch a child process and trace it from startup.
 
 ### Trace an existing process
 
@@ -28,13 +30,13 @@ To enable assembly loading events in the runtime and collect a trace of them, us
 dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 --process-id <pid>
 ```
 
-This will collect a trace of the specified `<pid>`, enabling the `AssemblyLoader` events in the `Microsoft-Windows-DotNETRuntime` provider. The result is a `.nettrace` file.
+This command collects a trace of the specified `<pid>`, enabling the `AssemblyLoader` events in the `Microsoft-Windows-DotNETRuntime` provider. The result is a `.nettrace` file.
 
 ### Use dotnet-trace to launch a child process and trace it from startup
 
 Sometimes it may be useful to collect a trace of a process from its startup. For apps running .NET 5.0 or later, you can use `dotnet-trace` to do this.
 
-The following command launches hello.exe with `arg1` and `arg2` as its command line arguments and collects a trace from its runtime startup:
+The following command launches *hello.exe* with `arg1` and `arg2` as its command line arguments and collects a trace from its runtime startup:
 
 ```console
 dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:4 -- hello.exe arg1 arg2
@@ -44,9 +46,9 @@ You can stop collecting the trace by pressing <kbd>Enter</kbd> or <kbd>Ctrl</kbd
 
 > [!NOTE]
 >
-> * Launching hello.exe via dotnet-trace will redirect its input and output, and you won't be able to interact with it on the console by default. Use the `--show-child-io` switch to interact with its `stdin` and `stdout`.
-> * Exiting the tool via CTRL+C or SIGTERM will safely end both the tool and the child process.
-> * If the child process exits before the tool, the tool will exit as well and the trace should be safely viewable.
+> * Launching *hello.exe* via `dotnet-trace` redirects its input and output, and you won't be able to interact with it on the console by default. Use the `--show-child-io` switch to interact with its `stdin` and `stdout`.
+> * Exiting the tool via <kbd>Ctrl</kbd>+<kbd>C</kbd> or `SIGTERM` safely ends both the tool and the child process.
+> * If the child process exits before the tool, the tool exits as well and the trace should be safely viewable.
 
 ## View a trace
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/12506#issuecomment-895276247

This article currently covers the verbose and (arguably, less common) way of using dotnet-trace to debug assembly loading issues, as most assembly loading issues likely occur when the generic IHostBuilder is initially called.

I debated rewriting the whole article to emphasize this use case, but I tempered that to simply get this documented with what I feel is the natural way to trace assembly loading events.

For the content, I elected to mostly use the docs @vitek-karas team has already written, here: https://github.com/dotnet/diagnostics/blob/main/documentation/dotnet-trace-instructions.md#using-dotnet-trace-to-launch-a-child-process-and-trace-it-from-startup

I realize copy-paste is not great, but I felt it was important to capture in this article the full flow of calling a new process.  I also fixed some minor stuff like kbd escape tags.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
