### PR TITLE
Multi-case active patterns can also take arguments

### DIFF
--- a/docs/fsharp/language-reference/active-patterns.md
+++ b/docs/fsharp/language-reference/active-patterns.md
@@ -19,7 +19,7 @@ let (|identifier1|identifier2|...|) valueToMatch = expression
 
 // Partial active pattern definition.
 // Uses a FSharp.Core.option<_> to represent if the type is satisfied at the call site.
-let (|identifier|_|) [arguments ] valueToMatch = expression
+let (|identifier|_|) [arguments] valueToMatch = expression
 ```
 
 ## Remarks
@@ -127,6 +127,10 @@ The output of the previous code is as follows:
 Hello, random citizen!
 Hello, George!
 ```
+
+Note however that only single-case active patterns can be parameterized.
+
+[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-2/snippet5008.fs)]
 
 ## See also
 

--- a/samples/snippets/fsharp/lang-ref-2/snippet5008.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5008.fs
@@ -1,0 +1,4 @@
+// A single-case partial active pattern can be parameterized
+let (| Foo|_|) s x = if x = s then Some Foo else None
+// A multi-case active patterns cannot be parameterized
+// let (| Even|Odd|Special |) (s: int) (x: int) = if x = s then Special elif x % 2 = 0 then Even else Odd


### PR DESCRIPTION
The following compiles (though I couldn't figure out how to use it):

```
let (| Even|Odd|Special |) (w: int) (x: int) = if x = w then Special elif x % 2 = 0 then Even else Odd;;
```

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
