### PR TITLE
cref=cref= typo fix

### DIFF
--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -336,7 +336,7 @@ The `<include>` tag lets you refer to comments in another file that describe the
 - `href="link"`: A clickable link to a given URL. For example, `<see href="https://github.com">GitHub</see>` produces a clickable link with text :::no-loc text="GitHub"::: that links to `https://github.com`.
 - `langword="keyword"`: A language keyword, such as `true`.
 
-The `<see>` tag lets you specify a link from within text. Use [\<seealso>](#seealso) to indicate that text should be placed in a See Also section. Use the [cref attribute](#cref-attribute) to create internal hyperlinks to documentation pages for code elements. You include the type parameters to specify a reference to a generic type or method, such as `cref="cref="IDictionary{T, U}"`. Also, ``href`` is a valid attribute that will function as a hyperlink.
+The `<see>` tag lets you specify a link from within text. Use [\<seealso>](#seealso) to indicate that text should be placed in a See Also section. Use the [cref attribute](#cref-attribute) to create internal hyperlinks to documentation pages for code elements. You include the type parameters to specify a reference to a generic type or method, such as `cref="IDictionary{T, U}"`. Also, ``href`` is a valid attribute that will function as a hyperlink.
 
 ### \<seealso>
 


### PR DESCRIPTION
## Summary

The code sample contained a typo: a duplicate attribute declaration.
