### PR TITLE
Switch to common parenthesis style in C# patterns snippet

### DIFF
--- a/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
@@ -27,7 +27,8 @@ namespace patterns
             else if (sequence is null)
             {
                 throw new ArgumentNullException(nameof(sequence), "Sequence can't be null.");
-            } else
+            }
+            else
             {
                 int halfLength = sequence.Count() / 2 - 1;
                 if (halfLength < 0) halfLength = 0;


### PR DESCRIPTION
## Summary

Minor change to fix an inconsistent parenthesis style

