### PR TITLE
Add vulnerable option to dotnet list package doc

### DIFF
--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet list package command
 description: The 'dotnet list package' command provides a convenient option to list the package references for a project or solution.
-ms.date: 11/11/2020
+ms.date: 08/16/2021
 ---
 # dotnet list package
 
@@ -15,7 +15,7 @@ ms.date: 11/11/2020
 
 ```dotnetcli
 dotnet list [<PROJECT>|<SOLUTION>] package [--config <SOURCE>]
-    [--deprecated]
+    [--deprecated] [--vulnerable]
     [--framework <FRAMEWORK>] [--highest-minor] [--highest-patch]
     [--include-prerelease] [--include-transitive] [--interactive]
     [--outdated] [--source <SOURCE>] [-v|--verbosity <LEVEL>]
@@ -79,6 +79,10 @@ The project or solution file to operate on. If not specified, the command search
 
   Displays packages that have been deprecated.
 
+- **`--vulnerable`**
+
+  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options.
+  
 - **`--framework <FRAMEWORK>`**
 
   Displays only the packages applicable for the specified [target framework](../../standard/frameworks.md). To specify multiple frameworks, repeat the option multiple times. For example: `--framework netcoreapp2.2 --framework netstandard2.0`.

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -15,10 +15,11 @@ ms.date: 08/16/2021
 
 ```dotnetcli
 dotnet list [<PROJECT>|<SOLUTION>] package [--config <SOURCE>]
-    [--deprecated] [--vulnerable]
+    [--deprecated]
     [--framework <FRAMEWORK>] [--highest-minor] [--highest-patch]
     [--include-prerelease] [--include-transitive] [--interactive]
     [--outdated] [--source <SOURCE>] [-v|--verbosity <LEVEL>]
+    [--vulnerable]
 
 dotnet list package -h|--help
 ```
@@ -78,10 +79,6 @@ The project or solution file to operate on. If not specified, the command search
 - **`--deprecated`**
 
   Displays packages that have been deprecated.
-
-- **`--vulnerable`**
-
-  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options.
   
 - **`--framework <FRAMEWORK>`**
 
@@ -116,6 +113,10 @@ The project or solution file to operate on. If not specified, the command search
   The NuGet sources to use when searching for newer packages. Requires the `--outdated` or `--deprecated` option.
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
+
+- **`--vulnerable`**
+
+  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The `dotnet list package` package is out of date, it is missing the `vulnerable` option. I used the output from `dotnet list package --help` as the content of my proposed changes.

Feel free to close this PR and update the documentation through a different PR if there's another preferred workflow for updating this content.
