### PR TITLE
Add note about dependent NuGet package, per customer feedback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,11 @@
         "XML",
         "YAML"
     ],
-    "git.ignoreLimitWarning": true
+    "git.ignoreLimitWarning": true,
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,11 +28,5 @@
         "XML",
         "YAML"
     ],
-    "git.ignoreLimitWarning": true,
-    "markdownlint.config": {
-        "MD028": false,
-        "MD025": {
-            "front_matter_title": ""
-        }
-    }
+    "git.ignoreLimitWarning": true
 }

--- a/docs/architecture/modern-web-apps-azure/develop-asp-net-core-mvc-apps.md
+++ b/docs/architecture/modern-web-apps-azure/develop-asp-net-core-mvc-apps.md
@@ -291,7 +291,7 @@ public class FeatureConvention : IControllerModelConvention
         controller.Properties.Add("feature",
         GetFeatureName(controller.ControllerType));
     }
-    
+
     private string GetFeatureName(TypeInfo controllerType)
     {
         string[] tokens = controllerType.FullName.Split('.');

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -3,7 +3,7 @@ title: Options pattern in .NET
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 12/15/2021
 ---
 
 # Options pattern in .NET
@@ -330,6 +330,9 @@ The following class implements <xref:Microsoft.Extensions.Options.IValidateOptio
 :::code language="csharp" source="snippets/configuration/console-json/ValidateSettingsOptions.cs":::
 
 `IValidateOptions` enables moving the validation code into a class.
+
+> [!NOTE]
+> This example code relies on the [Microsoft.Extensions.Configuration.Json](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json) NuGet package.
 
 Using the preceding code, validation is enabled in `ConfigureServices` with the following code:
 

--- a/docs/fsharp/language-reference/byrefs.md
+++ b/docs/fsharp/language-reference/byrefs.md
@@ -107,7 +107,7 @@ type C =
     static member M1(x, y: _ outref) =
         y <- x
         true
-        
+
 match C.M1 1 with
 | true, 1 -> printfn "Expected" // Fine with outref, error with byref
 | _ -> printfn "Never matched"


### PR DESCRIPTION
## Summary

- Update article `ms.date`
- Add note about dependent NuGet package, per customer feedback
- Automatic MD lint warnings addressed

Fixes #27561
