### PR TITLE
Change --install-dir documentation to reflect reality

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -123,7 +123,7 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`-InstallDir|--install-dir <DIRECTORY>`**
 
-  Specifies the installation path. The directory is created if it doesn't exist. The default value is *%LocalAppData%\Microsoft\dotnet* on Windows and */usr/share/dotnet* on Linux/macOS. Binaries are placed directly in this directory.
+  Specifies the installation path. The directory is created if it doesn't exist. The default value is *%LocalAppData%\Microsoft\dotnet* on Windows and *~/.dotnet* on Linux/macOS. Binaries are placed directly in this directory.
 
 - **`-JSonFile|--jsonfile <JSONFILE>`**
 


### PR DESCRIPTION
## Summary

The linux `dotnet-install.sh` script says the following:
```
Install Location:
  Location is chosen in following order:
    - --install-dir option
    - Environmental variable DOTNET_INSTALL_DIR
    - $HOME/.dotnet
```

If you review the source code, it matches this documentation. However, the online documentation claims that the default directory is `/usr/share/dotnet`, which is not true. It _is_ the directory where `apt-get` installs it globally though, but I don't think it's relevant in this doc.
