### PR TITLE
Add docs for diagnostics emitted by the System.Text.Json source generator

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -48,7 +48,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1032][1032] | The `System.Text.Json` source generator encountered a context class that is not partial |
 | [SYSLIB1033][1033] | The `System.Text.Json` source generator encountered a type that has multiple `[JsonConstructor]` annotations|
 | [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple [JsonExtensionData] annotations |
-| [SYSLIB1036][1036] | The `System.Text.Json` source generator encountered an invalid [JsonExtensionData] annotation |
+| [SYSLIB1036][1036] | The `System.Text.Json` source generator encountered an invalid `[JsonExtensionData]` annotation |
 | [SYSLIB1037][1037] | The `System.Text.Json` source generator encountered a type with init-only properties for which deserialization is not supported |
 | [SYSLIB1038][1038] | The `System.Text.Json` source generator encountered a property annotated with [JsonInclude] that has inaccessible accessors |
 

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -44,7 +44,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1022][1022] | Can't have malformed format strings (for example, dangling curly braces)                                     |
 | [SYSLIB1023][1023] | Generating more than six arguments is not supported                                                          |
 | [SYSLIB1030][1030] | The `System.Text.Json` source generator did not generate serialization metadata for type |
-| [SYSLIB1031][1031] | The `System.Text.Json` source generator encountered a duplicate JsonTypeInfo property name |
+| [SYSLIB1031][1031] | The `System.Text.Json` source generator encountered a duplicate `JsonTypeInfo` property name |
 | [SYSLIB1032][1032] | The `System.Text.Json` source generator encountered a context class that is not partial |
 | [SYSLIB1033][1033] | The `System.Text.Json` source generator encountered a type that has multiple [JsonConstructor] annotations|
 | [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple [JsonExtensionData] annotations |

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -47,7 +47,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1031][1031] | The `System.Text.Json` source generator encountered a duplicate `JsonTypeInfo` property name |
 | [SYSLIB1032][1032] | The `System.Text.Json` source generator encountered a context class that is not partial |
 | [SYSLIB1033][1033] | The `System.Text.Json` source generator encountered a type that has multiple `[JsonConstructor]` annotations|
-| [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple [JsonExtensionData] annotations |
+| [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple `[JsonExtensionData]` annotations |
 | [SYSLIB1036][1036] | The `System.Text.Json` source generator encountered an invalid `[JsonExtensionData]` annotation |
 | [SYSLIB1037][1037] | The `System.Text.Json` source generator encountered a type with init-only properties for which deserialization is not supported |
 | [SYSLIB1038][1038] | The `System.Text.Json` source generator encountered a property annotated with `[JsonInclude]` that has inaccessible accessors |

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -43,10 +43,14 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1021][1021] | Multiple message-template item names differ only by case                                              |
 | [SYSLIB1022][1022] | Can't have malformed format strings (for example, dangling curly braces)                                     |
 | [SYSLIB1023][1023] | Generating more than six arguments is not supported                                                          |
-<!-- commented out for now, as these do not exist.
-| [SYSLIB1030][1030] | [System.Text.Json.SourceGeneration] Did not generate serialization metadata for type.                        |
-| [SYSLIB1031][1031] | [System.Text.Json.SourceGeneration] Duplicate type name.                                                     |
--->
+| [SYSLIB1030][1030] | The `System.Text.Json` source generator did not generate serialization metadata for type |
+| [SYSLIB1031][1031] | The `System.Text.Json` source generator encountered a duplicate JsonTypeInfo property name |
+| [SYSLIB1032][1032] | The `System.Text.Json` source generator encountered a context class that is not partial |
+| [SYSLIB1033][1033] | The `System.Text.Json` source generator encountered a type that has multiple [JsonConstructor] annotations|
+| [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple [JsonExtensionData] annotations |
+| [SYSLIB1036][1036] | The `System.Text.Json` source generator encountered an invalid [JsonExtensionData] annotation |
+| [SYSLIB1037][1037] | The `System.Text.Json` source generator encountered a type with init-only properties for which deserialization is not supported |
+| [SYSLIB1038][1038] | The `System.Text.Json` source generator encountered a property annotated with [JsonInclude] that has inaccessible accessors |
 
 <!-- Include adds ## Suppress warnings (H2 heading) -->
 [!INCLUDE [suppress-source-generator-diagnostics](includes/suppress-source-generator-diagnostics.md)]
@@ -74,7 +78,11 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 [1021]: syslib1021.md
 [1022]: syslib1022.md
 [1023]: syslib1023.md
-<!--
 [1030]: syslib1030.md
 [1031]: syslib1031.md
--->
+[1032]: syslib1032.md
+[1033]: syslib1033.md
+[1035]: syslib1035.md
+[1036]: syslib1036.md
+[1037]: syslib1037.md
+[1039]: syslib1038.md

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -85,4 +85,4 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 [1035]: syslib1035.md
 [1036]: syslib1036.md
 [1037]: syslib1037.md
-[1039]: syslib1038.md
+[1038]: syslib1038.md

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -50,7 +50,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple [JsonExtensionData] annotations |
 | [SYSLIB1036][1036] | The `System.Text.Json` source generator encountered an invalid `[JsonExtensionData]` annotation |
 | [SYSLIB1037][1037] | The `System.Text.Json` source generator encountered a type with init-only properties for which deserialization is not supported |
-| [SYSLIB1038][1038] | The `System.Text.Json` source generator encountered a property annotated with [JsonInclude] that has inaccessible accessors |
+| [SYSLIB1038][1038] | The `System.Text.Json` source generator encountered a property annotated with `[JsonInclude]` that has inaccessible accessors |
 
 <!-- Include adds ## Suppress warnings (H2 heading) -->
 [!INCLUDE [suppress-source-generator-diagnostics](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -46,7 +46,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1030][1030] | The `System.Text.Json` source generator did not generate serialization metadata for type |
 | [SYSLIB1031][1031] | The `System.Text.Json` source generator encountered a duplicate `JsonTypeInfo` property name |
 | [SYSLIB1032][1032] | The `System.Text.Json` source generator encountered a context class that is not partial |
-| [SYSLIB1033][1033] | The `System.Text.Json` source generator encountered a type that has multiple [JsonConstructor] annotations|
+| [SYSLIB1033][1033] | The `System.Text.Json` source generator encountered a type that has multiple `[JsonConstructor]` annotations|
 | [SYSLIB1035][1035] | The `System.Text.Json` source generator encountered a type that has multiple [JsonExtensionData] annotations |
 | [SYSLIB1036][1036] | The `System.Text.Json` source generator encountered an invalid [JsonExtensionData] annotation |
 | [SYSLIB1037][1037] | The `System.Text.Json` source generator encountered a type with init-only properties for which deserialization is not supported |

--- a/docs/fundamentals/syslib-diagnostics/syslib1030.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1030.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1030 warning
+description: Learn about the diagnostic that generates compile-time warning SYSLIB1030.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1030: `System.Text.Json` source generator did not generate output for type
+
+The `System.Text.Json` source generator did not generate output for a given type in the input object graph. This typically means that the type is not supported by `JsonSerializer`, for example multi-dimensional arrays like `int[,]`.
+
+## Workarounds
+
+Register a [custom converter](../../standard/serialization/system-text-json-converters-how-to.md) for the type.
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1031.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1031.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1031 warning
+description: Learn about the diagnostic that generates compile-time warning SYSLIB1031.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1031: `System.Text.Json` source generator encountered a duplicate type info property name
+
+The `System.Text.Json` source generator encountered a duplicate type info property name to be generated on the specified partial context type.
+
+## Workarounds
+
+Specify a new type info property name for the duplicate instance using `System.Text.Json.Serialization.JsonSerializableAttribute.TypeInfoPropertyName`.
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1032.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1032.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1032 error
+description: Learn about the diagnostic that generates compile-time warning SYSLIB1032.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1032: Context classes to be augmented by the `System.Text.Json` source generator must be declared as partial
+
+The `System.Text.Json` source generator encountered a context type included for source generation which is not partial, or whose containing type(s) is not partial.
+
+## Workarounds
+
+Make the context type and all containing types partial.
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1032.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1032.md
@@ -6,7 +6,7 @@ ms.date: 05/07/2021
 
 # SYSLIB1032: Context classes to be augmented by the `System.Text.Json` source generator must be declared as partial
 
-The `System.Text.Json` source generator encountered a context type included for source generation which is not partial, or whose containing type(s) is not partial.
+The `System.Text.Json` source generator encountered a context type included for source generation that is not partial, or whose containing type(s) is not partial.
 
 ## Workarounds
 

--- a/docs/fundamentals/syslib-diagnostics/syslib1033.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1033.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1033 error
+description: Learn about the diagnostic that generates compile-time error SYSLIB1033.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1033: `System.Text.Json` source generator encountered a type with multiple `[JsonConstructor]` annotations
+
+The `System.Text.Json` source generator encountered a serializable type with multiple `[JsonConstructor]` annotations.
+
+## Workarounds
+
+Remove duplicate `[JsonConstructor]` annotations.
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1035.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1035.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1035 error
+description: Learn about the diagnostic that generates compile-time error SYSLIB1035.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1035: `System.Text.Json` source generator encountered a type with multiple `[JsonExtensionData]` annotations
+
+The `System.Text.Json` source generator encountered a serializable type with multiple `[JsonExtensionData]` annotations.
+
+## Workarounds
+
+Remove duplicate `[JsonExtensionData]` annotations.
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1036.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1036.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1036 error
+description: Learn about the diagnostic that generates compile-time error SYSLIB1036.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1036: `System.Text.Json` source generator encountered an invalid `[JsonExtensionData]` annotation
+
+The `System.Text.Json` source generator encountered a property or field annotated with `[JsonExtensionData]` but whose data type does not implement `IDictionary<string, JsonElement>`, `IDictionary<string, object>`, `IDictionary<string, JsonNode>`, or `JsonNode`.
+
+## Workarounds
+
+Ensure that the data type for any property or field that is annotated with `[JsonExtensionData]` implements `IDictionary<string, JsonElement>`, `IDictionary<string, object>`, `IDictionary<string, JsonNode>`, or `JsonNode`.
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1037.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1037.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1037 warning
+description: Learn about the diagnostic that generates compile-time warning SYSLIB1037.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1037: `System.Text.Json` source generator encountered a type with init-only properties which are not supported for deserialization
+
+The `System.Text.Json` source generator encountered a type with init-only properties, such as a record type. These properties are currently not supported by the source generator for deserialization.
+
+## Workarounds
+
+If deserialization of init-only properties is required, use the [reflection-based `JsonSerializer` implementation](../../standard/serialization/system-text-json-source-generation-modes.md).
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1038.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1038.md
@@ -1,0 +1,15 @@
+---
+title: SYSLIB1038 warning
+description: Learn about the diagnostic that generates compile-time warning SYSLIB1038.
+ms.date: 05/07/2021
+---
+
+# SYSLIB1038: `System.Text.Json` source generator encountered a property annotated with `[JsonInclude]` but with inaccessible accessors
+
+The `System.Text.Json` source generator encountered a property annotated with `[JsonInclude]` but with accessors that are inaccessible to the source generator, i.e. that are not `public` or `internal`.
+
+## Workarounds
+
+If serialization or deserialization of properties with accessors that are not `public` or `internal` is required, use the [reflection-based `JsonSerializer` implementation](../../standard/serialization/system-text-json-source-generation-modes.md).
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1038.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1038.md
@@ -6,7 +6,7 @@ ms.date: 05/07/2021
 
 # SYSLIB1038: `System.Text.Json` source generator encountered a property annotated with `[JsonInclude]` but with inaccessible accessors
 
-The `System.Text.Json` source generator encountered a property annotated with `[JsonInclude]` but with accessors that are inaccessible to the source generator, i.e. that are not `public` or `internal`.
+The `System.Text.Json` source generator encountered a property that is annotated with `[JsonInclude]` but has accessors that are inaccessible to the source generator. The property must have `public` or `internal` accessors.
 
 ## Workarounds
 


### PR DESCRIPTION
Along with https://github.com/dotnet/runtime/pull/61614, fixes https://github.com/dotnet/runtime/issues/60314 for .NET 6.0.
