### PR TITLE
Improve code analysis config options articles

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -598,18 +598,18 @@ The following table lists the property name for each rule category.
 
 | Property name | Rule category |
 | - |
-| `<AnalysisLevelDesign>` | Design rules |
-| `<AnalysisLevelDocumentation>` | Documentation rules |
-| `<AnalysisLevelGlobalization>` | Globalization rules |
-| `<AnalysisLevelInteroperability>` | Portability an interoperability rules |
-| `<AnalysisLevelMaintainability>` | Maintainability rules |
-| `<AnalysisLevelNaming>` | Naming rules |
-| `<AnalysisLevelPerformance>` | Performance rules |
-| `<AnalysisLevelSingleFile>` | Single-file application rules |
-| `<AnalysisLevelReliability>` | Reliability rules |
-| `<AnalysisLevelSecurity>` | Security rules |
-| `<AnalysisLevelStyle>` | All code-style (IDEXXXX) rules |
-| `<AnalysisLevelUsage>` | Usage rules |
+| `<AnalysisLevelDesign>` | [Design rules](../../fundamentals/code-analysis/quality-rules/design-warnings.md) |
+| `<AnalysisLevelDocumentation>` | [Documentation rules](../../fundamentals/code-analysis/quality-rules/documentation-warnings.md) |
+| `<AnalysisLevelGlobalization>` | [Globalization rules](../../fundamentals/code-analysis/quality-rules/globalization-warnings.md) |
+| `<AnalysisLevelInteroperability>` | [Portability and interoperability rules](../../fundamentals/code-analysis/quality-rules/interoperability-warnings.md) |
+| `<AnalysisLevelMaintainability>` | [Maintainability rules](../../fundamentals/code-analysis/quality-rules/maintainability-warnings.md) |
+| `<AnalysisLevelNaming>` | [Naming rules](../../fundamentals/code-analysis/quality-rules/naming-warnings.md) |
+| `<AnalysisLevelPerformance>` | [Performance rules](../../fundamentals/code-analysis/quality-rules/performance-warnings.md) |
+| `<AnalysisLevelSingleFile>` | [Single-file application rules](../../fundamentals/code-analysis/quality-rules/singlefile-warnings.md) |
+| `<AnalysisLevelReliability>` | [Reliability rules](../../fundamentals/code-analysis/quality-rules/reliability-warnings.md) |
+| `<AnalysisLevelSecurity>` | [Security rules](../../fundamentals/code-analysis/quality-rules/security-warnings.md) |
+| `<AnalysisLevelStyle>` | [Code-style (IDEXXXX) rules](../../fundamentals/code-analysis/style-rules/index.md) |
+| `<AnalysisLevelUsage>` | [Usage rules](../../fundamentals/code-analysis/quality-rules/usage-warnings.md) |
 
 ### AnalysisMode
 
@@ -652,18 +652,18 @@ The following table lists the property name for each rule category.
 
 | Property name | Rule category |
 | - |
-| `<AnalysisModeDesign>` | Design rules |
-| `<AnalysisModeDocumentation>` | Documentation rules |
-| `<AnalysisModeGlobalization>` | Globalization rules |
-| `<AnalysisModeInteroperability>` | Portability an interoperability rules |
-| `<AnalysisModeMaintainability>` | Maintainability rules |
-| `<AnalysisModeNaming>` | Naming rules |
-| `<AnalysisModePerformance>` | Performance rules |
-| `<AnalysisModeSingleFile>` | Single-file application rules |
-| `<AnalysisModeReliability>` | Reliability rules |
-| `<AnalysisModeSecurity>` | Security rules |
-| `<AnalysisModeStyle>` | All code-style (IDEXXXX) rules |
-| `<AnalysisModeUsage>` | Usage rules |
+| `<AnalysisModeDesign>` | [Design rules](../../fundamentals/code-analysis/quality-rules/design-warnings.md) |
+| `<AnalysisModeDocumentation>` | [Documentation rules](../../fundamentals/code-analysis/quality-rules/documentation-warnings.md) |
+| `<AnalysisModeGlobalization>` | [Globalization rules](../../fundamentals/code-analysis/quality-rules/globalization-warnings.md) |
+| `<AnalysisModeInteroperability>` | [Portability and interoperability rules](../../fundamentals/code-analysis/quality-rules/interoperability-warnings.md) |
+| `<AnalysisModeMaintainability>` | [Maintainability rules](../../fundamentals/code-analysis/quality-rules/maintainability-warnings.md) |
+| `<AnalysisModeNaming>` | [Naming rules](../../fundamentals/code-analysis/quality-rules/naming-warnings.md) |
+| `<AnalysisModePerformance>` | [Performance rules](../../fundamentals/code-analysis/quality-rules/performance-warnings.md) |
+| `<AnalysisModeSingleFile>` | [Single-file application rules](../../fundamentals/code-analysis/quality-rules/singlefile-warnings.md) |
+| `<AnalysisModeReliability>` | [Reliability rules](../../fundamentals/code-analysis/quality-rules/reliability-warnings.md) |
+| `<AnalysisModeSecurity>` | [Security rules](../../fundamentals/code-analysis/quality-rules/security-warnings.md) |
+| `<AnalysisModeStyle>` | [Code-style (IDEXXXX) rules](../../fundamentals/code-analysis/style-rules/index.md) |
+| `<AnalysisModeUsage>` | [Usage rules](../../fundamentals/code-analysis/quality-rules/usage-warnings.md) |
 
 ### CodeAnalysisTreatWarningsAsErrors
 

--- a/docs/fundamentals/code-analysis/configuration-files.md
+++ b/docs/fundamentals/code-analysis/configuration-files.md
@@ -12,6 +12,9 @@ Code analysis rules have various [configuration options](configuration-options.m
 - [EditorConfig](#editorconfig) file: File-based or folder-based configuration options.
 - [Global AnalyzerConfig](#global-analyzerconfig) file: Project-level configuration options. Useful when some project files reside outside the project folder.
 
+> [!TIP]
+> You can also set code analysis configuration properties in your project file. These properties configure code analysis at the bulk level, from completely turning it on or off down to  category-level configuration. For more information, see [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers), [AnalysisLevel](../../core/project-sdk/msbuild-props.md#analysislevel), [AnalysisLevel\<Category>](../../core/project-sdk/msbuild-props.md#analysislevelcategory), and [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode).
+
 ## EditorConfig
 
 [EditorConfig](/visualstudio/ide/create-portable-custom-editor-options) files are used to provide **options that apply to specific source files or folders**. Options are placed under section headers to identify the applicable files and folders. Add an entry for each rule you want to configure, and place it under the corresponding file extension section, for example, `[*.cs]`.

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -1,40 +1,46 @@
 ---
 title: Configure code analysis rules
 description: Learn how to configure code analysis rules in an analyzer configuration file.
-ms.date: 08/21/2021
+ms.date: 12/06/2021
 no-loc: ["EditorConfig"]
 ---
 # Configuration options for code analysis
 
-Code analysis rules have various configuration options. These options are specified as key-value pairs in an [analyzer configuration file](configuration-files.md) using the syntax `<option key> = <option value>`.
+Code analysis rules have various configuration options. Some of these options are specified as key-value pairs in an [analyzer configuration file](configuration-files.md) using the syntax `<option key> = <option value>`. Other options, which configure code analysis as a whole, are available as properties in your project file.
 
-The most common option you'll configure is a [rule's severity](#severity-level). You can configure severity level for all analyzer rules, including [code quality rules](quality-rules/index.md) and [code style rules](style-rules/index.md). For example, to enable a rule as a warning, you can add the following key-value pair to an EditorConfig file.
+The most common option you'll configure is a [rule's severity](#severity-level). You can configure the severity level for any rule, including [code quality rules](quality-rules/index.md) and [code style rules](style-rules/index.md). For example, to enable a rule as a warning, add the following key-value pair to an [analyzer configuration file](configuration-files.md) file:
 
 `dotnet_diagnostic.<rule ID>.severity = warning`
 
 You can also configure additional options to customize rule behavior:
 
-- Code quality rules have [additional options](code-quality-rule-options.md) to configure behavior, such as which method names a rule should apply to.
+- Code quality rules have [options](code-quality-rule-options.md) to configure behavior, such as which method names a rule should apply to.
 - Code style rules have [custom code style options](code-style-rule-options.md).
-- Third party analyzer rules can define their own configuration options, with custom key names and value formats.
-
-The syntax for configuring a specific rule's severity in an [analyzer configuration file](configuration-files.md) is as follows:
-
-```ini
-dotnet_diagnostic.<rule ID>.severity = <severity>
-```
+- Third-party analyzer rules can define their own configuration options, with custom key names and value formats.
 
 ## General options
 
-These options apply to code analysis as a whole. They cannot be applied only to a single rule or set of rules.
+These options apply to code analysis as a whole. They cannot be applied only to a specific rule.
+
+- [Analysis mode](#analysis-mode)
+- [Enable code analysis](#enable-code-analysis)
+- [Exclude generated code](#exclude-generated-code)
+
+For additional options, see [Code analysis properties](../../core/project-sdk/msbuild-props.md#code-analysis-properties).
+
+### Enable code analysis
+
+Code analysis is enabled by default for projects that target .NET 5 and later versions. If your project targets a different .NET implementation, you can manually enable code analysis by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property in your project file to `true`.
+
+### Analysis mode
+
+While the .NET SDK includes all code analysis rules, only some of them are enabled by default. The *analysis mode* determines which, if any, set of rules is enabled. You can choose a more aggressive analysis mode where most or all rules are enabled, or a more conservative analysis mode where most or all rules are disabled and, you can then opt in to specific rules as needed. Set your analysis mode by adding the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) property to your project file.
 
 ### Exclude generated code
 
-You can configure additional files and folders to be treated as generated code by adding a `generated_code = true | false` entry to your [configuration file](configuration-files.md). .NET code analyzer warnings aren't useful on generated code files, such as designer-generated files, which users can't edit to fix any violations. In most cases, code analyzers skip generated code files and don't report violations on these files.
+.NET code analyzer warnings aren't useful on generated code files, such as designer-generated files, which users can't edit to fix any violations. In most cases, code analyzers skip generated code files and don't report violations on these files.
 
-By default, files with certain file extensions or auto-generated file headers are treated as generated code files. For example, a file name ending with `.designer.cs` or `.generated.cs` is considered generated code. This configuration option lets you specify additional naming patterns.
-
-For example, to treat all files whose name ends with `.MyGenerated.cs` as generated code, add the following entry:
+By default, files with certain file extensions or auto-generated file headers are treated as generated code files. For example, a file name ending with `.designer.cs` or `.generated.cs` is considered generated code. This configuration option lets you specify additional naming patterns to be treated as generated code. You configure additional files and folders by adding a `generated_code = true | false` entry to your [configuration file](configuration-files.md). For example, to treat all files whose name ends with `.MyGenerated.cs` as generated code, add the following entry:
 
 ```ini
 [*.MyGenerated.cs]

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -30,11 +30,23 @@ For additional options, see [Code analysis properties](../../core/project-sdk/ms
 
 ### Enable code analysis
 
-Code analysis is enabled by default for projects that target .NET 5 and later versions. If your project targets a different .NET implementation, you can manually enable code analysis by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property in your project file to `true`.
+Code analysis is enabled by default for projects that target .NET 5 and later versions. If you have the .NET 5+ SDK but your project targets a different .NET implementation, you can manually enable code analysis by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property in your project file to `true`.
+
+```xml
+<PropertyGroup>
+  <EnableNETAnalyzers>true</EnableNETAnalyzers>
+</PropertyGroup>
+```
 
 ### Analysis mode
 
 While the .NET SDK includes all code analysis rules, only some of them are enabled by default. The *analysis mode* determines which, if any, set of rules is enabled. You can choose a more aggressive analysis mode where most or all rules are enabled, or a more conservative analysis mode where most or all rules are disabled and, you can then opt in to specific rules as needed. Set your analysis mode by adding the [AnalysisMode](../../core/project-sdk/msbuild-props.md#analysismode) property to your project file.
+
+```xml
+<PropertyGroup>
+  <AnalysisMode>Recommended</AnalysisMode>
+</PropertyGroup>
+```
 
 ### Exclude generated code
 


### PR DESCRIPTION
Options were spread out all over. Mention them all in one place.