### PR TITLE
Added the section title

### DIFF
--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -21,6 +21,8 @@ The following table shows the default values of C# types:
 |[struct](struct.md)|The value produced by setting all value-type fields to their default values and all reference-type fields to `null`.|
 |Any [nullable value type](nullable-value-types.md)|An instance for which the <xref:System.Nullable%601.HasValue%2A> property is `false` and the <xref:System.Nullable%601.Value%2A> property is undefined. That default value is also known as the *null* value of a nullable value type.|
 
+## Default value expressions
+
 Use the [`default` operator](../operators/default.md#default-operator) to produce the default value of a type, as the following example shows:
 
 ```csharp


### PR DESCRIPTION
This is to balance the "Parameterless constructor of a value type" section and separate the table with the default values from other article text.
