### PR TITLE
Use Generic Types in the LINQ Walkthrough Snippets

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQGettingStarted/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQGettingStarted/CS/Class1.cs
@@ -341,16 +341,16 @@ namespace LINQGettingStarted_1
             //</snippet13>
 
             //<snippet14>
-            // studentQuery2 is an IEnumerable<IGrouping<char, Student>>
-            var studentQuery2 =
+            // The first line could also be written as "var studentQuery2 ="
+            IEnumerable<IGrouping<char, Student>> studentQuery2 =
                 from student in students
                 group student by student.Last[0];
             //</snippet14>
 
             Console.WriteLine("\nExecuting Query 2..............");
             //<snippet15>
-            // studentGroup is a IGrouping<char, Student>
-            foreach (var studentGroup in studentQuery2)
+            // var could be used here also.
+            foreach (IGrouping<char, Student> studentGroup in studentQuery2)
             {
                 Console.WriteLine(studentGroup.Key);
                 foreach (Student student in studentGroup)


### PR DESCRIPTION
## Summary
In the LINQ Walkthrough [To Group The Results][to-group-the-results] you are using Implicitly Typed variables however in the following section [To Make The Variables Implicitly Typed][to-make-the-variables-implicitly-typed] you say;

> Explicitly coding `IEnumerables` of `IGroupings` can quickly become tedious.

I think it was intended to use Generic Types in the [To Group The Results][to-group-the-results] section.

I'm not sure if these snippets are used elsewhere and could not find a way to search for references to them.

[to-group-the-results]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/walkthrough-writing-queries-linq#to-group-the-results
[to-make-the-variables-implicitly-typed]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/walkthrough-writing-queries-linq#to-make-the-variables-implicitly-typed
