### PR TITLE
Remove redundant nullable operator

### DIFF
--- a/docs/csharp/whats-new/csharp-10.md
+++ b/docs/csharp/whats-new/csharp-10.md
@@ -119,7 +119,7 @@ int x = 0;
 Prior to C# 10, there were many scenarios where definite assignment and null-state analysis produced warnings that were false positives. These generally involved comparisons to boolean constants, accessing a variable only in the `true` or `false` statements in an `if` statement, and null coalescing expressions. These examples generated warnings in previous versions of C#, but don't in C# 10:
 
 ```csharp
-string? representation;
+string representation;
 if ((c != null) && c.GetDependentValue(out object obj)) == true)
 {
    representation = obj.ToString(); // undesired error

--- a/docs/csharp/whats-new/csharp-10.md
+++ b/docs/csharp/whats-new/csharp-10.md
@@ -119,7 +119,7 @@ int x = 0;
 Prior to C# 10, there were many scenarios where definite assignment and null-state analysis produced warnings that were false positives. These generally involved comparisons to boolean constants, accessing a variable only in the `true` or `false` statements in an `if` statement, and null coalescing expressions. These examples generated warnings in previous versions of C#, but don't in C# 10:
 
 ```csharp
-string representation;
+string representation = "N/A";
 if ((c != null) && c.GetDependentValue(out object obj)) == true)
 {
    representation = obj.ToString(); // undesired error


### PR DESCRIPTION
Removed redundant nullable operator for reference type. String is a reference type and always nullable,

## Summary

Removed redundant nullable operator for reference type. String is a reference type and always nullable,

Fixes #27021