### PR TITLE
'portable' --> 'not version-specific'

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Runtime Identifier (RID) catalog
 description: Learn about the Runtime Identifier (RID) and how RIDs are used in .NET.
-ms.date: 01/28/2021
+ms.date: 08/19/2021
 ms.topic: reference
 ---
 # .NET RID Catalog
@@ -77,7 +77,7 @@ There are some considerations about RIDs that you have to keep in mind when work
 To be able to use RIDs, you have to know which RIDs exist. New values are added regularly to the platform.
 For the latest and complete version, see the [runtime.json](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json) file in the `dotnet/runtime` repository.
 
-Portable RIDs are values added to the RID graph that aren't tied to a specific version or OS distribution. They are the preferred choice, especially when dealing with multiple Linux distros since most distribution RIDs are mapped to the portable RIDs.
+RIDs that aren't tied to a specific version or OS distribution are the preferred choice, especially when dealing with multiple Linux distros since most distribution RIDs are mapped to the not-distribution-specific RIDs.
 
 The following list shows a small subset of the most common RIDs used for each OS.
 
@@ -85,7 +85,7 @@ The following list shows a small subset of the most common RIDs used for each OS
 
 Only common values are listed. For the latest and complete version, see the [runtime.json](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json) file in the `dotnet/runtime` repository.
 
-- Portable
+- Windows, not version-specific
   - `win-x64`
   - `win-x86`
   - `win-arm`
@@ -107,9 +107,9 @@ For more information, see [.NET dependencies and requirements](./install/windows
 
 ## Linux RIDs
 
-Only common values are listed. For the latest and complete version, see the [runtime.json](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json) file in the `dotnet/runtime` repository. Devices running a distribution not listed below may work with one of the Portable RIDs. For example, Raspberry Pi devices running a Linux distribution not listed can be targeted with `linux-arm`.
+Only common values are listed. For the latest and complete version, see the [runtime.json](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json) file in the `dotnet/runtime` repository. Devices running a distribution not listed below may work with one of the not-distribution-specific RIDs. For example, Raspberry Pi devices running a Linux distribution not listed can be targeted with `linux-arm`.
 
-- Portable
+- Linux, not distribution-specific
   - `linux-x64` (Most desktop distributions like CentOS, Debian, Fedora, Ubuntu, and derivatives)
   - `linux-musl-x64` (Lightweight distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) like Alpine Linux)
   - `linux-arm` (Linux distributions running on ARM like Raspbian on Raspberry Pi Model 2+)
@@ -128,7 +128,7 @@ For more information, see [.NET dependencies and requirements](./install/linux.m
 
 macOS RIDs use the older "OSX" branding. Only common values are listed. For the latest and complete version, see the [runtime.json](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json) file in the `dotnet/runtime` repository.
 
-- Portable
+- macOS, not version-specific
   - `osx-x64` (Minimum OS version is macOS 10.12 Sierra)
 - macOS 10.10  Yosemite
   - `osx.10.10-x64`


### PR DESCRIPTION
Fixes #20562
Related to https://github.com/dotnet/core/issues/3554

"Portable" remained in the doc only as the group title for a group of RIDs that aren't OS-version/distribution-specific; I changed these subheadings to:

* Windows, not version-specific
* Linux, not-distribution-specific
* macOS, not version-specific