### PR TITLE
replace "disable" with "enable" in the CA5399 analyzer doc

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5399.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5399.md
@@ -8,7 +8,7 @@ ms.author: linche
 f1_keywords:
   - "CA5399"
 ---
-# CA5399: Definitely disable HttpClient certificate revocation list check
+# CA5399: Definitely enable HttpClient certificate revocation list check
 
 | | Value |
 |-|-|

--- a/docs/fundamentals/code-analysis/quality-rules/ca5399.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5399.md
@@ -8,7 +8,7 @@ ms.author: linche
 f1_keywords:
   - "CA5399"
 ---
-# CA5399: Definitely enable HttpClient certificate revocation list check
+# CA5399: Enable HttpClient certificate revocation list check
 
 | | Value |
 |-|-|


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/5695

The [solution](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5399#how-to-fix-violations) in the doc suggests setting `CheckCertificateRevocationList` to true but the `doc` title says, `definitely disable the check`. These statements contradict each other.

Fixes #Issue_Number (if available)
