### PR TITLE
Some improvements to the single-file publish doc

### DIFF
--- a/docs/core/deploying/single-file.md
+++ b/docs/core/deploying/single-file.md
@@ -7,7 +7,7 @@ ms.date: 08/10/2021
 ---
 # Single file deployment and executable
 
-Bundling all application-dependent files into a single binary provides an application developer with the attractive option to deploy and distribute the application as a single file. This deployment model has been available since .NET Core 3.0 and has been enhanced in .NET 5.0. Previously in .NET Core 3.0, when a user runs your single-file app, .NET Core host first extracts all files to a temporary directory before running the application. .NET 5.0 improves this experience by directly running the code without the need to extract the files from the app.
+Bundling all application-dependent files into a single binary provides an application developer with the attractive option to deploy and distribute the application as a single file. This deployment model has been available since .NET Core 3.0 and has been enhanced in .NET 5.0. Previously in .NET Core 3.0, when a user runs your single-file app, .NET Core host first extracts all files to a directory before running the application. .NET 5.0 improves this experience by directly running the code without the need to extract the files from the app.
 
 Single File deployment is available for both the [framework-dependent deployment model](index.md#publish-framework-dependent) and [self-contained applications](index.md#publish-self-contained). The size of the single file in a self-contained application will be large since it will include the runtime and the framework libraries. The single file deployment option can be combined with [ReadyToRun](ready-to-run.md) and [Trim (an experimental feature in .NET 5.0)](trim-self-contained.md) publish options.
 
@@ -15,7 +15,7 @@ Single file deployment isn't compatible with Windows 7.
 
 ## Output differences from .NET 3.x
 
-In .NET Core 3.x, publishing as a single file produced exactly one file, consisting of the app itself, dependencies, and any other files in the folder during publish. When the app starts, the single file app was extracted to a temporary folder and run from there. Starting with .NET 5, only managed DLLs are bundled with the app into a single executable. When the app starts, the managed DLLs are extracted and loaded in memory, avoiding the extraction to a temporary folder. On Windows, this means that the managed binaries are embedded in the single-file bundle, but the native binaries of the core runtime itself are separate files. To embed those files for extraction and get exactly one output file, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Including native libraries](#including-native-libraries).
+In .NET Core 3.x, publishing as a single file produced exactly one file, consisting of the app itself, dependencies, and any other files in the folder during publish. When the app starts, the single file app was extracted to a folder and run from there. Starting with .NET 5, only managed DLLs are bundled with the app into a single executable. When the app starts, the managed DLLs are extracted and loaded in memory, avoiding the extraction to a folder. On Windows, this means that the managed binaries are embedded in the single-file bundle, but the native binaries of the core runtime itself are separate files. To embed those files for extraction and get exactly one output file, like in .NET Core 3.x, set the property `IncludeNativeLibrariesForSelfExtract` to `true`. For more information about extraction, see [Including native libraries](#including-native-libraries).
 
 ## API incompatibility
 
@@ -39,7 +39,7 @@ We have some recommendations for fixing common scenarios:
 
 * To access files next to the executable, use <xref:System.AppContext.BaseDirectory?displayProperty=nameWithType>.
 
-* To find the file name of the executable, use the first element of <xref:System.Environment.GetCommandLineArgs?displayProperty=nameWithType>.
+* To find the file name of the executable, use the first element of <xref:System.Environment.GetCommandLineArgs?displayProperty=nameWithType>, or starting with .NET 6 use the file name from <xref:System.Environment.ProcessPath>.
 
 * To avoid shipping loose files entirely, consider using [embedded resources](../extensions/create-resource-files.md).
 
@@ -55,12 +55,22 @@ To fix these errors, _mscordbi_ needs to be copied next to the executable. _msco
 
 ## Including native libraries
 
-Single-file doesn't bundle native libraries by default. On Linux, we prelink the runtime into the bundle and only application native libraries are deployed to the same directory as the single-file app. On Windows, we prelink only the hosting code and both the runtime and application native libraries are deployed to the same directory as the single-file app. This is to ensure a good debugging experience, which requires native files to be excluded from the single file. There is an option to set a flag, `IncludeNativeLibrariesForSelfExtract`, to include native libraries in the single file bundle, but these files will be extracted to a temporary directory in the client machine when the single file application is run.
+Single-file doesn't bundle native libraries by default. On Linux, we prelink the runtime into the bundle and only application native libraries are deployed to the same directory as the single-file app. On Windows, we prelink only the hosting code and both the runtime and application native libraries are deployed to the same directory as the single-file app. This is to ensure a good debugging experience, which requires native files to be excluded from the single file.
 
-Specifying `IncludeAllContentForSelfExtract` will extract all files before running the executable. This preserves the original .NET Core single-file deployment behavior.
+Starting with .NET 6 the runtime is prelinked into the bundle on all platforms.
+
+There is an option to set a flag, `IncludeNativeLibrariesForSelfExtract`, to include native libraries in the single file bundle, but these files will be extracted to a directory in the client machine when the single file application is run.
+
+Specifying `IncludeAllContentForSelfExtract` will extract all files (even the managed assemblies) before running the executable. This preserves the original .NET Core single-file deployment behavior.
 
 > [!NOTE]
-> If extraction is used and the app is running on Linux or MacOS, either `$HOME` or `$DOTNET_BUNDLE_EXTRACT_BASE_DIR` must be set to a path. If `$HOME` is set, the files will be extracted in a directory under _$HOME/.net_, while if `$DOTNET_BUNDLE_EXTRACT_BASE_DIR` is set, it will take precedence and files will be created in directories below that path. To prevent tampering, these directories should not be writable by users or services with different privileges, **not** _/tmp_ or _/var/tmp_ on most systems).
+> If extraction is used the files are extracted to disk before the app starts:
+>
+> * If environment variable `DOTNET_BUNDLE_EXTRACT_BASE_DIR` is set to a path, the files will be extracted to a directory under that path.
+> * Otherwise if running on Linux or MacOS, the files will be extracted to a directory under `$HOME/.net`.
+> * If running on Windows, the files will be extracted to a directory under `%TEMP%/.net`.
+>
+> To prevent tampering, these directories should not be writable by users or services with different privileges, (so **not** _/tmp_ or _/var/tmp_ on most Linux and MacOS systems).
 
 ## Other considerations
 
@@ -116,7 +126,6 @@ Here's a sample project file that specifies single-file publishing:
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
@@ -128,13 +137,12 @@ These properties have the following functions:
 * `PublishSingleFile` - Enables single-file publishing. Also enables single-file warnings during `dotnet build`.
 * `SelfContained` - Determines whether the app will be self-contained or framework-dependent.
 * `RuntimeIdentifier` - Specifies the [OS and CPU type](../rid-catalog.md) you are targeting. Also sets `<SelfContained>true</SelfContained>` by default.
-* `PublishTrimmed` - Enables use of [assembly trimming](trim-self-contained.md), which is only supported for self-contained apps.
 * `PublishReadyToRun` - Enables [ahead-of-time (AOT) compilation](ready-to-run.md).
 
 **Notes:**
 
-* Apps are OS and architecture-specific. You need to publish for each configuration, such as Linux x64, Linux ARM64, Windows x64, and so forth.
-* Configuration files, such as *\*.runtimeconfig.json*, are included in the single file. If an additional configuration file is needed, you can place it beside the single file.
+* Single-file apps are always OS and architecture-specific. You need to publish for each configuration, such as Linux x64, Linux ARM64, Windows x64, and so forth.
+* Runtime configuration files, such as *\*.runtimeconfig.json* and *\*.deps.json*, are included in the single file. If an additional configuration file is needed, you can place it beside the single file.
 
 ## Publish a single file app - CLI
 


### PR DESCRIPTION
* Most importantly improve the description of how files are extracted to disk for all platforms.
* Removed the "temporary" work for files extraction as on Linux/MacOS there's nothing temporary about the default extraction directory
* Removed PublishTrimmed=true in the sample - in .NET 5 this is dangerous, and in .NET 6 it will typically lead to lot of warnings for most apps. The doc already mentions the possibility to use trimming with single-file anyway.
* Include changes in behavior in .NET 6 in the text (as we're starting to get lot of questions about .NET 6 single-file difference).
