### PR TITLE
Fix typo in rid-catalog.md

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -142,7 +142,7 @@ macOS RIDs use the older "OSX" branding. Only common values are listed. For the 
   - `osx.10.14-x64`
 - macOS 10.15 Catalina
   - `osx.10.15-x64`
-- macOS 11.01 Big Sur
+- macOS 11.0 Big Sur
   - `osx.11.0-x64`
   - `osx.11.0-arm64`
 


### PR DESCRIPTION
The RID version is 11.0 but the text mentioned 11.01
