### PR TITLE
Added more details about deconstruct

### DIFF
--- a/docs/csharp/fundamentals/functional/deconstruct.md
+++ b/docs/csharp/fundamentals/functional/deconstruct.md
@@ -1,7 +1,7 @@
 ---
 title: Deconstructing tuples and other types
 description: Learn how to deconstruct tuples and other types.
-ms.date: 06/30/2021
+ms.date: 11/10/2021
 ---
 # Deconstructing tuples and other types
 
@@ -92,7 +92,21 @@ If you didn't author a class, struct, or interface, you can still deconstruct ob
 
 The following example defines two `Deconstruct` extension methods for the <xref:System.Reflection.PropertyInfo?displayProperty=nameWithType> class. The first returns a set of values that indicate the characteristics of the property, including its type, whether it's static or instance, whether it's read-only, and whether it's indexed. The second indicates the property's accessibility. Because the accessibility of get and set accessors can differ, Boolean values indicate whether the property has separate get and set accessors and, if it does, whether they have the same accessibility. If there's only one accessor or both the get and the set accessor have the same accessibility, the `access` variable indicates the accessibility of the property as a whole. Otherwise, the accessibility of the get and set accessors are indicated by the `getAccess` and `setAccess` variables.
 
-[!code-csharp[Extension-deconstruct](./snippets/deconstructing-tuples/deconstruct-extension1.cs)]
+:::code source="./snippets/deconstructing-tuples/deconstruct-extension1.cs":::
+
+## Extension method for system types
+
+Some system types provide the `Deconstruct` method as a convenience. For example, the <xref:System.Collections.Generic.KeyValuePair%602?displayProperty=nameWithType> type provides this functionality. When you're iterating over a <xref:System.Collections.Generic.Dictionary%602?displayProperty=nameWithType> each element is a `KeyValuePair<TKey, TValue>` and can be deconstructed. Consider the following example:
+
+:::code source="./snippets/deconstructing-tuples/deconstruct-kvp.cs" id="KeyValuePair":::
+
+Not all type provide a `Deconstruct` methods as that's not practical, in fact very few types do. You may wish to add the `Deconstruct` method to various system types if deemed valuable. Consider the following extension method:
+
+:::code source="./snippets/deconstructing-tuples/deconstruct-extension2.cs" id="NullableExtensions":::
+
+This extension method allows all <xref:System.Nullable%601> types to be deconstructed into a tuple of `(bool hasValue, T value)`. Consider the following example:
+
+:::code source="./snippets/deconstructing-tuples/deconstruct-extension2.cs" id="NullableExample":::
 
 ## `record` types
 

--- a/docs/csharp/fundamentals/functional/deconstruct.md
+++ b/docs/csharp/fundamentals/functional/deconstruct.md
@@ -100,11 +100,11 @@ Some system types provide the `Deconstruct` method as a convenience. For example
 
 :::code source="./snippets/deconstructing-tuples/deconstruct-kvp.cs" id="KeyValuePair":::
 
-Not all type provide a `Deconstruct` methods as that's not practical, in fact very few types do. You may wish to add the `Deconstruct` method to various system types if deemed valuable. Consider the following extension method:
+You can add a `Deconstruct` method to system types that don't have one. Consider the following extension method:
 
 :::code source="./snippets/deconstructing-tuples/deconstruct-extension2.cs" id="NullableExtensions":::
 
-This extension method allows all <xref:System.Nullable%601> types to be deconstructed into a tuple of `(bool hasValue, T value)`. Consider the following example:
+This extension method allows all <xref:System.Nullable%601> types to be deconstructed into a tuple of `(bool hasValue, T value)`. The following example shows code that uses this extension method:
 
 :::code source="./snippets/deconstructing-tuples/deconstruct-extension2.cs" id="NullableExample":::
 

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/Program.cs
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/Program.cs
@@ -13,6 +13,8 @@ namespace deconstruction
             ExampleDiscard.Main();
             ExampleClassDeconstruction.Main();
             ExampleExtension.Main();
+            ExampleNullableEx.Main();
+            ExampleSystem.KeyValuePair();
         }
     }
 }

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-extension2.cs
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-extension2.cs
@@ -1,0 +1,38 @@
+using System;
+
+public class ExampleNullableEx
+{
+    public static void Main()
+    {
+        // <NullableExample>
+        DateTime? questionableDateTime = default;
+        var (hasValue, value) = questionableDateTime;
+        Console.WriteLine(
+            $"{{ HasValue = {hasValue}, Value = {value} }}");
+
+        questionableDateTime = DateTime.Now;
+        (hasValue, value) = questionableDateTime;
+        Console.WriteLine(
+            $"{{ HasValue = {hasValue}, Value = {value} }}");
+
+        // Example outputs:
+        // { HasValue = False, Value = 1/1/0001 12:00:00 AM }
+        // { HasValue = True, Value = 11/10/2021 6:11:45 PM }
+        // </NullableExample>
+    }
+}
+
+
+// <NullableExtensions>
+public static class NullableExtensions
+{
+    public static void Deconstruct<T>(
+        this T? nullable,
+        out bool hasValue,
+        out T value) where T : struct
+    {
+        hasValue = nullable.HasValue;
+        value = nullable.GetValueOrDefault();
+    }
+}
+// </NullableExtensions>

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-kvp.cs
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruct-kvp.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+public class ExampleSystem
+{
+    public static void KeyValuePair()
+    {
+        // <KeyValuePair>
+        Dictionary<string, int> snapshotCommitMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["https://github.com/dotnet/docs"] = 16_465,
+            ["https://github.com/dotnet/runtime"] = 114_223,
+            ["https://github.com/dotnet/installer"] = 22_436,
+            ["https://github.com/dotnet/roslyn"] = 79_484,
+            ["https://github.com/dotnet/aspnetcore"] = 48_386
+        };
+
+        foreach (var (repo, commitCount) in snapshotCommitMap)
+        {
+            Console.WriteLine(
+                $"The {repo} repository had {commitCount:N0} commits as of November 10th, 2021.");
+        }
+        // </KeyValuePair>
+    }
+}


### PR DESCRIPTION
## Summary

Added several examples of existing `Deconstruct` functionality in `System` types, and demonstrate how to add custom extension method for `System` types - specifically `Nullable`.

Fixes #20192

## Preview

✔️ [Deconstructing tuples and other types: Extension method for system types](https://review.docs.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/deconstruct?branch=pr-en-us-27017)