### PR TITLE
Fix Dispose(bool) method overload in ConjunctiveDisposable pattern

### DIFF
--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
@@ -28,9 +28,8 @@ public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
         if (disposing)
         {
             _jsonWriter?.Dispose();
+            _jsonWriter = null;
         }
-
-        _jsonWriter = null;
     }
 
     protected virtual async ValueTask DisposeAsyncCore()

--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
@@ -29,10 +29,9 @@ class ExampleConjunctiveDisposableusing : IDisposable, IAsyncDisposable
         {
             _disposableResource?.Dispose();
             (_asyncDisposableResource as IDisposable)?.Dispose();
+            _disposableResource = null;
+            _asyncDisposableResource = null;
         }
-
-        _disposableResource = null;
-        _asyncDisposableResource = null;
     }
 
     protected virtual async ValueTask DisposeAsyncCore()


### PR DESCRIPTION
As the same reason mentioned in [this pull](https://github.com/dotnet/docs/pull/27074).