### PR TITLE
Nit: fix typos in expanded LTTng name

### DIFF
--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -11,7 +11,7 @@ ms.date: 10/23/2020
 
 When performance problems are encountered on Linux, collecting a trace with `perfcollect` can be used to gather detailed information about what was happening on the machine at the time of the performance problem.
 
-`perfcollect` is a bash script that leverages [Linux Tracing Tookit-Next Generation (LTTng)](https://lttng.org) to collect events written from the runtime or any [EventSource](xref:System.Diagnostics.Tracing.EventListener), as well as [perf](https://perf.wiki.kernel.org/) to collect CPU samples of the target process.
+`perfcollect` is a bash script that leverages [Linux Trace Toolkit: next generation (LTTng)](https://lttng.org) to collect events written from the runtime or any [EventSource](xref:System.Diagnostics.Tracing.EventListener), as well as [perf](https://perf.wiki.kernel.org/) to collect CPU samples of the target process.
 
 ## Prepare your machine
 


### PR DESCRIPTION
Got the correct expanded name here: https://lttng.org/docs/v2.13/#doc-nuts-and-bolts
Linux Trace Toolkit: next generation

The expanded name listed on Wikipedia is close but doesn't match the capitalization:
Linux Trace Toolkit Next Generation
Seems reasonable to use the name listed on lttng.org instead.