### PR TITLE
LinkFix: docs (2021-11)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://aka.ms/feedback/report?space=61
     about: Log product issues here
   - name: .NET Q&A forums
-    url: https://docs.microsoft.com/answers/products/dotnet
+    url: /answers/products/dotnet
     about: Find answers to your technical questions about .NET
   - name: .NET tech community forums
     url: https://techcommunity.microsoft.com/t5/net/ct-p/dotnet

--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -12,7 +12,7 @@ assignees: ''
 
 	If the issue is:
 
-	- A simple typo or similar correction, consider submitting a PR to fix it instead of logging an issue. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
+	- A simple typo or similar correction, consider submitting a PR to fix it instead of logging an issue. See [the contributor guide](/contribute/#quick-edits-to-existing-documents) for instructions.
 	- A general support question, consider asking on a support forum site.
 	- A site design concern, create an issue at [MicrosoftDocs/feedback](https://github.com/MicrosoftDocs/feedback/issues/new/choose).
 	- A problem completing a tutorial, compare your code with the completed sample.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the .NET documentation!
 
-We have moved our guidelines into a site-wide contribution guide. To see the guidance, visit the [Microsoft Docs contributor guide](https://docs.microsoft.com/contribute/dotnet/dotnet-contribute).
+We have moved our guidelines into a site-wide contribution guide. To see the guidance, visit the [Microsoft Docs contributor guide](/contribute/dotnet/dotnet-contribute).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Markdownlint](https://github.com/dotnet/docs/workflows/Markdownlint/badge.svg) [![target supported version](https://github.com/dotnet/docs/actions/workflows/version-sweep.yml/badge.svg)](https://github.com/dotnet/docs/actions/workflows/version-sweep.yml)
 
-This repository contains the conceptual documentation for .NET. The [.NET documentation site](https://docs.microsoft.com/dotnet) is built from multiple repositories in addition to this one:
+This repository contains the conceptual documentation for .NET. The [.NET documentation site](/dotnet) is built from multiple repositories in addition to this one:
 
 - [API reference](https://github.com/dotnet/dotnet-api-docs)
 - [.NET Compiler Platform SDK reference](https://github.com/dotnet/roslyn-api-docs)
@@ -15,9 +15,9 @@ To contribute, see:
 
 - The [Contributing Guide](CONTRIBUTING.md) for instructions on procedures we use.
 - Issues labeled [`up-for-grabs`](https://github.com/dotnet/docs/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) for ideas.
-- [#Hacktoberfest and Microsoft Docs](https://docs.microsoft.com/contribute/hacktoberfest) for details on our participation in the annual event.
+- [#Hacktoberfest and Microsoft Docs](/contribute/hacktoberfest) for details on our participation in the annual event.
 
-If you're interested in helping migrate existing code that targets the .NET Framework from the [retired Code Gallery](https://docs.microsoft.com/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
+If you're interested in helping migrate existing code that targets the .NET Framework from the [retired Code Gallery](/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
 
 This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community.

--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -2,43 +2,43 @@
 hrefUpdated: true
 references:
 - uid: System.Diagnostics.PresentationTraceSources.TraceLevel*
-  href: https://msdn.microsoft.com/library/system.diagnostics.presentationtracesources.tracelevel.aspx
+  href: /previous-versions/bb778381(v=vs.110)
   name: TraceLevel
   name.vb: TraceLevel
   fullName: PresentationTraceSources.TraceLevel
   fullName.vb: PresentationTraceSources.TraceLevel
 - uid: System.Windows.Controls.Validation.HasError*
-  href: https://msdn.microsoft.com/library/system.windows.controls.validation.haserror
+  href: /dotnet/api/system.windows.controls.validation.haserror#System_Windows_Controls_Validation_HasError
   name: HasError
   name.vb: HasError
   fullName: Validation.HasError
   fullName.vb: Validation.HasError
 - uid: System.Windows.Controls.Validation.Errors*
-  href: https://msdn.microsoft.com/library/system.windows.controls.validation.errors.aspx
+  href: /dotnet/api/system.windows.controls.validation.errors#System_Windows_Controls_Validation_Errors
   name: Errors
   name.vb: Errors
   fullName: Validation.Errors
   fullName.vb: Validation.Errors
 - uid: System.Windows.Localization.Attributes*
-  href: https://msdn.microsoft.com/library/system.windows.localization.attributes.aspx
+  href: /previous-versions/bb341088(v=vs.110)
   name: Attributes
   name.vb: Attributes
   fullName: Localization.Attributes
   fullName.vb: Localization.Attributes
 - uid: System.Windows.Localization.Comments*
-  href: https://msdn.microsoft.com/library/system.windows.localization.comments.aspx
+  href: /previous-versions/bb156441(v=vs.110)
   name: Comments
   name.vb: Comments
   fullName: Localization.Comments
   fullName.vb: Localization.Comments
 - uid: System.Windows.Shell.WindowChrome.ResizeGripDirection*
-  href: https://msdn.microsoft.com/library/system.windows.shell.windowchrome.resizegripdirection.aspx
+  href: /previous-versions/hh199365(v=vs.110)
   name: ResizeGripDirection
   name.vb: ResizeGripDirection
   fullName: WindowChrome.ResizeGripDirection
   fullName.vb: WindowChrome.ResizeGripDirection
 - uid: System.Windows.VisualStateManager.VisualStateGroups*
-  href: https://msdn.microsoft.com/library/system.windows.visualstatemanager.visualstategroups.aspx
+  href: /dotnet/api/system.windows.visualstatemanager.visualstategroups#System_Windows_VisualStateManager_VisualStateGroups
   name: VisualStateGroups
   name.vb: VisualStateGroups
   fullName: VisualStateManager.VisualStateGroups

--- a/docs/core/testing/snippets/unit-testing-using-mstest/csharp/README.md
+++ b/docs/core/testing/snippets/unit-testing-using-mstest/csharp/README.md
@@ -1,6 +1,6 @@
 # Unit testing using MSTest sample
 
-This sample is part of the [unit testing tutorial](https://docs.microsoft.com/dotnet/core/testing/unit-testing-with-mstest) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
+This sample is part of the [unit testing tutorial](../../../unit-testing-with-mstest.md) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
 
 ## Key features
 
@@ -19,5 +19,5 @@ dotnet test
 
 `dotnet test` builds both projects and runs all of the configured tests.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/docs/fundamentals/index.yml
+++ b/docs/fundamentals/index.yml
@@ -51,7 +51,7 @@ landingContent:
       - linkListType: whats-new
         links:
           - text: What's new in .NET 5
-            url: ../core/dotnet-five.md
+            url: ../core/whats-new/dotnet-5.md
           - text: What's new in .NET Core 3.1
             url: ../core/whats-new/dotnet-core-3-1.md
           - text: What's new in .NET Core 3.0

--- a/samples/snippets/core/testing/unit-testing-using-dotnet-test/csharp/README.md
+++ b/samples/snippets/core/testing/unit-testing-using-dotnet-test/csharp/README.md
@@ -1,6 +1,6 @@
 # Unit testing using dotnet test sample
 
-This sample is part of the [unit testing tutorial](https://docs.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
+This sample is part of the [unit testing tutorial](../../../../../../docs/core/testing/unit-testing-with-dotnet-test.md) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
 
 ## Key features
 
@@ -19,5 +19,5 @@ dotnet test
 
 `dotnet test` builds both projects and runs all of the configured tests.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/core/testing/unit-testing-using-nunit/csharp/README.md
+++ b/samples/snippets/core/testing/unit-testing-using-nunit/csharp/README.md
@@ -1,6 +1,6 @@
 # Unit testing using NUnit sample
 
-This sample is part of the [unit testing tutorial](https://docs.microsoft.com/dotnet/core/testing/unit-testing-with-nunit) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
+This sample is part of the [unit testing tutorial](../../../../../../docs/core/testing/unit-testing-with-nunit.md) for creating applications with unit tests included. See that topic for detailed steps on the code for this sample.
 
 ## Key features
 
@@ -19,4 +19,4 @@ dotnet test
 `dotnet test` builds both projects and runs all of the configured tests.
 
 <a name="dotnet-restore-note"></a>
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/core/tutorials/cli-create-console-app/FibonacciBetterMsBuild/csharp/README.md
+++ b/samples/snippets/core/tutorials/cli-create-console-app/FibonacciBetterMsBuild/csharp/README.md
@@ -1,7 +1,7 @@
 Better Fibonacci Sample
 ================
 
-This sample is part of the [step-by-step tutorial](https://docs.microsoft.com/dotnet/core/tutorials/using-with-xplat-cli)
+This sample is part of the [step-by-step tutorial](../../../../../../../docs/core/tutorials/with-visual-studio-code.md)
 for creating .NET Core Console Applications. Please see that topic for detailed steps on the code
 for this sample.
 

--- a/samples/snippets/core/tutorials/cli-create-console-app/HelloMsBuild/csharp/README.md
+++ b/samples/snippets/core/tutorials/cli-create-console-app/HelloMsBuild/csharp/README.md
@@ -1,6 +1,6 @@
 # Hello Sample
 
-This sample is part of the [step-by-step tutorial](https://docs.microsoft.com/dotnet/core/tutorials/using-with-xplat-cli)
+This sample is part of the [step-by-step tutorial](../../../../../../../docs/core/tutorials/with-visual-studio-code.md)
 for creating .NET Core Console Applications. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -16,4 +16,4 @@ To build and run the sample, type the following command:
 
 `dotnet run` builds the sample and runs the output assembly. It implicitly calls `dotnet restore` on .NET Core 2.0 and later versions. If you're using a .NET Core 1.x SDK, you first have to call `dotnet restore` yourself.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/core/tutorials/cli-create-console-app/fibonacci-msbuild/csharp/README.md
+++ b/samples/snippets/core/tutorials/cli-create-console-app/fibonacci-msbuild/csharp/README.md
@@ -1,7 +1,7 @@
 Hello Sample
 ================
 
-This sample is part of the [step-by-step tutorial](https://docs.microsoft.com/dotnet/core/tutorials/using-with-xplat-cli)
+This sample is part of the [step-by-step tutorial](../../../../../../../docs/core/tutorials/with-visual-studio-code.md)
 for creating .NET Core Console Applications. Please see that topic for detailed steps on the code
 for this sample.
 

--- a/samples/snippets/core/tutorials/netcore-hosting/csharp/HostWithHostFxr/readme.md
+++ b/samples/snippets/core/tutorials/netcore-hosting/csharp/HostWithHostFxr/readme.md
@@ -2,7 +2,7 @@
 
 This project demonstrates a way for a native process to host .NET Core using the `nethost` and `hostfxr` libraries. Documentation on the `nethost` and `hostfxr` APIs can be found [here](https://github.com/dotnet/runtime/blob/main/docs/design/features/native-hosting.md).
 
-This sample is part of the [.NET Core hosting tutorial](https://docs.microsoft.com/dotnet/core/tutorials/netcore-hosting). Please see that topic for a more detailed explanation of the sample and the steps necessary to host .NET Core.
+This sample is part of the [.NET Core hosting tutorial](../../../../../../../docs/core/tutorials/netcore-hosting.md). Please see that topic for a more detailed explanation of the sample and the steps necessary to host .NET Core.
 
 The host is small and bypasses a lot of complexity (thorough error checking, etc.) that a real host would have. Hopefully by remaining simple, though, it will be useful for demonstrating the core concepts of hosting managed .NET Core code in a native process.
 
@@ -11,7 +11,7 @@ The host is small and bypasses a lot of complexity (thorough error checking, etc
 Demonstrates how to locate and initialize .NET Core runtime from a non-.NET Core process and subsequently load and call into a .NET Core assembly.
 
 The `nethost` header and library are part of the `Microsoft.NETCore.DotNetAppHost` package and are also installed as a runtime pack by the .NET Core SDK. The library should be deployed alongside the host. This sample uses the files installed with the .NET Core SDK.  
-*Note: The `Microsoft.NETCore.DotNetAppHost` package is a [metapackage](https://docs.microsoft.com/dotnet/core/packages#metapackages) that doesn't actually contain the files. It only references RID-specific packages that contain the files. For example, the package with the actual files for `linux-x64` is `runtime.linux-x64.Microsoft.NETCore.DotNetAppHost`.*
+*Note: The `Microsoft.NETCore.DotNetAppHost` package is a [metapackage](../../../../../../../docs/core/deploying/index.md#metapackages) that doesn't actually contain the files. It only references RID-specific packages that contain the files. For example, the package with the actual files for `linux-x64` is `runtime.linux-x64.Microsoft.NETCore.DotNetAppHost`.*
 
 The `coreclr_delegates.h` and `hostfxr.h` files are copied from the [dotnet/runtime](https://github.com/dotnet/runtime) repo - [coreclr_delegates.h](https://github.com/dotnet/runtime/blob/main/src/installer/corehost/cli/coreclr_delegates.h) and [hostfxr.h](https://github.com/dotnet/runtime/blob/main/src/installer/corehost/cli/hostfxr.h).
 

--- a/samples/snippets/core/tutorials/testing-with-cli/csharp/README.md
+++ b/samples/snippets/core/tutorials/testing-with-cli/csharp/README.md
@@ -1,6 +1,6 @@
 # NewTypes Pets Sample
 
-This sample is part of the [Organizing and testing projects with the .NET Core command line tutorial](https://docs.microsoft.com/dotnet/core/tutorials/testing-with-cli) for creating .NET Core console applications. See the tutorial for details on the code for this sample.
+This sample is part of the [Organizing and testing projects with the .NET Core command line tutorial](../../../../../../docs/core/tutorials/testing-with-cli.md) for creating .NET Core console applications. See the tutorial for details on the code for this sample.
 
 ## Key Features
 
@@ -28,4 +28,4 @@ dotnet test
 `dotnet build` will follow the dependency on the `NewTypesMsBuild` project and build both the app and unit tests projects. It implicitly runs `dotnet restore` on .NET Core 2.0 and later versions. If you're using .NET Core 1.0 or .NET Core 1.1, you first have to run `dotnet restore` yourself.
 
 <a name="dotnet-restore-note"></a>
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`. It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/delegates-and-events/README.md
+++ b/samples/snippets/csharp/delegates-and-events/README.md
@@ -1,6 +1,6 @@
 # C# Delegates and Events Sample
 
-This sample is created during the [Delegates and Events topic](https://docs.microsoft.com/dotnet/csharp/delegates-events)
+This sample is created during the [Delegates and Events topic](../../../../docs/csharp/delegates-overview.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -23,5 +23,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/events/README.md
+++ b/samples/snippets/csharp/events/README.md
@@ -1,6 +1,6 @@
 # C# Events Sample
 
-This sample is created during the [Delegates and Events topic](https://docs.microsoft.com/dotnet/csharp/delegates-events)
+This sample is created during the [Delegates and Events topic](../../../../docs/csharp/delegates-overview.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/getting-started/console-linq/README.md
+++ b/samples/snippets/csharp/getting-started/console-linq/README.md
@@ -1,6 +1,6 @@
 # C# LINQ Sample
 
-This sample is created during the [Working with LINQ tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/working-with-linq) for learning C# features. Please see that topic for detailed steps on the code for this sample.
+This sample is created during the [Working with LINQ tutorial](../../../../../docs/csharp/tutorials/working-with-linq.md) for learning C# features. Please see that topic for detailed steps on the code for this sample.
 
 ## Key Features
 
@@ -19,5 +19,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/getting-started/console-teleprompter/README.md
+++ b/samples/snippets/csharp/getting-started/console-teleprompter/README.md
@@ -1,6 +1,6 @@
 # C# Console Application Sample
 
-This sample is created during the [Console Application Tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/console-teleprompter)
+This sample is created during the [Console Application Tutorial](../../../../../docs/csharp/tutorials/console-teleprompter.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 

--- a/samples/snippets/csharp/getting-started/console-webapiclient/README.md
+++ b/samples/snippets/csharp/getting-started/console-webapiclient/README.md
@@ -1,6 +1,6 @@
 # C# REST Client Sample
 
-This sample is created during the [REST client tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/console-webapiclient)
+This sample is created during the [REST client tutorial](../../../../../docs/csharp/tutorials/console-webapiclient.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/versioning/new/README.md
+++ b/samples/snippets/csharp/versioning/new/README.md
@@ -1,6 +1,6 @@
 # C# Versioning Sample
 
-This sample is created during the [Versioning](https://docs.microsoft.com/dotnet/csharp/versioning)
+This sample is created during the [Versioning](../../../../../docs/csharp/versioning.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/csharp/versioning/override/README.md
+++ b/samples/snippets/csharp/versioning/override/README.md
@@ -1,6 +1,6 @@
 # C# Versioning Sample
 
-This sample is created during the [Versioning](https://docs.microsoft.com/dotnet/csharp/versioning)
+This sample is created during the [Versioning](../../../../../docs/csharp/versioning.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
@@ -22,5 +22,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
-It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](../../../../../docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/samples/snippets/standard/async/async-and-await/cs/readme.md
+++ b/samples/snippets/standard/async/async-and-await/cs/readme.md
@@ -11,11 +11,11 @@ description: "A .NET Core WPF application that contains the example method from 
 ---
 # Async programming with async and await in C\#
 
-This sample is a WPF application written in C# that contains the example method from [Task asynchronous programming model](https://docs.microsoft.com/dotnet/csharp/programming-guide/concepts/async/task-asynchronous-programming-model). The article gives an overview of asynchronous programming, including when to use it and how to write an async method. This sample contains an async function that is used as an illustration.
+This sample is a WPF application written in C# that contains the example method from [Task asynchronous programming model](../../../../../../docs/csharp/programming-guide/concepts/async/task-asynchronous-programming-model.md). The article gives an overview of asynchronous programming, including when to use it and how to write an async method. This sample contains an async function that is used as an illustration.
 
-[async](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/async) and [await](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/await) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
+[async](../../../../../../docs/csharp/language-reference/keywords/async.md) and [await](../../../../../../docs/csharp/language-reference/operators/await.md) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
 
-The example async function in this sample (named `GetStringAsync`) uses an [HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
+The example async function in this sample (named `GetStringAsync`) uses an [HttpClient](/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
 
 The code for the *MainWindow.xaml.cs* file from this sample is included in the article.
 

--- a/samples/snippets/standard/async/async-and-await/vb/readme.md
+++ b/samples/snippets/standard/async/async-and-await/vb/readme.md
@@ -11,11 +11,11 @@ description: "A .NET Core WPF application that contains the example method from 
 ---
 # Async Sample: Asynchronous Programming with Async and Await in Visual Basic
 
-This sample is a WPF application that contains the example method from [Asynchronous Progamming with Async and Await in Visual Basic](https://docs.microsoft.com/dotnet/visual-basic/programming-guide/concepts/async/). The topic gives an overview of asynchronous programming, including when to use it and how to write an Async method. This sample contains an Async function that is used as an illustration.
+This sample is a WPF application that contains the example method from [Asynchronous Progamming with Async and Await in Visual Basic](../../../../../../docs/visual-basic/programming-guide/concepts/async/index.md). The topic gives an overview of asynchronous programming, including when to use it and how to write an Async method. This sample contains an Async function that is used as an illustration.
 
-[Async](https://docs.microsoft.com/dotnet/visual-basic/language-reference/modifiers/async) and [Await](https://docs.microsoft.com/dotnet/visual-basic/language-reference/operators/await-operator) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
+[Async](../../../../../../docs/visual-basic/language-reference/modifiers/async.md) and [Await](../../../../../../docs/visual-basic/language-reference/operators/await-operator.md) provide all the advantages of traditional asynchronous programming, but with much less effort from the developer. The compiler does the difficult work that the developer used to do, yet the code retains a logical structure that resembles synchronous code.
 
-The example Async function in this sample (named `GetStringAsync`) uses an [HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
+The example Async function in this sample (named `GetStringAsync`) uses an [HttpClient](/dotnet/api/system.net.http.httpclient) method to download the contents of a website.
 
 The code for the *MainWindow.xaml.vb* file from this sample is included in the article.
 

--- a/styleguide/labels-projects.md
+++ b/styleguide/labels-projects.md
@@ -1,3 +1,3 @@
 # Labels and projects
 
-This content has been moved to the [Contributor guide](https://docs.microsoft.com/contribute/dotnet/labels-projects).
+This content has been moved to the [Contributor guide](/contribute/dotnet/labels-projects).

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -1,3 +1,3 @@
 # Article template
 
-This content has been moved to the [Contributor guide](https://docs.microsoft.com/contribute/dotnet-style-guide).
+This content has been moved to the [Contributor guide](/contribute/dotnet-style-guide).


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

```