### PR TITLE
Simplify WindowsBackgroundService

### DIFF
--- a/docs/core/extensions/snippets/workers/windows-service/WindowsBackgroundService.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/WindowsBackgroundService.cs
@@ -20,17 +20,10 @@ namespace App.WindowsService
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                try
-                {
-                    string joke = await _jokeService.GetJokeAsync();
-                    _logger.LogWarning(joke);
+                string joke = await _jokeService.GetJokeAsync();
+                _logger.LogWarning(joke);
 
-                    await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
             }
         }
     }


### PR DESCRIPTION
No need in `try-catch` for OperationCanceledException.

See https://github.com/dotnet/aspnetcore/pull/35127
