### PR TITLE
Remove lambda attributes

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1878,6 +1878,10 @@
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-9.0/records"
         },
         {
+            "source_path": "docs/csharp/language-reference/proposals/csharp-10.0/lambda-attributes.md",
+            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-10.0/lambda-improvements"
+        },
+        {
             "source_path": "docs/csharp/local-functions-vs-lambdas.md",
             "redirect_url": "/dotnet/csharp/programming-guide/classes-and-structs/local-functions"
         },

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1473,8 +1473,6 @@ items:
         href: ../../_csharplang/proposals/csharp-10.0/constant_interpolated_strings.md
       - name: Lambda improvements
         href: ../../_csharplang/proposals/csharp-10.0/lambda-improvements.md
-      - name: Lambda attributes
-        href: ../../_csharplang/proposals/csharp-10.0/lambda-attributes.md
       - name: Caller argument expression
         href: ../../_csharplang/proposals/csharp-10.0/caller-argument-expression.md
       - name: "Enhanced #line directives"


### PR DESCRIPTION
This is in response to dotnet/csharplang#5301. Pulling the attribute updates into the lambda improvements spec means this article should be removed.

Redirect removed file to updated spec.

Fixes #26545


/cc @cston 