### PR TITLE
Fix snippet from F# lang-ref functions chapter

### DIFF
--- a/samples/snippets/fsharp/lang-ref-1/snippet101.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet101.fs
@@ -1,7 +1,7 @@
 let list1 = [ 1; 2; 3]
 // Error: duplicate definition.
 let list1 = []
-let function1 =
+let function1 () =
    let list1 = [1; 2; 3]
    let list1 = []
    list1


### PR DESCRIPTION

## Summary

In https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/functions/
you can find this snippet; however, before this change, `function1` wasn't really
a function, but a value.

