### PR TITLE
Bump versions to .NET 6 and upgrade C# code to v10

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,6 +162,9 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
+# Namespace preference
+csharp_style_namespace_declarations = file_scoped
+
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = false:none

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,11 @@
         "XML",
         "YAML"
     ],
-    "git.ignoreLimitWarning": true
+    "git.ignoreLimitWarning": true,
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,11 +28,5 @@
         "XML",
         "YAML"
     ],
-    "git.ignoreLimitWarning": true,
-    "markdownlint.config": {
-        "MD028": false,
-        "MD025": {
-            "front_matter_title": ""
-        }
-    }
+    "git.ignoreLimitWarning": true
 }

--- a/docs/core/extensions/caching.md
+++ b/docs/core/extensions/caching.md
@@ -3,7 +3,7 @@ title: Caching in .NET
 description: Learn how to use various in-memory and distributed caching mechanisms in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/26/2021
+ms.date: 11/12/2021
 ---
 
 # Caching in .NET
@@ -49,19 +49,19 @@ Setting an expiration will cause entries in the cache to be *evicted* if they're
 
 To use the default <xref:Microsoft.Extensions.Caching.Memory.IMemoryCache> implementation, call the <xref:Microsoft.Extensions.DependencyInjection.MemoryCacheServiceCollectionExtensions.AddMemoryCache%2A> extension method to register all the required services with DI. In the following code sample, the generic host is used to expose the <xref:Microsoft.Extensions.Hosting.HostBuilder.ConfigureServices%2A> functionality:
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="3-9" highlight="6":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="1-7" highlight="6":::
 
 Depending on your .NET workload, you may access the `IMemoryCache` differently; such as constructor injection. In this sample, you use the `IServiceProvider` instance on the `host` and call generic <xref:Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService%60%601(System.IServiceProvider)> extension method:
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="11-12":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="9-10":::
 
 With in-memory caching services registered, and resolved through DI &mdash; you're ready to start caching. This sample iterates through the letters in the English alphabet 'A' through 'Z'. There is a `record` that holds the reference to the letter, and generates a message.
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="70-74":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="68-72":::
 
 The sample includes a helper function that iterates through the alphabet letters:
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="26-35":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="24-33":::
 
 In the preceding C# code:
 
@@ -70,7 +70,7 @@ In the preceding C# code:
 
 To add items to the cache call one of the `Create`, or `Set` APIs:
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="37-55" highlight="12-13":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="35-53" highlight="12-13":::
 
 In the preceding C# code:
 
@@ -86,11 +86,11 @@ For each letter in the alphabet, a cache entry is written with an expiration, an
 
 The post eviction callback writes the details of the value that was evicted to the console:
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="17-24":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="15-22":::
 
 Now that the cache is populated, another call to `IterateAlphabetAsync` is awaited, but this time you'll call <xref:Microsoft.Extensions.Caching.Memory.IMemoryCache.TryGetValue%2A?displayProperty=nameWithType>:
 
-:::code source="snippets/caching/memory-apis/Program.cs" range="57-66":::
+:::code source="snippets/caching/memory-apis/Program.cs" range="55-64":::
 
 If the `cache` contains the `letter` key, and the `value` is an instance of an `AlphabetLetter` it's written to the console. When the `letter` key is not in the cache, it was evicted and its post eviction callback was invoked.
 
@@ -188,7 +188,7 @@ Imagine you're developing a photo service that relies on third-party API accessi
 
 In the following example, you'll see several services being registered with DI. Each service has a single responsibility.
 
-:::code source="snippets/caching/memory-worker/Program.cs" range="1-18":::
+:::code source="snippets/caching/memory-worker/Program.cs" range="1-14":::
 
 In the preceding C# code:
 
@@ -270,9 +270,9 @@ To create values in the distributed cache, call one of the set APIs:
 
 Using the `AlphabetLetter` record from the in-memory cache example, you could serialize the object to JSON and then encode the `string` as a `byte[]`:
 
-:::code source="snippets/caching/distributed/Program.cs" range="41-51" highlight="7-9":::
+:::code source="snippets/caching/distributed/Program.cs" id="Create" highlight="7-9":::
 
-Much like in-memory caching, cache entries can have options to help fine tune their existence in the cache &mdash; in this case, the <xref:Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions>.
+Much like in-memory caching, cache entries can have options to help fine-tune their existence in the cache &mdash; in this case, the <xref:Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions>.
 
 ##### Create extension methods
 
@@ -288,7 +288,7 @@ To read values from the distributed cache, call one of the get APIs:
 - <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache.GetAsync%2A?displayProperty=nameWithType>
 - <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache.Get%2A?displayProperty=nameWithType>
 
-:::code source="snippets/caching/distributed/Program.cs" range="61-67" highlight="5-6":::
+:::code source="snippets/caching/distributed/Program.cs" id="Read" highlight="5-6":::
 
 Once a cache entry is read out of the cache, you can get the UTF8 encoded `string` representation from the `byte[]`
 

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -36,7 +36,7 @@ Overloads can specify:
 
 Consider the following code:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-37,41-43" highlight="21-27":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-37,43-44" highlight="21-27":::
 
 The preceding code:
 
@@ -62,11 +62,11 @@ Consider the `TransientFaultHandlingOptions` class defined as follows:
 
 The following code builds the configuration root, binds a section to the `TransientFaultHandlingOptions` class type, and prints the bound values to the console window:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="31-38":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="29-36":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="40-42":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" id="Output":::
 
 ### XML configuration provider
 
@@ -74,14 +74,14 @@ The <xref:Microsoft.Extensions.Configuration.Xml.XmlConfigurationProvider> class
 
 The following code demonstrates configuration of XML files using the XML configuration provider.
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-34,52,58-59" highlight="23-34":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-32,50,58-59" highlight="21-32":::
 
 The preceding code:
 
 - Clears all existing configuration providers that were added by default in the <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(System.String[])> method.
 - Configures the XML configuration provider to load the *appsettings.xml* and *repeating-example.xml* files with the following options:
   - `optional: true`: The file is optional.
-  - `reloadOnChange: true` : The file is reloaded when changes are saved.
+  - `reloadOnChange: true`: The file is reloaded when changes are saved.
 - Configures the environment variables configuration provider.
 - Configures the command-line configuration provider if the given `args` contains arguments.
 
@@ -97,11 +97,11 @@ In .NET 5 and earlier versions, add the `name` attribute to distinguish repeatin
 
 The following code reads the previous configuration file and displays the keys and values:
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="36-51":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="34-49":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="53-57":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" id="Output":::
 
 Attributes can be used to supply values:
 
@@ -126,7 +126,7 @@ The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> class
 
 The following code clears all the configuration providers and adds the `IniConfigurationProvider` with two INI files as the source:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-37,44-45" highlight="24-30":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-34,43-44" highlight="21-27":::
 
 An example *appsettings.ini* file with various configuration settings follows:
 
@@ -134,11 +134,11 @@ An example *appsettings.ini* file with various configuration settings follows:
 
 The following code displays the preceding configuration settings by writing them to the console window:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="32-36":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="29-33":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="38-43":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" id="Output":::
 
 ## Environment variable configuration provider
 
@@ -185,7 +185,7 @@ To test that the preceding commands override *appsettings.json* and *appsettings
 
 Call <xref:Microsoft.Extensions.Configuration.EnvironmentVariablesExtensions.AddEnvironmentVariables%2A> with a string to specify a prefix for environment variables:
 
-:::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="21-22":::
+:::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="20-21":::
 
 In the preceding code:
 
@@ -312,7 +312,7 @@ The <xref:Microsoft.Extensions.Configuration.Memory.MemoryConfigurationProvider>
 
 The following code adds a memory collection to the configuration system:
 
-:::code language="csharp" source="snippets/configuration/console-memory/Program.cs" highlight="22-29":::
+:::code language="csharp" source="snippets/configuration/console-memory/Program.cs" highlight="20-27":::
 
 In the preceding code, <xref:Microsoft.Extensions.Configuration.MemoryConfigurationBuilderExtensions.AddInMemoryCollection(Microsoft.Extensions.Configuration.IConfigurationBuilder,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}})?displayProperty=nameWithType> adds the memory provider after the default configuration providers. For an example of ordering the configuration providers, see [XML configuration provider](#xml-configuration-provider).
 

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -3,7 +3,7 @@ title: Configuration providers in .NET
 description: Learn how the Configuration provider API is used to configure .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 05/21/2021
+ms.date: 11/12/2021
 ms.topic: reference
 ---
 
@@ -36,14 +36,14 @@ Overloads can specify:
 
 Consider the following code:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-39,43-44" highlight="23-29":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-37,41-43" highlight="21-27":::
 
 The preceding code:
 
 - Clears all existing configuration providers that were added by default in the <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(System.String[])> method.
 - Configures the JSON configuration provider to load the *appsettings.json* and  *appsettings*.`Environment`.*json* files with the following options:
   - `optional: true`: The file is optional.
-  - `reloadOnChange: true` : The file is reloaded when changes are saved.
+  - `reloadOnChange: true`: The file is reloaded when changes are saved.
 
 The JSON settings are overridden by settings in the [Environment variables configuration provider](#environment-variable-configuration-provider) and the [Command-line configuration provider](#command-line-configuration-provider).
 

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -24,7 +24,7 @@ Configuration in .NET is performed using one or more [configuration providers](#
 
 New .NET console applications created using [dotnet new](../tools/dotnet-new.md) or Visual Studio by default *do not* expose configuration capabilities. To add configuration in a new .NET console application, [add a package reference](../tools/dotnet-add-package.md) to `Microsoft.Extensions.Hosting`. Modify the *Program.cs* file to match the following code:
 
-:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="18":::
+:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="17":::
 
 The <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(System.String[])?displayProperty=nameWithType> method provides default configuration for the app in the following order:
 

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -3,7 +3,7 @@ title: Configuration in .NET
 description: Learn how to use the Configuration API to configure .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/16/2020
+ms.date: 11/12/2021
 ms.topic: overview
 ---
 

--- a/docs/core/extensions/console-log-formatter.md
+++ b/docs/core/extensions/console-log-formatter.md
@@ -71,7 +71,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 By default, the `Simple` console log formatter is selected with default configuration. You change this by calling `AddJsonConsole` in the *Program.cs*:
 
-:::code language="csharp" source="snippets/logging/console-formatter-json/Program.cs" highlight="17-26":::
+:::code language="csharp" source="snippets/logging/console-formatter-json/Program.cs" highlight="14-22":::
 
 Run the app again, with the above change, the log message is now formatted as JSON:
 
@@ -103,7 +103,7 @@ To implement a custom formatter, you need to:
 
 Create an extension method to handle this for you:
 
-:::code language="csharp" source="snippets/logging/console-formatter-custom/ConsoleLoggerExtensions.cs" highlight="11-12":::
+:::code language="csharp" source="snippets/logging/console-formatter-custom/ConsoleLoggerExtensions.cs" highlight="10-11":::
 
 The `CustomOptions` are defined as follows:
 
@@ -121,7 +121,7 @@ The `AddConsoleFormatter` API:
 
 Define a `CustomerFormatter` subclass of `ConsoleFormatter`:
 
-:::code language="csharp" source="snippets/logging/console-formatter-custom/CustomFormatter.cs" highlight="24-45":::
+:::code language="csharp" source="snippets/logging/console-formatter-custom/CustomFormatter.cs" highlight="22-38":::
 
 The preceding `CustomFormatter.Write<TState>` API dictates what text gets wrapped around each log message. A standard `ConsoleFormatter` should be able to wrap around scopes, time stamps, and severity level of logs at a minimum. Additionally, you can encode ANSI colors in the log messages, and provide desired indentations as well. The implementation of the `CustomFormatter.Write<TState>` lacks these capabilities.
 
@@ -185,7 +185,7 @@ Next, write some extension methods in a `TextWriterExtensions` class that allow 
 
 A custom color formatter that handles applying custom colors could be defined as follows:
 
-:::code language="csharp" source="snippets/logging/console-formatter-custom/CustomColorFormatter.cs" highlight="15-18,52-65":::
+:::code language="csharp" source="snippets/logging/console-formatter-custom/CustomColorFormatter.cs" highlight="13-16,50-63":::
 
 When you run the application, the logs will show the `CustomPrefix` message in the color green when `FormatterOptions.ColorBehavior` is `Enabled`.
 

--- a/docs/core/extensions/console-log-formatter.md
+++ b/docs/core/extensions/console-log-formatter.md
@@ -3,7 +3,7 @@ title: Console log formatting
 description: Learn how to use available console log formatting, or implement custom log formatting for your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/14/2021
+ms.date: 11/12/2021
 ---
 
 # Console log formatting

--- a/docs/core/extensions/custom-configuration-provider.md
+++ b/docs/core/extensions/custom-configuration-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom configuration provider in .NET
 description: Learn how to implement a custom configuration provider in .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 04/19/2021
+ms.date: 11/12/2021
 ms.topic: how-to
 ---
 
@@ -20,7 +20,7 @@ The provider has the following characteristics:
 - The EF in-memory database is used for demonstration purposes.
   - To use a database that requires a connection string, get a connection string from an interim configuration.
 - The provider reads a database table into configuration at startup. The provider doesn't query the database on a per-key basis.
-- Reload-on-change isn't implemented, so updating the database after the app starts has no effect on the app's configuration.
+- Reload-on-change isn't implemented, so updating the database after the app has started will not affect the app's configuration.
 
 Define a `Settings` record type entity for storing configuration values in the database. For example, you could add a *Settings.cs* file in your *Models* folder:
 
@@ -59,7 +59,7 @@ An `AddEntityConfiguration` extension method permits adding the configuration so
 
 The following code shows how to use the custom `EntityConfigurationProvider` in *Program.cs*:
 
-:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="33":::
+:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="31":::
 
 ## Consume provider
 
@@ -69,7 +69,7 @@ To consume the custom configuration provider, you can use the [options pattern](
 
 A call to <xref:Microsoft.Extensions.Hosting.IHostBuilder.ConfigureServices%2A> configures the mapping of the options.
 
-:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="16-19,35-37":::
+:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="14-17,33-35":::
 
 The preceding code configures the `WidgetOptions` object from the `"WidgetOptions"` section of the configuration. This enables the options pattern, exposing a dependency injection-ready `IOptions<WidgetOptions>` representation of the EF settings. The options are ultimately provided from the custom configuration provider.
 

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom logging provider in .NET
 description: Learn how to implement a custom logging provider in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/30/2021
+ms.date: 11/12/2021
 ms.topic: how-to
 ---
 
@@ -32,7 +32,7 @@ The preceding code:
 - Creates a logger instance per category name.
 - Checks `_getCurrentConfig().LogLevels.ContainsKey(logLevel)` in `IsEnabled`, so each `logLevel` has a unique logger. Loggers should also be enabled for all higher log levels:
 
-:::code language="csharp" source="snippets/configuration/console-custom-logging/ColorConsoleLogger.cs" range="16-17":::
+:::code language="csharp" source="snippets/configuration/console-custom-logging/ColorConsoleLogger.cs" range="15-16":::
 
 The logger is instantiated with the `name` and a `Func<ColorConsoleLoggerConfiguration>`, which returns the current config &mdash; this handles updates to the config values as monitored through the <xref:Microsoft.Extensions.Options.IOptionsMonitor%601.OnChange%2A?displayProperty=nameWithType> callback.
 
@@ -53,7 +53,7 @@ By convention, registering services for dependency injection happens as part of 
 
 To add the custom logging provider and corresponding logger, add an <xref:Microsoft.Extensions.Logging.ILoggerProvider> with <xref:Microsoft.Extensions.Logging.ILoggingBuilder> from the <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.ConfigureLogging(Microsoft.Extensions.Hosting.IHostBuilder,System.Action{Microsoft.Extensions.Logging.ILoggingBuilder})?displayProperty=nameWithType>:
 
-:::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" highlight="23-33":::
+:::code language="csharp" source="snippets/configuration/console-custom-logging/Program.cs" highlight="23-31":::
 
 The `ILoggingBuilder` creates one or more `ILogger` instances. The `ILogger` instances are used by the framework to log the information.
 

--- a/docs/core/extensions/dependency-injection-guidelines.md
+++ b/docs/core/extensions/dependency-injection-guidelines.md
@@ -3,7 +3,7 @@ title: Dependency injection guidelines
 description: Learn various dependency injection guidelines and best practices for .NET application development.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/29/2020
+ms.date: 11/12/2021
 ms.topic: guide
 ---
 
@@ -39,7 +39,7 @@ The preceding disposable is intended to have a scoped lifetime.
 
 The preceding disposable is intended to have a singleton lifetime.
 
-:::code language="csharp" source="snippets/configuration/console-di-disposable/Program.cs" range="1-21,41-60" highlight="":::
+:::code language="csharp" source="snippets/configuration/console-di-disposable/Program.cs" id="ProgramOne,ProgramTwo":::
 
 The debug console shows the following sample output after running:
 
@@ -82,7 +82,7 @@ In the preceding code:
 - The framework does **not** dispose of the services automatically.
 - The developer is responsible for disposing the services.
 
-### IDisposable guidance for Transient and shared instances
+### IDisposable guidance for transient and shared instances
 
 #### Transient, limited lifetime
 
@@ -174,7 +174,7 @@ In addition to the guidelines in this article, there are several anti-patterns *
 
 When you register *Transient* services that implement <xref:System.IDisposable>, by default the DI container will hold onto these references, and not <xref:System.IDisposable.Dispose> of them until the container is disposed when application stops if they were resolved from the container, or until the scope is disposed if they were resolved from a scope. This can turn into a memory leak if resolved from container level.
 
-:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" range="18-30":::
+:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" id="TransientDisposable":::
 
 In the preceding anti-pattern, 1,000 `ExampleDisposable` objects are instantiated and rooted. They will not be disposed of until the `serviceProvider` instance is disposed.
 
@@ -184,11 +184,11 @@ For more information on debugging memory leaks, see [Debug a memory leak in .NET
 
 The term "DI factories" refers to the overload methods that exist when calling `Add{LIFETIME}`. There are overloads accepting a `Func<IServiceProvider, T>` where `T` is the service being registered, and the parameter is named `implementationFactory`. The `implementationFactory` can be provided as a lambda expression, local function, or method. If the factory is asynchronous, and you use <xref:System.Threading.Tasks.Task%601.Result?displayProperty=nameWithType>, this will cause a deadlock.
 
-:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" range="32-45" highlight="4-8":::
+:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" id="AsyncDeadlockOne" highlight="4-8":::
 
 In the preceding code, the `implementationFactory` is given a lambda expression where the body calls <xref:System.Threading.Tasks.Task%601.Result?displayProperty=nameWithType> on a `Task<Bar>` returning method. This ***causes a deadlock***. The `GetBarAsync` method simply emulates an asynchronous work operation with <xref:System.Threading.Tasks.Task.Delay%2A?displayProperty=nameWithType>, and then calls <xref:Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService%60%601(System.IServiceProvider)>.
 
-:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" range="47-53":::
+:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" id="AsyncDeadlockTwo":::
 
 For more information on asynchronous guidance, see [Asynchronous programming: Important info and advice](../../csharp/async.md#important-info-and-advice). For more information debugging deadlocks, see [Debug a deadlock in .NET](../diagnostics/debug-deadlock.md).
 
@@ -198,7 +198,7 @@ When you're running this anti-pattern and the deadlock occurs, you can view the 
 
 The term ["captive dependency"](https://blog.ploeh.dk/2014/06/02/captive-dependency) was coined by [Mark Seemann](https://blog.ploeh.dk/about), and refers to the misconfiguration of service lifetimes, where a longer-lived service holds a shorter-lived service captive.
 
-:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" range="55-65":::
+:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" id="CaptiveDependency":::
 
 In the preceding code, `Foo` is registered as a singleton and `Bar` is scoped - which on the surface seems valid. However, consider the implementation of `Foo`.
 
@@ -212,7 +212,7 @@ For more information, see [Scope validation](dependency-injection.md#scope-valid
 
 When using scoped services, if you're not creating a scope or within an existing scope - the service becomes a singleton.
 
-:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" range="68-82" highlight="13-14":::
+:::code language="csharp" source="snippets/configuration/di-anti-patterns/Program.cs" id="ScopedServiceBecomesSingleton" highlight="13-14":::
 
 In the preceding code, `Bar` is retrieved within an <xref:Microsoft.Extensions.DependencyInjection.IServiceScope>, which is correct. The anti-pattern is the retrieval of `Bar` outside of the scope, and the variable is named `avoid` to show which example retrieval is incorrect.
 

--- a/docs/core/extensions/dependency-injection-guidelines.md
+++ b/docs/core/extensions/dependency-injection-guidelines.md
@@ -39,7 +39,7 @@ The preceding disposable is intended to have a scoped lifetime.
 
 The preceding disposable is intended to have a singleton lifetime.
 
-:::code language="csharp" source="snippets/configuration/console-di-disposable/Program.cs" id="ProgramOne,ProgramTwo":::
+:::code language="csharp" source="snippets/configuration/console-di-disposable/Program.cs" range="1-20,42-60":::
 
 The debug console shows the following sample output after running:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -3,7 +3,7 @@ title: Use dependency injection in .NET
 description: Learn how to use dependency injection in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 04/12/2021
+ms.date: 11/12/2021
 ms.topic: tutorial
 no-loc: [Transient, Scoped, Singleton, Example]
 ---
@@ -78,7 +78,7 @@ The `OperationLogger` defines a constructor that requires each of the aforementi
 
 Update *Program.cs* with the following code:
 
-:::code language="csharp" source="snippets/configuration/console-di/Program.cs" range="1-18,35-60" highlight="22-26":::
+:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="ProgramOne,ProgramTwo" highlight="20-24":::
 
 Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -3,7 +3,7 @@ title: Use dependency injection in .NET
 description: Learn how to use dependency injection in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 11/17/2021
 ms.topic: tutorial
 no-loc: [Transient, Scoped, Singleton, Example]
 ---
@@ -78,7 +78,7 @@ The `OperationLogger` defines a constructor that requires each of the aforementi
 
 Update *Program.cs* with the following code:
 
-:::code language="csharp" source="snippets/configuration/console-di/Program.cs" range="1-17,37-61" highlight="21-25":::
+:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="Program" highlight="15-19":::
 
 Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -78,7 +78,7 @@ The `OperationLogger` defines a constructor that requires each of the aforementi
 
 Update *Program.cs* with the following code:
 
-:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="ProgramOne,ProgramTwo" highlight="20-24":::
+:::code language="csharp" source="snippets/configuration/console-di/Program.cs" range="1-17,37-60" highlight="21-25":::
 
 Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -78,7 +78,7 @@ The `OperationLogger` defines a constructor that requires each of the aforementi
 
 Update *Program.cs* with the following code:
 
-:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="Program" highlight="15-19":::
+:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="Program" highlight="7-11":::
 
 Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -78,7 +78,7 @@ The `OperationLogger` defines a constructor that requires each of the aforementi
 
 Update *Program.cs* with the following code:
 
-:::code language="csharp" source="snippets/configuration/console-di/Program.cs" range="1-17,37-60" highlight="21-25":::
+:::code language="csharp" source="snippets/configuration/console-di/Program.cs" range="1-17,37-61" highlight="21-25":::
 
 Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -78,7 +78,7 @@ The `OperationLogger` defines a constructor that requires each of the aforementi
 
 Update *Program.cs* with the following code:
 
-:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="Program" highlight="7-11":::
+:::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="Program" highlight="6-10":::
 
 Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 

--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -3,7 +3,7 @@ title: Dependency injection in .NET
 description: Learn how .NET implements dependency injection and how to use it.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/22/2021
+ms.date: 11/12/2021
 ms.topic: overview
 ---
 
@@ -274,11 +274,11 @@ Registering a service with only an implementation type is equivalent to register
 
 Any of the above service registration methods can be used to register multiple service instances of the same service type. In the following example, `AddSingleton` is called twice with `IMessageWriter` as the service type. The second call to `AddSingleton` overrides the previous one when resolved as `IMessageWriter` and adds to the previous one when multiple services are resolved via `IEnumerable<IMessageWriter>`. Services appear in the order they were registered when resolved via `IEnumerable<{SERVICE}>`.
 
-:::code language="csharp" source="snippets/configuration/console-di-ienumerable/Program.cs" highlight="19-24":::
+:::code language="csharp" source="snippets/configuration/console-di-ienumerable/Program.cs" highlight="18-23":::
 
 The preceding sample source code registers two implementations of the `IMessageWriter`.
 
-:::code language="csharp" source="snippets/configuration/console-di-ienumerable/ExampleService.cs" highlight="9-18":::
+:::code language="csharp" source="snippets/configuration/console-di-ienumerable/ExampleService.cs" highlight="7-16":::
 
 The `ExampleService` defines two constructor parameters; a single `IMessageWriter`, and an `IEnumerable<IMessageWriter>`. The single `IMessageWriter` is the last implementation to have been registered, whereas the `IEnumerable<IMessageWriter>` represents all registered implementations.
 
@@ -330,7 +330,7 @@ services.TryAddEnumerable(ServiceDescriptor.Singleton<IMessageWriter2, MessageWr
 services.TryAddEnumerable(ServiceDescriptor.Singleton<IMessageWriter1, MessageWriter>());
 ```
 
-Service registration is generally order independent except when registering multiple implementations of the same type.
+Service registration is generally order-independent except when registering multiple implementations of the same type.
 
 `IServiceCollection` is a collection of <xref:Microsoft.Extensions.DependencyInjection.ServiceDescriptor> objects. The following example shows how to register a service by creating and adding a `ServiceDescriptor`:
 
@@ -378,7 +378,7 @@ The <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory> is alwa
 
 To achieve scoping services within implementations of <xref:Microsoft.Extensions.Hosting.IHostedService>, such as the <xref:Microsoft.Extensions.Hosting.BackgroundService>, do *not* inject the service dependencies via constructor injection. Instead, inject <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>, create a scope, then resolve dependencies from the scope to use the appropriate service lifetime.
 
-:::code language="csharp" source="snippets/configuration/worker-scope/Worker.cs" highlight="13,15-16,22":::
+:::code language="csharp" source="snippets/configuration/worker-scope/Worker.cs" highlight="6,8-9,15":::
 
 In the preceding code, while the app is running, the background service:
 

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -3,7 +3,7 @@ title: File globbing in .NET
 author: IEvangelist
 description: Learn how to use file globbing in .NET to match various files with the same partial names, extensions, or segments.
 ms.author: dapine
-ms.date: 08/24/2021
+ms.date: 11/12/2021
 ---
 
 # File globbing in .NET

--- a/docs/core/extensions/generic-host.md
+++ b/docs/core/extensions/generic-host.md
@@ -3,7 +3,7 @@ title: .NET Generic Host
 author: IEvangelist
 description: Learn about the .NET Generic Host, which is responsible for app startup and lifetime management.
 ms.author: dapine
-ms.date: 07/27/2021
+ms.date: 11/12/2021
 ---
 
 # .NET Generic Host
@@ -86,15 +86,15 @@ Inject the <xref:Microsoft.Extensions.Hosting.IHostApplicationLifetime> service 
 
 The following example is an `IHostedService` implementation that registers `IHostApplicationLifetime` events:
 
-:::code language="csharp" source="snippets/configuration/app-lifetime/ExampleHostedService.cs" highlight="18-20":::
+:::code language="csharp" source="snippets/configuration/app-lifetime/ExampleHostedService.cs" highlight="16-18":::
 
 The Worker Service template could be modified to add the `ExampleHostedService` implementation:
 
-:::code language="csharp" source="snippets/configuration/app-lifetime/Program.cs" range="1-16,36" highlight="15":::
+:::code language="csharp" source="snippets/configuration/app-lifetime/Program.cs" id="Program" highlight="14":::
 
 The application would write the following sample output:
 
-:::code language="csharp" source="snippets/configuration/app-lifetime/Program.cs" range="17-35":::
+:::code language="csharp" source="snippets/configuration/app-lifetime/Program.cs" id="Output":::
 
 ## IHostLifetime
 
@@ -122,7 +122,7 @@ To add host configuration, call <xref:Microsoft.Extensions.Hosting.HostBuilder.C
 
 The following example creates host configuration:
 
-:::code language="csharp" source="snippets/configuration/console-host/Program.cs" highlight="19-25":::
+:::code language="csharp" source="snippets/configuration/console-host/Program.cs" highlight="17-23":::
 
 ## App configuration
 

--- a/docs/core/extensions/high-performance-logging.md
+++ b/docs/core/extensions/high-performance-logging.md
@@ -3,7 +3,7 @@ title: High-performance logging in .NET
 author: IEvangelist
 description: Learn how to use LoggerMessage to create cacheable delegates that require fewer object allocations for high-performance logging scenarios.
 ms.author: dapine
-ms.date: 08/26/2021
+ms.date: 11/12/2021
 ---
 
 # High-performance logging in .NET
@@ -47,7 +47,7 @@ Structured logging stores may use the event name when it's supplied with the eve
 
 The <xref:System.Action> is invoked through a strongly-typed extension method. The `PriorityItemProcessed` method logs a message every time a work item is being processed. Whereas, `FailedToProcessWorkItem` is called when (and if) an exception occurs:
 
-:::code language="csharp" source="snippets/configuration/worker-service-options/Worker.cs" range="18-39" highlight="15-18":::
+:::code language="csharp" source="snippets/configuration/worker-service-options/Worker.cs" range="13-34" highlight="15-18":::
 
 Inspect the app's console output:
 
@@ -73,7 +73,7 @@ The static extension method for logging that a work item is being processed, `Pr
 
 In the worker service's `ExecuteAsync` method, `PriorityItemProcessed` is called to log the message:
 
-:::code language="csharp" source="snippets/configuration/worker-service-options/Worker.cs" range="18-39" highlight="12":::
+:::code language="csharp" source="snippets/configuration/worker-service-options/Worker.cs" range="13-34" highlight="12":::
 
 Inspect the app's console output:
 
@@ -106,7 +106,7 @@ Provide a static extension method for the log message. Include any type paramete
 
 The scope wraps the logging extension calls in a [using](../../csharp/language-reference/keywords/using-statement.md) block:
 
-:::code language="csharp" source="snippets/configuration/worker-service-options/Worker.cs" range="18-39" highlight="4":::
+:::code language="csharp" source="snippets/configuration/worker-service-options/Worker.cs" range="13-349" highlight="4":::
 
 Inspect the log messages in the app's console output. The following result shows priority ordering of log messages with the log scope message included:
 

--- a/docs/core/extensions/http-client.md
+++ b/docs/core/extensions/http-client.md
@@ -3,7 +3,7 @@ title: HTTP with .NET
 description: Learn how to use the HttpClient and IHttpClientFactory implementations with dependency injection in your .NET workloads.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/04/2021
+ms.date: 11/12/2021
 ---
 
 # HTTP with .NET
@@ -44,7 +44,7 @@ To register the `IHttpClientFactory`, call `AddHttpClient`:
 
 Consuming services can require the `IHttpClientFactory` as a constructor parameter with [DI][di]. The following code uses `IHttpClientFactory` to create an `HttpClient` instance:
 
-:::code source="snippets/http/basic/JokeService.cs" highlight="12,16,18,23":::
+:::code source="snippets/http/basic/JokeService.cs" highlight="9,13,15,20":::
 
 Using `IHttpClientFactory` like in the preceding example is a good way to refactor an existing app. It has no impact on how `HttpClient` is used. In places where `HttpClient` instances are created in an existing app, replace those occurrences with calls to <xref:System.Net.Http.IHttpClientFactory.CreateClient%2A>.
 
@@ -80,7 +80,7 @@ Each time <xref:System.Net.Http.IHttpClientFactory.CreateClient%2A> is called:
 
 To create a named client, pass its name into `CreateClient`:
 
-:::code source="snippets/http/named/JokeService.cs" highlight="13,18,21-22,27-28,34-36":::
+:::code source="snippets/http/named/JokeService.cs" highlight="10,15,18-19,24-25,31-33":::
 
 In the preceding code, the HTTP request doesn't need to specify a hostname. The code can pass just the path, since the base address configured for the client is used.
 
@@ -97,7 +97,7 @@ Typed clients:
 
 A typed client accepts an `HttpClient` parameter in its constructor:
 
-:::code source="snippets/http/typed/JokeService.cs" highlight="12,16,18,26-28":::
+:::code source="snippets/http/typed/JokeService.cs" highlight="9,13,15,23-25":::
 
 In the preceding code:
 
@@ -108,7 +108,7 @@ API-specific methods can be created that expose `HttpClient` functionality. For 
 
 The following code calls <xref:Microsoft.Extensions.DependencyInjection.HttpClientFactoryServiceCollectionExtensions.AddHttpClient%2A> in `ConfigureServices` to register a typed client class:
 
-:::code source="snippets/http/typed/Program.cs" range="1-21" highlight="10-18":::
+:::code source="snippets/http/typed/Program.cs" range="1-21" highlight="9-17":::
 
 The typed client is registered as transient with DI. In the preceding code, `AddHttpClient` registers `JokeService` as a transient service. This registration uses a factory method to:
 
@@ -139,7 +139,7 @@ The preceding C# interface:
 
 A typed client can be added, using Refit to generate the implementation:
 
-:::code source="snippets/http/generated/Program.cs" range="1-22" highlight="12-20":::
+:::code source="snippets/http/generated/Program.cs" range="1-22" highlight="11-19":::
 
 The defined interface can be consumed where necessary, with the implementation provided by DI and Refit.
 
@@ -156,7 +156,7 @@ For a complete list of supported HTTP verbs, see <xref:System.Net.Http.HttpMetho
 
 The following example shows how to make an HTTP POST request:
 
-:::code source="snippets/http/basic/ItemService.cs" range="17-28":::
+:::code source="snippets/http/basic/ItemService.cs" id="Create":::
 
 In the preceding code, the `CreateItemAsync` method:
 
@@ -169,13 +169,13 @@ In the preceding code, the `CreateItemAsync` method:
 
 The following example shows an HTTP PUT request:
 
-:::code source="snippets/http/basic/ItemService.cs" range="30-41":::
+:::code source="snippets/http/basic/ItemService.cs" id="Update":::
 
 The preceding code is very similar to the POST example. The `UpdateItemAsync` method calls <xref:System.Net.Http.HttpClient.PutAsync%2A> instead of `PostAsync`.
 
 The following example shows an HTTP DELETE request:
 
-:::code source="snippets/http/basic/ItemService.cs" range="43-49":::
+:::code source="snippets/http/basic/ItemService.cs" id="Delete":::
 
 In the preceding code, the `DeleteItemAsync` method calls <xref:System.Net.Http.HttpClient.DeleteAsync%2A>. Because HTTP DELETE requests typically contain no body, the `DeleteAsync` method doesn't provide an overload that accepts an instance of `HttpContent`.
 

--- a/docs/core/extensions/httpclient-http3.md
+++ b/docs/core/extensions/httpclient-http3.md
@@ -3,7 +3,7 @@ title: Use HTTP/3 with HttpClient
 description: Learn how to use the HttpClient to access HTTP/3 servers in .NET 6
 author: IEvangelist
 ms.author: samsp
-ms.date: 09/13/2021
+ms.date: 11/12/2021
 ---
 
 # Use HTTP/3 with HttpClient
@@ -12,9 +12,9 @@ ms.date: 09/13/2021
 
 HTTP/3 and QUIC have a number of benefits compared to HTTP/1.1 and HTTP/2:
 
-- Faster response time of the first request. QUIC and HTTP/3 negotiates the connection in fewer round-trips between the client and the server. The first request reaches the server faster.
+- Faster response time of the first request. QUIC and HTTP/3 negotiate the connection in fewer round-trips between the client and the server. The first request reaches the server faster.
 - Improved experience when there is connection packet loss. HTTP/2 multiplexes multiple requests via one TCP connection. Packet loss on the connection affects all requests. This problem is called "head-of-line blocking". Because QUIC provides native multiplexing, lost packets only impact the requests where data has been lost.
-- Supports transitioning between networks. This feature is useful for mobile devices where it is common to switch between WIFI and cellular networks as a mobile device changes location. Currently HTTP/1.1 and HTTP/2 connections fail with an error when switching networks. An app or web browsers must retry any failed HTTP requests. HTTP/3 allows the app or web browser to seamlessly continue when a network changes. HttpClient and Kestrel do not support network transitions in .NET 6. It may be available in a future release.
+- Supports transitioning between networks. This feature is useful for mobile devices where it is common to switch between WIFI and cellular networks as a mobile device changes location. Currently, HTTP/1.1 and HTTP/2 connections fail with an error when switching networks. An app or web browser must retry any failed HTTP requests. HTTP/3 allows the app or web browser to seamlessly continue when a network changes. HttpClient and Kestrel do not support network transitions in .NET 6. It may be available in a future release.
 
 > [!IMPORTANT]
 >
@@ -54,9 +54,9 @@ HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 us
 
 ### Linux
 
-On Linux, libmsquic is published via Microsoft official Linux package repository packages.microsoft.com. In order to consume it, it must be added manually. See [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it can be installed via the package manager of your distro, for example, for Ubuntu:
+On Linux, libmsquic is published via Microsoft's official Linux package repository packages.microsoft.com. To consume it, it must be added manually. See [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it can be installed via the package manager of your distro, for example, for Ubuntu:
 
-```shell
+```bash
 sudo apt install libmsquic
 ```
 

--- a/docs/core/extensions/localization.md
+++ b/docs/core/extensions/localization.md
@@ -3,7 +3,7 @@ title: Localization in .NET
 description: Learn the concepts of localization while learning how to use the IStringLocalizer and IStringLocalizerFactory implementations in your .NET workloads.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/10/2021
+ms.date: 11/11/2021
 helpviewer_keywords:
   - "culture, localization"
   - "application development [.NET], localization"
@@ -36,7 +36,7 @@ The primary mechanism for isolating localizable strings is with **resource files
 Where:
 
 - The `<FullTypeName>` represents localizable resources for a specific type.
-- The optional `<.Locale>` represents the locale of the of the resource file contents.
+- The optional `<.Locale>` represents the locale of the resource file contents.
 
 ### Specifying locales
 
@@ -79,9 +79,9 @@ The "culture fallback" rule will ignore locales when there are no corresponding 
 
 Resource files are automatically resolved as part of a lookup routine. If your project file name is different than the root namespace of your project, the assembly name might differ. This can prevent resource lookup from being otherwise successful. To address this mismatch, use the <xref:Microsoft.Extensions.Localization.RootNamespaceAttribute> to provide a hint to the localization services. When provided, it is used during resource lookup.
 
-The example project is named *example.csproj*, which creates a *example.dll* and *example.exe* &mdash; however, the `Localization.Example` namespace is used. Apply an `assembly` level attribute to correct this mismatch:
+The example project is named *example.csproj*, which creates an *example.dll* and *example.exe* &mdash; however, the `Localization.Example` namespace is used. Apply an `assembly` level attribute to correct this mismatch:
 
-:::code source="snippets/localization/example/Program.cs" range="11":::
+:::code source="snippets/localization/example/Program.cs" range="10":::
 
 ## Register localization services
 

--- a/docs/core/extensions/localization.md
+++ b/docs/core/extensions/localization.md
@@ -3,7 +3,7 @@ title: Localization in .NET
 description: Learn the concepts of localization while learning how to use the IStringLocalizer and IStringLocalizerFactory implementations in your .NET workloads.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/11/2021
+ms.date: 11/12/2021
 helpviewer_keywords:
   - "culture, localization"
   - "application development [.NET], localization"
@@ -134,12 +134,12 @@ In the preceding C# code:
 
 The `IStringLocalizer` also supports parameterized string resources, consider the following `ParameterizedMessageService`:
 
-:::code source="snippets/localization/example/ParameterizedMessageService.cs" highlight="9,11-12,17":::
+:::code source="snippets/localization/example/ParameterizedMessageService.cs" highlight="8,10-11,16":::
 
 In the preceding C# code:
 
 - A `IStringLocalizer _localizer` field is declared.
-- The constructor takes a `IStringLocalizerFactory` parameter, which is used to create a `IStringLocalizer` from the `ParameterizedMessageService` type, and assigns it to the `_localizer` field.
+- The constructor takes an `IStringLocalizerFactory` parameter, which is used to create an `IStringLocalizer` from the `ParameterizedMessageService` type, and assigns it to the `_localizer` field.
 - The `GetFormattedMessage` method invokes <xref:Microsoft.Extensions.Localization.IStringLocalizer.Item(System.String,System.Object[])?displayProperty=nameWithType>, passing `"DinnerPriceFormat"`, a `dateTime` object, and `dinnerPrice` as arguments.
 
 > [!IMPORTANT]

--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -3,7 +3,7 @@ title: Compile-time logging source generation
 description: Learn how to use the LoggerMessageAttribute and compile-time source generation for logging in .NET.
 author: maryamariyan
 ms.author: maariyan
-ms.date: 08/25/2021
+ms.date: 11/12/2021
 ---
 
 # Compile-time logging source generation
@@ -174,7 +174,7 @@ public static partial void WarningLogMethod(
 > The warnings emitted provide details as to the correct usage of the `LoggerMessageAttribute`. In the preceding example, the `WarningLogMethod` will report a `DiagnosticSeverity.Warning` of `SYSLIB0025`.
 >
 > ```console
-> Don't include a template for ex in the logging message since it is implicitly taken care of.
+> Don't include a template for `ex` in the logging message since it is implicitly taken care of.
 > ```
 
 ### Case-insensitive template name support
@@ -205,7 +205,7 @@ public partial class LoggingExample
 }
 ```
 
-Consider the example logging output when using the `JsonConsole` formatter.
+Consider the example logging output when using the `JsonConsole` formatter:
 
 ```json
 {
@@ -306,7 +306,7 @@ public partial class LoggingSample
 }
 ```
 
-Consider the example logging output when using the `SimpleConsole` formatter.
+Consider the example logging output when using the `SimpleConsole` formatter:
 
 ```console
 trce: LoggingExample[9]
@@ -319,7 +319,7 @@ crit: LoggingExample[20]
       Value is 1.234568E+004
 ```
 
-Consider the example logging output when using the `JsonConsole` formatter.
+Consider the example logging output when using the `JsonConsole` formatter:
 
 ```json
 {

--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -3,7 +3,7 @@ title: Logging providers in .NET
 description: Learn how the logging provider API is used in .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/21/2021
+ms.date: 11/12/2021
 ---
 
 # Logging providers in .NET
@@ -19,7 +19,7 @@ The default .NET Worker app templates:
   - [EventSource](#event-source)
   - [EventLog](#windows-eventlog) (Windows only)
 
-:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="18":::
+:::code language="csharp" source="snippets/configuration/console/Program.cs" highlight="17":::
 
 The preceding code shows the `Program` class created with the .NET Worker app templates. The next several sections provide samples based on the .NET Worker app templates, which use the Generic Host.
 
@@ -188,10 +188,10 @@ This provider only logs when the project runs in the Azure environment.
 
 #### Azure log streaming
 
-Azure log streaming supports viewing log activity in real time from:
+Azure log streaming supports viewing log activity in real-time from:
 
 - The app server
-- The web server
+- The webserver
 - Failed request tracing
 
 To configure Azure log streaming:

--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -191,7 +191,7 @@ This provider only logs when the project runs in the Azure environment.
 Azure log streaming supports viewing log activity in real-time from:
 
 - The app server
-- The webserver
+- The web server
 - Failed request tracing
 
 To configure Azure log streaming:

--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -3,7 +3,7 @@ title: Logging in .NET
 author: IEvangelist
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
 ms.author: dapine
-ms.date: 07/30/2021
+ms.date: 11/12/2021
 ---
 
 # Logging in .NET
@@ -21,7 +21,7 @@ The following example:
 - Creates a logger, `ILogger<Worker>`, which uses a log *category* of the fully qualified name of the type `Worker`. The log category is a string that is associated with each log.
 - Calls <xref:Microsoft.Extensions.Logging.LoggerExtensions.LogInformation%2A> to log at the `Information` level. The Log *level* indicates the severity of the logged event.
 
-:::code language="csharp" source="snippets/configuration/worker-service/Worker.cs" range="9-24" highlight="12":::
+:::code language="csharp" source="snippets/configuration/worker-service/Worker.cs" range="3-18" highlight="12":::
 
 [Levels](#log-level) and [categories](#log-category) are explained in more detail later in this article.
 
@@ -527,7 +527,7 @@ class Program
 
 ### No asynchronous logger methods
 
-Logging should be so fast that it isn't worth the performance cost of asynchronous code. If a logging data store is slow, don't write to it directly. Consider writing the log messages to a fast store initially, then moving them to the slow store later. For example, when logging to SQL Server, don't do so directly in a `Log` method, since the `Log` methods are synchronous. Instead, synchronously add log messages to an in-memory queue and have a background worker pull the messages out of the queue to do the asynchronous work of pushing data to SQL Server.
+Logging should be so fast that it isn't worth the performance cost of asynchronous code. If a logging datastore is slow, don't write to it directly. Consider writing the log messages to a fast store initially, then moving them to the slow store later. For example, when logging to SQL Server, don't do so directly in a `Log` method, since the `Log` methods are synchronous. Instead, synchronously add log messages to an in-memory queue and have a background worker pull the messages out of the queue to do the asynchronous work of pushing data to SQL Server.
 
 ## Change log levels in a running app
 

--- a/docs/core/extensions/options-library-authors.md
+++ b/docs/core/extensions/options-library-authors.md
@@ -3,7 +3,7 @@ title: Options pattern guidance for .NET library authors
 author: IEvangelist
 description: Learn how to expose the options pattern as a library author in .NET.
 ms.author: dapine
-ms.date: 07/16/2021
+ms.date: 11/12/2021
 ---
 
 # Options pattern guidance for .NET library authors
@@ -59,7 +59,7 @@ In the preceding code, the `AddMyLibraryService`:
 
 Consumers in this pattern provide the scoped `IConfiguration` instance of the named section:
 
-:::code language="csharp" source="snippets/configuration/options-configparam/Program.cs" highlight="22-23":::
+:::code language="csharp" source="snippets/configuration/options-configparam/Program.cs" highlight="21-22":::
 
 The call to `.AddMyLibraryService` is made in the <xref:Microsoft.Extensions.Hosting.IHostBuilder.ConfigureServices%2A> method. The same is true when using a `Startup` class, the addition of services being registered occurs in `ConfigureServices`.
 
@@ -79,7 +79,7 @@ As the library author, specifying default values is up to you.
 
 Consumers of your library may be interested in providing a lambda expression that yields an instance of your options class. In this scenario, you define an `Action<LibraryOptions>` parameter in your extension method.
 
-:::code language="csharp" source="snippets/configuration/options-action/ServiceCollectionExtensions.cs" highlight="10,12":::
+:::code language="csharp" source="snippets/configuration/options-action/ServiceCollectionExtensions.cs" highlight="9,11":::
 
 In the preceding code, the `AddMyLibraryService`:
 
@@ -89,7 +89,7 @@ In the preceding code, the `AddMyLibraryService`:
 
 Consumers in this pattern provide a lambda expression (or a delegate that satisfies the `Action<LibraryOptions>` parameter):
 
-:::code language="csharp" source="snippets/configuration/options-action/Program.cs" highlight="22-26":::
+:::code language="csharp" source="snippets/configuration/options-action/Program.cs" highlight="21-25":::
 
 ## Options instance parameter
 
@@ -105,13 +105,13 @@ In the preceding code, the `AddMyLibraryService`:
 
 Consumers in this pattern provide an instance of the `LibraryOptions` class, defining desired property values inline:
 
-:::code language="csharp" source="snippets/configuration/options-object/Program.cs" highlight="22-26":::
+:::code language="csharp" source="snippets/configuration/options-object/Program.cs" highlight="21-25":::
 
 ## Post configuration
 
 After all configuration option values are bound or specified, post configuration functionality is available. Exposing the same [`Action<TOptions>` parameter](#actiontoptions-parameter) detailed earlier, you could choose to call <xref:Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions.PostConfigure%2A>. Post configure runs after all `.Configure` calls.
 
-:::code language="csharp" source="snippets/configuration/options-postconfig/ServiceCollectionExtensions.cs" highlight="10,12":::
+:::code language="csharp" source="snippets/configuration/options-postconfig/ServiceCollectionExtensions.cs" highlight="9,11":::
 
 In the preceding code, the `AddMyLibraryService`:
 
@@ -121,7 +121,7 @@ In the preceding code, the `AddMyLibraryService`:
 
 Consumers in this pattern provide a lambda expression (or a delegate that satisfies the `Action<LibraryOptions>` parameter), just as they would with the [`Action<TOptions>` parameter](#actiontoptions-parameter) in a non-post configuration scenario:
 
-:::code language="csharp" source="snippets/configuration/options-postconfig/Program.cs" highlight="22-26":::
+:::code language="csharp" source="snippets/configuration/options-postconfig/Program.cs" highlight="21-25":::
 
 ## See also
 

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -3,7 +3,7 @@ title: Options pattern in .NET
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine
-ms.date: 07/06/2021
+ms.date: 11/12/2021
 ---
 
 # Options pattern in .NET
@@ -25,7 +25,7 @@ For example, to read the following configuration values:
 
 Create the following `TransientFaultHandlingOptions` class:
 
-:::code language="csharp" source="snippets/configuration/console-json/TransientFaultHandlingOptions.cs" range="5-9":::
+:::code language="csharp" source="snippets/configuration/console-json/TransientFaultHandlingOptions.cs" range="3-7":::
 
 <span id="options-class"></span>
 When using the options pattern, an options class:
@@ -38,7 +38,7 @@ The following code:
 * Calls [ConfigurationBinder.Bind](xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind%2A) to bind the `TransientFaultHandlingOptions` class to the `"TransientFaultHandlingOptions"` section.
 * Displays the configuration data.
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="31-38":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="29-36":::
 
 In the preceding code, changes to the JSON configuration file after the app has started are read.
 

--- a/docs/core/extensions/primitives.md
+++ b/docs/core/extensions/primitives.md
@@ -3,7 +3,7 @@ title: "Primitives: the extensions library for .NET"
 description: Learn about the various primitive types from the Microsoft.Extensions.Primitives library.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/22/2021
+ms.date: 11/12/2021
 ---
 
 # Primitives: The extensions library for .NET

--- a/docs/core/extensions/queue-service.md
+++ b/docs/core/extensions/queue-service.md
@@ -3,7 +3,7 @@ title: Create a Queue Service
 description: Learn how to create a queue service subclass of BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/30/2021
+ms.date: 11/12/2021
 ms.topic: tutorial
 ---
 
@@ -52,7 +52,7 @@ In the following `QueueHostedService` example:
 
 Replace the existing `Worker` class with the following C# code, and rename the file to *QueueHostedService.cs*.
 
-:::code source="snippets/workers/queue-service/QueuedHostedService.cs" highlight="35-36,38":::
+:::code source="snippets/workers/queue-service/QueuedHostedService.cs" highlight="29-30,32":::
 
 A `MonitorLoop` service handles enqueuing tasks for the hosted service whenever the `w` key is selected on an input device:
 
@@ -62,15 +62,15 @@ A `MonitorLoop` service handles enqueuing tasks for the hosted service whenever 
   - Three 5-second delays are executed <xref:System.Threading.Tasks.Task.Delay%2A>.
   - A `try-catch` statement traps <xref:System.OperationCanceledException> if the task is canceled.
 
-:::code source="snippets/workers/queue-service/MonitorLoop.cs" highlight="11,16,41":::
+:::code source="snippets/workers/queue-service/MonitorLoop.cs" highlight="6,10,35":::
 
 Replace the existing `Program` contents with the following C# code:
 
-:::code source="snippets/workers/queue-service/Program.cs" highlight="8-18":::
+:::code source="snippets/workers/queue-service/Program.cs" highlight="6-16":::
 
 The services are registered in `IHostBuilder.ConfigureServices` (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method. `MonitorLoop` is started in *Program.cs* top-level statement:
 
-:::code source="snippets/workers/queue-service/Program.cs" range="22-23":::
+:::code source="snippets/workers/queue-service/Program.cs" range="20-21":::
 
 For more information on registering services, see [Dependency injection in .NET](dependency-injection.md).
 

--- a/docs/core/extensions/queue-service.md
+++ b/docs/core/extensions/queue-service.md
@@ -62,7 +62,7 @@ A `MonitorLoop` service handles enqueuing tasks for the hosted service whenever 
   - Three 5-second delays are executed <xref:System.Threading.Tasks.Task.Delay%2A>.
   - A `try-catch` statement traps <xref:System.OperationCanceledException> if the task is canceled.
 
-:::code source="snippets/workers/queue-service/MonitorLoop.cs" highlight="6,10,35":::
+:::code source="snippets/workers/queue-service/MonitorLoop.cs" highlight="5,10,35":::
 
 Replace the existing `Program` contents with the following C# code:
 

--- a/docs/core/extensions/scoped-service.md
+++ b/docs/core/extensions/scoped-service.md
@@ -3,7 +3,7 @@ title: Use scoped services within a BackgroundService
 description: Learn how to use scoped services within a BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/30/2021
+ms.date: 11/12/2021
 ms.topic: tutorial
 ---
 
@@ -49,13 +49,13 @@ The hosted service creates a scope to resolve the scoped background service to c
 
 Replace the existing `Worker` class with the following C# code, and rename the file to *ScopedBackgroundService.cs*:
 
-:::code source="snippets/workers/scoped-service/ScopedBackgroundService.cs" highlight="33-39":::
+:::code source="snippets/workers/scoped-service/ScopedBackgroundService.cs" highlight="26-32":::
 
 In the preceding code, an explicit scope is created and the `IScopedProcessingService` implementation is resolved from the dependency injection service provider. The resolved service instance is scoped, and its `DoWorkAsync` method is awaited.
 
 Replace the template *Program.cs* file contents with the following C# code:
 
-:::code source="snippets/workers/scoped-service/Program.cs" highlight="8-9":::
+:::code source="snippets/workers/scoped-service/Program.cs" highlight="6-7":::
 
 The services are registered in `IHostBuilder.ConfigureServices` (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method.
 

--- a/docs/core/extensions/snippets/caching/distributed/Program.cs
+++ b/docs/core/extensions/snippets/caching/distributed/Program.cs
@@ -36,6 +36,7 @@ static async ValueTask IterateAlphabetAsync(
 
 await IterateAlphabetAsync(async letter =>
 {
+    // <Create>
     DistributedCacheEntryOptions options = new()
     {
         AbsoluteExpirationRelativeToNow =
@@ -47,6 +48,7 @@ await IterateAlphabetAsync(async letter =>
     byte[] bytes = Encoding.UTF8.GetBytes(json);
 
     await cache.SetAsync(letter.ToString(), bytes, options);
+    // </Create>
 
     Console.WriteLine($"{alphabetLetter.Letter} was cached.");
 
@@ -56,6 +58,7 @@ await IterateAlphabetAsync(async letter =>
 
 await IterateAlphabetAsync(async letter =>
 {
+    // <Read>
     AlphabetLetter? alphabetLetter = null;
     byte[]? bytes = await cache.GetAsync(letter.ToString());
     if (bytes is { Length: > 0 })
@@ -63,6 +66,7 @@ await IterateAlphabetAsync(async letter =>
         string json = Encoding.UTF8.GetString(bytes);
         alphabetLetter = JsonSerializer.Deserialize<AlphabetLetter>(json);
     }
+    // </Read>
 
     if (alphabetLetter is not null)
     {

--- a/docs/core/extensions/snippets/caching/distributed/Program.cs
+++ b/docs/core/extensions/snippets/caching/distributed/Program.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/docs/core/extensions/snippets/caching/distributed/distributed-apis.csproj
+++ b/docs/core/extensions/snippets/caching/distributed/distributed-apis.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>CachingExamples.DistributedApis</RootNamespace>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/caching/memory-apis/Program.cs
+++ b/docs/core/extensions/snippets/caching/memory-apis/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Memory;
+﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 

--- a/docs/core/extensions/snippets/caching/memory-apis/memory-apis.csproj
+++ b/docs/core/extensions/snippets/caching/memory-apis/memory-apis.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>CachingExamples.MemoryApis</RootNamespace>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/caching/memory-worker/CacheSignal.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/CacheSignal.cs
@@ -1,23 +1,19 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
+﻿namespace CachingExamples.Memory;
 
-namespace CachingExamples.Memory
+public sealed class CacheSignal<T>
 {
-    public sealed class CacheSignal<T>
-    {
-        private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
 
-        /// <summary>
-        /// Exposes a <see cref="Task"/> that represents the asynchronous wait operation.
-        /// When signaled (consumer calls <see cref="Release"/>), the 
-        /// <see cref="Task.Status"/> is set as <see cref="TaskStatus.RanToCompletion"/>.
-        /// </summary>
-        public Task WaitAsync() => _semaphore.WaitAsync();
+    /// <summary>
+    /// Exposes a <see cref="Task"/> that represents the asynchronous wait operation.
+    /// When signaled (consumer calls <see cref="Release"/>), the 
+    /// <see cref="Task.Status"/> is set as <see cref="TaskStatus.RanToCompletion"/>.
+    /// </summary>
+    public Task WaitAsync() => _semaphore.WaitAsync();
 
-        /// <summary>
-        /// Exposes the ability to signal the release of the <see cref="WaitAsync"/>'s operation.
-        /// Callers who were waiting, will be able to continue.
-        /// </summary>
-        public void Release() => _semaphore.Release();
-    }
+    /// <summary>
+    /// Exposes the ability to signal the release of the <see cref="WaitAsync"/>'s operation.
+    /// Callers who were waiting, will be able to continue.
+    /// </summary>
+    public void Release() => _semaphore.Release();
 }

--- a/docs/core/extensions/snippets/caching/memory-worker/CacheWorker.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/CacheWorker.cs
@@ -1,79 +1,72 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Net.Http.Json;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
-namespace CachingExamples.Memory
+namespace CachingExamples.Memory;
+
+public class CacheWorker : BackgroundService
 {
-    public class CacheWorker : BackgroundService
+    private readonly ILogger<CacheWorker> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly CacheSignal<Photo> _cacheSignal;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _updateInterval = TimeSpan.FromHours(3);
+
+    private const string Url = "https://jsonplaceholder.typicode.com/photos";
+
+    public CacheWorker(
+        ILogger<CacheWorker> logger,
+        HttpClient httpClient,
+        CacheSignal<Photo> cacheSignal,
+        IMemoryCache cache) =>
+        (_logger, _httpClient, _cacheSignal, _cache) = (logger, httpClient, cacheSignal, cache);
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
     {
-        private readonly ILogger<CacheWorker> _logger;
-        private readonly HttpClient _httpClient;
-        private readonly CacheSignal<Photo> _cacheSignal;
-        private readonly IMemoryCache _cache;
-        private readonly TimeSpan _updateInterval = TimeSpan.FromHours(3);
+        await _cacheSignal.WaitAsync();
+        await base.StartAsync(cancellationToken);
+    }
 
-        private const string Url = "https://jsonplaceholder.typicode.com/photos";
-
-        public CacheWorker(
-            ILogger<CacheWorker> logger,
-            HttpClient httpClient,
-            CacheSignal<Photo> cacheSignal,
-            IMemoryCache cache) =>
-            (_logger, _httpClient, _cacheSignal, _cache) = (logger, httpClient, cacheSignal, cache);
-
-        public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
         {
-            await _cacheSignal.WaitAsync();
-            await base.StartAsync(cancellationToken);
-        }
+            _logger.LogInformation("Updating cache.");
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            while (!stoppingToken.IsCancellationRequested)
+            try
             {
-                _logger.LogInformation("Updating cache.");
+                Photo[]? photos =
+                    await _httpClient.GetFromJsonAsync<Photo[]>(
+                        Url, stoppingToken);
 
-                try
+                if (photos is { Length: > 0 })
                 {
-                    Photo[]? photos =
-                        await _httpClient.GetFromJsonAsync<Photo[]>(
-                            Url, stoppingToken);
-
-                    if (photos is { Length: > 0 })
-                    {
-                        _cache.Set("Photos", photos);
-                        _logger.LogInformation(
-                            "Cache updated with {Count:#,#} photos.", photos.Length);
-                    }
-                    else
-                    {
-                        _logger.LogWarning(
-                            "Unable to fetch photos to update cache.");
-                    }
-                }
-                finally
-                {
-                    _cacheSignal.Release();
-                }
-
-                try
-                {
+                    _cache.Set("Photos", photos);
                     _logger.LogInformation(
-                        "Will attempt to update the cache in {Hours} hours from now.",
-                        _updateInterval.Hours);
-
-                    await Task.Delay(_updateInterval, stoppingToken);
+                        "Cache updated with {Count:#,#} photos.", photos.Length);
                 }
-                catch (OperationCanceledException)
+                else
                 {
-                    _logger.LogWarning("Cancellation acknowledged: shutting down.");
-                    break;
+                    _logger.LogWarning(
+                        "Unable to fetch photos to update cache.");
                 }
+            }
+            finally
+            {
+                _cacheSignal.Release();
+            }
+
+            try
+            {
+                _logger.LogInformation(
+                    "Will attempt to update the cache in {Hours} hours from now.",
+                    _updateInterval.Hours);
+
+                await Task.Delay(_updateInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("Cancellation acknowledged: shutting down.");
+                break;
             }
         }
     }

--- a/docs/core/extensions/snippets/caching/memory-worker/Photo.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/Photo.cs
@@ -1,9 +1,8 @@
-﻿namespace CachingExamples.Memory
-{
-    public record Photo(
-        int AlbumId,
-        int Id,
-        string Title,
-        string Url,
-        string ThumbnailUrl);
-}
+﻿namespace CachingExamples.Memory;
+
+public record Photo(
+    int AlbumId,
+    int Id,
+    string Title,
+    string Url,
+    string ThumbnailUrl);

--- a/docs/core/extensions/snippets/caching/memory-worker/PhotoService.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/PhotoService.cs
@@ -1,53 +1,48 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Caching.Memory;
 
-namespace CachingExamples.Memory
+namespace CachingExamples.Memory;
+
+public sealed class PhotoService
 {
-    public sealed class PhotoService
+    private readonly IMemoryCache _cache;
+    private readonly CacheSignal<Photo> _cacheSignal;
+    private readonly ILogger<PhotoService> _logger;
+
+    public PhotoService(
+        IMemoryCache cache,
+        CacheSignal<Photo> cacheSignal,
+        ILogger<PhotoService> logger) =>
+        (_cache, _cacheSignal, _logger) = (cache, cacheSignal, logger);
+
+    public async IAsyncEnumerable<Photo> GetPhotosAsync(Func<Photo, bool>? filter = default)
     {
-        private readonly IMemoryCache _cache;
-        private readonly CacheSignal<Photo> _cacheSignal;
-        private readonly ILogger<PhotoService> _logger;
-
-        public PhotoService(
-            IMemoryCache cache,
-            CacheSignal<Photo> cacheSignal,
-            ILogger<PhotoService> logger) =>
-            (_cache, _cacheSignal, _logger) = (cache, cacheSignal, logger);
-
-        public async IAsyncEnumerable<Photo> GetPhotosAsync(Func<Photo, bool>? filter = default)
+        try
         {
-            try
-            {
-                await _cacheSignal.WaitAsync();
+            await _cacheSignal.WaitAsync();
 
-                Photo[] photos =
-                    await _cache.GetOrCreateAsync(
-                        "Photos", _ =>
-                        {
-                            _logger.LogWarning("This should never happen!");
-
-                            return Task.FromResult(Array.Empty<Photo>());
-                        });
-
-                // If no filter is provided, use a pass-thru.
-                filter ??= _ => true;
-
-                foreach (Photo? photo in photos)
-                {
-                    if (photo is not null && filter(photo))
+            Photo[] photos =
+                await _cache.GetOrCreateAsync(
+                    "Photos", _ =>
                     {
-                        yield return photo;
-                    }
+                        _logger.LogWarning("This should never happen!");
+
+                        return Task.FromResult(Array.Empty<Photo>());
+                    });
+
+            // If no filter is provided, use a pass-thru.
+            filter ??= _ => true;
+
+            foreach (Photo? photo in photos)
+            {
+                if (photo is not null && filter(photo))
+                {
+                    yield return photo;
                 }
             }
-            finally
-            {
-                _cacheSignal.Release();
-            }
+        }
+        finally
+        {
+            _cacheSignal.Release();
         }
     }
 }

--- a/docs/core/extensions/snippets/caching/memory-worker/Program.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/Program.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using CachingExamples.Memory;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+﻿using CachingExamples.Memory;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/docs/core/extensions/snippets/caching/memory-worker/memory-worker.csproj
+++ b/docs/core/extensions/snippets/caching/memory-worker/memory-worker.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>CachingExamples.Memory</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>CachingExamples.Memory</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/configuration/app-lifetime/ExampleHostedService.cs
+++ b/docs/core/extensions/snippets/configuration/app-lifetime/ExampleHostedService.cs
@@ -1,52 +1,49 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace AppLifetime.Example
+namespace AppLifetime.Example;
+
+public class ExampleHostedService : IHostedService
 {
-    public class ExampleHostedService : IHostedService
+    private readonly ILogger _logger;
+
+    public ExampleHostedService(
+        ILogger<ExampleHostedService> logger,
+        IHostApplicationLifetime appLifetime)
     {
-        private readonly ILogger _logger;
+        _logger = logger;
 
-        public ExampleHostedService(
-            ILogger<ExampleHostedService> logger,
-            IHostApplicationLifetime appLifetime)
-        {
-            _logger = logger;
+        appLifetime.ApplicationStarted.Register(OnStarted);
+        appLifetime.ApplicationStopping.Register(OnStopping);
+        appLifetime.ApplicationStopped.Register(OnStopped);
+    }
 
-            appLifetime.ApplicationStarted.Register(OnStarted);
-            appLifetime.ApplicationStopping.Register(OnStopping);
-            appLifetime.ApplicationStopped.Register(OnStopped);
-        }
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("1. StartAsync has been called.");
 
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("1. StartAsync has been called.");
+        return Task.CompletedTask;
+    }
 
-            return Task.CompletedTask;
-        }
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("4. StopAsync has been called.");
 
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("4. StopAsync has been called.");
+        return Task.CompletedTask;
+    }
 
-            return Task.CompletedTask;
-        }
+    private void OnStarted()
+    {
+        _logger.LogInformation("2. OnStarted has been called.");
+    }
 
-        private void OnStarted()
-        {
-            _logger.LogInformation("2. OnStarted has been called.");
-        }
+    private void OnStopping()
+    {
+        _logger.LogInformation("3. OnStopping has been called.");
+    }
 
-        private void OnStopping()
-        {
-            _logger.LogInformation("3. OnStopping has been called.");
-        }
-
-        private void OnStopped()
-        {
-            _logger.LogInformation("5. OnStopped has been called.");
-        }
+    private void OnStopped()
+    {
+        _logger.LogInformation("5. OnStopped has been called.");
     }
 }

--- a/docs/core/extensions/snippets/configuration/app-lifetime/Program.cs
+++ b/docs/core/extensions/snippets/configuration/app-lifetime/Program.cs
@@ -1,35 +1,38 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// <Program>
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace AppLifetime.Example
-{
-    class Program
-    {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+namespace AppLifetime.Example;
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddHostedService<ExampleHostedService>());
-    }
-    // Sample output:
-    //     info: ExampleHostedService[0]
-    //           1. StartAsync has been called.
-    //     info: ExampleHostedService[0]
-    //           2. OnStarted has been called.
-    //     info: Microsoft.Hosting.Lifetime[0]
-    //           Application started.Press Ctrl+C to shut down.
-    //     info: Microsoft.Hosting.Lifetime[0]
-    //           Hosting environment: Production
-    //     info: Microsoft.Hosting.Lifetime[0]
-    //           Content root path: ..\app-lifetime\bin\Debug\net5.0
-    //     info: ExampleHostedService[0]
-    //           3. OnStopping has been called.
-    //     info: Microsoft.Hosting.Lifetime[0]
-    //           Application is shutting down...
-    //     info: ExampleHostedService[0]
-    //           4. StopAsync has been called.
-    //     info: ExampleHostedService[0]
-    //           5. OnStopped has been called.
+class Program
+{
+    static Task Main(string[] args) =>
+        CreateHostBuilder(args).Build().RunAsync();
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddHostedService<ExampleHostedService>());
 }
+// </Program>
+// <Output>
+// Sample output:
+//     info: ExampleHostedService[0]
+//           1. StartAsync has been called.
+//     info: ExampleHostedService[0]
+//           2. OnStarted has been called.
+//     info: Microsoft.Hosting.Lifetime[0]
+//           Application started.Press Ctrl+C to shut down.
+//     info: Microsoft.Hosting.Lifetime[0]
+//           Hosting environment: Production
+//     info: Microsoft.Hosting.Lifetime[0]
+//           Content root path: ..\app-lifetime\bin\Debug\net5.0
+//     info: ExampleHostedService[0]
+//           3. OnStopping has been called.
+//     info: Microsoft.Hosting.Lifetime[0]
+//           Application is shutting down...
+//     info: ExampleHostedService[0]
+//           4. StopAsync has been called.
+//     info: ExampleHostedService[0]
+//           5. OnStopped has been called.
+// </Output>

--- a/docs/core/extensions/snippets/configuration/app-lifetime/Program.cs
+++ b/docs/core/extensions/snippets/configuration/app-lifetime/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace AppLifetime.Example

--- a/docs/core/extensions/snippets/configuration/app-lifetime/app-lifetime.csproj
+++ b/docs/core/extensions/snippets/configuration/app-lifetime/app-lifetime.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>AppLifetime.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 public class ColorConsoleLogger : ILogger
 {
@@ -11,7 +10,7 @@ public class ColorConsoleLogger : ILogger
         Func<ColorConsoleLoggerConfiguration> getCurrentConfig) =>
         (_name, _getCurrentConfig) = (name, getCurrentConfig);
 
-    public IDisposable BeginScope<TState>(TState state) => default;
+    public IDisposable BeginScope<TState>(TState state) => default!;
 
     public bool IsEnabled(LogLevel logLevel) =>
         _getCurrentConfig().LogLevels.ContainsKey(logLevel);

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerConfiguration.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 public class ColorConsoleLoggerConfiguration
 {

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerProvider.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Extensions/ColorConsoleLoggerExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Extensions/ColorConsoleLoggerExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/console-custom-logging.csproj
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/console-custom-logging.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleCustomLogging.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// <ProgramOne>
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace ConsoleDisposable.Example;
@@ -17,6 +18,8 @@ class Program
 
         await host.RunAsync();
     }
+// </ProgramOne>
+// <Output>
     // Sample output:
     //     Scope 1...
     //     ScopedDisposable.Dispose()
@@ -35,8 +38,8 @@ class Program
     //     info: Microsoft.Hosting.Lifetime[0]
     //          Application is shutting down...
     //     SingletonDisposable.Dispose()
-
-
+// </Output>
+// <ProgramTwo>
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((_, services) =>
@@ -56,3 +59,4 @@ class Program
         _ = provider.GetRequiredService<SingletonDisposable>();
     }
 }
+// </ProgramTwo>

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -1,61 +1,58 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleDisposable.Example
+namespace ConsoleDisposable.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            ExemplifyDisposableScoping(host.Services, "Scope 1");
-            Console.WriteLine();
+        ExemplifyDisposableScoping(host.Services, "Scope 1");
+        Console.WriteLine();
 
-            ExemplifyDisposableScoping(host.Services, "Scope 2");
-            Console.WriteLine();
+        ExemplifyDisposableScoping(host.Services, "Scope 2");
+        Console.WriteLine();
 
-            await host.RunAsync();
-        }
-        // Sample output:
-        //     Scope 1...
-        //     ScopedDisposable.Dispose()
-        //     TransientDisposable.Dispose()
-               
-        //     Scope 2...
-        //     ScopedDisposable.Dispose()
-        //     TransientDisposable.Dispose()
-               
-        //     info: Microsoft.Hosting.Lifetime[0]
-        //           Application started.Press Ctrl+C to shut down.
-        //     info: Microsoft.Hosting.Lifetime[0]
-        //          Hosting environment: Production
-        //     info: Microsoft.Hosting.Lifetime[0]
-        //          Content root path: .\configuration\console-di-disposable\bin\Debug\net5.0
-        //     info: Microsoft.Hosting.Lifetime[0]
-        //          Application is shutting down...
-        //     SingletonDisposable.Dispose()
+        await host.RunAsync();
+    }
+    // Sample output:
+    //     Scope 1...
+    //     ScopedDisposable.Dispose()
+    //     TransientDisposable.Dispose()
+
+    //     Scope 2...
+    //     ScopedDisposable.Dispose()
+    //     TransientDisposable.Dispose()
+
+    //     info: Microsoft.Hosting.Lifetime[0]
+    //           Application started.Press Ctrl+C to shut down.
+    //     info: Microsoft.Hosting.Lifetime[0]
+    //          Hosting environment: Production
+    //     info: Microsoft.Hosting.Lifetime[0]
+    //          Content root path: .\configuration\console-di-disposable\bin\Debug\net5.0
+    //     info: Microsoft.Hosting.Lifetime[0]
+    //          Application is shutting down...
+    //     SingletonDisposable.Dispose()
 
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddTransient<TransientDisposable>()
-                            .AddScoped<ScopedDisposable>()
-                            .AddSingleton<SingletonDisposable>());
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddTransient<TransientDisposable>()
+                        .AddScoped<ScopedDisposable>()
+                        .AddSingleton<SingletonDisposable>());
 
-        static void ExemplifyDisposableScoping(IServiceProvider services, string scope)
-        {
-            Console.WriteLine($"{scope}...");
+    static void ExemplifyDisposableScoping(IServiceProvider services, string scope)
+    {
+        Console.WriteLine($"{scope}...");
 
-            using IServiceScope serviceScope = services.CreateScope();
-            IServiceProvider provider = serviceScope.ServiceProvider;
+        using IServiceScope serviceScope = services.CreateScope();
+        IServiceProvider provider = serviceScope.ServiceProvider;
 
-            _ = provider.GetRequiredService<TransientDisposable>();
-            _ = provider.GetRequiredService<ScopedDisposable>();
-            _ = provider.GetRequiredService<SingletonDisposable>();
-        }
+        _ = provider.GetRequiredService<TransientDisposable>();
+        _ = provider.GetRequiredService<ScopedDisposable>();
+        _ = provider.GetRequiredService<SingletonDisposable>();
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/Program.cs
@@ -1,5 +1,4 @@
-﻿// <ProgramOne>
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace ConsoleDisposable.Example;
@@ -18,7 +17,7 @@ class Program
 
         await host.RunAsync();
     }
-// </ProgramOne>
+
 // <Output>
     // Sample output:
     //     Scope 1...
@@ -39,7 +38,7 @@ class Program
     //          Application is shutting down...
     //     SingletonDisposable.Dispose()
 // </Output>
-// <ProgramTwo>
+
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((_, services) =>
@@ -59,4 +58,3 @@ class Program
         _ = provider.GetRequiredService<SingletonDisposable>();
     }
 }
-// </ProgramTwo>

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/ScopedDisposable.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/ScopedDisposable.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿namespace ConsoleDisposable.Example;
 
-namespace ConsoleDisposable.Example
+public sealed class ScopedDisposable : IDisposable
 {
-    public class ScopedDisposable : IDisposable
-    {
-        public void Dispose() => Console.WriteLine($"{nameof(ScopedDisposable)}.Dispose()");
-    }
+    public void Dispose() => Console.WriteLine($"{nameof(ScopedDisposable)}.Dispose()");
 }

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/SingletonDisposable.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/SingletonDisposable.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿namespace ConsoleDisposable.Example;
 
-namespace ConsoleDisposable.Example
+public sealed class SingletonDisposable : IDisposable
 {
-    public class SingletonDisposable : IDisposable
-    {
-        public void Dispose() => Console.WriteLine($"{nameof(SingletonDisposable)}.Dispose()");
-    }
+    public void Dispose() => Console.WriteLine($"{nameof(SingletonDisposable)}.Dispose()");
 }

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/TransientDisposable.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/TransientDisposable.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿namespace ConsoleDisposable.Example;
 
-namespace ConsoleDisposable.Example
+public sealed class TransientDisposable : IDisposable
 {
-    public class TransientDisposable : IDisposable
-    {
-        public void Dispose() => Console.WriteLine($"{nameof(TransientDisposable)}.Dispose()");
-    }
+    public void Dispose() => Console.WriteLine($"{nameof(TransientDisposable)}.Dispose()");
 }

--- a/docs/core/extensions/snippets/configuration/console-di-disposable/console-di-disposable.csproj
+++ b/docs/core/extensions/snippets/configuration/console-di-disposable/console-di-disposable.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleDisposable.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/ConsoleMessageWriter.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/ConsoleMessageWriter.cs
@@ -1,11 +1,8 @@
-﻿using System;
+﻿namespace ConsoleDI.IEnumerableExample;
 
-namespace ConsoleDI.IEnumerableExample
+public class ConsoleMessageWriter : IMessageWriter
 {
-    public class ConsoleMessageWriter : IMessageWriter
-    {
-        public void Write(string message) => 
-            Console.WriteLine(
-                $"ConsoleMessageWriter.Write(message: \"{message}\")");
-    }
+    public void Write(string message) =>
+        Console.WriteLine(
+            $"ConsoleMessageWriter.Write(message: \"{message}\")");
 }

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/ExampleService.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/ExampleService.cs
@@ -1,20 +1,17 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Diagnostics;
 
-namespace ConsoleDI.IEnumerableExample
+namespace ConsoleDI.IEnumerableExample;
+
+public class ExampleService
 {
-    public class ExampleService
+    public ExampleService(
+        IMessageWriter messageWriter,
+        IEnumerable<IMessageWriter> messageWriters)
     {
-        public ExampleService(
-            IMessageWriter messageWriter,
-            IEnumerable<IMessageWriter> messageWriters)
-        {
-            Trace.Assert(messageWriter is LoggingMessageWriter);
+        Trace.Assert(messageWriter is LoggingMessageWriter);
 
-            var dependencyArray = messageWriters.ToArray();
-            Trace.Assert(dependencyArray[0] is ConsoleMessageWriter);
-            Trace.Assert(dependencyArray[1] is LoggingMessageWriter);
-        }
+        var dependencyArray = messageWriters.ToArray();
+        Trace.Assert(dependencyArray[0] is ConsoleMessageWriter);
+        Trace.Assert(dependencyArray[1] is LoggingMessageWriter);
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/IMessageWriter.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/IMessageWriter.cs
@@ -1,7 +1,6 @@
-﻿namespace ConsoleDI.IEnumerableExample
+﻿namespace ConsoleDI.IEnumerableExample;
+
+public interface IMessageWriter
 {
-    public interface IMessageWriter
-    {
-        void Write(string message);
-    }
+    void Write(string message);
 }

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/LoggingMessageWriter.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/LoggingMessageWriter.cs
@@ -1,15 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
 
-namespace ConsoleDI.IEnumerableExample
+namespace ConsoleDI.IEnumerableExample;
+
+public class LoggingMessageWriter : IMessageWriter
 {
-    public class LoggingMessageWriter : IMessageWriter
-    {
-        private readonly ILogger<LoggingMessageWriter> _logger;
+    private readonly ILogger<LoggingMessageWriter> _logger;
 
-        public LoggingMessageWriter(ILogger<LoggingMessageWriter> logger) =>
-            _logger = logger;
+    public LoggingMessageWriter(ILogger<LoggingMessageWriter> logger) =>
+        _logger = logger;
 
-        public void Write(string message) =>
-            _logger.LogInformation(message);
-    }
+    public void Write(string message) =>
+        _logger.LogInformation(message);
 }

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/Program.cs
@@ -1,26 +1,24 @@
-﻿using System.Threading.Tasks;
-using ConsoleDI.IEnumerableExample;
+﻿using ConsoleDI.IEnumerableExample;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleDI.Example
+namespace ConsoleDI.Example;
+
+class Program
 {
-    class Program
+    static Task Main(string[] args)
     {
-        static Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            _ = host.Services.GetService<ExampleService>();
+        _ = host.Services.GetService<ExampleService>();
 
-            return host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddSingleton<IMessageWriter, ConsoleMessageWriter>()
-                            .AddSingleton<IMessageWriter, LoggingMessageWriter>()
-                            .AddSingleton<ExampleService>());
+        return host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddSingleton<IMessageWriter, ConsoleMessageWriter>()
+                        .AddSingleton<IMessageWriter, LoggingMessageWriter>()
+                        .AddSingleton<ExampleService>());
 }

--- a/docs/core/extensions/snippets/configuration/console-di-ienumerable/console-di-ienumerable.csproj
+++ b/docs/core/extensions/snippets/configuration/console-di-ienumerable/console-di-ienumerable.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleDI.IEnumerableExample</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-di/DefaultOperation.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/DefaultOperation.cs
@@ -1,12 +1,11 @@
 ﻿using static System.Guid;
 
-namespace ConsoleDI.Example
+namespace ConsoleDI.Example;
+
+public class DefaultOperation :
+    ITransientOperation,
+    IScopedOperation,
+    ISingletonOperation
 {
-    public class DefaultOperation :
-        ITransientOperation,
-        IScopedOperation,
-        ISingletonOperation
-    {
-        public string OperationId { get; } = NewGuid().ToString()[^4..];
-    }
+    public string OperationId { get; } = NewGuid().ToString()[^4..];
 }

--- a/docs/core/extensions/snippets/configuration/console-di/IOperation.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/IOperation.cs
@@ -1,7 +1,6 @@
-﻿namespace ConsoleDI.Example
+﻿namespace ConsoleDI.Example;
+
+public interface IOperation
 {
-    public interface IOperation
-    {
-        string OperationId { get; }
-    }
+    string OperationId { get; }
 }

--- a/docs/core/extensions/snippets/configuration/console-di/IScopedOperation.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/IScopedOperation.cs
@@ -1,6 +1,5 @@
-﻿namespace ConsoleDI.Example
+﻿namespace ConsoleDI.Example;
+
+public interface IScopedOperation : IOperation
 {
-    public interface IScopedOperation : IOperation
-    {
-    }
 }

--- a/docs/core/extensions/snippets/configuration/console-di/ISingletonOperation.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/ISingletonOperation.cs
@@ -1,6 +1,5 @@
-﻿namespace ConsoleDI.Example
+﻿namespace ConsoleDI.Example;
+
+public interface ISingletonOperation : IOperation
 {
-    public interface ISingletonOperation : IOperation
-    {
-    }
 }

--- a/docs/core/extensions/snippets/configuration/console-di/ITransientOperation.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/ITransientOperation.cs
@@ -1,6 +1,5 @@
-﻿namespace ConsoleDI.Example
+﻿namespace ConsoleDI.Example;
+
+public interface ITransientOperation : IOperation
 {
-    public interface ITransientOperation : IOperation
-    {
-    }
 }

--- a/docs/core/extensions/snippets/configuration/console-di/OperationLogger.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/OperationLogger.cs
@@ -1,31 +1,28 @@
-﻿using System;
+﻿namespace ConsoleDI.Example;
 
-namespace ConsoleDI.Example
+public class OperationLogger
 {
-    public class OperationLogger
+    private readonly ITransientOperation _transientOperation;
+    private readonly IScopedOperation _scopedOperation;
+    private readonly ISingletonOperation _singletonOperation;
+
+    public OperationLogger(
+        ITransientOperation transientOperation,
+        IScopedOperation scopedOperation,
+        ISingletonOperation singletonOperation) =>
+        (_transientOperation, _scopedOperation, _singletonOperation) =
+            (transientOperation, scopedOperation, singletonOperation);
+
+    public void LogOperations(string scope)
     {
-        private readonly ITransientOperation _transientOperation;
-        private readonly IScopedOperation _scopedOperation;
-        private readonly ISingletonOperation _singletonOperation;
-
-        public OperationLogger(
-            ITransientOperation transientOperation,
-            IScopedOperation scopedOperation,
-            ISingletonOperation singletonOperation) =>
-            (_transientOperation, _scopedOperation, _singletonOperation) =
-                (transientOperation, scopedOperation, singletonOperation);
-
-        public void LogOperations(string scope)
-        {
-            LogOperation(_transientOperation, scope, "Always different");
-            LogOperation(_scopedOperation, scope, "Changes only with scope");
-            LogOperation(_singletonOperation, scope, "Always the same");
-        }
-            
-
-        private static void LogOperation<T>(T operation, string scope, string message)
-            where T : IOperation =>
-            Console.WriteLine(
-                $"{scope}: {typeof(T).Name,-19} [ {operation.OperationId}...{message,-23} ]");
+        LogOperation(_transientOperation, scope, "Always different");
+        LogOperation(_scopedOperation, scope, "Changes only with scope");
+        LogOperation(_singletonOperation, scope, "Always the same");
     }
+
+
+    private static void LogOperation<T>(T operation, string scope, string message)
+        where T : IOperation =>
+        Console.WriteLine(
+            $"{scope}: {typeof(T).Name,-19} [ {operation.OperationId}...{message,-23} ]");
 }

--- a/docs/core/extensions/snippets/configuration/console-di/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// <ProgramOne>
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace ConsoleDI.Example;
@@ -14,6 +15,8 @@ class Program
 
         return host.RunAsync();
     }
+// </ProgramOne>
+// <Output>
     // Sample output:
     // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ 80f4...Always different        ]
     // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
@@ -30,7 +33,8 @@ class Program
     // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ fa65...Always different        ]
     // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
     // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-
+// </Output>
+// <ProgramTwo>
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((_, services) =>
@@ -55,3 +59,4 @@ class Program
         Console.WriteLine();
     }
 }
+// </ProgramTwo>

--- a/docs/core/extensions/snippets/configuration/console-di/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/Program.cs
@@ -1,60 +1,53 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using ConsoleDI.Example;
 
-namespace ConsoleDI.Example;
+using IHost host = CreateHostBuilder(args).Build();
 
-class Program
+ExemplifyScoping(host.Services, "Scope 1");
+ExemplifyScoping(host.Services, "Scope 2");
+
+await host.RunAsync();
+
+static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureServices((_, services) =>
+            services.AddTransient<ITransientOperation, DefaultOperation>()
+                    .AddScoped<IScopedOperation, DefaultOperation>()
+                    .AddSingleton<ISingletonOperation, DefaultOperation>()
+                    .AddTransient<OperationLogger>());
+
+static void ExemplifyScoping(IServiceProvider services, string scope)
 {
-    static Task Main(string[] args)
-    {
-        using IHost host = CreateHostBuilder(args).Build();
+    using IServiceScope serviceScope = services.CreateScope();
+    IServiceProvider provider = serviceScope.ServiceProvider;
 
-        ExemplifyScoping(host.Services, "Scope 1");
-        ExemplifyScoping(host.Services, "Scope 2");
+    OperationLogger logger = provider.GetRequiredService<OperationLogger>();
+    logger.LogOperations($"{scope}-Call 1 .GetRequiredService<OperationLogger>()");
 
-        return host.RunAsync();
-    }
+    Console.WriteLine("...");
+
+    logger = provider.GetRequiredService<OperationLogger>();
+    logger.LogOperations($"{scope}-Call 2 .GetRequiredService<OperationLogger>()");
+
+    Console.WriteLine();
+}
 
 // <Output>
-    // Sample output:
-    // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ 80f4...Always different        ]
-    // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
-    // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-    // ...
-    // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ f3c0...Always different        ]
-    // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
-    // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-    //
-    // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ f9af...Always different        ]
-    // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
-    // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-    // ...
-    // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ fa65...Always different        ]
-    // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
-    // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+// Sample output:
+// Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ 80f4...Always different        ]
+// Scope 1-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
+// Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+// ...
+// Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ f3c0...Always different        ]
+// Scope 1-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
+// Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+//
+// Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ f9af...Always different        ]
+// Scope 2-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
+// Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+// ...
+// Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ fa65...Always different        ]
+// Scope 2-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
+// Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
 // </Output>
-
-    static IHostBuilder CreateHostBuilder(string[] args) =>
-        Host.CreateDefaultBuilder(args)
-            .ConfigureServices((_, services) =>
-                services.AddTransient<ITransientOperation, DefaultOperation>()
-                        .AddScoped<IScopedOperation, DefaultOperation>()
-                        .AddSingleton<ISingletonOperation, DefaultOperation>()
-                        .AddTransient<OperationLogger>());
-
-    static void ExemplifyScoping(IServiceProvider services, string scope)
-    {
-        using IServiceScope serviceScope = services.CreateScope();
-        IServiceProvider provider = serviceScope.ServiceProvider;
-
-        OperationLogger logger = provider.GetRequiredService<OperationLogger>();
-        logger.LogOperations($"{scope}-Call 1 .GetRequiredService<OperationLogger>()");
-
-        Console.WriteLine("...");
-
-        logger = provider.GetRequiredService<OperationLogger>();
-        logger.LogOperations($"{scope}-Call 2 .GetRequiredService<OperationLogger>()");
-
-        Console.WriteLine();
-    }
-}

--- a/docs/core/extensions/snippets/configuration/console-di/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/Program.cs
@@ -1,5 +1,4 @@
-﻿// <ProgramOne>
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace ConsoleDI.Example;
@@ -15,7 +14,7 @@ class Program
 
         return host.RunAsync();
     }
-// </ProgramOne>
+
 // <Output>
     // Sample output:
     // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ 80f4...Always different        ]
@@ -34,7 +33,7 @@ class Program
     // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
     // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
 // </Output>
-// <ProgramTwo>
+
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((_, services) =>
@@ -59,4 +58,3 @@ class Program
         Console.WriteLine();
     }
 }
-// </ProgramTwo>

--- a/docs/core/extensions/snippets/configuration/console-di/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/Program.cs
@@ -1,21 +1,20 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// <Program>
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ConsoleDI.Example;
 
-using IHost host = CreateHostBuilder(args).Build();
+using IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((_, services) =>
+        services.AddTransient<ITransientOperation, DefaultOperation>()
+            .AddScoped<IScopedOperation, DefaultOperation>()
+            .AddSingleton<ISingletonOperation, DefaultOperation>()
+            .AddTransient<OperationLogger>())
+    .Build();
 
 ExemplifyScoping(host.Services, "Scope 1");
 ExemplifyScoping(host.Services, "Scope 2");
 
 await host.RunAsync();
-
-static IHostBuilder CreateHostBuilder(string[] args) =>
-    Host.CreateDefaultBuilder(args)
-        .ConfigureServices((_, services) =>
-            services.AddTransient<ITransientOperation, DefaultOperation>()
-                    .AddScoped<IScopedOperation, DefaultOperation>()
-                    .AddSingleton<ISingletonOperation, DefaultOperation>()
-                    .AddTransient<OperationLogger>());
 
 static void ExemplifyScoping(IServiceProvider services, string scope)
 {
@@ -32,6 +31,7 @@ static void ExemplifyScoping(IServiceProvider services, string scope)
 
     Console.WriteLine();
 }
+// </Program>
 
 // <Output>
 // Sample output:

--- a/docs/core/extensions/snippets/configuration/console-di/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-di/Program.cs
@@ -1,60 +1,57 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleDI.Example
+namespace ConsoleDI.Example;
+
+class Program
 {
-    class Program
+    static Task Main(string[] args)
     {
-        static Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            ExemplifyScoping(host.Services, "Scope 1");
-            ExemplifyScoping(host.Services, "Scope 2");
+        ExemplifyScoping(host.Services, "Scope 1");
+        ExemplifyScoping(host.Services, "Scope 2");
 
-            return host.RunAsync();
-        }
-        // Sample output:
-        // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ 80f4...Always different        ]
-        // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
-        // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-        // ...
-        // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ f3c0...Always different        ]
-        // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
-        // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-        //
-        // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ f9af...Always different        ]
-        // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
-        // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
-        // ...
-        // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ fa65...Always different        ]
-        // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
-        // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+        return host.RunAsync();
+    }
+    // Sample output:
+    // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ 80f4...Always different        ]
+    // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
+    // Scope 1-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+    // ...
+    // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ f3c0...Always different        ]
+    // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ c878...Changes only with scope ]
+    // Scope 1-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+    //
+    // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ITransientOperation [ f9af...Always different        ]
+    // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
+    // Scope 2-Call 1 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
+    // ...
+    // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ITransientOperation [ fa65...Always different        ]
+    // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): IScopedOperation    [ 2bd0...Changes only with scope ]
+    // Scope 2-Call 2 .GetRequiredService<OperationLogger>(): ISingletonOperation [ 1586...Always the same         ]
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddTransient<ITransientOperation, DefaultOperation>()
-                            .AddScoped<IScopedOperation, DefaultOperation>()
-                            .AddSingleton<ISingletonOperation, DefaultOperation>()
-                            .AddTransient<OperationLogger>());
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddTransient<ITransientOperation, DefaultOperation>()
+                        .AddScoped<IScopedOperation, DefaultOperation>()
+                        .AddSingleton<ISingletonOperation, DefaultOperation>()
+                        .AddTransient<OperationLogger>());
 
-        static void ExemplifyScoping(IServiceProvider services, string scope)
-        {
-            using IServiceScope serviceScope = services.CreateScope();
-            IServiceProvider provider = serviceScope.ServiceProvider;
+    static void ExemplifyScoping(IServiceProvider services, string scope)
+    {
+        using IServiceScope serviceScope = services.CreateScope();
+        IServiceProvider provider = serviceScope.ServiceProvider;
 
-            OperationLogger logger = provider.GetRequiredService<OperationLogger>();
-            logger.LogOperations($"{scope}-Call 1 .GetRequiredService<OperationLogger>()");
+        OperationLogger logger = provider.GetRequiredService<OperationLogger>();
+        logger.LogOperations($"{scope}-Call 1 .GetRequiredService<OperationLogger>()");
 
-            Console.WriteLine("...");
+        Console.WriteLine("...");
 
-            logger = provider.GetRequiredService<OperationLogger>();
-            logger.LogOperations($"{scope}-Call 2 .GetRequiredService<OperationLogger>()");
+        logger = provider.GetRequiredService<OperationLogger>();
+        logger.LogOperations($"{scope}-Call 2 .GetRequiredService<OperationLogger>()");
 
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-di/console-di.csproj
+++ b/docs/core/extensions/snippets/configuration/console-di/console-di.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleDI.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-env/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-env/Program.cs
@@ -1,24 +1,22 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleEnvironment.Example
+namespace ConsoleEnvironment.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((hostingContext, configuration) =>
-                    configuration.AddEnvironmentVariables(
-                        prefix: "CustomPrefix_"));
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((hostingContext, configuration) =>
+                configuration.AddEnvironmentVariables(
+                    prefix: "CustomPrefix_"));
 }

--- a/docs/core/extensions/snippets/configuration/console-env/console-env.csproj
+++ b/docs/core/extensions/snippets/configuration/console-env/console-env.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleEnvironment.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-host/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-host/Program.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 class Program

--- a/docs/core/extensions/snippets/configuration/console-host/console-host.csproj
+++ b/docs/core/extensions/snippets/configuration/console-host/console-host.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleHost.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-ini/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-ini/Program.cs
@@ -1,45 +1,41 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleIni.Example
+namespace ConsoleIni.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((hostingContext, configuration) => 
-                {
-                    configuration.Sources.Clear();
-
-                    IHostEnvironment env = hostingContext.HostingEnvironment;
-
-                    configuration
-                        .AddIniFile("appsettings.ini", optional: true, reloadOnChange: true)
-                        .AddIniFile($"appsettings.{env.EnvironmentName}.ini", true, true);
-
-                    foreach ((string key, string value) in
-                        configuration.Build().AsEnumerable().Where(t => t.Value is not null))
-                    {
-                        Console.WriteLine($"{key}={value}");
-                    }
-                });
-        // Sample output:
-        //    TransientFaultHandlingOptions:Enabled=True
-        //    TransientFaultHandlingOptions:AutoRetryDelay=00:00:07
-        //    SecretKey=Secret key value
-        //    Logging:LogLevel:Microsoft=Warning
-        //    Logging:LogLevel:Default=Information
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((hostingContext, configuration) =>
+            {
+                configuration.Sources.Clear();
+
+                IHostEnvironment env = hostingContext.HostingEnvironment;
+
+                configuration
+                    .AddIniFile("appsettings.ini", optional: true, reloadOnChange: true)
+                    .AddIniFile($"appsettings.{env.EnvironmentName}.ini", true, true);
+
+                foreach ((string key, string value) in
+                    configuration.Build().AsEnumerable().Where(t => t.Value is not null))
+                {
+                    Console.WriteLine($"{key}={value}");
+                }
+            });
+    // Sample output:
+    //    TransientFaultHandlingOptions:Enabled=True
+    //    TransientFaultHandlingOptions:AutoRetryDelay=00:00:07
+    //    SecretKey=Secret key value
+    //    Logging:LogLevel:Microsoft=Warning
+    //    Logging:LogLevel:Default=Information
 }

--- a/docs/core/extensions/snippets/configuration/console-ini/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-ini/Program.cs
@@ -32,10 +32,12 @@ class Program
                     Console.WriteLine($"{key}={value}");
                 }
             });
+    // <Output>
     // Sample output:
     //    TransientFaultHandlingOptions:Enabled=True
     //    TransientFaultHandlingOptions:AutoRetryDelay=00:00:07
     //    SecretKey=Secret key value
     //    Logging:LogLevel:Microsoft=Warning
     //    Logging:LogLevel:Default=Information
+    // </Output>
 }

--- a/docs/core/extensions/snippets/configuration/console-ini/console-ini.csproj
+++ b/docs/core/extensions/snippets/configuration/console-ini/console-ini.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleIni.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-json/ExampleService.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/ExampleService.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+public class ExampleService
 {
-    public class ExampleService
+    private readonly TransientFaultHandlingOptions _options;
+
+    public ExampleService(IOptions<TransientFaultHandlingOptions> options) =>
+        _options = options.Value;
+
+    public void DisplayValues()
     {
-        private readonly TransientFaultHandlingOptions _options;
-
-        public ExampleService(IOptions<TransientFaultHandlingOptions> options) =>
-            _options = options.Value;
-
-        public void DisplayValues()
-        {
-            Console.WriteLine($"TransientFaultHandlingOptions.Enabled={_options.Enabled}");
-            Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={_options.AutoRetryDelay}");
-        }
+        Console.WriteLine($"TransientFaultHandlingOptions.Enabled={_options.Enabled}");
+        Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={_options.AutoRetryDelay}");
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-json/MonitorService.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/MonitorService.cs
@@ -1,21 +1,19 @@
-﻿using System;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+public class MonitorService
 {
-    public class MonitorService
+    private readonly IOptionsMonitor<TransientFaultHandlingOptions> _monitor;
+
+    public MonitorService(IOptionsMonitor<TransientFaultHandlingOptions> monitor) =>
+        _monitor = monitor;
+
+    public void DisplayValues()
     {
-        private readonly IOptionsMonitor<TransientFaultHandlingOptions> _monitor;
+        TransientFaultHandlingOptions options = _monitor.CurrentValue;
 
-        public MonitorService(IOptionsMonitor<TransientFaultHandlingOptions> monitor) =>
-            _monitor = monitor;
-
-        public void DisplayValues()
-        {
-            TransientFaultHandlingOptions options = _monitor.CurrentValue;
-
-            Console.WriteLine($"TransientFaultHandlingOptions.Enabled={options.Enabled}");
-            Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRetryDelay}");
-        }
+        Console.WriteLine($"TransientFaultHandlingOptions.Enabled={options.Enabled}");
+        Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRetryDelay}");
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-json/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/Program.cs
@@ -1,44 +1,41 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((hostingContext, configuration) =>
-                {
-                    configuration.Sources.Clear();
-
-                    IHostEnvironment env = hostingContext.HostingEnvironment;
-
-                    configuration
-                        .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", true, true);
-
-                    IConfigurationRoot configurationRoot = configuration.Build();
-
-                    TransientFaultHandlingOptions options = new();
-                    configurationRoot.GetSection(nameof(TransientFaultHandlingOptions))
-                                     .Bind(options);
-
-                    Console.WriteLine($"TransientFaultHandlingOptions.Enabled={options.Enabled}");
-                    Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRetryDelay}");
-                });
-        // Sample output:
-        //    TransientFaultHandlingOptions.Enabled=True
-        //    TransientFaultHandlingOptions.AutoRetryDelay=00:00:07
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((hostingContext, configuration) =>
+            {
+                configuration.Sources.Clear();
+
+                IHostEnvironment env = hostingContext.HostingEnvironment;
+
+                configuration
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                    .AddJsonFile($"appsettings.{env.EnvironmentName}.json", true, true);
+
+                IConfigurationRoot configurationRoot = configuration.Build();
+
+                TransientFaultHandlingOptions options = new();
+                configurationRoot.GetSection(nameof(TransientFaultHandlingOptions))
+                                 .Bind(options);
+
+                Console.WriteLine($"TransientFaultHandlingOptions.Enabled={options.Enabled}");
+                Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRetryDelay}");
+            });
+    // Sample output:
+    //    TransientFaultHandlingOptions.Enabled=True
+    //    TransientFaultHandlingOptions.AutoRetryDelay=00:00:07
 }

--- a/docs/core/extensions/snippets/configuration/console-json/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/Program.cs
@@ -35,7 +35,9 @@ class Program
                 Console.WriteLine($"TransientFaultHandlingOptions.Enabled={options.Enabled}");
                 Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={options.AutoRetryDelay}");
             });
+    // <Output>
     // Sample output:
     //    TransientFaultHandlingOptions.Enabled=True
     //    TransientFaultHandlingOptions.AutoRetryDelay=00:00:07
+    // </Output>
 }

--- a/docs/core/extensions/snippets/configuration/console-json/ScopedService.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/ScopedService.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+public class ScopedService
 {
-    public class ScopedService
+    private readonly TransientFaultHandlingOptions _options;
+
+    public ScopedService(IOptionsSnapshot<TransientFaultHandlingOptions> options) =>
+        _options = options.Value;
+
+    public void DisplayValues()
     {
-        private readonly TransientFaultHandlingOptions _options;
-
-        public ScopedService(IOptionsSnapshot<TransientFaultHandlingOptions> options) =>
-            _options = options.Value;
-
-        public void DisplayValues()
-        {
-            Console.WriteLine($"TransientFaultHandlingOptions.Enabled={_options.Enabled}");
-            Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={_options.AutoRetryDelay}");
-        }
+        Console.WriteLine($"TransientFaultHandlingOptions.Enabled={_options.Enabled}");
+        Console.WriteLine($"TransientFaultHandlingOptions.AutoRetryDelay={_options.AutoRetryDelay}");
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-json/SettingsOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/SettingsOptions.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+public class SettingsOptions
 {
-    public class SettingsOptions
-    {
-        public const string ConfigurationSectionName = "MyCustomSettingsSection";
+    public const string ConfigurationSectionName = "MyCustomSettingsSection";
 
-        [RegularExpression(@"^[a-zA-Z''-'\s]{1,40}$")]
-        public string SiteTitle { get; set; }
+    [RegularExpression(@"^[a-zA-Z''-'\s]{1,40}$")]
+    public string SiteTitle { get; set; } = null!;
 
-        [Range(0, 1000,
-            ErrorMessage = "Value for {0} must be between {1} and {2}.")]
-        public int Scale { get; set; }
+    [Range(0, 1000,
+        ErrorMessage = "Value for {0} must be between {1} and {2}.")]
+    public int Scale { get; set; }
 
-        public int VerbosityLevel { get; set; }
-    }
+    public int VerbosityLevel { get; set; }
 }

--- a/docs/core/extensions/snippets/configuration/console-json/TransientFaultHandlingOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/TransientFaultHandlingOptions.cs
@@ -1,10 +1,7 @@
-﻿using System;
+﻿namespace ConsoleJson.Example;
 
-namespace ConsoleJson.Example
+public class TransientFaultHandlingOptions
 {
-    public class TransientFaultHandlingOptions
-    {
-        public bool Enabled { get; set; }
-        public TimeSpan AutoRetryDelay { get; set; }
-    }
+    public bool Enabled { get; set; }
+    public TimeSpan AutoRetryDelay { get; set; }
 }

--- a/docs/core/extensions/snippets/configuration/console-json/ValidateSettingsOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/ValidateSettingsOptions.cs
@@ -2,39 +2,38 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+class ValidateSettingsOptions : IValidateOptions<SettingsOptions>
 {
-    class ValidateSettingsOptions : IValidateOptions<SettingsOptions>
+    public SettingsOptions _settings { get; private set; }
+
+    public ValidateSettingsOptions(IConfiguration config) =>
+        _settings = config.GetSection(SettingsOptions.ConfigurationSectionName)
+                          .Get<SettingsOptions>();
+
+    public ValidateOptionsResult Validate(string name, SettingsOptions options)
     {
-        public SettingsOptions _settings { get; private set; }
-
-        public ValidateSettingsOptions(IConfiguration config) =>
-            _settings = config.GetSection(SettingsOptions.ConfigurationSectionName)
-                              .Get<SettingsOptions>();
-
-        public ValidateOptionsResult Validate(string name, SettingsOptions options)
+        string result = "";
+        var rx = new Regex(@"^[a-zA-Z''-'\s]{1,40}$");
+        Match match = rx.Match(options.SiteTitle);
+        if (string.IsNullOrEmpty(match.Value))
         {
-            string result = "";
-            var rx = new Regex(@"^[a-zA-Z''-'\s]{1,40}$");
-            Match match = rx.Match(options.SiteTitle);
-            if (string.IsNullOrEmpty(match.Value))
-            {
-                result += $"{options.SiteTitle} doesn't match RegEx\n";
-            }
-
-            if (options.Scale < 0 || options.Scale > 1000)
-            {
-                result += $"{options.Scale} isn't within Range 0 - 1000\n";
-            }
-
-            if (_settings.Scale is 0 && _settings.VerbosityLevel <= _settings.Scale)
-            {
-                result += "VerbosityLevel must be > than Scale.";
-            }
-
-            return result != null 
-                ? ValidateOptionsResult.Fail(result)
-                : ValidateOptionsResult.Success;
+            result += $"{options.SiteTitle} doesn't match RegEx\n";
         }
+
+        if (options.Scale < 0 || options.Scale > 1000)
+        {
+            result += $"{options.Scale} isn't within Range 0 - 1000\n";
+        }
+
+        if (_settings.Scale is 0 && _settings.VerbosityLevel <= _settings.Scale)
+        {
+            result += "VerbosityLevel must be > than Scale.";
+        }
+
+        return result != null
+            ? ValidateOptionsResult.Fail(result)
+            : ValidateOptionsResult.Success;
     }
 }

--- a/docs/core/extensions/snippets/configuration/console-json/ValidationService.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/ValidationService.cs
@@ -1,30 +1,29 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace ConsoleJson.Example
+namespace ConsoleJson.Example;
+
+public class ValidationService
 {
-    public class ValidationService
+    private readonly ILogger<ValidationService> _logger;
+    private readonly IOptions<SettingsOptions> _config;
+
+    public ValidationService(
+        ILogger<ValidationService> logger,
+        IOptions<SettingsOptions> config)
     {
-        private readonly ILogger<ValidationService> _logger;
-        private readonly IOptions<SettingsOptions> _config;
+        _config = config;
+        _logger = logger;
 
-        public ValidationService(
-            ILogger<ValidationService> logger,
-            IOptions<SettingsOptions> config)
+        try
         {
-            _config = config;
-            _logger = logger;
-
-            try
+            SettingsOptions options = _config.Value;
+        }
+        catch (OptionsValidationException ex)
+        {
+            foreach (string failure in ex.Failures)
             {
-                SettingsOptions options = _config.Value;
-            }
-            catch (OptionsValidationException ex)
-            {
-                foreach (string failure in ex.Failures)
-                {
-                    _logger.LogError(failure);
-                }
+                _logger.LogError(failure);
             }
         }
     }

--- a/docs/core/extensions/snippets/configuration/console-json/console-json.csproj
+++ b/docs/core/extensions/snippets/configuration/console-json/console-json.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleJson.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-memory/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-memory/Program.cs
@@ -1,31 +1,28 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleMemory.Example
+namespace ConsoleMemory.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((_, configuration) =>
-                    configuration.AddInMemoryCollection(
-                        new Dictionary<string, string>
-                        {
-                            ["SecretKey"] = "Dictionary MyKey Value",
-                            ["TransientFaultHandlingOptions:Enabled"] = bool.TrueString,
-                            ["TransientFaultHandlingOptions:AutoRetryDelay"] = "00:00:07",
-                            ["Logging:LogLevel:Default"] = "Warning"
-                        }));
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((_, configuration) =>
+                configuration.AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["SecretKey"] = "Dictionary MyKey Value",
+                        ["TransientFaultHandlingOptions:Enabled"] = bool.TrueString,
+                        ["TransientFaultHandlingOptions:AutoRetryDelay"] = "00:00:07",
+                        ["Logging:LogLevel:Default"] = "Warning"
+                    }));
 }

--- a/docs/core/extensions/snippets/configuration/console-memory/console-memory.csproj
+++ b/docs/core/extensions/snippets/configuration/console-memory/console-memory.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleMemory.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console-xml/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-xml/Program.cs
@@ -48,9 +48,11 @@ class Program
                 Console.WriteLine($"{key10} = {val10}");
                 Console.WriteLine($"{key10} = {val11}");
             });
+    // <Output>
     // Sample output:
     //    section:section0:key:key0 = value 00
     //    section:section0:key:key1 = value 01
     //    section:section1:key:key0 = value 10
     //    section:section1:key:key0 = value 11
+    // </Output>
 }

--- a/docs/core/extensions/snippets/configuration/console-xml/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-xml/Program.cs
@@ -1,59 +1,56 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleXml.Example
+namespace ConsoleXml.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((hostingContext, configuration) =>
-                {
-                    configuration.Sources.Clear();
-
-                    configuration
-                        .AddXmlFile("appsettings.xml", optional: true, reloadOnChange: true)
-                        .AddXmlFile("repeating-example.xml", optional: true, reloadOnChange: true);
-
-                    configuration.AddEnvironmentVariables();
-
-                    if (args is { Length: > 0 })
-                    {
-                        configuration.AddCommandLine(args);
-                    }
-
-                    IConfigurationRoot configurationRoot = configuration.Build();
-
-                    string key00 = "section:section0:key:key0";
-                    string key01 = "section:section0:key:key1";
-                    string key10 = "section:section1:key:key0";
-                    string key11 = "section:section1:key:key1";
-
-                    string val00 = configurationRoot[key00];
-                    string val01 = configurationRoot[key01];
-                    string val10 = configurationRoot[key10];
-                    string val11 = configurationRoot[key11];
-
-                    Console.WriteLine($"{key00} = {val00}");
-                    Console.WriteLine($"{key01} = {val01}");
-                    Console.WriteLine($"{key10} = {val10}");
-                    Console.WriteLine($"{key10} = {val11}");
-                });
-        // Sample output:
-        //    section:section0:key:key0 = value 00
-        //    section:section0:key:key1 = value 01
-        //    section:section1:key:key0 = value 10
-        //    section:section1:key:key0 = value 11
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((hostingContext, configuration) =>
+            {
+                configuration.Sources.Clear();
+
+                configuration
+                    .AddXmlFile("appsettings.xml", optional: true, reloadOnChange: true)
+                    .AddXmlFile("repeating-example.xml", optional: true, reloadOnChange: true);
+
+                configuration.AddEnvironmentVariables();
+
+                if (args is { Length: > 0 })
+                {
+                    configuration.AddCommandLine(args);
+                }
+
+                IConfigurationRoot configurationRoot = configuration.Build();
+
+                string key00 = "section:section0:key:key0";
+                string key01 = "section:section0:key:key1";
+                string key10 = "section:section1:key:key0";
+                string key11 = "section:section1:key:key1";
+
+                string val00 = configurationRoot[key00];
+                string val01 = configurationRoot[key01];
+                string val10 = configurationRoot[key10];
+                string val11 = configurationRoot[key11];
+
+                Console.WriteLine($"{key00} = {val00}");
+                Console.WriteLine($"{key01} = {val01}");
+                Console.WriteLine($"{key10} = {val10}");
+                Console.WriteLine($"{key10} = {val11}");
+            });
+    // Sample output:
+    //    section:section0:key:key0 = value 00
+    //    section:section0:key:key1 = value 01
+    //    section:section1:key:key0 = value 10
+    //    section:section1:key:key0 = value 11
 }

--- a/docs/core/extensions/snippets/configuration/console-xml/console-xml.csproj
+++ b/docs/core/extensions/snippets/configuration/console-xml/console-xml.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>ConsoleXml.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/console/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console/Program.cs
@@ -1,20 +1,18 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 
-namespace Console.Example
+namespace Console.Example;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args);
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args);
 }

--- a/docs/core/extensions/snippets/configuration/console/console.csproj
+++ b/docs/core/extensions/snippets/configuration/console/console.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Console.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/custom-provider/Extensions/ConfigurationBuilderExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Extensions/ConfigurationBuilderExtensions.cs
@@ -1,17 +1,16 @@
 ﻿using CustomProvider.Example.Providers;
 
-namespace Microsoft.Extensions.Configuration
-{
-    public static class ConfigurationBuilderExtensions
-    {
-        public static IConfigurationBuilder AddEntityConfiguration(
-            this IConfigurationBuilder builder)
-        {
-            var tempConfig = builder.Build();
-            var connectionString =
-                tempConfig.GetConnectionString("WidgetConnectionString");
+namespace Microsoft.Extensions.Configuration;
 
-            return builder.Add(new EntityConfigurationSource(connectionString));
-        }
+public static class ConfigurationBuilderExtensions
+{
+    public static IConfigurationBuilder AddEntityConfiguration(
+        this IConfigurationBuilder builder)
+    {
+        var tempConfig = builder.Build();
+        var connectionString =
+            tempConfig.GetConnectionString("WidgetConnectionString");
+
+        return builder.Add(new EntityConfigurationSource(connectionString));
     }
 }

--- a/docs/core/extensions/snippets/configuration/custom-provider/Models/Settings.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Models/Settings.cs
@@ -1,4 +1,3 @@
-﻿namespace CustomProvider.Example.Models
-{
-    public record Settings(string Id, string Value);
-}
+﻿namespace CustomProvider.Example.Models;
+
+public record Settings(string Id, string Value);

--- a/docs/core/extensions/snippets/configuration/custom-provider/Program.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;

--- a/docs/core/extensions/snippets/configuration/custom-provider/Providers/EntityConfigurationContext.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Providers/EntityConfigurationContext.cs
@@ -1,24 +1,23 @@
 ﻿using CustomProvider.Example.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace CustomProvider.Example.Providers
+namespace CustomProvider.Example.Providers;
+
+public class EntityConfigurationContext : DbContext
 {
-    public class EntityConfigurationContext : DbContext
+    private readonly string _connectionString;
+
+    public DbSet<Settings>? Settings { get; set; }
+
+    public EntityConfigurationContext(string connectionString) =>
+        _connectionString = connectionString;
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        private readonly string _connectionString;
-
-        public DbSet<Settings> Settings { get; set; }
-
-        public EntityConfigurationContext(string connectionString) =>
-            _connectionString = connectionString;
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        _ = _connectionString switch
         {
-            _ = _connectionString switch
-            {
-                { Length: > 0 } => optionsBuilder.UseSqlServer(_connectionString),
-                _ => optionsBuilder.UseInMemoryDatabase("InMemoryDatabase")
-            };
-        }
+            { Length: > 0 } => optionsBuilder.UseSqlServer(_connectionString),
+            _ => optionsBuilder.UseInMemoryDatabase("InMemoryDatabase")
+        };
     }
 }

--- a/docs/core/extensions/snippets/configuration/custom-provider/Providers/EntityConfigurationSource.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Providers/EntityConfigurationSource.cs
@@ -1,15 +1,14 @@
 ﻿using Microsoft.Extensions.Configuration;
 
-namespace CustomProvider.Example.Providers
+namespace CustomProvider.Example.Providers;
+
+public class EntityConfigurationSource : IConfigurationSource
 {
-    public class EntityConfigurationSource : IConfigurationSource
-    {
-        private readonly string _connectionString;
+    private readonly string _connectionString;
 
-        public EntityConfigurationSource(string connectionString) =>
-            _connectionString = connectionString;
+    public EntityConfigurationSource(string connectionString) =>
+        _connectionString = connectionString;
 
-        public IConfigurationProvider Build(IConfigurationBuilder builder) =>
-            new EntityConfigurationProvider(_connectionString);
-    }
+    public IConfigurationProvider Build(IConfigurationBuilder builder) =>
+        new EntityConfigurationProvider(_connectionString);
 }

--- a/docs/core/extensions/snippets/configuration/custom-provider/WidgetOptions.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/WidgetOptions.cs
@@ -1,13 +1,10 @@
-﻿using System;
+﻿namespace CustomProvider.Example;
 
-namespace CustomProvider.Example
+public class WidgetOptions
 {
-    public class WidgetOptions
-    {
-        public Guid EndpointId { get; set; }
+    public Guid EndpointId { get; set; }
 
-        public string DisplayLabel { get; set; }
+    public string DisplayLabel { get; set; } = null!;
 
-        public string WidgetRoute { get; set; }
-    }
+    public string WidgetRoute { get; set; } = null!;
 }

--- a/docs/core/extensions/snippets/configuration/custom-provider/custom-provider.csproj
+++ b/docs/core/extensions/snippets/configuration/custom-provider/custom-provider.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>CustomProvider.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/dependency-injection/IMessageWriter.cs
+++ b/docs/core/extensions/snippets/configuration/dependency-injection/IMessageWriter.cs
@@ -1,7 +1,6 @@
-﻿namespace DependencyInjection.Example
+﻿namespace DependencyInjection.Example;
+
+public interface IMessageWriter
 {
-    public interface IMessageWriter
-    {
-        void Write(string message);
-    }
+    void Write(string message);
 }

--- a/docs/core/extensions/snippets/configuration/dependency-injection/LoggingMessageWriter.cs
+++ b/docs/core/extensions/snippets/configuration/dependency-injection/LoggingMessageWriter.cs
@@ -1,15 +1,12 @@
-﻿using Microsoft.Extensions.Logging;
+﻿namespace DependencyInjection.Example;
 
-namespace DependencyInjection.Example
+public class LoggingMessageWriter : IMessageWriter
 {
-    public class LoggingMessageWriter : IMessageWriter
-    {
-        private readonly ILogger<LoggingMessageWriter> _logger;
+    private readonly ILogger<LoggingMessageWriter> _logger;
 
-        public LoggingMessageWriter(ILogger<LoggingMessageWriter> logger) =>
-            _logger = logger;
+    public LoggingMessageWriter(ILogger<LoggingMessageWriter> logger) =>
+        _logger = logger;
 
-        public void Write(string message) =>
-            _logger.LogInformation(message);
-    }
+    public void Write(string message) =>
+        _logger.LogInformation(message);
 }

--- a/docs/core/extensions/snippets/configuration/dependency-injection/MessageWriter.cs
+++ b/docs/core/extensions/snippets/configuration/dependency-injection/MessageWriter.cs
@@ -1,12 +1,9 @@
-﻿using System;
+﻿namespace DependencyInjection.Example;
 
-namespace DependencyInjection.Example
+public class MessageWriter : IMessageWriter
 {
-    public class MessageWriter : IMessageWriter
+    public void Write(string message)
     {
-        public void Write(string message)
-        {
-            Console.WriteLine($"MessageWriter.Write(message: \"{message}\")");
-        }
+        Console.WriteLine($"MessageWriter.Write(message: \"{message}\")");
     }
 }

--- a/docs/core/extensions/snippets/configuration/dependency-injection/Program.cs
+++ b/docs/core/extensions/snippets/configuration/dependency-injection/Program.cs
@@ -1,18 +1,13 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+﻿namespace DependencyInjection.Example;
 
-namespace DependencyInjection.Example
+class Program
 {
-    class Program
-    {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+    static Task Main(string[] args) =>
+        CreateHostBuilder(args).Build().RunAsync();
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddHostedService<Worker>()
-                            .AddScoped<IMessageWriter, MessageWriter>());
-    }
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddHostedService<Worker>()
+                        .AddScoped<IMessageWriter, MessageWriter>());
 }

--- a/docs/core/extensions/snippets/configuration/dependency-injection/Worker.cs
+++ b/docs/core/extensions/snippets/configuration/dependency-injection/Worker.cs
@@ -1,24 +1,18 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
+﻿namespace DependencyInjection.Example;
 
-namespace DependencyInjection.Example
+public class Worker : BackgroundService
 {
-    public class Worker : BackgroundService
+    private readonly IMessageWriter _messageWriter;
+
+    public Worker(IMessageWriter messageWriter) =>
+        _messageWriter = messageWriter;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        private readonly IMessageWriter _messageWriter;
-
-        public Worker(IMessageWriter messageWriter) =>
-            _messageWriter = messageWriter;
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                _messageWriter.Write($"Worker running at: {DateTimeOffset.Now}");
-                await Task.Delay(1000, stoppingToken);
-            }
+            _messageWriter.Write($"Worker running at: {DateTimeOffset.Now}");
+            await Task.Delay(1000, stoppingToken);
         }
     }
 }

--- a/docs/core/extensions/snippets/configuration/dependency-injection/dependency-injection.csproj
+++ b/docs/core/extensions/snippets/configuration/dependency-injection/dependency-injection.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>DependencyInjection.Example</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/di-anti-patterns/ExampleDisposable.cs
+++ b/docs/core/extensions/snippets/configuration/di-anti-patterns/ExampleDisposable.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace DependencyInjection.AntiPatterns
+﻿namespace DependencyInjection.AntiPatterns
 {
     public class ExampleDisposable : IDisposable
     {

--- a/docs/core/extensions/snippets/configuration/di-anti-patterns/Program.cs
+++ b/docs/core/extensions/snippets/configuration/di-anti-patterns/Program.cs
@@ -11,6 +11,7 @@
             // ScopedServiceBecomesSingleton();
         }
 
+        // <TransientDisposable>
         static void TransientDisposablesWithoutDispose()
         {
             var services = new ServiceCollection();
@@ -24,7 +25,9 @@
 
             // serviceProvider.Dispose();
         }
+        // </TransientDisposable>
 
+        // <AsyncDeadlockOne>
         static void DeadLockWithAsyncFactory()
         {
             var services = new ServiceCollection();
@@ -39,7 +42,9 @@
             using ServiceProvider serviceProvider = services.BuildServiceProvider();
             _ = serviceProvider.GetRequiredService<Foo>();
         }
+        // </AsyncDeadlockOne>
 
+        // <AsyncDeadlockTwo>
         static async Task<Bar> GetBarAsync(IServiceProvider serviceProvider)
         {
             // Emulate asynchronous work operation
@@ -47,7 +52,9 @@
 
             return serviceProvider.GetRequiredService<Bar>();
         }
+        // </AsyncDeadlockTwo>
 
+        // <CaptiveDependency>
         static void CaptiveDependency()
         {
             var services = new ServiceCollection();
@@ -60,7 +67,9 @@
 
             _ = serviceProvider.GetRequiredService<Foo>();
         }
+        // </CaptiveDependency>
 
+        // <ScopedServiceBecomesSingleton>
         static void ScopedServiceBecomesSingleton()
         {
             var services = new ServiceCollection();
@@ -76,5 +85,6 @@
             // Not within a scope, becomes a singleton
             Bar avoid = serviceProvider.GetRequiredService<Bar>();
         }
+        // </ScopedServiceBecomesSingleton>
     }
 }

--- a/docs/core/extensions/snippets/configuration/di-anti-patterns/Program.cs
+++ b/docs/core/extensions/snippets/configuration/di-anti-patterns/Program.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-
-namespace DependencyInjection.AntiPatterns
+﻿namespace DependencyInjection.AntiPatterns
 {
     class Program
     {

--- a/docs/core/extensions/snippets/configuration/di-anti-patterns/di-anti-patterns.csproj
+++ b/docs/core/extensions/snippets/configuration/di-anti-patterns/di-anti-patterns.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>DependencyInjection.AntiPatterns</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/configuration/options-action/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-action/Program.cs
@@ -22,6 +22,6 @@ class Program
                 {
                         // User defined option values
                         // options.SomePropertyValue = ...
-                    });
+                });
             });
 }

--- a/docs/core/extensions/snippets/configuration/options-action/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-action/Program.cs
@@ -1,29 +1,27 @@
-﻿using System.Threading.Tasks;
-using ExampleLibrary.Extensions.DependencyInjection;
+﻿using ExampleLibrary.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Options.Action
+namespace Options.Action;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
+        await host.RunAsync();
+    }
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices(services => 
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices(services =>
+            {
+                services.AddMyLibraryService(options =>
                 {
-                    services.AddMyLibraryService(options =>
-                    {
                         // User defined option values
                         // options.SomePropertyValue = ...
                     });
-                });
-    }
+            });
 }

--- a/docs/core/extensions/snippets/configuration/options-action/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-action/ServiceCollectionExtensions.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace ExampleLibrary.Extensions.DependencyInjection
+namespace ExampleLibrary.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddMyLibraryService(
+        this IServiceCollection services,
+        Action<LibraryOptions> configureOptions)
     {
-        public static IServiceCollection AddMyLibraryService(
-          this IServiceCollection services,
-          Action<LibraryOptions> configureOptions)
-        {
-            services.Configure(configureOptions);
+        services.Configure(configureOptions);
 
-            // Register lib services here...
-            // services.AddScoped<ILibraryService, DefaultLibraryService>();
+        // Register lib services here...
+        // services.AddScoped<ILibraryService, DefaultLibraryService>();
 
-            return services;
-        }
+        return services;
     }
 }

--- a/docs/core/extensions/snippets/configuration/options-action/options-action.csproj
+++ b/docs/core/extensions/snippets/configuration/options-action/options-action.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Options.Action</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/configuration/options-configparam/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-configparam/Program.cs
@@ -1,26 +1,24 @@
-﻿using System.Threading.Tasks;
-using ExampleLibrary.Extensions.DependencyInjection;
+﻿using ExampleLibrary.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Options.ConfigParam
+namespace Options.ConfigParam;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((context, services) =>
-                {
-                    services.AddMyLibraryService(
-                        context.Configuration.GetSection("LibraryOptions"));
-                });
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((context, services) =>
+            {
+                services.AddMyLibraryService(
+                    context.Configuration.GetSection("LibraryOptions"));
+            });
 }

--- a/docs/core/extensions/snippets/configuration/options-configparam/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-configparam/ServiceCollectionExtensions.cs
@@ -1,22 +1,21 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace ExampleLibrary.Extensions.DependencyInjection
+namespace ExampleLibrary.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddMyLibraryService(
+      this IServiceCollection services,
+      IConfiguration namedConfigurationSection)
     {
-        public static IServiceCollection AddMyLibraryService(
-          this IServiceCollection services,
-          IConfiguration namedConfigurationSection)
-        {
-            // Default library options are overridden
-            // by bound configuration values.
-            services.Configure<LibraryOptions>(namedConfigurationSection);
+        // Default library options are overridden
+        // by bound configuration values.
+        services.Configure<LibraryOptions>(namedConfigurationSection);
 
-            // Register lib services here...
-            // services.AddScoped<ILibraryService, DefaultLibraryService>();
+        // Register lib services here...
+        // services.AddScoped<ILibraryService, DefaultLibraryService>();
 
-            return services;
-        }
+        return services;
     }
 }

--- a/docs/core/extensions/snippets/configuration/options-configparam/options-configparam.csproj
+++ b/docs/core/extensions/snippets/configuration/options-configparam/options-configparam.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Options.ConfigParam</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/configuration/options-noparams/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-noparams/Program.cs
@@ -1,26 +1,23 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using ExampleLibrary.Extensions.DependencyInjection;
+﻿using ExampleLibrary.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Options.NoParams
+namespace Options.NoParams;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices(services =>
-                {
-                    services.AddMyLibraryService();
-                });
+        await host.RunAsync();
     }
+
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices(services =>
+            {
+                services.AddMyLibraryService();
+            });
 }

--- a/docs/core/extensions/snippets/configuration/options-noparams/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-noparams/ServiceCollectionExtensions.cs
@@ -1,22 +1,21 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace ExampleLibrary.Extensions.DependencyInjection
+namespace ExampleLibrary.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddMyLibraryService(
+        this IServiceCollection services)
     {
-        public static IServiceCollection AddMyLibraryService(
-            this IServiceCollection services)
-        {
-            services.AddOptions<LibraryOptions>()
-                .Configure(options =>
-                {
+        services.AddOptions<LibraryOptions>()
+            .Configure(options =>
+            {
                     // Specify default option values
                 });
 
-            // Register lib services here...
-            // services.AddScoped<ILibraryService, DefaultLibraryService>();
+        // Register lib services here...
+        // services.AddScoped<ILibraryService, DefaultLibraryService>();
 
-            return services;
-        }
+        return services;
     }
 }

--- a/docs/core/extensions/snippets/configuration/options-noparams/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-noparams/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
             .Configure(options =>
             {
                     // Specify default option values
-                });
+            });
 
         // Register lib services here...
         // services.AddScoped<ILibraryService, DefaultLibraryService>();

--- a/docs/core/extensions/snippets/configuration/options-noparams/options-noparams.csproj
+++ b/docs/core/extensions/snippets/configuration/options-noparams/options-noparams.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Options.NoParams</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/configuration/options-object/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-object/Program.cs
@@ -22,6 +22,6 @@ class Program
                 {
                         // Specify option values
                         // SomePropertyValue = ...
-                    });
+                });
             });
 }

--- a/docs/core/extensions/snippets/configuration/options-object/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-object/Program.cs
@@ -1,29 +1,27 @@
-﻿using System.Threading.Tasks;
-using ExampleLibrary.Extensions.DependencyInjection;
+﻿using ExampleLibrary.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Options.Object
+namespace Options.Object;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
+        await host.RunAsync();
+    }
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices(services =>
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices(services =>
+            {
+                services.AddMyLibraryService(new LibraryOptions
                 {
-                    services.AddMyLibraryService(new LibraryOptions
-                    {
                         // Specify option values
                         // SomePropertyValue = ...
                     });
-                });
-    }
+            });
 }

--- a/docs/core/extensions/snippets/configuration/options-object/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-object/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class ServiceCollectionExtensions
                     // Overwrite default option values
                     // with the user provided options.
                     // options.SomeValue = userOptions.SomeValue;
-                });
+            });
 
         // Register lib services here...
         // services.AddScoped<ILibraryService, DefaultLibraryService>();

--- a/docs/core/extensions/snippets/configuration/options-object/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-object/ServiceCollectionExtensions.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace ExampleLibrary.Extensions.DependencyInjection
+namespace ExampleLibrary.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddMyLibraryService(
+      this IServiceCollection services,
+      LibraryOptions userOptions)
     {
-        public static IServiceCollection AddMyLibraryService(
-          this IServiceCollection services,
-          LibraryOptions userOptions)
-        {
-            services.AddOptions<LibraryOptions>()
-                .Configure(options =>
-                {
+        services.AddOptions<LibraryOptions>()
+            .Configure(options =>
+            {
                     // Overwrite default option values
                     // with the user provided options.
                     // options.SomeValue = userOptions.SomeValue;
                 });
 
-            // Register lib services here...
-            // services.AddScoped<ILibraryService, DefaultLibraryService>();
+        // Register lib services here...
+        // services.AddScoped<ILibraryService, DefaultLibraryService>();
 
-            return services;
-        }
+        return services;
     }
 }

--- a/docs/core/extensions/snippets/configuration/options-object/options-object.csproj
+++ b/docs/core/extensions/snippets/configuration/options-object/options-object.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Options.Object</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/configuration/options-postconfig/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-postconfig/Program.cs
@@ -1,29 +1,27 @@
-﻿using System.Threading.Tasks;
-using ExampleLibrary.Extensions.DependencyInjection;
+﻿using ExampleLibrary.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Options.PostConfig
+namespace Options.PostConfig;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        using IHost host = CreateHostBuilder(args).Build();
 
-            // Application code should start here.
+        // Application code should start here.
 
-            await host.RunAsync();
-        }
+        await host.RunAsync();
+    }
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices(services =>
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices(services =>
+            {
+                services.AddMyLibraryService(options =>
                 {
-                    services.AddMyLibraryService(options =>
-                    {
                         // Specify option values
                         // options.SomePropertyValue = ...
                     });
-                });
-    }
+            });
 }

--- a/docs/core/extensions/snippets/configuration/options-postconfig/Program.cs
+++ b/docs/core/extensions/snippets/configuration/options-postconfig/Program.cs
@@ -22,6 +22,6 @@ class Program
                 {
                         // Specify option values
                         // options.SomePropertyValue = ...
-                    });
+                });
             });
 }

--- a/docs/core/extensions/snippets/configuration/options-postconfig/ServiceCollectionExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/options-postconfig/ServiceCollectionExtensions.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace ExampleLibrary.Extensions.DependencyInjection
+namespace ExampleLibrary.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddMyLibraryService(
+      this IServiceCollection services,
+      Action<LibraryOptions> configureOptions)
     {
-        public static IServiceCollection AddMyLibraryService(
-          this IServiceCollection services,
-          Action<LibraryOptions> configureOptions)
-        {
-            services.PostConfigure(configureOptions);
+        services.PostConfigure(configureOptions);
 
-            // Register lib services here...
-            // services.AddScoped<ILibraryService, DefaultLibraryService>();
+        // Register lib services here...
+        // services.AddScoped<ILibraryService, DefaultLibraryService>();
 
-            return services;
-        }
+        return services;
     }
 }

--- a/docs/core/extensions/snippets/configuration/options-postconfig/options-postconfig.csproj
+++ b/docs/core/extensions/snippets/configuration/options-postconfig/options-postconfig.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Options.PostConfig</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/configuration/worker-scope/AutoIncrementingIdProvider.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/AutoIncrementingIdProvider.cs
@@ -1,9 +1,8 @@
-﻿namespace WorkerScope.Example
-{
-    class AutoIncrementingIdProvider : IObjectIdProvider
-    {
-        static int s_id;
+﻿namespace WorkerScope.Example;
 
-        int IObjectIdProvider.GetNextId() => ++ s_id;
-    }
+class AutoIncrementingIdProvider : IObjectIdProvider
+{
+    static int s_id;
+
+    int IObjectIdProvider.GetNextId() => ++s_id;
 }

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectIdProvider.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectIdProvider.cs
@@ -1,7 +1,6 @@
-﻿namespace WorkerScope.Example
+﻿namespace WorkerScope.Example;
+
+interface IObjectIdProvider
 {
-    interface IObjectIdProvider
-    {
-        int GetNextId();
-    }
+    int GetNextId();
 }

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectProcessor.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectProcessor.cs
@@ -1,9 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿namespace WorkerScope.Example;
 
-namespace WorkerScope.Example
+interface IObjectProcessor
 {
-    interface IObjectProcessor
-    {
-        Task ProcessAsync(ObjectGraph obj);
-    }
+    Task ProcessAsync(ObjectGraph obj);
 }

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectRelay.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectRelay.cs
@@ -1,9 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿namespace WorkerScope.Example;
 
-namespace WorkerScope.Example
+interface IObjectRelay
 {
-    interface IObjectRelay
-    {
-        Task RelayAsync(ObjectGraph obj);
-    }
+    Task RelayAsync(ObjectGraph obj);
 }

--- a/docs/core/extensions/snippets/configuration/worker-scope/IObjectStore.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/IObjectStore.cs
@@ -1,11 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿namespace WorkerScope.Example;
 
-namespace WorkerScope.Example
+interface IObjectStore
 {
-    interface IObjectStore
-    {
-        Task<ObjectGraph> GetNextAsync();
+    Task<ObjectGraph> GetNextAsync();
 
-        Task<ObjectGraph> MarkAsync(ObjectGraph graph);
-    }
+    Task<ObjectGraph> MarkAsync(ObjectGraph graph);
 }

--- a/docs/core/extensions/snippets/configuration/worker-scope/ObjectGraph.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/ObjectGraph.cs
@@ -1,4 +1,3 @@
-﻿namespace WorkerScope.Example
-{
-    record ObjectGraph(int Id, string Name, bool IsProcessed = false);
-}
+﻿namespace WorkerScope.Example;
+
+record ObjectGraph(int Id, string Name, bool IsProcessed = false);

--- a/docs/core/extensions/snippets/configuration/worker-scope/ObjectWorkerService.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/ObjectWorkerService.cs
@@ -1,55 +1,50 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+﻿using System.Collections.Concurrent;
 
-namespace WorkerScope.Example
+namespace WorkerScope.Example;
+
+internal class ObjectWorkerService :
+    IObjectProcessor,
+    IObjectRelay,
+    IObjectStore
 {
-    internal class ObjectWorkerService :
-        IObjectProcessor,
-        IObjectRelay,
-        IObjectStore
+    static readonly Random s_random = new((int)DateTime.Now.Ticks);
+    static readonly ConcurrentDictionary<int, ObjectGraph> s_objects = new();
+
+    static int NextRandomDelay => s_random.Next(250, 3000);
+
+    readonly IObjectIdProvider _objectIdProvider;
+
+    public ObjectWorkerService(ILogger<ObjectWorkerService> logger, IServiceProvider serviceProvider)
     {
-        static readonly Random s_random = new((int)DateTime.Now.Ticks);
-        static readonly ConcurrentDictionary<int, ObjectGraph> s_objects = new();
+        _objectIdProvider = serviceProvider.GetRequiredService<IObjectIdProvider>();
 
-        static int NextRandomDelay => s_random.Next(250, 3000);
-
-        readonly IObjectIdProvider _objectIdProvider;
-
-        public ObjectWorkerService(ILogger<ObjectWorkerService> logger, IServiceProvider serviceProvider)
-        {
-            _objectIdProvider = serviceProvider.GetRequiredService<IObjectIdProvider>();
-            
-            logger.LogInformation(
-                "ObjectWorkerService's provider hash: {hash}",
-                serviceProvider.GetHashCode());
-        }
-
-        public async Task<ObjectGraph> GetNextAsync()
-        {
-            await Task.Delay(NextRandomDelay);
-
-            var id = _objectIdProvider.GetNextId();
-
-            return s_objects.GetOrAdd(id, _ => new(id, $"Object #{id}"));
-        }
-
-        public int GetNextId() => s_objects.Count + 1;
-
-        public async Task<ObjectGraph> MarkAsync(ObjectGraph obj)
-        {
-            await Task.Delay(NextRandomDelay);
-
-            return s_objects.TryUpdate(obj.Id, obj with { IsProcessed = true }, obj) &&
-                s_objects.TryGetValue(obj.Id, out ObjectGraph updatedObject)
-                ? updatedObject
-                : obj;
-        }
-
-        public Task ProcessAsync(ObjectGraph obj) => Task.Delay(NextRandomDelay);
-
-        public Task RelayAsync(ObjectGraph obj) => Task.Delay(NextRandomDelay);
+        logger.LogInformation(
+            "ObjectWorkerService's provider hash: {hash}",
+            serviceProvider.GetHashCode());
     }
+
+    public async Task<ObjectGraph> GetNextAsync()
+    {
+        await Task.Delay(NextRandomDelay);
+
+        var id = _objectIdProvider.GetNextId();
+
+        return s_objects.GetOrAdd(id, _ => new(id, $"Object #{id}"));
+    }
+
+    public int GetNextId() => s_objects.Count + 1;
+
+    public async Task<ObjectGraph> MarkAsync(ObjectGraph obj)
+    {
+        await Task.Delay(NextRandomDelay);
+
+        return s_objects.TryUpdate(obj.Id, obj with { IsProcessed = true }, obj) &&
+            s_objects.TryGetValue(obj.Id, out ObjectGraph updatedObject)
+            ? updatedObject
+            : obj;
+    }
+
+    public Task ProcessAsync(ObjectGraph obj) => Task.Delay(NextRandomDelay);
+
+    public Task RelayAsync(ObjectGraph obj) => Task.Delay(NextRandomDelay);
 }

--- a/docs/core/extensions/snippets/configuration/worker-scope/Program.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/Program.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using WorkerScope.Example;
+﻿using WorkerScope.Example;
 
 using var host =
     Host.CreateDefaultBuilder(args)

--- a/docs/core/extensions/snippets/configuration/worker-scope/Worker.cs
+++ b/docs/core/extensions/snippets/configuration/worker-scope/Worker.cs
@@ -1,53 +1,45 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+﻿namespace WorkerScope.Example;
 
-namespace WorkerScope.Example
+public class Worker : BackgroundService
 {
-    public class Worker : BackgroundService
+    private readonly ILogger<Worker> _logger;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    public Worker(ILogger<Worker> logger, IServiceScopeFactory serviceScopeFactory) =>
+        (_logger, _serviceScopeFactory) = (logger, serviceScopeFactory);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        private readonly ILogger<Worker> _logger;
-        private readonly IServiceScopeFactory _serviceScopeFactory;
-
-        public Worker(ILogger<Worker> logger, IServiceScopeFactory serviceScopeFactory) =>
-            (_logger, _serviceScopeFactory) = (logger, serviceScopeFactory);
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            using (IServiceScope scope = _serviceScopeFactory.CreateScope())
             {
-                using (IServiceScope scope = _serviceScopeFactory.CreateScope())
+                try
                 {
-                    try
-                    {
-                        _logger.LogInformation(
-                            "Starting scoped work, provider hash: {hash}.",
-                            scope.ServiceProvider.GetHashCode());
+                    _logger.LogInformation(
+                        "Starting scoped work, provider hash: {hash}.",
+                        scope.ServiceProvider.GetHashCode());
 
-                        var store = scope.ServiceProvider.GetRequiredService<IObjectStore>();
-                        var next = await store.GetNextAsync();
-                        _logger.LogInformation("{next}", next);
+                    var store = scope.ServiceProvider.GetRequiredService<IObjectStore>();
+                    var next = await store.GetNextAsync();
+                    _logger.LogInformation("{next}", next);
 
-                        var processor = scope.ServiceProvider.GetRequiredService<IObjectProcessor>();
-                        await processor.ProcessAsync(next);
-                        _logger.LogInformation("Processing {name}.", next.Name);
+                    var processor = scope.ServiceProvider.GetRequiredService<IObjectProcessor>();
+                    await processor.ProcessAsync(next);
+                    _logger.LogInformation("Processing {name}.", next.Name);
 
-                        var relay = scope.ServiceProvider.GetRequiredService<IObjectRelay>();
-                        await relay.RelayAsync(next);
-                        _logger.LogInformation("Processed results have been relayed.");
+                    var relay = scope.ServiceProvider.GetRequiredService<IObjectRelay>();
+                    await relay.RelayAsync(next);
+                    _logger.LogInformation("Processed results have been relayed.");
 
-                        var marked = await store.MarkAsync(next);
-                        _logger.LogInformation("Marked as processed: {next}", marked);
-                    }
-                    finally
-                    {
-                        _logger.LogInformation(
-                            "Finished scoped work, provider hash: {hash}.{nl}",
-                            scope.ServiceProvider.GetHashCode(), Environment.NewLine);
-                    }
+                    var marked = await store.MarkAsync(next);
+                    _logger.LogInformation("Marked as processed: {next}", marked);
+                }
+                finally
+                {
+                    _logger.LogInformation(
+                        "Finished scoped work, provider hash: {hash}.{nl}",
+                        scope.ServiceProvider.GetHashCode(), Environment.NewLine);
                 }
             }
         }

--- a/docs/core/extensions/snippets/configuration/worker-scope/worker-scope.csproj
+++ b/docs/core/extensions/snippets/configuration/worker-scope/worker-scope.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>WorkerScope.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/configuration/worker-service-options/Extensions/LoggerExtensions.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/Extensions/LoggerExtensions.cs
@@ -1,61 +1,57 @@
-﻿using System;
-using Microsoft.Extensions.Logging;
+﻿namespace WorkerServiceOptions.Example.Extensions;
 
-namespace WorkerServiceOptions.Example.Extensions
+public static class LoggerExtensions
 {
-    public static class LoggerExtensions
+    #region ProcessingItemField
+    private static readonly Action<ILogger, WorkItem, Exception> _processingPriorityItem;
+    #endregion
+
+    #region FailedProcessingField
+    private static readonly Action<ILogger, Exception> _failedToProcessWorkItem;
+    #endregion
+
+    #region ProcessingWorkField
+    private static Func<ILogger, DateTime, IDisposable> _processingWorkScope;
+    #endregion
+
+    static LoggerExtensions()
     {
-        #region ProcessingItemField
-        private static readonly Action<ILogger, WorkItem, Exception> _processingPriorityItem;
+        #region ProcessingItemAssignment
+        _processingPriorityItem = LoggerMessage.Define<WorkItem>(
+            LogLevel.Information,
+            new EventId(1, nameof(PriorityItemProcessed)),
+            "Processing priority item: {Item}");
         #endregion
 
-        #region FailedProcessingField
-        private static readonly Action<ILogger, Exception> _failedToProcessWorkItem;
+        #region FailedProcessingAssignment
+        _failedToProcessWorkItem = LoggerMessage.Define(
+            LogLevel.Critical,
+            new EventId(13, nameof(FailedToProcessWorkItem)),
+            "Epic failure processing item!");
         #endregion
 
-        #region ProcessingWorkField
-        private static Func<ILogger, DateTime, IDisposable> _processingWorkScope;
-        #endregion
-
-        static LoggerExtensions()
-        {
-            #region ProcessingItemAssignment
-            _processingPriorityItem = LoggerMessage.Define<WorkItem>(
-                LogLevel.Information,
-                new EventId(1, nameof(PriorityItemProcessed)),
-                "Processing priority item: {Item}");
-            #endregion
-
-            #region FailedProcessingAssignment
-            _failedToProcessWorkItem = LoggerMessage.Define(
-                LogLevel.Critical,
-                new EventId(13, nameof(FailedToProcessWorkItem)),
-                "Epic failure processing item!");
-            #endregion
-
-            #region ProcessingWorkAssignment
-            _processingWorkScope =
-                LoggerMessage.DefineScope<DateTime>(
-                    "Processing work, started at: {DateTime}");
-            #endregion
-        }
-
-        #region ProcessingItemMethod
-        public static void PriorityItemProcessed(
-            this ILogger logger, WorkItem workItem) =>
-            _processingPriorityItem(logger, workItem, default!);
-        #endregion
-
-        #region FailedProcessingMethod
-        public static void FailedToProcessWorkItem(
-            this ILogger logger, Exception ex) =>
-            _failedToProcessWorkItem(logger, ex);
-        #endregion
-
-        #region ProcessingWorkMethod
-        public static IDisposable ProcessingWorkScope(
-            this ILogger logger, DateTime time) =>
-            _processingWorkScope(logger, time);
+        #region ProcessingWorkAssignment
+        _processingWorkScope =
+            LoggerMessage.DefineScope<DateTime>(
+                "Processing work, started at: {DateTime}");
         #endregion
     }
+
+    #region ProcessingItemMethod
+    public static void PriorityItemProcessed(
+        this ILogger logger, WorkItem workItem) =>
+        _processingPriorityItem(logger, workItem, default!);
+    #endregion
+
+    #region FailedProcessingMethod
+    public static void FailedToProcessWorkItem(
+        this ILogger logger, Exception ex) =>
+        _failedToProcessWorkItem(logger, ex);
+    #endregion
+
+    #region ProcessingWorkMethod
+    public static IDisposable ProcessingWorkScope(
+        this ILogger logger, DateTime time) =>
+        _processingWorkScope(logger, time);
+    #endregion
 }

--- a/docs/core/extensions/snippets/configuration/worker-service-options/Priority.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/Priority.cs
@@ -1,11 +1,10 @@
-﻿namespace WorkerServiceOptions.Example
+﻿namespace WorkerServiceOptions.Example;
+
+public enum Priority
 {
-    public enum Priority
-    {
-        Deferred = -1,
-        Low,
-        Medium,
-        High,
-        Extreme
-    }
+    Deferred = -1,
+    Low,
+    Medium,
+    High,
+    Extreme
 }

--- a/docs/core/extensions/snippets/configuration/worker-service-options/PriorityQueue.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/PriorityQueue.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿namespace WorkerServiceOptions.Example;
 
-namespace WorkerServiceOptions.Example
+public class PriorityQueue
 {
-    public class PriorityQueue
-    {
-        private readonly IList<WorkItem> _workItems = new List<WorkItem>
+    private readonly IList<WorkItem> _workItems = new List<WorkItem>
         {
             new WorkItem("Validate collection", Priority.High),
             new WorkItem("Health check network", Priority.Low),
@@ -16,18 +13,17 @@ namespace WorkerServiceOptions.Example
             new WorkItem("Enter pooling [contention]", Priority.Medium)
         };
 
-        public WorkItem? ProcessNextHighestPriority()
-        {
-            WorkItem? workItem =
-                _workItems.Where(work => !work.IsCompleted)
-                          .OrderByDescending(work => work.Priority)
-                          .FirstOrDefault();
+    public WorkItem? ProcessNextHighestPriority()
+    {
+        WorkItem? workItem =
+            _workItems.Where(work => !work.IsCompleted)
+                      .OrderByDescending(work => work.Priority)
+                      .FirstOrDefault();
 
-            return workItem switch
-            {
-                not null when _workItems.Remove(workItem) => workItem.MarkAsComplete(),
-                _ => default
-            };
-        }
+        return workItem switch
+        {
+            not null when _workItems.Remove(workItem) => workItem.MarkAsComplete(),
+            _ => default
+        };
     }
 }

--- a/docs/core/extensions/snippets/configuration/worker-service-options/Program.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/Program.cs
@@ -1,18 +1,13 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+﻿namespace WorkerServiceOptions.Example;
 
-namespace WorkerServiceOptions.Example
+class Program
 {
-    class Program
-    {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+    static Task Main(string[] args) =>
+        CreateHostBuilder(args).Build().RunAsync();
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddHostedService<Worker>()
-                            .AddTransient<PriorityQueue>());
-    }
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddHostedService<Worker>()
+                        .AddTransient<PriorityQueue>());
 }

--- a/docs/core/extensions/snippets/configuration/worker-service-options/WorkItem.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/WorkItem.cs
@@ -1,16 +1,13 @@
-﻿using System;
+﻿namespace WorkerServiceOptions.Example;
 
-namespace WorkerServiceOptions.Example
+public record WorkItem(
+    string Name, Priority Priority, bool IsCompleted = false)
 {
-    public record WorkItem(
-        string Name, Priority Priority, bool IsCompleted = false)
-    {
-        public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.NewGuid();
 
-        public WorkItem MarkAsComplete() =>
-            this with { IsCompleted = true };
+    public WorkItem MarkAsComplete() =>
+        this with { IsCompleted = true };
 
-        public override string ToString() =>
-            $"Priority-{Priority} ({Id}): '{Name}'";
-    }
+    public override string ToString() =>
+        $"Priority-{Priority} ({Id}): '{Name}'";
 }

--- a/docs/core/extensions/snippets/configuration/worker-service-options/Worker.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/Worker.cs
@@ -1,41 +1,35 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using WorkerServiceOptions.Example.Extensions;
+﻿using WorkerServiceOptions.Example.Extensions;
 
-namespace WorkerServiceOptions.Example
+namespace WorkerServiceOptions.Example;
+
+public class Worker : BackgroundService
 {
-    public class Worker : BackgroundService
+    private readonly ILogger<Worker> _logger;
+    private readonly PriorityQueue _priorityQueue;
+
+    public Worker(ILogger<Worker> logger, PriorityQueue priorityQueue) =>
+        (_logger, _priorityQueue) = (logger, priorityQueue);
+
+    protected override async Task ExecuteAsync(
+        CancellationToken stoppingToken)
     {
-        private readonly ILogger<Worker> _logger;
-        private readonly PriorityQueue _priorityQueue;
-
-        public Worker(ILogger<Worker> logger, PriorityQueue priorityQueue) =>
-            (_logger, _priorityQueue) = (logger, priorityQueue);
-
-        protected override async Task ExecuteAsync(
-            CancellationToken stoppingToken)
+        using IDisposable? scope = _logger.ProcessingWorkScope(DateTime.Now);
+        while (!stoppingToken.IsCancellationRequested)
         {
-            using IDisposable? scope = _logger.ProcessingWorkScope(DateTime.Now);
-            while (!stoppingToken.IsCancellationRequested)
+            WorkItem? nextItem = _priorityQueue.ProcessNextHighestPriority();
+            try
             {
-                WorkItem? nextItem = _priorityQueue.ProcessNextHighestPriority();
-                try
+                if (nextItem is not null)
                 {
-                    if (nextItem is not null)
-                    {
-                        _logger.PriorityItemProcessed(nextItem);
-                    }
+                    _logger.PriorityItemProcessed(nextItem);
                 }
-                catch (Exception ex)
-                {
-                    _logger.FailedToProcessWorkItem(ex);
-                }
-
-                await Task.Delay(1000, stoppingToken);
             }
+            catch (Exception ex)
+            {
+                _logger.FailedToProcessWorkItem(ex);
+            }
+
+            await Task.Delay(1000, stoppingToken);
         }
     }
 }

--- a/docs/core/extensions/snippets/configuration/worker-service-options/worker-service-options.csproj
+++ b/docs/core/extensions/snippets/configuration/worker-service-options/worker-service-options.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <UserSecretsId>dotnet-worker_service-42C16A5C-9E2E-4001-A935-0158BC6A5D10</UserSecretsId>
     <RootNamespace>WorkerServiceOptions.Example</RootNamespace>
   <Nullable>enable</Nullable>

--- a/docs/core/extensions/snippets/configuration/worker-service/Program.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service/Program.cs
@@ -1,17 +1,12 @@
-﻿using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+﻿namespace WorkerService.Example;
 
-namespace WorkerService.Example
+class Program
 {
-    class Program
-    {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+    static Task Main(string[] args) =>
+        CreateHostBuilder(args).Build().RunAsync();
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((_, services) =>
-                    services.AddHostedService<Worker>());
-    }
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((_, services) =>
+                services.AddHostedService<Worker>());
 }

--- a/docs/core/extensions/snippets/configuration/worker-service/Worker.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service/Worker.cs
@@ -1,25 +1,18 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+﻿namespace WorkerService.Example;
 
-namespace WorkerService.Example
+public class Worker : BackgroundService
 {
-    public class Worker : BackgroundService
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger) =>
+        _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        private readonly ILogger<Worker> _logger;
-
-        public Worker(ILogger<Worker> logger) =>
-            _logger = logger;
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.UtcNow);
-                await Task.Delay(1000, stoppingToken);
-            }
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.UtcNow);
+            await Task.Delay(1000, stoppingToken);
         }
     }
 }

--- a/docs/core/extensions/snippets/configuration/worker-service/worker-service.csproj
+++ b/docs/core/extensions/snippets/configuration/worker-service/worker-service.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <UserSecretsId>dotnet-worker_service-42C16A5C-9E2E-4001-A935-0158BC6A5D10</UserSecretsId>
     <RootNamespace>WorkerService.Example</RootNamespace>
   </PropertyGroup>

--- a/docs/core/extensions/snippets/fileglobbing/example/example.csproj
+++ b/docs/core/extensions/snippets/fileglobbing/example/example.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>FileGlobbing.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>FileGlobbing.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,8 +59,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/http/basic/ItemService.cs
+++ b/docs/core/extensions/snippets/http/basic/ItemService.cs
@@ -1,51 +1,47 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Mime;
+﻿using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Shared;
 
-namespace BasicHttp.Example
+namespace BasicHttp.Example;
+
+public class ItemService
 {
-    public class ItemService
+    private readonly HttpClient _httpClient = null!;
+
+    public ItemService(HttpClient httpClient) => _httpClient = httpClient;
+
+    public async Task CreateItemAsync(Item item)
     {
-        private readonly HttpClient _httpClient = null!;
+        using StringContent json = new(
+            JsonSerializer.Serialize(item, DefaultJsonSerialization.Options),
+            Encoding.UTF8,
+            MediaTypeNames.Application.Json);
 
-        public ItemService(HttpClient httpClient) => _httpClient = httpClient;
+        using HttpResponseMessage httpResponse =
+            await _httpClient.PostAsync("/api/items", json);
 
-        public async Task CreateItemAsync(Item item)
-        {
-            using StringContent json = new(
-                JsonSerializer.Serialize(item, DefaultJsonSerialization.Options),
-                Encoding.UTF8,
-                MediaTypeNames.Application.Json);
+        httpResponse.EnsureSuccessStatusCode();
+    }
 
-            using HttpResponseMessage httpResponse =
-                await _httpClient.PostAsync("/api/items", json);
+    public async Task UpdateItemAsync(Item item)
+    {
+        using StringContent json = new(
+            JsonSerializer.Serialize(item, DefaultJsonSerialization.Options),
+            Encoding.UTF8,
+            MediaTypeNames.Application.Json);
 
-            httpResponse.EnsureSuccessStatusCode();
-        }
+        using HttpResponseMessage httpResponse =
+            await _httpClient.PutAsync($"/api/items/{item.Id}", json);
 
-        public async Task UpdateItemAsync(Item item)
-        {
-            using StringContent json = new(
-                JsonSerializer.Serialize(item, DefaultJsonSerialization.Options),
-                Encoding.UTF8,
-                MediaTypeNames.Application.Json);
+        httpResponse.EnsureSuccessStatusCode();
+    }
 
-            using HttpResponseMessage httpResponse =
-                await _httpClient.PutAsync($"/api/items/{item.Id}", json);
+    public async Task DeleteItemAsync(Guid id)
+    {
+        using HttpResponseMessage httpResponse =
+            await _httpClient.DeleteAsync($"/api/items/{id}");
 
-            httpResponse.EnsureSuccessStatusCode();
-        }
-
-        public async Task DeleteItemAsync(Guid id)
-        {
-            using HttpResponseMessage httpResponse =
-                await _httpClient.DeleteAsync($"/api/items/{id}");
-
-            httpResponse.EnsureSuccessStatusCode();
-        }
+        httpResponse.EnsureSuccessStatusCode();
     }
 }

--- a/docs/core/extensions/snippets/http/basic/ItemService.cs
+++ b/docs/core/extensions/snippets/http/basic/ItemService.cs
@@ -11,6 +11,7 @@ public class ItemService
 
     public ItemService(HttpClient httpClient) => _httpClient = httpClient;
 
+    // <Create>
     public async Task CreateItemAsync(Item item)
     {
         using StringContent json = new(
@@ -23,7 +24,8 @@ public class ItemService
 
         httpResponse.EnsureSuccessStatusCode();
     }
-
+    // </Create>
+    // <Update>
     public async Task UpdateItemAsync(Item item)
     {
         using StringContent json = new(
@@ -36,7 +38,8 @@ public class ItemService
 
         httpResponse.EnsureSuccessStatusCode();
     }
-
+    // </Update>
+    // <Delete>
     public async Task DeleteItemAsync(Guid id)
     {
         using HttpResponseMessage httpResponse =
@@ -44,4 +47,5 @@ public class ItemService
 
         httpResponse.EnsureSuccessStatusCode();
     }
+    // </Delete>
 }

--- a/docs/core/extensions/snippets/http/basic/JokeService.cs
+++ b/docs/core/extensions/snippets/http/basic/JokeService.cs
@@ -1,46 +1,42 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Threading.Tasks;
+﻿using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Shared;
 
-namespace BasicHttp.Example
+namespace BasicHttp.Example;
+
+public class JokeService
 {
-    public class JokeService
+    private readonly IHttpClientFactory _httpClientFactory = null!;
+    private readonly ILogger<JokeService> _logger = null!;
+
+    public JokeService(
+        IHttpClientFactory httpClientFactory,
+        ILogger<JokeService> logger) =>
+        (_httpClientFactory, _logger) = (httpClientFactory, logger);
+
+    public async Task<string> GetRandomJokeAsync()
     {
-        private readonly IHttpClientFactory _httpClientFactory = null!;
-        private readonly ILogger<JokeService> _logger = null!;
+        // Create the client
+        HttpClient client = _httpClientFactory.CreateClient();
 
-        public JokeService(
-            IHttpClientFactory httpClientFactory,
-            ILogger<JokeService> logger) =>
-            (_httpClientFactory, _logger) = (httpClientFactory, logger);
-
-        public async Task<string> GetRandomJokeAsync()
+        try
         {
-            // Create the client
-            HttpClient client = _httpClientFactory.CreateClient();
+            // Make HTTP GET request
+            // Parse JSON response deserialize into ChuckNorrisJoke type
+            ChuckNorrisJoke? result = await client.GetFromJsonAsync<ChuckNorrisJoke>(
+                "https://api.icndb.com/jokes/random?limitTo=[nerdy]",
+                DefaultJsonSerialization.Options);
 
-            try
+            if (result?.Value?.Joke is not null)
             {
-                // Make HTTP GET request
-                // Parse JSON response deserialize into ChuckNorrisJoke type
-                ChuckNorrisJoke? result = await client.GetFromJsonAsync<ChuckNorrisJoke>(
-                    "https://api.icndb.com/jokes/random?limitTo=[nerdy]",
-                    DefaultJsonSerialization.Options);
-
-                if (result?.Value?.Joke is not null)
-                {
-                    return result.Value.Joke;
-                }
+                return result.Value.Joke;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError("Error getting something fun to say: {Error}", ex);
-            }
-
-            return "Oops, something has gone wrong - that's not funny at all!";
         }
+        catch (Exception ex)
+        {
+            _logger.LogError("Error getting something fun to say: {Error}", ex);
+        }
+
+        return "Oops, something has gone wrong - that's not funny at all!";
     }
 }

--- a/docs/core/extensions/snippets/http/basic/basic.csproj
+++ b/docs/core/extensions/snippets/http/basic/basic.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>BasicHttp.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>BasicHttp.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/core/extensions/snippets/http/generated/IJokeService.cs
+++ b/docs/core/extensions/snippets/http/generated/IJokeService.cs
@@ -1,12 +1,10 @@
-﻿using System.Threading.Tasks;
-using Refit;
+﻿using Refit;
 using Shared;
 
-namespace GeneratedHttp.Example
+namespace GeneratedHttp.Example;
+
+public interface IJokeService
 {
-    public interface IJokeService
-    {
-        [Get("/jokes/random?limitTo=[nerdy]")]
-        Task<ChuckNorrisJoke> GetRandomJokeAsync();
-    }
+    [Get("/jokes/random?limitTo=[nerdy]")]
+    Task<ChuckNorrisJoke> GetRandomJokeAsync();
 }

--- a/docs/core/extensions/snippets/http/generated/Program.cs
+++ b/docs/core/extensions/snippets/http/generated/Program.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GeneratedHttp.Example;
+﻿using GeneratedHttp.Example;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/docs/core/extensions/snippets/http/generated/generated.csproj
+++ b/docs/core/extensions/snippets/http/generated/generated.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>GeneratedHttp.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>GeneratedHttp.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="6.0.38" />
   </ItemGroup>
 

--- a/docs/core/extensions/snippets/http/named/JokeService.cs
+++ b/docs/core/extensions/snippets/http/named/JokeService.cs
@@ -1,51 +1,47 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Threading.Tasks;
+﻿using System.Net.Http.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Shared;
 
-namespace NamedHttp.Example
+namespace NamedHttp.Example;
+
+public class JokeService
 {
-    public class JokeService
+    private readonly IHttpClientFactory _httpClientFactory = null!;
+    private readonly IConfiguration _configuration = null!;
+    private readonly ILogger<JokeService> _logger = null!;
+
+    public JokeService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<JokeService> logger) =>
+        (_httpClientFactory, _configuration, _logger) =
+            (httpClientFactory, configuration, logger);
+
+    public async Task<string> GetRandomJokeAsync()
     {
-        private readonly IHttpClientFactory _httpClientFactory = null!;
-        private readonly IConfiguration _configuration = null!;
-        private readonly ILogger<JokeService> _logger = null!;
+        // Create the client
+        string httpClientName = _configuration["JokeHttpClientName"];
+        HttpClient client = _httpClientFactory.CreateClient(httpClientName);
 
-        public JokeService(
-            IHttpClientFactory httpClientFactory,
-            IConfiguration configuration,
-            ILogger<JokeService> logger) =>
-            (_httpClientFactory, _configuration, _logger) =
-                (httpClientFactory, configuration, logger);
-
-        public async Task<string> GetRandomJokeAsync()
+        try
         {
-            // Create the client
-            string httpClientName = _configuration["JokeHttpClientName"];
-            HttpClient client = _httpClientFactory.CreateClient(httpClientName);
+            // Make HTTP GET request
+            // Parse JSON response deserialize into ChuckNorrisJoke type
+            ChuckNorrisJoke? result = await client.GetFromJsonAsync<ChuckNorrisJoke>(
+                "jokes/random?limitTo=[nerdy]",
+                DefaultJsonSerialization.Options);
 
-            try
+            if (result?.Value?.Joke is not null)
             {
-                // Make HTTP GET request
-                // Parse JSON response deserialize into ChuckNorrisJoke type
-                ChuckNorrisJoke? result = await client.GetFromJsonAsync<ChuckNorrisJoke>(
-                    "jokes/random?limitTo=[nerdy]",
-                    DefaultJsonSerialization.Options);
-
-                if (result?.Value?.Joke is not null)
-                {
-                    return result.Value.Joke;
-                }
+                return result.Value.Joke;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError("Error getting something fun to say: {Error}", ex);
-            }
-
-            return "Oops, something has gone wrong - that's not funny at all!";
         }
+        catch (Exception ex)
+        {
+            _logger.LogError("Error getting something fun to say: {Error}", ex);
+        }
+
+        return "Oops, something has gone wrong - that's not funny at all!";
     }
 }

--- a/docs/core/extensions/snippets/http/named/Program.cs
+++ b/docs/core/extensions/snippets/http/named/Program.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>

--- a/docs/core/extensions/snippets/http/named/named.csproj
+++ b/docs/core/extensions/snippets/http/named/named.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>NamedHttp.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>NamedHttp.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/core/extensions/snippets/http/shared/ChuckNorrisJoke.cs
+++ b/docs/core/extensions/snippets/http/shared/ChuckNorrisJoke.cs
@@ -1,6 +1,5 @@
-﻿namespace Shared
-{
-    public record ChuckNorrisJoke(
-        string Type,
-        IdentifiableJokeValue Value);
-}
+﻿namespace Shared;
+
+public record ChuckNorrisJoke(
+    string Type,
+    IdentifiableJokeValue Value);

--- a/docs/core/extensions/snippets/http/shared/DefaultJsonSerialization.cs
+++ b/docs/core/extensions/snippets/http/shared/DefaultJsonSerialization.cs
@@ -1,18 +1,17 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Shared
+namespace Shared;
+
+public static class DefaultJsonSerialization
 {
-    public static class DefaultJsonSerialization
+    public static JsonSerializerOptions Options { get; } = new()
     {
-        public static JsonSerializerOptions Options { get; } = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true,
-            Converters =
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters =
             {
                 new JsonStringEnumConverter()
             }
-        };
-    }
+    };
 }

--- a/docs/core/extensions/snippets/http/shared/IdentifiableJokeValue.cs
+++ b/docs/core/extensions/snippets/http/shared/IdentifiableJokeValue.cs
@@ -1,5 +1,4 @@
-﻿namespace Shared
-{
-    public record IdentifiableJokeValue(
-        int Id, string Joke);
-}
+﻿namespace Shared;
+
+public record IdentifiableJokeValue(
+    int Id, string Joke);

--- a/docs/core/extensions/snippets/http/shared/Item.cs
+++ b/docs/core/extensions/snippets/http/shared/Item.cs
@@ -1,7 +1,4 @@
-﻿using System;
+﻿namespace Shared;
 
-namespace Shared
-{
-    public record Item(
-        Guid Id, string Name);
-}
+public record Item(
+    Guid Id, string Name);

--- a/docs/core/extensions/snippets/http/shared/shared.csproj
+++ b/docs/core/extensions/snippets/http/shared/shared.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>Shared</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>Shared</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/http/typed/JokeService.cs
+++ b/docs/core/extensions/snippets/http/typed/JokeService.cs
@@ -1,43 +1,39 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Threading.Tasks;
+﻿using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Shared;
 
-namespace TypedHttp.Example
+namespace TypedHttp.Example;
+
+public sealed class JokeService
 {
-    public sealed class JokeService
+    private readonly HttpClient _httpClient = null!;
+    private readonly ILogger<JokeService> _logger = null!;
+
+    public JokeService(
+        HttpClient httpClient,
+        ILogger<JokeService> logger) =>
+        (_httpClient, _logger) = (httpClient, logger);
+
+    public async Task<string> GetRandomJokeAsync()
     {
-        private readonly HttpClient _httpClient = null!;
-        private readonly ILogger<JokeService> _logger = null!;
-
-        public JokeService(
-            HttpClient httpClient,
-            ILogger<JokeService> logger) =>
-            (_httpClient, _logger) = (httpClient, logger);
-
-        public async Task<string> GetRandomJokeAsync()
+        try
         {
-            try
-            {
-                // Make HTTP GET request
-                // Parse JSON response deserialize into ChuckNorrisJoke type
-                ChuckNorrisJoke? result = await _httpClient.GetFromJsonAsync<ChuckNorrisJoke>(
-                    "https://api.icndb.com/jokes/random?limitTo=[nerdy]",
-                    DefaultJsonSerialization.Options);
+            // Make HTTP GET request
+            // Parse JSON response deserialize into ChuckNorrisJoke type
+            ChuckNorrisJoke? result = await _httpClient.GetFromJsonAsync<ChuckNorrisJoke>(
+                "https://api.icndb.com/jokes/random?limitTo=[nerdy]",
+                DefaultJsonSerialization.Options);
 
-                if (result?.Value?.Joke is not null)
-                {
-                    return result.Value.Joke;
-                }
-            }
-            catch (Exception ex)
+            if (result?.Value?.Joke is not null)
             {
-                _logger.LogError("Error getting something fun to say: {Error}", ex);
+                return result.Value.Joke;
             }
-
-            return "Oops, something has gone wrong - that's not funny at all!";
         }
+        catch (Exception ex)
+        {
+            _logger.LogError("Error getting something fun to say: {Error}", ex);
+        }
+
+        return "Oops, something has gone wrong - that's not funny at all!";
     }
 }

--- a/docs/core/extensions/snippets/http/typed/Program.cs
+++ b/docs/core/extensions/snippets/http/typed/Program.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/docs/core/extensions/snippets/http/typed/typed.csproj
+++ b/docs/core/extensions/snippets/http/typed/typed.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>TypedHttp.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>TypedHttp.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/core/extensions/snippets/localization/example/MessageService.cs
+++ b/docs/core/extensions/snippets/localization/example/MessageService.cs
@@ -1,20 +1,19 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Localization;
 
-namespace Localization.Example
+namespace Localization.Example;
+
+public class MessageService
 {
-    public class MessageService
+    private readonly IStringLocalizer<MessageService> _localizer = null!;
+
+    public MessageService(IStringLocalizer<MessageService> localizer) =>
+        _localizer = localizer;
+
+    [return: NotNullIfNotNull("_localizer")]
+    public string? GetGreetingMessage()
     {
-        private readonly IStringLocalizer<MessageService> _localizer = null!;
-
-        public MessageService(IStringLocalizer<MessageService> localizer) =>
-            _localizer = localizer;
-
-        [return: NotNullIfNotNull("_localizer")]
-        public string? GetGreetingMessage()
-        {
-            LocalizedString localizedString = _localizer["GreetingMessage"];
-            return localizedString;
-        }
+        LocalizedString localizedString = _localizer["GreetingMessage"];
+        return localizedString;
     }
 }

--- a/docs/core/extensions/snippets/localization/example/ParameterizedMessageService.cs
+++ b/docs/core/extensions/snippets/localization/example/ParameterizedMessageService.cs
@@ -1,21 +1,19 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Localization;
 
-namespace Localization.Example
+namespace Localization.Example;
+
+public class ParameterizedMessageService
 {
-    public class ParameterizedMessageService
+    private readonly IStringLocalizer _localizer = null!;
+
+    public ParameterizedMessageService(IStringLocalizerFactory factory) =>
+        _localizer = factory.Create(typeof(ParameterizedMessageService));
+
+    [return: NotNullIfNotNull("_localizer")]
+    public string? GetFormattedMessage(DateTime dateTime, double dinnerPrice)
     {
-        private readonly IStringLocalizer _localizer = null!;
-
-        public ParameterizedMessageService(IStringLocalizerFactory factory) =>
-            _localizer = factory.Create(typeof(ParameterizedMessageService));
-
-        [return: NotNullIfNotNull("_localizer")]
-        public string? GetFormattedMessage(DateTime dateTime, double dinnerPrice)
-        {
-            LocalizedString localizedString = _localizer["DinnerPriceFormat", dateTime, dinnerPrice];
-            return localizedString;
-        }
+        LocalizedString localizedString = _localizer["DinnerPriceFormat", dateTime, dinnerPrice];
+        return localizedString;
     }
 }

--- a/docs/core/extensions/snippets/localization/example/Program.cs
+++ b/docs/core/extensions/snippets/localization/example/Program.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using Localization.Example;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/docs/core/extensions/snippets/localization/example/example.csproj
+++ b/docs/core/extensions/snippets/localization/example/example.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>Localization.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>Localization.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/CustomTimePrefixingFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/CustomTimePrefixingFormatter.cs
@@ -3,52 +3,51 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 
-namespace Console.ExampleFormatters.CustomWithConfig
+namespace Console.ExampleFormatters.CustomWithConfig;
+
+public sealed class CustomTimePrefixingFormatter : ConsoleFormatter, IDisposable
 {
-    public sealed class CustomTimePrefixingFormatter : ConsoleFormatter, IDisposable
+    private readonly IDisposable _optionsReloadToken;
+    private CustomWrappingConsoleFormatterOptions _formatterOptions;
+
+    public CustomTimePrefixingFormatter(IOptionsMonitor<CustomWrappingConsoleFormatterOptions> options)
+        // Case insensitive
+        : base(nameof(CustomTimePrefixingFormatter)) =>
+        (_optionsReloadToken, _formatterOptions) =
+            (options.OnChange(ReloadLoggerOptions), options.CurrentValue);
+
+    private void ReloadLoggerOptions(CustomWrappingConsoleFormatterOptions options) =>
+        _formatterOptions = options;
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry,
+        IExternalScopeProvider scopeProvider,
+        TextWriter textWriter)
     {
-        private readonly IDisposable _optionsReloadToken;
-        private CustomWrappingConsoleFormatterOptions _formatterOptions;
+        string message =
+            logEntry.Formatter(
+                logEntry.State, logEntry.Exception);
 
-        public CustomTimePrefixingFormatter(IOptionsMonitor<CustomWrappingConsoleFormatterOptions> options)
-            // Case insensitive
-            : base(nameof(CustomTimePrefixingFormatter)) =>
-            (_optionsReloadToken, _formatterOptions) =
-                (options.OnChange(ReloadLoggerOptions), options.CurrentValue);
-
-        private void ReloadLoggerOptions(CustomWrappingConsoleFormatterOptions options) =>
-            _formatterOptions = options;
-
-        public override void Write<TState>(
-            in LogEntry<TState> logEntry,
-            IExternalScopeProvider scopeProvider,
-            TextWriter textWriter)
+        if (message == null)
         {
-            string message =
-                logEntry.Formatter(
-                    logEntry.State, logEntry.Exception);
-
-            if (message == null)
-            {
-                return;
-            }
-
-            WritePrefix(textWriter);
-            textWriter.Write(message);
-            WriteSuffix(textWriter);
+            return;
         }
 
-        private void WritePrefix(TextWriter textWriter)
-        {
-            DateTime now = _formatterOptions.UseUtcTimestamp
-                ? DateTime.UtcNow
-                : DateTime.Now;
-
-            textWriter.Write($"{_formatterOptions.CustomPrefix} {now.ToString(_formatterOptions.TimestampFormat)}");
-        }
-
-        private void WriteSuffix(TextWriter textWriter) => textWriter.WriteLine($" {_formatterOptions.CustomSuffix}");
-
-        public void Dispose() => _optionsReloadToken?.Dispose();
+        WritePrefix(textWriter);
+        textWriter.Write(message);
+        WriteSuffix(textWriter);
     }
+
+    private void WritePrefix(TextWriter textWriter)
+    {
+        DateTime now = _formatterOptions.UseUtcTimestamp
+            ? DateTime.UtcNow
+            : DateTime.Now;
+
+        textWriter.Write($"{_formatterOptions.CustomPrefix} {now.ToString(_formatterOptions.TimestampFormat)}");
+    }
+
+    private void WriteSuffix(TextWriter textWriter) => textWriter.WriteLine($" {_formatterOptions.CustomSuffix}");
+
+    public void Dispose() => _optionsReloadToken?.Dispose();
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/CustomTimePrefixingFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/CustomTimePrefixingFormatter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;

--- a/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/CustomWrappingConsoleFormatterOptions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/CustomWrappingConsoleFormatterOptions.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.Extensions.Logging.Console;
 
-namespace Console.ExampleFormatters.CustomWithConfig
-{
-    public class CustomWrappingConsoleFormatterOptions : ConsoleFormatterOptions
-    {
-        public string CustomPrefix { get; set; }
+namespace Console.ExampleFormatters.CustomWithConfig;
 
-        public string CustomSuffix { get; set; }
-    }
+public class CustomWrappingConsoleFormatterOptions : ConsoleFormatterOptions
+{
+    public string? CustomPrefix { get; set; }
+
+    public string? CustomSuffix { get; set; }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/Program.cs
@@ -2,29 +2,28 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Console.ExampleFormatters.CustomWithConfig
+namespace Console.ExampleFormatters.CustomWithConfig;
+
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            using IHost host = Host.CreateDefaultBuilder(args)
-                .ConfigureLogging(builder =>
-                {
-                    builder.AddConsole()
-                        .AddConsoleFormatter
-                            <CustomTimePrefixingFormatter, CustomWrappingConsoleFormatterOptions>();
-                })
-                .Build();
-
-            ILoggerFactory loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
-            ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
-
-            using (logger.BeginScope("Logging scope"))
+        using IHost host = Host.CreateDefaultBuilder(args)
+            .ConfigureLogging(builder =>
             {
-                logger.LogInformation("Hello World!");
-                logger.LogInformation("The .NET developer community happily welcomes you.");
-            }
+                builder.AddConsole()
+                    .AddConsoleFormatter
+                        <CustomTimePrefixingFormatter, CustomWrappingConsoleFormatterOptions>();
+            })
+            .Build();
+
+        ILoggerFactory loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
+        ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
+
+        using (logger.BeginScope("Logging scope"))
+        {
+            logger.LogInformation("Hello World!");
+            logger.LogInformation("The .NET developer community happily welcomes you.");
         }
     }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/console-formatter-custom-with-config.csproj
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom-with-config/console-formatter-custom-with-config.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Console.ExampleFormatters.CustomWithConfig</RootNamespace>
   </PropertyGroup>
 
@@ -17,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/ConsoleLoggerExtensions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/ConsoleLoggerExtensions.cs
@@ -1,14 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
-using System;
 
-namespace Console.ExampleFormatters.Custom
+namespace Console.ExampleFormatters.Custom;
+
+public static class ConsoleLoggerExtensions
 {
-    public static class ConsoleLoggerExtensions
-    {
-        public static ILoggingBuilder AddCustomFormatter(
-            this ILoggingBuilder builder,
-            Action<CustomOptions> configure) =>
-            builder.AddConsole(options => options.FormatterName = "customName")
-                .AddConsoleFormatter<CustomFormatter, CustomOptions>(configure);
-    }
+    public static ILoggingBuilder AddCustomFormatter(
+        this ILoggingBuilder builder,
+        Action<CustomOptions> configure) =>
+        builder.AddConsole(options => options.FormatterName = "customName")
+            .AddConsoleFormatter<CustomFormatter, CustomOptions>(configure);
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorFormatter.cs
@@ -3,65 +3,64 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 
-namespace Console.ExampleFormatters.Custom
+namespace Console.ExampleFormatters.Custom;
+
+public sealed class CustomColorFormatter : ConsoleFormatter, IDisposable
 {
-    public sealed class CustomColorFormatter : ConsoleFormatter, IDisposable
+    private readonly IDisposable _optionsReloadToken;
+    private CustomColorOptions _formatterOptions;
+
+    private bool ConsoleColorFormattingEnabled =>
+        _formatterOptions.ColorBehavior == LoggerColorBehavior.Enabled ||
+        _formatterOptions.ColorBehavior == LoggerColorBehavior.Default &&
+        System.Console.IsOutputRedirected == false;
+
+    public CustomColorFormatter(IOptionsMonitor<CustomColorOptions> options)
+        // Case insensitive
+        : base("customName") =>
+        (_optionsReloadToken, _formatterOptions) =
+            (options.OnChange(ReloadLoggerOptions), options.CurrentValue);
+
+    private void ReloadLoggerOptions(CustomColorOptions options) =>
+        _formatterOptions = options;
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry,
+        IExternalScopeProvider scopeProvider,
+        TextWriter textWriter)
     {
-        private readonly IDisposable _optionsReloadToken;
-        private CustomColorOptions _formatterOptions;
-
-        private bool ConsoleColorFormattingEnabled =>
-            _formatterOptions.ColorBehavior == LoggerColorBehavior.Enabled ||
-            _formatterOptions.ColorBehavior == LoggerColorBehavior.Default &&
-            System.Console.IsOutputRedirected == false;
-
-        public CustomColorFormatter(IOptionsMonitor<CustomColorOptions> options)
-            // Case insensitive
-            : base("customName") =>
-            (_optionsReloadToken, _formatterOptions) =
-                (options.OnChange(ReloadLoggerOptions), options.CurrentValue);
-
-        private void ReloadLoggerOptions(CustomColorOptions options) =>
-            _formatterOptions = options;
-
-        public override void Write<TState>(
-            in LogEntry<TState> logEntry,
-            IExternalScopeProvider scopeProvider,
-            TextWriter textWriter)
+        if (logEntry.Exception is null)
         {
-            if (logEntry.Exception is null)
-            {
-                return;
-            }
-
-            string? message =
-                logEntry.Formatter?.Invoke(
-                    logEntry.State, logEntry.Exception);
-
-            if (message is null)
-            {
-                return;
-            }
-
-            CustomLogicGoesHere(textWriter);
-            textWriter.WriteLine(message);
+            return;
         }
 
-        private void CustomLogicGoesHere(TextWriter textWriter)
+        string? message =
+            logEntry.Formatter?.Invoke(
+                logEntry.State, logEntry.Exception);
+
+        if (message is null)
         {
-            if (ConsoleColorFormattingEnabled)
-            {
-                textWriter.WriteWithColor(
-                    _formatterOptions.CustomPrefix ?? string.Empty,
-                    ConsoleColor.Black,
-                    ConsoleColor.Green);
-            }
-            else
-            {
-                textWriter.Write(_formatterOptions.CustomPrefix);
-            }
+            return;
         }
 
-        public void Dispose() => _optionsReloadToken?.Dispose();
+        CustomLogicGoesHere(textWriter);
+        textWriter.WriteLine(message);
     }
+
+    private void CustomLogicGoesHere(TextWriter textWriter)
+    {
+        if (ConsoleColorFormattingEnabled)
+        {
+            textWriter.WriteWithColor(
+                _formatterOptions.CustomPrefix ?? string.Empty,
+                ConsoleColor.Black,
+                ConsoleColor.Green);
+        }
+        else
+        {
+            textWriter.Write(_formatterOptions.CustomPrefix);
+        }
+    }
+
+    public void Dispose() => _optionsReloadToken?.Dispose();
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorFormatter.cs
@@ -2,8 +2,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
-using System;
-using System.IO;
 
 namespace Console.ExampleFormatters.Custom
 {
@@ -36,11 +34,11 @@ namespace Console.ExampleFormatters.Custom
                 return;
             }
 
-            string message =
-                logEntry.Formatter(
+            string? message =
+                logEntry.Formatter?.Invoke(
                     logEntry.State, logEntry.Exception);
 
-            if (message == null)
+            if (message is null)
             {
                 return;
             }
@@ -54,7 +52,7 @@ namespace Console.ExampleFormatters.Custom
             if (ConsoleColorFormattingEnabled)
             {
                 textWriter.WriteWithColor(
-                    _formatterOptions.CustomPrefix,
+                    _formatterOptions.CustomPrefix ?? string.Empty,
                     ConsoleColor.Black,
                     ConsoleColor.Green);
             }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorOptions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorOptions.cs
@@ -4,6 +4,6 @@ namespace Console.ExampleFormatters.Custom
 {
     public class CustomColorOptions : SimpleConsoleFormatterOptions
     {
-        public string CustomPrefix { get; set; }
+        public string? CustomPrefix { get; set; }
     }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorOptions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomColorOptions.cs
@@ -1,9 +1,8 @@
 ﻿using Microsoft.Extensions.Logging.Console;
 
-namespace Console.ExampleFormatters.Custom
+namespace Console.ExampleFormatters.Custom;
+
+public class CustomColorOptions : SimpleConsoleFormatterOptions
 {
-    public class CustomColorOptions : SimpleConsoleFormatterOptions
-    {
-        public string? CustomPrefix { get; set; }
-    }
+    public string? CustomPrefix { get; set; }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -2,8 +2,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
-using System;
-using System.IO;
 
 namespace Console.ExampleFormatters.Custom
 {

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomFormatter.cs
@@ -3,45 +3,44 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 
-namespace Console.ExampleFormatters.Custom
+namespace Console.ExampleFormatters.Custom;
+
+public sealed class CustomFormatter : ConsoleFormatter, IDisposable
 {
-    public sealed class CustomFormatter : ConsoleFormatter, IDisposable
+    private readonly IDisposable _optionsReloadToken;
+    private CustomOptions _formatterOptions;
+
+    public CustomFormatter(IOptionsMonitor<CustomOptions> options)
+        // Case insensitive
+        : base("customName") =>
+        (_optionsReloadToken, _formatterOptions) =
+            (options.OnChange(ReloadLoggerOptions), options.CurrentValue);
+
+    private void ReloadLoggerOptions(CustomOptions options) =>
+        _formatterOptions = options;
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry,
+        IExternalScopeProvider scopeProvider,
+        TextWriter textWriter)
     {
-        private readonly IDisposable _optionsReloadToken;
-        private CustomOptions _formatterOptions;
+        string? message =
+            logEntry.Formatter?.Invoke(
+                logEntry.State, logEntry.Exception);
 
-        public CustomFormatter(IOptionsMonitor<CustomOptions> options)
-            // Case insensitive
-            : base("customName") =>
-            (_optionsReloadToken, _formatterOptions) =
-                (options.OnChange(ReloadLoggerOptions), options.CurrentValue);
-
-        private void ReloadLoggerOptions(CustomOptions options) =>
-            _formatterOptions = options;
-
-        public override void Write<TState>(
-            in LogEntry<TState> logEntry,
-            IExternalScopeProvider scopeProvider,
-            TextWriter textWriter)
+        if (message is null)
         {
-            string message =
-                logEntry.Formatter(
-                    logEntry.State, logEntry.Exception);
-
-            if (message == null)
-            {
-                return;
-            }
-
-            CustomLogicGoesHere(textWriter);
-            textWriter.WriteLine(message);
+            return;
         }
 
-        private void CustomLogicGoesHere(TextWriter textWriter)
-        {
-            textWriter.Write(_formatterOptions.CustomPrefix);
-        }
-
-        public void Dispose() => _optionsReloadToken?.Dispose();
+        CustomLogicGoesHere(textWriter);
+        textWriter.WriteLine(message);
     }
+
+    private void CustomLogicGoesHere(TextWriter textWriter)
+    {
+        textWriter.Write(_formatterOptions.CustomPrefix);
+    }
+
+    public void Dispose() => _optionsReloadToken?.Dispose();
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/CustomOptions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/CustomOptions.cs
@@ -1,9 +1,8 @@
 ﻿using Microsoft.Extensions.Logging.Console;
 
-namespace Console.ExampleFormatters.Custom
+namespace Console.ExampleFormatters.Custom;
+
+public class CustomOptions : ConsoleFormatterOptions
 {
-    public class CustomOptions : ConsoleFormatterOptions
-    {
-        public string CustomPrefix { get; set; }
-    }
+    public string? CustomPrefix { get; set; }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/Program.cs
@@ -1,22 +1,21 @@
 ﻿using Microsoft.Extensions.Logging;
 
-namespace Console.ExampleFormatters.Custom
-{
-    class Program
-    {
-        static void Main()
-        {
-            using ILoggerFactory loggerFactory =
-                LoggerFactory.Create(builder =>
-                    builder.AddCustomFormatter(options =>
-                        options.CustomPrefix = " ~~~~~ "));
+namespace Console.ExampleFormatters.Custom;
 
-            ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
-            using (logger.BeginScope("TODO: Add logic to enable scopes"))
-            {
-                logger.LogInformation("Hello World!");
-                logger.LogInformation("TODO: Add logic to enable timestamp and log level info.");
-            }
+class Program
+{
+    static void Main()
+    {
+        using ILoggerFactory loggerFactory =
+            LoggerFactory.Create(builder =>
+                builder.AddCustomFormatter(options =>
+                    options.CustomPrefix = " ~~~~~ "));
+
+        ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
+        using (logger.BeginScope("TODO: Add logic to enable scopes"))
+        {
+            logger.LogInformation("Hello World!");
+            logger.LogInformation("TODO: Add logic to enable timestamp and log level info.");
         }
     }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/TextWriterExtensions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/TextWriterExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-namespace Console.ExampleFormatters.Custom
+﻿namespace Console.ExampleFormatters.Custom
 {
     public static class TextWriterExtensions
     {

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/TextWriterExtensions.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/TextWriterExtensions.cs
@@ -1,82 +1,81 @@
-﻿namespace Console.ExampleFormatters.Custom
+﻿namespace Console.ExampleFormatters.Custom;
+
+public static class TextWriterExtensions
 {
-    public static class TextWriterExtensions
+    const string DefaultForegroundColor = "\x1B[39m\x1B[22m";
+    const string DefaultBackgroundColor = "\x1B[49m";
+
+    public static void WriteWithColor(
+        this TextWriter textWriter,
+        string message,
+        ConsoleColor? background,
+        ConsoleColor? foreground)
     {
-        const string DefaultForegroundColor = "\x1B[39m\x1B[22m";
-        const string DefaultBackgroundColor = "\x1B[49m";
+        // Order:
+        //   1. background color
+        //   2. foreground color
+        //   3. message
+        //   4. reset foreground color
+        //   5. reset background color
 
-        public static void WriteWithColor(
-            this TextWriter textWriter,
-            string message,
-            ConsoleColor? background,
-            ConsoleColor? foreground)
+        var backgroundColor = background.HasValue ? GetBackgroundColorEscapeCode(background.Value) : null;
+        var foregroundColor = foreground.HasValue ? GetForegroundColorEscapeCode(foreground.Value) : null;
+
+        if (backgroundColor != null)
         {
-            // Order:
-            //   1. background color
-            //   2. foreground color
-            //   3. message
-            //   4. reset foreground color
-            //   5. reset background color
-
-            var backgroundColor = background.HasValue ? GetBackgroundColorEscapeCode(background.Value) : null;
-            var foregroundColor = foreground.HasValue ? GetForegroundColorEscapeCode(foreground.Value) : null;
-
-            if (backgroundColor != null)
-            {
-                textWriter.Write(backgroundColor);
-            }
-            if (foregroundColor != null)
-            {
-                textWriter.Write(foregroundColor);
-            }
-
-            textWriter.WriteLine(message);
-
-            if (foregroundColor != null)
-            {
-                textWriter.Write(DefaultForegroundColor);
-            }
-            if (backgroundColor != null)
-            {
-                textWriter.Write(DefaultBackgroundColor);
-            }
+            textWriter.Write(backgroundColor);
+        }
+        if (foregroundColor != null)
+        {
+            textWriter.Write(foregroundColor);
         }
 
-        static string GetForegroundColorEscapeCode(ConsoleColor color) =>
-            color switch
-            {
-                ConsoleColor.Black =>       "\x1B[30m",
-                ConsoleColor.DarkRed =>     "\x1B[31m",
-                ConsoleColor.DarkGreen =>   "\x1B[32m",
-                ConsoleColor.DarkYellow =>  "\x1B[33m",
-                ConsoleColor.DarkBlue =>    "\x1B[34m",
-                ConsoleColor.DarkMagenta => "\x1B[35m",
-                ConsoleColor.DarkCyan =>    "\x1B[36m",
-                ConsoleColor.Gray =>        "\x1B[37m",
-                ConsoleColor.Red =>         "\x1B[1m\x1B[31m",
-                ConsoleColor.Green =>       "\x1B[1m\x1B[32m",
-                ConsoleColor.Yellow =>      "\x1B[1m\x1B[33m",
-                ConsoleColor.Blue =>        "\x1B[1m\x1B[34m",
-                ConsoleColor.Magenta =>     "\x1B[1m\x1B[35m",
-                ConsoleColor.Cyan =>        "\x1B[1m\x1B[36m",
-                ConsoleColor.White =>       "\x1B[1m\x1B[37m",
+        textWriter.WriteLine(message);
 
-                _ => DefaultForegroundColor
-            };
-
-        static string GetBackgroundColorEscapeCode(ConsoleColor color) =>
-            color switch
-            {
-                ConsoleColor.Black =>       "\x1B[40m",
-                ConsoleColor.DarkRed =>     "\x1B[41m",
-                ConsoleColor.DarkGreen =>   "\x1B[42m",
-                ConsoleColor.DarkYellow =>  "\x1B[43m",
-                ConsoleColor.DarkBlue =>    "\x1B[44m",
-                ConsoleColor.DarkMagenta => "\x1B[45m",
-                ConsoleColor.DarkCyan =>    "\x1B[46m",
-                ConsoleColor.Gray =>        "\x1B[47m",
-
-                _ => DefaultBackgroundColor
-            };
+        if (foregroundColor != null)
+        {
+            textWriter.Write(DefaultForegroundColor);
+        }
+        if (backgroundColor != null)
+        {
+            textWriter.Write(DefaultBackgroundColor);
+        }
     }
+
+    static string GetForegroundColorEscapeCode(ConsoleColor color) =>
+        color switch
+        {
+            ConsoleColor.Black => "\x1B[30m",
+            ConsoleColor.DarkRed => "\x1B[31m",
+            ConsoleColor.DarkGreen => "\x1B[32m",
+            ConsoleColor.DarkYellow => "\x1B[33m",
+            ConsoleColor.DarkBlue => "\x1B[34m",
+            ConsoleColor.DarkMagenta => "\x1B[35m",
+            ConsoleColor.DarkCyan => "\x1B[36m",
+            ConsoleColor.Gray => "\x1B[37m",
+            ConsoleColor.Red => "\x1B[1m\x1B[31m",
+            ConsoleColor.Green => "\x1B[1m\x1B[32m",
+            ConsoleColor.Yellow => "\x1B[1m\x1B[33m",
+            ConsoleColor.Blue => "\x1B[1m\x1B[34m",
+            ConsoleColor.Magenta => "\x1B[1m\x1B[35m",
+            ConsoleColor.Cyan => "\x1B[1m\x1B[36m",
+            ConsoleColor.White => "\x1B[1m\x1B[37m",
+
+            _ => DefaultForegroundColor
+        };
+
+    static string GetBackgroundColorEscapeCode(ConsoleColor color) =>
+        color switch
+        {
+            ConsoleColor.Black => "\x1B[40m",
+            ConsoleColor.DarkRed => "\x1B[41m",
+            ConsoleColor.DarkGreen => "\x1B[42m",
+            ConsoleColor.DarkYellow => "\x1B[43m",
+            ConsoleColor.DarkBlue => "\x1B[44m",
+            ConsoleColor.DarkMagenta => "\x1B[45m",
+            ConsoleColor.DarkCyan => "\x1B[46m",
+            ConsoleColor.Gray => "\x1B[47m",
+
+            _ => DefaultBackgroundColor
+        };
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-custom/console-formatter-custom.csproj
+++ b/docs/core/extensions/snippets/logging/console-formatter-custom/console-formatter-custom.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Console.ExampleFormatters.Custom</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/logging/console-formatter-json/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-json/Program.cs
@@ -1,28 +1,23 @@
 ﻿using System.Text.Json;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
-namespace Console.ExampleFormatters.Json
+namespace Console.ExampleFormatters.Json;
+
+class Program
 {
-    class Program
-    {
-        static Task Main(string[] args) =>
-            CreateHostBuilder(args).Build().RunAsync();
+    static Task Main(string[] args) =>
+        CreateHostBuilder(args).Build().RunAsync();
 
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(builder => builder.UseStartup<Startup>())
-                .ConfigureLogging(builder =>
-                    builder.AddJsonConsole(options =>
+    static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(builder => builder.UseStartup<Startup>())
+            .ConfigureLogging(builder =>
+                builder.AddJsonConsole(options =>
+                {
+                    options.IncludeScopes = false;
+                    options.TimestampFormat = "hh:mm:ss ";
+                    options.JsonWriterOptions = new JsonWriterOptions
                     {
-                        options.IncludeScopes = false;
-                        options.TimestampFormat = "hh:mm:ss ";
-                        options.JsonWriterOptions = new JsonWriterOptions
-                        {
-                            Indented = true
-                        };
-                    }));
-    }
+                        Indented = true
+                    };
+                }));
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-json/Startup.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-json/Startup.cs
@@ -1,46 +1,45 @@
-﻿namespace Console.ExampleFormatters.Json
+﻿namespace Console.ExampleFormatters.Json;
+
+public class Startup
 {
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
+        Configuration = configuration;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllersWithViews();
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
+            app.UseDeveloperExceptionPage();
         }
-
-        public IConfiguration Configuration { get; }
-
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        else
         {
-            services.AddControllersWithViews();
+            app.UseExceptionHandler("/Home/Error");
+            // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+            app.UseHsts();
         }
+        app.UseHttpsRedirection();
+        app.UseStaticFiles();
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        app.UseRouting();
+
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
         {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Home/Error");
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                app.UseHsts();
-            }
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
-
-            app.UseRouting();
-
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllerRoute(
-                    name: "default",
-                    pattern: "{controller=Home}/{action=Index}/{id?}");
-            });
-        }
+            endpoints.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Home}/{action=Index}/{id?}");
+        });
     }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-json/Startup.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-json/Startup.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-
-namespace Console.ExampleFormatters.Json
+﻿namespace Console.ExampleFormatters.Json
 {
     public class Startup
     {

--- a/docs/core/extensions/snippets/logging/console-formatter-json/console-formatter-json.csproj
+++ b/docs/core/extensions/snippets/logging/console-formatter-json/console-formatter-json.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Console.ExampleFormatters.Json</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/logging/console-formatter-simple/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-simple/Program.cs
@@ -1,27 +1,26 @@
 ﻿using Microsoft.Extensions.Logging;
 
-namespace Console.ExampleFormatters.Simple
-{
-    class Program
-    {
-        static void Main()
-        {
-            using ILoggerFactory loggerFactory =
-                LoggerFactory.Create(builder =>
-                    builder.AddSimpleConsole(options =>
-                    {
-                        options.IncludeScopes = true;
-                        options.SingleLine = true;
-                        options.TimestampFormat = "hh:mm:ss ";
-                    }));
+namespace Console.ExampleFormatters.Simple;
 
-            ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
-            using (logger.BeginScope("[scope is enabled]"))
-            {
-                logger.LogInformation("Hello World!");
-                logger.LogInformation("Logs contain timestamp and log level.");
-                logger.LogInformation("Each log message is fit in a single line.");
-            }
+class Program
+{
+    static void Main()
+    {
+        using ILoggerFactory loggerFactory =
+            LoggerFactory.Create(builder =>
+                builder.AddSimpleConsole(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.SingleLine = true;
+                    options.TimestampFormat = "hh:mm:ss ";
+                }));
+
+        ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
+        using (logger.BeginScope("[scope is enabled]"))
+        {
+            logger.LogInformation("Hello World!");
+            logger.LogInformation("Logs contain timestamp and log level.");
+            logger.LogInformation("Each log message is fit in a single line.");
         }
     }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-simple/console-formatter-simple.csproj
+++ b/docs/core/extensions/snippets/logging/console-formatter-simple/console-formatter-simple.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Console.ExampleFormatters.Simple</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/logging/console-formatter-systemd/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-systemd/Program.cs
@@ -1,27 +1,26 @@
 ﻿using Microsoft.Extensions.Logging;
 
-namespace Console.ExampleFormatters.Systemd
-{
-    class Program
-    {
-        static void Main()
-        {
-            using ILoggerFactory loggerFactory =
-                LoggerFactory.Create(builder =>
-                    builder.AddSystemdConsole(options =>
-                    {
-                        options.IncludeScopes = true;
-                        options.TimestampFormat = "hh:mm:ss ";
-                    }));
+namespace Console.ExampleFormatters.Systemd;
 
-            ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
-            using (logger.BeginScope("[scope is enabled]"))
-            {
-                logger.LogInformation("Hello World!");
-                logger.LogInformation("Logs contain timestamp and log level.");
-                logger.LogInformation("Systemd console logs never provide color options.");
-                logger.LogInformation("Systemd console logs always appear in a single line.");
-            }
+class Program
+{
+    static void Main()
+    {
+        using ILoggerFactory loggerFactory =
+            LoggerFactory.Create(builder =>
+                builder.AddSystemdConsole(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.TimestampFormat = "hh:mm:ss ";
+                }));
+
+        ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
+        using (logger.BeginScope("[scope is enabled]"))
+        {
+            logger.LogInformation("Hello World!");
+            logger.LogInformation("Logs contain timestamp and log level.");
+            logger.LogInformation("Systemd console logs never provide color options.");
+            logger.LogInformation("Systemd console logs always appear in a single line.");
         }
     }
 }

--- a/docs/core/extensions/snippets/logging/console-formatter-systemd/console-formatter-systemd.csproj
+++ b/docs/core/extensions/snippets/logging/console-formatter-systemd/console-formatter-systemd.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Console.ExampleFormatters.Systemd</RootNamespace>
   </PropertyGroup>
 

--- a/docs/core/extensions/snippets/primitives/change/Example.Static.cs
+++ b/docs/core/extensions/snippets/primitives/change/Example.Static.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading;
-using Microsoft.Extensions.Primitives;
+﻿using Microsoft.Extensions.Primitives;
 
 internal static partial class Example
 {

--- a/docs/core/extensions/snippets/primitives/change/tokens.csproj
+++ b/docs/core/extensions/snippets/primitives/change/tokens.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>ChangeToken.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>ChangeToken.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/primitives/string/tokenizers.csproj
+++ b/docs/core/extensions/snippets/primitives/string/tokenizers.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>StringTokenizer.Example</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>StringTokenizer.Example</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/extensions/snippets/workers/background-service/App.WorkerService.csproj
+++ b/docs/core/extensions/snippets/workers/background-service/App.WorkerService.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>App.WorkerService</RootNamespace>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/workers/background-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/background-service/Program.cs
@@ -1,24 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using App.WorkerService;
 
-namespace App.WorkerService
-{
-    public class Program
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+        services.AddHostedService<Worker>();
+    })
+    .Build();
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((hostContext, services) =>
-                {
-                    services.AddHostedService<Worker>();
-                });
-    }
-}
+await host.RunAsync();

--- a/docs/core/extensions/snippets/workers/background-service/Worker.cs
+++ b/docs/core/extensions/snippets/workers/background-service/Worker.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace App.WorkerService
+﻿namespace App.WorkerService
 {
     public class Worker : BackgroundService
     {
@@ -20,14 +14,7 @@ namespace App.WorkerService
             while (!stoppingToken.IsCancellationRequested)
             {
                 _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                try
-                {
-                    await Task.Delay(1000, stoppingToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
+                await Task.Delay(1000, stoppingToken);
             }
         }
     }

--- a/docs/core/extensions/snippets/workers/cloud-service/App.CloudService.csproj
+++ b/docs/core/extensions/snippets/workers/cloud-service/App.CloudService.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker;Microsoft.NET.Sdk.Publish">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>App.CloudService</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>App.CloudService</RootNamespace>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/workers/cloud-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/cloud-service/Program.cs
@@ -1,6 +1,4 @@
 ﻿using App.CloudService;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((hostContext, services) =>

--- a/docs/core/extensions/snippets/workers/cloud-service/Worker.cs
+++ b/docs/core/extensions/snippets/workers/cloud-service/Worker.cs
@@ -1,33 +1,26 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿namespace App.CloudService;
 
-namespace App.CloudService
+public class Worker : BackgroundService
 {
-    public class Worker : BackgroundService
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
     {
-        private readonly ILogger<Worker> _logger;
+        _logger = logger;
+    }
 
-        public Worker(ILogger<Worker> logger)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
         {
-            _logger = logger;
-        }
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            while (!stoppingToken.IsCancellationRequested)
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+            try
             {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                try
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
             }
         }
     }

--- a/docs/core/extensions/snippets/workers/queue-service/App.QueueService.csproj
+++ b/docs/core/extensions/snippets/workers/queue-service/App.QueueService.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>App.QueueService</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>App.QueueService</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/workers/queue-service/DefaultBackgroundTaskQueue.cs
+++ b/docs/core/extensions/snippets/workers/queue-service/DefaultBackgroundTaskQueue.cs
@@ -1,41 +1,37 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
+﻿using System.Threading.Channels;
 
-namespace App.QueueService
+namespace App.QueueService;
+
+public class DefaultBackgroundTaskQueue : IBackgroundTaskQueue
 {
-    public class DefaultBackgroundTaskQueue : IBackgroundTaskQueue
+    private readonly Channel<Func<CancellationToken, ValueTask>> _queue;
+
+    public DefaultBackgroundTaskQueue(int capacity)
     {
-        private readonly Channel<Func<CancellationToken, ValueTask>> _queue;
-
-        public DefaultBackgroundTaskQueue(int capacity)
+        BoundedChannelOptions options = new(capacity)
         {
-            BoundedChannelOptions options = new(capacity)
-            {
-                FullMode = BoundedChannelFullMode.Wait
-            };
-            _queue = Channel.CreateBounded<Func<CancellationToken, ValueTask>>(options);
+            FullMode = BoundedChannelFullMode.Wait
+        };
+        _queue = Channel.CreateBounded<Func<CancellationToken, ValueTask>>(options);
+    }
+
+    public async ValueTask QueueBackgroundWorkItemAsync(
+        Func<CancellationToken, ValueTask> workItem)
+    {
+        if (workItem is null)
+        {
+            throw new ArgumentNullException(nameof(workItem));
         }
 
-        public async ValueTask QueueBackgroundWorkItemAsync(
-            Func<CancellationToken, ValueTask> workItem)
-        {
-            if (workItem is null)
-            {
-                throw new ArgumentNullException(nameof(workItem));
-            }
+        await _queue.Writer.WriteAsync(workItem);
+    }
 
-            await _queue.Writer.WriteAsync(workItem);
-        }
+    public async ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken)
+    {
+        Func<CancellationToken, ValueTask>? workItem =
+            await _queue.Reader.ReadAsync(cancellationToken);
 
-        public async ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(
-            CancellationToken cancellationToken)
-        {
-            Func<CancellationToken, ValueTask>? workItem =
-                await _queue.Reader.ReadAsync(cancellationToken);
-
-            return workItem;
-        }
+        return workItem;
     }
 }

--- a/docs/core/extensions/snippets/workers/queue-service/IBackgroundTaskQueue.cs
+++ b/docs/core/extensions/snippets/workers/queue-service/IBackgroundTaskQueue.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿namespace App.QueueService;
 
-namespace App.QueueService
+public interface IBackgroundTaskQueue
 {
-    public interface IBackgroundTaskQueue
-    {
-        ValueTask QueueBackgroundWorkItemAsync(
-            Func<CancellationToken, ValueTask> workItem);
+    ValueTask QueueBackgroundWorkItemAsync(
+        Func<CancellationToken, ValueTask> workItem);
 
-        ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(
-            CancellationToken cancellationToken);
-    }
+    ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken);
 }

--- a/docs/core/extensions/snippets/workers/queue-service/MonitorLoop.cs
+++ b/docs/core/extensions/snippets/workers/queue-service/MonitorLoop.cs
@@ -58,7 +58,7 @@ public class MonitorLoop
                 // Prevent throwing if the Delay is cancelled
             }
 
-            ++delayLoop;
+            ++ delayLoop;
 
             _logger.LogInformation("Queued work item {Guid} is running. {DelayLoop}/3", guid, delayLoop);
         }

--- a/docs/core/extensions/snippets/workers/queue-service/MonitorLoop.cs
+++ b/docs/core/extensions/snippets/workers/queue-service/MonitorLoop.cs
@@ -1,81 +1,74 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+﻿namespace App.QueueService;
 
-namespace App.QueueService
+public class MonitorLoop
 {
-    public class MonitorLoop
+    private readonly IBackgroundTaskQueue _taskQueue;
+    private readonly ILogger<MonitorLoop> _logger;
+    private readonly CancellationToken _cancellationToken;
+
+    public MonitorLoop(
+        IBackgroundTaskQueue taskQueue,
+        ILogger<MonitorLoop> logger,
+        IHostApplicationLifetime applicationLifetime)
     {
-        private readonly IBackgroundTaskQueue _taskQueue;
-        private readonly ILogger<MonitorLoop> _logger;
-        private readonly CancellationToken _cancellationToken;
+        _taskQueue = taskQueue;
+        _logger = logger;
+        _cancellationToken = applicationLifetime.ApplicationStopping;
+    }
 
-        public MonitorLoop(
-            IBackgroundTaskQueue taskQueue,
-            ILogger<MonitorLoop> logger,
-            IHostApplicationLifetime applicationLifetime)
+    public void StartMonitorLoop()
+    {
+        _logger.LogInformation($"{nameof(MonitorAsync)} loop is starting.");
+
+        // Run a console user input loop in a background thread
+        Task.Run(async () => await MonitorAsync());
+    }
+
+    private async ValueTask MonitorAsync()
+    {
+        while (!_cancellationToken.IsCancellationRequested)
         {
-            _taskQueue = taskQueue;
-            _logger = logger;
-            _cancellationToken = applicationLifetime.ApplicationStopping;
-        }
-
-        public void StartMonitorLoop()
-        {
-            _logger.LogInformation($"{nameof(MonitorAsync)} loop is starting.");
-
-            // Run a console user input loop in a background thread
-            Task.Run(async () => await MonitorAsync());
-        }
-
-        private async ValueTask MonitorAsync()
-        {
-            while (!_cancellationToken.IsCancellationRequested)
+            var keyStroke = Console.ReadKey();
+            if (keyStroke.Key == ConsoleKey.W)
             {
-                var keyStroke = Console.ReadKey();
-                if (keyStroke.Key == ConsoleKey.W)
-                {
-                    // Enqueue a background work item
-                    await _taskQueue.QueueBackgroundWorkItemAsync(BuildWorkItemAsync);
-                }
+                // Enqueue a background work item
+                await _taskQueue.QueueBackgroundWorkItemAsync(BuildWorkItemAsync);
             }
         }
+    }
 
-        private async ValueTask BuildWorkItemAsync(CancellationToken token)
+    private async ValueTask BuildWorkItemAsync(CancellationToken token)
+    {
+        // Simulate three 5-second tasks to complete
+        // for each enqueued work item
+
+        int delayLoop = 0;
+        var guid = Guid.NewGuid();
+
+        _logger.LogInformation("Queued work item {Guid} is starting.", guid);
+
+        while (!token.IsCancellationRequested && delayLoop < 3)
         {
-            // Simulate three 5-second tasks to complete
-            // for each enqueued work item
-
-            int delayLoop = 0;
-            var guid = Guid.NewGuid();
-
-            _logger.LogInformation("Queued work item {Guid} is starting.", guid);
-
-            while (!token.IsCancellationRequested && delayLoop < 3)
+            try
             {
-                try
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(5), token);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Prevent throwing if the Delay is cancelled
-                }
-
-                ++ delayLoop;
-
-                _logger.LogInformation("Queued work item {Guid} is running. {DelayLoop}/3", guid, delayLoop);
+                await Task.Delay(TimeSpan.FromSeconds(5), token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Prevent throwing if the Delay is cancelled
             }
 
-            string format = delayLoop switch
-            {
-                3 => "Queued Background Task {Guid} is complete.",
-                _ => "Queued Background Task {Guid} was cancelled."
-            };
+            ++delayLoop;
 
-            _logger.LogInformation(format, guid);
+            _logger.LogInformation("Queued work item {Guid} is running. {DelayLoop}/3", guid, delayLoop);
         }
+
+        string format = delayLoop switch
+        {
+            3 => "Queued Background Task {Guid} is complete.",
+            _ => "Queued Background Task {Guid} was cancelled."
+        };
+
+        _logger.LogInformation(format, guid);
     }
 }

--- a/docs/core/extensions/snippets/workers/queue-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/queue-service/Program.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using App.QueueService;
+﻿using App.QueueService;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>

--- a/docs/core/extensions/snippets/workers/scoped-service/App.ScopedService.csproj
+++ b/docs/core/extensions/snippets/workers/scoped-service/App.ScopedService.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>App.ScopedService</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>App.ScopedService</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/workers/scoped-service/DefaultScopedProcessingService.cs
+++ b/docs/core/extensions/snippets/workers/scoped-service/DefaultScopedProcessingService.cs
@@ -13,7 +13,7 @@ public class DefaultScopedProcessingService : IScopedProcessingService
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            ++_executionCount;
+            ++ _executionCount;
 
             _logger.LogInformation(
                 "{ServiceName} working, execution count: {Count}",

--- a/docs/core/extensions/snippets/workers/scoped-service/DefaultScopedProcessingService.cs
+++ b/docs/core/extensions/snippets/workers/scoped-service/DefaultScopedProcessingService.cs
@@ -1,31 +1,26 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿namespace App.ScopedService;
 
-namespace App.ScopedService
+public class DefaultScopedProcessingService : IScopedProcessingService
 {
-    public class DefaultScopedProcessingService : IScopedProcessingService
+    private int _executionCount;
+    private readonly ILogger<DefaultScopedProcessingService> _logger;
+
+    public DefaultScopedProcessingService(
+        ILogger<DefaultScopedProcessingService> logger) =>
+        _logger = logger;
+
+    public async Task DoWorkAsync(CancellationToken stoppingToken)
     {
-        private int _executionCount;
-        private readonly ILogger<DefaultScopedProcessingService> _logger;
-
-        public DefaultScopedProcessingService(
-            ILogger<DefaultScopedProcessingService> logger) =>
-            _logger = logger;
-
-        public async Task DoWorkAsync(CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                ++ _executionCount;
+            ++_executionCount;
 
-                _logger.LogInformation(
-                    "{ServiceName} working, execution count: {Count}",
-                    nameof(DefaultScopedProcessingService),
-                    _executionCount);
+            _logger.LogInformation(
+                "{ServiceName} working, execution count: {Count}",
+                nameof(DefaultScopedProcessingService),
+                _executionCount);
 
-                await Task.Delay(10_000, stoppingToken);
-            }
+            await Task.Delay(10_000, stoppingToken);
         }
     }
 }

--- a/docs/core/extensions/snippets/workers/scoped-service/IScopedProcessingService.cs
+++ b/docs/core/extensions/snippets/workers/scoped-service/IScopedProcessingService.cs
@@ -1,10 +1,6 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
+﻿namespace App.ScopedService;
 
-namespace App.ScopedService
+public interface IScopedProcessingService
 {
-    public interface IScopedProcessingService
-    {
-        Task DoWorkAsync(CancellationToken stoppingToken);
-    }
+    Task DoWorkAsync(CancellationToken stoppingToken);
 }

--- a/docs/core/extensions/snippets/workers/scoped-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/scoped-service/Program.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using App.ScopedService;
+﻿using App.ScopedService;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/docs/core/extensions/snippets/workers/timer-service/App.TimerHostedService.csproj
+++ b/docs/core/extensions/snippets/workers/timer-service/App.TimerHostedService.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>App.TimerHostedService</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>App.TimerHostedService</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/workers/timer-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/timer-service/Program.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using App.TimerHostedService;
+﻿using App.TimerHostedService;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/docs/core/extensions/snippets/workers/timer-service/TimerService.cs
+++ b/docs/core/extensions/snippets/workers/timer-service/TimerService.cs
@@ -1,55 +1,48 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿namespace App.TimerHostedService;
 
-namespace App.TimerHostedService
+public sealed class TimerService : IHostedService, IAsyncDisposable
 {
-    public sealed class TimerService : IHostedService, IAsyncDisposable
+    private readonly Task _completedTask = Task.CompletedTask;
+    private readonly ILogger<TimerService> _logger;
+    private int _executionCount = 0;
+    private Timer? _timer;
+
+    public TimerService(ILogger<TimerService> logger) => _logger = logger;
+
+    public Task StartAsync(CancellationToken stoppingToken)
     {
-        private readonly Task _completedTask = Task.CompletedTask;
-        private readonly ILogger<TimerService> _logger;
-        private int _executionCount = 0;
-        private Timer? _timer;
+        _logger.LogInformation($"{nameof(TimerHostedService)} is running.");
+        _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
 
-        public TimerService(ILogger<TimerService> logger) => _logger = logger;
+        return _completedTask;
+    }
 
-        public Task StartAsync(CancellationToken stoppingToken)
+    private void DoWork(object? state)
+    {
+        int count = Interlocked.Increment(ref _executionCount);
+
+        _logger.LogInformation(
+            $"{nameof(TimerHostedService)} is working, execution count: {{Count:#,0}}",
+            count);
+    }
+
+    public Task StopAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            $"{nameof(TimerHostedService)} is stopping.");
+
+        _timer?.Change(Timeout.Infinite, 0);
+
+        return _completedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_timer is IAsyncDisposable timer)
         {
-            _logger.LogInformation($"{nameof(TimerHostedService)} is running.");
-            _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
-
-            return _completedTask;
+            await timer.DisposeAsync();
         }
 
-        private void DoWork(object? state)
-        {
-            int count = Interlocked.Increment(ref _executionCount);
-
-            _logger.LogInformation(
-                $"{nameof(TimerHostedService)} is working, execution count: {{Count:#,0}}",
-                count);
-        }
-
-        public Task StopAsync(CancellationToken stoppingToken)
-        {
-            _logger.LogInformation(
-                $"{nameof(TimerHostedService)} is stopping.");
-
-            _timer?.Change(Timeout.Infinite, 0);
-
-            return _completedTask;
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            if (_timer is IAsyncDisposable timer)
-            {
-                await timer.DisposeAsync();
-            }
-
-            _timer = null;
-        }
+        _timer = null;
     }
 }

--- a/docs/core/extensions/snippets/workers/windows-service/App.WindowsService.csproj
+++ b/docs/core/extensions/snippets/workers/windows-service/App.WindowsService.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>App.WindowsService</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>App.WindowsService</RootNamespace>
     <OutputType>exe</OutputType>
     <PublishSingleFile>true</PublishSingleFile>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -11,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/docs/core/extensions/snippets/workers/windows-service/JokeService.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/JokeService.cs
@@ -1,44 +1,40 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Http.Json;
+﻿using System.Net.Http.Json;
 using System.Text.Json;
-using System.Threading.Tasks;
 
-namespace App.WindowsService
+namespace App.WindowsService;
+
+public class JokeService
 {
-    public class JokeService
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _options = new()
     {
-        private readonly HttpClient _httpClient;
-        private readonly JsonSerializerOptions _options = new()
+        PropertyNameCaseInsensitive = true
+    };
+
+    private const string JokeApiUrl =
+        "https://karljoke.herokuapp.com/jokes/programming/random";
+
+    public JokeService(HttpClient httpClient) => _httpClient = httpClient;
+
+    public async Task<string> GetJokeAsync()
+    {
+        try
         {
-            PropertyNameCaseInsensitive = true
-        };
+            // The API returns an array with a single entry.
+            Joke[]? jokes = await _httpClient.GetFromJsonAsync<Joke[]>(
+                JokeApiUrl, _options);
 
-        private const string JokeApiUrl =
-            "https://karljoke.herokuapp.com/jokes/programming/random";
+            Joke? joke = jokes?[0];
 
-        public JokeService(HttpClient httpClient) => _httpClient = httpClient;
-
-        public async Task<string> GetJokeAsync()
+            return joke is not null
+                ? $"{joke.Setup}{Environment.NewLine}{joke.Punchline}"
+                : "No joke here...";
+        }
+        catch (Exception ex)
         {
-            try
-            {
-                // The API returns an array with a single entry.
-                Joke[]? jokes = await _httpClient.GetFromJsonAsync<Joke[]>(
-                    JokeApiUrl, _options);
-
-                Joke? joke = jokes?[0];
-
-                return joke is not null
-                    ? $"{joke.Setup}{Environment.NewLine}{joke.Punchline}"
-                    : "No joke here...";
-            }
-            catch (Exception ex)
-            {
-                return $"That's not funny! {ex}";
-            }
+            return $"That's not funny! {ex}";
         }
     }
-
-    public record Joke(int Id, string Type, string Setup, string Punchline);
 }
+
+public record Joke(int Id, string Type, string Setup, string Punchline);

--- a/docs/core/extensions/snippets/workers/windows-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/Program.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using App.WindowsService;
+﻿using App.WindowsService;
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .UseWindowsService(options =>

--- a/docs/core/extensions/snippets/workers/windows-service/WindowsBackgroundService.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/WindowsBackgroundService.cs
@@ -1,30 +1,23 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿namespace App.WindowsService;
 
-namespace App.WindowsService
+public sealed class WindowsBackgroundService : BackgroundService
 {
-    public sealed class WindowsBackgroundService : BackgroundService
+    private readonly JokeService _jokeService;
+    private readonly ILogger<WindowsBackgroundService> _logger;
+
+    public WindowsBackgroundService(
+        JokeService jokeService,
+        ILogger<WindowsBackgroundService> logger) =>
+        (_jokeService, _logger) = (jokeService, logger);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        private readonly JokeService _jokeService;
-        private readonly ILogger<WindowsBackgroundService> _logger;
-
-        public WindowsBackgroundService(
-            JokeService jokeService,
-            ILogger<WindowsBackgroundService> logger) =>
-            (_jokeService, _logger) = (jokeService, logger);
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                string joke = await _jokeService.GetJokeAsync();
-                _logger.LogWarning(joke);
+            string joke = await _jokeService.GetJokeAsync();
+            _logger.LogWarning(joke);
 
-                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
-            }
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
         }
     }
 }

--- a/docs/core/extensions/timer-service.md
+++ b/docs/core/extensions/timer-service.md
@@ -3,7 +3,7 @@ title: Implement the IHostedService interface
 description: Learn how to implement a custom IHostedService interface with .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/30/2021
+ms.date: 11/12/2021
 ms.topic: tutorial
 ---
 
@@ -36,7 +36,7 @@ The timer-based background service makes use of the <xref:System.Threading.Timer
 
 Replace the contents of the `Worker` from the template with the following C# code, and rename the file to *TimerService.cs*:
 
-:::code source="snippets/workers/timer-service/TimerService.cs" highlight="40,47-50":::
+:::code source="snippets/workers/timer-service/TimerService.cs" highlight="34,41-44":::
 
 > [!IMPORTANT]
 > The `Worker` was a subclass of <xref:Microsoft.Extensions.Hosting.BackgroundService>. Now, the `TimerService` implements both the <xref:Microsoft.Extensions.Hosting.IHostedService>, and <xref:System.IAsyncDisposable> interfaces.
@@ -50,7 +50,7 @@ When <xref:Microsoft.Extensions.Hosting.IHostedService.StartAsync%2A> is called,
 
 Replace the existing `Program` contents with the following C# code:
 
-:::code source="snippets/workers/timer-service/Program.cs" highlight="8":::
+:::code source="snippets/workers/timer-service/Program.cs" highlight="6":::
 
 The service is registered in `IHostBuilder.ConfigureServices` (*Program.cs*) with the `AddHostedService` extension method. This is the same extension method you use when registering <xref:Microsoft.Extensions.Hosting.BackgroundService> subclasses, as they both implement the <xref:Microsoft.Extensions.Hosting.IHostedService> interface.
 

--- a/docs/core/extensions/windows-service.md
+++ b/docs/core/extensions/windows-service.md
@@ -3,7 +3,7 @@ title: Create a Windows Service using BackgroundService
 description: Learn how to create a Windows Service using the BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/05/2021
+ms.date: 11/12/2021
 ms.topic: tutorial
 ---
 
@@ -54,13 +54,13 @@ For more information on the .NET CLI add package command, see [`dotnet add packa
 
 After successfully adding the packages, your project file should now contain the following package references:
 
-:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="13-17" highlight="2-4":::
+:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="14-18" highlight="2-4":::
 
 ## Update project file
 
 This worker project makes use of C#'s [nullable reference types](../../csharp/nullable-references.md). To enable them for the entire project, update the project file accordingly:
 
-:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="1-7,11-18" highlight="6":::
+:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" range="1-7,12-20" highlight="5":::
 
 The preceding project file changes add the `<Nullable>enable<Nullable>` node. For more information, see [Setting the nullable context](../../csharp/language-reference/builtin-types/nullable-reference-types.md#setting-the-nullable-context).
 
@@ -106,7 +106,7 @@ In the preceding code, the `JokeService` is injected along with an `ILogger`. Bo
 
 Replace the template *Program.cs* file contents with the following C# code:
 
-:::code source="snippets/workers/windows-service/Program.cs" highlight="6-9,12-13":::
+:::code source="snippets/workers/windows-service/Program.cs" highlight="4-7,10-11":::
 
 The <xref:Microsoft.Extensions.Hosting.WindowsServiceLifetimeHostBuilderExtensions.UseWindowsService(Microsoft.Extensions.Hosting.IHostBuilder)> extension method configures the app to work as a Windows Service. The service name is set to `".NET Joke Service"`. The hosted service is registered, and the `HttpClient` is registered to the `JokeService` for dependency injection.
 
@@ -123,7 +123,7 @@ To create the .NET Worker Service app as a Windows Service, it's recommended tha
 > sc.exe create ".NET Joke Service" binpath="C:\Path\To\dotnet.exe C:\Path\To\App.WindowsService.dll"
 > ```
 
-:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" highlight="7-10":::
+:::code language="xml" source="snippets/workers/windows-service/App.WindowsService.csproj" highlight="8-11":::
 
 The preceding highlighted lines of the project file define the following behaviors:
 

--- a/docs/core/extensions/workers.md
+++ b/docs/core/extensions/workers.md
@@ -3,7 +3,7 @@ title: Worker Services in .NET
 description: Learn how to implement a custom IHostedService and use existing implementations with .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 05/26/2021
+ms.date: 11/15/2021
 ms.topic: overview
 ---
 
@@ -17,11 +17,11 @@ There are numerous reasons for creating long-running services such as:
 
 Background service processing usually doesn't involve a user interface (UI), but UIs can be built around them. In the early days with .NET Framework, Windows developers could create Windows Services for these reasons. Now with .NET, you can use the <xref:Microsoft.Extensions.Hosting.BackgroundService> &mdash; which is an implementation of <xref:Microsoft.Extensions.Hosting.IHostedService>, or implement your own.
 
-With .NET, you're no longer restricted to Windows. You can develop background services that are cross-platform. Hosted services are logging, configuration, and dependency injection (DI) ready. They're a part of the extensions suite of libraries, meaning they're fundamental to all .NET workloads that work with the [generic host](generic-host.md).
+With .NET, you're no longer restricted to Windows. You can develop cross-platform background services. Hosted services are logging, configuration, and dependency injection (DI) ready. They're a part of the extensions suite of libraries, meaning they're fundamental to all .NET workloads that work with the [generic host](generic-host.md).
 
 ## Terminology
 
-There are many terms that are mistakenly used synonymously. In this section, there are definitions for some of these terms to make their intent more apparent.
+Many terms are mistakenly used synonymously. In this section, there are definitions for some of these terms to make their intent more apparent.
 
 - **Background Service**: Refers to the <xref:Microsoft.Extensions.Hosting.BackgroundService> type.
 - **Hosted Service**: Implementations of <xref:Microsoft.Extensions.Hosting.IHostedService>, or referring to the <xref:Microsoft.Extensions.Hosting.IHostedService> itself.
@@ -104,7 +104,7 @@ The preceding *Dockerfile* steps include:
 
 When targeting Docker as a deployment strategy for your .NET Worker Service, there are a few considerations in the project file:
 
-:::code language="xml" source="snippets/workers/background-service/App.WorkerService.csproj" highlight="6,12":::
+:::code language="xml" source="snippets/workers/background-service/App.WorkerService.csproj" highlight="8,13":::
 
 In the preceding project file, the `<DockerDefaultTargetOS>` element specifies `Linux` as its target. To target Windows containers, use `Windows` instead. The [`Microsoft.VisualStudio.Azure.Containers.Tools.Targets` NuGet package](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets) is automatically added as a package reference when **Docker support** is selected from the template.
 

--- a/docs/csharp/tour-of-csharp/snippets/shared/AcmeStack.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/AcmeStack.cs
@@ -1,38 +1,35 @@
-﻿using System;
+﻿namespace Acme.Collections;
 
-namespace Acme.Collections
+public class Stack<T>
 {
-    public class Stack<T>
+    Entry _top;
+
+    public void Push(T data)
     {
-        Entry _top;
-        
-        public void Push(T data)
-        {
-            _top = new Entry(_top, data);
-        }
+        _top = new Entry(_top, data);
+    }
 
-        public T Pop()
+    public T Pop()
+    {
+        if (_top == null)
         {
-            if (_top == null)
-            {
-                throw new InvalidOperationException();
-            }
-            T result = _top.Data;
-            _top = _top.Next;
-            
-            return result;
+            throw new InvalidOperationException();
         }
+        T result = _top.Data;
+        _top = _top.Next;
 
-        class Entry
+        return result;
+    }
+
+    class Entry
+    {
+        public Entry Next { get; set; }
+        public T Data { get; set; }
+
+        public Entry(Entry next, T data)
         {
-            public Entry Next { get; set; }
-            public T Data { get; set; }
-            
-            public Entry(Entry next, T data)
-            {
-                Next = next;
-                Data = data;
-            }
+            Next = next;
+            Data = data;
         }
     }
 }

--- a/docs/csharp/tour-of-csharp/snippets/shared/ClassesObjects.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/ClassesObjects.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Snippets
+﻿namespace Snippets
 {
     // <ConsoleExtract>
     public class Console
@@ -18,11 +15,11 @@ namespace TourOfCsharp
     // <ColorClassDefinition>
     public class Color
     {
-        public static readonly Color Black = new Color(0, 0, 0);
-        public static readonly Color White = new Color(255, 255, 255);
-        public static readonly Color Red = new Color(255, 0, 0);
-        public static readonly Color Green = new Color(0, 255, 0);
-        public static readonly Color Blue = new Color(0, 0, 255);
+        public static readonly Color Black = new(0, 0, 0);
+        public static readonly Color White = new(255, 255, 255);
+        public static readonly Color Red = new(255, 0, 0);
+        public static readonly Color Green = new(0, 255, 0);
+        public static readonly Color Blue = new(0, 0, 255);
         
         public byte R;
         public byte G;
@@ -48,7 +45,7 @@ namespace TourOfCsharp
             {
                 j = i * i;
                 Console.WriteLine($"{i} x {i} = {j}");
-                i = i + 1;
+                i++;
             }
         }
     }
@@ -336,8 +333,8 @@ namespace TourOfCsharp
         {
             // <UsingEntity>
             Entity.SetNextSerialNo(1000);
-            Entity e1 = new Entity();
-            Entity e2 = new Entity();
+            Entity e1 = new();
+            Entity e2 = new();
             Console.WriteLine(e1.GetSerialNo());          // Outputs "1000"
             Console.WriteLine(e2.GetSerialNo());          // Outputs "1001"
             Console.WriteLine(Entity.GetNextSerialNo());  // Outputs "1002"
@@ -366,7 +363,7 @@ namespace TourOfCsharp
                     new Constant(2)
                 )
             );
-            Dictionary<string, object> vars = new Dictionary<string, object>();
+            Dictionary<string, object> vars = new();
             vars["x"] = 3;
             vars["y"] = 5;
             Console.WriteLine(e.Evaluate(vars)); // "21"
@@ -379,12 +376,12 @@ namespace TourOfCsharp
         private static void ListExampleOne()
         {
             // <CreateLists>
-            MyList<string> list1 = new MyList<string>();
-            MyList<string> list2 = new MyList<string>(10);
+            MyList<string> list1 = new();
+            MyList<string> list2 = new(10);
             // </CreateLists>
 
             // <AccessProperties>
-            MyList<string> names = new MyList<string>();
+            MyList<string> names = new();
             names.Capacity = 100;   // Invokes set accessor
             int i = names.Count;    // Invokes get accessor
             int j = names.Capacity; // Invokes get accessor
@@ -394,10 +391,10 @@ namespace TourOfCsharp
         private static void ListAddition()
         {
             // <ListAddition>
-            MyList<int> a = new MyList<int>();
+            MyList<int> a = new();
             a.Add(1);
             a.Add(2);
-            MyList<int> b = new MyList<int>();
+            MyList<int> b = new();
             b.Add(1);
             b.Add(2);
             Console.WriteLine(a == b);  // Outputs "True"
@@ -409,7 +406,7 @@ namespace TourOfCsharp
         private static void ListAccess()
         {
             // <ListAccess>
-            MyList<string> names = new MyList<string>();
+            MyList<string> names = new();
             names.Add("Liz");
             names.Add("Martha");
             names.Add("Beth");

--- a/docs/csharp/tour-of-csharp/snippets/shared/Features.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/Features.cs
@@ -1,211 +1,205 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿namespace TourOfCsharp;
 
-namespace TourOfCsharp
+// <DelegateExample>
+delegate double Function(double x);
+
+class Multiplier
 {
+    double _factor;
 
-    // <DelegateExample>
-    delegate double Function(double x);
-    
-    class Multiplier
+    public Multiplier(double factor) => _factor = factor;
+
+    public double Multiply(double x) => x * _factor;
+}
+
+class DelegateExample
+{
+    static double[] Apply(double[] a, Function f)
     {
-        double _factor;
-        
-        public Multiplier(double factor) => _factor = factor;
-        
-        public double Multiply(double x) => x * _factor;
+        var result = new double[a.Length];
+        for (int i = 0; i < a.Length; i++) result[i] = f(a[i]);
+        return result;
     }
-    
-    class DelegateExample
+
+    public static void Main()
     {
-        static double[] Apply(double[] a, Function f)
-        {
-            var result = new double[a.Length];
-            for (int i = 0; i < a.Length; i++) result[i] = f(a[i]);
-            return result;
-        }
-        
-        public static void Main()
-        {
-            double[] a = { 0.0, 0.5, 1.0 };
-            double[] squares = Apply(a, (x) => x * x);
-            double[] sines = Apply(a, Math.Sin);
-            Multiplier m = new Multiplier(2.0);
-            double[] doubles = Apply(a, m.Multiply);
-        }
+        double[] a = { 0.0, 0.5, 1.0 };
+        double[] squares = Apply(a, (x) => x * x);
+        double[] sines = Apply(a, Math.Sin);
+        Multiplier m = new(2.0);
+        double[] doubles = Apply(a, m.Multiply);
     }
-    // </DelegateExample>
+}
+// </DelegateExample>
 
-    // <DefineAttribute>
-    public class HelpAttribute : Attribute
+// <DefineAttribute>
+public class HelpAttribute : Attribute
+{
+    string _url;
+    string _topic;
+
+    public HelpAttribute(string url) => _url = url;
+
+    public string Url => _url;
+
+    public string Topic
     {
-        string _url;        
-        string _topic;
-        
-        public HelpAttribute(string url) => _url = url;
-
-        public string Url => _url;
-
-        public string Topic
-        {
-            get => _topic;
-            set => _topic = value;
-        }
+        get => _topic;
+        set => _topic = value;
     }
-    // </DefineAttribute>
+}
+// </DefineAttribute>
 
-    // <UseAttributes>
-    [Help("https://docs.microsoft.com/dotnet/csharp/tour-of-csharp/features")]
-    public class Widget
+// <UseAttributes>
+[Help("https://docs.microsoft.com/dotnet/csharp/tour-of-csharp/features")]
+public class Widget
+{
+    [Help("https://docs.microsoft.com/dotnet/csharp/tour-of-csharp/features",
+    Topic = "Display")]
+    public void Display(string text) { }
+}
+// </UseAttributes>
+
+
+class Features
+{
+    public static void Examples()
     {
-        [Help("https://docs.microsoft.com/dotnet/csharp/tour-of-csharp/features",
-        Topic = "Display")]
-        public void Display(string text) { }
+        ArraysSamples();
+        DeclareArrays();
+        ArrayOfArrays();
+        InitializeArray();
+
+        var weatherData = (Date: DateTime.Now, LowTemp: 5, HighTemp: 30);
+        // <StringInterpolation>
+        Console.WriteLine($"The low and high temperature on {weatherData.Date:MM-DD-YYYY}");
+        Console.WriteLine($"    was {weatherData.LowTemp} and {weatherData.HighTemp}.");
+        // Output (similar to):
+        // The low and high temperature on 08-11-2020
+        //     was 5 and 30.
+        // </StringInterpolation>
+        DelegateExample.Main();
+
+        ReadAttributes();
+
     }
-    // </UseAttributes>
 
-
-    class Features
+    // <AsyncExample>
+    public async Task<int> RetrieveDocsHomePage()
     {
-        public static void Examples()
+        var client = new HttpClient();
+        byte[] content = await client.GetByteArrayAsync("https://docs.microsoft.com/");
+
+        Console.WriteLine($"{nameof(RetrieveDocsHomePage)}: Finished downloading.");
+        return content.Length;
+    }
+    // </AsyncExample>
+
+
+    private static void ReadAttributes()
+    {
+        // <ReadAttributes>
+        Type widgetType = typeof(Widget);
+
+        object[] widgetClassAttributes = widgetType.GetCustomAttributes(typeof(HelpAttribute), false);
+
+        if (widgetClassAttributes.Length > 0)
         {
-            ArraysSamples();
-            DeclareArrays();
-            ArrayOfArrays();
-            InitializeArray();
-
-            var weatherData = (Date: DateTime.Now, LowTemp: 5, HighTemp: 30);
-            // <StringInterpolation>
-            Console.WriteLine($"The low and high temperature on {weatherData.Date:MM-DD-YYYY}");
-            Console.WriteLine($"    was {weatherData.LowTemp} and {weatherData.HighTemp}.");
-            // Output (similar to):
-            // The low and high temperature on 08-11-2020
-            //     was 5 and 30.
-            // </StringInterpolation>
-            DelegateExample.Main();
-
-            ReadAttributes();
-
+            HelpAttribute attr = (HelpAttribute)widgetClassAttributes[0];
+            Console.WriteLine($"Widget class help URL : {attr.Url} - Related topic : {attr.Topic}");
         }
 
-        // <AsyncExample>
-        public async Task<int> RetrieveDocsHomePage()
-        {
-            var client = new HttpClient();
-            byte[] content = await client.GetByteArrayAsync("https://docs.microsoft.com/");
+        System.Reflection.MethodInfo displayMethod = widgetType.GetMethod(nameof(Widget.Display));
 
-            Console.WriteLine($"{nameof(RetrieveDocsHomePage)}: Finished downloading.");
-            return content.Length;
+        object[] displayMethodAttributes = displayMethod.GetCustomAttributes(typeof(HelpAttribute), false);
+
+        if (displayMethodAttributes.Length > 0)
+        {
+            HelpAttribute attr = (HelpAttribute)displayMethodAttributes[0];
+            Console.WriteLine($"Display method help URL : {attr.Url} - Related topic : {attr.Topic}");
         }
-        // </AsyncExample>
+        // </ReadAttributes>
+    }
+
+    static double[] Apply(double[] a, Function f)
+    {
+        double[] result = new double[a.Length];
+        for (int i = 0; i < a.Length; i++) result[i] = f(a[i]);
+        return result;
+    }
 
 
-        private static void ReadAttributes()
+    static void ApplyDelegate()
+    {
+        double[] a = { 0.0, 0.5, 1.0 };
+        // <UseDelegate>
+        double[] doubles = Apply(a, (double x) => x * 2.0);
+        // </UseDelegate>
+    }
+
+
+    private static void InitializeArray()
+    {
         {
-            // <ReadAttributes>
-            Type widgetType = typeof(Widget);
+            // <InitializeArray>
+            int[] a = new int[] { 1, 2, 3 };
+            // </InitializeArray>
+        }
+        {
+            // <InitializeShortened>
+            int[] a = { 1, 2, 3 };
+            // </InitializeShortened>
+        }
+        {
+            // <InitializeGenerated>
+            int[] t = new int[3];
+            t[0] = 1;
+            t[1] = 2;
+            t[2] = 3;
+            int[] a = t;
+            // </InitializeGenerated>
 
-            object[] widgetClassAttributes = widgetType.GetCustomAttributes(typeof(HelpAttribute), false);
-
-            if (widgetClassAttributes.Length > 0)
+            // <EnumerateArray>
+            foreach (int item in a)
             {
-                HelpAttribute attr = (HelpAttribute)widgetClassAttributes[0];
-                Console.WriteLine($"Widget class help URL : {attr.Url} - Related topic : {attr.Topic}");
+                Console.WriteLine(item);
             }
-
-            System.Reflection.MethodInfo displayMethod = widgetType.GetMethod(nameof(Widget.Display));
-
-            object[] displayMethodAttributes = displayMethod.GetCustomAttributes(typeof(HelpAttribute), false);
-
-            if (displayMethodAttributes.Length > 0)
-            {
-                HelpAttribute attr = (HelpAttribute)displayMethodAttributes[0];
-                Console.WriteLine($"Display method help URL : {attr.Url} - Related topic : {attr.Topic}");
-            }
-            // </ReadAttributes>
+            // </EnumerateArray>
         }
 
-        static double[] Apply(double[] a, Function f)
+    }
+
+    private static void ArrayOfArrays()
+    {
+        // <ArrayOfArrays>
+        int[][] a = new int[3][];
+        a[0] = new int[10];
+        a[1] = new int[5];
+        a[2] = new int[20];
+        // </ArrayOfArrays>
+    }
+
+    private static void DeclareArrays()
+    {
+        // <DeclareArrays>
+        int[] a1 = new int[10];
+        int[,] a2 = new int[10, 5];
+        int[,,] a3 = new int[10, 5, 2];
+        // </DeclareArrays>
+    }
+
+    private static void ArraysSamples()
+    {
+        // <ArraysSample>
+        int[] a = new int[10];
+        for (int i = 0; i < a.Length; i++)
         {
-            double[] result = new double[a.Length];
-            for (int i = 0; i < a.Length; i++) result[i] = f(a[i]);
-            return result;
+            a[i] = i * i;
         }
-
-
-        static void ApplyDelegate()
+        for (int i = 0; i < a.Length; i++)
         {
-            double[] a = { 0.0, 0.5, 1.0 };
-            // <UseDelegate>
-            double[] doubles = Apply(a, (double x) => x * 2.0);
-            // </UseDelegate>
+            Console.WriteLine($"a[{i}] = {a[i]}");
         }
-
-
-        private static void InitializeArray()
-        {
-            {
-                // <InitializeArray>
-                int[] a = new int[] { 1, 2, 3 };
-                // </InitializeArray>
-            }
-            {
-                // <InitializeShortened>
-                int[] a = { 1, 2, 3 };
-                // </InitializeShortened>
-            }
-            {
-                // <InitializeGenerated>
-                int[] t = new int[3];
-                t[0] = 1;
-                t[1] = 2;
-                t[2] = 3;
-                int[] a = t;
-                // </InitializeGenerated>
-
-                // <EnumerateArray>
-                foreach (int item in a)
-                {
-                    Console.WriteLine(item);
-                }
-                // </EnumerateArray>
-            }
-
-        }
-
-        private static void ArrayOfArrays()
-        {
-            // <ArrayOfArrays>
-            int[][] a = new int[3][];
-            a[0] = new int[10];
-            a[1] = new int[5];
-            a[2] = new int[20];
-            // </ArrayOfArrays>
-        }
-
-        private static void DeclareArrays()
-        {
-            // <DeclareArrays>
-            int[] a1 = new int[10];
-            int[,] a2 = new int[10, 5];
-            int[,,] a3 = new int[10, 5, 2];
-            // </DeclareArrays>
-        }
-
-        private static void ArraysSamples()
-        {
-            // <ArraysSample>
-            int[] a = new int[10];
-            for (int i = 0; i < a.Length; i++)
-            {
-                a[i] = i * i;
-            }
-            for (int i = 0; i < a.Length; i++)
-            {
-                Console.WriteLine($"a[{i}] = {a[i]}");
-            }
-            // </ArraysSample>
-        }
+        // </ArraysSample>
     }
 }

--- a/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-class Hello
+﻿class Hello
 {
     static void Main()
     {

--- a/docs/csharp/tour-of-csharp/snippets/shared/Program.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/Program.cs
@@ -1,23 +1,22 @@
-﻿namespace TourOfCsharp
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            global::Example.Main();
-            Boxing();
-            Types.Examples();
-            ClassesObjects.Examples();
-            Features.Examples();
-        }
+﻿namespace TourOfCsharp;
 
-        private static void Boxing()
-        {
-            // <Boxing>
-            int i = 123;
-            object o = i;    // Boxing
-            int j = (int)o;  // Unboxing            
-            // </Boxing>
-        }
+class Program
+{
+    static void Main(string[] args)
+    {
+        global::Example.Main();
+        Boxing();
+        Types.Examples();
+        ClassesObjects.Examples();
+        Features.Examples();
+    }
+
+    private static void Boxing()
+    {
+        // <Boxing>
+        int i = 123;
+        object o = i;    // Boxing
+        int j = (int)o;  // Unboxing            
+        // </Boxing>
     }
 }

--- a/docs/csharp/tour-of-csharp/snippets/shared/StackUsage.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/StackUsage.cs
@@ -1,11 +1,8 @@
-using System;
-using Acme.Collections;
-
-class Example
+﻿class Example
 {
     public static void Main()
     {
-        var s = new Stack<int>();
+        var s = new Acme.Collections.Stack<int>();
         s.Push(1); // stack contains 1
         s.Push(10); // stack contains 1, 10
         s.Push(100); // stack contains 1, 10, 100

--- a/docs/csharp/tour-of-csharp/snippets/shared/TourOfCsharp.csproj
+++ b/docs/csharp/tour-of-csharp/snippets/shared/TourOfCsharp.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
     <StartupObject>TourOfCsharp.Program</StartupObject>
   </PropertyGroup>
 

--- a/docs/csharp/tour-of-csharp/snippets/shared/Types.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/Types.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace DeclareTypes
 {
-    // <PointStruct>
+    //<PointStruct>
     public struct Point
     {
         public double X { get; }
@@ -11,11 +10,11 @@ namespace DeclareTypes
         
         public Point(double x, double y) => (X, Y) = (x, y);
     }
-    // </PointStruct>
+    //</PointStruct>
 }
 namespace TourOfCsharp
 {
-    // <PointClass>
+    //<PointClass>
     public class Point
     {
         public int X { get; }
@@ -23,9 +22,9 @@ namespace TourOfCsharp
         
         public Point(int x, int y) => (X, Y) = (x, y);
     }
-    // </PointClass>
+    //</PointClass>
 
-    // <DefinePairClass>
+    //<DefinePairClass>
     public class Pair<TFirst, TSecond>
     {
         public TFirst First { get; }
@@ -34,9 +33,9 @@ namespace TourOfCsharp
         public Pair(TFirst first, TSecond second) => 
             (First, Second) = (first, second);
     }
-    // </DefinePairClass>
+    //</DefinePairClass>
 
-    // <Create3DPoint>
+    //<Create3DPoint>
     public class Point3D : Point
     {
         public int Z { get; set; }
@@ -46,9 +45,9 @@ namespace TourOfCsharp
             Z = z;
         }
     }
-    // </Create3DPoint>
+    //</Create3DPoint>
 
-    // <FirstInterfaces>
+    //<FirstInterfaces>
     interface IControl
     {
         void Paint();
@@ -65,9 +64,9 @@ namespace TourOfCsharp
     }
     
     interface IComboBox : ITextBox, IListBox { }
-    // </FirstInterfaces>
+    //</FirstInterfaces>
 
-    // <ImplementInterfaces>
+    //<ImplementInterfaces>
     interface IDataBound
     {
         void Bind(Binder b);
@@ -78,18 +77,18 @@ namespace TourOfCsharp
         public void Paint() { }
         public void Bind(Binder b) { }
     }
-    // </ImplementInterfaces>
+    //</ImplementInterfaces>
 
-    // <EnumDeclaration>
+    //<EnumDeclaration>
     public enum SomeRootVegetable
     {
         HorseRadish,
         Radish,
         Turnip
     }
-    // </EnumDeclaration>
+    //</EnumDeclaration>
 
-    // <FlagsEnumDeclaration>
+    //<FlagsEnumDeclaration>
     [Flags]
     public enum Seasons
     {
@@ -100,56 +99,56 @@ namespace TourOfCsharp
         Spring = 8,
         All = Summer | Autumn | Winter | Spring
     }
-    // </FlagsEnumDeclaration>
+    //</FlagsEnumDeclaration>
 
 
     public static class Types
     {
         public static void Examples()
         {
-            // <CreatePoints>
+            //<CreatePoints>
             var p1 = new Point(0, 0);
             var p2 = new Point(10, 20);
-            // </CreatePoints>
+            //</CreatePoints>
 
-            // <CreatePairObject>
+            //<CreatePairObject>
             var pair = new Pair<int, string>(1, "two");
-            int i = pair.First;     // TFirst int
-            string s = pair.Second; // TSecond string
-            // </CreatePairObject>
+            int i = pair.First;     //TFirst int
+            string s = pair.Second; //TSecond string
+            //</CreatePairObject>
 
-            // <ImplicitCastToBase>
-            Point a = new Point(10, 20);
+            //<ImplicitCastToBase>
+            Point a = new(10, 20);
             Point b = new Point3D(10, 20, 30);
-            // </ImplicitCastToBase>
+            //</ImplicitCastToBase>
 
-            // <UseInterfaces>
-            EditBox editBox = new EditBox();
+            //<UseInterfaces>
+            EditBox editBox = new();
             IControl control = editBox;
             IDataBound dataBound = editBox;
-            // </UseInterfaces>
+            //</UseInterfaces>
 
-            // <UsingEnums>
+            //<UsingEnums>
             var turnip = SomeRootVegetable.Turnip;
 
             var spring = Seasons.Spring;
             var startingOnEquinox = Seasons.Spring | Seasons.Autumn;
             var theYear = Seasons.All;
-            // </UsingEnums>
+            //</UsingEnums>
 
-            // <DeclareNullable>
+            //<DeclareNullable>
             int? optionalInt = default; 
             optionalInt = 5;
             string? optionalText = default;
             optionalText = "Hello World.";
-            // </DeclareNullable>
+            //</DeclareNullable>
 
-            // <DeclareTuples>
+            //<DeclareTuples>
             (double Sum, int Count) t2 = (4.5, 3);
             Console.WriteLine($"Sum of {t2.Count} elements is {t2.Sum}.");
-            // Output:
-            // Sum of 3 elements is 4.5.
-            // </DeclareTuples>
+            //Output:
+            //Sum of 3 elements is 4.5.
+            //</DeclareTuples>
         }
     }
 }


### PR DESCRIPTION
## Summary

Bump versions to .NET 6 and upgrade C# code to v10

> I really wish that the triple colon syntax for our MD code blocks would allow for comma-delimited `id` values!
>
> ```md
> :::code source="../path/to/file.cs" id="one,two":::
> ```
>
> This would avoid the `range` syntax, which is not future-proof. ☹️

Part of #26777, relying on GHA output from #26800, also fixes #27127

## Previews

Lots of content relied on `range`, ported what I could to `id` and fixed the remaining bits:

- [docs/core/extensions/configuration-providers.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/configuration-providers?branch=pr-en-us-27051)
- [docs/core/extensions/configuration.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-27051)
- [docs/core/extensions/console-log-formatter.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/console-log-formatter?branch=pr-en-us-27051)
- [docs/core/extensions/custom-configuration-provider.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/custom-configuration-provider?branch=pr-en-us-27051)
- [docs/core/extensions/custom-logging-provider.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/custom-logging-provider?branch=pr-en-us-27051)
- [docs/core/extensions/dependency-injection-guidelines.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-guidelines?branch=pr-en-us-27051)
- [docs/core/extensions/dependency-injection-usage.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-usage?branch=pr-en-us-27051)
- [docs/core/extensions/dependency-injection.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-27051)
- [docs/core/extensions/high-performance-logging.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging?branch=pr-en-us-27051)
- [docs/core/extensions/localization.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/localization?branch=pr-en-us-27051)
- [docs/core/extensions/logger-message-generator.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator?branch=pr-en-us-27051)
- [docs/core/extensions/logging-providers.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/logging-providers?branch=pr-en-us-27051)
- [docs/core/extensions/logging.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/logging?branch=pr-en-us-27051)
- [docs/core/extensions/options-library-authors.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/options-library-authors?branch=pr-en-us-27051)
- [docs/core/extensions/options.md](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/options?branch=pr-en-us-27051)


