### PR TITLE
Document new Roslyn Analyzer Rules for Wilson Token Validation

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5404.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5404.md
@@ -1,0 +1,72 @@
+---
+title: "CA5404: Do not disable token validation checks (code analysis)"
+description: Provides information about code analysis rule CA5404, including causes, how to fix violations, and when to suppress it.
+ms.date: 09/01/2021
+ms.topic: reference
+ms.author: timhann
+f1_keywords:
+  - "CA5404"
+---
+# CA5404: Do not disable token validation checks
+
+| | Value |
+|-|-|
+| **Rule ID** |CA5404|
+| **Category** |[Security](security-warnings.md)|
+| **Fix is breaking or non-breaking** |Non-breaking|
+
+## Cause
+
+Setting  <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties `RequireExpirationTime`, `ValidateAudience`, `ValidateIssuer`, or `ValidateLifetime` to `false`.
+
+## Rule description
+
+Token validation checks ensure that while validating tokens, all aspects are analyzed and verified. Turning off validation can lead to security holes by allowing untrusted tokens to make it through validation.
+
+More details about best practices for token validation can be found on the [library's wiki](https://aka.ms/wilson/tokenvalidation).
+
+## How to fix violations
+
+Set <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties `RequireExpirationTime`, `ValidateAudience`, `ValidateIssuer`, or `ValidateLifetime` to `true`. Or, remove the assignment to `false` because the default value is `true`.
+
+## When to suppress warnings
+
+While in the vast majority of cases, this validation is essential to ensure the security of the consuming app, there are some cases where this validation is not needed, especially in not standard token types. Before you disable this validation, be sure you have fully thought through the security implications. The [library's wiki](https://aka.ms/wilson/tokenvalidation) can prove useful when thinking about the tradeoffs.
+
+## Pseudo-code examples
+
+```csharp
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        TokenValidationParameters parameters = new TokenValidationParameters();
+        parameters.RequireExpirationTime = false;
+        parameters.ValidateAudience = false;
+        parameters.ValidateIssuer = false;
+        parameters.ValidateLifetime = false;
+    }
+}
+```
+
+### Solution
+
+```csharp
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        TokenValidationParameters parameters = new TokenValidationParameters();
+        parameters.RequireExpirationTime = true;
+        parameters.ValidateAudience = true;
+        parameters.ValidateIssuer = true;
+        parameters.ValidateLifetime = true;
+    }
+}
+```

--- a/docs/fundamentals/code-analysis/quality-rules/ca5404.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5404.md
@@ -31,7 +31,7 @@ Set <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties `
 
 ## When to suppress warnings
 
-While in the vast majority of cases, this validation is essential to ensure the security of the consuming app, there are some cases where this validation is not needed, especially in not standard token types. Before you disable this validation, be sure you have fully thought through the security implications. The [library's wiki](https://aka.ms/wilson/tokenvalidation) can prove useful when thinking about the tradeoffs.
+In the vast majority of cases, this validation is essential to ensure the security of the consuming app. However, there are some cases where this validation is not needed, especially in non-standard token types. Before you disable this validation, be sure you have fully thought through the security implications. For information about the trade-offs, see the [token validation library's wiki](https://aka.ms/wilson/tokenvalidation).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -1,0 +1,76 @@
+---
+title: "CA5045: Do not always skip token validation in delegates (code analysis)"
+description: Provides information about code analysis rule CA5405, including causes, how to fix violations, and when to suppress it.
+ms.date: 09/01/2021
+ms.topic: reference
+ms.author: timhann
+f1_keywords:
+  - "CA5405"
+---
+# CA5359: Do not always skip token validation in delegates
+
+| | Value |
+|-|-|
+| **Rule ID** |CA5405|
+| **Category** |[Security](security-warnings.md)|
+| **Fix is breaking or non-breaking** |Non-breaking|
+
+## Cause
+
+The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`.
+
+## Rule description
+
+By setting critical TokenValidationParameter validations delegates to always return true, important authentication safeguards are disabled which can lead to tokens from any issuer or expired tokens being wrongly validated.
+
+More details about best practices for token validation can be found on the [library's wiki](https://aka.ms/wilson/tokenvalidation).
+
+## How to fix violations
+
+- Improve the logic of the delegate so not all code paths return `true` which effectively disables that type of validation.
+- `SecurityTokenInvalidAudienceException` or `SecurityTokenInvalidLifetimeException` (respectively) can be thrown in failure cases for when you want to fail validation and have other cases pass by returning `true`.
+
+## When to suppress warnings
+
+In some very specific cases where you're utilizing the delegate for additional logging and it's for token types where, for special reasons, the specifc type of validation is not needed it may make sense to supress this warning. Before you disable this validation, be sure you have fully thought through the security implications. The [library's wiki](https://aka.ms/wilson/tokenvalidation) can prove useful when thinking about the tradeoffs.
+
+## Pseudo-code examples
+
+### Violation
+
+```csharp
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        TokenValidationParameters parameters = new TokenValidationParameters();
+        parameters.AudienceValidator = (audiences, token, tvp) => { return true; };
+    }
+}
+```
+
+### Solution
+
+```csharp
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        TokenValidationParameters parameters = new TokenValidationParameters();
+        parameters.AudienceValidator = (audiences, token, tvp) =>
+        {
+            // Implement your own custom audience validation
+            if (PerformCustomAudienceValidation(audiences, token))
+                return true;
+            else
+                return false;
+        };
+    }
+}
+```

--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -7,7 +7,7 @@ ms.author: timhann
 f1_keywords:
   - "CA5405"
 ---
-# CA5359: Do not always skip token validation in delegates
+# CA5405: Do not always skip token validation in delegates
 
 | | Value |
 |-|-|
@@ -21,18 +21,18 @@ The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>
 
 ## Rule description
 
-By setting critical TokenValidationParameter validations delegates to always return true, important authentication safeguards are disabled which can lead to tokens from any issuer or expired tokens being wrongly validated.
+By setting critical `TokenValidationParameter` validation delegates to always return `true`, important authentication safeguards are disabled. Disabling safeguards can lead to incorrect validation of tokens from any issuer or expired tokens.
 
-More details about best practices for token validation can be found on the [library's wiki](https://aka.ms/wilson/tokenvalidation).
+For more information about best practices for token validation, see the [library's wiki](https://aka.ms/wilson/tokenvalidation).
 
 ## How to fix violations
 
-- Improve the logic of the delegate so not all code paths return `true` which effectively disables that type of validation.
-- `SecurityTokenInvalidAudienceException` or `SecurityTokenInvalidLifetimeException` (respectively) can be thrown in failure cases for when you want to fail validation and have other cases pass by returning `true`.
+- Improve the logic of the delegate so not all code paths return `true`, which effectively disables that type of validation.
+- Throw `SecurityTokenInvalidAudienceException` or `SecurityTokenInvalidLifetimeException` in failure cases when you want to fail validation and have other cases pass by returning `true`.
 
 ## When to suppress warnings
 
-In some very specific cases where you're utilizing the delegate for additional logging and it's for token types where, for special reasons, the specifc type of validation is not needed it may make sense to supress this warning. Before you disable this validation, be sure you have fully thought through the security implications. The [library's wiki](https://aka.ms/wilson/tokenvalidation) can prove useful when thinking about the tradeoffs.
+In some specific cases where you're utilizing the delegate for additional logging and it's for token types where the specific type of validation is not needed, it may make sense to suppress this warning. Before you disable this validation, be sure you have fully thought through the security implications. For information about the trade-offs, see the [token validation library's wiki](https://aka.ms/wilson/tokenvalidation).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/index.md
+++ b/docs/fundamentals/code-analysis/quality-rules/index.md
@@ -272,7 +272,7 @@ The following table lists code quality analysis rules.
 > | [CA5401 Do not use CreateEncryptor with non-default IV](ca5401.md) | Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks. |
 > | [CA5402 Use CreateEncryptor with the default IV](ca5402.md) | Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks. |
 > | [CA5403: Do not hard-code certificate](ca5403.md) | The `data` or `rawData` parameter of a <xref:System.Security.Cryptography.X509Certificates.X509Certificate> or <xref:System.Security.Cryptography.X509Certificates.X509Certificate2> constructor is hard-coded. |
-> | [CA5404: Do not disable token validation checks](ca5404.md) | Setting  <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties controlling token validation to `false`. |
+> | [CA5404: Do not disable token validation checks](ca5404.md) | <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties that control token validation should not be set to `false`. |
 > | [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`. |
 > | [IL3000 Avoid accessing Assembly file path when publishing as a single file](il3000.md) | Avoid accessing Assembly file path when publishing as a single file. |
 > | [IL3001 Avoid accessing Assembly file path when publishing as a single-file](il3001.md) | Avoid accessing Assembly file path when publishing as a single file. |

--- a/docs/fundamentals/code-analysis/quality-rules/index.md
+++ b/docs/fundamentals/code-analysis/quality-rules/index.md
@@ -272,6 +272,8 @@ The following table lists code quality analysis rules.
 > | [CA5401 Do not use CreateEncryptor with non-default IV](ca5401.md) | Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks. |
 > | [CA5402 Use CreateEncryptor with the default IV](ca5402.md) | Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks. |
 > | [CA5403: Do not hard-code certificate](ca5403.md) | The `data` or `rawData` parameter of a <xref:System.Security.Cryptography.X509Certificates.X509Certificate> or <xref:System.Security.Cryptography.X509Certificates.X509Certificate2> constructor is hard-coded. |
+> | [CA5404: Do not disable token validation checks](ca5404.md) | Setting  <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties controlling token validation to `false`. |
+> | [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`. |
 > | [IL3000 Avoid accessing Assembly file path when publishing as a single file](il3000.md) | Avoid accessing Assembly file path when publishing as a single file. |
 > | [IL3001 Avoid accessing Assembly file path when publishing as a single-file](il3001.md) | Avoid accessing Assembly file path when publishing as a single file. |
 > | [IL3002 Avoid calling members annotated with 'RequiresAssemblyFilesAttribute' when publishing as a single file](il3002.md)|Avoid calling members annotated with 'RequiresAssemblyFilesAttribute' when publishing as a single file|

--- a/docs/fundamentals/code-analysis/quality-rules/security-warnings.md
+++ b/docs/fundamentals/code-analysis/quality-rules/security-warnings.md
@@ -113,5 +113,5 @@ Security rules support safer libraries and applications. These rules help preven
 |[CA5401: Do not use CreateEncryptor with non-default IV](ca5401.md)|Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.|
 |[CA5402: Use CreateEncryptor with the default IV](ca5402.md)|Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.|
 |[CA5403: Do not hard-code certificate](ca5403.md)|The `data` or `rawData` parameter of a <xref:System.Security.Cryptography.X509Certificates.X509Certificate> or <xref:System.Security.Cryptography.X509Certificates.X509Certificate2> constructor is hard-coded.|
-| [CA5404: Do not disable token validation checks](ca5404.md) | Setting  <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties controlling token validation to `false`. |
+| [CA5404: Do not disable token validation checks](ca5404.md) | <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties that control token validation should not be set to `false`. |
 | [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`. |

--- a/docs/fundamentals/code-analysis/quality-rules/security-warnings.md
+++ b/docs/fundamentals/code-analysis/quality-rules/security-warnings.md
@@ -113,3 +113,5 @@ Security rules support safer libraries and applications. These rules help preven
 |[CA5401: Do not use CreateEncryptor with non-default IV](ca5401.md)|Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.|
 |[CA5402: Use CreateEncryptor with the default IV](ca5402.md)|Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.|
 |[CA5403: Do not hard-code certificate](ca5403.md)|The `data` or `rawData` parameter of a <xref:System.Security.Cryptography.X509Certificates.X509Certificate> or <xref:System.Security.Cryptography.X509Certificates.X509Certificate2> constructor is hard-coded.|
+| [CA5404: Do not disable token validation checks](ca5404.md) | Setting  <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties controlling token validation to `false`. |
+| [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`. |

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1198,9 +1198,9 @@ items:
             href: code-analysis/quality-rules/ca5402.md
           - name: CA5403
             href: code-analysis/quality-rules/ca5403.md
-          - name: CA5403
+          - name: CA5404
             href: code-analysis/quality-rules/ca5404.md
-          - name: CA5403
+          - name: CA5405
             href: code-analysis/quality-rules/ca5405.md
         - name: Usage rules
           items:

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1198,6 +1198,10 @@ items:
             href: code-analysis/quality-rules/ca5402.md
           - name: CA5403
             href: code-analysis/quality-rules/ca5403.md
+          - name: CA5403
+            href: code-analysis/quality-rules/ca5404.md
+          - name: CA5403
+            href: code-analysis/quality-rules/ca5405.md
         - name: Usage rules
           items:
           - name: Overview


### PR DESCRIPTION
## Summary

* CA5404: Do not disable token validation checks
* CA5405: Do not always skip token validation in delegates

New Roslyn Analyzer Rules PR: https://github.com/dotnet/roslyn-analyzers/pull/5420
