### PR TITLE
Fixed Typo

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/NullableReferenceTypes.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/NullableReferenceTypes.cs
@@ -26,7 +26,7 @@ namespace builtin_types
             private string shortDescription;
             private string? detailedDescription;
 
-            public ProductDescription() // Warning! short description not initialized.
+            public ProductDescription() // Warning! shortDescription not initialized.
             {
             }
 


### PR DESCRIPTION
## Summary

changed "short description" to "shortDescription" in a comment to avoid confusion.

Fixes #27067
