### PR TITLE
Fix coding style in the example using casting

### DIFF
--- a/docs/csharp/programming-guide/types/boxing-and-unboxing.md
+++ b/docs/csharp/programming-guide/types/boxing-and-unboxing.md
@@ -88,13 +88,13 @@ This program outputs:
 If you change the statement:
 
 ```csharp
-int j = (short) o;
+int j = (short)o;
 ```
 
 to:
 
 ```csharp
-int j = (int) o;
+int j = (int)o;
 ```
 
 the conversion will be performed, and you will get the output:


### PR DESCRIPTION
Remove the space when casting to keep the style consistent

Fixes #25761
