### PR TITLE
Add clarification on resolution to CS0169 example

### DIFF
--- a/docs/csharp/misc/cs0169.md
+++ b/docs/csharp/misc/cs0169.md
@@ -21,8 +21,16 @@ The private field 'class member' is never used
 using System;  
 public class ClassX  
 {  
-   int i;   // CS0169, i is not used anywhere  
-  
+   int i;   // CS0169, i is not used anywhere
+   // Remove the above variable declaration or uncomment TestMethod to clear warning CS0169
+   /*
+   public void TestMethod()    
+   {
+       i = 5;
+       System.Console.WriteLine(i);
+   }
+   */
+   
    public static void Main()  
    {  
    }  


### PR DESCRIPTION
## Summary

Added notes on removal of variable or uncommenting sample method that uses the variable to clear warning

Fixes #26448