### PR TITLE
Clarify try-catch usage (#26560)

### DIFF
--- a/docs/csharp/language-reference/keywords/try-catch.md
+++ b/docs/csharp/language-reference/keywords/try-catch.md
@@ -28,11 +28,12 @@ try
 }
 ```
 
-Although the `catch` clause can be used without arguments to catch any type of exception, this usage is not recommended. In general, you should only catch those exceptions that you know how to recover from. Therefore, you should always specify an object argument derived from <xref:System.Exception?displayProperty=nameWithType> For example:
+Although the `catch` clause can be used without arguments to catch any type of exception, this usage is not recommended. In general, you should only catch those exceptions that you know how to recover from. Therefore, you should always specify an object argument derived from <xref:System.Exception?displayProperty=nameWithType>. The exception type should be as specific as possible in order to avoid incorrectly accepting exceptions that your exception handler is actually not able to resolve. As such, prefer concrete exceptions over the base `Exception` type. For example:
 
 ```csharp
 catch (InvalidCastException e)
 {
+    // recover from exception
 }
 ```
 
@@ -43,6 +44,7 @@ Using `catch` arguments is one way to filter for the exceptions you want to hand
 ```csharp
 catch (ArgumentException e) when (e.ParamName == "…")
 {
+    // recover from exception
 }
 ```
 


### PR DESCRIPTION
This addresses #26560 which suggests that the `catch (Exception)` examples on the try-catch docs page shouldn’t be left empty.

I did want to change the usage of the base `Exception` type to use a more specific type but ultimately didn’t because those `Exception` handlers all were logging out the exceptions (which is usually a fine thing to do when done at a central application entry point, e.g. `Main`) and because the examples actually throw example `Exception` types to demonstrate the behavior. At least in the case of those examples, the code was complete enough to show that there were no other unknown exceptions being thrown that could have been incorrectly caught here.

Instead, I have added some clarification on what exception type should be chosen when using a `catch` statement, to prefer specific exceptions over the base type if possible.