### PR TITLE
use non-deprecated CentOS repo

### DIFF
--- a/docs/core/install/linux-centos.md
+++ b/docs/core/install/linux-centos.md
@@ -50,7 +50,7 @@ The following versions of .NET are no longer supported. The downloads for these 
 [!INCLUDE [linux-prep-intro-generic](includes/linux-prep-intro-generic.md)]
 
 ```bash
-sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
+sudo rpm -Uvh https://packages.microsoft.com/rhel/7/prod/packages-microsoft-prod-1.0-1.el7.noarch.rpm
 ```
 
 [!INCLUDE [linux-yum-install-50](includes/linux-install-50-yum.md)]

--- a/docs/core/install/linux-centos.md
+++ b/docs/core/install/linux-centos.md
@@ -50,7 +50,7 @@ The following versions of .NET are no longer supported. The downloads for these 
 [!INCLUDE [linux-prep-intro-generic](includes/linux-prep-intro-generic.md)]
 
 ```bash
-sudo rpm -Uvh https://packages.microsoft.com/rhel/7/prod/packages-microsoft-prod-1.0-1.el7.noarch.rpm
+sudo rpm -Uvh rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
 ```
 
 [!INCLUDE [linux-yum-install-50](includes/linux-install-50-yum.md)]


### PR DESCRIPTION
The old one gives issues when installing Docker because of the Moby rename.

Also see https://github.com/docker/docker.github.io/issues/11198#issuecomment-667906042

Also see the official instructions here https://docs.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#enterprise-linux-rhel-and-variants

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
