### PR TITLE
Document dotnet workload restore command

### DIFF
--- a/docs/core/tools/dotnet-workload-install.md
+++ b/docs/core/tools/dotnet-workload-install.md
@@ -71,45 +71,29 @@ The `dotnet workload update` command also downloads advertising manifests. The d
 
 [!INCLUDE [config-file](../../../includes/cli-configfile.md)]
 
-- **`--disable-parallel`**
+[!INCLUDE [disable-parallel](../../../includes/cli-disable-parallel.md)]
 
-  Prevents restoring multiple projects in parallel.
+[!INCLUDE [download-to-cache](../../../includes/cli-download-to-cache.md)]
 
-- **`--download-to-cache <PATH_TO_CACHE>`**
-
-  Downloads packages needed for a workload to a folder that can be used for offline installation.
-
-- **`--from-cache <PATH_TO_CACHE>`**
-
-  Complete the operation from cache (offline).
+[!INCLUDE [from-cache](../../../includes/cli-from-cache.md)]
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
-- **`--ignore-failed-sources`**
+[!INCLUDE [ignore-failed-sources](../../../includes/cli-ignore-failed-sources.md)]
 
-  Treats package source failures as warnings.
-
-- **`--include-previews`**
-
-  Allows prerelease workload manifests.
+[!INCLUDE [include-previews](../../../includes/cli-include-previews.md)]
 
 [!INCLUDE [interactive](../../../includes/cli-interactive.md)]
 
-- **`--no-cache`**
-
-  Prevents caching of packages and http requests.
+[!INCLUDE [no-cache](../../../includes/cli-no-cache.md)]
 
 [!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
 
-- **`--skip-manifest-update`**
-
-  Skip updating the workload manifests. The workload manifests define what assets and versions need to be installed for each workload.
+[!INCLUDE [skip-manifest-update](../../../includes/cli-skip-manifest-update.md)]
 
 [!INCLUDE [source](../../../includes/cli-source.md)]
 
-- **`--temp-dir <PATH>`**
-
-  Configure the temporary directory used for this command (must be secure).
+[!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
 

--- a/docs/core/tools/dotnet-workload-list.md
+++ b/docs/core/tools/dotnet-workload-list.md
@@ -48,7 +48,7 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 [!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
-[!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
+[!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 
 ## Examples
 

--- a/docs/core/tools/dotnet-workload-list.md
+++ b/docs/core/tools/dotnet-workload-list.md
@@ -32,31 +32,21 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 <!-- markdownlint-disable MD012 -->
 
-- **`--disable-parallel`**
-
-  Prevents restoring multiple projects in parallel.
+[!INCLUDE [disable-parallel](../../../includes/cli-disable-parallel.md)]
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
-- **`--ignore-failed-sources`**
+[!INCLUDE [ignore-failed-sources](../../../includes/cli-ignore-failed-sources.md)]
 
-  Treats package source failures as warnings.
-
-- **`--include-previews`**
-
-  Allows prerelease workload manifests.
+[!INCLUDE [include-previews](../../../includes/cli-include-previews.md)]
 
 [!INCLUDE [interactive](../../../includes/cli-interactive.md)]
 
-- **`--no-cache`**
-
-  Prevents caching of packages and http requests.
+[!INCLUDE [no-cache](../../../includes/cli-no-cache.md)]
 
 [!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
 
-- **`--temp-dir <PATH>`**
-
-  Specify the temporary directory used to download and extract NuGet packages (must be secure).
+[!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
 

--- a/docs/core/tools/dotnet-workload-list.md
+++ b/docs/core/tools/dotnet-workload-list.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet workload list command
 description: The 'dotnet workload list' command lists installed workloads.
-ms.date: 07/08/2021
+ms.date: 08/12/2021
 ---
 # dotnet workload list
 
@@ -14,7 +14,10 @@ ms.date: 07/08/2021
 ### Synopsis
 
 ```dotnetcli
-dotnet workload list [-v|--verbosity <LEVEL>]
+dotnet workload list [--disable-parallel]
+    [--ignore-failed-sources] [--include-previews]
+    [--interactive] [--no-cache] [--sdk-version <VERSION>]
+    [--temp-dir <PATH>] [-v|--verbosity <LEVEL>]
 
 dotnet workload list [-?|-h|--help]
 ```
@@ -29,9 +32,33 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 <!-- markdownlint-disable MD012 -->
 
+- **`--disable-parallel`**
+
+  Prevents restoring multiple projects in parallel.
+
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
-[!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
+- **`--ignore-failed-sources`**
+
+  Treats package source failures as warnings.
+
+- **`--include-previews`**
+
+  Allows prerelease workload manifests.
+
+[!INCLUDE [interactive](../../../includes/cli-interactive.md)]
+
+- **`--no-cache`**
+
+  Prevents caching of packages and http requests.
+
+[!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
+
+- **`--temp-dir <PATH>`**
+
+  Specify the temporary directory used to download and extract NuGet packages (must be secure).
+
+[!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
 
 ## Examples
 

--- a/docs/core/tools/dotnet-workload-repair.md
+++ b/docs/core/tools/dotnet-workload-repair.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet workload repair command
 description: The 'dotnet workload repair' command repairs workload installations.
-ms.date: 07/08/2021
+ms.date: 08/12/2021
 ---
 # dotnet workload repair
 
@@ -15,8 +15,10 @@ ms.date: 07/08/2021
 
 ```dotnetcli
 dotnet workload repair
-    [--configfile <FILE>] [--sdk-version <VERSION>]
-    [--source <SOURCE>] [-v|--verbosity <LEVEL>]
+    [--configfile] [--disable-parallel] [--ignore-failed-sources]
+    [--interactive] [--no-cache] [--sdk-version <VERSION>]
+    [-s|--source <SOURCE>] [--temp-dir <PATH>]
+    [-v|--verbosity <LEVEL>]
 
 dotnet workload repair -?|-h|--help
 ```
@@ -39,11 +41,33 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 [!INCLUDE [config-file](../../../includes/cli-configfile.md)]
 
+- **`--disable-parallel`**
+
+  Prevents restoring multiple projects in parallel.
+
 [!INCLUDE [help](../../../includes/cli-help.md)]
+
+- **`--ignore-failed-sources`**
+
+  Treats package source failures as warnings.
+
+- **`--include-previews`**
+
+  Allows prerelease workload manifests.
+
+[!INCLUDE [interactive](../../../includes/cli-interactive.md)]
+
+- **`--no-cache`**
+
+  Prevents caching of packages and http requests.
 
 [!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
 
 [!INCLUDE [source](../../../includes/cli-source.md)]
+
+- **`--temp-dir <PATH>`**
+
+  Specify the temporary directory used to download and extract NuGet packages (must be secure).
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 

--- a/docs/core/tools/dotnet-workload-repair.md
+++ b/docs/core/tools/dotnet-workload-repair.md
@@ -41,33 +41,23 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 [!INCLUDE [config-file](../../../includes/cli-configfile.md)]
 
-- **`--disable-parallel`**
-
-  Prevents restoring multiple projects in parallel.
+[!INCLUDE [disable-parallel](../../../includes/cli-disable-parallel.md)]
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
-- **`--ignore-failed-sources`**
+[!INCLUDE [ignore-failed-sources](../../../includes/cli-ignore-failed-sources.md)]
 
-  Treats package source failures as warnings.
-
-- **`--include-previews`**
-
-  Allows prerelease workload manifests.
+[!INCLUDE [include-previews](../../../includes/cli-include-previews.md)]
 
 [!INCLUDE [interactive](../../../includes/cli-interactive.md)]
 
-- **`--no-cache`**
-
-  Prevents caching of packages and http requests.
+[!INCLUDE [no-cache](../../../includes/cli-no-cache.md)]
 
 [!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
 
 [!INCLUDE [source](../../../includes/cli-source.md)]
 
-- **`--temp-dir <PATH>`**
-
-  Specify the temporary directory used to download and extract NuGet packages (must be secure).
+[!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 

--- a/docs/core/tools/dotnet-workload-restore.md
+++ b/docs/core/tools/dotnet-workload-restore.md
@@ -42,45 +42,29 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 [!INCLUDE [config-file](../../../includes/cli-configfile.md)]
 
-- **`--disable-parallel`**
+[!INCLUDE [disable-parallel](../../../includes/cli-disable-parallel.md)]
 
-  Prevents restoring multiple projects in parallel.
+[!INCLUDE [download-to-cache](../../../includes/cli-download-to-cache.md)]
 
-- **`--download-to-cache <PATH_TO_CACHE>`**
-
-  Downloads packages needed for a workload to a folder that can be used for offline installation.
-
-- **`--from-cache <PATH_TO_CACHE>`**
-
-  Complete the operation from cache (offline).
+[!INCLUDE [from-cache](../../../includes/cli-from-cache.md)]
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
-- **`--ignore-failed-sources`**
+[!INCLUDE [ignore-failed-sources](../../../includes/cli-ignore-failed-sources.md)]
 
-  Treats package source failures as warnings.
-
-- **`--include-previews`**
-
-  Allows prerelease workload manifests.
+[!INCLUDE [include-previews](../../../includes/cli-include-previews.md)]
 
 [!INCLUDE [interactive](../../../includes/cli-interactive.md)]
 
-- **`--no-cache`**
-
-  Prevents caching of packages and http requests.
+[!INCLUDE [no-cache](../../../includes/cli-no-cache.md)]
 
 [!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
 
-- **`--skip-manifest-update`**
-
-  Skip updating the workload manifests. The workload manifests define what assets and versions need to be installed for each workload.
+[!INCLUDE [skip-manifest-update](../../../includes/cli-skip-manifest-update.md)]
 
 [!INCLUDE [source](../../../includes/cli-source.md)]
 
-- **`--temp-dir <PATH>`**
-
-  Configure the temporary directory used for this command (must be secure).
+[!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
 

--- a/docs/core/tools/dotnet-workload-restore.md
+++ b/docs/core/tools/dotnet-workload-restore.md
@@ -1,0 +1,94 @@
+---
+title: dotnet workload restore command
+description: The 'dotnet workload restore' command installs workloads needed for a project or a solution.
+ms.date: 08/12/2021
+---
+# dotnet workload restore
+
+**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+
+## Name
+
+`dotnet workload restore` - Installs workloads needed for a project or a solution.
+
+## Synopsis
+
+```dotnetcli
+dotnet workload restore [<PROJECT | SOLUTION>]
+    [--configfile <FILE>] [--disable-parallel]
+    [--download-to-cache <CACHE>] [--from-cache <CACHE>]
+    [--ignore-failed-sources] [--include-previews] [--interactive]
+    [--no-cache] [--sdk-version <VERSION>] [--skip-manifest-update]
+    [-s|--source <SOURCE>] [--temp-dir <PATH>] [-v|--verbosity <LEVEL>]
+
+dotnet workload restore -?|-h|--help
+```
+
+## Description
+
+The `dotnet workload restore` command analyzes a project or solution to determine which workloads it needs, then installs any workloads that are missing.
+
+For more information about the `dotnet workload` commands, see the [dotnet workload install](dotnet-workload-install.md#description) command.
+
+## Arguments
+
+- **`PROJECT | SOLUTION`**
+
+  The project or solution file to install workloads for. If a file is not specified, the command searches the current directory for one.
+
+## Options
+
+<!-- markdownlint-disable MD012 -->
+
+[!INCLUDE [config-file](../../../includes/cli-configfile.md)]
+
+- **`--disable-parallel`**
+
+  Prevents restoring multiple projects in parallel.
+
+- **`--download-to-cache <PATH_TO_CACHE>`**
+
+  Downloads packages needed for a workload to a folder that can be used for offline installation.
+
+- **`--from-cache <PATH_TO_CACHE>`**
+
+  Complete the operation from cache (offline).
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+- **`--ignore-failed-sources`**
+
+  Treats package source failures as warnings.
+
+- **`--include-previews`**
+
+  Allows prerelease workload manifests.
+
+[!INCLUDE [interactive](../../../includes/cli-interactive.md)]
+
+- **`--no-cache`**
+
+  Prevents caching of packages and http requests.
+
+[!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
+
+- **`--skip-manifest-update`**
+
+  Skip updating the workload manifests. The workload manifests define what assets and versions need to be installed for each workload.
+
+[!INCLUDE [source](../../../includes/cli-source.md)]
+
+- **`--temp-dir <PATH>`**
+
+  Configure the temporary directory used for this command (must be secure).
+
+[!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
+
+
+## Example
+
+- Restore workloads needed by MyApp.csproj:
+
+  ```dotnetcli
+  dotnet workload restore MyApp.csproj
+  ```

--- a/docs/core/tools/dotnet-workload-restore.md
+++ b/docs/core/tools/dotnet-workload-restore.md
@@ -66,7 +66,7 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 [!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
-[!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
+[!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 
 
 ## Example

--- a/docs/core/tools/dotnet-workload-update.md
+++ b/docs/core/tools/dotnet-workload-update.md
@@ -20,7 +20,7 @@ dotnet workload update
     [--download-to-cache <CACHE>] [--from-cache <CACHE>]
     [--from-previous-sdk] [--ignore-failed-sources]
     [--include-previews] [--interactive] [--no-cache]
-    [--sdk-version <VERSION>] [--source <SOURCE>]
+    [--sdk-version <VERSION>] [-s|--source <SOURCE>]
     [--temp-dir <PATH>] [-v|--verbosity <LEVEL>]
 
 dotnet workload update -?|-h|--help

--- a/docs/core/tools/dotnet-workload-update.md
+++ b/docs/core/tools/dotnet-workload-update.md
@@ -38,21 +38,15 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 - **`--advertising-manifests-only`**
 
-  Downloads [advertising manifests](dotnet-workload-install.md#advertising-manifests) but doesn't update any workloads. Available starting in .NET 6 Preview 7.
+  Downloads [advertising manifests](dotnet-workload-install.md#advertising-manifests) but doesn't update any workloads.
 
 [!INCLUDE [config-file](../../../includes/cli-configfile.md)]
 
-- **`--disable-parallel`**
+[!INCLUDE [disable-parallel](../../../includes/cli-disable-parallel.md)]
 
-  Prevents restoring multiple projects in parallel.
+[!INCLUDE [download-to-cache](../../../includes/cli-download-to-cache.md)]
 
-- **`--download-to-cache <PATH_TO_CACHE>`**
-
-  Downloads packages needed for a workload to a folder that can be used for offline installation.
-
-- **`--from-cache <PATH_TO_CACHE>`**
-
-  Completes the operation from cache (offline).
+[!INCLUDE [from-cache](../../../includes/cli-from-cache.md)]
 
 - **`--from-previous-sdk`**
 
@@ -60,27 +54,19 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
-- **`--ignore-failed-sources`**
+[!INCLUDE [ignore-failed-sources](../../../includes/cli-ignore-failed-sources.md)]
 
-  Treat package source failures as warnings.
-
-- **`--include-previews`**
-
-  Allow prerelease workload manifests.
+[!INCLUDE [include-previews](../../../includes/cli-include-previews.md)]
 
 [!INCLUDE [interactive](../../../includes/cli-interactive.md)]
 
-- **`--no-cache`**
-
-  Don't cache packages and HTTP requests.
+[!INCLUDE [no-cache](../../../includes/cli-no-cache.md)]
 
 [!INCLUDE [sdk-version](../../../includes/cli-sdk-version.md)]
 
 [!INCLUDE [source](../../../includes/cli-source.md)]
 
-- **`--temp-dir <PATH>`**
-
-  Configures the temporary directory used for this command (must be secure).
+[!INCLUDE [temp-dir](../../../includes/cli-temp-dir.md)]
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-packages.md)]
 

--- a/includes/cli-disable-parallel.md
+++ b/includes/cli-disable-parallel.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/12/2021
+ms.topic: include
+---
+- **`--disable-parallel`**
+
+  Prevents restoring multiple projects in parallel.

--- a/includes/cli-download-to-cache.md
+++ b/includes/cli-download-to-cache.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/04/2021
+ms.topic: include
+---
+- **`--download-to-cache <PATH_TO_CACHE>`**
+
+  Downloads packages needed for a workload to a folder that can be used for offline installation.

--- a/includes/cli-from-cache.md
+++ b/includes/cli-from-cache.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/12/2021
+ms.topic: include
+---
+- **`--from-cache <PATH_TO_CACHE>`**
+
+  Completes the operation from cache (offline).

--- a/includes/cli-ignore-failed-sources.md
+++ b/includes/cli-ignore-failed-sources.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/12/2021
+ms.topic: include
+---
+- **`--ignore-failed-sources`**
+
+  Treats package source failures as warnings.

--- a/includes/cli-include-previews.md
+++ b/includes/cli-include-previews.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/12/2021
+ms.topic: include
+---
+- **`--include-previews`**
+
+  Allows prerelease workload manifests.

--- a/includes/cli-no-cache.md
+++ b/includes/cli-no-cache.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/04/2021
+ms.topic: include
+---
+- **`--no-cache`**
+
+  Prevents caching of packages and http requests.

--- a/includes/cli-skip-manifest-update.md
+++ b/includes/cli-skip-manifest-update.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/12/2021
+ms.topic: include
+---
+- **`--skip-manifest-update`**
+
+  Skip updating the workload manifests. The workload manifests define what assets and versions need to be installed for each workload.

--- a/includes/cli-source.md
+++ b/includes/cli-source.md
@@ -1,10 +1,10 @@
 ---
 author: tdykstra
 ms.author: tdykstra
-ms.date: 08/04/2021
+ms.date: 08/12/2021
 ms.topic: include
 ---
 - **`-s|--source <SOURCE>`**
 
-  Specifies the URI of the NuGet package source to use. This setting overrides all of the sources specified in the *nuget.config* files. Multiple sources can be provided by specifying this option multiple times. Available starting in .NET 6 Preview 7 SDK.
+  Specifies the URI of the NuGet package source to use. This setting overrides all of the sources specified in the *nuget.config* files. Multiple sources can be provided by specifying this option multiple times.
   

--- a/includes/cli-temp-dir.md
+++ b/includes/cli-temp-dir.md
@@ -1,0 +1,9 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 08/12/2021
+ms.topic: include
+---
+- **`--temp-dir <PATH>`**
+
+  Specify the temporary directory used to download and extract NuGet packages (must be secure).


### PR DESCRIPTION
Fixes #25615

Also moves remaining options that are shared among multiple workload commands to include files.

File Type | File Name | Published Url
-- | -- | --
Content  | docs/core/tools/dotnet-workload-restore.md **New**| https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-restore?branch=pr-en-us-25623
Content | docs/core/tools/dotnet-workload-list.md **Added missing options**| https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-list?branch=pr-en-us-25623
Content | docs/core/tools/dotnet-workload-repair.md **Added missing options**| https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-repair?branch=pr-en-us-25623
Content | docs/core/tools/dotnet-workload-install.md **Only moved some options to includes**| https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install?branch=pr-en-us-25623
Content | docs/core/tools/dotnet-workload-update.md **Only moved some options to includes**| https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-update?branch=pr-en-us-25623
