### PR TITLE
Remove reference to absent code

### DIFF
--- a/docs/core/testing/unit-testing-fsharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-fsharp-with-nunit.md
@@ -178,8 +178,6 @@ let squaresOfOdds xs =
     |> Seq.filter isOdd
 ```
 
-Notice the call to `Seq.toList`. That creates a list, which implements the <xref:System.Collections.ICollection> interface.
-
 There's one more step to go: square each of the odd numbers. Start by writing a new test:
 
 ```fsharp


### PR DESCRIPTION
## Summary

There is a reference to `Seq.toList` in the current doc, which no longer seems necessary. The said reference seems part of code in a previous version of the doc. Removing it is safe, and it will make the doc more up-to-date.
