### PR TITLE
C# docset: Mention explicit struct parameterless constructor where necessary

### DIFF
--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -1,7 +1,7 @@
 ---
 title: "Default values of C# types - C# reference"
 description: "Learn the default values of C# types such as bool, char, int, float, double and more."
-ms.date: 12/18/2019
+ms.date: 09/28/2021
 helpviewer_keywords: 
   - "default [C#]"
   - "parameterless constructor [C#]"
@@ -33,7 +33,9 @@ Beginning with C# 7.1, you can use the [`default` literal](../operators/default.
 int a = default;
 ```
 
-For a value type, the implicit parameterless constructor also produces the default value of the type, as the following example shows:
+## Parameterless constructor of a value type
+
+For a value type, the *implicit* parameterless constructor also produces the default value of the type, as the following example shows:
 
 ```csharp-interactive
 var n = new System.Numerics.Complex();
@@ -41,6 +43,9 @@ Console.WriteLine(n);  // output: (0, 0)
 ```
 
 At run time, if the <xref:System.Type?displayProperty=nameWithType> instance represents a value type, you can use the <xref:System.Activator.CreateInstance(System.Type)?displayProperty=nameWithType> method to invoke the parameterless constructor to obtain the default value of the type.
+
+> [!NOTE]
+> In C# 10.0 and later, a [structure type](struct.md) (which is a value type) may have an [explicit parameterless constructor](struct.md#parameterless-constructors-and-field-initializers) that may produce a non-default value of the type. Thus, we recommend using the `default` operator or the `default` literal to produce the default value of a type.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/compiler-messages/cs0304.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0304.md
@@ -18,7 +18,7 @@ Cannot create an instance of the variable type 'type' because it does not have t
 class C<T> where T : new()  
 ```  
   
- The `new()` constraint enforces type safety by guaranteeing that any concrete type that is supplied for `T` has a default, parameterless constructor. CS0304 occurs if you attempt to use the `new` operator in the body of the class to create an instance of type parameter `T` when `T` does not specify the `new()` constraint. On the client side, if code attempts to instantiate the generic class with a type that has no parameterless constructor, that code will generate [Compiler Error CS0310](./cs0310.md).  
+ The `new()` constraint enforces type safety by guaranteeing that any concrete type that is supplied for `T` has a parameterless constructor. CS0304 occurs if you attempt to use the `new` operator in the body of the class to create an instance of type parameter `T` when `T` does not specify the `new()` constraint. On the client side, if code attempts to instantiate the generic class with a type that has no parameterless constructor, that code will generate [Compiler Error CS0310](./cs0310.md).  
   
  The following example generates CS0304.  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0310.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0310.md
@@ -12,7 +12,7 @@ ms.assetid: f7db7e56-f51f-406f-a54b-48ea61b5cb3e
 
 The type 'typename' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'parameter' in the generic type or method 'generic'  
   
- The generic type or method defines the [new() constraint](../keywords/new-constraint.md) in its `where` clause, so any type must have a public parameterless constructor in order to be used as a type argument for that generic type or method. To avoid this error, make sure that the type has the correct constructor, or modify the constraint clause of the generic type or method.  
+ The generic type or method defines the [`new()` constraint](../keywords/new-constraint.md) in its `where` clause, so any type must have a public parameterless constructor in order to be used as a type argument for that generic type or method. To avoid this error, make sure that the type has the correct constructor, or modify the constraint clause of the generic type or method.  
   
 ## Example  
 

--- a/docs/csharp/language-reference/compiler-messages/cs0310.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0310.md
@@ -12,7 +12,7 @@ ms.assetid: f7db7e56-f51f-406f-a54b-48ea61b5cb3e
 
 The type 'typename' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'parameter' in the generic type or method 'generic'  
   
- The generic type or method defines a new constraint in its where clause, so any type must have a public parameterless constructor in order to be used as a type argument for that generic type or method. To avoid this error, make sure that the type has the correct constructor, or modify the constraint clause of the generic type or method.  
+ The generic type or method defines the [new() constraint](../keywords/new-constraint.md) in its `where` clause, so any type must have a public parameterless constructor in order to be used as a type argument for that generic type or method. To avoid this error, make sure that the type has the correct constructor, or modify the constraint clause of the generic type or method.  
   
 ## Example  
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -136,8 +136,11 @@ A method definition can specify that its parameters are required or that they ar
 The parameter's default value must be assigned by one of the following kinds of expressions:
 
 - A constant, such as a literal string or number.
+- An expression of the form `default(SomeType)`, where `SomeType` can be either a value type or a reference type. If it's a reference type, it's effectively the same as specifying `null`. Beginning with C# 7.1, you can use the `default` literal, as the compiler can infer the type from the parameter's declaration.
 - An expression of the form `new ValType()`, where `ValType` is a value type. Note that this invokes the value type's implicit parameterless constructor, which is not an actual member of the type.
-- An expression of the form `default(SomeType)`, where `SomeType` can be either a value type or a reference type. If it's a reference type, it's effectively the same as specifying `null`.
+
+  > [!NOTE]
+  > In C# 10.0 and later, an expression of the form `new ValType()` is not allowed if it invokes the explicitly defined parameterless constructor of a value type. Use the `default(ValType)` expression or the `default` literal to provide the parameter's default value. For more information about parameterless constructors, see the [Parameterless constructors and field initializers](language-reference/builtin-types/struct.md#parameterless-constructors-and-field-initializers) section of the [Structure types](language-reference/builtin-types/struct.md) article.
 
 If a method includes both required and optional parameters, optional parameters are defined at the end of the parameter list, after all required parameters.
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -140,7 +140,7 @@ The parameter's default value must be assigned by one of the following kinds of 
 - An expression of the form `new ValType()`, where `ValType` is a value type. Note that this invokes the value type's implicit parameterless constructor, which is not an actual member of the type.
 
   > [!NOTE]
-  > In C# 10.0 and later, an expression of the form `new ValType()` is not allowed if it invokes the explicitly defined parameterless constructor of a value type. Use the `default(ValType)` expression or the `default` literal to provide the parameter's default value. For more information about parameterless constructors, see the [Parameterless constructors and field initializers](language-reference/builtin-types/struct.md#parameterless-constructors-and-field-initializers) section of the [Structure types](language-reference/builtin-types/struct.md) article.
+  > In C# 10.0 and later, when an expression of the form `new ValType()` invokes the explicitly defined parameterless constructor of a value type, the compiler generates an error as the default parameter value must be a compile-time constant. Use the `default(ValType)` expression or the `default` literal to provide the default parameter value. For more information about parameterless constructors, see the [Parameterless constructors and field initializers](language-reference/builtin-types/struct.md#parameterless-constructors-and-field-initializers) section of the [Structure types](language-reference/builtin-types/struct.md) article.
 
 If a method includes both required and optional parameters, optional parameters are defined at the end of the parameter list, after all required parameters.
 

--- a/docs/csharp/misc/cs0568.md
+++ b/docs/csharp/misc/cs0568.md
@@ -37,5 +37,5 @@ public class ClassX
 }  
 ```
 
-> [!TIP]
-> Starting with C# 10, parameterless struct constructors are allowed.
+> [!NOTE]
+> Beginning with C# 10.0, a structure type can contain an explicit parameterless constructor. For more information, see the [Parameterless constructors and field initializers](../language-reference/builtin-types/struct.md#parameterless-constructors-and-field-initializers) section of the [Structure types](../language-reference/builtin-types/struct.md) article.

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -23,15 +23,18 @@ When a [class](../../language-reference/keywords/class.md) or [struct](../../lan
  [!code-csharp[PrivateConstructor#2](snippets/using-constructors/Program.cs#2)]
   
  For more information, see [Private Constructors](./private-constructors.md).  
-  
- Constructors for [struct](../../language-reference/builtin-types/struct.md) types resemble class constructors, but `structs` cannot contain an explicit parameterless constructor because one is provided automatically by the compiler. This constructor initializes each field in the `struct` to the [default value](../../language-reference/builtin-types/default-values.md). However, this parameterless constructor is only invoked if the `struct` is instantiated with `new`. For example, this code uses the parameterless constructor for <xref:System.Int32>, so that you are assured that the integer is initialized:  
+
+Constructors for [struct](../../language-reference/builtin-types/struct.md) types resemble class constructors, but `structs` cannot contain an explicit parameterless constructor because one is provided automatically by the compiler. This constructor initializes each field in the `struct` to the [default value](../../language-reference/builtin-types/default-values.md). However, this parameterless constructor is only invoked if the `struct` is instantiated with `new`. For example, this code uses the parameterless constructor for <xref:System.Int32>, so that you are assured that the integer is initialized:  
   
 ```csharp  
 int i = new int();  
 Console.WriteLine(i);  
 ```  
-  
- The following code, however, causes a compiler error because it does not use `new`, and because it tries to use an object that has not been initialized:  
+
+> [!NOTE]
+> Beginning with C# 10.0, a structure type can contain an explicit parameterless constructor. For more information, see the [Parameterless constructors and field initializers](../../language-reference/builtin-types/struct.md#parameterless-constructors-and-field-initializers) section of the [Structure types](../../language-reference/builtin-types/struct.md) article.
+
+The following code, however, causes a compiler error because it does not use `new`, and because it tries to use an object that has not been initialized:  
   
 ```csharp  
 int i;  


### PR DESCRIPTION
Contributes to #25676

I've searched and checked only the "default constructor" and "parameterless constructor" entries in the C# doc set.
