### PR TITLE
ID change to syslib0003

### DIFF
--- a/docs/core/compatibility/core-libraries/6.0/diagnostic-id-change-for-obsoletions.md
+++ b/docs/core/compatibility/core-libraries/6.0/diagnostic-id-change-for-obsoletions.md
@@ -1,26 +1,28 @@
 ---
 title: ".NET 6 breaking change: New diagnostic IDs for obsoleted APIs"
 description: Learn about the .NET 6 preview-to-preview breaking change where the diagnostic ID for some obsoletions was changed.
-ms.date: 06/22/2021
+ms.date: 08/16/2021
 ---
 # New diagnostic IDs for obsoleted APIs
 
-During early .NET 6 previews, a few APIs were obsoleted without using custom diagnostic IDs. Starting in .NET 6 Preview 5, those APIs report as obsolete using different, custom diagnostic IDs. If you suppressed warnings for usage of those APIs through [CS0618](../../../../csharp/language-reference/compiler-messages/cs0618.md), modify the suppressions to use the new diagnostic IDs, which are  [SYSLIB0019](../../../../fundamentals/syslib-diagnostics/syslib0019.md) and [SYSLIB0020](../../../../fundamentals/syslib-diagnostics/syslib0020.md).
+Previously, a few APIs were obsoleted without using custom diagnostic IDs. Starting in .NET 6 Preview 5 and .NET 6 RC 1, those APIs report as obsolete using different, custom diagnostic IDs. If you suppressed warnings for usage of those APIs through [CS0618](../../../../csharp/language-reference/compiler-messages/cs0618.md), modify the suppressions to use the new diagnostic IDs, which are [SYSLIB0003](../../../../fundamentals/syslib-diagnostics/syslib0003.md), [SYSLIB0019](../../../../fundamentals/syslib-diagnostics/syslib0019.md), and [SYSLIB0020](../../../../fundamentals/syslib-diagnostics/syslib0020.md).
 
 ## Change description
 
 The following table shows the old and new diagnostic IDs for the listed obsolete API.
 
-| API | Previous diagnostic ID | New diagnostic ID |
-| --- | ---------------------- | ----------------- |
-| <xref:System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile?displayProperty=nameWithType> | CS0618 | SYSLIB0019 |
-| <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsIntPtr(System.Guid,System.Guid)?displayProperty=nameWithType> | CS0618 | SYSLIB0019 |
-| <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsObject(System.Guid,System.Guid)?displayProperty=nameWithType> | CS0618 | SYSLIB0019 |
-| <xref:System.Text.Json.JsonSerializerOptions.IgnoreNullValues?displayProperty=nameWithType> | CS0618 | SYSLIB0020 |
+| API | Previous diagnostic ID | New diagnostic ID | Version changed |
+| --- | ---------------------- | ----------------- | --------------- |
+| <xref:System.Threading.Thread.GetCompressedStack?displayProperty=nameWithType> | CS0618 | SYSLIB0003 | RC 1 |
+| <xref:System.Threading.Thread.SetCompressedStack(System.Threading.CompressedStack)?displayProperty=nameWithType> | CS0618 | SYSLIB0003 | RC 1 |
+| <xref:System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile?displayProperty=nameWithType> | CS0618 | SYSLIB0019 | Preview 5 |
+| <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsIntPtr(System.Guid,System.Guid)?displayProperty=nameWithType> | CS0618 | SYSLIB0019 | Preview 5 |
+| <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsObject(System.Guid,System.Guid)?displayProperty=nameWithType> | CS0618 | SYSLIB0019 | Preview 5 |
+| <xref:System.Text.Json.JsonSerializerOptions.IgnoreNullValues?displayProperty=nameWithType> | CS0618 | SYSLIB0020 | Preview 5 |
 
 ## Version introduced
 
-.NET 6 Preview 5
+.NET 6 Preview 5 and .NET 6 RC 1
 
 ## Reason for change
 
@@ -28,10 +30,12 @@ Starting in .NET 5, obsoletions are intended to use custom diagnostic ID values 
 
 ## Recommended action
 
-If the SYSLIB0019 or SYSLIB0020 diagnostic IDs are produced from your build, review the usage of the affected APIs. If possible, avoid using those APIs and refer to the messages and documentation for alternatives. If you need to retain the references to the obsolete APIs and you need to suppress the diagnostics, use the new diagnostic IDs instead of [CS0618](../../../../csharp/language-reference/compiler-messages/cs0618.md).
+If the SYSLIB0003, SYSLIB0019, or SYSLIB0020 diagnostic IDs are produced from your build, review the usage of the affected APIs. If possible, avoid using those APIs and refer to the messages and documentation for alternatives. If you need to retain the references to the obsolete APIs and suppress the diagnostics, suppress the warnings using the new diagnostic IDs instead of [CS0618](../../../../csharp/language-reference/compiler-messages/cs0618.md).
 
 ## Affected APIs
 
+- <xref:System.Threading.Thread.GetCompressedStack?displayProperty=fullName>
+- <xref:System.Threading.Thread.SetCompressedStack(System.Threading.CompressedStack)?displayProperty=fullName>
 - <xref:System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile?displayProperty=fullName>
 - <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsIntPtr(System.Guid,System.Guid)?displayProperty=fullName>
 - <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsObject(System.Guid,System.Guid)?displayProperty=fullName>
@@ -39,6 +43,7 @@ If the SYSLIB0019 or SYSLIB0020 diagnostic IDs are produced from your build, rev
 
 ## See also
 
+- [SYSLIB0003: Code access security is not supported](../../../../fundamentals/syslib-diagnostics/syslib0003.md)
 - [SYSLIB0019: Some RuntimeEnvironment APIs are obsolete](../../../../fundamentals/syslib-diagnostics/syslib0019.md)
 - [SYSLIB0020: IgnoreNullValues is obsolete](../../../../fundamentals/syslib-diagnostics/syslib0020.md)
 - [CS0618](../../../../csharp/language-reference/compiler-messages/cs0618.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib0003.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0003.md
@@ -148,7 +148,8 @@ The complete list of obsolete CAS APIs is as follows:
 - <xref:System.Security.Policy.Zone?displayProperty=fullName>
 - <xref:System.Security.SecurityManager?displayProperty=fullName>
 - <xref:System.ServiceProcess.ServiceControllerPermission?displayProperty=fullName>
-- <xref:System.ServiceProcess.ServiceControllerPermissionAttribute?displayProperty=fullName>
+- <xref:System.ServiceProcess.ServiceControllerPermissionAttribute?displayProperty=fullName>- <xref:System.Threading.Thread.GetCompressedStack?displayProperty=fullName>
+- <xref:System.Threading.Thread.SetCompressedStack(System.Threading.CompressedStack)?displayProperty=fullName>
 - <xref:System.Transactions.DistributedTransactionPermission?displayProperty=fullName>
 - <xref:System.Transactions.DistributedTransactionPermissionAttribute?displayProperty=fullName>
 - <xref:System.Web.AspNetHostingPermission?displayProperty=fullName>

--- a/docs/fundamentals/syslib-diagnostics/syslib0003.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0003.md
@@ -148,7 +148,8 @@ The complete list of obsolete CAS APIs is as follows:
 - <xref:System.Security.Policy.Zone?displayProperty=fullName>
 - <xref:System.Security.SecurityManager?displayProperty=fullName>
 - <xref:System.ServiceProcess.ServiceControllerPermission?displayProperty=fullName>
-- <xref:System.ServiceProcess.ServiceControllerPermissionAttribute?displayProperty=fullName>- <xref:System.Threading.Thread.GetCompressedStack?displayProperty=fullName>
+- <xref:System.ServiceProcess.ServiceControllerPermissionAttribute?displayProperty=fullName>
+- <xref:System.Threading.Thread.GetCompressedStack?displayProperty=fullName>
 - <xref:System.Threading.Thread.SetCompressedStack(System.Threading.CompressedStack)?displayProperty=fullName>
 - <xref:System.Transactions.DistributedTransactionPermission?displayProperty=fullName>
 - <xref:System.Transactions.DistributedTransactionPermissionAttribute?displayProperty=fullName>


### PR DESCRIPTION
Fixes #25464.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/diagnostic-id-change-for-obsoletions?branch=pr-en-us-25662).