### PR TITLE
Removing note about AppContext

### DIFF
--- a/docs/core/run-time-config/networking.md
+++ b/docs/core/run-time-config/networking.md
@@ -30,8 +30,6 @@ ms.topic: reference
 
 - If you omit this setting, <xref:System.Net.Http.HttpClientHandler> uses <xref:System.Net.Http.SocketsHttpHandler>. This is equivalent to setting the value to `true`.
 
-- You can configure this setting programmatically by calling the <xref:System.AppContext.SetSwitch%2A?displayProperty=nameWithType> method.
-
 | | Setting name | Values |
 | - | - | - |
 | **runtimeconfig.json** | `System.Net.Http.UseSocketsHttpHandler` | `true` - enables the use of <xref:System.Net.Http.SocketsHttpHandler><br/>`false` - enables the use of <xref:System.Net.Http.WinHttpHandler> on Windows or [libcurl](https://curl.haxx.se/libcurl/) on Linux |


### PR DESCRIPTION
All these switches (and many other switches in other areas) are also settable via `AppContext.SetSwitch`.
Right now, only this particular switch has it documented explicitly in these docs. Let's make it consistent with others and remove it.
The `AppContext.SetSwitch` setting is mentioned in the `Settings` intro doc: https://docs.microsoft.com/en-us/dotnet/core/run-time-config/ which should be sufficient.