### PR TITLE
Worker service updates

### DIFF
--- a/docs/core/deploying/trimming/trim-warnings/il2042.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2042.md
@@ -29,7 +29,7 @@ public Type MyProperty
 // To fix this annotate the accessors manually:
 public Type MyProperty
 {
-  [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicMethods)] 
+  [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicMethods)]
   get { return GetTheValue(); }
 
   [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicMethods)]

--- a/docs/core/deploying/trimming/trim-warnings/il2055.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2055.md
@@ -24,7 +24,7 @@ the trimmer currently cannot validate that the requirements are fulfilled by the
 ## Example
 
 ```C#
-class Lazy<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicParameterlessConstructor)] T> 
+class Lazy<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicParameterlessConstructor)] T>
 {
     // ...
 }

--- a/docs/core/deploying/trimming/trim-warnings/il2056.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2056.md
@@ -30,7 +30,7 @@ explicitly annotated with <xref:System.Runtime.CompilerServices.CompilerGenerate
 Type backingField;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-Type PropertyWithAnnotatedBackingField 
+Type PropertyWithAnnotatedBackingField
 {
   get { return backingField; }
   set { backingField = value; }

--- a/docs/core/deploying/trimming/trim-warnings/il2059.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2059.md
@@ -24,7 +24,7 @@ cannot guarantee the availability of the target static constructor.
 ```C#
 void TestMethod(Type type)
 {
-    // IL2059 Trim analysis: Unrecognized value passed to the parameter 'type' of method 'System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)'. 
+    // IL2059 Trim analysis: Unrecognized value passed to the parameter 'type' of method 'System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)'.
     // It's not possible to guarantee the availability of the target static constructor.
     RuntimeHelpers.RunClassConstructor(type.TypeHandle);
 }

--- a/docs/core/extensions/windows-service.md
+++ b/docs/core/extensions/windows-service.md
@@ -3,7 +3,7 @@ title: Create a Windows Service using BackgroundService
 description: Learn how to create a Windows Service using the BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/04/2021
+ms.date: 11/05/2021
 ms.topic: tutorial
 ---
 
@@ -56,6 +56,14 @@ After successfully adding the packages, your project file should now contain the
 
 :::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="13-17" highlight="2-4":::
 
+## Update project file
+
+This worker project makes use of C#'s [nullable reference types](../../csharp/nullable-references.md). To enable them for the entire project, update the project file accordingly:
+
+:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="1-7,11-18" highlight="6":::
+
+The preceding project file changes add the `<Nullable>enable<Nullable>` node. For more information, see [Setting the nullable context](../../csharp/language-reference/builtin-types/nullable-reference-types#setting-the-nullable-context).
+
 ## Create the service
 
 Add a new class to the project named *JokeService.cs*, and replace its contents with the following C# code:
@@ -106,7 +114,14 @@ For more information on registering services, see [Dependency injection in .NET]
 
 ## Publish the app
 
-To create the .NET Worker Service app as a Windows Service, it will need to be published as a single file executable.
+To create the .NET Worker Service app as a Windows Service, it's recommended that you publish the app as a single file executable. It's less error-prone to have a self-contained executable, as there aren't any dependent files lying around the file system. But you may choose a different publishing modality, which is perfectly acceptable, so long as you create an _*.exe_ file that can be targeted by the Windows Service Control Manager.
+
+> [!IMPORTANT]
+> An alternative publishing approach is to build the _*.dll_ (instead of an _*.exe_), and when you install the published app using the Windows Service Control Manager you delegate to the .NET CLI and pass the DLL. For more information, see [.NET CLI: dotnet command](../tools/dotnet.md).
+>
+> ```powershell
+> sc.exe create ".NET Joke Service" binpath="C:\Path\To\dotnet.exe C:\Path\To\App.WindowsService.dll"
+> ```
 
 :::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" highlight="7-10":::
 

--- a/docs/core/extensions/windows-service.md
+++ b/docs/core/extensions/windows-service.md
@@ -62,7 +62,7 @@ This worker project makes use of C#'s [nullable reference types](../../csharp/nu
 
 :::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="1-7,11-18" highlight="6":::
 
-The preceding project file changes add the `<Nullable>enable<Nullable>` node. For more information, see [Setting the nullable context](../../csharp/language-reference/builtin-types/nullable-reference-types#setting-the-nullable-context).
+The preceding project file changes add the `<Nullable>enable<Nullable>` node. For more information, see [Setting the nullable context](../../csharp/language-reference/builtin-types/nullable-reference-types.md#setting-the-nullable-context).
 
 ## Create the service
 

--- a/docs/core/tools/dotnet-new-list.md
+++ b/docs/core/tools/dotnet-new-list.md
@@ -86,7 +86,7 @@ The `dotnet new --list` option lists available templates to use with `dotnet new
   - before .NET SDK 6.0.100
 
   ```dotnetcli
-  dotnet new spa --list 
+  dotnet new spa --list
   ```
 
 - List all templates matching the *we* substring.
@@ -99,7 +99,7 @@ The `dotnet new --list` option lists available templates to use with `dotnet new
   - before .NET SDK 6.0.100
   
   ```dotnetcli
-  dotnet new we --list 
+  dotnet new we --list
   ```
 
 - List all templates matching the *we* substring that support the F# language.

--- a/docs/core/tools/dotnet-new-search.md
+++ b/docs/core/tools/dotnet-new-search.md
@@ -90,7 +90,7 @@ The `dotnet new --search` option searches for templates supported by `dotnet new
   - before .NET SDK 6.0.100
 
   ```dotnetcli
-  dotnet new spa --search 
+  dotnet new spa --search
   ```
 
 - Search for all templates available on NuGet.org matching the *we* substring and supporting the F# language.

--- a/docs/core/tutorials/cli-templates-create-template-package.md
+++ b/docs/core/tutorials/cli-templates-create-template-package.md
@@ -154,7 +154,7 @@ If you uploaded the NuGet package to a NuGet feed, you can use the `dotnet new -
 No matter how you installed the template package, either with the _.nupkg_ file directly or by NuGet feed, removing a template package is the same. Use the `<PackageId>` of the template you want to uninstall. You can get a list of templates that are installed by running the `dotnet new --uninstall` command.
 
 ```dotnetcli
-C:\working> dotnet new --uninstall 
+C:\working> dotnet new --uninstall
 
 Template Instantiation Commands for .NET CLI
 

--- a/docs/core/tutorials/top-level-templates.md
+++ b/docs/core/tutorials/top-level-templates.md
@@ -99,13 +99,13 @@ While a .NET 6 console app template will generate the new style of top-level sta
 
     ```diff
     <Project Sdk="Microsoft.NET.Sdk">
-    
+
       <PropertyGroup>
         <OutputType>Exe</OutputType>
     -   <TargetFramework>net5.0</TargetFramework>
     +   <TargetFramework>net6.0</TargetFramework>
       </PropertyGroup>
-    
+
     </Project>
     ```
 
@@ -113,14 +113,14 @@ While a .NET 6 console app template will generate the new style of top-level sta
 
     ```diff
     <Project Sdk="Microsoft.NET.Sdk">
-    
+
       <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
     +   <ImplicitUsings>enable</ImplicitUsings>
     +   <Nullable>enable</Nullable>
       </PropertyGroup>
-    
+
     </Project>
     ```
 
@@ -138,13 +138,13 @@ When you create a new console project in Visual Studio, you're prompted with a d
 
     ```diff
     <Project Sdk="Microsoft.NET.Sdk">
-    
+
       <PropertyGroup>
         <OutputType>Exe</OutputType>
     -   <TargetFramework>net5.0</TargetFramework>
     +   <TargetFramework>net6.0</TargetFramework>
       </PropertyGroup>
-    
+
     </Project>
     ```
 
@@ -156,14 +156,14 @@ When you create a new console project in Visual Studio, you're prompted with a d
 
     ```diff
     <Project Sdk="Microsoft.NET.Sdk">
-    
+
       <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
     +   <ImplicitUsings>enable</ImplicitUsings>
     +   <Nullable>enable</Nullable>
       </PropertyGroup>
-    
+
     </Project>
     ```
 

--- a/docs/csharp/misc/cs0169.md
+++ b/docs/csharp/misc/cs0169.md
@@ -24,13 +24,13 @@ public class ClassX
    int i;   // CS0169, i is not used anywhere
    // Remove the above variable declaration or uncomment TestMethod to clear warning CS0169
    /*
-   public void TestMethod()    
+   public void TestMethod()
    {
        i = 5;
        System.Console.WriteLine(i);
    }
    */
-   
+
    public static void Main()  
    {  
    }  

--- a/docs/csharp/misc/cs0815.md
+++ b/docs/csharp/misc/cs0815.md
@@ -31,7 +31,7 @@ class Test
     public static int Main()  
     {  
         var d = s => -1; // CS0815  
-        var e = (string s) => 0; // CS0815 for C# versions before 10 
+        var e = (string s) => 0; // CS0815 for C# versions before 10
         var p = null; // CS0815  
         var del = delegate(string a) { return -1; }; // CS0815  
         return -1;  

--- a/docs/csharp/programming-guide/file-system/how-to-read-a-text-file-one-line-at-a-time.md
+++ b/docs/csharp/programming-guide/file-system/how-to-read-a-text-file-one-line-at-a-time.md
@@ -19,7 +19,7 @@ This example reads the contents of a text file, one line at a time, into a strin
 int counter = 0;  
   
 // Read the file and display it line by line.  
-foreach (string line in System.IO.File.ReadLines(@"c:\test.txt")) 
+foreach (string line in System.IO.File.ReadLines(@"c:\test.txt"))
 {  
     System.Console.WriteLine(line);  
     counter++;  

--- a/docs/fsharp/language-reference/computation-expressions.md
+++ b/docs/fsharp/language-reference/computation-expressions.md
@@ -299,7 +299,7 @@ module Eventually =
         | Done value -> func value
         | NotYetDone work -> NotYetDone (fun () -> bind func (work()))
 
-    /// Return the final value 
+    /// Return the final value
     let result value = Done value
 
     /// The catch for the computations. Stitch try/with throughout
@@ -386,7 +386,7 @@ let comp =
             printfn $" x = %d{x}"
         return 3 + 4
     }
-    
+
 /// Try the remaining lines in F# interactive to see how this
 /// computation expression works in practice.
 let step x = Eventually.step x

--- a/docs/fsharp/language-reference/functions/entry-point.md
+++ b/docs/fsharp/language-reference/functions/entry-point.md
@@ -21,7 +21,7 @@ let printSomeText() =
 let showCommandLineArgs() =
     for arg in Environment.GetCommandLineArgs() do
         printfn $"arg = {arg}"
-    
+
 printSomeText()
 showCommandLineArgs()
 exit 100

--- a/docs/fsharp/language-reference/task-expressions.md
+++ b/docs/fsharp/language-reference/task-expressions.md
@@ -91,7 +91,7 @@ By default, .NET tasks are scheduled using <xref:System.Threading.Synchronizatio
 In practice, it's often desirable that library code generating tasks ignores the synchronization context and instead always switches to the .NET thread pool, if necessary. This can be achieved using `backgroundTask { }`:
 
 ```fsharp
-backgroundTask { expression }    
+backgroundTask { expression }
 ```
 
 A background task ignores any `SynchronizationContext.Current` in the following sense: if started on a thread with non-null `SynchronizationContext.Current`, it switches to a background thread in the thread pool using `Task.Run`. If started on a thread with null `SynchronizationContext.Current`, it executes on that same thread.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1850.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1850.md
@@ -48,7 +48,7 @@ public bool CheckHash(byte[] buffer)
 {
   using (var sha256 = SHA256.Create())
   {
-    byte[] digest = sha256.ComputeHash(buffer);    
+    byte[] digest = sha256.ComputeHash(buffer);
     return DoesHashExist(digest);
   }
 }

--- a/docs/fundamentals/package-validation/compatible-framework-validator.md
+++ b/docs/fundamentals/package-validation/compatible-framework-validator.md
@@ -27,7 +27,7 @@ For example, consider the following scenario. You're working on a library involv
 The resulting package structure looks as follows.
 
 ```xml
-lib/net6.0/A.dll 
+lib/net6.0/A.dll
 runtimes/unix/lib/net6.0/A.dll
 ```
 
@@ -59,7 +59,7 @@ You realize your mistake and add `A.B.Open(string)` to the Unix runtime as well.
     {
         // call unix specific stuff
     }
-    
+
     public static void Open(string path)
     {
         throw new PlatformNotSupportedException();

--- a/docs/machine-learning/tutorials/movie-recommendation-model-builder.md
+++ b/docs/machine-learning/tutorials/movie-recommendation-model-builder.md
@@ -136,7 +136,7 @@ When adding a console app to your solution, you will be prompted to name the pro
     UserId: 1
     MovieId: 1
     Rating: 4
-    
+
     Predicted Rating: 4.577113
     ```
 

--- a/docs/standard/native-interop/tutorial-comwrappers.md
+++ b/docs/standard/native-interop/tutorial-comwrappers.md
@@ -174,7 +174,7 @@ s_DemoImplDefinition = entries;
 The allocation of vtables and entries for the Managed Object Wrapper can and should be done ahead of time since the data can be used for all instances of the type. The work here could be performed in a `static` constructor or a module initializer, but it should be done ahead of time so the `ComputeVtables()` method is as simple and quick as possible.
 
 ```csharp
-protected override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, 
+protected override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags,
 out int count)
 {
     if (obj is DemoImpl)

--- a/docs/visual-basic/programming-guide/concepts/caller-information.md
+++ b/docs/visual-basic/programming-guide/concepts/caller-information.md
@@ -79,7 +79,7 @@ End Sub
 You use the <xref:System.Runtime.CompilerServices.CallerArgumentExpressionAttribute?displayProperty=nameWithType> when you want to capture the expression used for an argument. Diagnostic libraries may want to provide more details about the *expressions* passed as an arguments. By providing the expression that triggered the diagnostic, in addition to the parameter name, developers have more details about the condition that triggered the diagnostic. That extra information makes it easier to fix. The following method uses the <xref:System.Runtime.CompilerServices.CallerArgumentExpressionAttribute> to display the condition that must be `True`:
 
 ```vb
-Public Shared Sub ValidateArgument(ByVal parameterName As String, 
+Public Shared Sub ValidateArgument(ByVal parameterName As String,
 ByVal condition As Boolean,
 <CallerArgumentExpression("condition")> ByVal Optional message As String? = Nothing)
     If Not condition Then


### PR DESCRIPTION
## Summary

Address two customer concerns:

- The #nullable warnings were triggered as the article didn't instruct the reader to enable nullable context, updated to include that step.
- The wording was adjusted to state that it is only a recommendation to use the single file executable, and provided the reasoning. Additionally, alternative publishing approaches were highlighted.
- Local Pre-commit hook, applied automatic markdownlint CLI fixes

Fixes #26809
Fixes #26736

## Preview

✔️ [Create a Windows Service using `BackgroundService`](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/windows-service?branch=pr-en-us-26836)