### PR TITLE
Fix wrong link

### DIFF
--- a/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-fsharp-with-dotnet-test.md
@@ -164,6 +164,6 @@ You've built a small library and a set of unit tests for that library. You've st
 ## See also
 
 - [dotnet new](../tools/dotnet-new.md)
-- [dotnet sln](../tools/dotnet-new.md)
+- [dotnet sln](../tools/dotnet-sln.md)
 - [dotnet add reference](../tools/dotnet-add-reference.md)
 - [dotnet test](../tools/dotnet-test.md)


### PR DESCRIPTION
## Summary

Link to `dotnet sln` documentation was incorrectly pointing to `dotnet new`.
