### PR TITLE
Fedora .NET 6 packages are now available

### DIFF
--- a/docs/core/install/includes/linux-install-60-dnf.md
+++ b/docs/core/install/includes/linux-install-60-dnf.md
@@ -1,0 +1,28 @@
+---
+author: adegeo
+ms.author: adegeo
+ms.date: 10/26/2021
+ms.topic: include
+---
+
+### Install the SDK
+
+The .NET SDK allows you to develop apps with .NET. If you install the .NET SDK, you don't need to install the corresponding runtime. To install the .NET SDK, run the following command:
+
+```bash
+sudo dnf install dotnet-sdk-6.0
+```
+
+### Install the runtime
+
+The ASP.NET Core Runtime allows you to run apps that were made with .NET that didn't provide the runtime. The following command installs the ASP.NET Core Runtime, which is the most compatible runtime for .NET. In your terminal, run the following command:
+
+```bash
+sudo dnf install aspnetcore-runtime-6.0
+```
+
+As an alternative to the ASP.NET Core Runtime, you can install the .NET Runtime, which doesn't include ASP.NET Core support: replace `aspnetcore-runtime-6.0` in the previous command with `dotnet-runtime-6.0`:
+
+```bash
+sudo dnf install dotnet-runtime-6.0
+```

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -12,23 +12,15 @@ ms.date: 11/15/2021
 
 [!INCLUDE [linux-intro-sdk-vs-runtime](includes/linux-intro-sdk-vs-runtime.md)]
 
-<!-- temporary removal so that it's not duplicating what is in the .NET 6 section
 For more information on installing .NET without a package manager, see one of the following articles:
 
 - [Install the .NET SDK or the .NET Runtime with Snap.](linux-snap.md)
 - [Install the .NET SDK or the .NET Runtime with a script.](linux-scripted-manual.md#scripted-install)
 - [Install the .NET SDK or the .NET Runtime manually.](linux-scripted-manual.md#manual-install)
--->
 
 ## Install .NET 6
 
-The latest version of .NET that's available in the default package repositories for Fedora is .NET 5. Installing .NET 6 through the default package repositories is coming soon. For now, you'll need to install .NET 6 in one of the following ways:
-
-- [Install the .NET SDK or the .NET Runtime with Snap.](linux-snap.md)
-- [Install the .NET SDK or the .NET Runtime with a script.](linux-scripted-manual.md#scripted-install)
-- [Install the .NET SDK or the .NET Runtime manually.](linux-scripted-manual.md#manual-install)
-
-You can track the .NET 6 for Fedora release through [Red Hat Bugzilla bug #2021763](https://bugzilla.redhat.com/show_bug.cgi?id=2021763).
+[!INCLUDE [linux-dnf-install-60](includes/linux-install-60-dnf.md)]
 
 ## Install .NET 5
 


### PR DESCRIPTION
.NET 6 packages for both Fedora 35 and 34 are in the process of being
released:

34: https://bodhi.fedoraproject.org/updates/FEDORA-2021-22cd8b68c0
35: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9f61773163

cc @adegeo 