### PR TITLE
Add the HTTP keyword to the expected list of available slug completions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "F#",
         "HashiCorp Configuration Language (HCL)",
         "HTML",
+        "HTTP",
         "Ini",
         "JavaScript",
         "JSON",


### PR DESCRIPTION
## Summary (Auto-merge enabled)

Add the HTTP keyword to the expected list of available slug completions
