### PR TITLE
Adding summary table

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -19,15 +19,15 @@ All types and type members have an accessibility level. The accessibility level 
 - [private protected](../../language-reference/keywords/private-protected.md): The type or member can be accessed only within its declaring assembly, by code in the same `class` or in a type that is derived from that `class`.
 
 **Summary Table**
-| Caller's location ↓  | public | protected internal | protected | internal | private protected | private
-| -- | -- | -- | -- | -- | -- | --
-| ***Within the assembly*** |   |   |   |   |   |  
-| Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-| Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-| Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌
-| ***In an external assembly*** |   |   |   |   |   |  
-| Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-| Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌
+| Caller's location ↓  | public | protected internal | protected | internal | private protected | private |
+| -- | -- | -- | -- | -- | -- | -- |
+| ***Within the assembly*** |   |   |   |   |   |   |
+| Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ |
+| Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌ |
+| ***In an external assembly*** |   |   |   |   |   |   |
+| Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ |
+| Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 The following examples demonstrate how to specify access modifiers on a type and member:
 

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -18,7 +18,8 @@ All types and type members have an accessibility level. The accessibility level 
 - [protected internal](../../language-reference/keywords/protected-internal.md): The type or member can be accessed by any code in the assembly in which it's declared, or from within a derived `class` in another assembly.
 - [private protected](../../language-reference/keywords/private-protected.md): The type or member can be accessed only within its declaring assembly, by code in the same `class` or in a type that is derived from that `class`.
 
-**Summary Table**
+**Summary table**
+
 | Caller's location ↓  | public | protected internal | protected | internal | private protected | private |
 | -- | -- | -- | -- | -- | -- | -- |
 | ***Within the assembly*** |   |   |   |   |   |   |

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -19,7 +19,7 @@ All types and type members have an accessibility level. The accessibility level 
 - [private protected](../../language-reference/keywords/private-protected.md): The type or member can be accessed only within its declaring assembly, by code in the same `class` or in a type that is derived from that `class`.
 
 **Summary Table**
-| Caller's location ↓  | public | protected internal | protected | internal | private protected | private 
+| Caller's location ↓  | public | protected internal | protected | internal | private protected | private
 | -- | -- | -- | -- | -- | -- | --
 | ***Within the assembly*** |   |   |   |   |   |  
 | Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -18,6 +18,17 @@ All types and type members have an accessibility level. The accessibility level 
 - [protected internal](../../language-reference/keywords/protected-internal.md): The type or member can be accessed by any code in the assembly in which it's declared, or from within a derived `class` in another assembly.
 - [private protected](../../language-reference/keywords/private-protected.md): The type or member can be accessed only within its declaring assembly, by code in the same `class` or in a type that is derived from that `class`.
 
+**Summary Table**
+Caller's location ↓  | public | protected internal | protected | internal | private protected | private 
+-- | -- | -- | -- | -- | -- | --
+**<ins>Within the assembly</ins>** |   |   |   |   |   |  
+Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
+Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌
+**<ins>In an external assembly</ins>** |   |   |   |   |   |  
+Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
+Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌
+
 The following examples demonstrate how to specify access modifiers on a type and member:
 
 [!code-csharp[PublicAccess](~/samples/snippets/csharp/objectoriented/accessmodifiers.cs#PublicAccess)]

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -20,7 +20,7 @@ All types and type members have an accessibility level. The accessibility level 
 
 **Summary table**
 
-| Caller's location ↓  | public | protected internal | protected | internal | private protected | private |
+| Caller's location  | `public` | `protected internal` | `protected` | `internal` | `private protected` | `private` |
 | -- | -- | -- | -- | -- | -- | -- |
 | ***Within the assembly*** |   |   |   |   |   |   |
 | Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -21,11 +21,11 @@ All types and type members have an accessibility level. The accessibility level 
 **Summary Table**
 | Caller's location ↓  | public | protected internal | protected | internal | private protected | private 
 | -- | -- | -- | -- | -- | -- | --
-| **<ins>Within the assembly</ins>** |   |   |   |   |   |  
+| ***Within the assembly*** |   |   |   |   |   |  
 | Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
 | Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
 | Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌
-| **<ins>In an external assembly</ins>** |   |   |   |   |   |  
+| ***In an external assembly*** |   |   |   |   |   |  
 | Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
 | Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌
 

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -19,15 +19,15 @@ All types and type members have an accessibility level. The accessibility level 
 - [private protected](../../language-reference/keywords/private-protected.md): The type or member can be accessed only within its declaring assembly, by code in the same `class` or in a type that is derived from that `class`.
 
 **Summary Table**
-Caller's location ↓  | public | protected internal | protected | internal | private protected | private 
--- | -- | -- | -- | -- | -- | --
-**<ins>Within the assembly</ins>** |   |   |   |   |   |  
-Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌
-**<ins>In an external assembly</ins>** |   |   |   |   |   |  
-Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌
+| Caller's location ↓  | public | protected internal | protected | internal | private protected | private 
+| -- | -- | -- | -- | -- | -- | --
+| **<ins>Within the assembly</ins>** |   |   |   |   |   |  
+| Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+| Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
+| Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌
+| **<ins>In an external assembly</ins>** |   |   |   |   |   |  
+| Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
+| Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌
 
 The following examples demonstrate how to specify access modifiers on a type and member:
 


### PR DESCRIPTION
## Summary

Adding a summary table for Access Modifiers:

**Summary Table**
Caller's location ↓  | public | protected internal | protected | internal | private protected | private 
-- | -- | -- | -- | -- | -- | --
**<ins>Within the assembly</ins>** |   |   |   |   |   |  
Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌
**<ins>In an external assembly</ins>** |   |   |   |   |   |  
Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌

I took @BillWagner's suggestion for the order of the columns and also switched some rows to make the table look even better with an almost perfect triangular shape.

Fixes #25424

