### PR TITLE
Use formattable string approach to align logging API convention

### DIFF
--- a/docs/core/extensions/snippets/workers/timer-service/TimerService.cs
+++ b/docs/core/extensions/snippets/workers/timer-service/TimerService.cs
@@ -11,7 +11,7 @@ public sealed class TimerService : IHostedService, IAsyncDisposable
 
     public Task StartAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation($"{nameof(TimerHostedService)} is running.");
+        _logger.LogInformation("{Service} is running.", nameof(TimerHostedService));
         _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
 
         return _completedTask;
@@ -22,14 +22,15 @@ public sealed class TimerService : IHostedService, IAsyncDisposable
         int count = Interlocked.Increment(ref _executionCount);
 
         _logger.LogInformation(
-            $"{nameof(TimerHostedService)} is working, execution count: {{Count:#,0}}",
+            "{Service} is working, execution count: {{Count:#,0}}",
+            nameof(TimerHostedService),
             count);
     }
 
     public Task StopAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation(
-            $"{nameof(TimerHostedService)} is stopping.");
+            "{Service} is stopping.", nameof(TimerHostedService));
 
         _timer?.Change(Timeout.Infinite, 0);
 

--- a/docs/core/extensions/timer-service.md
+++ b/docs/core/extensions/timer-service.md
@@ -36,7 +36,7 @@ The timer-based background service makes use of the <xref:System.Threading.Timer
 
 Replace the contents of the `Worker` from the template with the following C# code, and rename the file to *TimerService.cs*:
 
-:::code source="snippets/workers/timer-service/TimerService.cs" highlight="34,41-44":::
+:::code source="snippets/workers/timer-service/TimerService.cs" highlight="35,42-45":::
 
 > [!IMPORTANT]
 > The `Worker` was a subclass of <xref:Microsoft.Extensions.Hosting.BackgroundService>. Now, the `TimerService` implements both the <xref:Microsoft.Extensions.Hosting.IHostedService>, and <xref:System.IAsyncDisposable> interfaces.

--- a/docs/core/extensions/timer-service.md
+++ b/docs/core/extensions/timer-service.md
@@ -3,7 +3,7 @@ title: Implement the IHostedService interface
 description: Learn how to implement a custom IHostedService interface with .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 12/17/2021
 ms.topic: tutorial
 ---
 


### PR DESCRIPTION
## Summary

Use formattable string approach to align logging API convention

Fixes #27468

✔️ [Preview: Implement the `IHostedService` interface](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/timer-service?branch=pr-en-us-27618)