### PR TITLE
remove extra link for NRT

### DIFF
--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1411,8 +1411,6 @@ items:
       items:
       - name: Nullable reference types - proposal
         href: ../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
-      - name: Nullable reference types - specification
-        href: ../../_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md
       - name: Recursive pattern matching
         href: ../../_csharplang/proposals/csharp-8.0/patterns.md
       - name: Default interface methods


### PR DESCRIPTION
The Nullable Reference Types specification moved folders.  Remove the extra link.
