### PR TITLE
Update Sentiment Analysis Tutorial to .NET 6

### DIFF
--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Analyze website comments - binary classification'
 description: This tutorial shows you how to create a .NET Core console application that classifies sentiment from website comments and takes the appropriate action. The binary sentiment classifier uses C# in Visual Studio.
-ms.date: 06/30/2020
+ms.date: 11/03/2021
 ms.topic: tutorial
 ms.custom: mvc
 recommendations: false
@@ -26,17 +26,19 @@ You can find the source code for this tutorial at the [dotnet/samples](https://g
 
 ## Prerequisites
 
-- [Visual Studio 2017 version 15.6 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the ".NET Core cross-platform development" workload installed
+- [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/).
 
 - [UCI Sentiment Labeled Sentences dataset](https://archive.ics.uci.edu/ml/machine-learning-databases/00331/sentiment%20labelled%20sentences.zip) (ZIP file)
 
 ## Create a console application
 
-1. Create a **.NET Core Console Application** called "SentimentAnalysis".
+1. Create a C# **Console Application** called "SentimentAnalysis". Click the **Next** button.
 
-2. Create a directory named *Data* in your project to save your data set files.
+2. Choose .NET 6 as the framework to use. Click the **Create** button.
 
-3. Install the **Microsoft.ML NuGet Package**:
+3. Create a directory named *Data* in your project to save your data set files.
+
+4. Install the **Microsoft.ML NuGet Package**:
 
     [!INCLUDE [mlnet-current-nuget-version](../../../includes/mlnet-current-nuget-version.md)]
 

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Analyze website comments - binary classification'
 description: This tutorial shows you how to create a .NET Core console application that classifies sentiment from website comments and takes the appropriate action. The binary sentiment classifier uses C# in Visual Studio.
-ms.date: 11/03/2021
+ms.date: 11/04/2021
 ms.topic: tutorial
 ms.custom: mvc
 recommendations: false

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -9,7 +9,7 @@ recommendations: false
 ---
 # Tutorial: Analyze sentiment of website comments with binary classification in ML.NET
 
-This tutorial shows you how to create a .NET Core console application that classifies sentiment from website comments and takes the appropriate action. The binary sentiment classifier uses C# in Visual Studio 2017.
+This tutorial shows you how to create a .NET Core console application that classifies sentiment from website comments and takes the appropriate action. The binary sentiment classifier uses C# in Visual Studio 2022.
 
 In this tutorial, you learn how to:
 > [!div class="checklist"]

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -61,7 +61,7 @@ You can find the source code for this tutorial at the [dotnet/samples](https://g
 
     [!code-csharp[AddUsings](./snippets/sentiment-analysis/csharp/Program.cs#AddUsings "Add necessary usings")]
 
-1. Add the following code to the line right above the `Main` method, to create a field to hold the recently downloaded dataset file path:
+1. Add the following code to the line right below the `using` statements, to create a field to hold the recently downloaded dataset file path:
 
     [!code-csharp[Declare global variables](./snippets/sentiment-analysis/csharp/Program.cs#DeclareGlobalVariables "Declare global variables")]
 
@@ -104,18 +104,18 @@ The [MLContext class](xref:Microsoft.ML.MLContext) is a starting point for all M
 
 You prepare the app, and then load data:
 
-1. Replace the `Console.WriteLine("Hello World!")` line in the `Main` method with the following code to declare and initialize the mlContext variable:
+1. Replace the `Console.WriteLine("Hello World!")` line with the following code to declare and initialize the mlContext variable:
 
     [!code-csharp[CreateMLContext](./snippets/sentiment-analysis/csharp/Program.cs#CreateMLContext "Create the ML Context")]
 
-2. Add the following as the next line of code in the `Main()` method:
+2. Add the following as the next line of code:
 
     [!code-csharp[CallLoadData](./snippets/sentiment-analysis/csharp/Program.cs#CallLoadData)]
 
-3. Create the `LoadData()` method, just after the `Main()` method, using the following code:
+3. Create a `LoadData()` method at the bottom of the `Program.cs` file using the following code:
 
     ```csharp
-    public static TrainTestData LoadData(MLContext mlContext)
+    TrainTestData LoadData(MLContext mlContext)
     {
 
     }
@@ -149,7 +149,7 @@ When preparing a model, you use part of the dataset to train it and part of the 
 
 ## Build and train the model
 
-1. Add the following call to the `BuildAndTrainModel`method as the next line of code in the `Main()` method:
+1. Add the following call to the `BuildAndTrainModel`method below the call to the `LoadData` method:
 
     [!code-csharp[CallBuildAndTrainModel](./snippets/sentiment-analysis/csharp/Program.cs#CallBuildAndTrainModel)]
 
@@ -160,10 +160,10 @@ When preparing a model, you use part of the dataset to train it and part of the 
     - Predicts sentiment based on test data.
     - Returns the model.
 
-2. Create the `BuildAndTrainModel()` method, just after the `Main()` method, using the following code:
+2. Create the `BuildAndTrainModel()` method, below the `LoadData()` method, using the following code:
 
     ```csharp
-    public static ITransformer BuildAndTrainModel(MLContext mlContext, IDataView splitTrainSet)
+    ITransformer BuildAndTrainModel(MLContext mlContext, IDataView splitTrainSet)
     {
 
     }
@@ -215,7 +215,7 @@ After your model is trained, use your test data to validate the model's performa
 1. Create the `Evaluate()` method, just after `BuildAndTrainModel()`, with the following code:
 
     ```csharp
-    public static void Evaluate(MLContext mlContext, ITransformer model, IDataView splitTestSet)
+    void Evaluate(MLContext mlContext, ITransformer model, IDataView splitTestSet)
     {
 
     }
@@ -228,7 +228,7 @@ After your model is trained, use your test data to validate the model's performa
     - Evaluates the model and creates metrics.
     - Displays the metrics.
 
-2. Add a call to the new method from the `Main()` method, right under the `BuildAndTrainModel()` method call, using the following code:
+2. Add a call to the new method below the `BuildAndTrainModel` method call using the following code:
 
     [!code-csharp[CallEvaluate](./snippets/sentiment-analysis/csharp/Program.cs#CallEvaluate "Call the Evaluate method")]
 
@@ -261,7 +261,7 @@ Use the following code to display the metrics:
 1. Create the `UseModelWithSingleItem()` method, just after the `Evaluate()` method, using the following code:
 
     ```csharp
-    private static void UseModelWithSingleItem(MLContext mlContext, ITransformer model)
+    void UseModelWithSingleItem(MLContext mlContext, ITransformer model)
     {
 
     }
@@ -274,7 +274,7 @@ Use the following code to display the metrics:
     - Combines test data and predictions for reporting.
     - Displays the predicted results.
 
-2. Add a call to the new method from the `Main()` method, right under the `Evaluate()` method call, using the following code:
+2. Add a call to the new method right under the `Evaluate()` method call using the following code:
 
     [!code-csharp[CallUseModelWithSingleItem](./snippets/sentiment-analysis/csharp/Program.cs#CallUseModelWithSingleItem "Call the UseModelWithSingleItem method")]
 
@@ -308,7 +308,7 @@ Use the following code to display the metrics:
 1. Create the `UseModelWithBatchItems()` method, just after the `UseModelWithSingleItem()` method, using the following code:
 
     ```csharp
-    public static void UseModelWithBatchItems(MLContext mlContext, ITransformer model)
+    void UseModelWithBatchItems(MLContext mlContext, ITransformer model)
     {
 
     }
@@ -321,7 +321,7 @@ Use the following code to display the metrics:
     - Combines test data and predictions for reporting.
     - Displays the predicted results.
 
-2. Add a call to the new method from the `Main` method, right under the `UseModelWithSingleItem()` method call, using the following code:
+2. Add a call to the new method right under the `UseModelWithSingleItem()` method call using the following code:
 
     [!code-csharp[CallPredictModelBatchItems](./snippets/sentiment-analysis/csharp/Program.cs#CallUseModelWithBatchItems "Call the CallUseModelWithBatchItems method")]
 

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
@@ -1,211 +1,197 @@
 ﻿// <SnippetAddUsings>
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using SentimentAnalysisTutorial;
 using static Microsoft.ML.DataOperationsCatalog;
-using Microsoft.ML.Trainers;
-using Microsoft.ML.Transforms.Text;
 // </SnippetAddUsings>
 
-namespace SentimentAnalysis
+// <SnippetDeclareGlobalVariables>
+string _dataPath = Path.Combine(Environment.CurrentDirectory, "Data", "yelp_labelled.txt");
+// </SnippetDeclareGlobalVariables>
+
+// Create ML.NET context/local environment - allows you to add steps in order to keep everything together
+// as you discover the ML.NET trainers and transforms
+// <SnippetCreateMLContext>
+MLContext mlContext = new MLContext();
+// </SnippetCreateMLContext>
+
+// <SnippetCallLoadData>
+TrainTestData splitDataView = LoadData(mlContext);
+// </SnippetCallLoadData>
+
+// <SnippetCallBuildAndTrainModel>
+ITransformer model = BuildAndTrainModel(mlContext, splitDataView.TrainSet);
+// </SnippetCallBuildAndTrainModel>
+
+// <SnippetCallEvaluate>
+Evaluate(mlContext, model, splitDataView.TestSet);
+// </SnippetCallEvaluate>
+
+// <SnippetCallUseModelWithSingleItem>
+UseModelWithSingleItem(mlContext, model);
+// </SnippetCallUseModelWithSingleItem>
+
+// <SnippetCallUseModelWithBatchItems>
+UseModelWithBatchItems(mlContext, model);
+// </SnippetCallUseModelWithBatchItems>
+
+Console.WriteLine();
+Console.WriteLine("=============== End of process ===============");
+
+TrainTestData LoadData(MLContext mlContext)
 {
-    class Program
+    // Note that this case, loading your training data from a file,
+    // is the easiest way to get started, but ML.NET also allows you
+    // to load data from databases or in-memory collections.
+    // <SnippetLoadData>
+    IDataView dataView = mlContext.Data.LoadFromTextFile<SentimentData>(_dataPath, hasHeader: false);
+    // </SnippetLoadData>
+
+    // You need both a training dataset to train the model and a test dataset to evaluate the model.
+    // Split the loaded dataset into train and test datasets
+    // Specify test dataset percentage with the `testFraction`parameter
+    // <SnippetSplitData>
+    TrainTestData splitDataView = mlContext.Data.TrainTestSplit(dataView, testFraction: 0.2);
+    // </SnippetSplitData>
+
+    // <SnippetReturnSplitData>
+    return splitDataView;
+    // </SnippetReturnSplitData>
+}
+
+ITransformer BuildAndTrainModel(MLContext mlContext, IDataView splitTrainSet)
+{
+    // Create a flexible pipeline (composed by a chain of estimators) for creating/training the model.
+    // This is used to format and clean the data.
+    // Convert the text column to numeric vectors (Features column)
+    // <SnippetFeaturizeText>
+    var estimator = mlContext.Transforms.Text.FeaturizeText(outputColumnName: "Features", inputColumnName: nameof(SentimentData.SentimentText))
+    //</SnippetFeaturizeText>
+    // append the machine learning task to the estimator
+    // <SnippetAddTrainer>
+    .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(labelColumnName: "Label", featureColumnName: "Features"));
+    // </SnippetAddTrainer>
+
+    // Create and train the model based on the dataset that has been loaded, transformed.
+    // <SnippetTrainModel>
+    Console.WriteLine("=============== Create and Train the Model ===============");
+    var model = estimator.Fit(splitTrainSet);
+    Console.WriteLine("=============== End of training ===============");
+    Console.WriteLine();
+    // </SnippetTrainModel>
+
+    // Returns the model we trained to use for evaluation.
+    // <SnippetReturnModel>
+    return model;
+    // </SnippetReturnModel>
+}
+
+void Evaluate(MLContext mlContext, ITransformer model, IDataView splitTestSet)
+{
+    // Evaluate the model and show accuracy stats
+
+    //Take the data in, make transformations, output the data.
+    // <SnippetTransformData>
+    Console.WriteLine("=============== Evaluating Model accuracy with Test data===============");
+    IDataView predictions = model.Transform(splitTestSet);
+    // </SnippetTransformData>
+
+    // BinaryClassificationContext.Evaluate returns a BinaryClassificationEvaluator.CalibratedResult
+    // that contains the computed overall metrics.
+    // <SnippetEvaluate>
+    CalibratedBinaryClassificationMetrics metrics = mlContext.BinaryClassification.Evaluate(predictions, "Label");
+    // </SnippetEvaluate>
+
+    // The Accuracy metric gets the accuracy of a model, which is the proportion
+    // of correct predictions in the test set.
+
+    // The AreaUnderROCCurve metric is equal to the probability that the algorithm ranks
+    // a randomly chosen positive instance higher than a randomly chosen negative one
+    // (assuming 'positive' ranks higher than 'negative').
+
+    // The F1Score metric gets the model's F1 score.
+    // The F1 score is the harmonic mean of precision and recall:
+    //  2 * precision * recall / (precision + recall).
+
+    // <SnippetDisplayMetrics>
+    Console.WriteLine();
+    Console.WriteLine("Model quality metrics evaluation");
+    Console.WriteLine("--------------------------------");
+    Console.WriteLine($"Accuracy: {metrics.Accuracy:P2}");
+    Console.WriteLine($"Auc: {metrics.AreaUnderRocCurve:P2}");
+    Console.WriteLine($"F1Score: {metrics.F1Score:P2}");
+    Console.WriteLine("=============== End of model evaluation ===============");
+    //</SnippetDisplayMetrics>
+}
+
+void UseModelWithSingleItem(MLContext mlContext, ITransformer model)
+{
+    // <SnippetCreatePredictionEngine1>
+    PredictionEngine<SentimentData, SentimentPrediction> predictionFunction = mlContext.Model.CreatePredictionEngine<SentimentData, SentimentPrediction>(model);
+    // </SnippetCreatePredictionEngine1>
+
+    // <SnippetCreateTestIssue1>
+    SentimentData sampleStatement = new SentimentData
     {
-        // <SnippetDeclareGlobalVariables>
-        static readonly string _dataPath = Path.Combine(Environment.CurrentDirectory, "Data", "yelp_labelled.txt");
-        // </SnippetDeclareGlobalVariables>
+        SentimentText = "This was a very bad steak"
+    };
+    // </SnippetCreateTestIssue1>
 
-        static void Main(string[] args)
+    // <SnippetPredict>
+    var resultPrediction = predictionFunction.Predict(sampleStatement);
+    // </SnippetPredict>
+    // <SnippetOutputPrediction>
+    Console.WriteLine();
+    Console.WriteLine("=============== Prediction Test of model with a single sample and test dataset ===============");
+
+    Console.WriteLine();
+    Console.WriteLine($"Sentiment: {resultPrediction.SentimentText} | Prediction: {(Convert.ToBoolean(resultPrediction.Prediction) ? "Positive" : "Negative")} | Probability: {resultPrediction.Probability} ");
+
+    Console.WriteLine("=============== End of Predictions ===============");
+    Console.WriteLine();
+    // </SnippetOutputPrediction>
+}
+
+void UseModelWithBatchItems(MLContext mlContext, ITransformer model)
+{
+    // Adds some comments to test the trained model's data points.
+    // <SnippetCreateTestIssues>
+    IEnumerable<SentimentData> sentiments = new[]
+    {
+        new SentimentData
         {
-            // Create ML.NET context/local environment - allows you to add steps in order to keep everything together
-            // as you discover the ML.NET trainers and transforms
-            // <SnippetCreateMLContext>
-            MLContext mlContext = new MLContext();
-            // </SnippetCreateMLContext>
-
-            // <SnippetCallLoadData>
-            TrainTestData splitDataView = LoadData(mlContext);
-            // </SnippetCallLoadData>
-
-            // <SnippetCallBuildAndTrainModel>
-            ITransformer model = BuildAndTrainModel(mlContext, splitDataView.TrainSet);
-            // </SnippetCallBuildAndTrainModel>
-
-            // <SnippetCallEvaluate>
-            Evaluate(mlContext, model, splitDataView.TestSet);
-            // </SnippetCallEvaluate>
-
-            // <SnippetCallUseModelWithSingleItem>
-            UseModelWithSingleItem(mlContext, model);
-            // </SnippetCallUseModelWithSingleItem>
-
-            // <SnippetCallUseModelWithBatchItems>
-            UseModelWithBatchItems(mlContext, model);
-            // </SnippetCallUseModelWithBatchItems>
-
-            Console.WriteLine();
-            Console.WriteLine("=============== End of process ===============");
-        }
-
-        public static TrainTestData LoadData(MLContext mlContext)
+            SentimentText = "This was a horrible meal"
+        },
+        new SentimentData
         {
-            // Note that this case, loading your training data from a file,
-            // is the easiest way to get started, but ML.NET also allows you
-            // to load data from databases or in-memory collections.
-            // <SnippetLoadData>
-            IDataView dataView = mlContext.Data.LoadFromTextFile<SentimentData>(_dataPath, hasHeader: false);
-            // </SnippetLoadData>
-
-            // You need both a training dataset to train the model and a test dataset to evaluate the model.
-            // Split the loaded dataset into train and test datasets
-            // Specify test dataset percentage with the `testFraction`parameter
-            // <SnippetSplitData>
-            TrainTestData splitDataView = mlContext.Data.TrainTestSplit(dataView, testFraction: 0.2);
-            // </SnippetSplitData>
-
-            // <SnippetReturnSplitData>
-            return splitDataView;
-            // </SnippetReturnSplitData>
+            SentimentText = "I love this spaghetti."
         }
+    };
+    // </SnippetCreateTestIssues>
 
-        public static ITransformer BuildAndTrainModel(MLContext mlContext, IDataView splitTrainSet)
-        {
-            // Create a flexible pipeline (composed by a chain of estimators) for creating/training the model.
-            // This is used to format and clean the data.
-            // Convert the text column to numeric vectors (Features column)
-            // <SnippetFeaturizeText>
-            var estimator = mlContext.Transforms.Text.FeaturizeText(outputColumnName: "Features", inputColumnName: nameof(SentimentData.SentimentText))
-            //</SnippetFeaturizeText>
-            // append the machine learning task to the estimator
-            // <SnippetAddTrainer>
-            .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(labelColumnName: "Label", featureColumnName: "Features"));
-            // </SnippetAddTrainer>
+    // Load batch comments just created
+    // <SnippetPrediction>
+    IDataView batchComments = mlContext.Data.LoadFromEnumerable(sentiments);
 
-            // Create and train the model based on the dataset that has been loaded, transformed.
-            // <SnippetTrainModel>
-            Console.WriteLine("=============== Create and Train the Model ===============");
-            var model = estimator.Fit(splitTrainSet);
-            Console.WriteLine("=============== End of training ===============");
-            Console.WriteLine();
-            // </SnippetTrainModel>
+    IDataView predictions = model.Transform(batchComments);
 
-            // Returns the model we trained to use for evaluation.
-            // <SnippetReturnModel>
-            return model;
-            // </SnippetReturnModel>
-        }
+    // Use model to predict whether comment data is Positive (1) or Negative (0).
+    IEnumerable<SentimentPrediction> predictedResults = mlContext.Data.CreateEnumerable<SentimentPrediction>(predictions, reuseRowObject: false);
+    // </SnippetPrediction>
 
-        public static void Evaluate(MLContext mlContext, ITransformer model, IDataView splitTestSet)
-        {
-            // Evaluate the model and show accuracy stats
+    // <SnippetAddInfoMessage>
+    Console.WriteLine();
 
-            //Take the data in, make transformations, output the data.
-            // <SnippetTransformData>
-            Console.WriteLine("=============== Evaluating Model accuracy with Test data===============");
-            IDataView predictions = model.Transform(splitTestSet);
-            // </SnippetTransformData>
+    Console.WriteLine("=============== Prediction Test of loaded model with multiple samples ===============");
+    // </SnippetAddInfoMessage>
 
-            // BinaryClassificationContext.Evaluate returns a BinaryClassificationEvaluator.CalibratedResult
-            // that contains the computed overall metrics.
-            // <SnippetEvaluate>
-            CalibratedBinaryClassificationMetrics metrics = mlContext.BinaryClassification.Evaluate(predictions, "Label");
-            // </SnippetEvaluate>
+    Console.WriteLine();
 
-            // The Accuracy metric gets the accuracy of a model, which is the proportion
-            // of correct predictions in the test set.
-
-            // The AreaUnderROCCurve metric is equal to the probability that the algorithm ranks
-            // a randomly chosen positive instance higher than a randomly chosen negative one
-            // (assuming 'positive' ranks higher than 'negative').
-
-            // The F1Score metric gets the model's F1 score.
-            // The F1 score is the harmonic mean of precision and recall:
-            //  2 * precision * recall / (precision + recall).
-
-            // <SnippetDisplayMetrics>
-            Console.WriteLine();
-            Console.WriteLine("Model quality metrics evaluation");
-            Console.WriteLine("--------------------------------");
-            Console.WriteLine($"Accuracy: {metrics.Accuracy:P2}");
-            Console.WriteLine($"Auc: {metrics.AreaUnderRocCurve:P2}");
-            Console.WriteLine($"F1Score: {metrics.F1Score:P2}");
-            Console.WriteLine("=============== End of model evaluation ===============");
-            //</SnippetDisplayMetrics>
-        }
-
-        private static void UseModelWithSingleItem(MLContext mlContext, ITransformer model)
-        {
-            // <SnippetCreatePredictionEngine1>
-            PredictionEngine<SentimentData, SentimentPrediction> predictionFunction = mlContext.Model.CreatePredictionEngine<SentimentData, SentimentPrediction>(model);
-            // </SnippetCreatePredictionEngine1>
-
-            // <SnippetCreateTestIssue1>
-            SentimentData sampleStatement = new SentimentData
-            {
-                SentimentText = "This was a very bad steak"
-            };
-            // </SnippetCreateTestIssue1>
-
-            // <SnippetPredict>
-            var resultPrediction = predictionFunction.Predict(sampleStatement);
-            // </SnippetPredict>
-            // <SnippetOutputPrediction>
-            Console.WriteLine();
-            Console.WriteLine("=============== Prediction Test of model with a single sample and test dataset ===============");
-
-            Console.WriteLine();
-            Console.WriteLine($"Sentiment: {resultPrediction.SentimentText} | Prediction: {(Convert.ToBoolean(resultPrediction.Prediction) ? "Positive" : "Negative")} | Probability: {resultPrediction.Probability} ");
-
-            Console.WriteLine("=============== End of Predictions ===============");
-            Console.WriteLine();
-            // </SnippetOutputPrediction>
-        }
-
-        public static void UseModelWithBatchItems(MLContext mlContext, ITransformer model)
-        {
-            // Adds some comments to test the trained model's data points.
-            // <SnippetCreateTestIssues>
-            IEnumerable<SentimentData> sentiments = new[]
-            {
-                new SentimentData
-                {
-                    SentimentText = "This was a horrible meal"
-                },
-                new SentimentData
-                {
-                    SentimentText = "I love this spaghetti."
-                }
-            };
-            // </SnippetCreateTestIssues>
-
-            // Load batch comments just created
-            // <SnippetPrediction>
-            IDataView batchComments = mlContext.Data.LoadFromEnumerable(sentiments);
-
-            IDataView predictions = model.Transform(batchComments);
-
-            // Use model to predict whether comment data is Positive (1) or Negative (0).
-            IEnumerable<SentimentPrediction> predictedResults = mlContext.Data.CreateEnumerable<SentimentPrediction>(predictions, reuseRowObject: false);
-            // </SnippetPrediction>
-
-            // <SnippetAddInfoMessage>
-            Console.WriteLine();
-
-            Console.WriteLine("=============== Prediction Test of loaded model with multiple samples ===============");
-            // </SnippetAddInfoMessage>
-
-            Console.WriteLine();
-
-            // <SnippetDisplayResults>
-            foreach (SentimentPrediction prediction  in predictedResults)
-            {
-                Console.WriteLine($"Sentiment: {prediction.SentimentText} | Prediction: {(Convert.ToBoolean(prediction.Prediction) ? "Positive" : "Negative")} | Probability: {prediction.Probability} ");
-            }
-            Console.WriteLine("=============== End of predictions ===============");
-            // </SnippetDisplayResults>
-        }
+    // <SnippetDisplayResults>
+    foreach (SentimentPrediction prediction  in predictedResults)
+    {
+        Console.WriteLine($"Sentiment: {prediction.SentimentText} | Prediction: {(Convert.ToBoolean(prediction.Prediction) ? "Positive" : "Negative")} | Probability: {prediction.Probability} ");
     }
+    Console.WriteLine("=============== End of predictions ===============");
+    // </SnippetDisplayResults>
 }

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
@@ -1,5 +1,6 @@
 ﻿// <SnippetAddUsings>
 using System;
+using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using SentimentAnalysis;

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
@@ -1,7 +1,7 @@
 ﻿// <SnippetAddUsings>
 using Microsoft.ML;
 using Microsoft.ML.Data;
-using SentimentAnalysisTutorial;
+using SentimentAnalysis;
 using static Microsoft.ML.DataOperationsCatalog;
 // </SnippetAddUsings>
 

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
@@ -1,7 +1,4 @@
 ﻿// <SnippetAddUsings>
-using System;
-using System.IO;
-using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using SentimentAnalysis;

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
@@ -1,5 +1,6 @@
 ﻿// <SnippetAddUsings>
 using System;
+using System.IO;
 using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.Data;

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/Program.cs
@@ -1,4 +1,5 @@
 ﻿// <SnippetAddUsings>
+using System;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using SentimentAnalysis;

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
@@ -6,10 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.ML" Version="1.6.0" />
   </ItemGroup>

--- a/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
+++ b/docs/machine-learning/tutorials/snippets/sentiment-analysis/csharp/SentimentAnalysis.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the sentiment analysis tutorial with the ML.NET API to .NET 6.

Updates #26778.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/tutorials/sentiment-analysis?branch=pr-en-us-26824)