### PR TITLE
Clarify note on overload resolution for parameters

### DIFF
--- a/docs/csharp/language-reference/keywords/in-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-parameter-modifier.md
@@ -22,7 +22,7 @@ Variables passed as `in` arguments must be initialized before being passed in a 
 
 The `in` parameter modifier is available in C# 7.2 and later. Previous versions generate compiler error `CS8107` ("Feature 'readonly references' is not available in C# 7.0. Please use language version 7.2 or greater.") To configure the compiler language version, see [Select the C# language version](../configure-language-version.md).
 
-The `in`, `ref`, and `out` keywords are not considered part of the method signature for the purpose of overload resolution. Therefore, methods cannot be overloaded if the only difference is that one method takes a `ref` or `in` argument and the other takes an `out` argument. The following code, for example, will not compile:  
+Although `in`, `out,` and `ref` parameter modifiers are considered part of a signature, members declared in a single type cannot differ in signature solely by `in`, `ref` and `out`. Therefore, methods cannot be overloaded if the only difference is that one method takes a `ref` or `in` argument and the other takes an `out` argument. The following code, for example, will not compile:  
   
 ```csharp
 class CS0663_Example


### PR DESCRIPTION
See https://github.com/dotnet/docs/issues/25639#issuecomment-899780457.

This takes the text from the standard at [§8.6 Signatures and overloading](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/basic-concepts.md#86-signatures-and-overloading) to address the concerns of the comment.

