### PR TITLE
Document compiler options (MSBuild and csc.exe) in table

### DIFF
--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -13,7 +13,7 @@ helpviewer_keywords:
 ---
 # C# Compiler Options that control compiler output
 
-The following options control compiler output generation. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* syntax is shown in `code style`.
+The following options control compiler output generation.
 | MSBuild | *csc.exe* | Description |
 |---|---|---|
 | -**DocumentationFile** | `/doc:` | Generate XML doc file from `///` comments. |

--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -14,6 +14,7 @@ helpviewer_keywords:
 # C# Compiler Options that control compiler output
 
 The following options control compiler output generation.
+
 | MSBuild | *csc.exe* | Description |
 |---|---|---|
 | **DocumentationFile** | `-doc:` | Generate XML doc file from `///` comments. |

--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -16,11 +16,11 @@ helpviewer_keywords:
 The following options control compiler output generation.
 | MSBuild | *csc.exe* | Description |
 |---|---|---|
-| -**DocumentationFile** | `/doc:` | Generate XML doc file from `///` comments. |
-| -**OutputAssembly** | `/out:` | Specify the output assembly file. |
-| -**PlatformTarget** | `/platform:` | Specify the target platform CPU. |
-| -**ProduceReferenceAssembly** | `/refout:` | Generate a reference assembly. |
-| -**TargetType** | `/target:` | Specify the type of the output assembly. |
+| **DocumentationFile** | `-doc:` | Generate XML doc file from `///` comments. |
+| **OutputAssembly** | `-out:` | Specify the output assembly file. |
+| **PlatformTarget** | `-platform:` | Specify the target platform CPU. |
+| **ProduceReferenceAssembly** | `-refout:` | Generate a reference assembly. |
+| **TargetType** | `-target:` | Specify the type of the output assembly. |
 
 ## DocumentationFile
 

--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -14,12 +14,13 @@ helpviewer_keywords:
 # C# Compiler Options that control compiler output
 
 The following options control compiler output generation. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* syntax is shown in `code style`.
-
-- **DocumentationFile** / `-doc`: Generate XML doc file from `///` comments.
-- **OutputAssembly** / `-out`: Specify the output assembly file.
-- **PlatformTarget** / `-platform`: Specify the target platform CPU.
-- **ProduceReferenceAssembly** / `-refout`: Generate a reference assembly.
-- **TargetType** `-target`: Specify the type of the output assembly.
+| MSBuild | *csc.exe* | Description |
+|---|---|---|
+| -**DocumentationFile** | `/doc:` | Generate XML doc file from `///` comments. |
+| -**OutputAssembly** | `/out:` | Specify the output assembly file. |
+| -**PlatformTarget** | `/platform:` | Specify the target platform CPU. |
+| -**ProduceReferenceAssembly** | `/refout:` | Generate a reference assembly. |
+| -**TargetType** | `/target:` | Specify the type of the output assembly. |
 
 ## DocumentationFile
 


### PR DESCRIPTION
## Summary

Describe **MSBuild** and *csc.exe* options in table. This should be more readable and easier to distinguish what is what.
Colons for *csc.exe* are in a right place.

Fixes #26517 
