### PR TITLE
Replace argument about culture-sensitive comparison #25440

### DIFF
--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -14,11 +14,10 @@ equal?" or "In what order should these strings be placed when sorting them?"
 
 Those two questions are complicated by factors that affect string comparisons:
 
--   You can choose an ordinal or linguistic comparison.
--   You can choose if case matters.
--   You can choose culture-specific comparisons.
--   Linguistic comparisons are culture and platform-dependent.
-
+- You can choose an ordinal or linguistic comparison.
+- You can choose if case matters.
+- You can choose culture-specific comparisons.
+- Linguistic comparisons are culture and platform-dependent.
 [!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
 When you compare strings, you define an order among them. Comparisons are
@@ -31,8 +30,8 @@ equality, but some differences, such as case differences, may be ignored.
 
 By default, the most common operations:
 
--   <xref:System.String.Equals%2A?displayProperty=nameWithType>
--   <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively
+- <xref:System.String.Equals%2A?displayProperty=nameWithType>
+- <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively
 
 perform a case-sensitive ordinal comparison, and in the case of <xref:System.String.Equals%2A?displayProperty=nameWithType> a <xref:System.StringComparison> argument can be provided to alter its sorting rules. The following example demonstrates that:
 
@@ -151,8 +150,8 @@ You can intern a string or retrieve a reference to an existing interned string b
 
 ## See also
 
--   <xref:System.Globalization.CultureInfo?displayProperty=nameWithType>
--   <xref:System.StringComparer?displayProperty=nameWithType>
--   [Strings](../programming-guide/strings/index.md)
--   [Comparing strings](../../standard/base-types/comparing.md)
--   [Globalizing and localizing applications](/visualstudio/ide/globalizing-and-localizing-applications)
+- <xref:System.Globalization.CultureInfo?displayProperty=nameWithType>
+- <xref:System.StringComparer?displayProperty=nameWithType>
+- [Strings](../programming-guide/strings/index.md)
+- [Comparing strings](../../standard/base-types/comparing.md)
+- [Globalizing and localizing applications](/visualstudio/ide/globalizing-and-localizing-applications)

--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -2,10 +2,11 @@
 title: "How to compare strings - C# Guide"
 description: Learn how to compare and order string values, with or without case, with or without culture specific ordering
 ms.date: 10/03/2018
-helpviewer_keywords: 
-  - "strings [C#], comparison"
-  - "comparing strings [C#]"
+helpviewer_keywords:
+    - "strings [C#], comparison"
+    - "comparing strings [C#]"
 ---
+
 # How to compare strings in C\#
 
 You compare strings to answer one of two questions: "Are these two strings
@@ -13,10 +14,10 @@ equal?" or "In what order should these strings be placed when sorting them?"
 
 Those two questions are complicated by factors that affect string comparisons:
 
-- You can choose an ordinal or linguistic comparison.
-- You can choose if case matters.
-- You can choose culture-specific comparisons.
-- Linguistic comparisons are culture and platform-dependent.
+-   You can choose an ordinal or linguistic comparison.
+-   You can choose if case matters.
+-   You can choose culture-specific comparisons.
+-   Linguistic comparisons are culture and platform-dependent.
 
 [!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
@@ -30,10 +31,10 @@ equality, but some differences, such as case differences, may be ignored.
 
 By default, the most common operations:
 
-- <xref:System.String.Equals%2A?displayProperty=nameWithType>
-- <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively
+-   <xref:System.String.Equals%2A?displayProperty=nameWithType>
+-   <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively
 
-perform a case-sensitive ordinal comparison and, if necessary, use the current culture. The following example demonstrates that:
+perform a case-sensitive ordinal comparison, and in the case of <xref:System.String.Equals%2A?displayProperty=nameWithType> a <xref:System.StringComparison> argument can be provided to alter its sorting rules. The following example demonstrates that:
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet1":::
 
@@ -118,7 +119,7 @@ This example shows how to sort an array of strings using the current culture:
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet5":::
 
-Once the array is sorted, you can search for entries using a binary search. A binary search starts in the middle of the collection to determine which half of the collection would contain the sought string. Each subsequent comparison subdivides the remaining part of the collection in half.  The array is sorted using the <xref:System.StringComparer.CurrentCulture?displayProperty=nameWithType>. The local function `ShowWhere` displays information about where the string was found. If the string wasn't found, the returned value indicates where it would be if it were found.
+Once the array is sorted, you can search for entries using a binary search. A binary search starts in the middle of the collection to determine which half of the collection would contain the sought string. Each subsequent comparison subdivides the remaining part of the collection in half. The array is sorted using the <xref:System.StringComparer.CurrentCulture?displayProperty=nameWithType>. The local function `ShowWhere` displays information about where the string was found. If the string wasn't found, the returned value indicates where it would be if it were found.
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet6":::
 
@@ -139,7 +140,7 @@ Collection classes such as <xref:System.Collections.Hashtable?displayProperty=na
 ## Reference equality and string interning
 
 None of the samples have used <xref:System.Object.ReferenceEquals%2A>. This method determines if two strings
-are the same object, which can lead to inconsistent results in string comparisons. The following example demonstrates the *string interning* feature of C#. When a program declares two or more identical string variables, the compiler stores them all in the same location. By calling the <xref:System.Object.ReferenceEquals%2A> method, you can see that the two strings actually refer to the same object in memory. Use the <xref:System.String.Copy%2A?displayProperty=nameWithType> method to avoid interning. After the copy has been made, the two strings have different storage locations, even though they have the same value. Run the following sample to show that strings `a` and `b` are *interned* meaning they share the same storage. The strings `a` and `c` are not.
+are the same object, which can lead to inconsistent results in string comparisons. The following example demonstrates the _string interning_ feature of C#. When a program declares two or more identical string variables, the compiler stores them all in the same location. By calling the <xref:System.Object.ReferenceEquals%2A> method, you can see that the two strings actually refer to the same object in memory. Use the <xref:System.String.Copy%2A?displayProperty=nameWithType> method to avoid interning. After the copy has been made, the two strings have different storage locations, even though they have the same value. Run the following sample to show that strings `a` and `b` are _interned_ meaning they share the same storage. The strings `a` and `c` are not.
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet9":::
 
@@ -150,8 +151,8 @@ You can intern a string or retrieve a reference to an existing interned string b
 
 ## See also
 
-- <xref:System.Globalization.CultureInfo?displayProperty=nameWithType>
-- <xref:System.StringComparer?displayProperty=nameWithType>
-- [Strings](../programming-guide/strings/index.md)
-- [Comparing strings](../../standard/base-types/comparing.md)
-- [Globalizing and localizing applications](/visualstudio/ide/globalizing-and-localizing-applications)
+-   <xref:System.Globalization.CultureInfo?displayProperty=nameWithType>
+-   <xref:System.StringComparer?displayProperty=nameWithType>
+-   [Strings](../programming-guide/strings/index.md)
+-   [Comparing strings](../../standard/base-types/comparing.md)
+-   [Globalizing and localizing applications](/visualstudio/ide/globalizing-and-localizing-applications)


### PR DESCRIPTION
## Summary

Replace argument about culture-sensitive comparison with an explanation of how `string.Equals` works.

Fixes  #25440
