### PR TITLE
Moved Program.cs comment

### DIFF
--- a/docs/core/tutorials/top-level-templates.md
+++ b/docs/core/tutorials/top-level-templates.md
@@ -8,8 +8,8 @@ ms.date: 07/13/2021
 Starting with the .NET 6 Preview 7 SDK, the console app template generates the following code:
 
 ```csharp
-Console.WriteLine("Hello, World!");
 // See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");
 ```
 
 The new output uses recent C# features that simplify the code you need to write for a program. Traditionally, the console app template generated the following code:


### PR DESCRIPTION
[A relatively recent change](https://github.com/dotnet/templating/commit/871b9c01c808915a0825226987bb40bfa2d7ed8e#diff-79f14e93e40296be130cbc2a92583b0522f70abb362d6f9ca89068e68a17576c) moved the comment above the `Console.WriteLine` line. Since this change was included in Preview 7, this article should reflect it.