### PR TITLE
XNodeReader.GetAttribute breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -63,6 +63,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
 | [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
+| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | | | Preview 2 |
 
 ## Cryptography
 

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -63,7 +63,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
 | [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
-| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | | | Preview 2 |
+| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ | Preview 2 |
 
 ## Cryptography
 

--- a/docs/core/compatibility/core-libraries/6.0/xnodereader-getattribute.md
+++ b/docs/core/compatibility/core-libraries/6.0/xnodereader-getattribute.md
@@ -1,0 +1,39 @@
+---
+title: "Breaking change: XNodeReader.GetAttribute and invalid indices"
+description: Learn about the .NET 6.0 breaking change where XNodeReader.GetAttribute now throws an exception for an invalid index.
+ms.date: 10/19/2021
+---
+# XNodeReader.GetAttribute behavior for invalid index
+
+`XNodeReader` is an internal class, but it's accessible through the <xref:System.Xml.XmlReader> class if you call <xref:System.Xml.Linq.XNode.CreateReader%2A?displayProperty=nameWithType>. All <xref:System.Xml.XmlReader> implementations except `XNodeReader` threw an <xref:System.ArgumentOutOfRangeException> for an invalid index in the <xref:System.Xml.XmlReader.GetAttribute(System.Int32)> method. With this change, `XNodeReader.GetAttribute(int)` now also throws an <xref:System.ArgumentOutOfRangeException> for an invalid index.
+
+## Old behavior
+
+`XNodeReader.GetAttribute(int)` returned `null` if the index was invalid.
+
+## New behavior
+
+`XNodeReader.GetAttribute(int)` throws an <xref:System.ArgumentOutOfRangeException> if the index is invalid.
+
+## Version introduced
+
+6.0 Preview 2
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+`XmlReader.GetAttribute(int)` is well documented, and `XNodeReader` was not behaving as documented. It's behavior for invalid indices was also inconsistent with other <xref:System.Xml.XmlReader> implementations.
+
+## Recommended action
+
+To avoid an invalid index:
+
+- Call <xref:System.Xml.XmlReader.AttributeCount?displayProperty=nameWithType> to retrieve the number of attributes in the current node.
+- Then, pass a value of range `0..XmlReader.AttributeCount-1` to <xref:System.Xml.XmlReader.GetAttribute(System.Int32)?displayProperty=nameWithType>.
+
+## Affected APIs
+
+- <xref:System.Xml.XmlReader.GetAttribute(System.Int32)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -111,6 +111,8 @@ items:
           href: core-libraries/6.0/task-fromresult-returns-singleton.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
+        - name: XNodeReader.GetAttribute behavior for invalid index
+          href: core-libraries/6.0/xnodereader-getattribute.md
       - name: Cryptography
         items:
         - name: CreateEncryptor methods throw exception for incorrect feedback size
@@ -647,6 +649,8 @@ items:
           href: core-libraries/6.0/task-fromresult-returns-singleton.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
+        - name: XNodeReader.GetAttribute behavior for invalid index
+          href: core-libraries/6.0/xnodereader-getattribute.md
       - name: .NET 5
         items:
         - name: Assembly-related API changes for single-file publishing


### PR DESCRIPTION
Fixes #26551 

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/xnodereader-getattribute?branch=pr-en-us-26579)