### PR TITLE
Fix comma placement in StackallocInNestedExpressions

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
@@ -57,7 +57,7 @@ namespace operators
         {
             // <SnippetNested>
             Span<int> numbers = stackalloc[] { 1, 2, 3, 4, 5, 6 };
-            var ind = numbers.IndexOfAny(stackalloc[] { 2, 4, 6 ,8 });
+            var ind = numbers.IndexOfAny(stackalloc[] { 2, 4, 6, 8 });
             Console.WriteLine(ind);  // output: 1
             // </SnippetNested>
         }


### PR DESCRIPTION
## Summary
Fix the position of the last comma in the middle line of code from the `StackallocInNestedExpressions` example snippet.