### PR TITLE
Update with COMWrapper API usage tutorial

### DIFF
--- a/docs/standard/native-interop/cominterop.md
+++ b/docs/standard/native-interop/cominterop.md
@@ -12,4 +12,4 @@ The Component Object Model (COM) lets an object expose its functionality to othe
 - [COM Callable Wrappers](./com-callable-wrapper.md)
 - [Runtime Callable Wrappers](./runtime-callable-wrapper.md)
 - [Qualifying .NET Types for COM Interoperation](./qualify-net-types-for-interoperation.md)
-- [Trimmer and Native AOT-friendly COM interop](./tutorial-comwrappers/md)
+- [Trimmer and Native AOT-friendly COM interop](./tutorial-comwrappers.md)

--- a/docs/standard/native-interop/cominterop.md
+++ b/docs/standard/native-interop/cominterop.md
@@ -12,3 +12,4 @@ The Component Object Model (COM) lets an object expose its functionality to othe
 - [COM Callable Wrappers](./com-callable-wrapper.md)
 - [Runtime Callable Wrappers](./runtime-callable-wrapper.md)
 - [Qualifying .NET Types for COM Interoperation](./qualify-net-types-for-interoperation.md)
+- [Trimmer and Native AOT-friendly COM interop](./tutorial-comwrappers/md)


### PR DESCRIPTION

## Summary

We point developers to this page (COM Interop in .NET) when they run into trimming issues with build-in COM interop. Adding a link to COMWrapper tutorial to help with trimming and AOT

Fixes #24645
