### PR TITLE
argumemts -> arguments, very tiny typo

### DIFF
--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -141,7 +141,7 @@ You can learn about async method builders by reading about the following builder
 
 In C# 10 and later, the `AsyncMethodBuilder` attribute can be applied to an async method to override the builder for that type.
 
-## `InterpolatedStringHandler` and `InterpolatedStringHandlerArgumemts` attributes
+## `InterpolatedStringHandler` and `InterpolatedStringHandlerArguments` attributes
 
 Starting with C# 10, you use these attributes to specify that a type is an *interpolated string handler*. The .NET 6 library already includes <xref:System.Runtime.CompilerServices.DefaultInterpolatedStringHandler?displayProperty=nameWithType> for scenarios where you use an interpolated string as the argument for a `string` parameter. You may have other instances where you want to control how interpolated strings are processed. You apply the <xref:System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute?displayProperty=nameWithType> to the type that implements your handler. You apply the <xref:System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute?displayProperty=nameWithType> to parameters of that type's constructor.
 


### PR DESCRIPTION
## Summary

It's in the title, there's a small typo in one bit of documentation where `InterpolatedStringHandlerArguments` is referred to as `InterpolatedStringHandlerArgumemts`

Fixes #Issue_Number (if available) n/a, figured one-liners might not require an issue
