### PR TITLE
Remove .NET 6 versions from breaking change issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/breaking-change.yml
@@ -18,9 +18,6 @@ body:
       label: Version
       description: What version of .NET introduced the breaking change?
       options:
-        - .NET 6 RC 1
-        - .NET 6 RC 2
-        - .NET 6 GA
         - .NET 7 Preview 1
         - .NET 7 Preview 2
         - .NET 7 Preview 3


### PR DESCRIPTION
Contributes to #27139 