### PR TITLE
Add binder breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -54,6 +54,12 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | Preview 7 |
 | [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | Preview 4 |
 
+## Extensions
+
+| Title | Introduced |
+| - | - |
+| [Microsoft.Extensions.Configuration binder binds single elements to an array](extensions/6.0/bind-single-elements-to-array.md) | RC 1 |
+
 ## Globalization
 
 | Title | Introduced |

--- a/docs/core/compatibility/extensions/6.0/bind-single-elements-to-array.md
+++ b/docs/core/compatibility/extensions/6.0/bind-single-elements-to-array.md
@@ -51,7 +51,7 @@ The JSON configuration provider would not bind that JSON because it does not spe
 }
 ```
 
-However, when binding the following XML in previous .NET versions, the XML configuration provider has no way of knowing that `TvShows` can contain multiple `Metadata` elements and that they are bound to an array. Thus, the binder fails to bind when a single element is provided. The key doesn't contain any index in the target array, which the binder expects when binding to an array, and the binder returns a `Metadata[]` array with a `null` object.
+In addition, when binding the following XML in previous .NET versions, the XML configuration provider has no way of knowing that `TvShows` can contain multiple `Metadata` elements and that they are bound to an array. Thus, the binder fails to bind when a single element is provided. The key doesn't contain any index in the target array, which the binder expects when binding to an array, and the binder returns a `Metadata[]` array with a `null` object.
 
 ```xml
 <TvShow>
@@ -91,7 +91,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 ## Reason for change
 
-This change was made to allow the XML configuration provider to bind a single element to an array. It was originally requested as an API addition to <xref:Microsoft.Extensions.Configuration.BinderOptions>. For more information, see [dotnet/runtime#57325]().
+This change was made to allow the XML configuration provider to bind a single element to an array. It was originally requested as an API addition to <xref:Microsoft.Extensions.Configuration.BinderOptions>. For more information, see [dotnet/runtime#57325](https://github.com/dotnet/runtime/issues/57325).
 
 ## Recommended action
 

--- a/docs/core/compatibility/extensions/6.0/bind-single-elements-to-array.md
+++ b/docs/core/compatibility/extensions/6.0/bind-single-elements-to-array.md
@@ -1,0 +1,92 @@
+---
+title: "Breaking change: Configuration binder binds single elements to an array"
+description: Learn about the .NET 6.0 breaking change in .NET extensions where Microsoft.Extensions.Configuration binder will now bind a single element to an array.
+ms.date: 09/08/2021
+---
+# Microsoft.Extensions.Configuration binder binds single elements to an array
+
+Starting in .NET 6, the <xref:Microsoft.Extensions.Configuration?displayProperty=fullName> binder will bind single elements to an array.
+
+## Version introduced
+
+6.0 RC 1
+
+## Previous behavior
+
+Consider the following JSON snippet:
+
+```json
+{
+   "tvshow": {
+        "metadata": [
+            {
+               "name": "PrisonBreak"
+            }
+         ]
+    }
+}
+```
+
+The JSON configuration provider would bind that JSON to the following classes without any problem:
+
+```csharp
+public class TvShow
+{
+  public Metadata[] Metadata { get; set; }
+}
+
+public class Metadata
+{
+  public string Name { get; set; }
+}
+```
+
+However, when binding the following XML in previous .NET versions, the XML configuration provider has no way of knowing that `TvShows` can contain multiple `Metadata` elements and that they are bound to an array.
+
+```xml
+<TvShow>
+  <Metadata>
+    <Name>Prison Break</Name>
+  </Metadata>
+</TvShow>
+```
+
+Thus, the binder fails to bind when a single element is provided. The key doesn't contain any index in the target array, which the binder expects when binding to an array, and the binder returns a `Metadata[]` array with a `null` object.
+
+## New behavior
+
+To support binding to array elements for the XML configuration provider, we changed the binder to account for keys without an index suffix&mdash;that is, there is a single child element.
+
+This is a breaking change for other providers. For example, if you change the JSON shown in the [Previous behavior](#previous-behavior) section so that it does not specify an array, it will still bind to the previous class that contains an array of `Metadata` objects:
+
+```json
+{
+   "tvshow": {
+        "metadata": {
+            "name": "PrisonBreak"
+          }
+    }
+}
+```
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change was made to allow the XML configuration provider to bind a single element to an array. It was originally requested as an API addition to <xref:Microsoft.Extensions.Configuration.BinderOptions>. For more information, see [dotnet/runtime#57325]().
+
+## Recommended action
+
+If you want to switch back to the previous behavior where the JSON would need to specify an array to bind to an array, you can set the following app context switch:
+
+```csharp
+AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", false);
+```
+
+## Affected APIs
+
+- <xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration,System.Object,System.Action{Microsoft.Extensions.Configuration.BinderOptions})?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration,System.String,System.Object)?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration,System.Object)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -91,6 +91,10 @@ items:
           href: core-libraries/6.0/system-drawing-common-windows-only.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
+      - name: Extensions
+        items:
+        - name: Configuration binder binds single elements to an array
+          href: extensions/6.0/bind-single-elements-to-array.md
       - name: Globalization
         items:
         - name: Culture creation and case mapping in globalization-invariant mode
@@ -657,6 +661,12 @@ items:
         href: /ef/core/what-is-new/ef-core-5.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
       - name: EF Core 3.1
         href: /ef/core/what-is-new/ef-core-3.x/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
+    - name: Extensions
+      items:
+      - name: .NET 6
+        items:
+        - name: Configuration binder binds single elements to an array
+          href: extensions/6.0/bind-single-elements-to-array.md
     - name: Globalization
       items:
       - name: .NET 6


### PR DESCRIPTION
Fixes #25779

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/extensions/6.0/bind-single-elements-to-array?branch=pr-en-us-26031).