### PR TITLE
Update protobuf-data-types.md

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md
@@ -166,9 +166,6 @@ namespace CustomTypes
             Nanos = nanos;
         }
 
-        public long Units { get; }
-        public int Nanos { get; }
-
         public static implicit operator decimal(CustomTypes.DecimalValue grpcDecimal)
         {
             return grpcDecimal.Units + grpcDecimal.Nanos / NanoFactor;


### PR DESCRIPTION
Since DecimalValue is a partial class with its other part being defined in DecimalValue.proto properties `Units` and `Nanos` are already defined. Existing code will not compile

