### PR TITLE
Adjust warning number

### DIFF
--- a/docs/fsharp/language-reference/casting-and-conversions.md
+++ b/docs/fsharp/language-reference/casting-and-conversions.md
@@ -180,7 +180,7 @@ let purchaseOrder = XElement.Load("PurchaseOrder.xml")
 let partNos = purchaseOrder.Descendants("Item")
 ```
 
-You can also optionally enable the warning 3390 (`/warnon:3390` or property `<WarnOn>3390</WarnOn>`) to show a warning at every point a .NET-style implicit conversion is used.
+You can also optionally enable the warning 3395 (`/warnon:3395` or property `<WarnOn>3395</WarnOn>`) to show a warning at every point a .NET-style implicit conversion is used.
 
 .NET-style `op_Implicit` conversions are also applied automatically for non-method-argument expressions in the same situations as implicit upcasts. However, when used widely or inappropriately, implicit conversions can interact poorly with type inference and lead to code that's harder to understand. For this reason, these always generate warnings when used in non-argument positions.
 
@@ -192,8 +192,8 @@ The following optional warnings are provided for uses of implicit conversions:
 
 * `/warnon:3388` (additional implicit upcast)
 * `/warnon:3389` (implicit numeric widening)
-* `/warnon:3390` (`op_Implicit` at method arguments)
 * `/warnon:3391` (`op_Implicit` at non-method arguments, on by default)
+* `/warnon:3395` (`op_Implicit` at method arguments)
 
 ## See also
 

--- a/docs/fsharp/whats-new/fsharp-6.md
+++ b/docs/fsharp/whats-new/fsharp-6.md
@@ -282,7 +282,8 @@ let partNos = purchaseOrder.Descendants("Item")
 
 You may optionally enable the warning `/warnon:3395` to show a warning at every point implicit numeric widening is used, as described in [Optional warnings for implicit conversions](#optional-warnings-for-implicit-conversions).
 
-> NOTE: In the first release of F# 6, this warning number was `/warnon:3390`. Due to a conflict this was later updated to `/warnon:3395`.
+> [!NOTE]
+> In the first release of F# 6, this warning number was `/warnon:3390`. Due to a conflict, the warning number was later updated to `/warnon:3395`.
 
 ### Optional warnings for implicit conversions
 

--- a/docs/fsharp/whats-new/fsharp-6.md
+++ b/docs/fsharp/whats-new/fsharp-6.md
@@ -280,7 +280,9 @@ let purchaseOrder = XElement.Load("PurchaseOrder.xml")
 let partNos = purchaseOrder.Descendants("Item")
 ```
 
-You may optionally enable the warning `/warnon:3390` to show a warning at every point implicit numeric widening is used, as described in [Optional warnings for implicit conversions](#optional-warnings-for-implicit-conversions).
+You may optionally enable the warning `/warnon:3395` to show a warning at every point implicit numeric widening is used, as described in [Optional warnings for implicit conversions](#optional-warnings-for-implicit-conversions).
+
+> NOTE: In the first release of F# 6, this warning number was `/warnon:3390`. Due to a conflict this was later updated to `/warnon:3395`.
 
 ### Optional warnings for implicit conversions
 
@@ -288,10 +290,10 @@ Type-directed and implicit conversions can interact poorly with type inference a
 
 * `/warnon:3388` (additional implicit upcast)
 * `/warnon:3389` (implicit numeric widening)
-* `/warnon:3390` (op_Implicit at method arguments)
 * `/warnon:3391` (op_Implicit at non-method arguments, on by default)
+* `/warnon:3395` (op_Implicit at method arguments)
 
-If your team wants to ban all uses of implicit conversions, you can also specify `/warnaserror:3388`, `/warnaserror:3389`, `/warnaserror:3390`, and `/warnaserror:3391`.
+If your team wants to ban all uses of implicit conversions, you can also specify `/warnaserror:3388`, `/warnaserror:3389`, `/warnaserror:3391`, and `/warnaserror:3395`.
 
 ## Formatting for binary numbers
 


### PR DESCRIPTION

In F# 6 we accidentally re-used an opt-in warning number 3390.  We are pushing through a change to update this to 3395.

https://github.com/dotnet/fsharp/pull/12428
