### PR TITLE
use double quotes.

### DIFF
--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -39,7 +39,7 @@ jobs:
       - name: 'Print manual run reason'
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          echo 'Reason: ${{ github.event.inputs.reason }}'
+          echo "Reason: ${{ github.event.inputs.reason }}"
 
       # Print dotnet info
       - name: Display .NET info


### PR DESCRIPTION
single quotes prevented the substitution, and resulted in an invalid sh command.
