### PR TITLE
Manifest file names with 2 dots don't work

### DIFF
--- a/docs/core/resources/manifest-file-names.md
+++ b/docs/core/resources/manifest-file-names.md
@@ -42,16 +42,15 @@ For example, the manifest name for the resource file that's defined in the follo
 >
 >   The following example works correctly:
 >
->   ```
+>   ```xml
 >   <EmbeddedResource Include="X.resx" />
 >   ```
 >
 >   The following example doesn't work:
 >
+>   ```xml
+>   <EmbeddedResource Include="X.fr-FR.resx" />
 >   ```
->   <EmbeddedResource Include="X.fr-FR.resx"></EmbeddedResource>
->   ```
-
 
 ## ManifestResourceName metadata
 

--- a/docs/core/resources/manifest-file-names.md
+++ b/docs/core/resources/manifest-file-names.md
@@ -36,6 +36,23 @@ For example, the manifest name for the resource file that's defined in the follo
 <EmbeddedResource Include="X.fr-FR.resx" LogicalName="SomeName.resources" />
 ```
 
+> [!NOTE]
+>
+> - If `LogicalName` is not specified, an `EmbeddedResource` with two dots (`.`) in the file name doesn't work, which means that `GetManifestResourceNames` doesn't return that file.
+>
+>   The following example works correctly:
+>
+>   ```
+>   <EmbeddedResource Include="X.resx" />
+>   ```
+>
+>   The following example doesn't work:
+>
+>   ```
+>   <EmbeddedResource Include="X.fr-FR.resx"></EmbeddedResource>
+>   ```
+
+
 ## ManifestResourceName metadata
 
 If a resource file is explicitly included in the project file as an `EmbeddedResource` item with `ManifestResourceName` metadata (and `LogicalName` is absent), the `ManifestResourceName` value, combined with the file extension *.resources*, is used as the manifest file name.


### PR DESCRIPTION
Fixes #20643

File Type | File Name | Published Url
-- | -- | --
Content | docs/core/resources/manifest-file-names.md | https://review.docs.microsoft.com/en-us/dotnet/core/resources/manifest-file-names?branch=pr-en-us-25734
