### PR TITLE
Improved public access modifier definition - #26273

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -11,7 +11,7 @@ ms.assetid: 6e81ee82-224f-4a12-9baf-a0dca2656c5b
 
 All types and type members have an accessibility level. The accessibility level controls whether they can be used from other code in your assembly or other assemblies. Use the following access modifiers to specify the accessibility of a type or member when you declare it:
 
-- [public](../../language-reference/keywords/public.md): The type or member can be accessed by any other code in the same assembly or another assembly that references it.
+- [public](../../language-reference/keywords/public.md): The type or member can be accessed by any other code in the same assembly or another assembly that references it. The accessibility level of public members of a type is controlled by the accessibility level of the type itself.
 - [private](../../language-reference/keywords/private.md): The type or member can be accessed only by code in the same `class` or `struct`.
 - [protected](../../language-reference/keywords/protected.md): The type or member can be accessed only by code in the same `class`, or in a `class` that is derived from that `class`.
 - [internal](../../language-reference/keywords/internal.md): The type or member can be accessed by any code in the same assembly, but not from another assembly.
@@ -22,11 +22,11 @@ All types and type members have an accessibility level. The accessibility level 
 
 | Caller's location                      | `public` | `protected internal` | `protected` | `internal` | `private protected` | `private` |
 | -------------------------------------- | :------: | :------------------: | :---------: | :--------: | :-----------------: | :-------: |
-| Within the class                       |   ✔️️   |         ✔️         |     ✔️     |     ✔️     |         ✔️          |    ✔️     |
-| Derived class (same assembly)          |   ✔️   |         ✔️         |     ✔️     |     ✔️     |         ✔️          |    ❌     |
-| Non-derived class (same assembly)      |   ✔️   |         ✔️         |     ❌     |     ✔️     |         ❌          |    ❌     |
-| Derived class (different assembly)     |   ✔️   |         ✔️         |     ✔️     |     ❌     |         ❌          |    ❌     |
-| Non-derived class (different assembly) |   ✔️   |         ❌         |     ❌     |     ❌     |         ❌          |    ❌     |
+| Within the class                       |    ✔️️     |          ✔️           |      ✔️      |     ✔️      |          ✔️          |     ✔️     |
+| Derived class (same assembly)          |    ✔️     |          ✔️           |      ✔️      |     ✔️      |          ✔️          |     ❌     |
+| Non-derived class (same assembly)      |    ✔️     |          ✔️           |      ❌      |     ✔️      |          ❌          |     ❌     |
+| Derived class (different assembly)     |    ✔️     |          ✔️           |      ✔️      |     ❌      |          ❌          |     ❌     |
+| Non-derived class (different assembly) |    ✔️     |          ❌           |      ❌      |     ❌      |          ❌          |     ❌     |
 
 The following examples demonstrate how to specify access modifiers on a type and member:
 


### PR DESCRIPTION
## Summary

- Improved the definition of public access modifier by adding additional clarification related to the accessibility level of public members.

Fixes #26273 
