### PR TITLE
Fix grammar and indent code

### DIFF
--- a/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
+++ b/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
@@ -113,7 +113,7 @@ The following are our recommendations for successfully using <xref:System.Memory
 
 Using a parameter of type <xref:System.Span%601> instead of type <xref:System.Memory%601> also helps you write a correct consuming method implementation. You'll automatically get compile-time checks to ensure that you're not attempting to access the buffer beyond your method's lease (more on this later).
 
-Sometimes, you'll have to use a <xref:System.Memory%601> parameter instead of a <xref:System.Span%601> parameter, even if you're fully synchronous. Perhaps an API that you depend accepts only <xref:System.Memory%601> arguments. This is fine, but be aware of the tradeoffs involved when using <xref:System.Memory%601> synchronously.
+Sometimes, you'll have to use a <xref:System.Memory%601> parameter instead of a <xref:System.Span%601> parameter, even if you're fully synchronous. Perhaps an API that you depend on accepts only <xref:System.Memory%601> arguments. This is fine, but be aware of the tradeoffs involved when using <xref:System.Memory%601> synchronously.
 
 <a name="rule-2"></a>
 

--- a/samples/snippets/standard/buffers/memory-t/task-returning2/task-returning2.cs
+++ b/samples/snippets/standard/buffers/memory-t/task-returning2/task-returning2.cs
@@ -11,7 +11,7 @@ public class Example
     {
         // Run in the background so that we don't block the main thread while performing IO.
         return Task.Run(() => {
-                    StreamWriter sw = File.AppendText(@".\input-numbers.dat");
+            StreamWriter sw = File.AppendText(@".\input-numbers.dat");
             sw.WriteLine(message);
             sw.Flush();
         });


### PR DESCRIPTION
In "Memory&lt;T&gt; and Span&lt;T&gt; usage guidelines" page,
- fix grammar
- fix code indentation
