### PR TITLE
Rewrite 'Avoid multiple asserts' to 'Avoid multiple acts'

### DIFF
--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -255,23 +255,20 @@ In unit testing frameworks, `Setup` is called before each and every unit test wi
 
 [!code-csharp[AfterSetup](../../../samples/snippets/core/testing/unit-testing-best-practices/csharp/after/StringCalculatorTests.cs#AfterSetup)]
 
-### Avoid multiple asserts
+### Avoid multiple acts
 
-When writing your tests, try to only include one Assert per test. Common approaches to using only one assert include:
+When writing your tests, try to only include one Act per test. Common approaches to using only one act include:
 
-- Create a separate test for each assert.
+- Create a separate test for each act.
 - Use parameterized tests.
 
 #### Why?
 
-- If one Assert fails, the subsequent Asserts will not be evaluated.
-- Ensures you are not asserting multiple cases in your tests.
+- When the test fails it is not clear which Act is failing.
+- Ensures the test is focussed on just a single case.
 - Gives you the entire picture as to why your tests are failing.
 
-When introducing multiple asserts into a test case, it is not guaranteed that all of the asserts will be executed. In most unit testing frameworks, once an assertion fails in a unit test, the proceeding tests are automatically considered to be failing. This can be confusing as functionality that is actually working, will be shown as failing.
-
-> [!NOTE]
-> A common exception to this rule is when asserting against an object. In this case, it is generally acceptable to have multiple asserts against each property to ensure the object is in the state that you expect it to be in.
+Multiple Acts need to be individually Asserted and it is not guaranteed that all of the Asserts will be executed. In most unit testing frameworks, once an Assert fails in a unit test, the proceeding tests are automatically considered to be failing. This can be confusing as functionality that is actually working, will be shown as failing.
 
 #### Bad:
 

--- a/samples/snippets/core/testing/unit-testing-best-practices/csharp/after/StringCalculatorTests.cs
+++ b/samples/snippets/core/testing/unit-testing-best-practices/csharp/after/StringCalculatorTests.cs
@@ -75,15 +75,18 @@ namespace UnitTestingBestPracticesAfter
 
         // <SnippetAfterMultipleAsserts>
         [Theory]
-        [InlineData(null)]
-        [InlineData("a")]
-        public void Add_InputNullOrAlphabetic_ThrowsArgumentException(string input)
+        [InlineData("", 0)]
+        [InlineData(",", 0)]
+        public void Add_EmptyEntries_ShouldBeTreatedAsZero(string input, int expected)
         {
+            // Arrange
             var stringCalculator = new StringCalculator();
 
-            Action actual = () => stringCalculator.Add(input);
+            // Act
+            var actual = stringCalculator.Add(input);
 
-            Assert.Throws<ArgumentException>(actual);
+            // Assert
+            Assert.Equal(expected, actual);
         }
         // </SnippetAfterMultipleAsserts>
 

--- a/samples/snippets/core/testing/unit-testing-best-practices/csharp/before/StringCalculatorTests.cs
+++ b/samples/snippets/core/testing/unit-testing-best-practices/csharp/before/StringCalculatorTests.cs
@@ -103,10 +103,15 @@ namespace UnitTestingBestPracticesBefore
 
         // <SnippetBeforeMultipleAsserts>
         [Fact]
-        public void Add_EdgeCases_ThrowsArgumentExceptions()
+        public void Add_EmptyEntries_ShouldBeTreatedAsZero()
         {
-            Assert.Throws<ArgumentException>(() => stringCalculator.Add(null));
-            Assert.Throws<ArgumentException>(() => stringCalculator.Add("a"));
+            // Act
+            var actual1 = stringCalculator.Add("");
+            var actual2 = stringCalculator.Add(",");
+
+            // Assert
+            Assert.Equal(0,actual1);
+            Assert.Equal(0,actual2);
         }
         // </SnippetBeforeMultipleAsserts>
     }

--- a/samples/snippets/core/testing/unit-testing-best-practices/csharp/unit-testing-best-practices/StringCalculator.cs
+++ b/samples/snippets/core/testing/unit-testing-best-practices/csharp/unit-testing-best-practices/StringCalculator.cs
@@ -10,7 +10,7 @@ namespace UnitTestingBestPractices
         {
             if (numbers == null)
             {
-                throw new ArgumentException(nameof(numbers));
+                throw new ArgumentNullException(nameof(numbers));
             }
 
             int result;
@@ -49,7 +49,8 @@ namespace UnitTestingBestPractices
             var result = int.TryParse(number, out var parsedNumber);
             if (result == false)
             {
-                 throw new ArgumentException(nameof(number));
+                throw new ArgumentException(
+                    $"Unable to parse {nameof(number)} as an Int32.", nameof(number));
             }
 
             return parsedNumber;


### PR DESCRIPTION
## Summary

The problem is not with multiple asserts. Multiple asserts is fine, as noted in the exception to the rule, the problem stems from multiple acts. By rewriting it as 'Avoid multiple acts' the exception to the rule can be removed.

The accompanying code sample is also updated because in the previous one the Assert and Act was conflated. By adding an explicit Act step the explanation becomes easier to understand.

Fixes #27099
