### PR TITLE
Make `private` article follow ms coding-styles

### DIFF
--- a/docs/csharp/language-reference/keywords/private.md
+++ b/docs/csharp/language-reference/keywords/private.md
@@ -20,8 +20,8 @@ Private access is the least permissive access level. Private members are accessi
 ```csharp
 class Employee
 {
-    private int i;
-    double d;   // private access by default
+    private int _i;
+    double _d;   // private access by default
 }
 ```
 
@@ -33,7 +33,7 @@ For a comparison of `private` with the other access modifiers, see [Accessibilit
 
 ## Example
 
-In this example, the `Employee` class contains two private data members, `name` and `salary`. As private members, they cannot be accessed except by member methods. Public methods named `GetName` and `Salary` are added to allow controlled access to the private members. The `name` member is accessed by way of a public method, and the `salary` member is accessed by way of a public read-only property. (See [Properties](../../programming-guide/classes-and-structs/properties.md) for more information.)
+In this example, the `Employee` class contains two private data members, `_name` and `_salary`. As private members, they cannot be accessed except by member methods. Public methods named `GetName` and `Salary` are added to allow controlled access to the private members. The `_name` member is accessed by way of a public method, and the `_salary` member is accessed by way of a public read-only property. (See [Properties](../../programming-guide/classes-and-structs/properties.md) for more information.)
 
 [!code-csharp[csrefKeywordsModifiers#10](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#10)]
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -319,17 +319,17 @@ namespace csrefKeywordsModifiers
     //<snippet10>
     class Employee2
     {
-        private string name = "FirstName, LastName";
-        private double salary = 100.0;
+        private readonly string _name = "FirstName, LastName";
+        private readonly double _salary = 100.0;
 
         public string GetName()
         {
-            return name;
+            return _name;
         }
 
         public double Salary
         {
-            get { return salary; }
+            get { return _salary; }
         }
     }
 
@@ -341,8 +341,8 @@ namespace csrefKeywordsModifiers
 
             // The data members are inaccessible (private), so
             // they can't be accessed like this:
-            //    string n = e.name;
-            //    double s = e.salary;
+            //    string n = e._name;
+            //    double s = e._salary;
 
             // 'name' is indirectly accessed via method:
             string n = e.GetName();


### PR DESCRIPTION
## Summary
Hello everyone 😃 

In #25767 a user states, that the article about private variables does not follow the[ C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#camel-case)

> - Use camel casing ("camelCasing") when naming private or internal fields, and prefix them with _.
> - When working with static fields that are private or internal, use the s_ prefix and for thread static use t_.

Fixes #25767

There are other samples with the same issue, but i did not touch them, as they sometimes do not follow the conventions on purpose.

If i forgot something, let me know.