### PR TITLE
Fix Dispose(bool) method overload 

### DIFF
--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
@@ -28,9 +28,8 @@ public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
         if (disposing)
         {
             _jsonWriter?.Dispose();
+            _jsonWriter = null;
         }
-
-        _jsonWriter = null;
     }
 
     protected virtual async ValueTask DisposeAsyncCore()


### PR DESCRIPTION
In the [frees managed resources](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#the-disposebool-method-overload) docs, there is

> Managed objects that consume large amounts of memory or consume scarce resources. Assign large managed object references to null to make them more likely to be unreachable. This releases them faster than if they were reclaimed non-deterministically.

So, the operation assigned `null` to `_jsonWriter` should be located in the section while the `bool disposing` is `true`.

On the other hand, as the [Note section](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#the-disposeasync-method) describes,

> One primary difference in the async dispose pattern compared to the dispose pattern, is that the call from DisposeAsync() to the Dispose(bool) overload method is given false as an argument.

We can know the operations in `DisposeAsyncCore()` is the same as `Dispose(disposing: true)` minus `Dispose(disposing: false)` in semantics.

So the the operation assigned `null` to `_jsonWriter` should be located in free managed resource section in my opinion.