### PR TITLE
Add Task.FromResult breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -56,6 +56,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
 | [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
 | [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
+| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
 | [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
 
 ## Entity Framework Core

--- a/docs/core/compatibility/core-libraries/6.0/task-fromresult-returns-singleton.md
+++ b/docs/core/compatibility/core-libraries/6.0/task-fromresult-returns-singleton.md
@@ -1,0 +1,54 @@
+---
+title: "Breaking change: Task.FromResult may return singleton"
+description: Learn about the .NET 6.0 breaking change where Task.FromResult may return a singleton.
+ms.date: 10/01/2021
+---
+# Task.FromResult may return singleton
+
+<xref:System.Threading.Tasks.Task.FromResult%60%601(%60%600)?displayProperty=nameWithType> may now return a cached <xref:System.Threading.Tasks.Task%601> instance rather than always creating a new instance.
+
+## Old behavior
+
+In previous versions, <xref:System.Threading.Tasks.Task.FromResult%60%601(%60%600)?displayProperty=nameWithType> would always allocate a new <xref:System.Threading.Tasks.Task%601>, regardless of the type of `T` or the result value.
+
+## New behavior
+
+For some `T` types and some result values, <xref:System.Threading.Tasks.Task.FromResult%60%601(%60%600)?displayProperty=nameWithType> may return a cached singleton object rather than allocating a new object. For example, it is likely that every call to `Task.FromResult(true)` will return the same already-completed `Task<bool>` object.
+
+## Version introduced
+
+6.0 Preview 1
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+Many developers expected <xref:System.Threading.Tasks.Task.FromResult%60%601(%60%600)?displayProperty=nameWithType> to behave similarly to asynchronous methods, which already performed such caching. Developers that knew about the allocation behavior often maintained their own cache to avoid the performance cost of always allocating for these commonly used values. For example:
+
+```csharp
+private static readonly Task<bool> s_trueTask = Task.FromResult(true);
+```
+
+Now, such custom caches are no longer required for values such as <xref:System.Boolean> and small <xref:System.Int32> values.
+
+## Recommended action
+
+Unless you're using reference equality to check whether one `Task` instance is the same as another `Task` instance, you should not be impacted by this change. If you are using such reference equality and need to continue this checking, use the following code to be guaranteed to always get back a unique <xref:System.Threading.Tasks.Task%601> instance:
+
+```csharp
+private static Task<T> NewInstanceFromResult<T>(T result)
+{
+    var tcs = new TaskCompletionSource<T>();
+    tcs.TrySetResult(result);
+    return tcs.Task;
+}
+```
+
+> [!NOTE]
+> This pattern is much less efficient than just using `Task.FromResult(result)`, and should be avoided unless you really need it.
+
+## Affected APIs
+
+- <xref:System.Threading.Tasks.Task.FromResult%60%601(%60%600)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -97,6 +97,8 @@ items:
           href: core-libraries/6.0/static-abstract-interface-methods.md
         - name: System.Drawing.Common only supported on Windows
           href: core-libraries/6.0/system-drawing-common-windows-only.md
+        - name: Task.FromResult may return singleton
+          href: core-libraries/6.0/task-fromresult-returns-singleton.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
       - name: Entity Framework Core
@@ -613,6 +615,8 @@ items:
           href: core-libraries/6.0/static-abstract-interface-methods.md
         - name: System.Drawing.Common only supported on Windows
           href: core-libraries/6.0/system-drawing-common-windows-only.md
+        - name: Task.FromResult may return singleton
+          href: core-libraries/6.0/task-fromresult-returns-singleton.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
       - name: .NET 5


### PR DESCRIPTION
Fixes #26321 

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/task-fromresult-returns-singleton?branch=pr-en-us-26345)