### PR TITLE
--version-suffix example uses incorrect naming

### DIFF
--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -126,7 +126,7 @@ Web projects aren't packable by default. To override the default behavior, add t
   | `VersionSuffix` only                | `1.0.0-$(VersionSuffix)`            |
   | `VersionPrefix` and `VersionSuffix` | `$(VersionPrefix)-$(VersionSuffix)` |
 
-  If you want to use `--version-suffix`, specify `VersionPrefix` and not `Version` in the project file. For example, if `VersionPrefix` is `0.1.2` and you pass `--version-suffix rc1` to `dotnet pack`, the package version will be `0.1.2-rc1`.
+  If you want to use `--version-suffix`, specify `VersionPrefix` and not `Version` in the project file. For example, if `VersionPrefix` is `0.1.2` and you pass `--version-suffix rc.1` to `dotnet pack`, the package version will be `0.1.2-rc.1`.
 
   If `Version` has a value and you pass `--version-suffix` to `dotnet pack`, the value specified for `--version-suffix` is ignored.
 


### PR DESCRIPTION
semver 2.0 should use `rc.1` not `rc1`, as per conversation I had with @joelverhagen where I was using it incorrectly.  I believe the example in this article is likely the root cause as to why I thought `rc1` was correct, so it would be great to update and fix this. See discussion here https://github.com/NuGet/NuGetGallery/issues/8325
