### PR TITLE
Fix compile error in CA5394 solution code

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5394.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5394.md
@@ -56,9 +56,9 @@ using System.Security.Cryptography;
 
 class ExampleClass
 {
-    public void ExampleMethod(RandomNumberGenerator randomNumberGenerator, int toExclusive)
+    public void ExampleMethod(int toExclusive)
     {
-        var sensitiveVariable = randomNumberGenerator.GetInt32(toExclusive);
+        var sensitiveVariable = RandomNumberGenerator.GetInt32(toExclusive);
     }
 }
 ```


### PR DESCRIPTION
Seems like `GetInt32` is a static method

https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator.getint32?view=net-5.0