### PR TITLE
Use lowercase `string`

### DIFF
--- a/docs/core/tutorials/snippets/library-with-visual-studio-6-0/csharp/StringLibraryTest/UnitTest1.cs
+++ b/docs/core/tutorials/snippets/library-with-visual-studio-6-0/csharp/StringLibraryTest/UnitTest1.cs
@@ -15,7 +15,7 @@ public class UnitTest1
         {
             bool result = word.StartsWithUpper();
             Assert.IsTrue(result,
-                   String.Format("Expected for '{0}': true; Actual: {1}",
+                   string.Format("Expected for '{0}': true; Actual: {1}",
                                  word, result));
         }
     }
@@ -30,7 +30,7 @@ public class UnitTest1
         {
             bool result = word.StartsWithUpper();
             Assert.IsFalse(result,
-                   String.Format("Expected for '{0}': false; Actual: {1}",
+                   string.Format("Expected for '{0}': false; Actual: {1}",
                                  word, result));
         }
     }
@@ -44,7 +44,7 @@ public class UnitTest1
         {
             bool result = StringLibrary.StartsWithUpper(word);
             Assert.IsFalse(result,
-                   String.Format("Expected for '{0}': false; Actual: {1}",
+                   string.Format("Expected for '{0}': false; Actual: {1}",
                                  word == null ? "<null>" : word, result));
         }
     }

--- a/docs/core/tutorials/snippets/library-with-visual-studio/csharp/StringLibraryTest/UnitTest1.cs
+++ b/docs/core/tutorials/snippets/library-with-visual-studio/csharp/StringLibraryTest/UnitTest1.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UtilityLibraries;
 
 namespace StringLibraryTest
@@ -16,7 +15,7 @@ namespace StringLibraryTest
             {
                 bool result = word.StartsWithUpper();
                 Assert.IsTrue(result,
-                       String.Format("Expected for '{0}': true; Actual: {1}",
+                       string.Format("Expected for '{0}': true; Actual: {1}",
                                      word, result));
             }
         }
@@ -31,7 +30,7 @@ namespace StringLibraryTest
             {
                 bool result = word.StartsWithUpper();
                 Assert.IsFalse(result,
-                       String.Format("Expected for '{0}': false; Actual: {1}",
+                       string.Format("Expected for '{0}': false; Actual: {1}",
                                      word, result));
             }
         }
@@ -45,7 +44,7 @@ namespace StringLibraryTest
             {
                 bool result = StringLibrary.StartsWithUpper(word);
                 Assert.IsFalse(result,
-                       String.Format("Expected for '{0}': false; Actual: {1}",
+                       string.Format("Expected for '{0}': false; Actual: {1}",
                                      word == null ? "<null>" : word, result));
             }
         }


### PR DESCRIPTION
Fixes #27740

Code sample is already correct, but using language keywords is a better and more common practice anyway.