### PR TITLE
Update nullable-migration-strategies.md

### DIFF
--- a/docs/csharp/nullable-migration-strategies.md
+++ b/docs/csharp/nullable-migration-strategies.md
@@ -85,7 +85,7 @@ However, for public libraries, or libraries with large user bases, you may prefe
 
 Several attributes have been added to express additional information about the null state of variables. All code you wrote before C# 8 introduced nullable reference types was *null oblivious*. That means any reference type variable may be null, but null checks aren't required. Once your code is *nullable aware*, those rules change. Reference types should never be the `null` value, and nullable reference types must be checked against `null` before being dereferenced.
 
-The rules for your APIs are likely more complicated, as you saw with the `TryGetValue` API scenario. Many of your APIs have more complex rules for when variables can or can't be `null`. In these cases, you'll use attributes to express those rules. The attributes that describe the semantics of your API are found in the article on [Attributes that impact nullable analysis](./language-reference/attributes/nullable-analysis.md).
+The rules for your APIs are likely more complicated, as you saw with the `TryGetMessage` API scenario. Many of your APIs have more complex rules for when variables can or can't be `null`. In these cases, you'll use attributes to express those rules. The attributes that describe the semantics of your API are found in the article on [Attributes that impact nullable analysis](./language-reference/attributes/nullable-analysis.md).
 
 ## Generic definitions and nullability
 


### PR DESCRIPTION
The documentation used an example with a method called TryGetMessage and later referred back to it as TryGetValue. This updates the method's name so it's consistent.
