### PR TITLE
Add note about indentation of match and DU constructors when using less than 4 spaces

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -592,6 +592,34 @@ type SynBinding =
         seqPoint: DebugPointAtBinding
 ```
 
+If using less than 4 spaces of indentation, the fields should still be indented 4 spaces to ensure sufficient visual separation between the cases and the fields.
+
+```fsharp
+// Using 2 spaces of indentation
+
+// OK
+type MyUnion =
+  | Case1 of
+      field1: int *
+      field2: string *
+      field3: bool
+  | Case2 of
+      field1: int *
+      field2: string *
+      field3: bool
+      
+// Not OK
+type MyUnion =
+  | Case1 of
+    field1: int *
+    field2: string *
+    field3: bool
+  | Case2 of
+    field1: int *
+    field2: string *
+    field3: bool
+```
+
 You can also use triple-slash `///` comments.
 
 ```fsharp

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -971,7 +971,7 @@ match lam with
 
 ```
 
-If using less than 4 spaces of indentation, the expression should still be indented 4 spaces to ensure sufficient separation between the clauses and the subexpression.
+If using less than 4 spaces of indentation, the expression should still be indented 4 spaces to ensure sufficient visual separation between the clauses and the subexpression.
 
 ```fsharp
 // Using 2 spaces of indentation

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -971,6 +971,28 @@ match lam with
 
 ```
 
+If using less than 4 spaces of indentation, the expression should still be indented 4 spaces to ensure sufficient separation between the clauses and the subexpression.
+
+```fsharp
+// Using 2 spaces of indentation
+
+// OK
+match lam with
+| Var v -> 1
+| Abs(x, body) ->
+    1 + sizeLambda body
+| App(lam1, lam2) ->
+    sizeLambda lam1 + sizeLambda lam2
+
+// Not OK
+match lam with
+| Var v -> 1
+| Abs(x, body) ->
+  1 + sizeLambda body
+| App(lam1, lam2) ->
+  sizeLambda lam1 + sizeLambda lam2
+```
+
 Pattern matching of anonymous functions, starting by `function`, should generally not indent too far. For example, indenting one scope as follows is fine:
 
 ```fsharp


### PR DESCRIPTION
Indenting pattern match "bodies" (to the right of the arrow) and DU constructor fields one level works fine with 4 spaces of indentation, but with 2 spaces of indentation, due to the initial `| `, the rules make the body/fields line up with the clause/constructor, which makes it more difficult to visually separate the clauses/constructors and the bodies/fields.

This PR fixes that by instructing to indented 4 spaces if using less than 2 spaces of indentation, to ensure sufficient separation.

/cc @cartermp