### PR TITLE
Adding parentheses to be consistent on using parentheses on both condition

### DIFF
--- a/samples/snippets/csharp/programming-guide/ref-returns/NumberStoreUpdated.cs
+++ b/samples/snippets/csharp/programming-guide/ref-returns/NumberStoreUpdated.cs
@@ -12,7 +12,7 @@
         {
             ref int returnVal = ref numbers[0];
             var ctr = numbers.Length - 1;
-            while ((ctr >= 0) && numbers[ctr] >= target)
+            while ((ctr >= 0) && (numbers[ctr] >= target))
             {
                 returnVal = ref numbers[ctr];
                 ctr--;


### PR DESCRIPTION
## Summary
In the C# programming guide section of the documentation, the last snippet of this [page ](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/ref-returns) uses parentheses for its first condition but doesn't use any in the second one. Fixing the snippet so that it has consistent use of parentheses. (Has parentheses for both of the conditions)

Fixes #27406 
