### PR TITLE
C# guide: Revise and update the article about instance constructors

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -1,20 +1,16 @@
 ---
-title: "Constructors - C# Programming Guide"
+title: "Constructors - C# programming guide"
 description: A constructor in C# is called when a class or struct is created. Use constructors to set defaults, limit instantiation, and write flexible, easy-to-read code.
-ms.date: 05/05/2017
+ms.date: 09/27/2021
 helpviewer_keywords: 
   - "constructors [C#]"
   - "classes [C#], constructors"
   - "C# language, constructors"
 ms.assetid: df2e2e9d-7998-418b-8e7d-890c17ff6c95
 ---
-# Constructors (C# Programming Guide)
+# Constructors (C# programming guide)
 
-Whenever a [class](../../language-reference/keywords/class.md) or [struct](../../language-reference/builtin-types/struct.md) is created, its constructor is called. A class or struct may have multiple constructors that take different arguments. Constructors enable the programmer to set default values, limit instantiation, and write code that is flexible and easy to read. For more information and examples, see [Using Constructors](./using-constructors.md) and [Instance Constructors](./instance-constructors.md).  
-
-## Parameterless constructors
-  
-If you don't provide a constructor for your class, C# creates one by default that instantiates the object and sets member variables to the default values as listed in the [Default values of C# types](../../language-reference/builtin-types/default-values.md) article. If you don't provide a constructor for your struct, C# relies on an *implicit parameterless constructor* to automatically initialize each field to its default value. For more information and examples, see [Instance constructors](instance-constructors.md).  
+Whenever a [class](../../language-reference/keywords/class.md) or [struct](../../language-reference/builtin-types/struct.md) is created, its constructor is called. A class or struct may have multiple constructors that take different arguments. Constructors enable the programmer to set default values, limit instantiation, and write code that is flexible and easy to read. For more information and examples, see [Instance constructors](instance-constructors.md) and [Using constructors](using-constructors.md).
 
 ## Constructor syntax
 

--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -1,73 +1,44 @@
 ---
-title: "Instance Constructors - C# Programming Guide"
-description: Instance constructors in C# create and initialize any instance member variables when you use the new expression to create an object of a class.
-ms.date: 07/20/2015
+title: "Instance constructors - C# programming guide"
+description: Instance constructors in C# create and initialize any instance member variables when you use the new expression to create an instance of a type.
+ms.date: 09/27/2021
 helpviewer_keywords: 
   - "constructors [C#], instance constructors"
   - "instance constructors [C#]"
 ms.assetid: 24663779-c1e5-4af4-a942-ca554e4c542d
 ---
-# Instance Constructors (C# Programming Guide)
+# Instance constructors (C# programming guide)
 
-Instance constructors are used to create and initialize any instance member variables when you use the [new](../../language-reference/operators/new-operator.md) expression to create an object of a [class](../../language-reference/keywords/class.md). To initialize a [static](../../language-reference/keywords/static.md) class, or static variables in a non-static class, you define a static constructor. For more information, see [Static Constructors](./static-constructors.md).  
-  
- The following example shows an instance constructor:  
-  
- [!code-csharp[CoordsWithParameterlessConstructorOnly#1](snippets/instance-constructors/coords/Program.cs#1)]
-  
-> [!NOTE]
-> For clarity, this class contains public fields. The use of public fields is not a recommended programming practice because it allows any method anywhere in a program unrestricted and unverified access to an object's inner workings. Data members should generally be private, and should be accessed only through class methods and properties.  
-  
- This instance constructor is called whenever an object based on the `Coords` class is created. A constructor like this one, which takes no arguments, is called a *parameterless constructor*. However, it is often useful to provide additional constructors. For example, we can add a constructor to the `Coords` class that allows us to specify the initial values for the data members:  
-  
- [!code-csharp[TwoArgumentConstructor#2](snippets/instance-constructors/coords/Program.cs#2)]
-  
- This allows `Coords` objects to be created with default or specific initial values, like this:  
-  
- [!code-csharp[InstantiatingCoords#3](snippets/instance-constructors/coords/Program.cs#3)]
-  
- If a class does not have a constructor, a parameterless constructor is automatically generated and default values are used to initialize the object fields. For example, an [int](../../language-reference/builtin-types/integral-numeric-types.md) is initialized to 0. For information about the type default values, see [Default values of C# types](../../language-reference/builtin-types/default-values.md). Therefore, because the `Coords` class parameterless constructor initializes all data members to zero, it can be removed altogether without changing how the class works. A complete example using multiple constructors is provided in Example 1 later in this topic, and an example of an automatically generated constructor is provided in Example 2.  
-  
- Instance constructors can also be used to call the instance constructors of base classes. The class constructor can invoke the constructor of the base class through the initializer, as follows:  
-  
-```csharp
-class Circle : Shape
-{
-    public Circle(double radius)
-        : base(radius, 0)
-    {
-    }
-}
-```
-  
- In this example, the `Circle` class passes values representing radius and height to the constructor provided by `Shape` from which `Circle` is derived. A complete example using `Shape` and `Circle` appears in this topic as Example 3.  
-  
-## Example 1  
+You declare an instance constructor to specify the code that is executed when you create a new instance of a type with the [`new` expression](../../language-reference/operators/new-operator.md). To initialize a [static](../../language-reference/keywords/static.md) class or static variables in a non-static class, you can define a [static constructor](static-constructors.md).
 
- The following example demonstrates a class with two class constructors, one without parameters and one with two parameters.  
-  
- [!code-csharp[CoordsFullExample#4](snippets/instance-constructors/coords/Program.cs#4)]
-  
-## Example 2  
+As the following example shows, you can declare several instance constructors in one type:
 
- In this example, the class `Person` does not have any constructors, in which case, a parameterless constructor is automatically provided and the fields are initialized to their default values.  
-  
- [!code-csharp[Person](snippets/instance-constructors/person/Program.cs)]
-  
- Notice that the default value of `age` is `0` and the default value of `name` is `null`.
-  
-## Example 3  
+:::code language="csharp" source="snippets/instance-constructors/coords/Program.cs":::
 
- The following example demonstrates using the base class initializer. The `Circle` class is derived from the general class `Shape`, and the `Cylinder` class is derived from the `Circle` class. The constructor on each derived class is using its base class initializer.  
-  
- [!code-csharp[ShapesExample](snippets/instance-constructors/shapes/Program.cs)]
-  
- For more examples on invoking the base class constructors, see [virtual](../../language-reference/keywords/virtual.md), [override](../../language-reference/keywords/override.md), and [base](../../language-reference/keywords/base.md).  
-  
+In the preceding example, the first, parameterless, constructor calls the second constructor with both arguments equal `0`. To do that, use the `this` keyword.
+
+When you declare an instance constructor in a derived class, you can call a constructor of a base class. To do that, use the `base` keyword, as the following example shows:
+
+:::code language="csharp" source="snippets/instance-constructors/shapes/Program.cs":::
+
+## Parameterless constructors
+
+If a *class* has no explicit instance constructors, C# provides a parameterless constructor that you can use to instantiate an instance of that class, as the following example shows:
+
+:::code language="csharp" source="snippets/instance-constructors/person/Program.cs":::
+
+That constructor initializes instance fields and properties according to the corresponding initializers. If a field or property has no initializer, its value is set to the [default value](../../language-reference/builtin-types/default-values.md) of the field's or property's type. If you declare at least one instance constructor in a class, C# doesn't provide a parameterless constructor.
+
+A *structure* type always provides a parameterless constructor as follows:
+
+- In C# 9.0 and earlier, that is an implicit parameterless constructor that produces the [default value](../../language-reference/builtin-types/default-values.md) of a type.
+- In C# 10.0 and later, that is either an implicit parameterless constructor that produces the default value of a type or an explicitly declared parameterless constructor. For more information, see the [Parameterless constructors and field initializers](../../language-reference/builtin-types/struct.md#parameterless-constructors-and-field-initializers) section of the [Structure types](../../language-reference/builtin-types/struct.md) article.
+
 ## See also
 
-- [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
-- [Constructors](./constructors.md)
-- [Finalizers](./finalizers.md)
-- [static](../../language-reference/keywords/static.md)
+- [C# programming guide](../index.md)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
+- [Constructors](constructors.md)
+- [Finalizers](finalizers.md)
+- [base](../../language-reference/keywords/base.md)
+- [this](../../language-reference/keywords/this.md)

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/coords/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/coords/Program.cs
@@ -1,68 +1,33 @@
 ﻿using System;
 
-namespace CoordsWithParameterlessConstructorOnly
+class Coords
 {
-    //<Snippet1>
-    class Coords
+    public Coords()
+        : this(0, 0)
+    {  }
+
+    public Coords(int x, int y)
     {
-        public int x, y;
-    
-        // constructor
-        public Coords()
-        {
-            x = 0;
-            y = 0;
-        }
+        X = x;
+        Y = y;
     }
-    //</Snippet1>
+
+    public int X { get; set; }
+    public int Y { get; set; }
+
+    public override string ToString() => $"({X},{Y})";
 }
 
-namespace CoordsWithTwoArgumentsConstructorAndToString
+class Example
 {
-    //<Snippet4>
-    class Coords
+    static void Main()
     {
-        public int x, y;
+        var p1 = new Coords();
+        Console.WriteLine($"Coords #1 at {p1}");
+        // Output: Coords #1 at (0,0)
 
-        // Parameterless constructor.
-        public Coords()
-        {
-            x = 0;
-            y = 0;
-        }
-
-        //<Snippet2>
-        // A constructor with two parameters.
-        public Coords(int x, int y)
-        {
-            this.x = x;
-            this.y = y;
-        }
-        //</Snippet2>
-
-        public override string ToString()
-        {
-            return $"({x},{y})";
-        }
+        var p2 = new Coords(5, 3);
+        Console.WriteLine($"Coords #2 at {p2}");
+        // Output: Coords #2 at (5,3)
     }
-
-    class MainClass
-    {
-        static void Main()
-        {
-            //<Snippet3>
-            var p1 = new Coords();
-            var p2 = new Coords(5, 3);
-            //</Snippet3>
-
-            Console.WriteLine($"Coords #1 at {p1}");
-            Console.WriteLine($"Coords #2 at {p2}");
-            Console.ReadKey();
-        }
-    }
-    /* Output:
-     Coords #1 at (0,0)
-     Coords #2 at (5,3)
-    */
-    //</Snippet4>
 }

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/person/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/person/Program.cs
@@ -3,19 +3,15 @@
 public class Person
 {
     public int age;
-    public string name;
+    public string name = "unknown";
 }
 
-class TestPerson
+class Example
 {
     static void Main()
     {
         var person = new Person();
-
         Console.WriteLine($"Name: {person.name}, Age: {person.age}");
-        // Keep the console window open in debug mode.
-        Console.WriteLine("Press any key to exit.");
-        Console.ReadKey();
+        // Output:  Name: unknown, Age: 0
     }
 }
-// Output:  Name: , Age: 0

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/shapes/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/shapes/Program.cs
@@ -18,13 +18,9 @@ class Circle : Shape
 {
     public Circle(double radius)
         : base(radius, 0)
-    {
-    }
+    {  }
 
-    public override double Area()
-    {
-        return pi * x * x;
-    }
+    public override double Area() => pi * x * x;
 }
 
 class Cylinder : Circle
@@ -35,31 +31,22 @@ class Cylinder : Circle
         y = height;
     }
 
-    public override double Area()
-    {
-        return (2 * base.Area()) + (2 * pi * x * y);
-    }
+    public override double Area() => (2 * base.Area()) + (2 * pi * x * y);
 }
 
-class TestShapes
+class Example
 {
     static void Main()
     {
         double radius = 2.5;
         double height = 3.0;
 
-        Circle ring = new Circle(radius);
-        Cylinder tube = new Cylinder(radius, height);
-
-        Console.WriteLine("Area of the circle = {0:F2}", ring.Area());
-        Console.WriteLine("Area of the cylinder = {0:F2}", tube.Area());
-
-        // Keep the console window open in debug mode.
-        Console.WriteLine("Press any key to exit.");
-        Console.ReadKey();
+        var ring = new Circle(radius);
+        Console.WriteLine($"Area of the circle = {ring.Area():F2}");
+        // Output: Area of the circle = 19.63
+        
+        var tube = new Cylinder(radius, height);
+        Console.WriteLine($"Area of the cylinder = {tube.Area():F2}");
+        // Output: Area of the cylinder = 86.39
     }
 }
-/* Output:
-    Area of the circle = 19.63
-    Area of the cylinder = 86.39
-*/


### PR DESCRIPTION
- Cleaned up examples, made them "integrated" into the text
- Moved the info about parameterless constructors into the Instance constructors article, as it was partially duplicated
- Mention/reference C# 10 changes with regards to struct parameterless constructors.

Contributes to #25676
