### PR TITLE
Fix errors for required statuses

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -1,28 +1,12 @@
 # This is a basic workflow to help you get started with Actions
-name: Snippets 5000
+name: 'Snippets 5000'
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events on the main branch only.
 on:
-  pull_request:
-    paths:
-      - "**.cs"
-      - "**.vb"
-      - "**.fs"
-      - "**.cpp"
-      - "**.h"
-      - "**.xaml"
-      - "**.razor"
-      - "**.cshtml"
-      - "**.vbhtml"
-      - "**.csproj"
-      - "**.vbproj"
-      - "**.fsproj"
-      - "**.vcxproj"
-      - "**.sln"
-      - "**global.json"
-      - "**snippets.5000.json"
+  pull_request_target:
     branches: [ main ]
+    types: [opened, synchronize, reopened]
 
 env:
   DOTNET_INSTALLER_CHANNEL: '6.0'
@@ -31,8 +15,8 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  # This workflow contains a single job called "snippets-build"
+  snippets-build:
     # The type of runner that the job will run on
     runs-on: windows-latest
 

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -9,7 +9,7 @@ on:
       - ".markdownlint.json"
       - ".github/workflows/markdownlint.yml"
       - ".github/workflows/markdownlint-problem-matcher.json"
-  pull_request:
+  pull_request_target:
     paths:
       - "**/*.md"
       - ".markdownlint.json"


### PR DESCRIPTION
See #27012 

The way GitHub implements "required checks", if a check doesn't run, it's marked as "pending", and never completes. That meant our "Snippets 5000" would stay in a stuck "pending" state forever on any PR that didn't change source code, or a project file. 

The fix is to remove the "paths" filter, so this check does run on all PRs. See https://github.community/t/expected-waiting-for-status-to-be-reported/18001/6 for details.

The other main functional check is to change the trigger from "pull_request" to "pull_request_target". That runs the actions as configured on the target branch, not as created in the PR. As a result of that change, we won't need to allow checks to run on PRs created on other forks from people who aren't maintainers.

Other changes are cosmetic to improve the UI for the branch protection screen.

Detailed changes:

- Remove the paths filter.
- Update labels so it's easier to find this check in the "branch protection" page.
- Change `pull_request` to `pull_request-target`
