### PR TITLE
Update GitHub Action and .NET related content to include workload and SDK callouts

### DIFF
--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -45,7 +45,7 @@ From a workflow file, you're able to `run` any of the available [.NET CLI comman
 
 ### The .NET SDK is a workflow necessity
 
-All .NET workflows require the .NET SDK, and this can be set up by the [`actions/setup-dotnet` GitHub Action](https://github.com/actions/setup-dotnet). This action sets up a [.NET CLI](../../core/tools/index.md) environment for use in actions. Some [GitHub hosted runners](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software) have .NET SDK preinstalled, but that's subject to change. As a best practice, use the `actions/setup-dotnet` action to ensure the proper version is available.
+All .NET workflows require the .NET SDK, and this can be set up by the [`actions/setup-dotnet` GitHub Action](https://github.com/actions/setup-dotnet). This action sets up a [.NET CLI](../../core/tools/index.md) environment for use in actions. Some [GitHub hosted runners](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software) have the .NET SDK preinstalled, but that's subject to change. As a best practice, use the `actions/setup-dotnet` action to ensure the proper version is available.
 
 ## Create a basic build workflow
 

--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -37,11 +37,11 @@ The `steps` node can be as easy as inline commands, or they can be actions. Most
 
 From a workflow file, you're able to `run` any of the available [.NET CLI commands](../../core/tools/index.md). For example, if you're required to build, test, and deploy an ASP.NET Core Blazor WebAssembly app with Ahead-of-Time (AoT) compilation, you'd use the following commands:
 
-- [dotnet workload install](../core/tools/dotnet-workload-install.md)
-- [dotnet restore](../core/tools/dotnet-restore.md)
-- [dotnet build](../core/tools/dotnet-build.md)
-- [dotnet test](../core/tools/dotnet-test.md)
-- [dotnet publish](../core/tools/dotnet-publish.md)
+- [dotnet workload install](../../core/tools/dotnet-workload-install.md)
+- [dotnet restore](../../core/tools/dotnet-restore.md)
+- [dotnet build](../../core/tools/dotnet-build.md)
+- [dotnet test](../../core/tools/dotnet-test.md)
+- [dotnet publish](../../core/tools/dotnet-publish.md)
 
 ### The .NET SDK is a workflow necessity
 

--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -2,7 +2,7 @@
 title: DevOps with .NET and GitHub Actions - Build a .NET Web App
 description: Start your journey of DevOps with .NET and GitHub Actions by building a .NET web app
 author: colindembovsky
-ms.date: 03/04/2021
+ms.date: 10/05/2021
 ---
 # Build a .NET web app using GitHub Actions
 
@@ -34,6 +34,18 @@ The `steps` node can be as easy as inline commands, or they can be actions. Most
 
 > [!TIP]
 > For more information, see [GitHub Actions YAML syntax](https://docs.github.com/actions/reference/workflow-syntax-for-github-actions).
+
+From a workflow file, you're able to `run` any of the available [.NET CLI commands](../../core/tools/index.md). For example, if you're required to build, test, and deploy an ASP.NET Core Blazor WebAssembly app with Ahead-of-Time (AoT) compilation, you'd use the following commands:
+
+- [dotnet workload install](../core/tools/dotnet-workload-install.md)
+- [dotnet restore](../core/tools/dotnet-restore.md)
+- [dotnet build](../core/tools/dotnet-build.md)
+- [dotnet test](../core/tools/dotnet-test.md)
+- [dotnet publish](../core/tools/dotnet-publish.md)
+
+### The .NET SDK is a workflow necessity
+
+All .NET workflows require the .NET SDK, and this can be set up by the [`actions/setup-dotnet` GitHub Action](https://github.com/actions/setup-dotnet). This action sets up a [.NET CLI](../../core/tools/index.md) environment for use in actions. Some [GitHub hosted runners](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software) have .NET SDK preinstalled, but that's subject to change. As a best practice, use the `actions/setup-dotnet` action to ensure the proper version is available.
 
 ## Create a basic build workflow
 

--- a/docs/devops/dotnet-build-github-action.md
+++ b/docs/devops/dotnet-build-github-action.md
@@ -45,7 +45,7 @@ In the preceding workflow composition:
   - There is a single job, named `build-<os>` where the `<os>` is the operating system name from the `strategy/matrix`. The `name` and `runs-on` elements are dynamic for each value in the `matrix/os`. This will run on the latest versions of Ubuntu, Windows, and macOS.
   - The `actions/setup-dotnet@v1` GitHub Action is required to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
   - (Optionally) Additional steps may be required, depending on your .NET workload. They're omitted from this example, but you may need additional tools installed to build your apps.
-    - For example, when building an ASP.NET Core Blazor WebAssembly application with Ahead-of-Time (AoT) compilation you'd install the corresponding workload.
+    - For example, when building an ASP.NET Core Blazor WebAssembly application with Ahead-of-Time (AoT) compilation you'd install the corresponding workload before running restore/build/publish operations.
 
     ```yaml
     - name: Install WASM Tools Workload

--- a/docs/devops/dotnet-build-github-action.md
+++ b/docs/devops/dotnet-build-github-action.md
@@ -3,7 +3,7 @@ title: Create a build validation GitHub Action
 description: In this quickstart, you will learn how to create a GitHub Action to validate .NET app compilation.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/06/2021
+ms.date: 10/05/2021
 ms.topic: quickstart
 recommendations: false
 ---
@@ -43,9 +43,21 @@ In the preceding workflow composition:
   :::code language="yml" source="snippets/dotnet-build-github-action/build-validation.yml" range="14-34" highlight="2,4-8,13-15,18,21":::
 
   - There is a single job, named `build-<os>` where the `<os>` is the operating system name from the `strategy/matrix`. The `name` and `runs-on` elements are dynamic for each value in the `matrix/os`. This will run on the latest versions of Ubuntu, Windows, and macOS.
-  - The `actions/setup-dotnet@v1` GitHub Action is used to setup the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
+  - The `actions/setup-dotnet@v1` GitHub Action is required to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
+  - (Optionally) Additional steps may be required, depending on your .NET workload. They're omitted from this example, but you may need additional tools installed to build your apps.
+    - For example, when building an ASP.NET Core Blazor WebAssembly application with Ahead-of-Time (AoT) compilation you'd install the corresponding workload.
+
+    ```yaml
+    - name: Install WASM Tools Workload
+      run: dotnet workload install wasm-tools
+    ```
+
+    For more information on .NET workloads, see [`dotnet workload install`](../core/tools/dotnet-workload-install.md).
+
   - The [`dotnet restore`](../core/tools/dotnet-restore.md) command is called.
   - The [`dotnet build`](../core/tools/dotnet-build.md) command is called.
+
+In this case, you should think of a workflow file as your composition that represents the various steps to build your application. There are many [.NET CLI commands](../core/tools/index.md) available, most of which could be used in the context of a GitHub Action.
 
 [!INCLUDE [add-status-badge](includes/add-status-badge.md)]
 

--- a/docs/devops/dotnet-build-github-action.md
+++ b/docs/devops/dotnet-build-github-action.md
@@ -57,7 +57,7 @@ In the preceding workflow composition:
   - The [`dotnet restore`](../core/tools/dotnet-restore.md) command is called.
   - The [`dotnet build`](../core/tools/dotnet-build.md) command is called.
 
-In this case, you should think of a workflow file as your composition that represents the various steps to build your application. There are many [.NET CLI commands](../core/tools/index.md) available, most of which could be used in the context of a GitHub Action.
+In this case, think of a workflow file as a composition that represents the various steps to build an application. Many [.NET CLI commands](../core/tools/index.md) are available, most of which could be used in the context of a GitHub Action.
 
 [!INCLUDE [add-status-badge](includes/add-status-badge.md)]
 

--- a/docs/devops/dotnet-publish-github-action.md
+++ b/docs/devops/dotnet-publish-github-action.md
@@ -3,14 +3,14 @@ title: Create a publish app GitHub Action
 description: In this quickstart, you will learn how to create a GitHub Action to publish your .NET source code.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/06/2021
+ms.date: 10/05/2021
 ms.topic: quickstart
 recommendations: false
 ---
 
 # Quickstart: Create a publish app GitHub Action
 
-In this quickstart, you will learn how to create a GitHub Action to publish your .NET app from source code. Automatically publishing your .NET app from GitHub to a destination is referred to as continuous deployment (CD). There are many possible destinations to publish an application, in this quickstart you'll publish to Azure.
+In this quickstart, you will learn how to create a GitHub Action to publish your .NET app from source code. Automatically publishing your .NET app from GitHub to a destination is referred to as a continuous deployment (CD). There are many possible destinations to publish an application, in this quickstart you'll publish to Azure.
 
 ## Prerequisites
 
@@ -66,7 +66,7 @@ In the preceding workflow composition:
   :::code language="yml" source="snippets/dotnet-publish-github-action/publish-app.yml" range="12-42" highlight="2,4,9-11,14,19-20,24,26-31":::
 
   - There is a single job, named `publish` that will run on the latest version of Ubuntu.
-  - The `actions/setup-dotnet@v1` GitHub Action is used to setup the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
+  - The `actions/setup-dotnet@v1` GitHub Action is used to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
   - The [`dotnet restore`](../core/tools/dotnet-restore.md) command is called.
   - The [`dotnet build`](../core/tools/dotnet-build.md) command is called.
   - The [`dotnet publish`](../core/tools/dotnet-publish.md) command is called.

--- a/docs/devops/dotnet-secure-github-action.md
+++ b/docs/devops/dotnet-secure-github-action.md
@@ -3,7 +3,7 @@ title: Create a security scan GitHub Action
 description: In this quickstart, you will learn how to create a CodeQL GitHub Action to automate the discovery of vulnerabilities in your .NET codebase.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/09/2021
+ms.date: 10/05/2021
 ms.topic: quickstart
 recommendations: false
 ---
@@ -12,7 +12,7 @@ recommendations: false
 
 In this quickstart, you will learn how to create a CodeQL GitHub Action to automate the discovery of vulnerabilities in your .NET codebase.
 
-> In CodeQL, code is treated like data. Security vulnerabilities, bugs, and other errors are modeled as queries that can be executed against databases extracted from code.
+> In CodeQL, code is treated as data. Security vulnerabilities, bugs, and other errors are modeled as queries that can be executed against databases extracted from code.
 >
 > &mdash; [GitHub CodeQL: About](https://codeql.github.com/docs/codeql-overview/about-codeql)
 
@@ -35,7 +35,7 @@ In the preceding workflow composition:
   :::code language="yml" source="snippets/dotnet-secure-github-action/codeql-analysis.yml" range="3-15":::
 
   - Triggered when a `push` or `pull_quest` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
-  - As a cron job (on a schedule) &mdash; runs at 8:00 UTC every Thursday.
+  - As a cron job (on a schedule) &mdash; to run at 8:00 UTC every Thursday.
 
 - The `jobs` node builds out the steps for the workflow to take.
 

--- a/docs/devops/github-actions-overview.md
+++ b/docs/devops/github-actions-overview.md
@@ -176,7 +176,7 @@ jobs:
     # additional steps omitted for brevity
 ```
 
-In the preceding workflow, the `workflow_dispatch` event requires a `reason` as input. GitHub sees this and it's UI dynamically changes to prompt the user into provided the reason for manually running the workflow. The `steps` will print the provided reason from the user.
+In the preceding workflow, the `workflow_dispatch` event requires a `reason` as input. GitHub sees this and its UI dynamically changes to prompt the user into provided the reason for manually running the workflow. The `steps` will print the provided reason from the user.
 
 For more information, see [Events that trigger workflows](https://docs.github.com/actions/reference/events-that-trigger-workflows).
 
@@ -184,7 +184,7 @@ For more information, see [Events that trigger workflows](https://docs.github.co
 
 The .NET command-line interface (CLI) is a cross-platform toolchain for developing, building, running, and publishing .NET applications. The .NET CLI is used to `run` as part of individual `steps` within a workflow file. Common command include:
 
-- [dotnet workflow install](../core/tools/dotnet-workflow-install.md)
+- [dotnet workflow install](../core/tools/dotnet-workload-install.md)
 - [dotnet restore](../core/tools/dotnet-restore.md)
 - [dotnet build](../core/tools/dotnet-build.md)
 - [dotnet test](../core/tools/dotnet-test.md)

--- a/docs/devops/github-actions-overview.md
+++ b/docs/devops/github-actions-overview.md
@@ -184,6 +184,7 @@ For more information, see [Events that trigger workflows](https://docs.github.co
 
 The .NET command-line interface (CLI) is a cross-platform toolchain for developing, building, running, and publishing .NET applications. The .NET CLI is used to `run` as part of individual `steps` within a workflow file. Common command include:
 
+- [dotnet workflow install](../core/tools/dotnet-workflow-install.md)
 - [dotnet restore](../core/tools/dotnet-restore.md)
 - [dotnet build](../core/tools/dotnet-build.md)
 - [dotnet test](../core/tools/dotnet-test.md)

--- a/docs/devops/github-actions-overview.md
+++ b/docs/devops/github-actions-overview.md
@@ -3,13 +3,13 @@ title: GitHub Actions and .NET
 description: Learn what role GitHub Actions play in .NET application development.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/06/2021
+ms.date: 10/05/2021
 ms.topic: overview
 ---
 
 # GitHub Actions and .NET
 
-In this overview, you'll learn what role [GitHub Actions](https://docs.github.com/actions) play in .NET application development. GitHub Actions allow your source code repositories to automate continuous integration (CI) and continuous delivery (CD). Beyond that, GitHub Actions expose more advanced scenarios &mdash; providing hooks for automation with code reviews, branch management, and issue triaging. With your .NET source code in GitHub you can leverage GitHub Actions to in many ways.
+In this overview, you'll learn what role [GitHub Actions](https://docs.github.com/actions) play in .NET application development. GitHub Actions allow your source code repositories to automate continuous integration (CI) and continuous delivery (CD). Beyond that, GitHub Actions expose more advanced scenarios &mdash; providing hooks for automation with code reviews, branch management, and issue triaging. With your .NET source code in GitHub you can leverage GitHub Actions in many ways.
 
 ## GitHub Actions
 
@@ -21,7 +21,7 @@ GitHub Actions represent standalone commands, such as:
 
 While these commands are isolated to a single action, they're powerful through *workflow composition*. In workflow composition, you define the *events* that trigger the workflow. Once a workflow is running, there are various *jobs* it's instructed to perform &mdash; with each job defining any number of *steps*. The *steps* delegate out to GitHub Actions, or alternatively call command-line scripts.
 
-For more information, see [Introduction to GitHub Actions](https://docs.github.com/actions/learn-github-actions/introduction-to-github-actions).
+For more information, see [Introduction to GitHub Actions](https://docs.github.com/actions/learn-github-actions/introduction-to-github-actions). You should think of a workflow file as your composition that represents the various steps to either build, test, and/or publish your application. There are many [.NET CLI commands](../core/tools/index.md) available, most of which could be used in the context of a GitHub Action.
 
 ### Custom GitHub Actions
 
@@ -72,7 +72,7 @@ There are many examples of .NET workflow files provided as [tutorials](create-do
         [*codeql-analysis.yml*](dotnet-secure-github-action.md)
     :::column-end:::
     :::column span="3":::
-        Analyzes your code for security vulnerabilities and coding errors. Any discovered vulnerabilities could cause fail.
+        Analyzes your code for security vulnerabilities and coding errors. Any discovered vulnerabilities could cause failure.
     :::column-end:::
 :::row-end:::
 
@@ -84,7 +84,7 @@ To use *encrypted secrets* in your workflow files, you reference the secrets usi
 ${{ secrets.MY_SECRET_VALUE }} # The MY_SECRET_VALUE must exist in the repository as a secret
 ```
 
-Secret values are never printed to the logs, instead their names are printed with asterisk representing their values. For example, as each step runs within a job &mdash; all of the values it uses are output to the action log. When secret values are out, they render similar to the following:
+Secret values are never printed in the logs, instead, their names are printed with the asterisk representing their values. For example, as each step runs within a job &mdash; all of the values it uses are output to the action log. When secret values are out, they render similar to the following:
 
 ```console
 MY_SECRET_VALUE: ***
@@ -146,7 +146,7 @@ jobs:
     # steps omitted for brevity
 ```
 
-In the preceding workflow, the `schedule` event specifies the `cron` of `'0 0 1 * *'` which will trigger the workflow to run on the first day of every month. Running workflows on a schedule are great for workflows that take a long time to run, or perform actions that require less frequent attention.
+In the preceding workflow, the `schedule` event specifies the `cron` of `'0 0 1 * *'` which will trigger the workflow to run on the first day of every month. Running workflows on a schedule is great for workflows that take a long time to run, or perform actions that require less frequent attention.
 
 #### Example manual event
 

--- a/docs/devops/github-actions-overview.md
+++ b/docs/devops/github-actions-overview.md
@@ -21,7 +21,7 @@ GitHub Actions represent standalone commands, such as:
 
 While these commands are isolated to a single action, they're powerful through *workflow composition*. In workflow composition, you define the *events* that trigger the workflow. Once a workflow is running, there are various *jobs* it's instructed to perform &mdash; with each job defining any number of *steps*. The *steps* delegate out to GitHub Actions, or alternatively call command-line scripts.
 
-For more information, see [Introduction to GitHub Actions](https://docs.github.com/actions/learn-github-actions/introduction-to-github-actions). You should think of a workflow file as your composition that represents the various steps to either build, test, and/or publish your application. There are many [.NET CLI commands](../core/tools/index.md) available, most of which could be used in the context of a GitHub Action.
+For more information, see [Introduction to GitHub Actions](https://docs.github.com/actions/learn-github-actions/introduction-to-github-actions). Think of a workflow file as a composition that represents the various steps to build, test, and/or publish an application. Many [.NET CLI commands](../core/tools/index.md) are available, most of which could be used in the context of a GitHub Action.
 
 ### Custom GitHub Actions
 
@@ -84,7 +84,7 @@ To use *encrypted secrets* in your workflow files, you reference the secrets usi
 ${{ secrets.MY_SECRET_VALUE }} # The MY_SECRET_VALUE must exist in the repository as a secret
 ```
 
-Secret values are never printed in the logs, instead, their names are printed with the asterisk representing their values. For example, as each step runs within a job &mdash; all of the values it uses are output to the action log. When secret values are out, they render similar to the following:
+Secret values are never printed in the logs. Instead, their names are printed with an asterisk representing their values. For example, as each step runs within a job, all of the values it uses are output to the action log. Secret values render similar to the following:
 
 ```console
 MY_SECRET_VALUE: ***


### PR DESCRIPTION
## Summary

- Added various details about the .NET SDK being a requirement of .NET-based GitHub Action workflows.
- Add examples related to `dotnet workload install` as it relates to GitHub Actions.
- Minor editorial updates, clean up and fixes.

Fixes #26368

## Internal preview links

✔️ [Build a .NET web app using GitHub Actions: Workflow structure](https://review.docs.microsoft.com/en-us/dotnet/architecture/devops-for-aspnet-developers/actions-build?branch=pr-en-us-26386#workflow-structure)
✔️ [GitHub Actions and .NET](https://review.docs.microsoft.com/en-us/dotnet/devops/github-actions-overview?branch=pr-en-us-26386)
✔️ [Create a build validation GitHub Action: Create a workflow file](https://review.docs.microsoft.com/en-us/dotnet/devops/dotnet-build-github-action?branch=pr-en-us-26386#create-a-workflow-file)

/cc @timheuer and @KathleenDollard