### PR TITLE
Update simd.md to fix Vector sample code issue

### DIFF
--- a/docs/standard/simd.md
+++ b/docs/standard/simd.md
@@ -80,7 +80,7 @@ double[] SimdVectorProd(double[] left, double[] right)
     var offset = Vector<double>.Count;
     double[] result = new double[left.Length];
     int i = 0;
-    for (i = 0; i < left.Length; i += offset)
+    for (i = 0; i + offset <= left.Length; i += offset)
     {
         var v1 = new Vector<double>(left, i);
         var v2 = new Vector<double>(right, i);

--- a/docs/standard/simd.md
+++ b/docs/standard/simd.md
@@ -77,10 +77,10 @@ The example below demonstrates adding long arrays elements using <xref:System.Nu
 ```csharp
 double[] SimdVectorProd(double[] left, double[] right)
 {
-    var offset = Vector<double>.Count;
+    var vectorSize = Vector<double>.Count;
     double[] result = new double[left.Length];
     int i = 0;
-    for (i = 0; i + offset <= left.Length; i += offset)
+    for (; i <= left.Length - vectorSize; i += vectorSize)
     {
         var v1 = new Vector<double>(left, i);
         var v2 = new Vector<double>(right, i);


### PR DESCRIPTION
## Summary

In Vector<T> sample code, it has logic of handling case about input array length not be integral multiple of Vector.Count, but first half of code cannot handle it and will throw out of range related exception if happens. This PR is for that.

Fixes #26195 
