### PR TITLE
Fix CustomPrefix example per discussion on #27227

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -197,9 +197,9 @@ The prefix is stripped off when the configuration key-value pairs are read.
 The following commands test the custom prefix:
 
 ```dotnetcli
-set CustomPrefix__SecretKey="Secret key with CustomPrefix_ environment"
-set CustomPrefix__TransientFaultHandlingOptions__Enabled=true
-set CustomPrefix__TransientFaultHandlingOptions__AutoRetryDelay=00:00:21
+set CustomPrefix_SecretKey="Secret key with CustomPrefix_ environment"
+set CustomPrefix_TransientFaultHandlingOptions__Enabled=true
+set CustomPrefix_TransientFaultHandlingOptions__AutoRetryDelay=00:00:21
 
 dotnet run
 ```


### PR DESCRIPTION
See https://github.com/dotnet/docs/issues/27227

## Summary

Prefixes should be followed by a single underscore; double underscore instead represents a separator (`:`).

Fixes #27227
