### PR TITLE
Add ComWrappers tutorial

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -8,7 +8,7 @@ ms.date: 09/01/2021
 
 C# 8.0 introduces features that you can use to minimize the likelihood that your code causes the runtime to throw <xref:System.NullReferenceException?displayProperty=nameWithType>. There are three features that help you avoid these exceptions.
 
-- Improved static flow analysis that determines if a variable may be `null` before dereferencing it. 
+- Improved static flow analysis that determines if a variable may be `null` before dereferencing it.
 - Attributes that annotate APIs so that the flow analysis determines *null-state*.
 - Variable annotations that developers use to explicitly declare the intended *null-state* for a variable.
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2472,12 +2472,10 @@ items:
           href: ../standard/native-interop/runtime-callable-wrapper.md
         - name: COM-callable wrapper
           href: ../standard/native-interop/com-callable-wrapper.md
+        - name: Tutorial: Use the ComWrappers API
+          href: ../standard/native-interop/tutorial-comwrappers.md
       - name: Qualifying .NET types for COM interop
         href: ../standard/native-interop/qualify-net-types-for-interoperation.md
-      - name: Tutorials
-        items:
-        - name: Using the ComWrappers API
-          href: ../standard/native-interop/tutorial-comwrappers.md
     - name: Apply interop attributes
       href: ../standard/native-interop/apply-interop-attributes.md
     - name: Exceptions

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2472,7 +2472,7 @@ items:
           href: ../standard/native-interop/runtime-callable-wrapper.md
         - name: COM-callable wrapper
           href: ../standard/native-interop/com-callable-wrapper.md
-        - name: Tutorial: Use the ComWrappers API
+        - name: Tutorial - Use the ComWrappers API
           href: ../standard/native-interop/tutorial-comwrappers.md
       - name: Qualifying .NET types for COM interop
         href: ../standard/native-interop/qualify-net-types-for-interoperation.md

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2475,6 +2475,10 @@ items:
           href: ../standard/native-interop/com-callable-wrapper.md
       - name: Qualifying .NET types for COM interop
         href: ../standard/native-interop/qualify-net-types-for-interoperation.md
+      - name: Tutorials
+        items:
+        - name: Using the ComWrappers API
+          href: ../standard/native-interop/tutorial-comwrappers.md
     - name: Apply interop attributes
       href: ../standard/native-interop/apply-interop-attributes.md
     - name: Exceptions

--- a/docs/standard/native-interop/tutorial-comwrappers.md
+++ b/docs/standard/native-interop/tutorial-comwrappers.md
@@ -1,3 +1,15 @@
+---
+title: "Using the ComWrappers API"
+description: A tutorial on properly implementing the ComWrappers API.
+author: arobins
+ms.date: "02/09/2021"
+helpviewer_keywords:
+  - "COM interop, ComWrappers"
+  - "RCW"
+  - "CCW"
+  - "interoperation with unmanaged code, COM wrappers"
+  - "NativeAOT"
+---
 # Using the `ComWrappers` API
 
 In this tutorial we are going to see how to properly subclass the [`ComWrappers`][api_comwrappers] type to provide an optimized and AOT friendly COM interop solution. It is assumed the reader of this document is familiar COM, its architecture, and existing COM interop solutions.
@@ -375,22 +387,22 @@ Aside from the lifetime, type system, and functional features that are discussed
 
 <!-- Reusable links -->
 
-[api_allocatetypeassociatedmemory]:https://docs.microsoft.com/dotnet/api/system.runtime.compilerservices.runtimehelpers.allocatetypeassociatedmemory
-[api_comwrappers]:https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.comwrappers
-[api_dynamicinterfacecastableimplementation]:https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.dynamicinterfacecastableimplementationattribute
-[api_idynamicinterfacecastable]:https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.idynamicinterfacecastable
-[api_marshalqueryinterface]:https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.queryinterface
-[api_referencetracker]:https://docs.microsoft.com/windows/win32/api/windows.ui.xaml.hosting.referencetracker/
-[api_rogetagilereference]:https://docs.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-rogetagilereference
-[api_unmanagedcallersonly]:https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.unmanagedcallersonlyattribute
+[api_allocatetypeassociatedmemory]:/dotnet/api/system.runtime.compilerservices.runtimehelpers.allocatetypeassociatedmemory
+[api_comwrappers]:/dotnet/api/system.runtime.interopservices.comwrappers
+[api_dynamicinterfacecastableimplementation]:/dotnet/api/system.runtime.interopservices.dynamicinterfacecastableimplementationattribute
+[api_idynamicinterfacecastable]:/dotnet/api/system.runtime.interopservices.idynamicinterfacecastable
+[api_marshalqueryinterface]:/dotnet/api/system.runtime.interopservices.marshal.queryinterface
+[api_referencetracker]:/windows/win32/api/windows.ui.xaml.hosting.referencetracker/
+[api_rogetagilereference]:/windows/win32/api/combaseapi/nf-combaseapi-rogetagilereference
+[api_unmanagedcallersonly]:/dotnet/api/system.runtime.interopservices.unmanagedcallersonlyattribute
 
-[doc_comapartments]:https://docs.microsoft.com/windows/win32/com/processes--threads--and-apartments
-[doc_comsecurity]:https://docs.microsoft.com/windows/win32/com/security-in-com
-[doc_globalinterfacetable]:https://docs.microsoft.com/windows/win32/com/when-to-use-the-global-interface-table
-[doc_impliunknown]:https://docs.microsoft.com/windows/win32/com/using-and-implementing-iunknown
-[doc_nullable]:https://docs.microsoft.com//dotnet/csharp/nullable-references
-[doc_unloadability]:https://docs.microsoft.com/dotnet/standard/assembly/unloadability
-[doc_unsafekeyword]:https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/unsafe
+[doc_comapartments]:/windows/win32/com/processes--threads--and-apartments
+[doc_comsecurity]:/windows/win32/com/security-in-com
+[doc_globalinterfacetable]:/windows/win32/com/when-to-use-the-global-interface-table
+[doc_impliunknown]:/windows/win32/com/using-and-implementing-iunknown
+[doc_nullable]:/dotnet/csharp/nullable-references
+[doc_unloadability]:/dotnet/standard/assembly/unloadability
+[doc_unsafekeyword]:/dotnet/csharp/language-reference/keywords/unsafe
 
 [repo_cswinrt]:https://github.com/microsoft/CsWinRT
 

--- a/docs/standard/native-interop/tutorial-comwrappers.md
+++ b/docs/standard/native-interop/tutorial-comwrappers.md
@@ -1,7 +1,7 @@
 ---
 title: "Using the ComWrappers API"
 description: A tutorial on properly implementing the ComWrappers API.
-author: arobins
+author: AaronRobinsonMSFT
 ms.date: "02/09/2021"
 helpviewer_keywords:
   - "COM interop, ComWrappers"

--- a/docs/standard/native-interop/tutorial-comwrappers.md
+++ b/docs/standard/native-interop/tutorial-comwrappers.md
@@ -7,6 +7,7 @@ We will be implementing the following interface definitions. These interfaces an
 All source code used in this tutorial is available in the final section of this document.
 
 **C# definitions**
+
 ```csharp
 interface IDemoGetType
 {
@@ -20,6 +21,7 @@ interface IDemoStoreType
 ```
 
 **Win32 C++ definitions**
+
 ```c++
 MIDL_INTERFACE("92BAA992-DB5A-4ADD-977B-B22838EE91FD")
 IDemoGetType : public IUnknown
@@ -306,6 +308,7 @@ Unlike the Managed Object Wrapper, which is controlled by calls to its `AddRef()
 We now have a `ComWrappers` subclass that can be tested. In order to avoid creating a native library that returns a COM instance that implements `IDemoGetType` and `IDemoStoreType` we are going to use the Managed Object Wrapper and treat it as a COM instance &ndash; this must be possible in order to pass it COM anyways.
 
 Let's create a Managed Object Wrapper first. We will instantiate a `DemoImpl` instance display its current string state.
+
 ```csharp
 var demo = new DemoImpl();
 
@@ -314,6 +317,7 @@ Console.WriteLine($"Initial string: {value ?? "<null>"}");
 ```
 
 Now we can create an instance of `DemoComWrappers` and create a Managed Object Wrapper that we could then pass into a COM environment.
+
 ```csharp
 var cw = new DemoComWrappers();
 
@@ -321,11 +325,13 @@ IntPtr ccw = cw.GetOrCreateComInterfaceForObject(demo, CreateComInterfaceFlags.N
 ```
 
 Instead of passing the Managed Object Wrapper to a COM environment let's pretend we just received this COM instance and instead create a Native Object Wrapper for it.
+
 ```csharp
 var rcw = cw.GetOrCreateObjectForComInstance(ccw, CreateObjectFlags.UniqueInstance);
 ```
 
 With the Native Object Wrapper we should be able to cast it to one of the desired interfaces and use it as a normal managed object. We can examine the `DemoImpl` instance and observe the impact of operations on the Native Object Wrapper that is wrapping a Managed Object Wrapper that is in turn wrapping the managed instance is reflected.
+
 ```csharp
 var getter = (IDemoGetType)rcw;
 var store = (IDemoStoreType)rcw;
@@ -346,6 +352,7 @@ Console.WriteLine($"Get string through wrapper: {value}");
 ```
 
 Since our `ComWrapper` subclass was designed to support `CreateObjectFlags.UniqueInstance` we can clean up the Native Object Wrapper immediately instead of waiting for a GC to occur.
+
 ```csharp
 (rcw as IDisposable)?.Dispose();
 ```

--- a/docs/standard/native-interop/tutorial-comwrappers.md
+++ b/docs/standard/native-interop/tutorial-comwrappers.md
@@ -260,7 +260,7 @@ internal class DemoNativeDynamicWrapper
 }
 ```
 
-Let's look at one of the types that `DemoNativeDynamicWrapper` will dynamically support. The following code defines the `IDataStoreType` type using the *default interface methods* feature.
+Let's look at one of the interfaces that `DemoNativeDynamicWrapper` will dynamically support. The following code provides the implementation of `IDemoStoreType` using the *default interface methods* feature.
 
 ```csharp
 [DynamicInterfaceCastableImplementation]
@@ -278,7 +278,7 @@ unsafe interface IDemoStoreTypeNativeWrapper : IDemoStoreType
 
 There are two important things to note in this example:
 
-1) The `DynamicInterfaceCastableImplementationAttribute` attribute. This attribute is required on any type that is returned from a `IDynamicInterfaceCastable` method. It has the added benefit of making IL Linking easier, which means NativeAOT scenarios are more reliable.
+1) The `DynamicInterfaceCastableImplementationAttribute` attribute. This attribute is required on any type that is returned from a `IDynamicInterfaceCastable` method. It has the added benefit of making IL trimming easier, which means NativeAOT scenarios are more reliable.
 2) The cast to `DemoNativeDynamicWrapper`. This is part of the dynamic nature of `IDynamicInterfaceCastable`. The type that's returned from `IDynamicInterfaceCastable.GetInterfaceImplementation()` is used to blanket the type that implements `IDynamicInterfaceCastable`.
 
 Regardless of which Native Object Wrapper is used, you need the ability to invoke functions on a COM instance. The implementation of `IDemoStoreTypeNativeWrapper.StoreString()` can serve as an example of employing `unmanaged` C# function pointers.
@@ -315,7 +315,7 @@ Once the `CreateObject()` method is implemented, the `ComWrappers` subclass will
 
 ```csharp
 IntPtr iunk = ...; // Get a COM instance from native code.
-object rcw = cw.GetOrCreateObjectForComInstance(ccw, CreateObjectFlags.UniqueInstance);
+object rcw = cw.GetOrCreateObjectForComInstance(iunk, CreateObjectFlags.UniqueInstance);
 ```
 
 ### Step 4 &ndash; Handle Native Object Wrapper lifetime details


### PR DESCRIPTION
## Summary

Add a tutorial on using the `ComWrappers` API introduced in .NET 5.

Source for tutorial is in PR at https://github.com/dotnet/samples/pull/4798.

/cc @gewarren @jkoritzinsky @elinor-fung @agocke @sbomer @vitek-karas 
