### PR TITLE
Reword confusing sentence

### DIFF
--- a/docs/csharp/whats-new/csharp-10.md
+++ b/docs/csharp/whats-new/csharp-10.md
@@ -55,7 +55,7 @@ You can use a new form of the [`namespace` declaration](../language-reference/ke
 namespace MyNamespace;
 ```
 
-This new syntax saves both horizontal and vertical space for the most common `namespace` declarations.
+This new syntax saves both horizontal and vertical space for `namespace` declarations.
 
 ## Extended property patterns
 


### PR DESCRIPTION
This part of sentence looks confusing to. The space is saved for any `namespace` declaration that's using this new syntax. What does "common" really mean here?

Will update the PR with another wording instead of removing this part if someone knows the original intent.