### PR TITLE
Remove 'preview'

### DIFF
--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -6,7 +6,7 @@ ms.date: 07/07/2021
 ---
 # dotnet nuget sign
 
-**This article applies to:** ✔️ .NET 6.0 Preview 5 SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -101,7 +101,7 @@ To run the application, the `dotnet run` command resolves the dependencies of th
 
   Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
 
-  The [`-p` abbreviation for `--project` is deprecated](../compatibility/sdk/6.0/deprecate-p-option-dotnet-run.md) starting in .NET 6 Preview SDK. For a limited time starting in .NET 6 RC1 SDK, `-p` can still be used for `--project` despite the deprecation warning. If the argument provided for the option doesn't contain `=`, the command accepts `-p` as short for `--project`. Otherwise, the command assumes that `-p` is short for `--property`. This flexible use of `-p` for `--project` will be phased out in .NET 7.
+  The [`-p` abbreviation for `--project` is deprecated](../compatibility/sdk/6.0/deprecate-p-option-dotnet-run.md) starting in .NET 6 SDK. For a limited time starting in .NET 6 RC1 SDK, `-p` can still be used for `--project` despite the deprecation warning. If the argument provided for the option doesn't contain `=`, the command accepts `-p` as short for `--project`. Otherwise, the command assumes that `-p` is short for `--property`. This flexible use of `-p` for `--project` will be phased out in .NET 7.
 
 - **`--property:<NAME>=<VALUE>`**
 

--- a/docs/core/tools/dotnet-sdk-check.md
+++ b/docs/core/tools/dotnet-sdk-check.md
@@ -5,7 +5,7 @@ ms.date: 06/30/2021
 ---
 # dotnet sdk check
 
-**This article applies to:** ✔️ .NET 6 (preview) and later versions
+**This article applies to:** ✔️ .NET 6 and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -76,7 +76,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates a sequence file in `TestResults/<Guid>/<Guid>_Sequence.xml` that captures the order of tests that were run before the crash.
 
-- **`--blame-crash`** (Available since .NET 5.0 preview SDK)
+- **`--blame-crash`** (Available since .NET 5.0 SDK)
 
   Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
   
@@ -86,23 +86,23 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
   
   To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the `VSTEST_DUMP_FORCEPROCDUMP` environment variable to `1`.
 
-- **`--blame-crash-dump-type <DUMP_TYPE>`** (Available since .NET 5.0 preview SDK)
+- **`--blame-crash-dump-type <DUMP_TYPE>`** (Available since .NET 5.0 SDK)
 
   The type of crash dump to be collected. Implies `--blame-crash`.
 
-- **`--blame-crash-collect-always`** (Available since .NET 5.0 preview SDK)
+- **`--blame-crash-collect-always`** (Available since .NET 5.0 SDK)
 
   Collects a crash dump on expected as well as unexpected test host exit.
 
-- **`--blame-hang`** (Available since .NET 5.0 preview SDK)
+- **`--blame-hang`** (Available since .NET 5.0 SDK)
 
   Run the tests in blame mode and collects a hang dump when a test exceeds the given timeout.
 
-- **`--blame-hang-dump-type <DUMP_TYPE>`** (Available since .NET 5.0 preview SDK)
+- **`--blame-hang-dump-type <DUMP_TYPE>`** (Available since .NET 5.0 SDK)
 
   The type of crash dump to be collected. It should be `full`, `mini`, or `none`. When `none` is specified, test host is terminated on timeout, but no dump is collected. Implies `--blame-hang`.
 
-- **`--blame-hang-timeout <TIMESPAN>`** (Available since .NET 5.0 preview SDK)
+- **`--blame-hang-timeout <TIMESPAN>`** (Available since .NET 5.0 SDK)
 
   Per-test timeout, after which a hang dump is triggered and the test host process and all of its child processes are dumped and terminated. The timeout value is specified in one of the following formats:
   

--- a/docs/core/tools/dotnet-workload-install.md
+++ b/docs/core/tools/dotnet-workload-install.md
@@ -5,7 +5,7 @@ ms.date: 09/10/2021
 ---
 # dotnet workload install
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 
@@ -41,7 +41,7 @@ The `dotnet workload` commands operate in the context of specific SDK versions. 
 
 The names and versions of the assets that a workload installation requires are maintained in *manifests*. By default, the `dotnet workload install` command downloads the latest available manifests before it installs a workload. The local copy of a manifest then provides the information needed to find and download the assets for a workload.
 
-The `dotnet workload list` command compares the versions of installed workloads with the currently available versions.  When it finds that a version newer than the installed version is available, it advertises that fact in the command output. These newer-version notifications in `dotnet workload list` are available starting in .NET 6 Preview 7.
+The `dotnet workload list` command compares the versions of installed workloads with the currently available versions.  When it finds that a version newer than the installed version is available, it advertises that fact in the command output. These newer-version notifications in `dotnet workload list` are available starting in .NET 6.
 
 To enable these notifications, the latest available versions of the manifests are downloaded and stored as *advertising manifests*.  These downloads happen asynchronously in the background when any of the following commands are run.
 
@@ -56,7 +56,7 @@ If a command finishes before the manifest download finishes, the download is sto
 
 You can prevent the `dotnet workload install` command from doing manifest downloads by using the `--skip-manifest-update` option.
 
-The `dotnet workload update` command also downloads advertising manifests. The downloads are required to learn if an update is available, so there is no option to prevent them from running. However, you can use the `--advertising-manifests-only` option to skip workload updates and only do the manifest downloads. This option is available starting in .NET 6 Preview 7.
+The `dotnet workload update` command also downloads advertising manifests. The downloads are required to learn if an update is available, so there is no option to prevent them from running. However, you can use the `--advertising-manifests-only` option to skip workload updates and only do the manifest downloads. This option is available starting in .NET 6.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-workload-list.md
+++ b/docs/core/tools/dotnet-workload-list.md
@@ -5,7 +5,7 @@ ms.date: 08/31/2021
 ---
 # dotnet workload list
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-workload-repair.md
+++ b/docs/core/tools/dotnet-workload-repair.md
@@ -5,7 +5,7 @@ ms.date: 08/31/2021
 ---
 # dotnet workload repair
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-workload-restore.md
+++ b/docs/core/tools/dotnet-workload-restore.md
@@ -5,7 +5,7 @@ ms.date: 09/10/2021
 ---
 # dotnet workload restore
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-workload-search.md
+++ b/docs/core/tools/dotnet-workload-search.md
@@ -5,7 +5,7 @@ ms.date: 08/31/2021
 ---
 # dotnet workload search
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-workload-uninstall.md
+++ b/docs/core/tools/dotnet-workload-uninstall.md
@@ -5,7 +5,7 @@ ms.date: 07/08/2021
 ---
 # dotnet workload uninstall
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-workload-update.md
+++ b/docs/core/tools/dotnet-workload-update.md
@@ -5,7 +5,7 @@ ms.date: 09/10/2021
 ---
 # dotnet workload update
 
-**This article applies to:** ✔️ .NET 6 Preview SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 ## Name
 

--- a/docs/standard/serialization/system-text-json-customize-properties.md
+++ b/docs/standard/serialization/system-text-json-customize-properties.md
@@ -17,11 +17,6 @@ ms.topic: how-to
 
 # How to customize property names and values with System.Text.Json
 
-:::zone pivot="dotnet-6-0"
-> [!IMPORTANT]
-> Some information relates to prerelease product that may be substantially modified before it's released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
-:::zone-end
-
 :::zone pivot="dotnet-6-0,dotnet-5-0,dotnet-core-3-1"
 By default, property names and dictionary keys are unchanged in the JSON output, including case. Enum values are represented as numbers. In this article, you'll learn how to:
 ::: zone-end

--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -16,11 +16,6 @@ ms.topic: how-to
 
 # How to migrate from Newtonsoft.Json to System.Text.Json
 
-:::zone pivot="dotnet-6-0"
-> [!IMPORTANT]
-> Some information relates to prerelease product that may be substantially modified before it's released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
-:::zone-end
-
 This article shows how to migrate from [Newtonsoft.Json](https://www.newtonsoft.com/json) to <xref:System.Text.Json>.
 
 The `System.Text.Json` namespace provides functionality for serializing to and deserializing from JavaScript Object Notation (JSON). The `System.Text.Json` library is included in the runtime for [.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet/3.1) and later versions. For other target frameworks, install the [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) NuGet package. The package supports:

--- a/docs/standard/serialization/system-text-json-source-generation-modes.md
+++ b/docs/standard/serialization/system-text-json-source-generation-modes.md
@@ -15,9 +15,6 @@ ms.topic: how-to
 # How to choose reflection or source generation in System.Text.Json
 
 :::zone pivot="dotnet-6-0"
-> [!IMPORTANT]
-> Some information relates to prerelease product that may be substantially modified before it's released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
-
 By default, `System.Text.Json` uses run-time reflection to gather the metadata it needs to access properties of objects for serialization and deserialization. As an alternative, `System.Text.Json` 6.0 can use the C# [source generation](../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../core/deploying/trimming/trim-self-contained.md), which reduces app size.
 
 You can use version 6.0 of System.Text.Json in projects that target earlier frameworks. For more information, see [How to get the library](system-text-json-overview.md#how-to-get-the-library).

--- a/docs/standard/serialization/system-text-json-source-generation.md
+++ b/docs/standard/serialization/system-text-json-source-generation.md
@@ -18,8 +18,6 @@ ms.topic: how-to
 # How to use source generation in System.Text.Json
 
 :::zone pivot="dotnet-6-0"
-> [!IMPORTANT]
-> Some information relates to prerelease product that may be substantially modified before it's released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
 
 This article shows how to use the source generation features of [System.Text.Json](system-text-json-overview.md).
 :::zone-end

--- a/docs/standard/serialization/system-text-json-use-dom-utf8jsonreader-utf8jsonwriter.md
+++ b/docs/standard/serialization/system-text-json-use-dom-utf8jsonreader-utf8jsonwriter.md
@@ -17,11 +17,6 @@ ms.topic: how-to
 
 # How to use a JSON document, Utf8JsonReader, and Utf8JsonWriter in System.Text.Json
 
-:::zone pivot="dotnet-6-0"
-> [!IMPORTANT]
-> Some information relates to prerelease product that may be substantially modified before it's released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
-:::zone-end
-
 This article shows how to use:
 
 * A [JSON Document Object Model (DOM)](#json-dom-choices) for random access to data in a JSON payload.

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -42,9 +42,9 @@ groups:
   title: .NET version
   prompt: Choose a .NET version
   pivots:
+    - id: dotnet-6-0
+      title: .NET 6
     - id: dotnet-5-0
       title: .NET 5
     - id: dotnet-core-3-1
       title: .NET Core 3.1
-    - id: dotnet-6-0
-      title: .NET 6

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -47,4 +47,4 @@ groups:
     - id: dotnet-core-3-1
       title: .NET Core 3.1
     - id: dotnet-6-0
-      title: .NET 6 Preview
+      title: .NET 6


### PR DESCRIPTION
For GA release, removes "preview" after .NET 6 and removes prelease warning alert boxes.