### PR TITLE
Fix info about struct equality (#26619)

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/index.md
+++ b/docs/csharp/fundamentals/object-oriented/index.md
@@ -96,7 +96,7 @@ C# 9 introduces the `record` type, a reference type that you can create instead 
 
 * Concise syntax for creating a reference type with immutable properties.
 * Value equality.
-  Two variables of a record type are equal if the record type definitions are identical, and if for every field, the values in both records are equal. Classes use reference equality: two variables of a class type are equal if they refer to the same object.
+  Two variables of a record type are equal if they have the same type, and if, for every field, the values in both records are equal. Classes use reference equality: two variables of a class type are equal if they refer to the same object.
 * Concise syntax for nondestructive mutation.
   A `with` expression lets you create a new record instance that is a copy of an existing instance but with specified property values changed.
 * Built-in formatting for display.

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -94,11 +94,10 @@ The features unique to record types are implemented by compiler-synthesized meth
 For any type you define, you can override <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType>, and overload [`operator ==`](../operators/equality-operators.md#equality-operator-). If you don't override `Equals` or overload `operator ==`, the type you declare governs how equality is defined:
 
 - For `class` types, two objects are equal if they refer to the same object in memory.
-- For `record` types, two objects are equal if they store the same values, and are the same type.
-- For `struct` types, two objects are equal if they store  the same values.
-- For `record struct` and `readonly record struct` types, two objects are equal if they store the same values.
+- For `struct` types, two objects are equal if they are of the same type and store the same values.
+- For `record` types, including `record struct` and `readonly record struct`, two objects are equal if they are of the same type and store the same values.
 
-The definition of equality for a `record struct` is the same as for a `struct`. The difference is that for a `struct`, the implementation is in <xref:System.ValueType.Equals(System.Object)?displayProperty=nameWithType> and relies on reflection. For a `record struct`, the implementation is compiler synthesized and uses the declared data members.
+The definition of equality for a `record struct` is the same as for a `struct`. The difference is that for a `struct`, the implementation is in <xref:System.ValueType.Equals(System.Object)?displayProperty=nameWithType> and relies on reflection. For records, the implementation is compiler synthesized and uses the declared data members.
 
 Reference equality is required for some data models. For example, [Entity Framework Core](/ef/core/) depends on reference equality to ensure that it uses only one instance of an entity type for what is conceptually one entity. For this reason, records and record structs aren't appropriate for use as entity types in Entity Framework Core.
 


### PR DESCRIPTION
This fixes #26619: Records are only equal if they actually have the _same_ type (an identical but different type will not be enough), and `record struct` (and `readonly record struct`) types actually behave just the same as `record` types, so there is no need for a special mention there.

---

Example [on SharpLab](https://sharplab.io/#v2:EYLgtghglgdgNAFxAJwK7wCYgNQB8ACATAIwCwAUBfsQJwAUMApgO4AEAygmgMYICCrAN6sAahAA2qRqwC8rAKysAvgDoAogEdUEgM4MWHLql4AhIaIlTZC5QEpbAblYB6Z6wBiuxlVr62nHn5zMUlpOUVVTW1xPSZ/I14BYRCrcLtHFzcAFTRvSnJqejjWACVGbgB7ZAwki1DrCPUtXT9S8qqMM2TLMJsleydXDy8fIoMyyuralN7GqJbiiY7pnob0wezcilHWpeqA4yDu+rTI5pjd9v2EhC661L6BzOGYvMLLyYwDxODV06borFxlcvjcVidHhkhjkpNsCr5FhU9qDAuCHnNzkC2CUkSDvrdfhCIk8hp5XjtEcj8WjZsoAQtxrjPtTCej1s8YXkqABmVg6G6GVFCCisUWsfC82AIe7SYQAc0YCCcOkVTiUFHVBV5/MCgsOXRFYolrClMvMCqVfNVyg1cONyBBbU+SUNouNppm5utKstms19sdyIN5DF4slMGlnvl3utfrtvIdnz5AqpYOFIaN4cjq2jlp9attWtYiY6yd1qcCwdD7ojZtzytjhZ5xcYEAwFRg4gAni2kzrDqUmR0WYJXWGTbWo6wLU5YFBfYWA22O93e6X+7xBxX9enq1m69PrXOF+QlEA):

```csharp
using System;

Console.WriteLine(new StructA { Value = 5 }.Equals(new StructB { Value = 5 })); // False
Console.WriteLine(new StructA { Value = 5 }.Equals(new StructA { Value = 5 })); // True

Console.WriteLine(new RecordA { Value = 5 }.Equals(new RecordB { Value = 5 })); // False
Console.WriteLine(new RecordA { Value = 5 }.Equals(new RecordA { Value = 5 })); // True

Console.WriteLine(new RecordStructA { Value = 5 }.Equals(new RecordStructB { Value = 5 })); // False
Console.WriteLine(new RecordStructA { Value = 5 }.Equals(new RecordStructA { Value = 5 })); // True

Console.WriteLine(new RoRecordStructA { Value = 5 }.Equals(new RoRecordStructB { Value = 5 })); // False
Console.WriteLine(new RoRecordStructA { Value = 5 }.Equals(new RoRecordStructA { Value = 5 })); // True

public struct StructA {
    public int Value { get; set; }
}
public struct StructB {
    public int Value { get; set; }
}

public record RecordA {
    public int Value { get; set; }
}
public record RecordB {
    public int Value { get; set; }
}

public record struct RecordStructA {
    public int Value { get; set; }
}
public record struct RecordStructB {
    public int Value { get; set; }
}

public readonly record struct RoRecordStructA {
    public int Value { get; init; }
}
public readonly record struct RoRecordStructB {
    public int Value { get; init; }
}
```