### PR TITLE
Prediction engine pool multiple predictions

### DIFF
--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -1,7 +1,7 @@
 ---
 title: Make predictions with a trained model
 description: Learn to make predictions using a trained ML.NET model
-ms.date: 08/09/2021
+ms.date: 08/11/2021
 author: luisquintanilla
 ms.author: luquinta
 ms.custom: mvc, how-to
@@ -141,12 +141,12 @@ The predicted values in the score column should look like the following:
 
 ## Multiple predictions (PredictionEnginePool)
 
-To make multiple predictions using [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602), you can take an `IEnumerable` containing multiple instances of your model input. For example and `IEnumerable<HousingInput>` and apply the [`Predict`](xref:Microsoft.Extensions.ML.PredictionEnginePoolExtensions.Predict%2A) method to each element using LINQ's [`Select`](xref:System.Linq.Enumerable.Select%2A) method.
+To make multiple predictions using [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602), you can take an `IEnumerable` containing multiple instances of your model input. For example an `IEnumerable<HousingInput>` and apply the [`Predict`](xref:Microsoft.Extensions.ML.PredictionEnginePoolExtensions.Predict%2A) method to each element using LINQ's [`Select`](xref:System.Linq.Enumerable.Select%2A) method.
 
-This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) called `predictionEnginePool` and an `IEnumerable<HousingData>` called `inputs`.
+This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) called `predictionEnginePool` and an `IEnumerable<HousingData>` called `housingData`.
 
 ```csharp
-IEnumerable<HousingPrediction> predictions = inputs.Select(input => predictionEnginePool.Predict(input));
+IEnumerable<HousingPrediction> predictions = housingData.Select(input => predictionEnginePool.Predict(input));
 ```
 
 The result is an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingPrediction>`.

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -86,10 +86,10 @@ If you access the `Score` property of the `prediction` object, you should get a 
 
 > [!TIP]
 > [`PredictionEngine`](xref:Microsoft.ML.PredictionEngine%602) is not thread-safe. Additionally, you have to create an instance of it everywhere it is needed within your application. As your application grows, this process can become unmanageable. For improved performance and thread safety, use a combination of dependency injection and the [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) service, which creates an [`ObjectPool`](xref:Microsoft.Extensions.ObjectPool.ObjectPool%601) of [`PredictionEngine`](xref:Microsoft.ML.PredictionEngine%602) objects for use throughout your application.
+>
+> The following link provides more information if you want to learn more about [dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection).
 
-The following link provides more information if you want to learn more about dependency injection in ASP.NET Core.
-
-## Multiple predictions (Transform)
+## Multiple predictions (IDataView)
 
 Given the following data, load it into an [`IDataView`](xref:Microsoft.ML.IDataView). In this case, the name of the [`IDataView`](xref:Microsoft.ML.IDataView) is `inputData`. Because `CurrentPrice` is the target or label you're trying to predict using new data, it's assumed there is no value for it at the moment.
 
@@ -139,7 +139,7 @@ The predicted values in the score column should look like the following:
 
 ## Multiple predictions (PredictionEnginePool)
 
-To make multiple predictions using [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602), you can take an `IEnumerable` containing multiple instances of your model input. For example and `IEnumerable<HousingInput>` and apply the [`Predict`](xref:Microsoft.Extensions.ML.PredictionEnginePoolExtensions.Predict) method to each element using LINQ's [`Select`](xref:System.Linq.Enumerable.Select%2A) method.
+To make multiple predictions using [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602), you can take an `IEnumerable` containing multiple instances of your model input. For example and `IEnumerable<HousingInput>` and apply the [`Predict`](xref:Microsoft.Extensions.ML.PredictionEnginePoolExtensions.Predict%2A) method to each element using LINQ's [`Select`](xref:System.Linq.Enumerable.Select%2A) method.
 
 This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) called `predictionEnginePool` and an `IEnumerable<HousingData>` called `inputs`.
 

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -144,7 +144,7 @@ To make multiple predictions using [PredictionEnginePool](xref:Microsoft.Extensi
 This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) called `predictionEnginePool` and an `IEnumerable<HousingData>` called `inputs`.
 
 ```csharp
-IEnumerable<HousingOutputs> predictions = inputs.Select(input => predictionEnginePool.Predict(input));
+IEnumerable<HousingPrediction> predictions = inputs.Select(input => predictionEnginePool.Predict(input));
 ```
 
 The result is an an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingPrediction>`.

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -149,4 +149,4 @@ This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extens
 IEnumerable<HousingPrediction> predictions = inputs.Select(input => predictionEnginePool.Predict(input));
 ```
 
-The result is an an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingPrediction>`.
+The result is an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingPrediction>`.

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -1,7 +1,7 @@
 ---
 title: Make predictions with a trained model
-description: Learn to make predictions using a trained model
-ms.date: 09/18/2019
+description: Learn to make predictions using a trained ML.NET model
+ms.date: 08/09/2021
 author: luisquintanilla
 ms.author: luquinta
 ms.custom: mvc, how-to
@@ -84,7 +84,12 @@ HousingPrediction prediction = predictionEngine.Predict(inputData);
 
 If you access the `Score` property of the `prediction` object, you should get a value similar to `150079`.
 
-## Multiple predictions
+> [!TIP]
+> [`PredictionEngine`](xref:Microsoft.ML.PredictionEngine%602) is not thread-safe. Additionally, you have to create an instance of it everywhere it is needed within your application. As your application grows, this process can become unmanageable. For improved performance and thread safety, use a combination of dependency injection and the [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) service, which creates an [`ObjectPool`](xref:Microsoft.Extensions.ObjectPool.ObjectPool%601) of [`PredictionEngine`](xref:Microsoft.ML.PredictionEngine%602) objects for use throughout your application.
+
+The following link provides more information if you want to learn more about dependency injection in ASP.NET Core.
+
+## Multiple predictions (Transform)
 
 Given the following data, load it into an [`IDataView`](xref:Microsoft.ML.IDataView). In this case, the name of the [`IDataView`](xref:Microsoft.ML.IDataView) is `inputData`. Because `CurrentPrice` is the target or label you're trying to predict using new data, it's assumed there is no value for it at the moment.
 
@@ -131,3 +136,15 @@ The predicted values in the score column should look like the following:
 | 1 | 144638.2 |
 | 2 | 150079.4 |
 | 3 | 107789.8 |
+
+## Multiple predictions (PredictionEnginePool)
+
+To make multiple predictions using [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602), you can take an `IEnumerable` containing multiple instances of your model input. For example and `IEnumerable<HousingInput>` and apply the [`Predict`](xref:Microsoft.Extensions.ML.PredictionEnginePoolExtensions.Predict) method to each element using LINQ's [`Select`](xref:System.Linq.Enumerable.Select%2A) method.
+
+This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) called `predictionEnginePool` and an `IEnumerable<HousingData>` called `inputs`.
+
+```csharp
+IEnumerable<HousingOutputs> predictions = inputs.Select(input => predictionEnginePool.Predict(input));
+```
+
+The result is an an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingOutputs>`.

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -89,7 +89,7 @@ If you access the `Score` property of the `prediction` object, you should get a 
 >
 > For examples on how to use the [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) service, see [deploy a model to a web API](serve-model-web-api-ml-net.md) and [deploy a model to Azure Functions](serve-model-serverless-azure-functions-ml-net.md).
 >
-> See [dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection) for more information. 
+> See [dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection) for more information.
 
 
 ## Multiple predictions (IDataView)

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -147,4 +147,4 @@ This code sample assumes you have a [PredictionEnginePool](xref:Microsoft.Extens
 IEnumerable<HousingOutputs> predictions = inputs.Select(input => predictionEnginePool.Predict(input));
 ```
 
-The result is an an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingOutputs>`.
+The result is an an `IEnumerable` containing instances of your predictions. In this case, it would be `IEnumerable<HousingPrediction>`.

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -91,7 +91,6 @@ If you access the `Score` property of the `prediction` object, you should get a 
 >
 > See [dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection) for more information.
 
-
 ## Multiple predictions (IDataView)
 
 Given the following data, load it into an [`IDataView`](xref:Microsoft.ML.IDataView). In this case, the name of the [`IDataView`](xref:Microsoft.ML.IDataView) is `inputData`. Because `CurrentPrice` is the target or label you're trying to predict using new data, it's assumed there is no value for it at the moment.

--- a/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net.md
@@ -87,7 +87,10 @@ If you access the `Score` property of the `prediction` object, you should get a 
 > [!TIP]
 > [`PredictionEngine`](xref:Microsoft.ML.PredictionEngine%602) is not thread-safe. Additionally, you have to create an instance of it everywhere it is needed within your application. As your application grows, this process can become unmanageable. For improved performance and thread safety, use a combination of dependency injection and the [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) service, which creates an [`ObjectPool`](xref:Microsoft.Extensions.ObjectPool.ObjectPool%601) of [`PredictionEngine`](xref:Microsoft.ML.PredictionEngine%602) objects for use throughout your application.
 >
-> The following link provides more information if you want to learn more about [dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection).
+> For examples on how to use the [PredictionEnginePool](xref:Microsoft.Extensions.ML.PredictionEnginePool%602) service, see [deploy a model to a web API](serve-model-web-api-ml-net.md) and [deploy a model to Azure Functions](serve-model-serverless-azure-functions-ml-net.md).
+>
+> See [dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection) for more information. 
+
 
 ## Multiple predictions (IDataView)
 


### PR DESCRIPTION
Add PredictionEnginePool information and how to use it to make multiple predictions.

Fixes #24841

[Preview Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/machine-learning-model-predictions-ml-net?branch=pr-en-us-25540)