### PR TITLE
Include StreamJsonRpc as a remoting alternative in porting docs

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -21,7 +21,7 @@ There are a few technologies in .NET Framework that don't exist in .NET:
 
 - [Remoting](net-framework-tech-unavailable.md#remoting)
 
-  Remoting is used for communicating across application domains, which are no longer supported. For communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class.
+  Remoting is used for communicating across application domains, which are no longer supported. For simple communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class. For more complex scenarios, consider frameworks such as [StreamJsonRpc](https://github.com/microsoft/vs-streamjsonrpc) or [ASP.NET Core](https://docs.microsoft.com/aspnet/core) (either using [gRPC](https://docs.microsoft.com/aspnet/core/grpc) or [RESTful Web API services](https://docs.microsoft.com/aspnet/core/web-api)).
 
 - [Code access security (CAS)](net-framework-tech-unavailable.md#code-access-security-cas)
 

--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -22,9 +22,11 @@ To make code migration from .NET Framework easier, .NET 5+ exposes some of the <
 
 .NET Remoting isn't supported on .NET 5+ (and .NET Core). .NET remoting was identified as a problematic architecture. It's used for communicating across application domains, which are no longer supported. Also, remoting requires runtime support, which is expensive to maintain.
 
-For communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class.
+For simple communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class. For more complex scenarios, the open-source [StreamJsonRpc](https://github.com/microsoft/vs-streamjsonrpc) project provides a cross-platform .NET Standard remoting framework that works on top of existing stream or pipe connections.
 
-Across machines, use a network-based solution as an alternative. Preferably, use a low-overhead plain text protocol, such as HTTP. The [Kestrel web server](/aspnet/core/fundamentals/servers/kestrel), which is the web server used by ASP.NET Core, is an option here. Also, consider using <xref:System.Net.Sockets> for network-based, cross-machine scenarios. For more options, see [.NET Open Source Developer Projects: Messaging](https://github.com/Microsoft/dotnet/blob/master/dotnet-developer-projects.md#messaging).
+Across machines, use a network-based solution as an alternative. Preferably, use a low-overhead plain text protocol, such as HTTP. The [Kestrel web server](/aspnet/core/fundamentals/servers/kestrel), which is the web server used by ASP.NET Core, is an option here. Also, consider using <xref:System.Net.Sockets> for network-based, cross-machine scenarios. StreamJsonRpc, mentioned earlier, can be used for JSON or binary (via MessagePack) communication over web sockets.
+
+For more messaging options, see [.NET Open Source Developer Projects: Messaging](https://github.com/Microsoft/dotnet/blob/master/dotnet-developer-projects.md#messaging).
 
 ## Code access security (CAS)
 


### PR DESCRIPTION
## Summary

This PR adds [StreamJsonRpc](https://github.com/microsoft/vs-streamjsonrpc) to the list of recommended alternatives for remoting when moving from .NET Framework to .NET Core. Based on customer engagements, this is a useful option that would be worthwhile for developers to consider when upgrading from Framework to Core.

Including @AArnott as a reviewer to provide SME feedback.