### PR TITLE
Fix uses of "Red Hat"

### DIFF
--- a/docs/architecture/cloud-native/definition.md
+++ b/docs/architecture/cloud-native/definition.md
@@ -274,7 +274,7 @@ Note how container orchestrators embrace the **Disposability** and **Concurrency
 
 While several container orchestrators exist, [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) has become the de facto standard for the cloud-native world. It's a portable, extensible, open-source platform for managing containerized workloads.
 
-You could host your own instance of Kubernetes, but then you'd be responsible for provisioning and managing its resources - which can be complex. The Azure cloud features Kubernetes as a managed service. Both  [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/services/kubernetes-service/) and [Azure RedHat OpenShift (ARO)](https://azure.microsoft.com/services/openshift/) enable you to fully leverage the features and power of Kubernetes as a managed service, without having to install and maintain it.
+You could host your own instance of Kubernetes, but then you'd be responsible for provisioning and managing its resources - which can be complex. The Azure cloud features Kubernetes as a managed service. Both  [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/services/kubernetes-service/) and [Azure Red Hat OpenShift (ARO)](https://azure.microsoft.com/services/openshift/) enable you to fully leverage the features and power of Kubernetes as a managed service, without having to install and maintain it.
 
 Container orchestration is covered in detail in [Scaling Cloud-Native Applications](./scale-applications.md).
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -33,7 +33,7 @@ items:
         href: ../core/install/linux-fedora.md
       - name: OpenSUSE
         href: ../core/install/linux-opensuse.md
-      - name: Redhat Enterprise Linux
+      - name: Red Hat Enterprise Linux
         href: ../core/install/linux-rhel.md
       - name: SLES
         href: ../core/install/linux-sles.md


### PR DESCRIPTION
It's generally two words, where both are capitalized.

https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux says the product is "Red Hat Enterprise Linux"

https://azure.microsoft.com/en-ca/services/openshift/ says the product is called "Azure Red Hat OpenShift"