### PR TITLE
Clarify information about reference validity in a finalizer (#26710)

### DIFF
--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -87,7 +87,7 @@ If your class owns a field or property, and its type implements <xref:System.IDi
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/Foo.vb":::
 
 > [!TIP]
-> There are cases when you may want to perform `null`-checking in a finalizer (which includes the `Dispose(false)` method invoked by a finalizer), one of the primary reasons is if you're unsure whether the instance got fully initialized (ie. exception may be thrown in a constructor).
+> There are cases when you may want to perform `null`-checking in a finalizer (which includes the `Dispose(false)` method invoked by a finalizer), one of the primary reasons is if you're unsure whether the instance got fully initialized (for example, an exception may be thrown in a constructor).
 
 ## Implement the dispose pattern
 

--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -77,7 +77,7 @@ The body of the method consists of three blocks of code:
 
   - **Managed objects that consume large amounts of memory or consume scarce resources.** Assign large managed object references to `null` to make them more likely to be unreachable. This releases them faster than if they were reclaimed non-deterministically.
 
-If the method call comes from a finalizer, only the code that frees unmanaged resources should execute. The implementer is responsible for ensuring that the false path doesn't interact with managed objects that may have been reclaimed. This is important because the order in which the garbage collector destroys managed objects during finalization is non-deterministic.
+If the method call comes from a finalizer, only the code that frees unmanaged resources should execute. The implementer is responsible for ensuring that the false path doesn't interact with managed objects that may have been disposed. This is important because the order in which the garbage collector disposes managed objects during finalization is non-deterministic.
 
 ## Cascade dispose calls
 
@@ -85,6 +85,9 @@ If your class owns a field or property, and its type implements <xref:System.IDi
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/Foo.vb":::
+
+> [!TIP]
+> There are cases when you may want to perform `null`-checking in a finalizer (which includes the `Dispose(false)` method invoked by a finalizer), one of the primary reasons is if you're unsure whether the instance got fully initialized (ie. exception may be thrown in a constructor).
 
 ## Implement the dispose pattern
 

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs
@@ -9,5 +9,5 @@ public sealed class Foo : IDisposable
         _bar = new Bar();
     }
 
-    public void Dispose() => _bar?.Dispose();
+    public void Dispose() => _bar.Dispose();
 }


### PR DESCRIPTION
## Summary

References of other instances in of finalizable instances are not reclaimed before finalizer runs, finalizable objects are sources of GC roots.

Also adds information about possible null references during finalize operation.

Fixes #26710