### PR TITLE
Restore the Azure for .NET devs tile

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -47,6 +47,10 @@ highlightedContent:
     - title: "What's new in .NET docs"
       itemType: whats-new
       url: whats-new/index.yml
+    # Card
+    - title: "Azure for .NET developers"
+      itemType: overview
+      url: azure/index.yml
 
 # conceptualContent section (optional)
 conceptualContent:


### PR DESCRIPTION
Restore the Azure for .NET devs tile on the hub page. It was removed in https://github.com/dotnet/docs/pull/26869. This tile is key in driving traffic to the relevant Azure content.
