### PR TITLE
Add missing options to dotnet-format documentation

### DIFF
--- a/docs/core/tools/dotnet-format.md
+++ b/docs/core/tools/dotnet-format.md
@@ -87,6 +87,12 @@ None of the options below are required for the `dotnet format` command to succee
 
 The `dotnet format whitespace` subcommand will only run formatting rules associated with whitespace formatting. For a complete list of possible formatting options that you can specify in your *.editorconfig* file, see the [whitespace formatting documentation](/visualstudio/ide/reference/options-text-editor-csharp-formatting).
 
+#### Options
+
+* **`--folder`**
+
+  Whether to treat the `<PROJECT | SOLUTION>` argument as a path to a simple folder of code files.
+
 ### Style
 
 `dotnet format style` - Formats code to match EditorConfig settings for code style.
@@ -96,6 +102,10 @@ The `dotnet format whitespace` subcommand will only run formatting rules associa
 The `dotnet format style` subcommand will only run formatting rule associated with code style formatting. For a complete list of possible formatting options that you can specify in your `editorconfig` file see the [code style documentation](../../fundamentals/code-analysis/style-rules/index.md).
 
 #### Options
+
+* **`--diagnostics <DIAGNOSTICS>`**
+
+  A space separated list of diagnostic ids to use as a filter when fixing code quality or 3rd party issues. Default value is whichever ids are listed in the `editorconfig` file. For a list of built-in analyzer rule ids that you can specify see the list of ids see the [documentation of code-analysis quality rules](../../fundamentals/code-analysis/quality-rules/index.md).
 
 * **`--severity`**
 


### PR DESCRIPTION
## Summary

Adds options that were added to the RC2 release of `dotnet format`.

cc: @jmarolf 
