### PR TITLE
Fix formatting

### DIFF
--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -41,11 +41,12 @@ member => expression;
 
 where `expression` is a valid expression. The return type of `expression` must be implicitly convertible to the member's return type. If the member:
 
-* Has a `void` return type:
-* Is a:
-  * Constructor
-  * Finalizer
-  * Property or indexer `set` accessor
+- Has a `void` return type or
+- Is a:
+  - Constructor
+  - Finalizer
+  - Property or indexer `set` accessor
+
 `expression` must be a [*statement expression*](~/_csharplang/spec/statements.md#expression-statements). Because the expression's result is discarded, the return type of that expression can be any type.
 
 The following example shows an expression body definition for a `Person.ToString` method:


### PR DESCRIPTION
An empty line after the list is essential. Current rendering:
![image](https://user-images.githubusercontent.com/15279990/142923507-60f24234-fb40-4098-8ae0-0ddf14a166da.png)

