### PR TITLE
Disable snippet interactivity

### DIFF
--- a/docs/csharp/language-reference/statements/jump-statements.md
+++ b/docs/csharp/language-reference/statements/jump-statements.md
@@ -74,7 +74,7 @@ For more information about ref returns, see [Ref returns and ref locals](../../p
 
 The `goto` statement transfers control to a statement that is marked by a label, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/GotoStatement.cs" id="NestedLoops":::
+:::code language="csharp" source="snippets/jump-statements/GotoStatement.cs" id="NestedLoops":::
 
 As the preceding example shows, you can use the `goto` statement to get out of a nested loop.
 


### PR DESCRIPTION
Another issue with an interactive snippet:
![image](https://user-images.githubusercontent.com/15279990/145443926-7fec5a5b-57e8-4909-b9ec-a10e57f7142c.png)

This is the first snippet in the following section:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/statements/jump-statements#the-goto-statement

If you prefer interactivity over the KeyValuePair deconstruction, please let me know: I'll refactor the loop then.

In general, is there any work done/planned on improving the interactive experience in the docs, like this or supporting C# 8 and later?

/cc: @IEvangelist 

