### PR TITLE
Fix the build for unit-testing-best-practices.sln on VS2022 by altering the arguments to ArgumentException

### DIFF
--- a/samples/snippets/core/testing/unit-testing-best-practices/csharp/unit-testing-best-practices/StringCalculator.cs
+++ b/samples/snippets/core/testing/unit-testing-best-practices/csharp/unit-testing-best-practices/StringCalculator.cs
@@ -10,7 +10,7 @@ namespace UnitTestingBestPractices
         {
             if (numbers == null)
             {
-                throw new ArgumentException(nameof(numbers));
+                throw new ArgumentNullException(nameof(numbers));
             }
 
             int result;
@@ -49,7 +49,7 @@ namespace UnitTestingBestPractices
             var result = int.TryParse(number, out var parsedNumber);
             if (result == false)
             {
-                 throw new ArgumentException(nameof(number));
+                throw new ArgumentException($"Unable to parse {nameof(number)} as an Int32.", nameof(number));
             }
 
             return parsedNumber;


### PR DESCRIPTION
## Summary

The project unit-testing-best-practices.sln does not build with a fresh install of VS2022 because of error CA2208.
The fix page mentioned below suggests two solutions. I implemented the second because that seems to be most in line the original intent to only pass in the name of the violating parameter.

See: https://docs.microsoft.com/nl-nl/dotnet/fundamentals/code-analysis/quality-rules/ca2208#how-to-fix-violations

Fixes #27133
