### PR TITLE
Fix snippet interactivity

### DIFF
--- a/docs/csharp/language-reference/statements/jump-statements.md
+++ b/docs/csharp/language-reference/statements/jump-statements.md
@@ -83,7 +83,7 @@ As the preceding example shows, you can use the `goto` statement to get out of a
 
 You can also use the `goto` statement in the [`switch` statement](selection-statements.md#the-switch-statement) to transfer control to a switch section with a constant case label, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet" source="snippets/jump-statements/GotoStatement.cs" id="InsideSwitch":::
+:::code language="csharp" interactive="try-dotnet" source="snippets/jump-statements/GotoInSwitchExample.cs":::
 
 Within the `switch` statement, you can also use the statement `goto default;` to transfer control to the switch section with the `default` label.
 

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/GotoInSwitchExample.cs
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/GotoInSwitchExample.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+public enum CoffeChoice
+{
+    Plain,
+    WithMilk,
+    WithIceCream,
+}
+
+public class GotoInSwitchExample
+{
+    public static void Main()
+    {
+        Console.WriteLine(CalculatePrice(CoffeChoice.Plain));  // output: 10.0
+        Console.WriteLine(CalculatePrice(CoffeChoice.WithMilk));  // output: 15.0
+        Console.WriteLine(CalculatePrice(CoffeChoice.WithIceCream));  // output: 17.0
+    }
+
+    private static decimal CalculatePrice(CoffeChoice choice)
+    {
+        decimal price = 0;
+        switch (choice)
+        {
+            case CoffeChoice.Plain:
+                price += 10.0m;
+                break;
+
+            case CoffeChoice.WithMilk:
+                price += 5.0m;
+                goto case CoffeChoice.Plain;
+
+            case CoffeChoice.WithIceCream:
+                price += 7.0m;
+                goto case CoffeChoice.Plain;
+        }
+        return price;
+    }
+}

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/GotoStatement.cs
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/GotoStatement.cs
@@ -53,43 +53,4 @@ public static class GotoStatement
         // Not found 4 in matrix B.
         // </NestedLoops>
     }
-
-    // <InsideSwitch>
-    public enum CoffeChoice
-    {
-        Plain,
-        WithMilk,
-        WithIceCream,
-    }
-
-    public class GotoInSwitchExample
-    {
-        public static void Main()
-        {
-            Console.WriteLine(CalculatePrice(CoffeChoice.Plain));  // output: 10.0
-            Console.WriteLine(CalculatePrice(CoffeChoice.WithMilk));  // output: 15.0
-            Console.WriteLine(CalculatePrice(CoffeChoice.WithIceCream));  // output: 17.0
-        }
-
-        private static decimal CalculatePrice(CoffeChoice choice)
-        {
-            decimal price = 0;
-            switch (choice)
-            {
-                case CoffeChoice.Plain:
-                    price += 10.0m;
-                    break;
-
-                case CoffeChoice.WithMilk:
-                    price += 5.0m;
-                    goto case CoffeChoice.Plain;
-
-                case CoffeChoice.WithIceCream:
-                    price += 7.0m;
-                    goto case CoffeChoice.Plain;
-            }
-            return price;
-        }
-        // </InsideSwitch>
-    }
 }


### PR DESCRIPTION
When published, this interactive snippet requires `using System;` directive. So, I've just moved the code to the separate file and added that directive.

This is about the last snippet in the following section (now it also misses the last closing brace):
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/statements/jump-statements#the-goto-statement
