### PR TITLE
Link to C# compiler options

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -415,7 +415,8 @@ For more information about deployment, see [.NET application deployment](../depl
 The following MSBuild properties are documented in this section:
 
 - [EmbeddedResourceUseDependentUponConvention](#embeddedresourceusedependentuponconvention)
-- [LangVersion](#langversion)
+
+C# compiler options can also be specified as MSBuild properties in your project file. For more information, see [C# compiler options](../../csharp/language-reference/compiler-options/index.md).
 
 ### EmbeddedResourceUseDependentUponConvention
 
@@ -431,18 +432,6 @@ By default, in a new .NET project, this property is set to `true`. If set to `fa
   <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
 </PropertyGroup>
 ```
-
-### LangVersion
-
-The `LangVersion` property lets you specify a specific programming language version. For example, if you want access to C# preview features, set `LangVersion` to `preview`.
-
-```xml
-<PropertyGroup>
-  <LangVersion>preview</LangVersion>
-</PropertyGroup>
-```
-
-For more information, see [C# language versioning](../../csharp/language-reference/configure-language-version.md#override-a-default).
 
 ## Default item inclusion properties
 

--- a/docs/csharp/language-reference/compiler-options/index.md
+++ b/docs/csharp/language-reference/compiler-options/index.md
@@ -1,7 +1,7 @@
 ---
 description: "C# Compiler Options. Learn the options that control the behavior of the C# compiler."
 title: "C# Compiler Options"
-ms.date: 03/12/2021
+ms.date: 09/01/2021
 f1_keywords: 
   - "cs.build.options"
 helpviewer_keywords: 
@@ -12,14 +12,43 @@ helpviewer_keywords:
   - "Visual C#, compiler options"
 ms.assetid: d3403556-1816-4546-a782-e8223a772e44
 ---
-# C# Compiler Options
+# C# compiler options
 
-This section describes the options interpreted by the C# compiler. There are two different ways to set compiler options in .NET projects:
+This section describes the options interpreted by the C# compiler.
 
-- ***Specify option in your \*.csproj file***: You can add XML elements for any compiler option in your *\*.csproj* file. The element name is the same as the compiler option. The value of the XML element sets the value of the compiler option. For more information on setting options in project files, see the article [MSBuild properties for .NET SDK Projects](../../../core/project-sdk/msbuild-props.md).
-- ***Using the Visual Studio Property pages***: Visual Studio provides property pages to edit build properties. To learn more about them, see [Manage project and solution properties - Windows](/visualstudio/ide/managing-project-and-solution-properties#c-visual-basic-and-f-projects) or [Manage project and solution properties - Mac](/visualstudio/mac/managing-solutions-and-project-properties).
+## Index
 
-## .NET Framework projects
+- [Options for language feature rules](language.md)
+- [Options that control compiler output](output.md)
+- [Options that specify inputs](inputs.md)
+- [Options to report errors and warnings](errors-warnings.md)
+- [Options that control code generation](code-generation.md)
+- [Options for security options](security.md)
+- [Options that specify resources](resources.md)
+- [Miscellaneous options](miscellaneous.md)
+- [Advanced options](advanced.md)
+
+## How to set options
+
+There are two different ways to set compiler options in .NET projects:
+
+- ***In your \*.csproj file***
+
+  You can add MSBuild properties for any compiler option in your *\*.csproj* file in XML format. The property name is the same as the compiler option. The value of the property sets the value of the compiler option. For example, the following project file snippet sets the `LangVersion` property.
+
+  ```xml
+  <PropertyGroup>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  ```
+
+  For more information on setting options in project files, see the article [MSBuild properties for .NET SDK Projects](../../../core/project-sdk/msbuild-props.md).
+
+- ***Using the Visual Studio Property pages***
+
+  Visual Studio provides property pages to edit build properties. To learn more about them, see [Manage project and solution properties - Windows](/visualstudio/ide/managing-project-and-solution-properties#c-visual-basic-and-f-projects) or [Manage project and solution properties - Mac](/visualstudio/mac/managing-solutions-and-project-properties).
+
+### .NET Framework projects
 
 > [!IMPORTANT]
 > This section applies to .NET Framework projects only.

--- a/docs/csharp/language-reference/compiler-options/index.md
+++ b/docs/csharp/language-reference/compiler-options/index.md
@@ -18,12 +18,12 @@ This section describes the options interpreted by the C# compiler.
 
 ## Index
 
-- [Options for language feature rules](language.md)
+- [Language feature options](language.md)
 - [Options that control compiler output](output.md)
 - [Options that specify inputs](inputs.md)
 - [Options to report errors and warnings](errors-warnings.md)
-- [Options that control code generation](code-generation.md)
-- [Options for security options](security.md)
+- [Code generation options](code-generation.md)
+- [Security options](security.md)
 - [Options that specify resources](resources.md)
 - [Miscellaneous options](miscellaneous.md)
 - [Advanced options](advanced.md)

--- a/docs/csharp/language-reference/compiler-options/index.md
+++ b/docs/csharp/language-reference/compiler-options/index.md
@@ -14,19 +14,7 @@ ms.assetid: d3403556-1816-4546-a782-e8223a772e44
 ---
 # C# compiler options
 
-This section describes the options interpreted by the C# compiler.
-
-## Index
-
-- [Language feature options](language.md)
-- [Options that control compiler output](output.md)
-- [Options that specify inputs](inputs.md)
-- [Options to report errors and warnings](errors-warnings.md)
-- [Code generation options](code-generation.md)
-- [Security options](security.md)
-- [Options that specify resources](resources.md)
-- [Miscellaneous options](miscellaneous.md)
-- [Advanced options](advanced.md)
+This section describes the options interpreted by the C# compiler. Options are grouped into separate articles based on what they control, for example, language features, code generation, and output. Use the table of contents to navigate amongst them.
 
 ## How to set options
 

--- a/docs/csharp/language-reference/compiler-options/security.md
+++ b/docs/csharp/language-reference/compiler-options/security.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
   - "KeyContainer compiler option [C#]"
   - "HighEntropyVA compiler option [C#]"
 ---
-# C# Compiler Options for security options
+# C# compiler options for security
 
 The following options control compiler security options. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* syntax is shown in `code style`.
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1264,7 +1264,7 @@ items:
     displayName: \#if, \#else, \#elif, \#endif, \#define, \#undef, \#warning, \#error, \#line, \#nullable, \#region, \#endregion, \#pragma, warning, checksum
   - name: Compiler options
     items:
-    - name: How to set options
+    - name: Overview
       href: language-reference/compiler-options/index.md
     - name: Language options
       displayName: CheckForOverflowUnderflow, checked, AllowUnsafeBlocks, unsafe, DefineConstants, define, LangVersion, langversion, Nullable, nullable


### PR DESCRIPTION
- Add index to compiler options overview page (basically so I can link to this page from the MSBuild properties page).
- Remove LangVersion property from MSBuild props article and link to C# compiler options section instead.

Fixes #23456.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/?branch=pr-en-us-25909).