### PR TITLE
Updated the workdir for UNIX

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -136,9 +136,9 @@ export PATH=$PATH:$DOTNET_ROOT
 > - **Korn Shell**: *~/.kshrc* or *.profile*
 > - **Z Shell**: *~/.zshrc* or *.zprofile*
 >
-> Edit the appropriate source file for your shell and add `:$HOME/dotnet` to the end of the existing `PATH` statement. If no `PATH` statement is included, add a new line with `export PATH=$PATH:$HOME/dotnet`.
+> Edit the appropriate source file for your shell and add `:$HOME/.dotnet` to the end of the existing `PATH` statement. If no `PATH` statement is included, add a new line with `export PATH=$PATH:$HOME/.dotnet`.
 >
-> Also, add `export DOTNET_ROOT=$HOME/dotnet` to the end of the file.
+> Also, add `export DOTNET_ROOT=$HOME/.dotnet` to the end of the file.
 
 This approach lets you install different versions into separate locations and choose explicitly which one to use by which application.
 


### PR DESCRIPTION
## Summary

The DOTNET_ROOT dir after using the dotnet_install.sh script for Unix has changed to `$HOME/.dotnet` (with a dot in the beginning). Changed the TIP area
