### PR TITLE
Add restart as an option for updating ML services.

### DIFF
--- a/docs/machine-learning/how-to-guides/serve-model-serverless-azure-functions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/serve-model-serverless-azure-functions-ml-net.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a model to Azure Functions
 description: Serve ML.NET sentiment analysis machine learning model for prediction over the internet using Azure Functions
-ms.date: 09/07/2020
+ms.date: 09/07/2021
 author: luisquintanilla
 ms.author: luquinta
 ms.custom: mvc, how-to

--- a/docs/machine-learning/how-to-guides/serve-model-serverless-azure-functions-ml-net.md
+++ b/docs/machine-learning/how-to-guides/serve-model-serverless-azure-functions-ml-net.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a model to Azure Functions
 description: Serve ML.NET sentiment analysis machine learning model for prediction over the internet using Azure Functions
-ms.date: 02/21/2020
+ms.date: 09/07/2020
 author: luisquintanilla
 ms.author: luquinta
 ms.custom: mvc, how-to
@@ -145,7 +145,7 @@ The following link provides more information if you want to learn more about [de
 
 At a high level, this code initializes the objects and services automatically for later use when requested by the application instead of having to manually do it.
 
-Machine learning models are not static. As new training data becomes available, the model is retrained and redeployed. One way to get the latest version of the model into your application is to redeploy the entire application. However, this introduces application downtime. The `PredictionEnginePool` service provides a mechanism to reload an updated model without taking your application down.
+Machine learning models are not static. As new training data becomes available, the model is retrained and redeployed. One way to get the latest version of the model into your application is to restart or redeploy your application. However, this introduces application downtime. The `PredictionEnginePool` service provides a mechanism to reload an updated model without restarting or redeploying your application.
 
 Set the `watchForChanges` parameter to `true`, and the `PredictionEnginePool` starts a [`FileSystemWatcher`](xref:System.IO.FileSystemWatcher) that listens to the file system change notifications and raises events when there is a change to the file. This prompts the `PredictionEnginePool` to automatically reload the model.
 

--- a/docs/machine-learning/how-to-guides/serve-model-web-api-ml-net.md
+++ b/docs/machine-learning/how-to-guides/serve-model-web-api-ml-net.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a model in an ASP.NET Core Web API
 description: Serve ML.NET sentiment analysis machine learning model over the internet using ASP.NET Core Web API
-ms.date: 08/06/2021
+ms.date: 09/07/2021
 author: luisquintanilla
 ms.author: luquinta
 ms.custom: mvc,how-to
@@ -121,7 +121,7 @@ The following link provides more information if you want to learn more about [de
 
 At a high level, this code initializes the objects and services automatically for later use when requested by the application instead of having to manually do it.
 
-Machine learning models are not static. As new training data becomes available, the model is retrained and redeployed. One way to get the latest version of the model into your application is to redeploy the entire application. However, this introduces application downtime. The `PredictionEnginePool` service provides a mechanism to reload an updated model without taking your application down.
+Machine learning models are not static. As new training data becomes available, the model is retrained and redeployed. One way to get the latest version of the model into your application is to restart or redeploy your application. However, this introduces application downtime. The `PredictionEnginePool` service provides a mechanism to reload an updated model without restarting or redeploying your application.
 
 Set the `watchForChanges` parameter to `true`, and the `PredictionEnginePool` starts a [`FileSystemWatcher`](xref:System.IO.FileSystemWatcher) that listens to the file system change notifications and raises events when there is a change to the file. This prompts the `PredictionEnginePool` to automatically reload the model.
 


### PR DESCRIPTION
Clarify that you can restart or redeploy an application to update web services hosting models. 

Fixes #19234

## Preview Links

File Type | File Name | Published Url
-- | -- | --
Content | docs/machine-learning/how-to-guides/serve-model-serverless-azure-functions-ml-net.md | https://review.docs.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/serve-model-serverless-azure-functions-ml-net?branch=pr-en-us-25981
Content | docs/machine-learning/how-to-guides/serve-model-web-api-ml-net.md | https://review.docs.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/serve-model-web-api-ml-net?branch=pr-en-us-25981
