### PR TITLE
Corrected Linux RID value for "dot net publish" command

### DIFF
--- a/docs/spark/tutorials/hdinsight-deployment.md
+++ b/docs/spark/tutorials/hdinsight-deployment.md
@@ -94,7 +94,7 @@ Next, you publish the *mySparkApp* created in the [.NET for Apache Spark - Get S
 
    ```bash
    cd mySparkApp
-   foo@bar:~/path/to/app$ dotnet publish -c Release -f netcoreapp3.1 -r ubuntu.16.04-x64
+   dotnet publish -c Release -f netcoreapp3.1 -r linux-x64
    ```
 
 2. Do the following tasks to zip your published app files so that you can easily upload them to your HDInsight cluster. Zip the contents of the publish folder, *publish.zip* for example, that was created as a result of Step 1. All the assemblies should be in the first layer of the ZIP file and there should be no intermediate folder layer. This means when you unzip *publish.zip*, all assemblies are extracted into your current working directory.


### PR DESCRIPTION
See, https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#linux-rids for valid values of RID for Linux.
Also removed the shell prompt string to make it easy to copy and paste.