### PR TITLE
Remove sql-cache from list of bundled .NET tools

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -239,7 +239,6 @@ Starting with .NET Core SDK 2.1.300, a number of tools that were available only 
 | ------------------------------------------------- | ------------------------------------------------------------ |
 | dev-certs                                         | Creates and manages development certificates.                |
 | [ef](/ef/core/miscellaneous/cli/dotnet)           | Entity Framework Core command-line tools.                    |
-| sql-cache                                         | SQL Server cache command-line tools.                         |
 | [user-secrets](/aspnet/core/security/app-secrets) | Manages development user secrets.                            |
 | [watch](/aspnet/core/tutorials/dotnet-watch)      | Starts a file watcher that runs a command when files change. |
 


### PR DESCRIPTION
It was removed as a bundled tool more than 2 years ago: https://github.com/dotnet/installer/pull/2014, in the 3.1 preview timeframe.

See also https://github.com/dotnet/sdk/pull/21464