### PR TITLE
CA5400 is similar to CA5399

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -20,7 +20,7 @@ f1_keywords:
 
 Using <xref:System.Net.Http.HttpClient?displayProperty=fullName> while providing a platform specific handler (<xref:System.Net.Http.WinHttpHandler?displayProperty=fullName> or <xref:System.Net.Http.HttpClientHandler?displayProperty=fullName>) whose `CheckCertificateRevocationList` property is possibly set to `false` will allow revoked certificates to be accepted by the <xref:System.Net.Http.HttpClient> as valid.
 
-This rule is similar to [CA5400](ca5400.md), but analysis can't determine that the `CheckCertificateRevocationList` property is definitely `false` or not set.
+This rule is similar to [CA5399](ca5399.md), but analysis can't determine that the `CheckCertificateRevocationList` property is definitely `false` or not set.
 
 ## Rule description
 


### PR DESCRIPTION
## Summary

Describe your changes here.

`CA5400` analyzer is similar to `CA5399`. The doc says `CA5400` rule is similar to itself which seems incorrect to me.

Fixes #Issue_Number (if available)
