### PR TITLE
Add GenerateDocumentationFile property

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -394,9 +394,9 @@ Library authors who intend to ship preview assemblies should set this property t
 
 ### DocumentationFile
 
-The `DocumentationFile` property lets you specify a file name for the XML file that contains the documentation for your library. For IntelliSense to function correctly with your documentation, the file name must be the same as the assembly name and must be in the same directory as the assembly. If you don't specify this property but you do set [GenerateDocumentationFile](#generatedocumentationfile) to `true`, the name of the documentation file defaults to the name of your assembly but with an *.xml* file extension.
+The `DocumentationFile` property lets you specify a file name for the XML file that contains the documentation for your library. For IntelliSense to function correctly with your documentation, the file name must be the same as the assembly name and must be in the same directory as the assembly. If you don't specify this property but you do set [GenerateDocumentationFile](#generatedocumentationfile) to `true`, the name of the documentation file defaults to the name of your assembly but with an *.xml* file extension. For this reason, it's often easier to omit this property and use the [GenerateDocumentationFile property](#generatedocumentationfile) instead.
 
-If you specify this property but you set [GenerateDocumentationFile](#generatedocumentationfile) to `false`, the compiler does not generate a documentation file.
+If you specify this property but you set [GenerateDocumentationFile](#generatedocumentationfile) to `false`, the compiler *does not* generate a documentation file. If you specify this property and omit the [GenerateDocumentationFile property](#generatedocumentationfile), the compiler *does* generate a documentation file.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1,7 +1,7 @@
 ---
 title: MSBuild properties for Microsoft.NET.Sdk
 description: Reference for the MSBuild properties and items that are understood by the .NET SDK.
-ms.date: 09/02/2021
+ms.date: 11/22/2021
 ms.topic: reference
 ms.custom: updateeachrelease
 ---
@@ -317,7 +317,7 @@ The `RuntimeIdentifiers` property lets you specify a semicolon-delimited list of
 </PropertyGroup>
 ```
 
-## SatelliteResourceLanguages
+### SatelliteResourceLanguages
 
 The `SatelliteResourceLanguages` property lets you specify which languages you want to preserve satellite resource assemblies for during build and publish. Many NuGet packages include localized resource satellite assemblies in the main package. For projects that reference these NuGet packages that don't require localized resources, the localized assemblies can unnecessarily inflate the build and publish output size. By adding the `SatelliteResourceLanguages` property to your project file, only localized assemblies for the languages you specify will be included in the build and publish output. For example, in the following project file, only English (US) resource satellite assemblies will be retained.
 
@@ -348,8 +348,10 @@ For more information about deployment, see [.NET application deployment](../depl
 
 The following MSBuild properties are documented in this section:
 
+- [DocumentationFile](#documentationfile)
 - [EmbeddedResourceUseDependentUponConvention](#embeddedresourceusedependentuponconvention)
 - [EnablePreviewFeatures](#enablepreviewfeatures)
+- [GenerateDocumentationFile](#generatedocumentationfile)
 - [GenerateRequiresPreviewFeaturesAttribute](#generaterequirespreviewfeaturesattribute)
 - [OptimizeImplicitlyTriggeredBuild](#optimizeimplicitlytriggeredbuild)
 
@@ -389,6 +391,30 @@ When a project contains this property set to `True`, the following assembly-leve
 An analyzer warns if this attribute is present on dependencies for projects where `EnablePreviewFeatures` is not set to `True`.
 
 Library authors who intend to ship preview assemblies should set this property to `True`. If an assembly needs to ship with a mixture of preview and non-preview APIs, see the [GenerateRequiresPreviewFeaturesAttribute](#generaterequirespreviewfeaturesattribute) section below.
+
+### DocumentationFile
+
+The `DocumentationFile` property lets you specify a file name for the XML file that contains the documentation for your library. For IntelliSense to function correctly with your documentation, the file name must be the same as the assembly name and must be in the same directory as the assembly. If you don't specify this property but you do set [GenerateDocumentationFile](#generatedocumentationfile) to `true`, the name of the documentation file defaults to the name of your assembly but with an *.xml* file extension.
+
+If you specify this property but you set [GenerateDocumentationFile](#generatedocumentationfile) to `false`, the compiler does not generate a documentation file.
+
+```xml
+<PropertyGroup>
+  <DocumentationFile>path/to/file.xml</DocumentationFile>
+</PropertyGroup>
+```
+
+### GenerateDocumentationFile
+
+The `GenerateDocumentationFile` property controls whether the compiler generates an XML documentation file for your library. If you set this property to `true` and you don't specify a file name via the [DocumentationFile property](#documentationfile), the generated XML file is placed in the same output directory as your assembly and has the same file name (but with an *.xml* extension).
+
+```xml
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
+
+For more information about generating documentation from code comments, see [XML documentation comments (C#)](../../csharp/language-reference/xmldoc/index.md), [Document your code with XML (Visual Basic)](../../visual-basic/programming-guide/program-structure/documenting-your-code-with-xml.md), or [Document your code with XML (F#)](../../fsharp/language-reference/xml-documentation.md).
 
 ### GenerateRequiresPreviewFeaturesAttribute
 

--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -36,6 +36,8 @@ The source code file that contains Main or top-level statements is output first 
 > [!NOTE]
 > The **DocumentationFile** option applies to all files in the project. To disable warnings related to documentation comments for a specific file or section of code, use [#pragma warning](../preprocessor-directives.md#pragma-warning).
 
+This option is not specific to the C# compiler. For more information, see [DocumentationFile property](../../../core/project-sdk/msbuild-props.md#documentationfile).
+
 ## OutputAssembly
 
 The **OutputAssembly** option specifies the name of the output file. The output path specifies the folder where compiler output is placed.

--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -36,7 +36,7 @@ The source code file that contains Main or top-level statements is output first 
 > [!NOTE]
 > The **DocumentationFile** option applies to all files in the project. To disable warnings related to documentation comments for a specific file or section of code, use [#pragma warning](../preprocessor-directives.md#pragma-warning).
 
-This option is not specific to the C# compiler. For more information, see [DocumentationFile property](../../../core/project-sdk/msbuild-props.md#documentationfile).
+This option can be used in any .NET SDK-style project. For more information, see [DocumentationFile property](../../../core/project-sdk/msbuild-props.md#documentationfile).
 
 ## OutputAssembly
 

--- a/docs/csharp/language-reference/xmldoc/index.md
+++ b/docs/csharp/language-reference/xmldoc/index.md
@@ -42,7 +42,7 @@ You create documentation for your code by writing special comment fields indicat
 public class MyClass {}
 ```
 
-You set the [**DocumentationFile**](../../language-reference/compiler-options/output.md#documentationfile) option and the compiler will find all comment fields with XML tags in the source code and create an XML documentation file from those comments. When this option is enabled, the compiler generates the [CS1591](../compiler-messages/cs1591.md) warning for any publicly visible member declared in your project without XML documentation comments.
+You set either the [**GenerateDocumentationFile**](../../../core/project-sdk/msbuild-props.md#generatedocumentationfile) or [**DocumentationFile**](../../language-reference/compiler-options/output.md#documentationfile) property, and the compiler will find all comment fields with XML tags in the source code and create an XML documentation file from those comments. When this option is enabled, the compiler generates the [CS1591](../compiler-messages/cs1591.md) warning for any publicly visible member declared in your project without XML documentation comments.
 
 ## XML comment formats
 

--- a/docs/csharp/language-reference/xmldoc/index.md
+++ b/docs/csharp/language-reference/xmldoc/index.md
@@ -42,7 +42,7 @@ You create documentation for your code by writing special comment fields indicat
 public class MyClass {}
 ```
 
-You set either the [**GenerateDocumentationFile**](../../../core/project-sdk/msbuild-props.md#generatedocumentationfile) or [**DocumentationFile**](../../language-reference/compiler-options/output.md#documentationfile) property, and the compiler will find all comment fields with XML tags in the source code and create an XML documentation file from those comments. When this option is enabled, the compiler generates the [CS1591](../compiler-messages/cs1591.md) warning for any publicly visible member declared in your project without XML documentation comments.
+You set either the [**GenerateDocumentationFile**](../../../core/project-sdk/msbuild-props.md#generatedocumentationfile) or [**DocumentationFile**](../../language-reference/compiler-options/output.md#documentationfile) option, and the compiler will find all comment fields with XML tags in the source code and create an XML documentation file from those comments. When this option is enabled, the compiler generates the [CS1591](../compiler-messages/cs1591.md) warning for any publicly visible member declared in your project without XML documentation comments.
 
 ## XML comment formats
 

--- a/docs/fsharp/language-reference/xml-documentation.md
+++ b/docs/fsharp/language-reference/xml-documentation.md
@@ -26,6 +26,8 @@ You can generate the XML file at compile time by doing one of the following:
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
    ```
 
+  For more information, see [GenerateDocumentationFile property](../../core/project-sdk/msbuild-props.md#generatedocumentationfile).
+
 - If you are developing an application using Visual Studio, right-click on the project and select **Properties**. In the properties dialog, select the **Build** tab, and check **XML documentation file**. You can also change the location to which the compiler writes the file.
 
 There are two ways to write XML documentation comments: with and without XML tags. Both use triple-slash comments.

--- a/docs/visual-basic/programming-guide/program-structure/documenting-your-code-with-xml.md
+++ b/docs/visual-basic/programming-guide/program-structure/documenting-your-code-with-xml.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: Document your code with XML (Visual Basic)"
 title: "Documenting Your Code with XML"
-ms.date: 07/20/2015
+ms.date: 11/22/2021
 helpviewer_keywords:
   - "XML [Visual Basic], documenting code"
   - "XML comments, Visual Basic"
@@ -14,7 +14,7 @@ In Visual Basic, you can document your code using XML.
 
 ## XML documentation comments
 
-Visual Basic provides an easy way to automatically create XML documentation for projects. You can automatically generate an XML skeleton for your types and members, and then provide summaries, descriptive documentation for each parameter, and other remarks. With the appropriate setup, the XML documentation is automatically emitted into an XML file with the same root file name as your project. For more information, see [-doc](../../reference/command-line-compiler/doc.md).
+Visual Basic provides an easy way to automatically create XML documentation for projects. You can automatically generate an XML skeleton for your types and members, and then provide summaries, descriptive documentation for each parameter, and other remarks. With the appropriate setup, the XML documentation is automatically emitted into an XML file with the same root file name as your project. For information about configuring the generation of the XML documentation file, see [-doc compiler option](../../reference/command-line-compiler/doc.md) and [GenerateDocumentationFile MSBuild property](../../../core/project-sdk/msbuild-props.md#generatedocumentationfile).
 
 The XML file can be consumed or otherwise manipulated as XML. This file is located in the same directory as the output .exe or .dll file of your project.
 


### PR DESCRIPTION
Contributes to microsoftdocs/visualstudio-docs#407.

Previews:

- [MSBuild props](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-27231#documentationfile)
- [C# create XML docs](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/?branch=pr-en-us-27231#create-xml-documentation-output)