### PR TITLE
Update migrate-request-reply.md

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/migrate-request-reply.md
+++ b/docs/architecture/grpc-for-wcf-developers/migrate-request-reply.md
@@ -167,7 +167,7 @@ message GetAllResponse {
 }
 
 service Portfolios {
-    rpc Get(GetRequest) returns (Portfolio);
+    rpc Get(GetRequest) returns (GetResponse);
     rpc GetAll(GetAllRequest) returns (GetAllResponse);
 }
 ```


### PR DESCRIPTION
Made Portfolios service responses consistent on page [Migrate a WCF request-reply service to a gRPC unary RPC](https://docs.microsoft.com/en-us/dotnet/architecture/grpc-for-wcf-developers/migrate-request-reply)

## Summary

For GetAll method inside the Portfolios service, both the request and response have their own message defined (GetAllRequest, GetAllResponse) and these are used in the method declaration. 
For Get also this is defined but for the response, a Portfolio is returned instead of GetResponse. This created some inconsistency between the two methods.
So brought the following change.
```
service Portfolios {
    rpc Get(GetRequest) returns (Portfolio);
    rpc GetAll(GetAllRequest) returns (GetAllResponse);
}
```

to

```
service Portfolios {
    rpc Get(GetRequest) returns (GetResponse);
    rpc GetAll(GetAllRequest) returns (GetAllResponse);
}
```

Fixes #26418
