### PR TITLE
Note that .NET 6 projects are nullable enabled

### DIFF
--- a/docs/csharp/language-reference/builtin-types/nullable-reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/nullable-reference-types.md
@@ -62,7 +62,7 @@ The preceding examples demonstrate how compiler's static analysis determines the
 
 ## Setting the nullable context
 
-There are two ways to control the nullable context. At the project level, you can add the `<Nullable>enable</Nullable>` project setting. In a single C# source file, you can add the `#nullable enable` pragma to enable the nullable context. See the article on [setting a nullable strategy](../../nullable-migration-strategies.md). Prior to .NET 6, new projects use the default, `<Nullable>disable</Nullable>. Beginning with .NET 6, new projects include the `<Nullable>enable</Nullable> element in the project file.
+There are two ways to control the nullable context. At the project level, you can add the `<Nullable>enable</Nullable>` project setting. In a single C# source file, you can add the `#nullable enable` pragma to enable the nullable context. See the article on [setting a nullable strategy](../../nullable-migration-strategies.md). Prior to .NET 6, new projects use the default, `<Nullable>disable</Nullable>`. Beginning with .NET 6, new projects include the `<Nullable>enable</Nullable>` element in the project file.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/builtin-types/nullable-reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/nullable-reference-types.md
@@ -62,7 +62,7 @@ The preceding examples demonstrate how compiler's static analysis determines the
 
 ## Setting the nullable context
 
-There are two ways to control the nullable context. At the project level, you can add the `<Nullable>enable</Nullable>` project setting. In a single C# source file, you can add the `#nullable enable` pragma to enable the nullable context. See the article on [setting a nullable strategy](../../nullable-migration-strategies.md).
+There are two ways to control the nullable context. At the project level, you can add the `<Nullable>enable</Nullable>` project setting. In a single C# source file, you can add the `#nullable enable` pragma to enable the nullable context. See the article on [setting a nullable strategy](../../nullable-migration-strategies.md). Prior to .NET 6, new projects use the default, `<Nullable>disable</Nullable>. Beginning with .NET 6, new projects include the `<Nullable>enable</Nullable> element in the project file.
 
 ## C# language specification
 

--- a/docs/csharp/whats-new/tutorials/nullable-reference-types.md
+++ b/docs/csharp/whats-new/tutorials/nullable-reference-types.md
@@ -39,6 +39,8 @@ Create a new console application either in Visual Studio or from the command lin
 <Nullable>enable</Nullable>
 ```
 
+Prior to .NET 6, new projects do not include the `Nullable` element. Beginning with .NET 6, new projects include the `<Nullable>enable</Nullable> element in the project file.
+
 ### Design the types for the application
 
 This survey application requires creating a number of classes:


### PR DESCRIPTION
Fixes #25483

I didn't follow the notes in my last comment on #25483 because the "get started" tutorials don't examine the project file, or use constructs that behave different when Nullable is enabled. I believe calling out the different behavior would only distract from the get started experience.