### PR TITLE
Improve accessibility for summary table

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -18,17 +18,15 @@ All types and type members have an accessibility level. The accessibility level 
 - [protected internal](../../language-reference/keywords/protected-internal.md): The type or member can be accessed by any code in the assembly in which it's declared, or from within a derived `class` in another assembly.
 - [private protected](../../language-reference/keywords/private-protected.md): The type or member can be accessed only within its declaring assembly, by code in the same `class` or in a type that is derived from that `class`.
 
-**Summary table**
+## Summary table
 
-| Caller's location  | `public` | `protected internal` | `protected` | `internal` | `private protected` | `private` |
-| -- | -- | -- | -- | -- | -- | -- |
-| ***Within the assembly*** |   |   |   |   |   |   |
-| Within the class | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
-| Derived class | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ |
-| Non-derived class | ✔ | ✔ | ❌ | ✔ | ❌ | ❌ |
-| ***In an external assembly*** |   |   |   |   |   |   |
-| Derived class | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ |
-| Non-derived class | ✔ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Caller's location                      | `public` | `protected internal` | `protected` | `internal` | `private protected` | `private` |
+| -------------------------------------- | :------: | :------------------: | :---------: | :--------: | :-----------------: | :-------: |
+| Within the class                       |   ✔️️   |         ✔️         |     ✔️     |     ✔️     |         ✔️          |    ✔️     |
+| Derived class (same assembly)          |   ✔️   |         ✔️         |     ✔️     |     ✔️     |         ✔️          |    ❌     |
+| Non-derived class (same assembly)      |   ✔️   |         ✔️         |     ❌     |     ✔️     |         ❌          |    ❌     |
+| Derived class (different assembly)     |   ✔️   |         ✔️         |     ✔️     |     ❌     |         ❌          |    ❌     |
+| Non-derived class (different assembly) |   ✔️   |         ❌         |     ❌     |     ❌     |         ❌          |    ❌     |
 
 The following examples demonstrate how to specify access modifiers on a type and member:
 


### PR DESCRIPTION
- Changed checkmark icon
- Centered cell data
- Removed subheaders that were nested in the table - it seems like this would be confusing to hear read aloud

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers?branch=pr-en-us-25653).