### PR TITLE
Endpoint name metadata breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -23,6 +23,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ | Preview 6 |
 | [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |  |
 | [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |  |
+| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ | RC 2 |
 | [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |  |
 | [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |  |
 | [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |  |

--- a/docs/core/compatibility/aspnet-core/6.0/endpointname-metadata.md
+++ b/docs/core/compatibility/aspnet-core/6.0/endpointname-metadata.md
@@ -1,0 +1,48 @@
+---
+title: "Breaking change: EndpointName metadata no longer automatically set"
+description: "Learn about the breaking change in ASP.NET Core 6.0 where EndpointName metadata is no longer automatically set for minimal endpoints."
+ms.date: 10/18/2021
+---
+# EndpointName metadata not set automatically
+
+Behavior that was introduced in .NET 6 RC 1 to automatically set `IEndpointNameMetadata` for endpoints has been reverted. `IEndpointNameMetadata` is no longer set automatically to avoid issues with duplicate endpoint names.
+
+## Version introduced
+
+ASP.NET Core 6 RC 2
+
+## Previous behavior
+
+In ASP.NET Core 6 RC 1, `IEndpointNameMetadata` was automatically set for endpoints that referenced a method group. For example, the following code produced an endpoint for `/foo` with `EndpointName` set to `GetFoo`.
+
+```csharp
+app.MapGet("/foo", GetFoo);
+```
+
+## New behavior
+
+Starting in ASP.NET Core 6 RC 2, `IEndpointNameMetadata` is not automatically set. The following code does not generate any `IEndpointNameMetadata`.
+
+```csharp
+app.MapGet("/foo", GetFoo);
+```
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+The behavior of automatically setting endpoint name metadata was not robust and resulted in issues where the same name was set for different endpoints. For more information, see [dotnet/aspnetcore#36487](https://github.com/dotnet/aspnetcore/issues/36487).
+
+## Recommended action
+
+We recommend that you manually set `IEndpointNameMetadata` using the `WithName` extension method to set the metadata.
+
+```csharp
+app.MapGet("/foo", GetFoo).WithName("GetFoo");
+```
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -37,6 +37,8 @@ items:
           href: aspnet-core/6.0/byte-array-interop.md
         - name: ClientCertificate doesn't trigger renegotiation
           href: aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md
+        - name: EndpointName metadata not set automatically
+          href: aspnet-core/6.0/endpointname-metadata.md
         - name: "Kestrel: Log message attributes changed"
           href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
         - name: "MessagePack: Library changed in @microsoft/signalr-protocol-msgpack"
@@ -469,6 +471,8 @@ items:
           href: aspnet-core/6.0/byte-array-interop.md
         - name: ClientCertificate doesn't trigger renegotiation
           href: aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md
+        - name: EndpointName metadata not set automatically
+          href: aspnet-core/6.0/endpointname-metadata.md
         - name: "Kestrel: Log message attributes changed"
           href: aspnet-core/6.0/kestrel-log-message-attributes-changed.md
         - name: "MessagePack: Library changed in @microsoft/signalr-protocol-msgpack"


### PR DESCRIPTION
Address aspnet/announcements#473.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/6.0/endpointname-metadata?branch=pr-en-us-26561).