### PR TITLE
Update cs5001.md

### DIFF
--- a/docs/csharp/misc/cs5001.md
+++ b/docs/csharp/misc/cs5001.md
@@ -14,7 +14,7 @@ Program does not contain a static 'Main' method suitable for an entry point
 
 This error occurs when no static `Main` method with a correct signature is found in the code that produces an executable file. It also occurs if the entry point function, `Main`, is defined with the wrong case, such as lower-case `main`. For information about the rules that apply to the `Main` method, see [Main() and Command-Line Arguments](../fundamentals/program-structure/main-command-line.md).
 
-If the `Main` method has an `async` modifier, make sure that the [selected C# language version](../language-reference/configure-language-version.md) is 7.1 or higher and to use Task as the return type.
+If the `Main` method has an `async` modifier, make sure that the [selected C# language version](../language-reference/configure-language-version.md) is 7.1 or higher and to use `Task` or `Task<int>` as the return type.
 
 The `Main` method is only required when compiling an executable file, that is, when the **exe** or **winexe** element of the [**TargetType**](../language-reference/compiler-options/output.md#targettype) compiler option is specified. The following Visual Studio project types specify one of these options by default:
 

--- a/docs/csharp/misc/cs5001.md
+++ b/docs/csharp/misc/cs5001.md
@@ -14,7 +14,7 @@ Program does not contain a static 'Main' method suitable for an entry point
 
 This error occurs when no static `Main` method with a correct signature is found in the code that produces an executable file. It also occurs if the entry point function, `Main`, is defined with the wrong case, such as lower-case `main`. For information about the rules that apply to the `Main` method, see [Main() and Command-Line Arguments](../fundamentals/program-structure/main-command-line.md).
 
-If the `Main` method has an `async` modifier, make sure that the [selected C# language version](../language-reference/configure-language-version.md) is 7.1 or higher.
+If the `Main` method has an `async` modifier, make sure that the [selected C# language version](../language-reference/configure-language-version.md) is 7.1 or higher and to use Task as the return type.
 
 The `Main` method is only required when compiling an executable file, that is, when the **exe** or **winexe** element of the [**TargetType**](../language-reference/compiler-options/output.md#targettype) compiler option is specified. The following Visual Studio project types specify one of these options by default:
 


### PR DESCRIPTION
## Summary

Return type void is not allowed when in the Main method when using async.
