### PR TITLE
F# can't produce default interface methods

### DIFF
--- a/docs/fsharp/language-reference/interfaces.md
+++ b/docs/fsharp/language-reference/interfaces.md
@@ -38,7 +38,7 @@ let class-name (argument-list) =
 
 ## Remarks
 
-Interface declarations resemble class declarations except that no members are implemented. Instead, all the members are abstract, as indicated by the keyword `abstract`. You do not provide a method body for abstract methods. However, you can provide a default implementation by also including a separate definition of the member as a method together with the `default` keyword. Doing so is equivalent to creating a virtual method in a base class in other .NET languages. Such a virtual method can be overridden in classes that implement the interface.
+Interface declarations resemble class declarations except that no members are implemented. Instead, all the members are abstract, as indicated by the keyword `abstract`. You do not provide a method body for abstract methods.
 
 The default accessibility for interfaces is `public`.
 

--- a/docs/fsharp/language-reference/interfaces.md
+++ b/docs/fsharp/language-reference/interfaces.md
@@ -38,7 +38,7 @@ let class-name (argument-list) =
 
 ## Remarks
 
-Interface declarations resemble class declarations except that no members are implemented. Instead, all the members are abstract, as indicated by the keyword `abstract`. You do not provide a method body for abstract methods.
+Interface declarations resemble class declarations except that no members are implemented. Instead, all the members are abstract, as indicated by the keyword `abstract`. You do not provide a method body for abstract methods. F# cannot define a default method implementation on an interface, but it is compatible with default implementations defined by C#. Default implementations using the `default` keyword are only supported when inheriting from a non-interface base class.
 
 The default accessibility for interfaces is `public`.
 


### PR DESCRIPTION
The remark section on the [page about F# interfaces](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/interfaces) seems to allude to a capability that I don't think it has:

> However, you can provide a default implementation by also including a separate definition of the member as a method together with the default keyword. Doing so is equivalent to creating a virtual method in a base class in other .NET languages. Such a virtual method can be overridden in classes that implement the interface.

I may be misinterpreting this; I was surprised to see the git blame for this paragraph is quite old. F#5 can use C# default interface methods, but it cannot provide them. 

Related: [https://github.com/fsharp/fslang-suggestions/issues/679](https://github.com/fsharp/fslang-suggestions/issues/679)

If the existing remark is in fact wrong, I would of course like feedback on the wording of the clarification (in PR).
