### PR TITLE
OutputType breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -81,6 +81,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | Preview 1 |
 | [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | Preview 1 |
 | [Implicit namespaces in C# projects](sdk/6.0/implicit-namespaces.md) | Preview 7 |
+| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | RC 1 |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/6.0/outputtype-not-set-automatically.md
+++ b/docs/core/compatibility/sdk/6.0/outputtype-not-set-automatically.md
@@ -13,11 +13,17 @@ In .NET 5, a change was made to automatically change `OutputType` from `Exe` to 
 
 ## Previous behavior
 
-If a project targeted .NET 5 or higher, the `OutputType` was `Exe`, and `UseWindowsForms` or `UseWPF` was set to `true`, then the .NET SDK would change the `OutputType` to `WinExe`.
+If a project targeted .NET 5 or higher, `OutputType` was set to `Exe`, and `UseWindowsForms` or `UseWPF` was set to `true`, then the .NET SDK would change `OutputType` to `WinExe`.
 
 ## New behavior
 
 `OutputType` is no longer changed from what's in the project file.
+
+```xml
+<PropertyGroup>
+  <OutputType>Exe</OutputType>
+</PropertyGroup>
+```
 
 ## Change category
 
@@ -25,7 +31,7 @@ This change may affect [*source compatibility*](../../categories.md#source-compa
 
 ## Reason for change
 
-The [.NET 5 change](../5.0/automatically-infer-winexe-output-type.md) was intended to simplify .NET MAUI apps, so that the `OutputType` wouldn't need to be conditioned on the `TargetFramework`. However:
+The [.NET 5 change](../5.0/automatically-infer-winexe-output-type.md) was intended to simplify .NET MAUI apps, so that `OutputType` wouldn't need to be conditioned on the target framework. However:
 
 - Automatically inferring `OutputType` broke user expectations and frustrated developers. For more information, see [dotnet/sdk#16563](https://github.com/dotnet/sdk/issues/16563) and its linked issues.
 - .NET MAUI apps will use WinUI by default, not Windows Forms or WPF, so the automatic inference doesn't even apply to .NET MAUI apps.

--- a/docs/core/compatibility/sdk/6.0/outputtype-not-set-automatically.md
+++ b/docs/core/compatibility/sdk/6.0/outputtype-not-set-automatically.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: `OutputType` no longer automatically set to WinExe"
+description: Learn about the breaking change in .NET 6 where `OutputType` for WPF and Windows Forms projects is no longer automatically set to `WinExe`.
+ms.date: 08/17/2021
+---
+# OutputType not automatically set to WinExe
+
+In .NET 5, a change was made to automatically change `OutputType` from `Exe` to `WinExe` for WPF and Windows Forms apps. In .NET 6, we are reverting that change and `OutputType` will no longer be changed by the SDK.
+
+## Version introduced
+
+.NET 6 RC 1
+
+## Previous behavior
+
+If a project targeted .NET 5 or higher, the `OutputType` was `Exe`, and `UseWindowsForms` or `UseWPF` was set to `true`, then the .NET SDK would change the `OutputType` to `WinExe`.
+
+## New behavior
+
+`OutputType` is no longer changed from what's in the project file.
+
+## Change category
+
+This change may affect [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+The [.NET 5 change](../5.0/automatically-infer-winexe-output-type.md) was intended to simplify .NET MAUI apps, so that the `OutputType` wouldn't need to be conditioned on the `TargetFramework`. However:
+
+- Automatically inferring `OutputType` broke user expectations and frustrated developers. For more information, see [dotnet/sdk#16563](https://github.com/dotnet/sdk/issues/16563) and its linked issues.
+- .NET MAUI apps will use WinUI by default, not Windows Forms or WPF, so the automatic inference doesn't even apply to .NET MAUI apps.
+
+## Recommended action
+
+If you relied on the fact that `OutputType` was changed from `Exe` to `WinExe`, you should explicitly set it to `WinExe` in the project file.
+
+If you were impacted by the previous breaking change and had to set `DisableWinExeOutputInference` in order to disable the logic that was added in .NET 5, you can remove that property now.
+
+## Affected APIs
+
+N/A
+
+## See also
+
+- [OutputType set to WinExe for WPF and WinForms apps](../5.0/automatically-infer-winexe-output-type.md)

--- a/docs/core/compatibility/sdk/6.0/outputtype-not-set-automatically.md
+++ b/docs/core/compatibility/sdk/6.0/outputtype-not-set-automatically.md
@@ -3,7 +3,7 @@ title: "Breaking change: `OutputType` no longer automatically set to WinExe"
 description: Learn about the breaking change in .NET 6 where `OutputType` for WPF and Windows Forms projects is no longer automatically set to `WinExe`.
 ms.date: 08/17/2021
 ---
-# OutputType not automatically set to WinExe
+# OutputType not changed from Exe to WinExe for Windows Forms and WPF projects
 
 In .NET 5, a change was made to automatically change `OutputType` from `Exe` to `WinExe` for WPF and Windows Forms apps. In .NET 6, we are reverting that change and `OutputType` will no longer be changed by the SDK.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -115,6 +115,8 @@ items:
           href: sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md
         - name: Implicit namespaces in C# projects
           href: sdk/6.0/implicit-namespaces.md
+        - name: OutputType not automatically set to WinExe
+          href: sdk/6.0/outputtype-not-set-automatically.md
       - name: Windows Forms
         items:
         - name: APIs throw ArgumentNullException
@@ -719,6 +721,8 @@ items:
           href: sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md
         - name: Implicit namespaces in C# projects
           href: sdk/6.0/implicit-namespaces.md
+        - name: OutputType not automatically set to WinExe
+          href: sdk/6.0/outputtype-not-set-automatically.md
       - name: .NET 5
         items:
         - name: Directory.Packages.props files imported by default


### PR DESCRIPTION
Fixes #25636 

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/outputtype-not-set-automatically?branch=pr-en-us-25685).