### PR TITLE
C# reference: Highlight links to the patterns reference

### DIFF
--- a/docs/csharp/language-reference/operators/is.md
+++ b/docs/csharp/language-reference/operators/is.md
@@ -37,7 +37,8 @@ The `is` operator can be useful in the following scenarios:
 
   :::code language="csharp" source="snippets/shared/IsOperator.cs" id="NonNullCheck":::
 
-For the complete list of patterns supported by the `is` operator, see [Patterns](patterns.md).
+> [!NOTE]
+> For the complete list of patterns supported by the `is` operator, see [Patterns](patterns.md).
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/switch-expression.md
+++ b/docs/csharp/language-reference/operators/switch-expression.md
@@ -26,7 +26,8 @@ At the preceding example, a `switch` expression uses the following patterns:
 - A [constant pattern](patterns.md#constant-pattern): to handle the defined values of the `Direction` enumeration.
 - A [discard pattern](patterns.md#discard-pattern): to handle any integer value that doesn't have the corresponding member of the `Direction` enumeration (for example, `(Direction)10`). That makes the `switch` expression [exhaustive](#non-exhaustive-switch-expressions).
 
-For information about the patterns supported by a `switch` expression, see [Patterns](patterns.md).
+> [!IMPORTANT]
+> For information about the patterns supported by the `switch` expression and more examples, see [Patterns](patterns.md).
 
 The result of a `switch` expression is the value of the expression of the first `switch` expression arm whose pattern matches the input expression and whose case guard, if present, evaluates to `true`. The `switch` expression arms are evaluated in text order.
 

--- a/docs/csharp/language-reference/statements/selection-statements.md
+++ b/docs/csharp/language-reference/statements/selection-statements.md
@@ -53,7 +53,8 @@ At the preceding example, the `switch` statement uses the following patterns:
 - A [relational pattern](../operators/patterns.md#relational-patterns): to compare an expression result with a constant.
 - A [constant pattern](../operators/patterns.md#constant-pattern): to test if an expression result equals a constant.
 
-For information about the patterns supported by the `switch` statement, see [Patterns](../operators/patterns.md).
+> [!IMPORTANT]
+> For information about the patterns supported by the `switch` statement, see [Patterns](../operators/patterns.md).
 
 The preceding example also demonstrates the `default` case. The `default` case specifies statements to execute when a match expression doesn't match any other case pattern. If a match expression doesn't match any case pattern and there is no `default` case, control falls through a `switch` statement.
 


### PR DESCRIPTION
Fixes #25606

/cc: @michael-hawker
