### PR TITLE
C# 10 reference update: Add the parameterless constructor section to the struct reference

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -7,6 +7,9 @@ namespace builtin_types
         public static void Examples()
         {
             without_new.StructWithoutNew.Main();
+            parameterless_constructor.Example.Main();
+            field_initializer.Example.Main();
+            field_initializer_no_constructor.Example.Main();
         }
 
         // <SnippetStructExample>
@@ -122,5 +125,109 @@ namespace builtin_types
             public ReadOnlySpan<double> Values { get; }
         }
         // </SnippetReadonlyRef>
+    }
+
+    namespace parameterless_constructor
+    {
+        public static class Example
+        {
+            // <ParameterlessConstructor>
+            public readonly struct Measurement
+            {
+                public Measurement()
+                {
+                    Value = double.NaN;
+                    Description = "Undefined";
+                }
+
+                public Measurement(double value, string description)
+                {
+                    Value = value;
+                    Description = description;
+                }
+            
+                public double Value { get; init; }
+                public string Description { get; init; }
+            
+                public override string ToString() => $"{Value} ({Description})";
+            }
+
+            public static void Main()
+            {
+                var m1 = new Measurement();
+                Console.WriteLine(m1);  // output: NaN (Undefined)
+
+                var m2 = default(Measurement);
+                Console.WriteLine(m2);  // output: 0 ()
+
+                var ms = new Measurement[2];
+                Console.WriteLine(string.Join(", ", ms));  // output: 0 (), 0 ()
+            }
+            // </ParameterlessConstructor>
+        }
+    }
+
+    namespace field_initializer
+    {
+        public static class Example
+        {
+            // <FieldInitializer>
+            public readonly struct Measurement
+            {
+                public Measurement(double value)
+                {
+                    Value = value;
+                }
+
+                public Measurement(double value, string description)
+                {
+                    Value = value;
+                    Description = description;
+                }
+            
+                public double Value { get; init; }
+                public string Description { get; init; } = "Ordinary measurement";
+            
+                public override string ToString() => $"{Value} ({Description})";
+            }
+
+            public static void Main()
+            {
+                var m1 = new Measurement(5);
+                Console.WriteLine(m1);  // output: 5 (Ordinary measurement)
+
+                var m2 = new Measurement();
+                Console.WriteLine(m2);  // output: 0 ()
+            }
+            // </FieldInitializer>
+        }
+    }
+
+    namespace field_initializer_no_constructor
+    {
+        public static class Example
+        {
+            // <FieldInitializerNoConstructor>
+            public struct Coords
+            {
+                public double X = double.NaN;
+                public double Y = double.NaN;
+            
+                public override string ToString() => $"({X}, {Y})";
+            }
+
+            public static void Main()
+            {
+                var p1 = new Coords();
+                Console.WriteLine(p1);  // output: (NaN, NaN)
+
+                var p2 = default(Coords);
+                Console.WriteLine(p2);  // output: (0, 0)
+
+                var ps = new Coords[3];
+                Console.WriteLine(string.Join(", ", ps));  // output: (0, 0), (0, 0), (0, 0)
+            }
+            // </FieldInitializerNoConstructor>
+        }
     }
 }

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net6</TargetFramework>
+    <Nullable>enable</Nullable>
     <StartupObject>builtin_types.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>AnyCPU;x86</Platforms>

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -97,7 +97,7 @@ Beginning with C# 10.0, you can declare a parameterless instance constructor in 
 
 :::code language="csharp" source="snippets/shared/StructType.cs" id="ParameterlessConstructor":::
 
-As the preceding example shows, the [default value expression](../operators/default.md) ignores a parameterless constructor and produces the default value of a structure type, which is the value produced by setting all value-type fields to their [default values](default-values.md) and all reference-type fields to `null`. Structure-type array instantiation also ignores a parameterless constructor and produces an array populated with the default values of a structure type.
+As the preceding example shows, the [default value expression](../operators/default.md) ignores a parameterless constructor and produces the default value of a structure type, which is the value produced by setting all value-type fields to their [default values](default-values.md) (the 0-bit pattern) and all reference-type fields to `null`. Structure-type array instantiation also ignores a parameterless constructor and produces an array populated with the default values of a structure type.
 
 Beginning with C# 10.0, you can also initialize an instance field or property at its declaration, as the following example shows:
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -103,9 +103,12 @@ Beginning with C# 10.0, you can also initialize an instance field or property at
 
 :::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializer":::
 
-As the preceding example shows, if you don't declare a parameterless constructor, the implicit parameterless constructor produces the default value of a structure type, regardless of field initializers. However, if a structure type has no explicit instance constructors and has field initializers, the compiler synthesizes a public parameterless constructor that performs the specified field initializations, as the following example shows:
+If you don't declare a parameterless constructor explicitly, a structure type provides a parameterless constructor whose behavior is as follows:
 
-:::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializerNoConstructor":::
+- If a structure type has explicit instance constructors or has no field initializers, an implicit parameterless constructor produces the default value of a structure type, regardless of field initializers, as the preceding example shows.
+- If a structure type has no explicit instance constructors and has field initializers, the compiler synthesizes a public parameterless constructor that performs the specified field initializations, as the following example shows:
+
+  :::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializerNoConstructor":::
 
 As the preceding example shows, the default value expression and array instantiation ignore field initializers.
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -85,7 +85,7 @@ When you design a structure type, you have the same capabilities as with a [clas
   > [!NOTE]
   > Beginning with C# 10.0, you can initialize an instance field or property at its declaration. For more information, see the [Parameterless constructors and field initializers](#parameterless-constructors-and-field-initializers) section.
 
-- A constructor of a structure type must initialize all instance fields and properties of the type.
+- A constructor of a structure type must initialize all instance fields of the type.
 
 - A structure type can't inherit from other class or structure type and it can't be the base of a class. However, a structure type can implement [interfaces](../keywords/interface.md).
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -1,7 +1,7 @@
 ---
 title: "Structure types - C# reference"
 description: Learn about the struct type in C#
-ms.date: 10/23/2020
+ms.date: 09/07/2021
 f1_keywords: 
   - "struct_CSharpKeyword"
 helpviewer_keywords: 
@@ -77,13 +77,39 @@ When you design a structure type, you have the same capabilities as with a [clas
 
 - You can't declare a parameterless constructor. Every structure type already provides an implicit parameterless constructor that produces the [default value](default-values.md) of the type.
 
+  > [!NOTE]
+  > Beginning with C# 10.0, you can declare a parameterless constructor in a structure type. For more information, see the [Parameterless constructors and field initializers](#parameterless-constructors-and-field-initializers) section.
+
 - You can't initialize an instance field or property at its declaration. However, you can initialize a [static](../keywords/static.md) or [const](../keywords/const.md) field or a static property at its declaration.
 
-- A constructor of a structure type must initialize all instance fields of the type.
+  > [!NOTE]
+  > Beginning with C# 10.0, you can initialize an instance field or property at its declaration. For more information, see the [Parameterless constructors and field initializers](#parameterless-constructors-and-field-initializers) section.
+
+- A constructor of a structure type must initialize all instance fields and properties of the type.
 
 - A structure type can't inherit from other class or structure type and it can't be the base of a class. However, a structure type can implement [interfaces](../keywords/interface.md).
 
 - You can't declare a [finalizer](../../programming-guide/classes-and-structs/destructors.md) within a structure type.
+
+## Parameterless constructors and field initializers
+
+Beginning with C# 10.0, you can declare a parameterless instance constructor in a structure type, as the following example shows:
+
+:::code language="csharp" source="snippets/shared/StructType.cs" id="ParameterlessConstructor":::
+
+As the preceding example shows, the [default value expression](../operators/default.md) ignores a parameterless constructor and produces the default value of a structure type, which is the value produced by setting all value-type fields to their [default values](default-values.md) and all reference-type fields to `null`. Structure-type array instantiation also ignores a parameterless constructor and produces an array populated with the default values of a structure type.
+
+Beginning with C# 10.0, you can also initialize an instance field or property at its declaration, as the following example shows:
+
+:::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializer":::
+
+As the preceding example shows, if you don't declare a parameterless constructor, the implicit parameterless constructor produces the default value of a structure type, regardless of field initializers. However, if a structure type has no explicit instance constructors and has field initializers, the compiler synthesizes a public parameterless constructor that performs the specified field initializations, as the following example shows:
+
+:::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializerNoConstructor":::
+
+As the preceding example shows, the default value expression and array instantiation ignore field initializers.
+
+For more information, see the [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md) feature proposal note.
 
 ## Instantiation of a structure type
 
@@ -141,6 +167,7 @@ For more information about features introduced in C# 7.2 and later, see the foll
 - [Readonly structs](~/_csharplang/proposals/csharp-7.2/readonly-ref.md#readonly-structs)
 - [Readonly instance members](~/_csharplang/proposals/csharp-8.0/readonly-instance-members.md)
 - [Compile-time safety for ref-like types](~/_csharplang/proposals/csharp-7.2/span-safety.md)
+- [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -1,7 +1,7 @@
 ---
 title: "Structure types - C# reference"
 description: Learn about the struct type in C#
-ms.date: 09/07/2021
+ms.date: 09/13/2021
 f1_keywords: 
   - "struct_CSharpKeyword"
 helpviewer_keywords: 


### PR DESCRIPTION
Contributes to #25676 (only updates the **Structure types** reference article)
