### PR TITLE
Fix typo in the namespace.md

### DIFF
--- a/docs/csharp/language-reference/keywords/namespace.md
+++ b/docs/csharp/language-reference/keywords/namespace.md
@@ -20,7 +20,7 @@ The `namespace` keyword is used to declare a scope that contains a set of relate
 
 :::code language="csharp" source="snippets/filescopednamespace.cs" :::
 
-The preceding example doesn't include a nested namespace. File scoped namespaces can't include additional namespace declarations. You cannot declare a nested namesapce or a second file-scoped namespace:
+The preceding example doesn't include a nested namespace. File scoped namespaces can't include additional namespace declarations. You cannot declare a nested namespace or a second file-scoped namespace:
 
 ```csharp
 namespace SampleNamespace;


### PR DESCRIPTION
Hi, 

I've fixed the typo in the word 'namespace' in the namespace.md file. 
