### PR TITLE
Fix wrong example on how to set the drawing unix runtime switch.

### DIFF
--- a/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
+++ b/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
@@ -62,10 +62,8 @@ Alternatively, you can enable support for non-Windows platforms by setting the `
 
 ```json
 {
-   "runtimeOptions": {
-      "configProperties": {
-         "System.Drawing.EnableUnixSupport": true
-      }
+   "configProperties": {
+      "System.Drawing.EnableUnixSupport": true
    }
 }
 ```


### PR DESCRIPTION
## Summary

The runtime switch should not go under a runtimeOptions node.


Related to: https://github.com/dotnet/runtime/issues/63027
