### PR TITLE
String interpolation updates

### DIFF
--- a/docs/csharp/whats-new/tutorials/interpolated-string-handler.md
+++ b/docs/csharp/whats-new/tutorials/interpolated-string-handler.md
@@ -169,6 +169,7 @@ You can make one final update to the handler's constructor that improves efficie
 
 :::code language="csharp" source="./snippets/interpolated-string-handler/logger-v4.cs" id="UseOutParameter":::
 
+That change means you can remove the `enabled` field. Then, you can change the return type of `AppendLiteral` and `AppendFormattable` to `void`.
 Now, when you run the sample, you'll see the following output:
 
 ```powershell

--- a/docs/csharp/whats-new/tutorials/interpolated-string-handler.md
+++ b/docs/csharp/whats-new/tutorials/interpolated-string-handler.md
@@ -1,7 +1,7 @@
 ---
 title: Explore string interpolation handlers
 description: This advanced tutorial shows how you can write a custom string interpolation handler that hooks into the runtime processing of an interpolated string.
-ms.date: 10/19/2021
+ms.date: 12/16/2021
 ---
 # Tutorial: Write a custom string interpolation handler
 

--- a/docs/csharp/whats-new/tutorials/snippets/interpolated-string-handler/Logger-v2.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/interpolated-string-handler/Logger-v2.cs
@@ -10,7 +10,6 @@ namespace interpolated_string_handler.Version2
         // Storage for the built-up string
         StringBuilder builder;
 
-        // Add the receiver argument:
         public LogInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             builder = new StringBuilder(literalLength);

--- a/docs/csharp/whats-new/tutorials/snippets/interpolated-string-handler/logger-v4.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/interpolated-string-handler/logger-v4.cs
@@ -7,19 +7,16 @@ namespace interpolated_string_handler.Version4
     public ref struct LogInterpolatedStringHandler
     {
         // Storage for the built-up string
-        StringBuilder builder = default!;
+        StringBuilder builder;
 
         private readonly bool enabled;
 
         // <UseOutParameter>
-        public LogInterpolatedStringHandler(int literalLength, int formattedCount, LogLevel level, Logger logger, out bool isEnabled)
+        public LogInterpolatedStringHandler(int literalLength, int formattedCount, Logger logger, LogLevel level, out bool isEnabled)
         {
             enabled = logger.EnabledLevel >= level;
             Console.WriteLine($"\tliteral length: {literalLength}, formattedCount: {formattedCount}");
-            if (enabled)
-            {
-                builder = new StringBuilder(literalLength);
-            }
+            builder = enabled ? new StringBuilder(literalLength) : default!;
             isEnabled = enabled;
         }
         // </UseOutParameter>
@@ -80,7 +77,7 @@ namespace interpolated_string_handler.Version4
             if (EnabledLevel < level) return;
             Console.WriteLine(msg);
         }
-        public void LogMessage(LogLevel level, [InterpolatedStringHandlerArgument("level", "")] LogInterpolatedStringHandler builder)
+        public void LogMessage(LogLevel level, [InterpolatedStringHandlerArgument("", "level")] LogInterpolatedStringHandler builder)
         {
             if (EnabledLevel < level) return;
             Console.WriteLine(builder.GetFormattedText());

--- a/docs/csharp/whats-new/tutorials/snippets/interpolated-string-handler/logger-v4.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/interpolated-string-handler/logger-v4.cs
@@ -9,49 +9,41 @@ namespace interpolated_string_handler.Version4
         // Storage for the built-up string
         StringBuilder builder;
 
-        private readonly bool enabled;
 
         // <UseOutParameter>
         public LogInterpolatedStringHandler(int literalLength, int formattedCount, Logger logger, LogLevel level, out bool isEnabled)
         {
-            enabled = logger.EnabledLevel >= level;
+            isEnabled = logger.EnabledLevel >= level;
             Console.WriteLine($"\tliteral length: {literalLength}, formattedCount: {formattedCount}");
-            builder = enabled ? new StringBuilder(literalLength) : default!;
-            isEnabled = enabled;
+            builder = isEnabled ? new StringBuilder(literalLength) : default!;
         }
         // </UseOutParameter>
 
         // These can return a bool to support a fixed length buffer.
 
-        public bool AppendLiteral(string s)
+        public void AppendLiteral(string s)
         {
             Console.WriteLine($"\tAppendLiteral called: {s}");
-            if (!enabled) return false;
             builder.Append(s);
             Console.WriteLine($"\tAppended the literal string");
-            return true;
         }
 
         // <AppendIFormattable>
-        public bool AppendFormatted<T>(T t, string format) where T : IFormattable
+        public void AppendFormatted<T>(T t, string format) where T : IFormattable
         {
             Console.WriteLine($"\tAppendFormatted (IFormattable version) called: {t} with format {{{format}}} is of type {typeof(T)},");
-            if (!enabled) return false;
 
             builder.Append(t?.ToString(format, null));
             Console.WriteLine($"\tAppended the formatted object");
-            return true;
         }
         // </AppendIFormattable>
 
-        public bool AppendFormatted<T>(T t)
+        public void AppendFormatted<T>(T t)
         {
             Console.WriteLine($"\tAppendFormatted called: {t} is of type {typeof(T)}");
-            if (!enabled) return false;
 
             builder.Append(t?.ToString());
             Console.WriteLine($"\tAppended the formatted object");
-            return true;
         }
 
         // Not part of the pattern, but needed to retrieve the formatted string


### PR DESCRIPTION
Review and fix open issues on the string interpolation tutorial

Fixes #27209

- Remove stray comment.
- Ensure parameters are ordered consistently across all snippet versions.

Fixes #27271 

- A little refactoring and explanation.
