### PR TITLE
Remove `APP_NI_PATHS` property mentions from .NET documentation

### DIFF
--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -32,7 +32,7 @@ Additionally, the *\*.deps.json* files for any referenced frameworks are similar
 
 Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an `--additional-deps` optional parameter to set this value on application startup.
 
-The `APP_PATHS` property is not populated by default and omitted for most applications.
+The `APP_PATHS` property is not populated by default and is omitted for most applications.
 
 The list of all *\*.deps.json* files used by the application can be accessed via `System.AppContext.GetData("APP_CONTEXT_DEPS_FILES")`.
 

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -20,7 +20,6 @@ Each probing property is optional. If present, each property is a string value t
 |`PLATFORM_RESOURCE_ROOTS`       | List of directory paths to search for satellite resource assemblies. |
 |`NATIVE_DLL_SEARCH_DIRECTORIES` | List of directory paths to search for unmanaged (native) libraries.        |
 |`APP_PATHS`                     | List of directory paths to search for managed assemblies. |
-|`APP_NI_PATHS`                  | List of directory paths to search for native images of managed assemblies. |
 
 ### How are the properties populated?
 
@@ -33,7 +32,7 @@ Additionally, the *\*.deps.json* files for any referenced frameworks are similar
 
 Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an `--additional-deps` optional parameter to set this value on application startup.
 
-The `APP_PATHS` and `APP_NI_PATHS` properties are not populated by default and are omitted for most applications.
+The `APP_PATHS` property is not populated by default and omitted for most applications.
 
 The list of all *\*.deps.json* files used by the application can be accessed via `System.AppContext.GetData("APP_CONTEXT_DEPS_FILES")`.
 
@@ -56,7 +55,6 @@ The .NET Core runtime host will output useful trace messages when certain enviro
 When probing to locate a managed assembly, the <xref:System.Runtime.Loader.AssemblyLoadContext.Default%2A?displayProperty=nameWithType> looks in order at:
 
 - Files matching the <xref:System.Reflection.AssemblyName.Name?displayProperty=nameWithType> in `TRUSTED_PLATFORM_ASSEMBLIES` (after removing file extensions).
-- Native image assembly files in `APP_NI_PATHS` with common file extensions.
 - Assembly files in `APP_PATHS` with common file extensions.
 
 ## Satellite (resource) assembly probing

--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -112,8 +112,6 @@ Common properties include:
    This is a list of assembly paths (delimited by ';' on Windows and ':' on Linux) which the runtime will be able to resolve by default. Some hosts have hard-coded manifests listing assemblies they can load. Others will put any library in certain locations (next to *coreclr.dll*, for example) on this list.
 * `APP_PATHS`
    This is a list of paths to probe in for an assembly if it can't be found in the trusted platform assemblies (TPA) list. Because the host has more control over which assemblies are loaded using the TPA list, it is a best practice for hosts to determine which assemblies they expect to load and list them explicitly. If probing at run time is needed, however, this property can enable that scenario.
-* `APP_NI_PATHS`
-   This list is similar to APP_PATHS except that it's meant to be paths that will be probed for native images.
 * `NATIVE_DLL_SEARCH_DIRECTORIES`
    This property is a list of paths the loader should probe when looking for native libraries called via p/invoke.
 * `PLATFORM_RESOURCE_ROOTS`


### PR DESCRIPTION
## Summary

Updating based on https://github.com/dotnet/runtime/pull/57616

This property is a historical artifact from very early CoreCLR uses. It hasn't had much utility since before CoreCLR 1.0 therefore I don't see a need to document when it was respected vs removed.

/cc @vitek-karas @elinor-fung 
