### PR TITLE
Describe difference in behaviour in VS2022

### DIFF
--- a/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
+++ b/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
@@ -173,7 +173,8 @@ Console.WriteLine(x);
 ```
 
 The light bulb should appear, and your analyzer should report a diagnostic. However, depending on your version of Visual Studio, you'll either see:
-* the light bulb, which still uses uses the template generated code fix, will tell you it can be made upper case. 
+
+* The light bulb, which still uses uses the template generated code fix, will tell you it can be made upper case.
 * a banner message at the top of editor saying the 'MakeConstCodeFixProvider' encountered an error and has been disabled.'. This is becuase the code fix provider hasn't yet been changed and still expects to find `TypeDeclarationSyntax` elements instead of `LocalDeclarationStatementSyntax` elements.
 
 The next section explains how to write the code fix.

--- a/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
+++ b/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
@@ -172,7 +172,11 @@ int x = 0;
 Console.WriteLine(x);
 ```
 
-The light bulb should appear, and your analyzer should report a diagnostic. However, the light bulb still uses the template generated code fix, and tells you it can be made upper case. The next section explains how to write the code fix.
+The light bulb should appear, and your analyzer should report a diagnostic. However, depending on your version of Visual Studio, you'll either see:
+* the light bulb, which still uses uses the template generated code fix, will tell you it can be made upper case. 
+* a banner message at the top of editor saying the 'MakeConstCodeFixProvider' encountered an error and has been disabled.'. This is becuase the code fix provider hasn't yet been changed and still expects to find `TypeDeclarationSyntax` elements instead of `LocalDeclarationStatementSyntax` elements.
+
+The next section explains how to write the code fix.
 
 ## Write the code fix
 

--- a/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
+++ b/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
@@ -175,7 +175,7 @@ Console.WriteLine(x);
 The light bulb should appear, and your analyzer should report a diagnostic. However, depending on your version of Visual Studio, you'll either see:
 
 * The light bulb, which still uses uses the template generated code fix, will tell you it can be made upper case.
-* a banner message at the top of editor saying the 'MakeConstCodeFixProvider' encountered an error and has been disabled.'. This is becuase the code fix provider hasn't yet been changed and still expects to find `TypeDeclarationSyntax` elements instead of `LocalDeclarationStatementSyntax` elements.
+* A banner message at the top of editor saying the 'MakeConstCodeFixProvider' encountered an error and has been disabled.'. This is becuase the code fix provider hasn't yet been changed and still expects to find `TypeDeclarationSyntax` elements instead of `LocalDeclarationStatementSyntax` elements.
 
 The next section explains how to write the code fix.
 


### PR DESCRIPTION
VS2022 shows a banner error message at the top of the editor window saying that the analyzer has been disabled

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
