### PR TITLE
Fix the build for unit-testing-best-practices.sln on VS2022 by altering the arguments to ArgumentException

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
+    - uses: actions/checkout@v2
 
     # Get the latest preview SDK (or sdk not installed by the runner)
     - name: Setup .NET SDK
@@ -54,7 +54,7 @@ jobs:
         
     # Update build output json file
     - name: Upload build results
-      uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 #@v1
+      uses: actions/upload-artifact@v1
       with:
         name: build
         path: ./output.json

--- a/samples/snippets/core/testing/unit-testing-best-practices/csharp/unit-testing-best-practices/StringCalculator.cs
+++ b/samples/snippets/core/testing/unit-testing-best-practices/csharp/unit-testing-best-practices/StringCalculator.cs
@@ -10,7 +10,7 @@ namespace UnitTestingBestPractices
         {
             if (numbers == null)
             {
-                throw new ArgumentException(nameof(numbers));
+                throw new ArgumentException(null, nameof(numbers));
             }
 
             int result;
@@ -49,7 +49,7 @@ namespace UnitTestingBestPractices
             var result = int.TryParse(number, out var parsedNumber);
             if (result == false)
             {
-                 throw new ArgumentException(nameof(number));
+                 throw new ArgumentException(null, nameof(number));
             }
 
             return parsedNumber;


### PR DESCRIPTION
## Summary

The project unit-testing-best-practices.sln does not build with a fresh install of VS2022 because of error CA2208.
The fix page mentioned below suggests two solutions. I implemented the second because that seems to be most in line the original intent to only pass in the name of the violating parameter.

See: https://docs.microsoft.com/nl-nl/dotnet/fundamentals/code-analysis/quality-rules/ca2208#how-to-fix-violations


Fixes #Issue_Number (if available)
