### PR TITLE
Remove hyperlink to MSDN video

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -263,4 +263,3 @@ A recommended goal is to achieve complete or near-complete [Referential Transpar
 
 * [Async in-depth](../standard/async-in-depth.md) provides more information about how Tasks work.
 * [The Task asynchronous programming model (C#)](./programming-guide/concepts/async/task-asynchronous-programming-model.md).
-* Lucian Wischik's [Six Essential Tips for Async](https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async) is a wonderful resource for async programming.


### PR DESCRIPTION
Fixes #27287

I wish we had a better fix, but I think this one is lost.
