### PR TITLE
Preview-to-preview breaking change for implicit namespaces

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -81,8 +81,8 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | Preview 6 |
 | [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | Preview 1 |
 | [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | Preview 1 |
-| [Implicit namespaces in C# projects](sdk/6.0/implicit-namespaces.md) | Preview 7 |
-| [Implicit namespaces disabled by default](sdk/6.0/implicit-namespaces-rc1.md) | RC 1|
+| [Implicit global using directives in C# projects](sdk/6.0/implicit-namespaces.md) | Preview 7 |
+| [Implicit global using directives disabled](sdk/6.0/implicit-namespaces-rc1.md) | RC 1|
 | [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | RC 1 |
 
 ## Serialization

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -82,6 +82,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | Preview 1 |
 | [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | Preview 1 |
 | [Implicit namespaces in C# projects](sdk/6.0/implicit-namespaces.md) | Preview 7 |
+| [Implicit namespaces disabled by default](sdk/6.0/implicit-namespaces-rc1.md) | RC 1|
 | [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | RC 1 |
 
 ## Serialization

--- a/docs/core/compatibility/sdk/6.0/implicit-namespaces-rc1.md
+++ b/docs/core/compatibility/sdk/6.0/implicit-namespaces-rc1.md
@@ -1,11 +1,11 @@
 ---
-title: "Preview-to-preview breaking change: Implicit namespaces disabled by default"
-description: Learn about the preview-to-preview breaking change in .NET 6 where the implicit namespaces feature is disabled by default in C# projects.
+title: "Preview-to-preview breaking change: Implicit `global using` directives disabled for existing projects"
+description: Learn about the preview-to-preview breaking change in .NET 6 where the implicit `global using` directives feature is disabled by default for existing C# projects.
 ms.date: 09/02/2021
 ---
-# Implicit namespaces disabled by default
+# Implicit `global using` directives disabled by default
 
-C# 10.0 introduced [global namespace](../../../../csharp/language-reference/keywords/using-directive.md#global-modifier) support for C# projects. In Preview 7, [the .NET SDK implicitly added global namespaces](implicit-namespaces.md) to .NET projects, and the feature was enabled by default. In .NET 6 RC 1, implicit namespaces are disabled by default, and some of the associated MSBuild property and item names have changed. You may need to re-enable the feature or explicitly include namespaces that your project depends on.
+C# 10.0 introduced [`global using`](../../../../csharp/language-reference/keywords/using-directive.md#global-modifier) directive support for C# projects. In Preview 7, [the .NET SDK implicitly added `global using` directives](implicit-namespaces.md) to new and existing .NET projects, by default. In .NET 6 RC 1, implicit `global using` directives are disabled for existing projects, and some of the associated MSBuild property and item names have changed. You may need to re-enable the feature or explicitly include namespaces that your project depends on.
 
 ## Version introduced
 
@@ -13,7 +13,7 @@ C# 10.0 introduced [global namespace](../../../../csharp/language-reference/keyw
 
 ## Old behavior
 
-In .NET 6 Preview 7, the .NET SDK implicitly includes a set of default namespaces for C# projects that target .NET 6 or later and that use one of the following SDKs:
+In .NET 6 Preview 7, the .NET SDK implicitly included a set of default namespaces for new *and existing* C# projects that target .NET 6 or later and that use one of the following SDKs:
 
 - Microsoft.NET.Sdk
 - Microsoft.NET.Sdk.Web
@@ -26,14 +26,15 @@ In addition, you could:
 
 ## New behavior
 
-Starting in .NET 6 RC 1, no implicit namespaces are included, by default. However, you can enable the feature in your C# project by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
+Starting in .NET 6 RC 1, no implicit `global using` directives are added when you retarget an existing project to .NET 6 or later. However, you can enable the feature in your C# project by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
 
 In addition, for C# projects:
 
+- For *new* projects that target .NET 6 or later, the `ImplicitUsings` property is set to `true`, so `global using` directives are added.
 - The MSBuild property used to enable or disable the feature is renamed to `ImplicitUsings`, and the SDK-specific properties, such as `DisableImplicitNamespaceImports_DotNet`, are no longer valid. The feature is either completely enabled or completely disabled.
 - The item type to include a specific namespaces is renamed to `Using`. For Visual Basic projects, you can continue to use the `Import` item type.
 
-If you enable implicit namespaces, the .NET SDK includes the default namespaces by adding `global using` directives to a generated file in the project's *obj* directory. The default namespaces are as follows:
+If you enable implicit `global using` directives, the .NET SDK adds `global using` directives for a set of default namespaces to a generated file in the project's *obj* directory. The default namespaces are as follows:
 
 | SDK | Default namespaces |
 | - | - |
@@ -53,8 +54,8 @@ The [Preview 7 breaking change](implicit-namespaces.md) caused a few issues in s
 
 If you relied on namespaces being implicitly included in your C# project, you can:
 
-- Re-enable implicit namespaces by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
-- Add `using` directives to your source files.
+- Re-enable implicit `global using` directives by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
+
 - Include the namespaces globally by adding `Using` items to your project file (or renaming your existing `Import` items). For example:
 
   ```xml
@@ -62,6 +63,8 @@ If you relied on namespaces being implicitly included in your C# project, you ca
     <Using Include="System.IO.Pipes" />
   </ItemGroup>
   ```
+
+- Add `using` directives to your source files or `global using` directives to a single source file.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/sdk/6.0/implicit-namespaces-rc1.md
+++ b/docs/core/compatibility/sdk/6.0/implicit-namespaces-rc1.md
@@ -1,0 +1,68 @@
+---
+title: "Preview-to-preview breaking change: Implicit namespaces disabled by default"
+description: Learn about the preview-to-preview breaking change in .NET 6 where the implicit namespaces feature is disabled by default in C# projects.
+ms.date: 09/02/2021
+---
+# Implicit namespaces disabled by default
+
+C# 10.0 introduced [global namespace](../../../../csharp/language-reference/keywords/using-directive.md#global-modifier) support for C# projects. In Preview 7, [the .NET SDK implicitly added global namespaces](implicit-namespaces.md) to .NET projects, and the feature was enabled by default. In .NET 6 RC 1, implicit namespaces are disabled by default, and some of the associated MSBuild property and item names have changed. You may need to re-enable the feature or explicitly include namespaces that your project depends on.
+
+## Version introduced
+
+.NET 6 RC 1
+
+## Old behavior
+
+In .NET 6 Preview 7, the .NET SDK implicitly includes a set of default namespaces for C# projects that target .NET 6 or later and that use one of the following SDKs:
+
+- Microsoft.NET.Sdk
+- Microsoft.NET.Sdk.Web
+- Microsoft.NET.Sdk.Worker
+
+In addition, you could:
+
+- Disable the feature globally using the `DisableImplicitNamespaceImports` MSBuild property, or on an SDK-specific basis using the `DisableImplicitNamespaceImports_DotNet`, `DisableImplicitNamespaceImports_Web`, and `DisableImplicitNamespaceImports_Worker` properties.
+- Import specific namespaces using the `Import` item type.
+
+## New behavior
+
+Starting in .NET 6 RC 1, no implicit namespaces are included, by default. However, you can enable the feature in your C# project by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
+
+If you enable the feature, the default namespaces are included by adding `global using` directives to a generated file in the project's *obj* directory. The default namespaces are as follows:
+
+| SDK | Default namespaces |
+| - | - |
+| Microsoft.NET.Sdk | <xref:System><br/><xref:System.Collections.Generic?displayProperty=fullName><br/><xref:System.IO?displayProperty=fullName><br/><xref:System.Linq?displayProperty=fullName><br/><xref:System.Net.Http?displayProperty=fullName><br/><xref:System.Threading?displayProperty=fullName><br/><xref:System.Threading.Tasks?displayProperty=fullName> |
+| Microsoft.NET.Sdk.Web | <xref:System.Net.Http.Json?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Builder?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Hosting?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Http?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Routing?displayProperty=fullName><br/><xref:Microsoft.Extensions.Configuration?displayProperty=fullName><br/><xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName><br/><xref:Microsoft.Extensions.Hosting?displayProperty=fullName><br/><xref:Microsoft.Extensions.Logging?displayProperty=fullName> |
+| Microsoft.NET.Sdk.Worker | <xref:Microsoft.Extensions.Configuration?displayProperty=fullName><br/><xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName><br/><xref:Microsoft.Extensions.Hosting?displayProperty=fullName><br/><xref:Microsoft.Extensions.Logging?displayProperty=fullName> |
+
+In addition, for C# projects:
+
+- The MSBuild property used to enable or disable the feature is renamed to `ImplicitUsings`, and the SDK-specific properties, such as `DisableImplicitNamespaceImports_DotNet`, are no longer valid. The feature is either completely enabled or completely disabled.
+- The item type to include a specific namespaces is renamed to `Using`. For Visual Basic projects, you can continue to use the `Import` item type.
+
+## Change category
+
+This change may affect [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+The [Preview 7 breaking change](implicit-namespaces.md) caused a few issues in some important scenarios. We are changing the feature to mitigate the issues and generally improve its usability.
+
+## Recommended action
+
+If you relied on namespaces being implicitly included in your C# project, you can:
+
+- Re-enable implicit namespaces by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
+- Add `using` directives to your source files.
+- Include the namespaces globally by adding `Using` items to your project file (or renaming your existing `Import` items). For example:
+
+  ```xml
+  <ItemGroup>
+    <Using Include="System.IO.Pipes" />
+  </ItemGroup>
+  ```
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/sdk/6.0/implicit-namespaces-rc1.md
+++ b/docs/core/compatibility/sdk/6.0/implicit-namespaces-rc1.md
@@ -28,18 +28,18 @@ In addition, you could:
 
 Starting in .NET 6 RC 1, no implicit namespaces are included, by default. However, you can enable the feature in your C# project by setting the [`ImplicitUsings` MSBuild property](../../../project-sdk/msbuild-props.md#implicitusings) to `true` or `enable`.
 
-If you enable the feature, the default namespaces are included by adding `global using` directives to a generated file in the project's *obj* directory. The default namespaces are as follows:
+In addition, for C# projects:
+
+- The MSBuild property used to enable or disable the feature is renamed to `ImplicitUsings`, and the SDK-specific properties, such as `DisableImplicitNamespaceImports_DotNet`, are no longer valid. The feature is either completely enabled or completely disabled.
+- The item type to include a specific namespaces is renamed to `Using`. For Visual Basic projects, you can continue to use the `Import` item type.
+
+If you enable implicit namespaces, the .NET SDK includes the default namespaces by adding `global using` directives to a generated file in the project's *obj* directory. The default namespaces are as follows:
 
 | SDK | Default namespaces |
 | - | - |
 | Microsoft.NET.Sdk | <xref:System><br/><xref:System.Collections.Generic?displayProperty=fullName><br/><xref:System.IO?displayProperty=fullName><br/><xref:System.Linq?displayProperty=fullName><br/><xref:System.Net.Http?displayProperty=fullName><br/><xref:System.Threading?displayProperty=fullName><br/><xref:System.Threading.Tasks?displayProperty=fullName> |
 | Microsoft.NET.Sdk.Web | <xref:System.Net.Http.Json?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Builder?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Hosting?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Http?displayProperty=fullName><br/><xref:Microsoft.AspNetCore.Routing?displayProperty=fullName><br/><xref:Microsoft.Extensions.Configuration?displayProperty=fullName><br/><xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName><br/><xref:Microsoft.Extensions.Hosting?displayProperty=fullName><br/><xref:Microsoft.Extensions.Logging?displayProperty=fullName> |
 | Microsoft.NET.Sdk.Worker | <xref:Microsoft.Extensions.Configuration?displayProperty=fullName><br/><xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName><br/><xref:Microsoft.Extensions.Hosting?displayProperty=fullName><br/><xref:Microsoft.Extensions.Logging?displayProperty=fullName> |
-
-In addition, for C# projects:
-
-- The MSBuild property used to enable or disable the feature is renamed to `ImplicitUsings`, and the SDK-specific properties, such as `DisableImplicitNamespaceImports_DotNet`, are no longer valid. The feature is either completely enabled or completely disabled.
-- The item type to include a specific namespaces is renamed to `Using`. For Visual Basic projects, you can continue to use the `Import` item type.
 
 ## Change category
 

--- a/docs/core/compatibility/sdk/6.0/implicit-namespaces.md
+++ b/docs/core/compatibility/sdk/6.0/implicit-namespaces.md
@@ -11,6 +11,9 @@ The implicit namespace feature is enabled by default for C# projects that target
 
 If your project uses a C# version less than 10, you must explicitly [disable this feature](#recommended-action).
 
+> [!IMPORTANT]
+> The implicit namespaces feature was [changed in .NET 6 RC1](implicit-namespaces-rc1.md), such that this is only a breaking change for the Preview 7 version of .NET 6.
+
 ## Version introduced
 
 .NET 6 Preview 7

--- a/docs/core/compatibility/sdk/6.0/implicit-namespaces.md
+++ b/docs/core/compatibility/sdk/6.0/implicit-namespaces.md
@@ -1,9 +1,9 @@
 ---
-title: "Breaking change: Implicit namespaces in C# projects"
+title: "Breaking change: Implicit `global using` directives in C# projects"
 description: Learn about the breaking change in .NET 6 where the .NET SDK implicitly includes some namespaces globally in C# projects.
 ms.date: 07/20/2021
 ---
-# Implicit namespaces in C# projects
+# Implicit `global using` directives in C# projects
 
 .NET 6 introduces implicit namespace support for C# projects. To reduce the amount of `using` directives boilerplate in .NET C# project templates, namespaces are implicitly included by utilizing the `global using` feature introduced in C# 10.
 
@@ -12,7 +12,7 @@ The implicit namespace feature is enabled by default for C# projects that target
 If your project uses a C# version less than 10, you must explicitly [disable this feature](#recommended-action).
 
 > [!IMPORTANT]
-> The implicit namespaces feature was [changed in .NET 6 RC1](implicit-namespaces-rc1.md), such that this is only a breaking change for the Preview 7 version of .NET 6.
+> The implicit `global using` directives feature was [changed in .NET 6 RC1](implicit-namespaces-rc1.md), such that this is only a breaking change for the Preview 7 version of .NET 6.
 
 ## Version introduced
 
@@ -20,7 +20,7 @@ If your project uses a C# version less than 10, you must explicitly [disable thi
 
 ## Old behavior
 
-No implicit namespaces are added to C# projects and there are no type conflicts.
+No implicit `global using` directives are added to C# projects and there are no type conflicts.
 
 ## New behavior
 
@@ -55,10 +55,10 @@ This change was made to reduce the number of boilerplate `using` directives that
 
 ## Recommended action
 
-For most users, you need take no action. However, this change can cause type-name conflicts with the namespaces that are implicitly included. If that happens, modify the list of implicit namespaces or fully qualify your type references. You can modify the list of implicit namespaces in several ways:
+For most users, you need take no action. However, this change can cause type-name conflicts with the namespaces that are implicitly included. If that happens, modify the list of `global using` directives or fully qualify your type references. You can modify the list of `global using` directives in several ways:
 
 - Disable the feature completely by setting `<DisableImplicitNamespaceImports>` to `true` in the project file. For more information, see [DisableImplicitNamespaceImports](../../../project-sdk/msbuild-props.md#disableimplicitnamespaceimports).
-- Disable a set of implicit namespaces added by an SDK by setting the `DisableImplicitNamespaceImports_DotNet`, `DisableImplicitNamespaceImports_Web`, or `DisableImplicitNamespaceImports_Worker` property to `true` in the project file. For more information, see [DisableImplicitNamespaceImports](../../../project-sdk/msbuild-props.md#disableimplicitnamespaceimports).
+- Disable a set of implicit `global using` directives added by an SDK by setting the `DisableImplicitNamespaceImports_DotNet`, `DisableImplicitNamespaceImports_Web`, or `DisableImplicitNamespaceImports_Worker` property to `true` in the project file. For more information, see [DisableImplicitNamespaceImports](../../../project-sdk/msbuild-props.md#disableimplicitnamespaceimports).
 - Add or remove individual namespaces by modifying the `<Import>` item group in the project file. For example:
 
   ```xml

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -117,6 +117,8 @@ items:
           href: sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md
         - name: Implicit namespaces in C# projects
           href: sdk/6.0/implicit-namespaces.md
+        - name: Implicit namespaces disabled by default
+          href: sdk/6.0/implicit-namespaces-rc1.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md
       - name: Windows Forms
@@ -725,6 +727,8 @@ items:
           href: sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md
         - name: Implicit namespaces in C# projects
           href: sdk/6.0/implicit-namespaces.md
+        - name: Implicit namespaces disabled by default
+          href: sdk/6.0/implicit-namespaces-rc1.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md
       - name: .NET 5

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -725,9 +725,9 @@ items:
           href: sdk/6.0/duplicate-files-in-output.md
         - name: GetTargetFrameworkProperties and GetNearestTargetFramework removed
           href: sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md
-        - name: Implicit namespaces in C# projects
+        - name: Implicit `global using` directives in C# projects
           href: sdk/6.0/implicit-namespaces.md
-        - name: Implicit namespaces disabled by default
+        - name: Implicit `global using` directives disabled
           href: sdk/6.0/implicit-namespaces-rc1.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -115,9 +115,9 @@ items:
           href: sdk/6.0/duplicate-files-in-output.md
         - name: GetTargetFrameworkProperties and GetNearestTargetFramework removed
           href: sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md
-        - name: Implicit namespaces in C# projects
+        - name: Implicit `global using` directives in C# projects
           href: sdk/6.0/implicit-namespaces.md
-        - name: Implicit namespaces disabled by default
+        - name: Implicit `global using` directives disabled
           href: sdk/6.0/implicit-namespaces-rc1.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -870,7 +870,7 @@ The following properties concern code in generated files:
 
 ### DisableImplicitNamespaceImports
 
-The `DisableImplicitNamespaceImports` property can be used to disable [implicit `global using` directives](../compatibility/sdk/6.0/implicit-namespaces.md) in Visual Basic projects that target .NET 6 or a later version. Implicit namespaces are the default namespaces that are globally included in a Visual Basic project. Set this property to `true` to disable implicit namespaces.
+The `DisableImplicitNamespaceImports` property can be used to disable [implicit namespace imports](../compatibility/sdk/6.0/implicit-namespaces.md) in Visual Basic projects that target .NET 6 or a later version. Implicit namespaces are the default namespaces that are imported globally in a Visual Basic project. Set this property to `true` to disable implicit namespace imports.
 
 ```xml
 <PropertyGroup>
@@ -880,13 +880,16 @@ The `DisableImplicitNamespaceImports` property can be used to disable [implicit 
 
 ### ImplicitUsings
 
-The `ImplicitUsings` property can be used to enable and disable implicit `global using` directives in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. Implicit `global using` directives are added for a set of default namespaces based on the type of SDK. Set this property to `true` or `enable` to enable implicit `global using` directives. To disable implicit `global using` directives, remove the property or set it to `false` .
+The `ImplicitUsings` property can be used to enable and disable implicit `global using` directives in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. When the feature is enabled, the .NET SDK adds `global using` directives for a set of default namespaces based on the type of project SDK. Set this property to `true` or `enable` to enable implicit `global using` directives. To disable implicit `global using` directives, remove the property or set it to `false` .
 
 ```xml
 <PropertyGroup>
   <ImplicitUsings>true</ImplicitUsings>
 </PropertyGroup>
 ```
+
+> [!NOTE]
+> For new C# projects that target .NET 6 or later, `ImplicitUsings` is set to `true` by default.
 
 ## Items
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -870,7 +870,7 @@ The following properties concern code in generated files:
 
 ### DisableImplicitNamespaceImports
 
-The `DisableImplicitNamespaceImports` property can be used to disable [implicit namespaces](../compatibility/sdk/6.0/implicit-namespaces.md) in Visual Basic projects that target .NET 6 or a later version. Implicit namespaces are the default namespaces that are globally included in a Visual Basic project. Set this property to `true` to disable implicit namespaces.
+The `DisableImplicitNamespaceImports` property can be used to disable [implicit `global using` directives](../compatibility/sdk/6.0/implicit-namespaces.md) in Visual Basic projects that target .NET 6 or a later version. Implicit namespaces are the default namespaces that are globally included in a Visual Basic project. Set this property to `true` to disable implicit namespaces.
 
 ```xml
 <PropertyGroup>
@@ -880,7 +880,7 @@ The `DisableImplicitNamespaceImports` property can be used to disable [implicit 
 
 ### ImplicitUsings
 
-The `ImplicitUsings` property can be used to enable implicit namespaces in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. Implicit namespaces are the default namespaces that are globally included in a project based on the type of SDK. Set this property to `true` or `enable` to enable implicit namespaces.
+The `ImplicitUsings` property can be used to enable and disable implicit `global using` directives in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. Implicit `global using` directives are added for a set of default namespaces based on the type of SDK. Set this property to `true` or `enable` to enable implicit `global using` directives. Set it to `false` to disable implicit `global using` directives.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -880,7 +880,7 @@ The `DisableImplicitNamespaceImports` property can be used to disable [implicit 
 
 ### ImplicitUsings
 
-The `ImplicitUsings` property can be used to enable and disable implicit `global using` directives in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. Implicit `global using` directives are added for a set of default namespaces based on the type of SDK. Set this property to `true` or `enable` to enable implicit `global using` directives. Set it to `false` to disable implicit `global using` directives.
+The `ImplicitUsings` property can be used to enable and disable implicit `global using` directives in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. Implicit `global using` directives are added for a set of default namespaces based on the type of SDK. Set this property to `true` or `enable` to enable implicit `global using` directives. To disable implicit `global using` directives, remove the property or set it to `false` .
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -880,7 +880,7 @@ The `DisableImplicitNamespaceImports` property can be used to disable [implicit 
 
 ### ImplicitUsings
 
-The `ImplicitUsings` property can be used to enable implicit namespaces in C# projects that target .NET 6 or a later version and that use C# 10.0 or a later version. Implicit namespaces are the default namespaces that are globally included in a project based on the type of SDK. Set this property to `true` to enable implicit namespaces.
+The `ImplicitUsings` property can be used to enable implicit namespaces in C# projects that target .NET 6 or a later version and C# 10.0 or a later version. Implicit namespaces are the default namespaces that are globally included in a project based on the type of SDK. Set this property to `true` or `enable` to enable implicit namespaces.
 
 ```xml
 <PropertyGroup>
@@ -894,6 +894,7 @@ The `ImplicitUsings` property can be used to enable implicit namespaces in C# pr
 
 - [PackageReference](#packagereference)
 - [TrimmerRootAssembly](#trimmerrootassembly)
+- [Using](#using)
 
 You can use any of the standard [item attributes](/visualstudio/msbuild/item-element-msbuild#attributes-and-elements), for example, `Include` and `Update`, on these items. Use `Include` to add a new item, and use `Update` to modify an existing item. For example, `Update` is often used to modify an item that has implicitly been added by the .NET SDK.
 
@@ -945,13 +946,18 @@ The `Using` item lets you [globally include a namespace](../../csharp/language-r
 </ItemGroup>
 ```
 
-You can also use the `Using` item to define global `using <alias>` and `using static <type>` directives. For example, `<Using Include="Microsoft.AspNetCore.Http.Results" Alias="Results" />` emits `global using Results = global::Microsoft.AspNetCore.Http.Results;`, and `<Using Include="Microsoft.AspNetCore.Http.Results" Static="True" />` emits `global using static global::Microsoft.AspNetCore.Http.Results;`.
+You can also use the `Using` item to define global `using <alias>` and `using static <type>` directives.
 
 ```xml
 <ItemGroup>
   <Using Include="My.Awesome.Namespace" Alias="Awesome" />
 </ItemGroup>
 ```
+
+For example:
+ 
+- `<Using Include="Microsoft.AspNetCore.Http.Results" Alias="Results" />` emits `global using Results = global::Microsoft.AspNetCore.Http.Results;`
+- `<Using Include="Microsoft.AspNetCore.Http.Results" Static="True" />` emits `global using static global::Microsoft.AspNetCore.Http.Results;`
 
 For more information about aliased `using` directives and `using static <type>` directives, see [using directive](../../csharp/language-reference/keywords/using-directive.md#static-modifier).
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -955,7 +955,7 @@ You can also use the `Using` item to define global `using <alias>` and `using st
 ```
 
 For example:
- 
+
 - `<Using Include="Microsoft.AspNetCore.Http.Results" Alias="Results" />` emits `global using Results = global::Microsoft.AspNetCore.Http.Results;`
 - `<Using Include="Microsoft.AspNetCore.Http.Results" Static="True" />` emits `global using static global::Microsoft.AspNetCore.Http.Results;`
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1,7 +1,7 @@
 ---
 title: MSBuild properties for Microsoft.NET.Sdk
 description: Reference for the MSBuild properties and items that are understood by the .NET SDK.
-ms.date: 02/14/2020
+ms.date: 09/02/2021
 ms.topic: reference
 ms.custom: updateeachrelease
 ---
@@ -866,10 +866,11 @@ The `EnableDynamicLoading` property indicates that an assembly is a dynamically 
 The following properties concern code in generated files:
 
 - [DisableImplicitNamespaceImports](#disableimplicitnamespaceimports)
+- [ImplicitUsings](#implicitusings)
 
 ### DisableImplicitNamespaceImports
 
-The `DisableImplicitNamespaceImports` property can be used to disable [implicit namespaces](../compatibility/sdk/6.0/implicit-namespaces.md) in C# projects that target .NET 6 or a later version. Implicit namespaces are the default namespaces that are globally included in a project based on the type of SDK. Set this property to `true` to disable implicit namespaces.
+The `DisableImplicitNamespaceImports` property can be used to disable [implicit namespaces](../compatibility/sdk/6.0/implicit-namespaces.md) in Visual Basic projects that target .NET 6 or a later version. Implicit namespaces are the default namespaces that are globally included in a Visual Basic project. Set this property to `true` to disable implicit namespaces.
 
 ```xml
 <PropertyGroup>
@@ -877,13 +878,15 @@ The `DisableImplicitNamespaceImports` property can be used to disable [implicit 
 </PropertyGroup>
 ```
 
-Setting the `DisableImplicitNamespaceImports` property to `true` completely disables the implicit namespaces feature of the .NET SDK. If you want to disable only a set of implicit namespaces, use one of the following SDK-specific properties instead.
+### ImplicitUsings
 
-| Property | SDK | Affected namespaces |
-| - | - | - |
-| `DisableImplicitNamespaceImports_DotNet` | Microsoft.NET.Sdk | System<br/>System.Collections.Generic<br/>System.IO<br/>System.Linq<br/>System.Net.Http<br/>System.Threading<br/>System.Threading.Tasks |
-| `DisableImplicitNamespaceImports_Web` | Microsoft.NET.Sdk.Web | System.Net.Http.Json<br/>Microsoft.AspNetCore.Builder<br/>Microsoft.AspNetCore.Hosting<br/>Microsoft.AspNetCore.Http<br/>Microsoft.AspNetCore.Routing<br/>Microsoft.Extensions.Configuration<br/>Microsoft.Extensions.DependencyInjection<br/>Microsoft.Extensions.Hosting<br/>Microsoft.Extensions.Logging |
-| `DisableImplicitNamespaceImports_Worker` | Microsoft.NET.Sdk.Worker | Microsoft.Extensions.Configuration<br/>Microsoft.Extensions.DependencyInjection<br/>Microsoft.Extensions.Hosting<br/>Microsoft.Extensions.Logging |
+The `ImplicitUsings` property can be used to enable implicit namespaces in C# projects that target .NET 6 or a later version and that use C# 10.0 or a later version. Implicit namespaces are the default namespaces that are globally included in a project based on the type of SDK. Set this property to `true` to enable implicit namespaces.
+
+```xml
+<PropertyGroup>
+  <ImplicitUsings>true</ImplicitUsings>
+</PropertyGroup>
+```
 
 ## Items
 
@@ -931,6 +934,26 @@ The following XML excludes the `System.Security` assembly from trimming.
   <TrimmerRootAssembly Include="System.Security" />
 </ItemGroup>
 ```
+
+### Using
+
+The `Using` item lets you [globally include a namespace](../../csharp/language-reference/keywords/using-directive.md#global-modifier) across your C# project, such that you don't have to add a `using` directive for the namespace at the top of your source files. This item is similar to the `Import` item that can be used for the same purpose in Visual Basic projects. This property is available starting in .NET 6.
+
+```xml
+<ItemGroup>
+  <Using Include="My.Awesome.Namespace" />
+</ItemGroup>
+```
+
+You can also use the `Using` item to define global `using <alias>` and `using static <type>` directives. For example, `<Using Include="Microsoft.AspNetCore.Http.Results" Alias="Results" />` emits `global using Results = global::Microsoft.AspNetCore.Http.Results;`, and `<Using Include="Microsoft.AspNetCore.Http.Results" Static="True" />` emits `global using static global::Microsoft.AspNetCore.Http.Results;`.
+
+```xml
+<ItemGroup>
+  <Using Include="My.Awesome.Namespace" Alias="Awesome" />
+</ItemGroup>
+```
+
+For more information about aliased `using` directives and `using static <type>` directives, see [using directive](../../csharp/language-reference/keywords/using-directive.md#static-modifier).
 
 ## Item metadata
 

--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -68,7 +68,7 @@ The `global` modifier may be combined with the `static` modifier. The `global` m
 global using static System.Math;
 ```
 
-You can also add globally include a namespace by adding a `<Using>` item to your project file, for example, `<Using Include="My.Awesome.Namespace" />`. For more information, see [`<Using>` item](../../../core/project-sdk/msbuild-props.md#using).
+You can also globally include a namespace by adding a `<Using>` item to your project file, for example, `<Using Include="My.Awesome.Namespace" />`. For more information, see [`<Using>` item](../../../core/project-sdk/msbuild-props.md#using).
 
 [!INCLUDE [csharp10-templates](../../../../includes/csharp10-templates.md)]
 

--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -68,6 +68,8 @@ The `global` modifier may be combined with the `static` modifier. The `global` m
 global using static System.Math;
 ```
 
+You can also add globally include a namespace by adding a `<Using>` item to your project file, for example, `<Using Include="My.Awesome.Namespace" />`. For more information, see [`<Using>` item](../../../core/project-sdk/msbuild-props.md#using).
+
 [!INCLUDE [csharp10-templates](../../../../includes/csharp10-templates.md)]
 
 ## static modifier

--- a/docs/whats-new/dotnet-docs-2021-07-01.md
+++ b/docs/whats-new/dotnet-docs-2021-07-01.md
@@ -24,7 +24,7 @@ Welcome to what's new in the .NET docs from July 1, 2021 through July 31, 2021. 
 ### New articles
 
 - [Culture creation and case mapping in globalization-invariant mode](../core/compatibility/globalization/6.0/culture-creation-invariant-mode.md)
-- [Implicit namespaces in C# projects](../core/compatibility/sdk/6.0/implicit-namespaces.md)
+- [Implicit `global using` directives in C# projects](../core/compatibility/sdk/6.0/implicit-namespaces.md)
 - [ClientCertificate property no longer triggers renegotiation for HttpSys](../core/compatibility/aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md)
 - [Environment variables used by .NET SDK, .NET CLI, and .NET runtime](../core/tools/dotnet-environment-variables.md)
 - [SYSLIB0027: PublicKey.Key is obsolete](../fundamentals/syslib-diagnostics/syslib0027.md)

--- a/includes/csharp10-templates.md
+++ b/includes/csharp10-templates.md
@@ -1,10 +1,10 @@
 ---
 author: billwagner
 ms.author: wiwagn
-ms.date: 08/20/2021
+ms.date: 09/02/2021
 ms.topic: include
 ---
 > [!IMPORTANT]
 > The C# templates for .NET 6 use *top level statements*. Your application may not match the code in this article, if you've already upgraded to the .NET 6 previews. For more information see the article on [New C# templates generate top level statements](~/docs/core/tutorials/top-level-templates.md)
 >
-> The .NET 6.0 SDK also adds a set of *implicit* `global using` directives based on the workload of the project. Those implicit global usings include the most common namespaces for that project type. The implicit using depend on the workload. For more information see the article on [Breaking change: Implicit namespaces in C# projects](~/docs/core/compatibility/sdk/6.0/implicit-namespaces.md#new-behavior).
+> For certain C# project templates, the .NET 6 SDK also adds a set of *implicit* `global using` directives based on the workload of the project. Those implicit global `using` directives include the most common namespaces for that project type.

--- a/includes/csharp10-templates.md
+++ b/includes/csharp10-templates.md
@@ -7,4 +7,10 @@ ms.topic: include
 > [!IMPORTANT]
 > The C# templates for .NET 6 use *top level statements*. Your application may not match the code in this article, if you've already upgraded to the .NET 6 previews. For more information see the article on [New C# templates generate top level statements](~/docs/core/tutorials/top-level-templates.md)
 >
-> For certain C# project templates, the .NET 6 SDK also adds a set of *implicit* `global using` directives based on the workload of the project. Those implicit global `using` directives include the most common namespaces for that project type.
+> The .NET 6 SDK also adds a set of *implicit* `global using` directives for projects that use the following SDKs:
+>
+> - Microsoft.NET.Sdk
+> - Microsoft.NET.Sdk.Web
+> - Microsoft.NET.Sdk.Worker
+>
+> These implicit `global using` directives include the most common namespaces for the project type.


### PR DESCRIPTION
Fixes #25927.

Also adds `Using` item and `ImplicitUsings` property to MSBuild properties reference.

Preview links:

- [Using item](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-25939#using)
- [ImplicitUsings property](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-25939#implicitusings)
- [P2P breaking change](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-rc1?branch=pr-en-us-25939)
- [Using directive article](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive?branch=pr-en-us-25939#global-modifier)