### PR TITLE
Enable write permissions to create PR

### DIFF
--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   DOTNET_VERSION: '5.0.301' # set this to the dot net version to use
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -24,6 +23,8 @@ jobs:
   create-what-is-new:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -60,7 +61,7 @@ jobs:
 
       # Create the PR for the new article
       - name: create-pull-request
-        uses: peter-evans/create-pull-request@v3.10.0
+        uses: peter-evans/create-pull-request@v3.11.0
         with:
           title: 'What''s new article'
           commit-message: 'Bot 🤖 generated "What''s new article"'


### PR DESCRIPTION
I discovered this morning that the [What's new action](https://github.com/dotnet/docs/runs/4374969602?check_suite_focus=true) failed because it did not have permissions to push to a new branch and create a PR. 

This change adds `write` permissions for this action.

Also, remove the redundant secret.

Finally, upgrade to the latest version
