### PR TITLE
LinkFix docs (2021-10)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,5 @@ contact_links:
     url: https://aka.ms/feedback/report?space=61
     about: Log product issues here
 - name: .NET Q&A forums
-    url: https://docs.microsoft.com/en-us/answers/products/dotnet
+    url: https://docs.microsoft.com/answers/products/dotnet
     about: Find answers to your technical questions about .NET

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,5 @@ contact_links:
     url: https://aka.ms/feedback/report?space=61
     about: Log product issues here
 - name: .NET Q&A forums
-    url: /answers/products/dotnet
+    url: https://docs.microsoft.com/en-us/answers/products/dotnet
     about: Find answers to your technical questions about .NET

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,12 @@
 blank_issues_enabled: true
 contact_links:
-  - name: docs.microsoft.com site feedback
+
+- name: docs.microsoft.com site feedback
     url: https://github.com/MicrosoftDocs/feedback/issues/new/choose
     about: Log general docs.microsoft.com site issues here
-  - name: .NET platform and other product feedback
+- name: .NET platform and other product feedback
     url: https://aka.ms/feedback/report?space=61
     about: Log product issues here
-  - name: .NET Q&A forums
-    url: https://docs.microsoft.com/answers/products/dotnet
+- name: .NET Q&A forums
+    url: /answers/products/dotnet
     about: Find answers to your technical questions about .NET

--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -12,7 +12,7 @@ assignees: ''
 
 	If the issue is:
 
-	- A simple typo or similar correction, consider submitting a PR to fix it instead of logging an issue. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
+	- A simple typo or similar correction, consider submitting a PR to fix it instead of logging an issue. See [the contributor guide](/contribute/#quick-edits-to-existing-documents) for instructions.
 	- A general support question, consider asking on a support forum site.
 	- A site design concern, create an issue at [MicrosoftDocs/feedback](https://github.com/MicrosoftDocs/feedback/issues/new/choose).
 	- A problem completing a tutorial, compare your code with the completed sample.
@@ -41,4 +41,5 @@ If using the .NET Core SDK, include `dotnet --info` output. If using .NET Framew
 ```console
 <replace>
 ```
+
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the .NET documentation!
 
-We have moved our guidelines into a site-wide contribution guide. To see the guidance, visit the [Microsoft Docs contributor guide](https://docs.microsoft.com/contribute/dotnet/dotnet-contribute).
+We have moved our guidelines into a site-wide contribution guide. To see the guidance, visit the [Microsoft Docs contributor guide](/contribute/dotnet/dotnet-contribute).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Markdownlint](https://github.com/dotnet/docs/workflows/Markdownlint/badge.svg) [![target supported version](https://github.com/dotnet/docs/actions/workflows/version-sweep.yml/badge.svg)](https://github.com/dotnet/docs/actions/workflows/version-sweep.yml)
 
-This repository contains the conceptual documentation for .NET. The [.NET documentation site](https://docs.microsoft.com/dotnet) is built from multiple repositories in addition to this one:
+This repository contains the conceptual documentation for .NET. The [.NET documentation site](/dotnet) is built from multiple repositories in addition to this one:
 
 - [API reference](https://github.com/dotnet/dotnet-api-docs)
 - [.NET Compiler Platform SDK reference](https://github.com/dotnet/roslyn-api-docs)
@@ -15,9 +15,9 @@ To contribute, see:
 
 - The [Contributing Guide](CONTRIBUTING.md) for instructions on procedures we use.
 - Issues labeled [`up-for-grabs`](https://github.com/dotnet/docs/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) for ideas.
-- [#Hacktoberfest and Microsoft Docs](https://docs.microsoft.com/contribute/hacktoberfest) for details on our participation in the annual event.
+- [#Hacktoberfest and Microsoft Docs](/contribute/hacktoberfest) for details on our participation in the annual event.
 
-If you're interested in helping migrate existing code that targets the .NET Framework from the [retired Code Gallery](https://docs.microsoft.com/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
+If you're interested in helping migrate existing code that targets the .NET Framework from the [retired Code Gallery](/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
 
 This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community.

--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -4,43 +4,43 @@ hrefUpdated: true
 references:
 
 - uid: System.Diagnostics.PresentationTraceSources.TraceLevel*
-  href: /previous-versions/bb778381(v=vs.110)
+  href: https://docs.microsoft.com/previous-versions/bb778381(v=vs.110)
   name: TraceLevel
   name.vb: TraceLevel
   fullName: PresentationTraceSources.TraceLevel
   fullName.vb: PresentationTraceSources.TraceLevel
 - uid: System.Windows.Controls.Validation.HasError*
-  href: /dotnet/api/system.windows.controls.validation.haserror#System_Windows_Controls_Validation_HasError
+  href: https://docs.microsoft.com/dotnet/api/system.windows.controls.validation.haserror#System_Windows_Controls_Validation_HasError
   name: HasError
   name.vb: HasError
   fullName: Validation.HasError
   fullName.vb: Validation.HasError
 - uid: System.Windows.Controls.Validation.Errors*
-  href: /dotnet/api/system.windows.controls.validation.errors#System_Windows_Controls_Validation_Errors
+  href: https://docs.microsoft.com/dotnet/api/system.windows.controls.validation.errors#System_Windows_Controls_Validation_Errors
   name: Errors
   name.vb: Errors
   fullName: Validation.Errors
   fullName.vb: Validation.Errors
 - uid: System.Windows.Localization.Attributes*
-  href: /previous-versions/bb341088(v=vs.110)
+  href: https://docs.microsoft.com/previous-versions/bb341088(v=vs.110)
   name: Attributes
   name.vb: Attributes
   fullName: Localization.Attributes
   fullName.vb: Localization.Attributes
 - uid: System.Windows.Localization.Comments*
-  href: /previous-versions/bb156441(v=vs.110)
+  href: https://docs.microsoft.com/previous-versions/bb156441(v=vs.110)
   name: Comments
   name.vb: Comments
   fullName: Localization.Comments
   fullName.vb: Localization.Comments
 - uid: System.Windows.Shell.WindowChrome.ResizeGripDirection*
-  href: /previous-versions/hh199365(v=vs.110)
+  href: https://docs.microsoft.com/previous-versions/hh199365(v=vs.110)
   name: ResizeGripDirection
   name.vb: ResizeGripDirection
   fullName: WindowChrome.ResizeGripDirection
   fullName.vb: WindowChrome.ResizeGripDirection
 - uid: System.Windows.VisualStateManager.VisualStateGroups*
-  href: /dotnet/api/system.windows.visualstatemanager.visualstategroups#System_Windows_VisualStateManager_VisualStateGroups
+  href: https://docs.microsoft.com/dotnet/api/system.windows.visualstatemanager.visualstategroups#System_Windows_VisualStateManager_VisualStateGroups
   name: VisualStateGroups
   name.vb: VisualStateGroups
   fullName: VisualStateManager.VisualStateGroups

--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -1,44 +1,46 @@
 ### YamlMime:XRefMap
+
 hrefUpdated: true
 references:
+
 - uid: System.Diagnostics.PresentationTraceSources.TraceLevel*
-  href: https://msdn.microsoft.com/library/system.diagnostics.presentationtracesources.tracelevel.aspx
+  href: /previous-versions/bb778381(v=vs.110)
   name: TraceLevel
   name.vb: TraceLevel
   fullName: PresentationTraceSources.TraceLevel
   fullName.vb: PresentationTraceSources.TraceLevel
 - uid: System.Windows.Controls.Validation.HasError*
-  href: https://msdn.microsoft.com/library/system.windows.controls.validation.haserror
+  href: /dotnet/api/system.windows.controls.validation.haserror#System_Windows_Controls_Validation_HasError
   name: HasError
   name.vb: HasError
   fullName: Validation.HasError
   fullName.vb: Validation.HasError
 - uid: System.Windows.Controls.Validation.Errors*
-  href: https://msdn.microsoft.com/library/system.windows.controls.validation.errors.aspx
+  href: /dotnet/api/system.windows.controls.validation.errors#System_Windows_Controls_Validation_Errors
   name: Errors
   name.vb: Errors
   fullName: Validation.Errors
   fullName.vb: Validation.Errors
 - uid: System.Windows.Localization.Attributes*
-  href: https://msdn.microsoft.com/library/system.windows.localization.attributes.aspx
+  href: /previous-versions/bb341088(v=vs.110)
   name: Attributes
   name.vb: Attributes
   fullName: Localization.Attributes
   fullName.vb: Localization.Attributes
 - uid: System.Windows.Localization.Comments*
-  href: https://msdn.microsoft.com/library/system.windows.localization.comments.aspx
+  href: /previous-versions/bb156441(v=vs.110)
   name: Comments
   name.vb: Comments
   fullName: Localization.Comments
   fullName.vb: Localization.Comments
 - uid: System.Windows.Shell.WindowChrome.ResizeGripDirection*
-  href: https://msdn.microsoft.com/library/system.windows.shell.windowchrome.resizegripdirection.aspx
+  href: /previous-versions/hh199365(v=vs.110)
   name: ResizeGripDirection
   name.vb: ResizeGripDirection
   fullName: WindowChrome.ResizeGripDirection
   fullName.vb: WindowChrome.ResizeGripDirection
 - uid: System.Windows.VisualStateManager.VisualStateGroups*
-  href: https://msdn.microsoft.com/library/system.windows.visualstatemanager.visualstategroups.aspx
+  href: /dotnet/api/system.windows.visualstatemanager.visualstategroups#System_Windows_VisualStateManager_VisualStateGroups
   name: VisualStateGroups
   name.vb: VisualStateGroups
   fullName: VisualStateManager.VisualStateGroups

--- a/docs/architecture/cloud-native/candidate-apps.md
+++ b/docs/architecture/cloud-native/candidate-apps.md
@@ -71,7 +71,7 @@ With the introduction behind, we now dive into a much more detailed look at clou
 
 - [.NET Microservices: Architecture for Containerized .NET applications](https://dotnet.microsoft.com/download/thank-you/microservices-architecture-ebook)
 
-- [Microsoft Azure Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/)
+- [Microsoft Azure Well-Architected Framework](/azure/architecture/framework/)
 
 - [Modernize existing .NET applications with Azure cloud and Windows Containers](https://dotnet.microsoft.com/download/thank-you/modernizing-existing-net-apps-ebook)
 
@@ -79,7 +79,7 @@ With the introduction behind, we now dive into a much more detailed look at clou
 
 - [Cloud native applications: Ship faster, reduce risk, and grow your business](https://tanzu.vmware.com/cloud-native)
 
-- [Dapr for .NET Developers](https://docs.microsoft.com/dotnet/architecture/dapr-for-net-developers/)
+- [Dapr for .NET Developers](../dapr-for-net-developers/index.md)
 
 - [Dapr documents](https://dapr.io/)
 

--- a/docs/architecture/cloud-native/definition.md
+++ b/docs/architecture/cloud-native/definition.md
@@ -100,17 +100,17 @@ We'll refer to many of the 12+ factors in this chapter and throughout the book.
 
 Designing and deploying cloud-based workloads can be challenging, especially when implementing cloud-native architecture. Microsoft provides industry standard best practices to help you and your team deliver robust cloud solutions.
 
-The [Microsoft Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/) provides a set of guiding tenets that can be used to improve the quality of a cloud-native workload. The framework consists of five pillars of architecture excellence:
+The [Microsoft Well-Architected Framework](/azure/architecture/framework/) provides a set of guiding tenets that can be used to improve the quality of a cloud-native workload. The framework consists of five pillars of architecture excellence:
 
 |    Tenant | Description  |
 | :-------- | :-------- |
-| [Cost management](https://docs.microsoft.com/azure/architecture/framework/#cost-optimization) | Focus on generating incremental value early. Apply *Build-Measure-Learn* principles to accelerate time to market while avoiding capital-intensive solutions. Using a pay-as-you-go strategy, invest as you scale out, rather than delivering a large investment up front. |
-| [Operational excellence](https://docs.microsoft.com/azure/architecture/framework/#operational-excellence) | Automate the environment and operations to increase speed and reduce human error. Roll problem updates back or forward quickly. Implement monitoring and diagnostics from the start. |
-| [Performance efficiency](https://docs.microsoft.com/azure/architecture/framework/#performance-efficiency) | Efficiently meet demands placed on your workloads. Favor horizontal scaling (scaling out) and design it into your systems. Continually conduct performance and load testing to identify potential bottlenecks. |
-| [Reliability](https://docs.microsoft.com/azure/architecture/framework/#reliability)  | Build workloads that are both resilient and available. Resiliency enables workloads to recover from failures and continue functioning. Availability ensures users access to your workload at all times. Design applications to expect failures and recover from them. |
-| [Security](https://docs.microsoft.com/azure/architecture/framework/#security) | Implement security across the entire lifecycle of an application, from design and implementation to deployment and operations. Pay close attention to identity management, infrastructure access, application security, and data sovereignty and encryption. |
+| [Cost management](/azure/architecture/framework/#cost-optimization) | Focus on generating incremental value early. Apply *Build-Measure-Learn* principles to accelerate time to market while avoiding capital-intensive solutions. Using a pay-as-you-go strategy, invest as you scale out, rather than delivering a large investment up front. |
+| [Operational excellence](/azure/architecture/framework/#operational-excellence) | Automate the environment and operations to increase speed and reduce human error. Roll problem updates back or forward quickly. Implement monitoring and diagnostics from the start. |
+| [Performance efficiency](/azure/architecture/framework/#performance-efficiency) | Efficiently meet demands placed on your workloads. Favor horizontal scaling (scaling out) and design it into your systems. Continually conduct performance and load testing to identify potential bottlenecks. |
+| [Reliability](/azure/architecture/framework/#reliability)  | Build workloads that are both resilient and available. Resiliency enables workloads to recover from failures and continue functioning. Availability ensures users access to your workload at all times. Design applications to expect failures and recover from them. |
+| [Security](/azure/architecture/framework/#security) | Implement security across the entire lifecycle of an application, from design and implementation to deployment and operations. Pay close attention to identity management, infrastructure access, application security, and data sovereignty and encryption. |
 
-To get started, Microsoft provides a set of [online assessments](https://docs.microsoft.com/assessments/?mode=pre-assessment&session=local) to help you assess your current cloud workloads against the five well-architected pillars.
+To get started, Microsoft provides a set of [online assessments](/assessments/?mode=pre-assessment&session=local) to help you assess your current cloud workloads against the five well-architected pillars.
 
 ## Microservices
 
@@ -207,7 +207,7 @@ The components row represents a large set of pre-defined infrastructure componen
 
 The bottom row highlights the portability of Dapr and the diverse environments across which it can run.
 
-Microsoft features a free ebook [Dapr for .NET Developers](https://docs.microsoft.com/dotnet/architecture/dapr-for-net-developers) for learning Dapr.
+Microsoft features a free ebook [Dapr for .NET Developers](../dapr-for-net-developers/index.md) for learning Dapr.
 
 Looking ahead, Dapr has the potential to have a profound impact on cloud-native application development.
 
@@ -320,7 +320,7 @@ With IaC, you automate platform provisioning and application deployment. You ess
 
 ### Automating infrastructure
 
-Tools like [Azure Resource Manager](/azure/azure-resource-manager/management/overview), [Azure Bicep](https://docs.microsoft.com/azure/azure-resource-manager/bicep/overview), [Terraform](https://www.terraform.io/) from HashiCorp, and the [Azure CLI](/cli/azure/), enable you to declaratively script the cloud infrastructure you require. Resource names, locations, capacities, and secrets are parameterized and dynamic. The script is versioned and checked into source control as an artifact of your project. You invoke the script to provision a consistent and repeatable infrastructure across system environments, such as QA, staging, and production.
+Tools like [Azure Resource Manager](/azure/azure-resource-manager/management/overview), [Azure Bicep](/azure/azure-resource-manager/bicep/overview), [Terraform](https://www.terraform.io/) from HashiCorp, and the [Azure CLI](/cli/azure/), enable you to declaratively script the cloud infrastructure you require. Resource names, locations, capacities, and secrets are parameterized and dynamic. The script is versioned and checked into source control as an artifact of your project. You invoke the script to provision a consistent and repeatable infrastructure across system environments, such as QA, staging, and production.
 
 Under the hood, IaC is idempotent, meaning that you can run the same script over and over without side effects. If the team needs to make a change, they edit and rerun the script. Only the updated resources are affected.
 

--- a/docs/architecture/containerized-lifecycle/design-develop-containerized-apps/docker-apps-inner-loop-workflow.md
+++ b/docs/architecture/containerized-lifecycle/design-develop-containerized-apps/docker-apps-inner-loop-workflow.md
@@ -143,7 +143,7 @@ In the DockerFile, you can also instruct Docker to listen to the TCP port that y
 You can specify additional configuration settings in the Dockerfile, depending on the language and framework you're using. For instance, the `ENTRYPOINT` line with `["dotnet", "WebMvcApplication.dll"]` tells Docker to run a .NET application. If you're using the SDK and the .NET CLI (`dotnet CLI`) to build and run the .NET application, this setting would be different. The key point here is that the ENTRYPOINT line and other settings depend on the language and platform you choose for your application.
 
 > [!TIP]
-> For more information about building Docker images for .NET applications, go to [https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images](/dotnet/core/docker/building-net-docker-images).
+> For more information about building Docker images for .NET applications, go to [https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images](/aspnet/core/host-and-deploy/docker/building-net-docker-images).
 >
 > To learn more about building your own images, go to <https://docs.docker.com/engine/tutorials/dockerimages/>.
 

--- a/docs/architecture/modern-web-apps-azure/common-web-application-architectures.md
+++ b/docs/architecture/modern-web-apps-azure/common-web-application-architectures.md
@@ -300,7 +300,7 @@ If you want to add Docker support to your application using Visual Studio, make 
 - **Architecting Microservices e-book**  
   <https://aka.ms/MicroservicesEbook>
 - **DDD (Domain-Driven Design)**  
-  [https://docs.microsoft.com/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/](/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/)
+  [https://docs.microsoft.com/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/](../microservices/microservice-ddd-cqrs-patterns/index.md)
 
 >[!div class="step-by-step"]
 >[Previous](architectural-principles.md)

--- a/docs/azure/index.yml
+++ b/docs/azure/index.yml
@@ -12,7 +12,9 @@ metadata:
   ms.date: 05/13/2021
 
 highlightedContent:
+
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | whats-new
+
   items:
     - itemType: overview
       title: Introduction to Azure and .NET
@@ -42,7 +44,9 @@ highlightedContent:
 conceptualContent:
   title: Featured content
   summary: Learn to develop .NET apps leveraging a variety of Azure services.
+
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
+
   items:
     - title: Create web apps
       links:
@@ -223,13 +227,13 @@ conceptualContent:
       links:
         - itemType: download
           text: Packages
-          url: packages.md
+          url: ./sdk/packages.md
         - itemType: concept
           text: Authentication for apps
-          url: authentication.md
+          url: ./sdk/authentication.md
         - itemType: concept
           text: Logging
-          url: logging.md
+          url: ./sdk/logging.md
         - itemType: sample
           text: SDK example app
           url: /samples/dotnet/samples/azure-identity-resource-management-storage/
@@ -271,5 +275,6 @@ additionalContent:
             - text: .NET Platform
               url: https://github.com/dotnet/
 
-  # footer (optional)
+# footer (optional)
+
   footer: "Are you interested in contributing to the .NET docs? For more information, see our [contributor guide](/contribute/dotnet/dotnet-contribute)."

--- a/docs/azure/landing-page.yml
+++ b/docs/azure/landing-page.yml
@@ -36,9 +36,9 @@ landingContent:
           - text: .NET developer tools
             url: ./dotnet-dev-env-checklist.md
           - text: Authenticate your app
-            url: authentication.md
+            url: ./sdk/authentication.md
           - text: Logging
-            url: logging.md
+            url: ./sdk/logging.md
           - text: SDK example
             url: /samples/dotnet/samples/azure-identity-resource-management-storage/
       - linkListType: learn

--- a/docs/core/testing/snippets/unit-testing-using-mstest/csharp/README.md
+++ b/docs/core/testing/snippets/unit-testing-using-mstest/csharp/README.md
@@ -1,6 +1,6 @@
 # Unit testing using MSTest sample
 
-This sample is part of the [unit testing tutorial](https://docs.microsoft.com/dotnet/core/testing/unit-testing-with-mstest) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
+This sample is part of the [unit testing tutorial](../../../unit-testing-with-mstest.md) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
 
 ## Key features
 
@@ -19,5 +19,5 @@ dotnet test
 
 `dotnet test` builds both projects and runs all of the configured tests.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/docs/csharp/fundamentals/tutorials/safely-cast-using-pattern-matching-is-and-as-operators.md
+++ b/docs/csharp/fundamentals/tutorials/safely-cast-using-pattern-matching-is-and-as-operators.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # How to safely cast by using pattern matching and the is and as operators
 
-Because objects are polymorphic, it's possible for a variable of a base class type to hold a derived [type](/dotnet/csharp/fundamentals/types). To access the derived type's instance members, it's necessary to [cast](../../programming-guide/types/casting-and-type-conversions.md) the value back to the derived type. However, a cast creates the risk of throwing an <xref:System.InvalidCastException>. C# provides [pattern matching](../functional/pattern-matching.md) statements that perform a cast conditionally only when it will succeed. C# also provides the [is](../../language-reference/operators/type-testing-and-cast.md#is-operator) and [as](../../language-reference/operators/type-testing-and-cast.md#as-operator) operators to test if a value is of a certain type.
+Because objects are polymorphic, it's possible for a variable of a base class type to hold a derived [type](../types/index.md). To access the derived type's instance members, it's necessary to [cast](../../programming-guide/types/casting-and-type-conversions.md) the value back to the derived type. However, a cast creates the risk of throwing an <xref:System.InvalidCastException>. C# provides [pattern matching](../functional/pattern-matching.md) statements that perform a cast conditionally only when it will succeed. C# also provides the [is](../../language-reference/operators/type-testing-and-cast.md#is-operator) and [as](../../language-reference/operators/type-testing-and-cast.md#as-operator) operators to test if a value is of a certain type.
 
 The following example shows how to use the pattern matching `is` statement:
 

--- a/docs/csharp/fundamentals/types/index.md
+++ b/docs/csharp/fundamentals/types/index.md
@@ -130,7 +130,7 @@ All arrays are reference types, even if their elements are value types. Arrays i
 
 :::code language="csharp" source="../../programming-guide/types/snippets/index/Program.cs" ID="ArrayDeclaration":::
 
-Reference types fully support inheritance. When you create a class, you can inherit from any other interface or class that isn't defined as [sealed](../../language-reference/keywords/sealed.md). Other classes can inherit from your class and override your virtual methods. For more information about how to create your own classes, see [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented). For more information about inheritance and virtual methods, see [Inheritance](../object-oriented/inheritance.md).
+Reference types fully support inheritance. When you create a class, you can inherit from any other interface or class that isn't defined as [sealed](../../language-reference/keywords/sealed.md). Other classes can inherit from your class and override your virtual methods. For more information about how to create your own classes, see [Classes, structs, and records](../object-oriented/index.md). For more information about inheritance and virtual methods, see [Inheritance](../object-oriented/inheritance.md).
 
 ## Types of literal values
 

--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -37,14 +37,14 @@ landingContent:
 
   - title: "C# fundamentals"
     linkLists:
-      - linkListType: overview
+  - linkListType: overview
         links:
           - text: "A tour of C#"
             url: tour-of-csharp/index.md
           - text: "Inside a C# program"
-            url: programming-guide/inside-a-program/index.md
+            url: ./fundamentals/program-structure/index.md
           - text: Main() and command-line arguments
-            url: programming-guide/main-and-command-args/index.md
+            url: ./fundamentals/program-structure/main-command-line.md
       - linkListType: concept
         links:
           - text: "The C# and .NET type system"
@@ -56,13 +56,13 @@ landingContent:
       - linkListType: tutorial
         links:
           - text: Object-oriented inheritance
-            url: tutorials/inheritance.md
+            url: ./fundamentals/object-oriented/inheritance.md
           - text: Use LINQ to query data
             url: tutorials/working-with-linq.md
           - text: Format text using string interpolation
             url: tutorials/string-interpolation.md
           - text: Browse all tutorials
-            url: ./tutorials/intro-to-csharp/introduction-to-classes.md
+            url: ./fundamentals/tutorials/classes.md
   
   - title: "New features in C# 9.0"
     linkLists:

--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -37,7 +37,7 @@ landingContent:
 
   - title: "C# fundamentals"
     linkLists:
-  - linkListType: overview
+      - linkListType: overview
         links:
           - text: "A tour of C#"
             url: tour-of-csharp/index.md

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -234,5 +234,5 @@ For more information about features introduced in C# 9 and later, see the follow
 - [C# reference](../index.md)
 - [Design guidelines - Choosing between class and struct](../../../standard/design-guidelines/choosing-between-class-and-struct.md)
 - [Design guidelines - Struct design](../../../standard/design-guidelines/struct.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [`with` expression](../operators/with-expression.md)

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -184,4 +184,4 @@ For more information about features introduced in C# 7.2 and later, see the foll
 - [C# reference](../index.md)
 - [Design guidelines - Choosing between class and struct](../../../standard/design-guidelines/choosing-between-class-and-struct.md)
 - [Design guidelines - Struct design](../../../standard/design-guidelines/struct.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)

--- a/docs/csharp/language-reference/compiler-messages/cs0116.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0116.md
@@ -58,7 +58,7 @@ namespace x
 }
 ```
 
-Note that in C#, methods and variables must be declared and defined within a struct or class. For more information on program structure in C#, see the [General Structure of a C# Program](/dotnet/csharp/fundamentals/program-structure) article. To fix this error, rewrite your code such that all methods and fields are contained within either a struct or a class:
+Note that in C#, methods and variables must be declared and defined within a struct or class. For more information on program structure in C#, see the [General Structure of a C# Program](../../fundamentals/program-structure/index.md) article. To fix this error, rewrite your code such that all methods and fields are contained within either a struct or a class:
 
 ```csharp
 namespace x
@@ -99,6 +99,6 @@ namespace x
 
 ## See also
 
-- [General Structure of a C# Program](/dotnet/csharp/fundamentals/program-structure)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [General Structure of a C# Program](../../fundamentals/program-structure/index.md)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Namespaces](../../fundamentals/types/namespaces.md)

--- a/docs/csharp/language-reference/compiler-messages/cs0120.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0120.md
@@ -160,4 +160,4 @@ public class MyClass
 
 ## See also
 
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)

--- a/docs/csharp/language-reference/compiler-messages/cs0151.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0151.md
@@ -12,7 +12,7 @@ ms.assetid: 1adda08b-6be5-46c8-96f9-5ac7c7bfe48c
 
 A value of an integral type expected
 
-A variable was used in a situation where an integral data type was required. For more information, see [Types](/dotnet/csharp/fundamentals/types).
+A variable was used in a situation where an integral data type was required. For more information, see [Types](../../fundamentals/types/index.md).
 
 ## Example of ambiguous conversion
 

--- a/docs/csharp/language-reference/compiler-messages/cs1001.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1001.md
@@ -63,4 +63,4 @@ class CMyTest : IMyTest
 ## See also
 
 - [Statements, Expressions, and Operators](../../programming-guide/statements-expressions-operators/index.md)
-- [Types](/dotnet/csharp/fundamentals/types)
+- [Types](../../fundamentals/types/index.md)

--- a/docs/csharp/language-reference/compiler-messages/cs1061.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1061.md
@@ -52,5 +52,5 @@ public class Program
 
 ## See also
 
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Extension Methods](../../programming-guide/classes-and-structs/extension-methods.md)

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -58,7 +58,7 @@ You use the `.` token to access a member of a namespace or a type, as the follow
 
   Use a [`using` directive](../keywords/using-directive.md) to make the use of qualified names optional.
 
-- Use `.` to access [type members](/dotnet/csharp/fundamentals/object-oriented#members), static and non-static, as the following code shows:
+- Use `.` to access [type members](../../fundamentals/object-oriented/index.md#members), static and non-static, as the following code shows:
 
  :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="TypeMemberAccess" interactive="try-dotnet-method":::
 

--- a/docs/csharp/misc/cs0023.md
+++ b/docs/csharp/misc/cs0023.md
@@ -12,7 +12,7 @@ ms.assetid: 7a30073c-99de-41fa-ac6d-4a0dfbb76de9
 
 Operator 'operator' cannot be applied to operand of type 'type'  
   
- An attempt was made to apply an operator to a variable whose type was not designed to work with the operator. For more information, see [Types](/dotnet/csharp/fundamentals/types) and [C# Operators](../language-reference/operators/index.md).  
+ An attempt was made to apply an operator to a variable whose type was not designed to work with the operator. For more information, see [Types](../fundamentals/types/index.md) and [C# Operators](../language-reference/operators/index.md).  
   
  The following sample generates CS0023:  
   

--- a/docs/csharp/misc/cs0031.md
+++ b/docs/csharp/misc/cs0031.md
@@ -12,7 +12,7 @@ ms.assetid: 91f11ae9-9143-41f4-8002-5c38c8ee0651
 
 Constant value 'value' cannot be converted to a 'type'.
 
-An attempt was made to assign a value to a variable whose type cannot store the value. For more information, see [Types](/dotnet/csharp/fundamentals/types).
+An attempt was made to assign a value to a variable whose type cannot store the value. For more information, see [Types](../fundamentals/types/index.md).
 
 The following sample generates CS0031 in both checked and unchecked contexts:
 

--- a/docs/csharp/misc/cs0155.md
+++ b/docs/csharp/misc/cs0155.md
@@ -12,7 +12,7 @@ ms.assetid: 6c92984a-2b10-453e-9cb7-e6a1d1b98aa6
 
 The type caught or thrown must be derived from System.Exception  
   
- An attempt was made to pass a data type that does not derive from **System.Exception** into a [catch](../language-reference/keywords/try-catch.md) block. Only data types that derive from **System.Exception** can be passed into a **catch** block. For more information, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ An attempt was made to pass a data type that does not derive from **System.Exception** into a [catch](../language-reference/keywords/try-catch.md) block. Only data types that derive from **System.Exception** can be passed into a **catch** block. For more information, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
  The following sample generates CS0155:  
   

--- a/docs/csharp/misc/cs0156.md
+++ b/docs/csharp/misc/cs0156.md
@@ -14,7 +14,7 @@ A throw statement with no arguments is not allowed in a finally clause that is n
   
  A [throw](../language-reference/keywords/throw.md) statement with no parameters can only appear in a **catch** clause that takes no parameters.  
   
- For more information, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ For more information, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
  The following sample generates CS0156:  
   

--- a/docs/csharp/misc/cs0157.md
+++ b/docs/csharp/misc/cs0157.md
@@ -12,7 +12,7 @@ ms.assetid: a5d9d506-81f8-47dd-85b6-85f8170bcbef
 
 Control cannot leave the body of a finally clause  
   
- All of the statements in a [finally](../language-reference/keywords/try-catch-finally.md) clause must execute. For more information, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ All of the statements in a [finally](../language-reference/keywords/try-catch-finally.md) clause must execute. For more information, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
  The following sample generates CS0157:  
   

--- a/docs/csharp/misc/cs0160.md
+++ b/docs/csharp/misc/cs0160.md
@@ -14,7 +14,7 @@ A previous catch clause already catches all exceptions of this or of a super typ
   
 A series of [catch](../language-reference/keywords/try-catch.md) statements needs to be in decreasing order of derivation. For example, the most derived objects must appear first.
   
- For more information, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ For more information, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
  The following sample generates CS0160:  
   

--- a/docs/csharp/misc/cs0255.md
+++ b/docs/csharp/misc/cs0255.md
@@ -12,7 +12,7 @@ ms.assetid: b45f5d5a-1923-4fe1-a858-e5ef5590a108
 
 stackalloc may not be used in a catch or finally block  
   
-You cannot use the [stackalloc operator](../language-reference/operators/stackalloc.md) in a [catch](../language-reference/keywords/try-catch.md) or [finally](../language-reference/keywords/try-catch-finally.md) block. For more information, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+You cannot use the [stackalloc operator](../language-reference/operators/stackalloc.md) in a [catch](../language-reference/keywords/try-catch.md) or [finally](../language-reference/keywords/try-catch-finally.md) block. For more information, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
 The following sample generates CS0255:  
   

--- a/docs/csharp/misc/cs0426.md
+++ b/docs/csharp/misc/cs0426.md
@@ -37,4 +37,4 @@ class D
   
 ## See also
 
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../fundamentals/object-oriented/index.md)

--- a/docs/csharp/misc/cs1015.md
+++ b/docs/csharp/misc/cs1015.md
@@ -12,7 +12,7 @@ ms.assetid: 53179feb-e8be-41e0-bb0b-f7879e9fa613
 
 An object, string, or class type expected  
   
- An attempt was made to pass a predefined data type into a [catch](../language-reference/keywords/try-catch.md) block. Only data types that derive from <xref:System.Exception?displayProperty=nameWithType> can be passed into a `catch` block. For more information on exceptions, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ An attempt was made to pass a predefined data type into a [catch](../language-reference/keywords/try-catch.md) block. Only data types that derive from <xref:System.Exception?displayProperty=nameWithType> can be passed into a `catch` block. For more information on exceptions, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs1017.md
+++ b/docs/csharp/misc/cs1017.md
@@ -12,7 +12,7 @@ ms.assetid: e0902e8a-b042-4711-a8a6-83456a3f88cb
 
 Catch clauses cannot follow the general catch clause of a try statement  
   
- A `catch` block that does not take any parameters must be the last in a series of `catch` blocks. For more information on exceptions, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ A `catch` block that does not take any parameters must be the last in a series of `catch` blocks. For more information on exceptions, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs1524.md
+++ b/docs/csharp/misc/cs1524.md
@@ -14,7 +14,7 @@ Expected catch or finally
   
  A `try` block must be followed by a `catch` or `finally` block.  
   
- For more information on exceptions, see [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions).  
+ For more information on exceptions, see [Exceptions and Exception Handling](../fundamentals/exceptions/index.md).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs1913.md
+++ b/docs/csharp/misc/cs1913.md
@@ -44,4 +44,4 @@ public class Test
   
 ## See also
 
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../fundamentals/object-oriented/index.md)

--- a/docs/csharp/programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md
@@ -48,7 +48,7 @@ The [abstract](../../language-reference/keywords/abstract.md) keyword enables yo
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Inheritance](../../fundamentals/object-oriented/inheritance.md)
 - [Methods](./methods.md)
 - [Fields](./fields.md)

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -75,7 +75,7 @@ Delegates behave like classes and structs. By default, they have `internal` acce
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Interfaces](../../fundamentals/types/interfaces.md)
 - [private](../../language-reference/keywords/private.md)
 - [public](../../language-reference/keywords/public.md)

--- a/docs/csharp/programming-guide/classes-and-structs/constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constants.md
@@ -45,8 +45,8 @@ Constants are immutable values which are known at compile time and do not change
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Properties](./properties.md)
-- [Types](/dotnet/csharp/fundamentals/types)
+- [Types](../../fundamentals/types/index.md)
 - [readonly](../../language-reference/keywords/readonly.md)
 - [Immutability in C# Part One: Kinds of Immutability](/archive/blogs/ericlippert/immutability-in-c-part-one-kinds-of-immutability)

--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -51,7 +51,7 @@ For more information and examples, see [Static Constructors](./static-constructo
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Finalizers](./finalizers.md)
 - [static](../../language-reference/keywords/static.md)
 - [Why Do Initializers Run In The Opposite Order As Constructors? Part One](/archive/blogs/ericlippert/why-do-initializers-run-in-the-opposite-order-as-constructors-part-one)

--- a/docs/csharp/programming-guide/classes-and-structs/fields.md
+++ b/docs/csharp/programming-guide/classes-and-structs/fields.md
@@ -46,7 +46,7 @@ A field can be declared [readonly](../../language-reference/keywords/readonly.md
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Using Constructors](./using-constructors.md)
 - [Inheritance](../../fundamentals/object-oriented/inheritance.md)
 - [Access Modifiers](./access-modifiers.md)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-declare-and-use-read-write-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-declare-and-use-read-write-properties.md
@@ -58,4 +58,4 @@ person.SetAge(person.GetAge() + 1);
 
 - [C# Programming Guide](../index.md)
 - [Properties](./properties.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-define-abstract-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-define-abstract-properties.md
@@ -52,6 +52,6 @@ The following example shows how to define [abstract](../../language-reference/ke
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Abstract and Sealed Classes and Class Members](./abstract-and-sealed-classes-and-class-members.md)
 - [Properties](./properties.md)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-define-constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-define-constants.md
@@ -28,4 +28,4 @@ Constants are fields whose values are set at compile time and can never be chang
   
 ## See also
 
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-override-the-tostring-method.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-override-the-tostring-method.md
@@ -44,7 +44,7 @@ To override the `ToString` method in your class or struct:
 
 - <xref:System.IFormattable>
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Strings](../strings/index.md)
 - [string](../../language-reference/builtin-types/reference-types.md)
 - [override](../../language-reference/keywords/override.md)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md
@@ -24,6 +24,6 @@ C# [records](../../fundamentals/types/records.md) provide a copy constructor for
 - <xref:System.ICloneable>
 - [Records](../../fundamentals/types/records.md)
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Constructors](./constructors.md)
 - [Finalizers](./finalizers.md)

--- a/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md
@@ -540,7 +540,7 @@ namespace OverrideAndNew2
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Versioning with the Override and New Keywords](./versioning-with-the-override-and-new-keywords.md)
 - [base](../../language-reference/keywords/base.md)
 - [abstract](../../language-reference/keywords/abstract.md)

--- a/docs/csharp/programming-guide/classes-and-structs/methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/methods.md
@@ -165,7 +165,7 @@ For more information, see [Iterators](../concepts/iterators.md).
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Access Modifiers](access-modifiers.md)
 - [Static Classes and Static Class Members](static-classes-and-static-class-members.md)
 - [Inheritance](../../fundamentals/object-oriented/inheritance.md)

--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -41,7 +41,7 @@ In the previous declaration, the full name of class `Nested` is `Container.Neste
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Access Modifiers](./access-modifiers.md)
 - [Constructors](./constructors.md)
 - [CA1034 rule](../../../fundamentals/code-analysis/quality-rules/ca1034.md)

--- a/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
@@ -34,7 +34,7 @@ For more information, see [Private constructors](~/_csharplang/spec/classes.md#p
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Constructors](./constructors.md)
 - [Finalizers](./finalizers.md)
 - [private](../../language-reference/keywords/private.md)

--- a/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
@@ -61,7 +61,7 @@ For more information, see the [Static constructors](~/_csharplang/spec/classes.m
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Constructors](./constructors.md)
 - [Static Classes and Static Class Members](./static-classes-and-static-class-members.md)
 - [Finalizers](./finalizers.md)

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -93,6 +93,6 @@ For more information, see [Instance constructors](~/_csharplang/spec/classes.md#
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Constructors](./constructors.md)
 - [Finalizers](./finalizers.md)

--- a/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/versioning-with-the-override-and-new-keywords.md
@@ -78,6 +78,6 @@ The C# language is designed so that versioning between [base](../../language-ref
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Methods](./methods.md)
 - [Inheritance](../../fundamentals/object-oriented/inheritance.md)

--- a/docs/csharp/programming-guide/index.md
+++ b/docs/csharp/programming-guide/index.md
@@ -21,7 +21,7 @@ This section provides detailed information on key C# language features and featu
   
 ## Program sections
 
-[Inside a C# Program](/dotnet/csharp/fundamentals/program-structure)  
+[Inside a C# Program](../fundamentals/program-structure/index.md)  
   
 [Main() and Command-Line Arguments](../fundamentals/program-structure/main-command-line.md)  
 
@@ -29,9 +29,9 @@ This section provides detailed information on key C# language features and featu
 
 [Statements, Expressions, and Operators](./statements-expressions-operators/index.md)  
 
- [Types](/dotnet/csharp/fundamentals/types)  
+ [Types](../fundamentals/types/index.md)  
 
- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)  
+ [Classes, structs, and records](../fundamentals/object-oriented/index.md)  
   
  [Interfaces](../fundamentals/types/interfaces.md)  
 
@@ -57,7 +57,7 @@ This section provides detailed information on key C# language features and featu
   
  [Unsafe Code and Pointers](../language-reference/unsafe-code.md)  
   
- [XML Documentation Comments](/dotnet/csharp/language-reference/xmldoc)  
+ [XML Documentation Comments](../language-reference/xmldoc/index.md)  
   
 ## Platform Sections
 
@@ -69,7 +69,7 @@ This section provides detailed information on key C# language features and featu
   
  [Collections](./concepts/collections.md)  
   
- [Exceptions and Exception Handling](/dotnet/csharp/fundamentals/exceptions)  
+ [Exceptions and Exception Handling](../fundamentals/exceptions/index.md)  
   
  [File System and the Registry (C# Programming Guide)](./file-system/index.md)  
   

--- a/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
+++ b/docs/csharp/programming-guide/interfaces/explicit-interface-implementation.md
@@ -43,6 +43,6 @@ Any class that implements the `IControl` interface can override the default `Pai
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Classes, structs, and records](/dotnet/csharp/fundamentals/object-oriented)
+- [Classes, structs, and records](../../fundamentals/object-oriented/index.md)
 - [Interfaces](../../fundamentals/types/interfaces.md)
 - [Inheritance](../../fundamentals/object-oriented/inheritance.md)

--- a/docs/framework/index.yml
+++ b/docs/framework/index.yml
@@ -8,9 +8,9 @@ metadata:
   description: Find information about .NET Framework, a development platform for building apps for web, Windows, and Microsoft Azure.
   ms.topic: landing-page
   ms.custom: updateeachrelease
-  f1_keywords: 
+  f1_keywords:
     - "f61f02f2-2f20-483d-8f56-a9c8f3a54986"
-  helpviewer_keywords: 
+  helpviewer_keywords:
     - ".NET Framework guide"
   ms.date: 04/22/2020
 
@@ -67,7 +67,7 @@ landingContent:
           - text: Install .NET Framework on Windows 10 
             url: install/on-windows-10.md
           - text: Install .NET Framework 3.5
-            url: install/dotnet-35-windows-10.md
+            url: ./install/dotnet-35-windows.md
           - text: Install the developer pack or redistributable 
             url: install/guide-for-developers.md
           - text: Troubleshoot blocked installations

--- a/samples/snippets/core/testing/unit-testing-using-dotnet-test/csharp/README.md
+++ b/samples/snippets/core/testing/unit-testing-using-dotnet-test/csharp/README.md
@@ -1,6 +1,6 @@
 # Unit testing using dotnet test sample
 
-This sample is part of the [unit testing tutorial](https://docs.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
+This sample is part of the [unit testing tutorial](../../../../../../docs/core/testing/unit-testing-with-dotnet-test.md) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
 
 ## Key features
 
@@ -19,5 +19,5 @@ dotnet test
 
 `dotnet test` builds both projects and runs all of the configured tests.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/core/testing/unit-testing-using-nunit/csharp/README.md
+++ b/samples/snippets/core/testing/unit-testing-using-nunit/csharp/README.md
@@ -1,6 +1,6 @@
 # Unit testing using NUnit sample
 
-This sample is part of the [unit testing tutorial](https://docs.microsoft.com/dotnet/core/testing/unit-testing-with-nunit) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
+This sample is part of the [unit testing tutorial](../../../../../../docs/core/testing/unit-testing-with-nunit.md) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
 
 ## Key features
 
@@ -19,4 +19,4 @@ dotnet test
 `dotnet test` builds both projects and runs all of the configured tests.
 
 <a name="dotnet-restore-note"></a>
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/core/tutorials/cli-create-console-app/FibonacciBetterMsBuild/csharp/README.md
+++ b/samples/snippets/core/tutorials/cli-create-console-app/FibonacciBetterMsBuild/csharp/README.md
@@ -1,7 +1,7 @@
 Better Fibonacci Sample
 ================
 
-This sample is part of the [step-by-step tutorial](https://docs.microsoft.com/dotnet/core/tutorials/using-with-xplat-cli)
+This sample is part of the [step-by-step tutorial](../../../../../../../docs/core/tutorials/with-visual-studio-code.md)
 for creating .NET Core Console Applications. Please see that topic for detailed steps on the code
 for this sample.
 

--- a/samples/snippets/core/tutorials/cli-create-console-app/HelloMsBuild/csharp/README.md
+++ b/samples/snippets/core/tutorials/cli-create-console-app/HelloMsBuild/csharp/README.md
@@ -1,6 +1,6 @@
 # Hello Sample
 
-This sample is part of the [step-by-step tutorial](https://docs.microsoft.com/dotnet/core/tutorials/using-with-xplat-cli)
+This sample is part of the [step-by-step tutorial](../../../../../../../docs/core/tutorials/with-visual-studio-code.md)
 for creating .NET Core Console Applications. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -16,4 +16,4 @@ To build and run the sample, type the following command:
 
 `dotnet run` builds the sample and runs the output assembly. It implicitly calls `dotnet restore` on .NET Core 2.0 and later versions. If you're using a .NET Core 1.x SDK, you first have to call `dotnet restore` yourself.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/core/tutorials/cli-create-console-app/fibonacci-msbuild/csharp/README.md
+++ b/samples/snippets/core/tutorials/cli-create-console-app/fibonacci-msbuild/csharp/README.md
@@ -1,7 +1,7 @@
 Hello Sample
 ================
 
-This sample is part of the [step-by-step tutorial](https://docs.microsoft.com/dotnet/core/tutorials/using-with-xplat-cli)
+This sample is part of the [step-by-step tutorial](../../../../../../../docs/core/tutorials/with-visual-studio-code.md)
 for creating .NET Core Console Applications. Please see that topic for detailed steps on the code
 for this sample.
 

--- a/samples/snippets/core/tutorials/netcore-hosting/csharp/HostWithHostFxr/readme.md
+++ b/samples/snippets/core/tutorials/netcore-hosting/csharp/HostWithHostFxr/readme.md
@@ -2,7 +2,7 @@
 
 This project demonstrates a way for a native process to host .NET Core using the `nethost` and `hostfxr` libraries. Documentation on the `nethost` and `hostfxr` APIs can be found [here](https://github.com/dotnet/runtime/blob/main/docs/design/features/native-hosting.md).
 
-This sample is part of the [.NET Core hosting tutorial](../../../../../../../docs/core/tutorials/netcore-hosting.md). Please see that topic for a more detailed explanation of the sample and the steps necessary to host .NET Core.
+This sample is part of the [.NET Core hosting tutorial](https://docs.microsoft.com/dotnet/docs/core/tutorials/netcore-hosting). Please see that topic for a more detailed explanation of the sample and the steps necessary to host .NET Core.
 
 The host is small and bypasses a lot of complexity (thorough error checking, etc.) that a real host would have. Hopefully by remaining simple, though, it will be useful for demonstrating the core concepts of hosting managed .NET Core code in a native process.
 
@@ -11,7 +11,7 @@ The host is small and bypasses a lot of complexity (thorough error checking, etc
 Demonstrates how to locate and initialize .NET Core runtime from a non-.NET Core process and subsequently load and call into a .NET Core assembly.
 
 The `nethost` header and library are part of the `Microsoft.NETCore.DotNetAppHost` package and are also installed as a runtime pack by the .NET Core SDK. The library should be deployed alongside the host. This sample uses the files installed with the .NET Core SDK.  
-*Note: The `Microsoft.NETCore.DotNetAppHost` package is a [metapackage](../../../../../../../docs/core/deploying/index.md#metapackages) that doesn't actually contain the files. It only references RID-specific packages that contain the files. For example, the package with the actual files for `linux-x64` is `runtime.linux-x64.Microsoft.NETCore.DotNetAppHost`.*
+*Note: The `Microsoft.NETCore.DotNetAppHost` package is a [metapackage](https://docs.microsoft.com/dotnet/docs/core/deploying/index#metapackages) that doesn't actually contain the files. It only references RID-specific packages that contain the files. For example, the package with the actual files for `linux-x64` is `runtime.linux-x64.Microsoft.NETCore.DotNetAppHost`.*
 
 The `coreclr_delegates.h` and `hostfxr.h` files are copied from the [dotnet/runtime](https://github.com/dotnet/runtime) repo - [coreclr_delegates.h](https://github.com/dotnet/runtime/blob/main/src/installer/corehost/cli/coreclr_delegates.h) and [hostfxr.h](https://github.com/dotnet/runtime/blob/main/src/installer/corehost/cli/hostfxr.h).
 

--- a/samples/snippets/core/tutorials/netcore-hosting/csharp/HostWithHostFxr/readme.md
+++ b/samples/snippets/core/tutorials/netcore-hosting/csharp/HostWithHostFxr/readme.md
@@ -2,7 +2,7 @@
 
 This project demonstrates a way for a native process to host .NET Core using the `nethost` and `hostfxr` libraries. Documentation on the `nethost` and `hostfxr` APIs can be found [here](https://github.com/dotnet/runtime/blob/main/docs/design/features/native-hosting.md).
 
-This sample is part of the [.NET Core hosting tutorial](https://docs.microsoft.com/dotnet/core/tutorials/netcore-hosting). Please see that topic for a more detailed explanation of the sample and the steps necessary to host .NET Core.
+This sample is part of the [.NET Core hosting tutorial](../../../../../../../docs/core/tutorials/netcore-hosting.md). Please see that topic for a more detailed explanation of the sample and the steps necessary to host .NET Core.
 
 The host is small and bypasses a lot of complexity (thorough error checking, etc.) that a real host would have. Hopefully by remaining simple, though, it will be useful for demonstrating the core concepts of hosting managed .NET Core code in a native process.
 
@@ -11,7 +11,7 @@ The host is small and bypasses a lot of complexity (thorough error checking, etc
 Demonstrates how to locate and initialize .NET Core runtime from a non-.NET Core process and subsequently load and call into a .NET Core assembly.
 
 The `nethost` header and library are part of the `Microsoft.NETCore.DotNetAppHost` package and are also installed as a runtime pack by the .NET Core SDK. The library should be deployed alongside the host. This sample uses the files installed with the .NET Core SDK.  
-*Note: The `Microsoft.NETCore.DotNetAppHost` package is a [metapackage](https://docs.microsoft.com/dotnet/core/packages#metapackages) that doesn't actually contain the files. It only references RID-specific packages that contain the files. For example, the package with the actual files for `linux-x64` is `runtime.linux-x64.Microsoft.NETCore.DotNetAppHost`.*
+*Note: The `Microsoft.NETCore.DotNetAppHost` package is a [metapackage](../../../../../../../docs/core/deploying/index.md#metapackages) that doesn't actually contain the files. It only references RID-specific packages that contain the files. For example, the package with the actual files for `linux-x64` is `runtime.linux-x64.Microsoft.NETCore.DotNetAppHost`.*
 
 The `coreclr_delegates.h` and `hostfxr.h` files are copied from the [dotnet/runtime](https://github.com/dotnet/runtime) repo - [coreclr_delegates.h](https://github.com/dotnet/runtime/blob/main/src/installer/corehost/cli/coreclr_delegates.h) and [hostfxr.h](https://github.com/dotnet/runtime/blob/main/src/installer/corehost/cli/hostfxr.h).
 

--- a/samples/snippets/core/tutorials/testing-with-cli/csharp/README.md
+++ b/samples/snippets/core/tutorials/testing-with-cli/csharp/README.md
@@ -1,6 +1,6 @@
 # NewTypes Pets Sample
 
-This sample is part of the [Organizing and testing projects with the .NET Core command line tutorial](https://docs.microsoft.com/dotnet/core/tutorials/testing-with-cli) for creating .NET Core console applications. See the tutorial for details on the code for this sample.
+This sample is part of the [Organizing and testing projects with the .NET Core command line tutorial](../../../../../../docs/core/tutorials/testing-with-cli.md) for creating .NET Core console applications. See the tutorial for details on the code for this sample.
 
 ## Key Features
 
@@ -28,4 +28,4 @@ dotnet test
 `dotnet build` will follow the dependency on the `NewTypesMsBuild` project and build both the app and unit tests projects. It implicitly runs `dotnet restore` on .NET Core 2.0 and later versions. If you're using .NET Core 1.0 or .NET Core 1.1, you first have to run `dotnet restore` yourself.
 
 <a name="dotnet-restore-note"></a>
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/delegates-and-events/README.md
+++ b/samples/snippets/csharp/delegates-and-events/README.md
@@ -1,6 +1,6 @@
 # C# Delegates and Events Sample
 
-This sample is created during the [Delegates and Events topic](https://docs.microsoft.com/dotnet/csharp/delegates-events)
+This sample is created during the [Delegates and Events topic](../../../../docs/csharp/delegates-overview.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -23,5 +23,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/events/README.md
+++ b/samples/snippets/csharp/events/README.md
@@ -1,6 +1,6 @@
 # C# Events Sample
 
-This sample is created during the [Delegates and Events topic](https://docs.microsoft.com/dotnet/csharp/delegates-events)
+This sample is created during the [Delegates and Events topic](../../../../docs/csharp/delegates-overview.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/getting-started/console-linq/README.md
+++ b/samples/snippets/csharp/getting-started/console-linq/README.md
@@ -1,6 +1,6 @@
 # C# LINQ Sample
 
-This sample is created during the [Working with LINQ tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/working-with-linq) for learning C# features. Please see that topic for detailed steps on the code for this sample.
+This sample is created during the [Working with LINQ tutorial](../../../../../docs/csharp/tutorials/working-with-linq.md) for learning C# features. Please see that topic for detailed steps on the code for this sample.
 
 ## Key Features
 
@@ -19,5 +19,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/getting-started/console-teleprompter/README.md
+++ b/samples/snippets/csharp/getting-started/console-teleprompter/README.md
@@ -1,6 +1,6 @@
 # C# Console Application Sample
 
-This sample is created during the [Console Application Tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/console-teleprompter)
+This sample is created during the [Console Application Tutorial](../../../../../docs/csharp/tutorials/console-teleprompter.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 

--- a/samples/snippets/csharp/getting-started/console-webapiclient/README.md
+++ b/samples/snippets/csharp/getting-started/console-webapiclient/README.md
@@ -1,6 +1,6 @@
 # C# REST Client Sample
 
-This sample is created during the [REST client tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/console-webapiclient)
+This sample is created during the [REST client tutorial](../../../../../docs/csharp/tutorials/console-webapiclient.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/versioning/new/README.md
+++ b/samples/snippets/csharp/versioning/new/README.md
@@ -1,6 +1,6 @@
 # C# Versioning Sample
 
-This sample is created during the [Versioning](https://docs.microsoft.com/dotnet/csharp/versioning)
+This sample is created during the [Versioning](../../../../../docs/csharp/versioning.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/versioning/override/README.md
+++ b/samples/snippets/csharp/versioning/override/README.md
@@ -1,6 +1,6 @@
 # C# Versioning Sample
 
-This sample is created during the [Versioning](https://docs.microsoft.com/dotnet/csharp/versioning)
+This sample is created during the [Versioning](../../../../../docs/csharp/versioning.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/standard/async/async-and-await/cs/readme.md
+++ b/samples/snippets/standard/async/async-and-await/cs/readme.md
@@ -11,11 +11,11 @@ description: "A .NET Core WPF application that contains the example method from 
 ---
 # Async programming with async and await in C\#
 
-This sample is a WPF application written in C# that contains the example method from [Task asynchronous programming model](https://docs.microsoft.com/dotnet/csharp/programming-guide/concepts/async/task-asynchronous-programming-model). The article gives an overview of asynchronous programming, including when to use it and how to write an async method. This sample contains an async function that is used as an illustration.
+This sample is a WPF application written in C# that contains the example method from [Task asynchronous programming model](../../../../../../docs/csharp/programming-guide/concepts/async/task-asynchronous-programming-model.md). The article gives an overview of asynchronous programming, including when to use it and how to write an async method. This sample contains an async function that is used as an illustration.
 
-[async](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/async) and [await](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/await) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
+[async](../../../../../../docs/csharp/language-reference/keywords/async.md) and [await](../../../../../../docs/csharp/language-reference/operators/await.md) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
 
-The example async function in this sample (named `GetStringAsync`) uses an [HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
+The example async function in this sample (named `GetStringAsync`) uses an [HttpClient](/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
 
 The code for the *MainWindow.xaml.cs* file from this sample is included in the article.
 

--- a/samples/snippets/standard/async/async-and-await/vb/readme.md
+++ b/samples/snippets/standard/async/async-and-await/vb/readme.md
@@ -11,11 +11,11 @@ description: "A .NET Core WPF application that contains the example method from 
 ---
 # Async Sample: Asynchronous Programming with Async and Await in Visual Basic
 
-This sample is a WPF application that contains the example method from [Asynchronous Progamming with Async and Await in Visual Basic](https://docs.microsoft.com/dotnet/visual-basic/programming-guide/concepts/async/). The topic gives an overview of asynchronous programming, including when to use it and how to write an Async method. This sample contains an Async function that is used as an illustration.
+This sample is a WPF application that contains the example method from [Asynchronous Progamming with Async and Await in Visual Basic](../../../../../../docs/visual-basic/programming-guide/concepts/async/index.md). The topic gives an overview of asynchronous programming, including when to use it and how to write an Async method. This sample contains an Async function that is used as an illustration.
 
-[Async](https://docs.microsoft.com/dotnet/visual-basic/language-reference/modifiers/async) and [Await](https://docs.microsoft.com/dotnet/visual-basic/language-reference/operators/await-operator) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
+[Async](../../../../../../docs/visual-basic/language-reference/modifiers/async.md) and [Await](../../../../../../docs/visual-basic/language-reference/operators/await-operator.md) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
 
-The example Async function in this sample (named `GetStringAsync`) uses an [HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
+The example Async function in this sample (named `GetStringAsync`) uses an [HttpClient](/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
 
 The code for the *MainWindow.xaml.vb* file from this sample is included in the article.
 

--- a/styleguide/labels-projects.md
+++ b/styleguide/labels-projects.md
@@ -1,3 +1,3 @@
 # Labels and projects
 
-This content has been moved to the [Contributor guide](https://docs.microsoft.com/contribute/dotnet/labels-projects).
+This content has been moved to the [Contributor guide](/contribute/dotnet/labels-projects).

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -1,3 +1,3 @@
 # Article template
 
-This content has been moved to the [Contributor guide](https://docs.microsoft.com/contribute/dotnet-style-guide).
+This content has been moved to the [Contributor guide](/contribute/dotnet-style-guide).


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 