### PR TITLE
Address review feedback and correct deviation from analyzer dispose pattern impls.

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/snippets/extensions/linq.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/extensions/linq.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <nullable>enable</nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/partition/partition.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/partition/partition.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/projection/projection.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/projection/projection.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/set-operators/set-operators.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/set-operators/set-operators.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <nullable>enable</nullable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -1,7 +1,7 @@
 ---
 title: "Implement a Dispose method"
 description: In this article, learn to implement the Dispose method, which releases unmanaged resources used by your code in .NET.
-ms.date: 08/20/2021
+ms.date: 09/29/2021
 dev_langs:
   - "csharp"
   - "vb"
@@ -97,7 +97,7 @@ All non-sealed classes or (Visual Basic classes not modified as `NotInheritable`
 > [!IMPORTANT]
 > It is possible for a base class to only reference managed objects, and implement the dispose pattern. In these cases, a finalizer is unnecessary. A finalizer is only required if you directly reference unmanaged resources.
 
-Here's an example (of general pattern) for implementing the dispose pattern for a base class that uses a safe handle.
+Here's an example of the general pattern for implementing the dispose pattern for a base class that uses a safe handle.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base1.vb":::
@@ -120,7 +120,7 @@ A class derived from a class that implements the <xref:System.IDisposable> inter
 - A `protected override void Dispose(bool)` method that overrides the base class method and performs the actual cleanup of the derived class. This method must also call the `base.Dispose(bool)` (`MyBase.Dispose(bool)` in Visual Basic) method passing it the disposing status (`bool disposing` parameter) as an argument.
 - Either a class derived from <xref:System.Runtime.InteropServices.SafeHandle> that wraps your unmanaged resource (recommended), or an override to the <xref:System.Object.Finalize%2A?displayProperty=nameWithType> method. The <xref:System.Runtime.InteropServices.SafeHandle> class provides a finalizer that frees you from having to code one. If you do provide a finalizer, it must call the `Dispose(bool)` overload with `false` argument.
 
-Here's an example (of general pattern) for implementing the dispose pattern for a derived class that uses a safe handle:
+Here's an example of the general pattern for implementing the dispose pattern for a derived class that uses a safe handle:
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived1.cs":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/derived1.vb":::

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Disposable.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Disposable.cs
@@ -16,18 +16,20 @@ public class Disposable : IDisposable
     // <SnippetDisposeBool>
     protected virtual void Dispose(bool disposing)
     {
-    	if (_disposed)    	
-    		return;       	
-    		
-    	// A block that frees unmanaged resources.	
-    	
-    	if(disposing) 
-    	{
-	    	// Deterministic call…
-    		// A conditional block that frees managed resources.    	
-	    }	    
-	    
-	    _disposed = true;	    
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            // TODO: dispose managed state (managed objects).
+        }
+
+        // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+        // TODO: set large fields to null.
+
+        _disposed = true;
     }
     // </SnippetDisposeBool>
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs
@@ -2,7 +2,12 @@
 
 public sealed class Foo : IDisposable
 {
-    // Model simplified for brevity sake.
-    private readonly IDisposable _bar = new Bar();
-    public void Dispose() => _bar.Dispose();
+    private readonly IDisposable _bar;
+
+    public Foo()
+    {
+        _bar = new Bar();
+    }
+
+    public void Dispose() => _bar?.Dispose();
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 class BaseClassWithSafeHandle : IDisposable
 {
     // To detect redundant calls
-    private bool _disposed = false;
+    private bool _disposedValue;
 
     // Instantiate a SafeHandle instance.
     private SafeHandle _safeHandle = new SafeFileHandle(IntPtr.Zero, true);
@@ -16,16 +16,14 @@ class BaseClassWithSafeHandle : IDisposable
     // Protected implementation of Dispose pattern.
     protected virtual void Dispose(bool disposing)
     {
-        if (_disposed)
+        if (!_disposedValue)
         {
-            return;
-        }
+            if (disposing)
+            {
+                _safeHandle.Dispose();
+            }
 
-        if (disposing)
-        {
-            _safeHandle.Dispose();
+            _disposedValue = true;
         }
-
-        _disposed = true;
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base2.cs
@@ -3,7 +3,7 @@
 class BaseClassWithFinalizer : IDisposable
 {
     // To detect redundant calls
-    private bool _disposed = false;
+    private bool _disposedValue;
 
     ~BaseClassWithFinalizer() => Dispose(false);
 
@@ -17,19 +17,16 @@ class BaseClassWithFinalizer : IDisposable
     // Protected implementation of Dispose pattern.
     protected virtual void Dispose(bool disposing)
     {
-        if (_disposed)
+        if (!_disposedValue)
         {
-            return;
+            if (disposing)
+            {
+                // TODO: dispose managed state (managed objects)
+            }
+
+            // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+            // TODO: set large fields to null
+            _disposedValue = true;
         }
-
-        if (disposing)
-        {
-        	// Dispose managed objects that implement IDisposable.
-	        // Assign null to managed objects that consume large amounts of memory or consume scarce resources.
-        }
-
-        // Free unmanaged resources (unmanaged objects).
-
-        _disposed = true;
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived1.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 class DerivedClassWithSafeHandle : BaseClassWithSafeHandle
 {
     // To detect redundant calls
-    private bool _disposed = false;
+    private bool _disposedValue;
 
     // Instantiate a SafeHandle instance.
     private SafeHandle _safeHandle = new SafeFileHandle(IntPtr.Zero, true);
@@ -13,17 +13,15 @@ class DerivedClassWithSafeHandle : BaseClassWithSafeHandle
     // Protected implementation of Dispose pattern.
     protected override void Dispose(bool disposing)
     {
-        if (_disposed)
+        if (!_disposedValue)
         {
-            return;
-        }
+            if (disposing)
+            {
+                _safeHandle.Dispose();
+            }
 
-        if (disposing)
-        {
-            _safeHandle.Dispose();
+            _disposed = true;
         }
-
-        _disposed = true;
 
         // Call base class implementation.
         base.Dispose(disposing);

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs
@@ -1,26 +1,24 @@
 ﻿class DerivedClassWithFinalizer : BaseClassWithFinalizer
 {
     // To detect redundant calls
-    bool _disposed = false;
+    private bool _disposedValue;
 
     ~DerivedClassWithFinalizer() => this.Dispose(false);
 
     // Protected implementation of Dispose pattern.
     protected override void Dispose(bool disposing)
     {
-        if (_disposed)
+        if (!_disposedValue)
         {
-            return;
-        }
+            if (disposing)
+            {
+                // TODO: dispose managed state (managed objects).
+            }
 
-        if (disposing)
-        {
-            // Dispose managed objects that implement IDisposable.
-	        // Assign null to managed objects that consume large amounts of memory or consume scarce resources.
+            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+            // TODO: set large fields to null.
+            _disposedValue = true;
         }
-
-        // Free unmanaged resources (unmanaged objects).
-        _disposed = true;
 
         // Call the base class implementation.
         base.Dispose(disposing);


### PR DESCRIPTION
## Summary

- Corrected issues introduced from #26192, formatting, deviation from analyzer provided implementation of Dispose, code style, etc.
- Add enable implicit usings in new LINQ bits
- Follow up from review feedback that wasn't incorporated: https://github.com/dotnet/docs/pull/26192#pullrequestreview-761065050
- The example for `Foo` needs to remain as such as well, since it aligns with the Framework guidance on implementing the dispose pattern.
