### PR TITLE
Improve the clarity of Compound assignment example

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
@@ -152,19 +152,29 @@ namespace operators
         private static void CompoundAssignment()
         {
             // <SnippetCompoundAssignment>
-            uint a = 0b_1111_1000;
-            a &= 0b_1001_1101;
+            uint a = 0b_1111_1000; // init 'a' variable
+
+            // logical AND operator
+            a &= 0b_1001_1101; 
             Display(a);  // output: 10011000
 
-            a |= 0b_0011_0001;
+            // logical OR operator
+            a = 0b_1111_1000; // re-assign
+            a |= 0b_0011_0001; 
             Display(a);  // output: 10111001
 
+            // logical exclusive OR operator (known as XOR)
+            a = 0b_1111_1000; // re-assign
             a ^= 0b_1000_0000;
             Display(a);  // output:   111001
 
+            // left-shift operator <<
+            a = 0b_1111_1000; // re-assign
             a <<= 2;
             Display(a);  // output: 11100100
 
+            // right-shift operator >>
+            a = 0b_1111_1000; // re-assign
             a >>= 4;
             Display(a);  // output:     1110
 

--- a/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
@@ -153,15 +153,14 @@ namespace operators
         {
             // <SnippetCompoundAssignment>
             uint INITIAL_VALUE = 0b_1111_1000;
+            
             uint a = INITIAL_VALUE;
-
             a &= 0b_1001_1101; 
             Display(a);  // output: 10011000
 
             a = INITIAL_VALUE;
             a |= 0b_0011_0001; 
             Display(a);  // output: 11111001
-
 
             a = INITIAL_VALUE;
             a ^= 0b_1000_0000;
@@ -170,7 +169,6 @@ namespace operators
             a = INITIAL_VALUE;
             a <<= 2;
             Display(a);  // output: 1111100000
-
 
             a = INITIAL_VALUE;
             a >>= 4;

--- a/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
@@ -152,31 +152,29 @@ namespace operators
         private static void CompoundAssignment()
         {
             // <SnippetCompoundAssignment>
-            uint a = 0b_1111_1000; // init 'a' variable
+            uint INITIAL_VALUE = 0b_1111_1000;
+            uint a = INITIAL_VALUE;
 
-            // logical AND operator
             a &= 0b_1001_1101; 
             Display(a);  // output: 10011000
 
-            // logical OR operator
-            a = 0b_1111_1000; // re-assign
+            a = INITIAL_VALUE;
             a |= 0b_0011_0001; 
-            Display(a);  // output: 10111001
+            Display(a);  // output: 11111001
 
-            // logical exclusive OR operator (known as XOR)
-            a = 0b_1111_1000; // re-assign
+
+            a = INITIAL_VALUE;
             a ^= 0b_1000_0000;
-            Display(a);  // output:   111001
+            Display(a);  // output: 1111000
 
-            // left-shift operator <<
-            a = 0b_1111_1000; // re-assign
+            a = INITIAL_VALUE;
             a <<= 2;
-            Display(a);  // output: 11100100
+            Display(a);  // output: 1111100000
 
-            // right-shift operator >>
-            a = 0b_1111_1000; // re-assign
+
+            a = INITIAL_VALUE;
             a >>= 4;
-            Display(a);  // output:     1110
+            Display(a);  // output: 1111
 
             void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2), 8}");
             // </SnippetCompoundAssignment>


### PR DESCRIPTION
## Summary

This PR improves the clarity of Compound assignment example.
- re-assign `a` variable for each operator
- add comment with used operator

Fixes #26518 
