### PR TITLE
fixed Json.NET casing

### DIFF
--- a/docs/framework/data/adonet/dataset-datatable-dataview/security-guidance.md
+++ b/docs/framework/data/adonet/dataset-datatable-dataview/security-guidance.md
@@ -445,7 +445,7 @@ In these cases, the threat model and security guarantees are the same as the [Da
 
 ## Deserialize a DataSet or DataTable via JsonConvert
 
-The popular third-party Newtonsoft library [JSON.NET](https://www.newtonsoft.com/json) can be used to deserialize `DataSet` and `DataTable` instances, as shown in the following code:
+The popular third-party Newtonsoft library [Json.NET](https://www.newtonsoft.com/json) can be used to deserialize `DataSet` and `DataTable` instances, as shown in the following code:
 
 ```csharp
 using System.Data;

--- a/docs/fsharp/get-started/get-started-command-line.md
+++ b/docs/fsharp/get-started/get-started-command-line.md
@@ -58,7 +58,7 @@ open Newtonsoft.Json
 
 let getJsonNetJson value =
     let json = JsonConvert.SerializeObject(value)
-    $"I used to be {value} but now I'm {json} thanks to JSON.NET!"
+    $"I used to be {value} but now I'm {json} thanks to Json.NET!"
 ```
 
 Add the Newtonsoft.Json NuGet package to the Library project.
@@ -105,7 +105,7 @@ open Library
 
 [<EntryPoint>]
 let main argv =
-    printfn "Nice command-line arguments! Here's what JSON.NET has to say about them:"
+    printfn "Nice command-line arguments! Here's what Json.NET has to say about them:"
 
     for arg in argv do
         let value = getJsonNetJson arg
@@ -138,10 +138,10 @@ dotnet run Hello World
 You should see the following results:
 
 ```console
-Nice command-line arguments! Here's what JSON.NET has to say about them:
+Nice command-line arguments! Here's what Json.NET has to say about them:
 
-I used to be Hello but now I'm ""Hello"" thanks to JSON.NET!
-I used to be World but now I'm ""World"" thanks to JSON.NET!
+I used to be Hello but now I'm ""Hello"" thanks to Json.NET!
+I used to be World but now I'm ""World"" thanks to Json.NET!
 ```
 
 ## Next steps

--- a/docs/standard/linq/index.md
+++ b/docs/standard/linq/index.md
@@ -105,7 +105,7 @@ End Function
 
 Writing code to manually traverse the XML document to do this task would be far more challenging.
 
-Interacting with XML isn't the only thing you can do with LINQ Providers. [Linq to SQL](../../framework/data/adonet/sql/linq/index.md) is a fairly bare-bones Object-Relational Mapper (ORM) for an MSSQL Server Database. The [JSON.NET](https://www.newtonsoft.com/json/help/html/LINQtoJSON.htm) library provides efficient JSON Document traversal via LINQ. Furthermore, if there isn't a library that does what you need, you can also [write your own LINQ Provider](/previous-versions/visualstudio/visual-studio-2012/bb546158(v=vs.110))!
+Interacting with XML isn't the only thing you can do with LINQ Providers. [Linq to SQL](../../framework/data/adonet/sql/linq/index.md) is a fairly bare-bones Object-Relational Mapper (ORM) for an MSSQL Server Database. The [Json.NET](https://www.newtonsoft.com/json/help/html/LINQtoJSON.htm) library provides efficient JSON Document traversal via LINQ. Furthermore, if there isn't a library that does what you need, you can also [write your own LINQ Provider](/previous-versions/visualstudio/visual-studio-2012/bb546158(v=vs.110))!
 
 ## Reasons to use the query syntax
 


### PR DESCRIPTION
I noticed that Json.NET was not always spelled in the official way, so I changed it to use the correct name according to https://www.newtonsoft.com/json
