### PR TITLE
Add section about formatting range operator expressions.

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -521,6 +521,39 @@ x &&& y // Bitwise and, also for working with “flags” enumeration
 x ^^^ y // Bitwise xor, also for working with “flags” enumeration
 ```
 
+### Formatting range operator expressions
+
+Only add spaces around the `..` when all expressions are non-atomic.
+Integers and single word identifiers are considered atomic.
+
+```fsharp
+// ✔️ OK
+let a = [ 2..7 ] // integers
+let b = [ one..two ] // identifiers
+let c = [ ..9 ] // also when there is only one expression
+let d = [ 0.7 .. 9.2 ] // doubles
+let e = [ 2L .. number / 2L ] // complex expression
+let f = [| A.B .. C.D |] // identifiers with dots
+let g = [ .. (39 - 3) ] // complex expression
+let h = [| 1 .. MyModule.SomeConst |] // not all expressions are atomic
+
+for x in 1..2 do
+    printfn " x = %d" x
+
+let s = seq { 0..10..100 }
+
+// ❌ Not OK
+let a = [ 2 .. 7 ]
+let b = [ one .. two ]
+```
+
+These rules also apply to slicing:
+
+```fsharp
+// ✔️ OK
+arr[0..10]
+```
+
 ### Formatting if expressions
 
 Indentation of conditionals depends on the size and complexity of the expressions that make them up.

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -552,6 +552,7 @@ These rules also apply to slicing:
 ```fsharp
 // ✔️ OK
 arr[0..10]
+list.[..^1]
 ```
 
 ### Formatting if expressions


### PR DESCRIPTION
## Summary

As discussed, @dsyme let me know if some things need a tweak.
I'm not sure `single word identifiers` is a good term there.

Fixes #26646
