### PR TITLE
List multi-module assemblies as an unsupported technology

### DIFF
--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -58,6 +58,12 @@ As an alternative, consider the [ILPack library](https://github.com/Lokad/ILPack
 
 For more information, see [dotnet/runtime issue 15704](https://github.com/dotnet/runtime/issues/15704).
 
+## Loading multi-module assemblies
+
+Assemblies that consist of multiple modules (`OutputType=Module` in MSBuild) are not supported in .NET 5+ (including .NET Core).
+
+As an alternative, consider merging the individual modules into a single assembly file.
+
 ## See also
 
 - [Overview of porting from .NET Framework to .NET](index.md)


### PR DESCRIPTION
I couldn't find this being spelled out anywhere and this seems like a good spot.

See e.g. https://github.com/dotnet/runtime/issues/10571 for details.
