### PR TITLE
Restrict all actions that rely on the `GITHUB_TOKEN`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -163,7 +163,7 @@ csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # Namespace preference
-csharp_style_namespace_declarations = file_scoped
+csharp_style_namespace_declarations = file_scoped:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
 csharp_style_var_for_built_in_types = false:suggestion

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -19,6 +19,8 @@ jobs:
   snippets-build:
     # The type of runner that the job will run on
     runs-on: windows-latest
+    permissions:
+        statuses: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -8,6 +8,8 @@ jobs:
   status_checker_job:
     name: Look for build warnings
     runs-on: ubuntu-latest
+    permissions:
+        statuses: write
     steps:
     - uses: dotnet/docs-actions/actions/status-checker@main
       with:

--- a/.github/workflows/docs-verifier.yml
+++ b/.github/workflows/docs-verifier.yml
@@ -8,7 +8,8 @@ jobs:
   validate:
     name: MSDocs build verifier
     runs-on: ubuntu-latest
-
+    permissions:
+        statuses: write
     steps:
     - name: Checkout the repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -20,6 +20,8 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
+    permissions:
+        statuses: write
 
     steps:
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2

--- a/.github/workflows/version-sweep.yml
+++ b/.github/workflows/version-sweep.yml
@@ -20,6 +20,9 @@ jobs:
   version-sweep:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Summary

In this PR, we're explicitly declaring the individual actions' `permissions`. This overrides the default permissions for the `GITHUB_TOKEN`, restricting it to the bare minimal access in order for the given action to run. For more information, see:

- [Workflow syntax for GitHub Actions: `permissions`](https://docs.github.com/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions)
- [Permissions for the `GITHUB_TOKEN`](https://docs.github.com/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

