### PR TITLE
MSBuild breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -90,7 +90,8 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | Preview 1 |
 | [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | Preview 1 |
 | [Implicit global using directives in C# projects](sdk/6.0/implicit-namespaces.md) | Preview 7 |
-| [Implicit global using directives disabled](sdk/6.0/implicit-namespaces-rc1.md) | RC 1|
+| [Implicit global using directives disabled](sdk/6.0/implicit-namespaces-rc1.md) | RC 1 |
+| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | RC 1 |
 | [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | RC 1 |
 
 ## Serialization

--- a/docs/core/compatibility/sdk/6.0/calling-gettype-property-functions.md
+++ b/docs/core/compatibility/sdk/6.0/calling-gettype-property-functions.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: MSBuild 17 doesn't support GetType()"
+description: Learn about the breaking change in the .NET 6 SDK where it's no longer supported to call GetType() within MSBuild property functions.
+ms.date: 09/13/2021
+---
+# MSBuild no longer supports calling GetType()
+
+MSBuild 17 no longer supports calling the `GetType()` instance method within property functions. This method allowed unpredictable code execution during evaluation and could cause Visual Studio hangs.
+
+## Version introduced
+
+.NET SDK 6.0.100-rc1
+
+## Previous behavior
+
+`GetType()` calls in MSBuild property functions would execute and sometimes caused unpredictable behavior in Visual Studio.
+
+## New behavior
+
+Starting with the .NET 6 SDK, if you call `GetType()` in an MSBuild property function, you'll see the following compile-time error during project evaluation:
+
+**The function "GetType" on type "System.String" is not available for execution as an MSBuild property function.**
+
+## Change category
+
+This change affects [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This functionality was not documented or commonly used. It caused performance and reliability issues with project loading, especially in Visual Studio.
+
+The only known common use of this pattern was in the [CBT system](https://commonbuildtoolset.github.io/), which has been deprecated.
+
+## Recommended action
+
+Replace any calls to `GetType()` with alternative MSBuild logic.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -127,6 +127,8 @@ items:
           href: sdk/6.0/implicit-namespaces.md
         - name: Implicit `global using` directives disabled
           href: sdk/6.0/implicit-namespaces-rc1.md
+        - name: MSBuild no longer supports calling GetType()
+          href: sdk/6.0/calling-gettype-property-functions.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md
       - name: Windows Forms
@@ -745,6 +747,8 @@ items:
           href: sdk/6.0/implicit-namespaces.md
         - name: Implicit `global using` directives disabled
           href: sdk/6.0/implicit-namespaces-rc1.md
+        - name: MSBuild no longer supports calling GetType()
+          href: sdk/6.0/calling-gettype-property-functions.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md
       - name: .NET 5


### PR DESCRIPTION
Fixes #26048 

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/calling-gettype-property-functions?branch=pr-en-us-26088)