### PR TITLE
CS1617: Clarify valid language versions (#20259)

### DIFF
--- a/docs/csharp/misc/cs1617.md
+++ b/docs/csharp/misc/cs1617.md
@@ -18,8 +18,8 @@ For example, compiling with `csc -langversion:ISO` will generate error CS1617.
 
 ## Valid values for -langversion
 
-The following table specifies the valid values for -langversion:
+The valid values for the language versions depend on the .NET version you are using. See [the language version rules](/language-reference/configure-language-version#defaults) for more information on which language version is available with which version of .NET. If you are receiving this error while attempting to use a newer language version, either downgrade to a lower language version or update your .NET SDK to a version that supports the language version.
+
+The following table specifies the current valid values for `-langversion`:
 
 [!INCLUDE [lang-versions-table](../language-reference/includes/langversion-table.md)]
-
-If you are using a valid value from the table above and still seeing the error, you may have an older SDK that doesn't support this language version. Make sure to install the [latest .NET SDK](https://dotnet.microsoft.com/download/).


### PR DESCRIPTION
This attempts to fix #20259 which highlighted a misunderstanding with the list of valid language versions for CS1617 since it didn’t specify that the valid language versions depend on the version of .NET that is being used.

## Summary

Clarify for CS1617 that the list of valid language versions depends on
the .NET version that is being used to compile the application. Newer
language versions will only be available by .NET versions that came
after the language version was introduced. The displayed list only
shows the versions for the current version of .NET.
