### PR TITLE
Add third correction option (tuple deconstruction) to information for CS0189.

### DIFF
--- a/docs/csharp/misc/cs0819.md
+++ b/docs/csharp/misc/cs0819.md
@@ -16,10 +16,11 @@ Implicitly-typed variables cannot have multiple declarators.
 
 ## To correct this error
 
-There are two options:
+There are three options:
 
 1. If the variables are of the same type, use explicit declarations.
 1. Declare and assign a value to each implicitly typed local variable on a separate line.
+1. Declare a variable using [Tuple deconstruction](../fundamentals/functional/deconstruct.md#tuples) syntax. **Note**: this option will not work inside a `using` statement as `Tuple` does not implement `IDisposable`.
 
 ## Example 1
 
@@ -39,6 +40,9 @@ class Program
         // Second correction option.
         //var a = 3;
         //var b = 2;
+
+        // Third correction option.
+        //var (a, b) = (3, 2);
     }
 }
 ```
@@ -60,7 +64,7 @@ class Program
 
         // First correction option.
         //using (Font font1 = new Font("Arial", 10.0f),
-        //    font2 = new Font("Arial", 10.0f)) // CS0819
+        //    font2 = new Font("Arial", 10.0f))
         //{
         //}
 
@@ -71,8 +75,6 @@ class Program
         //    {
         //    }
         //}
-
-
     }
 }
 ```
@@ -80,3 +82,4 @@ class Program
 ## See also
 
 - [Implicitly Typed Local Variables](../programming-guide/classes-and-structs/implicitly-typed-local-variables.md)
+- [Deconstructing Tuples and Other Types](../fundamentals/functional/deconstruct.md#tuples)


### PR DESCRIPTION
One note on this - the third option does not work for Example 2 as Tuple<T,...> does not implement IDisposable (I played with it a bit in VS2022 / .NET 6) which would generate [CS1674](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1674).

I also believe I found an error in the existing sample: in the first correction option in Example 2 (fonts), the `// CS0819` seems to perhaps have been copy/pasted from above. I removed it as this example is intended to **resolve** that error :)
I also removed unnecessary linebreaks at end of example 2.

Finally, added a suggested reading link to Tuple deconstruction page.

Resolves #26066