### PR TITLE
New nullability annotation (breaking change)

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -48,6 +48,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | Preview 4 |
 | [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | Preview 5 |
 | [New JsonSerializer source generator overloads](core-libraries/6.0/jsonserializer-source-generator-overloads.md) | Preview 6 |
+| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | RC 2 |
 | [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | Preview 3-4 |
 | [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | Preview 5 |
 | [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | Preview 6 |

--- a/docs/core/compatibility/core-libraries/6.0/nullable-ref-type-annotation-changes.md
+++ b/docs/core/compatibility/core-libraries/6.0/nullable-ref-type-annotation-changes.md
@@ -19,6 +19,10 @@ Other changes that aren't considered to be breaking are also documented on this 
 
 6.0
 
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
 ## Reason for change
 
 Starting in .NET Core 3.0, nullability annotations were applied to the .NET libraries. From the outset of the effort, mistakes in these annotations were anticipated. Through feedback and further testing, the nullable annotations for the affected APIs were determined to be inaccurate. The updated annotations correctly represent the nullability contracts for the APIs.
@@ -86,38 +90,3 @@ The following table lists the affected APIs:
 
 - [Attributes for null-state static analysis](../../../../csharp/language-reference/attributes/nullable-analysis.md)
 - [Nullable reference type annotation changes in ASP.NET Core](../../aspnet-core/6.0/nullable-reference-type-annotations-changed.md)
-
-<!--
-
-### Category
-
-Core .NET libraries
-
-### Affected APIs
-
-- `P:System.ComponentModel.ISite.Container`
-- `M:System.Xml.Linq.XContainer.Add(System.Object[])`
-- `M:System.Xml.Linq.XContainer.AddFirst(System.Object[])`
-- `M:System.Xml.Linq.XContainer.ReplaceNodes(System.Object[])`
-- `M:System.Xml.Linq.XDocument.#ctor(System.Object[])`
-- `M:System.Xml.Linq.XDocument.#ctor(System.Xml.Linq.XDeclaration,System.Object[])`
-- `M:System.Xml.Linq.XElement.#ctor(System.Xml.Linq.XName,System.Object[])`
-- `M:System.Xml.Linq.XElement.ReplaceAll(System.Object[])`
-- `M:System.Xml.Linq.XElement.ReplaceAttributes(System.Object[])`
-- `M:System.Xml.Linq.XNode.AddAfterSelf(System.Object[])`
-- `M:System.Xml.Linq.XNode.AddBeforeSelf(System.Object[])`
-- `M:System.Xml.Linq.XNode.ReplaceWith(System.Object[])`
-- `M:System.Xml.Linq.XStreamingElement.#ctor(System.Xml.Linq.XName,System.Object)`
-- `M:System.Xml.Linq.XStreamingElement.#ctor(System.Xml.Linq.XName,System.Object[])`
-- `M:System.Xml.Linq.XStreamingElement.Add(System.Object[])`
-- `O:System.Net.Http.HttpClient.PatchAsync`
-- `O:System.Net.Http.HttpClient.PostAsync`
-- `O:System.Net.Http.HttpClient.PutAsync`
-- `M:System.Linq.Expressions.MethodCallExpression.Update(System.Linq.Expressions.Expression,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression})`
-- `M:System.Linq.Expressions.Expression%601.Update(System.Linq.Expressions.Expression,System.Collections.Generic.IEnumerable{System.Linq.Expressions.ParameterExpression})`
-- `M:System.Data.IDataRecord.GetBytes(System.Int32,System.Int64,System.Byte[],System.Int32,System.Int32)`
-- `M:System.Data.IDataRecord.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)`
-- `M:System.Data.Common.DbDataRecord.GetBytes(System.Int32,System.Int64,System.Byte[],System.Int32,System.Int32)`
-- `M:System.Data.Common.DbDataRecord.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)`
-
--->

--- a/docs/core/compatibility/core-libraries/6.0/nullable-ref-type-annotations-added.md
+++ b/docs/core/compatibility/core-libraries/6.0/nullable-ref-type-annotations-added.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: Nullable annotation on AssociatedMetadataTypeTypeDescriptionProvider method"
+description: Learn about the .NET 6 breaking change in core .NET libraries where a nullable reference type annotation was added to `AssociatedMetadataTypeTypeDescriptionProvider.GetTypeDescriptor`.
+ms.date: 09/21/2021
+---
+# New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider
+
+In .NET 6, a nullability annotation has been added to <xref:System.ComponentModel.DataAnnotations.AssociatedMetadataTypeTypeDescriptionProvider.GetTypeDescriptor(System.Type,System.Object)?displayProperty=nameWithType>. This method was previously unannotated for nullable reference types.
+
+## Previous behavior
+
+The affected method was treated as "oblivious" with regard to reference type nullability.
+
+## New behavior
+
+The affected method is now annotated with accurate nullability conditions.
+
+## Version introduced
+
+6.0 RC 2
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This method had dependencies on other APIs that were previously unannotated. The dependencies have since been annotated, allowing this API to also be annotated. This change completes our nullable reference type annotations for the shared framework libraries.
+
+## Recommended action
+
+Update code that calls this method to reflect the revised nullability contract.
+
+## Affected APIs
+
+- <xref:System.ComponentModel.DataAnnotations.AssociatedMetadataTypeTypeDescriptionProvider.GetTypeDescriptor(System.Type,System.Object)?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/6.0/nullable-ref-type-annotations-added.md
+++ b/docs/core/compatibility/core-libraries/6.0/nullable-ref-type-annotations-added.md
@@ -13,7 +13,7 @@ The affected method was treated as "oblivious" with regard to reference type nul
 
 ## New behavior
 
-The affected method is now annotated with accurate nullability conditions.
+The parameters of the affected method are now annotated with accurate nullability conditions.
 
 ## Version introduced
 
@@ -33,4 +33,6 @@ Update code that calls this method to reflect the revised nullability contract.
 
 ## Affected APIs
 
-- <xref:System.ComponentModel.DataAnnotations.AssociatedMetadataTypeTypeDescriptionProvider.GetTypeDescriptor(System.Type,System.Object)?displayProperty=fullName>
+| API | What changed |
+|-|-|
+| <xref:System.ComponentModel.DataAnnotations.AssociatedMetadataTypeTypeDescriptionProvider.GetTypeDescriptor(System.Type,System.Object)?displayProperty=fullName> | `instance` parameter type is nullable |

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -79,6 +79,8 @@ items:
           href: core-libraries/6.0/diagnostic-id-change-for-obsoletions.md
         - name: New JsonSerializer source generator overloads
           href: core-libraries/6.0/jsonserializer-source-generator-overloads.md
+        - name: New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider
+          href: core-libraries/6.0/nullable-ref-type-annotations-added.md
         - name: New Queryable method overloads
           href: core-libraries/6.0/additional-linq-queryable-method-overloads.md
         - name: Nullability annotation changes
@@ -577,6 +579,8 @@ items:
           href: core-libraries/6.0/diagnostic-id-change-for-obsoletions.md
         - name: New JsonSerializer source generator overloads
           href: core-libraries/6.0/jsonserializer-source-generator-overloads.md
+        - name: New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider
+          href: core-libraries/6.0/nullable-ref-type-annotations-added.md
         - name: New Queryable method overloads
           href: core-libraries/6.0/additional-linq-queryable-method-overloads.md
         - name: Nullability annotation changes


### PR DESCRIPTION
Fixes #25957.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/nullable-ref-type-annotations-added?branch=pr-en-us-26212).