### PR TITLE
Remove ReadFromTSV unused method

### DIFF
--- a/docs/machine-learning/tutorials/image-classification.md
+++ b/docs/machine-learning/tutorials/image-classification.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: ML.NET classification model to categorize images'
 description: Learn how to train a classification model to categorize images using a pre-trained TensorFlow model for image processing. 
-ms.date: 04/13/2021
+ms.date: 09/24/2021
 ms.topic: tutorial
 ms.custom: mvc, title-hack-0612
 recommendations: false
@@ -198,23 +198,6 @@ Since you'll display the image data and the related predictions more than once, 
 1. Fill in the body of the `DisplayResults` method:
 
     [!code-csharp[DisplayPredictions](./snippets/image-classification/csharp/Program.cs#DisplayPredictions)]
-
-### Create a .tsv file utility method
-
-1. Create the `ReadFromTsv()` method, just after the `DisplayResults()` method, using the following code:
-
-    ```csharp
-    public static IEnumerable<ImageData> ReadFromTsv(string file, string folder)
-    {
-
-    }
-    ```
-
-1. Fill in the body of the `ReadFromTsv` method:
-
-    [!code-csharp[ReadFromTsv](./snippets/image-classification/csharp/Program.cs#ReadFromTsv)]
-
-    The code parses through the `tags.tsv` file to add the file path to the image file name for the `ImagePath` property and load it and the `Label` into an `ImageData` object.
 
 ### Create a method to make a prediction
 

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/Program.cs
@@ -136,21 +136,6 @@ namespace TransferLearningTF
             // </SnippetDisplayPredictions>
         }
 
-        public static IEnumerable<ImageData> ReadFromTsv(string file, string folder)
-        {
-            //Need to parse through the tags.tsv file to combine the file path to the
-            // image name for the ImagePath property so that the image file can be found.
-
-            // <SnippetReadFromTsv>
-            return File.ReadAllLines(file)
-             .Select(line => line.Split('\t'))
-             .Select(line => new ImageData()
-             {
-                 ImagePath = Path.Combine(folder, line[0])
-             });
-            // </SnippetReadFromTsv>
-        }
-
         // <SnippetInceptionSettings>
         private struct InceptionSettings
         {


### PR DESCRIPTION
## Summary

Remove ReadFromTSV unused method

Fixes #22121 

[Preview Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/tutorials/image-classification?branch=pr-en-us-26262)

Related Samples PR: dotnet/samples#4822