### PR TITLE
Async dispose pattern mini fixes

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -29,7 +29,6 @@ Signatures:
 - `public ValueTask DisposeAsync()` – an <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementation
 - `protected virtual ValueTask DisposeAsyncCore()`
 
-
 ### The DisposeAsync() method
 
 The `public` parameterless `DisposeAsync()` method is called implicitly in an `await using` statement, and its purpose is to free unmanaged resources, perform general cleanup, and to indicate that the finalizer, if one is present, need not run. Freeing the memory associated with a managed object is always the domain of the [garbage collector](index.md). Because of this, it has a standard implementation:

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -76,9 +76,9 @@ You may need to implement both the <xref:System.IDisposable> and <xref:System.IA
 
 The <xref:System.IDisposable.Dispose?displayProperty=nameWithType> and <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementations are both simple boilerplate code.
 
-In the `Dispose(bool)` overload method, the <xref:System.IDisposable> instance is conditionally disposed of if it is not `null`. The <xref:System.IAsyncDisposable> instance is cast as <xref:System.IDisposable>, and if it is also not `null`, it is disposed of as well. Both instances are then assigned to `null`.
+In the managed resources disposal block of the `Dispose(bool)` overload method, the <xref:System.IDisposable> instance is conditionally disposed of if it is not `null`. The <xref:System.IAsyncDisposable> instance is cast as <xref:System.IDisposable>, and if it is also not `null`, it is disposed of as well. Both variables are then assigned to `null`.
 
-With the `DisposeAsyncCore()` method, the same logical approach is followed. If the <xref:System.IAsyncDisposable> instance is not `null`, its call to `DisposeAsync().ConfigureAwait(false)` is awaited. If the <xref:System.IDisposable> instance is also an implementation of <xref:System.IAsyncDisposable>, it's also disposed of asynchronously. Both instances are then assigned to `null`.
+With the `DisposeAsyncCore()` method, the same logical approach is followed. If the <xref:System.IAsyncDisposable> instance is not `null`, its call to `DisposeAsync().ConfigureAwait(false)` is awaited. If the <xref:System.IDisposable> instance is also an implementation of <xref:System.IAsyncDisposable>, it's also disposed of asynchronously. Both variables are then assigned to `null`.
 
 ## Using async disposable
 

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Implement a DisposeAsync method
 description: Learn how to implement DisposeAsync and DisposeAsyncCore methods to perform asynchronous resource cleanup.
 author: IEvangelist
@@ -121,12 +121,9 @@ In the preceding example, each asynchronous clean up operation is implicitly sco
 
 ### Unacceptable pattern
 
-The highlighted lines in the following code show what it means to have "stacked usings". If an exception is thrown from the `AnotherAsyncDisposable` constructor, neither object is properly disposed of. The variable `objTwo` is never assigned because the constructor did not complete successfully. As a result, the constructor for `AnotherAsyncDisposable` is responsible for disposing any resources allocated before it throws an exception.
+The highlighted lines in the following code show what it means to have "stacked usings". If an exception is thrown from the `AnotherAsyncDisposable` constructor, neither object is properly disposed of.
 
 :::code language="csharp" id="dontdothis" source="snippets/dispose-async/ExamplePatterns.cs" highlight="9-10":::
-
-> [!TIP]
-> Avoid this pattern as it could lead to unexpected behavior.
 
 ## See also
 

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -24,14 +24,11 @@ It is typical when implementing the <xref:System.IAsyncDisposable> interface tha
 
 The <xref:System.IAsyncDisposable> interface declares a single parameterless method, <xref:System.IAsyncDisposable.DisposeAsync>. Any non-sealed class should have an additional `DisposeAsyncCore()` method that also returns a <xref:System.Threading.Tasks.ValueTask>.
 
-- A `public` <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementation that has no parameters.
-- A `protected virtual ValueTask DisposeAsyncCore()` method whose signature is:
+Signatures:
 
-  ```csharp
-  protected virtual ValueTask DisposeAsyncCore()
-  {
-  }
-  ```
+- `public ValueTask DisposeAsync()` – an <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementation
+- `protected virtual ValueTask DisposeAsyncCore()`
+
 
 ### The DisposeAsync() method
 

--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -28,9 +28,8 @@ public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
         if (disposing)
         {
             _jsonWriter?.Dispose();
+            _jsonWriter = null;
         }
-
-        _jsonWriter = null;
     }
 
     protected virtual async ValueTask DisposeAsyncCore()

--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
@@ -29,10 +29,10 @@ class ExampleConjunctiveDisposableusing : IDisposable, IAsyncDisposable
         {
             _disposableResource?.Dispose();
             (_asyncDisposableResource as IDisposable)?.Dispose();
-        }
 
-        _disposableResource = null;
-        _asyncDisposableResource = null;
+            _disposableResource = null;
+            _asyncDisposableResource = null;
+        }
     }
 
     protected virtual async ValueTask DisposeAsyncCore()


### PR DESCRIPTION
## Summary
In commit order:

1. Unacceptable pattern – managed resource must be handled only in managed resources disposal block.
2. Same.
3. More clear definitions on `DisposeAsync` and `DisposeAsyncCore`. Code showing nothing unsaid removal.
4. Clarification on place of disposal, it is likely not known if variables refer to any instances (they were [even] checked for).
5. What happens on producer side (`AnotherAsyncDisposable`) is not conditional from-by consumer pattern. Thus is irrelevant to denote any responsibilities resulting from bad pattern on consumer side. It is not important whether variable is assigned or not. Important is that valid instance referred to by `objOne` `DisposeAsync` is not called while it should and can be.
----
Check also #26270.