### PR TITLE
Specifying the default value for Nullable

### DIFF
--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -121,7 +121,7 @@ The following table lists the minimum versions of the SDK with the C# compiler t
 
 ## Nullable
 
-The **Nullable** option lets you specify the nullable context.
+The **Nullable** option lets you specify the nullable context.  The default value for this option is `disable`.
 
 ```xml
 <Nullable>enable</Nullable>


### PR DESCRIPTION
This is intended to contribute to Hacktoberfest.

## Summary

Adding in the default value for Nullable, inline with the other defaults specified on the page.

Fixes #26336
