### PR TITLE
Add improved definite assignment

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -65,6 +65,9 @@ void FindRoot(Node node, Action<Node> processNode)
 
 The previous code doesn't generate any warnings for dereferencing the variable `current`. Static analysis determines that `current` is never dereferenced when it's *maybe-null*. The variable `current` is checked against `null` before `current.Parent` is accessed, and before passing `current` to the `ProcessNode` action. The previous examples show how the compiler determines *null-state* for local variables when initialized, assigned, or compared to `null`.
 
+> [!NOTE]
+> A number of improvements to definite assignment and null state analysis were added in C# 10. When you upgrade to C# 10, you may find fewer nullable warnings that are false positives. You can learn more about the improvements in the [features specification for definite assignment improvements](~/_csharplang/proposals/csharp-10.0/improved-definite-assignment.md).
+
 ## Attributes on API signatures
 
 The null state analysis needs hints from developers to understand the semantics of APIs. Some APIs provide null checks, and should change the *null-state* of a variable from *maybe-null* to *not-null*. Other APIs return expressions that are *not-null* or *maybe-null* depending on the *null-state* of the input arguments. For example, consider the following code that displays a message:

--- a/docs/csharp/whats-new/csharp-10.md
+++ b/docs/csharp/whats-new/csharp-10.md
@@ -115,7 +115,7 @@ int x = 0;
 
 ## Improved definite assignment
 
-There were a number of scenarios were definite assignment, and null-state analysis produced warnings that were false positives. These generally involved comparisons to boolean constants, accessing a variable only in the `true` or `false` statements in an `if` statement, and null coalescing expressions. These examples generate warnings in previous versions of C#, but don't in C# 10:
+Prior to C# 10, there were a number of scenarios where definite assignment and null-state analysis produced warnings that were false positives. These generally involved comparisons to boolean constants, accessing a variable only in the `true` or `false` statements in an `if` statement, and null coalescing expressions. These examples generated warnings in previous versions of C#, but don't in C# 10:
 
 ```csharp
 string? representation;

--- a/docs/csharp/whats-new/csharp-10.md
+++ b/docs/csharp/whats-new/csharp-10.md
@@ -18,6 +18,7 @@ C# 10.0 adds the following features and enhancements to the C# language:
 - [Extended property patterns](#extended-property-patterns)
 - [Allow `const` interpolated strings](#constant-interpolated-strings)
 - [Record types can seal `ToString()`](#record-types-can-seal-tostring)
+- [Improved definite assignment](#improved-definite-assignment)
 - [Allow both assignment and declaration in the same deconstruction](#assignment-and-declaration-in-same-deconstruction)
 - [Allow `AsyncMethodBuilder` attribute on methods](#allow-asyncmethodbuilder-attribute-on-methods)
 
@@ -111,6 +112,32 @@ int x = 0;
 
 > [!NOTE]
 > When using .NET 6.0 preview 5, this feature requires setting the `<LangVersion>` element in your *csproj* file to `preview`.
+
+## Improved definite assignment
+
+There were a number of scenarios were definite assignment, and null-state analysis produced warnings that were false positives. These generally involved comparisons to boolean constants, accessing a variable only in the `true` or `false` statements in an `if` statement, and null coalescing expressions. These examples generate warnings in previous versions of C#, but don't in C# 10:
+
+```csharp
+string? representation;
+if ((c != null) && c.GetDependentValue(out object obj)) == true)
+{
+   representation = obj.ToString(); // undesired error
+}
+
+// Or, using ?.
+if (c?.GetDependentValue(out object obj) == true)
+{
+   representation = obj.ToString(); // undesired error
+}
+
+// Or, using ??
+if (c?.GetDependentValue(out object obj) ?? false)
+{
+   representation = obj.ToString(); // undesired error
+}
+```
+
+The main impact of this improvement is that the warnings for definite assignment and null-state analysis are more accurate.
 
 ## Allow AsyncMethodBuilder attribute on methods
 


### PR DESCRIPTION
Fixes #25671

This is a smaller PR. The main impact of the feature is that existing warning diagnostics are more accurate.
