### PR TITLE
Apply uniform spelling of Elasticsearch

### DIFF
--- a/docs/architecture/cloud-native/logging-with-elastic-stack.md
+++ b/docs/architecture/cloud-native/logging-with-elastic-stack.md
@@ -6,7 +6,7 @@ ms.date: 01/19/2021
 
 # Logging with Elastic Stack
 
-There are many good centralized logging tools and they vary in cost from being free, open-source tools, to more expensive options. In many cases, the free tools are as good as or better than the paid offerings. One such tool is a combination of three open-source components: Elastic search, Logstash, and Kibana.
+There are many good centralized logging tools and they vary in cost from being free, open-source tools, to more expensive options. In many cases, the free tools are as good as or better than the paid offerings. One such tool is a combination of three open-source components: Elasticsearch, Logstash, and Kibana.
 
 Collectively these tools are known as the Elastic Stack or ELK stack.
 
@@ -66,11 +66,11 @@ output {
 
 For scenarios where extensive log manipulation isn't needed there's an alternative to Logstash known as [Beats](https://www.elastic.co/products/beats). Beats is a family of tools that can gather a wide variety of data from logs to network data and uptime information. Many applications will use both Logstash and Beats.
 
-Once the logs have been gathered by Logstash, it needs somewhere to put them. While Logstash supports many different outputs, one of the more exciting ones is Elastic search.
+Once the logs have been gathered by Logstash, it needs somewhere to put them. While Logstash supports many different outputs, one of the more exciting ones is Elasticsearch.
 
-## Elastic search
+## Elasticsearch
 
-Elastic search is a powerful search engine that can index logs as they arrive. It makes running queries against the logs quick. Elastic search can handle huge quantities of logs and, in extreme cases, can be scaled out across many nodes.
+Elasticsearch is a powerful search engine that can index logs as they arrive. It makes running queries against the logs quick. Elasticsearch can handle huge quantities of logs and, in extreme cases, can be scaled out across many nodes.
 
 Log messages that have been crafted to contain parameters or that have had parameters split from them through Logstash processing, can be queried directly as Elasticsearch preserves this information.
 


### PR DESCRIPTION
## Summary

The spelling of Elasticsearch is not applied in a uniform way. This change applies an uniform spelling of Elasticsearch.