### PR TITLE
Update the `Program` to a top-level program

### DIFF
--- a/docs/core/extensions/custom-configuration-provider.md
+++ b/docs/core/extensions/custom-configuration-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom configuration provider in .NET
 description: Learn how to implement a custom configuration provider in .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 12/17/2021
 ms.topic: how-to
 ---
 
@@ -59,7 +59,7 @@ An `AddEntityConfiguration` extension method permits adding the configuration so
 
 The following code shows how to use the custom `EntityConfigurationProvider` in *Program.cs*:
 
-:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="31":::
+:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="11":::
 
 ## Consume provider
 
@@ -69,7 +69,7 @@ To consume the custom configuration provider, you can use the [options pattern](
 
 A call to <xref:Microsoft.Extensions.Hosting.IHostBuilder.ConfigureServices%2A> configures the mapping of the options.
 
-:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="14-17,33-35":::
+:::code language="csharp" source="snippets/configuration/custom-provider/Program.cs" highlight="15-15,18-21":::
 
 The preceding code configures the `WidgetOptions` object from the `"WidgetOptions"` section of the configuration. This enables the options pattern, exposing a dependency injection-ready `IOptions<WidgetOptions>` representation of the EF settings. The options are ultimately provided from the custom configuration provider.
 

--- a/docs/core/extensions/snippets/configuration/custom-provider/Program.cs
+++ b/docs/core/extensions/snippets/configuration/custom-provider/Program.cs
@@ -2,36 +2,26 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using CustomProvider.Example;
 
-namespace CustomProvider.Example
-{
-    class Program
+using IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((_, configuration) =>
     {
-        static async Task Main(string[] args)
-        {
-            using IHost host = CreateHostBuilder(args).Build();
+        configuration.Sources.Clear();
+        configuration.AddEntityConfiguration();
+    })
+    .ConfigureServices((context, services) =>
+        services.Configure<WidgetOptions>(
+            context.Configuration.GetSection("WidgetOptions")))
+    .Build();
 
-            var options = host.Services.GetRequiredService<IOptions<WidgetOptions>>().Value;
-            Console.WriteLine($"DisplayLabel={options.DisplayLabel}");
-            Console.WriteLine($"EndpointId={options.EndpointId}");
-            Console.WriteLine($"WidgetRoute={options.WidgetRoute}");
+var options = host.Services.GetRequiredService<IOptions<WidgetOptions>>().Value;
+Console.WriteLine($"DisplayLabel={options.DisplayLabel}");
+Console.WriteLine($"EndpointId={options.EndpointId}");
+Console.WriteLine($"WidgetRoute={options.WidgetRoute}");
 
-            await host.RunAsync();
-        }
-        // Sample output:
-        //    WidgetRoute=api/widgets
-        //    EndpointId=b3da3c4c-9c4e-4411-bc4d-609e2dcc5c67
-        //    DisplayLabel=Widgets Incorporated, LLC.
-
-        static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((_, configuration) =>
-                {
-                    configuration.Sources.Clear();
-                    configuration.AddEntityConfiguration();
-                })
-                .ConfigureServices((context, services) =>
-                    services.Configure<WidgetOptions>(
-                        context.Configuration.GetSection("WidgetOptions")));
-    }
-}
+await host.RunAsync();
+// Sample output:
+//    WidgetRoute=api/widgets
+//    EndpointId=b3da3c4c-9c4e-4411-bc4d-609e2dcc5c67
+//    DisplayLabel=Widgets Incorporated, LLC.


### PR DESCRIPTION
## Summary

- Use top-level statement
- Remove explicit `Program` class
- Remove `namespace`

Fixes #27502

✔️ [Preview: Implement a custom configuration provider in .NET](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/custom-configuration-provider?branch=pr-en-us-27617)