### PR TITLE
Update PNSE page with CNG classes

### DIFF
--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -2,7 +2,7 @@
 title: Unsupported APIs on .NET Core and .NET 5+
 titleSuffix: ""
 description: Learn which .NET APIs always throw an exception on .NET Core and .NET 5 and later versions.
-ms.date: 09/17/2021
+ms.date: 11/23/2021
 ---
 # APIs that always throw exceptions on .NET Core and .NET 5+
 
@@ -232,6 +232,13 @@ This article organizes the affected APIs by namespace.
 | Member | Platforms that throw |
 | - | - |
 | <xref:System.Security.Cryptography.AsymmetricAlgorithm.Create(System.String)?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.CngAlgorithm?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.CngAlgorithmGroup?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.CngKey?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.CngKeyBlobFormat?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.CngKeyCreationParameters?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.CngProvider?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.CngUIPolicy?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.CryptoConfig.EncodeOID(System.String)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.%23ctor%2A> | Linux and macOS |
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.Accessible?displayProperty=nameWithType> | Linux and macOS |

--- a/docs/core/whats-new/dotnet-6.md
+++ b/docs/core/whats-new/dotnet-6.md
@@ -26,7 +26,7 @@ This article does not cover all of the new features of .NET 6. To see all of the
 
 ## Performance
 
-.NET 6 includes numerous performance improvements. This section lists some of the improvements. For detailed information, see the [Performance improvements in .NET 6](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/) blog post.
+.NET 6 includes numerous performance improvements. This section lists some of the improvements&mdash;in [FileStream](#filestream), [profile-guided optimization](#profile-guided-optimization), and [AOT compilation](#crossgen2). For detailed information, see the [Performance improvements in .NET 6](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/) blog post.
 
 ### FileStream
 


### PR DESCRIPTION
Update PNSE page with CNG classes - see https://github.com/dotnet/dotnet-api-docs/pull/7323.
Also a small update to the What's new article.