### PR TITLE
Fix ICorProfilerInfo11 .NET Core version

### DIFF
--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo11-interface.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo11-interface.md
@@ -25,7 +25,7 @@ api_type:
 
 **Platforms:** See [.NET Core supported operating systems](../../../core/install/windows.md?pivots=os-windows).  
 **Header:** CorProf.idl, CorProf.h  
-**.NET Versions:** [!INCLUDE[net_core](../../../../includes/net-core-50-md.md)]  
+**.NET Versions:** [!INCLUDE[net_core](../../../../includes/net-core-31-md.md)]  
 
 ## See also
 


### PR DESCRIPTION
## Summary

ICorProfilerInfo11 was available since .NET Core 3.1

- https://github.com/dotnet/coreclr/blob/v3.1.0/src/pal/prebuilt/inc/corprof.h#L16179

Also both method pages correctly list .NET Core 3.1 as the version
- https://github.com/dotnet/docs/blob/main/docs/framework/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method.md
- https://github.com/dotnet/docs/blob/main/docs/framework/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method.md
