### PR TITLE
UseSocketsHttpHandler - clarify .NET Core versions

### DIFF
--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -21,7 +21,7 @@ ms.topic: reference
 | **runtimeconfig.json** | `System.Net.Http.SocketsHttpHandler.Http2Support` | `false` - disabled<br/>`true` - enabled |
 | **Environment variable** | `DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT` | `0` - disabled<br/>`1` - enabled |
 
-## UseSocketsHttpHandler
+## UseSocketsHttpHandler (.NET Core 2.1-3.1 only)
 
 - Configures whether <xref:System.Net.Http.HttpClientHandler?displayProperty=nameWithType> uses <xref:System.Net.Http.SocketsHttpHandler?displayProperty=nameWithType> or older HTTP protocol stacks (<xref:System.Net.Http.WinHttpHandler> on Windows and `CurlHandler`, an internal class implemented on top of [libcurl](https://curl.haxx.se/libcurl/), on Linux).
 


### PR DESCRIPTION
Clarify availability of UseSocketsHttpHandler in .NET Core 2.1-3.1 also in the title.
Same way as Latin1 headers setting in next section.