### PR TITLE
remove coining of "vanity alignment"

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -56,7 +56,7 @@ let myLongValueName = someExpression
                       |> anotherExpression
 ```
 
-This is sometimes called “vanity alignment” or “vanity indentation”. The primary reasons for avoiding this are:
+The primary reasons for avoiding this are:
 
 * Important code is moved far to the right
 * There is less width left for the actual code


### PR DESCRIPTION
motives: 
* vanity sounds like a character and pejorative judgement
* some languages (haskell AFAIK) use similar alignment commonly, I have doubts it is referred as such at places where it is commonly used
* web search for "vanity alignment" doesn't return anything relevant but this document
 
I'd prefer the pejorative adjective not be associated with alignment styles, the justification for the guidelines stand on its own without the coining of this alignment style as vain.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
