### PR TITLE
Specify that rules for explicit generic type arguments also apply to function application

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1568,7 +1568,7 @@ val SampleMixedFunction:
 
 ### Formatting explicit generic type arguments and constraints
 
-The guidelines below apply to function definitions, member definitions, and type definitions.
+The guidelines below apply to function definitions, member definitions, type definitions, and function applications.
 
 Keep generic type arguments and constraints on a single line if it’s not too long:
 
@@ -1612,6 +1612,24 @@ let inline f<^T1, ^T2
     and ^T2 : (member Foo3: string -> ^T1 option)>
     =
     // function body
+```
+
+The same rules apply for function applications:
+
+```f#
+// ✔️ OK
+myObj
+|> Json.serialize<
+    {| child: {| displayName: string; kind: string |}
+       newParent: {| id: string; displayName: string |}
+       requiresApproval: bool |}>
+       
+// ✔️ OK
+Json.serialize<
+    {| child: {| displayName: string; kind: string |}
+       newParent: {| id: string; displayName: string |}
+       requiresApproval: bool |}>
+    myObj
 ```
 
 ## Formatting attributes

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1616,7 +1616,7 @@ let inline f<^T1, ^T2
 
 The same rules apply for function applications:
 
-```f#
+```fsharp
 // ✔️ OK
 myObj
 |> Json.serialize<


### PR DESCRIPTION
It makes sense that the same rules should apply to explicit generic parameters in function application, too.

Currently Fantomas formats this in a way that breaks the "avoid name-sensitive alignment" clause:

```f#
Json.serialize<{| child: {| displayName: string; kind: string |}
                  newParent: {| id: string; displayName: string |}
                  requiresApproval: bool |}>
```

Here is a better formatting that is consistent with the rules for function/member/type definitions:

```f#
Json.serialize<
    {| child: {| displayName: string; kind: string |}
       newParent: {| id: string; displayName: string |}
       requiresApproval: bool |}>
```

I am updating the style guide to clarify this so there is no doubt, and so that Fantomas can hopefully be updated accordingly.

/cc @nojaf @dsyme