### PR TITLE
Resolves dotnet/docs#26188 -- dotnet sln remove contains wrong argument description

### DIFF
--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -125,7 +125,7 @@ dotnet sln [<SOLUTION_FILE>] remove [-h|--help]
 
 - **`PROJECT_PATH`**
 
-  The path to the project or projects to add to the solution. Unix/Linux shell [globbing pattern](https://en.wikipedia.org/wiki/Glob_(programming)) expansions are processed correctly by the `dotnet sln` command.
+  The path to the project or projects to remove from the solution. Unix/Linux shell [globbing pattern](https://en.wikipedia.org/wiki/Glob_(programming)) expansions are processed correctly by the `dotnet sln` command.
 
 #### Options
 


### PR DESCRIPTION
Improve description of `dotnet sln remove` of argument `PROJECT_PATH`

## Summary

Description of argument `PROJECT_PATH` in `dotnet sln remove` was explaining to add projects whereas they are actually removed from the solution file.

Fixes #26188