### PR TITLE
Fix a (I think?) typo in class-invariance sample-code

### DIFF
--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md
@@ -107,7 +107,7 @@ ICovariant<Object> iobj = ibutton;
 SampleImplementation<Button> button = new SampleImplementation<Button>();
 // The following statement generates a compiler error
 // because classes are invariant.
-// SampleImplementation<Object> obj = button;
+// object obj = button;
 ```
 
 ## Extending Variant Generic Interfaces


### PR DESCRIPTION
## Summary

Shouldn't this be attempting to assign to a *less* derived type, to demonstrate the invariance? The current code assigns to the same type twice.