### PR TITLE
Remove backticks from page metadata

### DIFF
--- a/docs/core/compatibility/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
+++ b/docs/core/compatibility/interop/5.0/casting-rcw-to-inspectable-interface-throws-exception.md
@@ -1,6 +1,6 @@
 ---
-title: "Breaking change: Casting RCW to `InterfaceIsIInspectable` throws exception"
-description: Learn about the interop breaking change in .NET 5 where casting an RCW to an `InterfaceIsIInspectable` interface throws a PlatformNotSupportedException.
+title: "Breaking change: Casting RCW to InterfaceIsIInspectable throws exception"
+description: Learn about the interop breaking change in .NET 5 where casting an RCW to an InterfaceIsIInspectable interface throws a PlatformNotSupportedException.
 ms.date: 09/13/2020
 ---
 # Casting RCW to an `InterfaceIsIInspectable` interface throws PlatformNotSupportedException

--- a/docs/fundamentals/code-analysis/quality-rules/ca1846.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1846.md
@@ -1,6 +1,6 @@
 ---
-title: "CA1846: Prefer `AsSpan` over `Substring`"
-description: "Learn about code analysis rule CA1846: Prefer `AsSpan` over `Substring`"
+title: "CA1846: Prefer AsSpan over Substring"
+description: "Learn about code analysis rule CA1846: Prefer AsSpan over Substring"
 ms.date: 05/21/2021
 ms.topic: reference
 f1_keywords:

--- a/docs/fundamentals/code-analysis/quality-rules/ca1850.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1850.md
@@ -1,6 +1,6 @@
 ---
-title: "CA1850: Prefer static `HashData` method over `ComputeHash`"
-description: "It is more efficient to use the static `HashData` method over creating and managing a HashAlgorithm instance to call `ComputeHash`"
+title: "CA1850: Prefer static HashData method over ComputeHash"
+description: "It is more efficient to use the static HashData method over creating and managing a HashAlgorithm instance to call ComputeHash"
 ms.date: 10/23/2021
 ms.topic: reference
 f1_keywords:

--- a/docs/fundamentals/code-analysis/quality-rules/ca2018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2018.md
@@ -1,6 +1,6 @@
 ---
-title: "CA2018: The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy"
-description: "Learn about code analysis rule CA2018: The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy"
+title: "CA2018: The count argument to Buffer.BlockCopy should specify the number of bytes to copy"
+description: "Learn about code analysis rule CA2018: The count argument to Buffer.BlockCopy should specify the number of bytes to copy"
 ms.date: 08/17/2021
 ms.topic: reference
 f1_keywords:

--- a/docs/fundamentals/code-analysis/quality-rules/ca2250.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2250.md
@@ -1,6 +1,6 @@
 ---
-title: "CA2250: Use `ThrowIfCancellationRequested`"
-description: "Learn about code analysis rule CA2250: Use `ThrowIfCancellationRequested`"
+title: "CA2250: Use ThrowIfCancellationRequested"
+description: "Learn about code analysis rule CA2250: Use ThrowIfCancellationRequested"
 ms.date: 05/21/2021
 ms.topic: reference
 f1_keywords:

--- a/docs/fundamentals/code-analysis/quality-rules/ca2251.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2251.md
@@ -1,6 +1,6 @@
 ---
-title: "CA2251: Use `String.Equals` over `String.Compare`"
-description: "Learn about code analysis rule CA2251: Use `String.Equals` over `String.Compare`"
+title: "CA2251: Use String.Equals over String.Compare"
+description: "Learn about code analysis rule CA2251: Use String.Equals over String.Compare"
 ms.date: 05/31/2021
 ms.topic: reference
 f1_keywords:


### PR DESCRIPTION
## Summary

As noted in https://github.com/dotnet/docs/pull/27096#discussion_r750562268, we should not have `` ` `` characters in page metadata (title/description) as it renders poorly where those strings are used. This removes the occurrences found by the regex: `` ^(title|description).*` ``.