### PR TITLE
Fix text element count not starting at 1

### DIFF
--- a/docs/standard/base-types/snippets/character-encoding-introduction/csharp/InsertNewlines.cs
+++ b/docs/standard/base-types/snippets/character-encoding-introduction/csharp/InsertNewlines.cs
@@ -31,7 +31,7 @@ namespace RuneSamples
 
                 TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(input);
 
-                int textElementCount = 0;
+                int textElementCount = 1;
                 while (enumerator.MoveNext())
                 {
                     builder.Append(enumerator.Current);


### PR DESCRIPTION
When the code sample `InsertNewlinesEveryTenTextElements` is run, the first newline is 11 characters long when it is meant to be 10. This commit fixes that by making the `textElementCount` start at 1.
