### PR TITLE
Adjust wording to avoid future tense

### DIFF
--- a/includes/core-changes/aspnetcore/3.0/sharedfx-app-shared-framework-assemblies.md
+++ b/includes/core-changes/aspnetcore/3.0/sharedfx-app-shared-framework-assemblies.md
@@ -43,18 +43,18 @@ For more information on the motivation for this change, see [this blog post](htt
 
 #### Recommended action
 
-It won't be necessary for projects to consume assemblies in `Microsoft.AspNetCore.App` as NuGet packages. To simplify the targeting and usage of the ASP.NET Core shared framework, many NuGet packages shipped since ASP.NET Core 1.0 are no longer produced. The APIs those packages provide are still available to apps by using a `<FrameworkReference>` to `Microsoft.AspNetCore.App`. Common API examples include Kestrel, MVC, and Razor.
+Starting with ASP.NET Core 3.0, it is no longer necessary for projects to consume assemblies in `Microsoft.AspNetCore.App` as NuGet packages. To simplify the targeting and usage of the ASP.NET Core shared framework, many NuGet packages shipped since ASP.NET Core 1.0 are no longer produced. The APIs those packages provide are still available to apps by using a `<FrameworkReference>` to `Microsoft.AspNetCore.App`. Common API examples include Kestrel, MVC, and Razor.
 
 This change doesn't apply to all binaries referenced via `Microsoft.AspNetCore.App` in ASP.NET Core 2.x. Notable exceptions include:
 
-- `Microsoft.Extensions` libraries that continue to target .NET Standard will be available as NuGet packages (see <https://github.com/dotnet/extensions>).
+- `Microsoft.Extensions` libraries that continue to target .NET Standard are available as NuGet packages (see <https://github.com/dotnet/extensions>).
 - APIs produced by the ASP.NET Core team that aren't part of `Microsoft.AspNetCore.App`. For example, the following components are available as NuGet packages:
   - Entity Framework Core
   - APIs that provide third-party integration
   - Experimental features
   - APIs with dependencies that couldn't [fulfill the requirements to be in the shared framework](https://github.com/dotnet/aspnetcore/blob/4e44e5bcbedd961cc0d4f6b846699c7c494f5597/docs/SharedFramework.md)
-- Extensions to MVC that maintain support for Json.NET. An API will be provided as a NuGet package to support using Json.NET and MVC.
-- The SignalR .NET client will continue to support .NET Standard and ship as a NuGet package. It's intended for use on many .NET runtimes, such as Xamarin and UWP.
+- Extensions to MVC that maintain support for Json.NET. An API is provided as [a NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson) to support using Json.NET and MVC. See the [ASP.NET Core migration guide for more details](/aspnet/core/migration/22-to-30#newtonsoftjson-jsonnet-support).
+- The SignalR .NET client continues to support .NET Standard and ships as [a NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client). It's intended for use on many .NET runtimes, such as Xamarin and UWP.
 
 For more information, see [Stop producing packages for shared framework assemblies in 3.0](https://github.com/dotnet/aspnetcore/issues/3756). For discussion, see [dotnet/aspnetcore#3757](https://github.com/dotnet/aspnetcore/issues/3757).
 


### PR DESCRIPTION
Since the changes were already made in the past, adjust the wording to document the current state instead of hinting at a planned future.

Fixes #18483.

---

There are probably lots of other similar changes necessary in all those other documented changes. It might be a good idea to discuss how to generally document these in a way that they don’t sound outdated as soon as the release hits.