### PR TITLE
Add ConfigureAwait(false) to DisposeAsync example

### DIFF
--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleAsyncDisposable.cs
@@ -15,7 +15,7 @@ public class ExampleAsyncDisposable : IAsyncDisposable, IDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await DisposeAsyncCore();
+        await DisposeAsyncCore().ConfigureAwait(false);
 
         Dispose(disposing: false);
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize

--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
@@ -15,7 +15,7 @@ class ExampleConjunctiveDisposableusing : IDisposable, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await DisposeAsyncCore();
+        await DisposeAsyncCore().ConfigureAwait(false);
 
         Dispose(disposing: false);
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize


### PR DESCRIPTION
This example calls `ConfigureAwait(false)` in `DisposeAsyncCore()`, but doesn't in `DisposeAsync`. The example should consistently use `ConfigureAwait`.