### PR TITLE
New example snippet for IntroExample of IsOperator.cs

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
@@ -10,7 +10,8 @@ namespace operators
         }
 
         // <IntroExample>
-        static bool IsFirstFridayOfOctober(DateTime date) => date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
+        static bool IsFirstFridayOfOctober(DateTime date) =>
+            date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
         // </IntroExample>
 
         private static void DeclarationPattern()

--- a/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
@@ -10,7 +10,7 @@ namespace operators
         }
 
         // <IntroExample>
-        static bool isFirstFridayOfOctober(DateTime date) => date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
+        static bool IsFirstFridayOfOctober(DateTime date) => date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
         // </IntroExample>
 
         private static void DeclarationPattern()

--- a/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
@@ -10,7 +10,7 @@ namespace operators
         }
 
         // <IntroExample>
-        static bool IsFirstSummerMonday(DateTime date) => date is { Month: 6, Day: <=7, DayOfWeek: DayOfWeek.Monday };
+        static bool isFirstFridayOfOctober(DateTime date) => date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
         // </IntroExample>
 
         private static void DeclarationPattern()


### PR DESCRIPTION
## Summary


Provided a new example which follows the same pattern as the previous example for the usage of **is** operator with pattern matching

Fixes #26597
