### PR TITLE
dotnet 6.0 update to Hub pages

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -292,10 +292,6 @@ additionalContent:
         summary: API reference documentation for .NET
         url: ../api/index.md?view=net-6.0
       # Card
-      - title: ".NET Core API reference"
-        summary: API reference documentation for .NET Core
-        url: ../api/index.md?view=netcore-3.1&preserve-view=true
-      # Card
       - title: ".NET Framework API reference"
         summary: API reference documentation for .NET Framework
         url: ../api/index.md?view=netframework-4.8&preserve-view=true

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -123,7 +123,7 @@ conceptualContent:
         - url: core/compatibility/index.md
           itemType: concept
           text: .NET breaking changes
-        - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-5.0&preserve-view=true
+        - url: /dotnet/desktop/wpf/get-started/create-app-visual-studio?view=netdesktop-6.0&preserve-view=true
           itemType: tutorial
           text: Create .NET desktop apps for Windows
     # Card
@@ -216,7 +216,7 @@ additionalContent:
             text: Windows Presentation Foundation (.NET 5+)
           - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Presentation Foundation (.NET Framework)
-          - url: /dotnet/desktop/winforms/?view=netdesktop-5.0&preserve-view=true
+          - url: /dotnet/desktop/winforms/?view=netdesktop-6.0&preserve-view=true
             text: Windows Forms (.NET 5+)
           - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Forms (.NET Framework)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -40,13 +40,13 @@ highlightedContent:
       itemType: learn
       url: /learn/dotnet/
     # Card
-    - title: "What's new in .NET docs"
-      itemType: whats-new
-      url: whats-new/index.yml
-    # Card
     - title: "Interactive introduction to C#"
       itemType: get-started
       url: csharp/tour-of-csharp/tutorials/hello-world.yml
+    # Card
+    - title: "What's new in .NET docs"
+      itemType: whats-new
+      url: whats-new/index.yml
 
 # conceptualContent section (optional)
 conceptualContent:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 06/22/2021
+  ms.date: 11/04/2021
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -40,10 +40,6 @@ highlightedContent:
       itemType: learn
       url: /learn/dotnet/
     # Card
-    - title: "Azure for .NET developers"
-      itemType: overview
-      url: azure/index.yml
-    # Card
     - title: "What's new in .NET docs"
       itemType: whats-new
       url: whats-new/index.yml
@@ -67,9 +63,9 @@ conceptualContent:
         - url: core/tutorials/index.md
           itemType: tutorial
           text: .NET tutorials
-        - url: core/dotnet-five.md
+        - url: core/dotnet-6.md
           itemType: whats-new
-          text: What's new in .NET 5
+          text: What's new in .NET 6
         - url: core/deploying/index.md
           itemType: deploy
           text: Deploy .NET apps
@@ -211,14 +207,12 @@ additionalContent:
             text: Xamarin.Android
           - url: /azure/developer/mobile-apps
             text: Develop Xamarin apps with Azure
-          - url: /dotnet/maui
-            text: .NET Multi-platform App UI (MAUI)
       # Card
       - title: Desktop
         links:
           - url: /uwp
             text: Universal Windows apps
-          - url: /dotnet/desktop/wpf/?view=netdesktop-5.0&preserve-view=true
+          - url: /dotnet/desktop/wpf/?view=netdesktop-6.0&preserve-view=true
             text: Windows Presentation Foundation (.NET 5+)
           - url: /dotnet/desktop/wpf/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Presentation Foundation (.NET Framework)
@@ -227,9 +221,7 @@ additionalContent:
           - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Forms (.NET Framework)
           - url: /xamarin/mac
-            text: Xamarin for macOS
-          - url: /dotnet/maui
-            text: .NET Multi-platform App UI (MAUI)          
+            text: Xamarin for macOS         
       # Card
       - title: Microservices
         links:
@@ -298,7 +290,7 @@ additionalContent:
       # Card
       - title: ".NET API reference"
         summary: API reference documentation for .NET
-        url: ../api/index.md?view=net-5.0
+        url: ../api/index.md?view=net-6.0
       # Card
       - title: ".NET Core API reference"
         summary: API reference documentation for .NET Core

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.collection: collection
   author: BillWagner
   ms.author: wiwagn
-  ms.date: 11/04/2021
+  ms.date: 11/05/2021
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -63,7 +63,7 @@ conceptualContent:
         - url: core/tutorials/index.md
           itemType: tutorial
           text: .NET tutorials
-        - url: core/dotnet-6.md
+        - url: core/whats-new/dotnet-6.md
           itemType: whats-new
           text: What's new in .NET 6
         - url: core/deploying/index.md


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/dotnet/?branch=pr-en-us-26869)

First round of immediate updates to align with .NET 6.0:
Contributes to #21005

- Updated links for What's New, reference and any other links where a .NET 6.0 specific topic is now available and the version has to be specified to get there.
- Reviewed past data for this hub page to see what might need a change.
- Reduced the number of top highlight links to reflect top most used links, and where top traffic is to be driven to.
- Removed original Maui links, new links will be added as owners provide new ones in a future PR.
