### PR TITLE
Use top-level programs for config provider article

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -3,7 +3,7 @@ title: Configuration providers in .NET
 description: Learn how the Configuration provider API is used to configure .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 01/06/2022
 ms.topic: reference
 ---
 
@@ -36,7 +36,7 @@ Overloads can specify:
 
 Consider the following code:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-37,43-44" highlight="21-27":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="1-29" highlight="8-14":::
 
 The preceding code:
 
@@ -62,7 +62,7 @@ Consider the `TransientFaultHandlingOptions` class defined as follows:
 
 The following code builds the configuration root, binds a section to the `TransientFaultHandlingOptions` class type, and prints the bound values to the console window:
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="29-36":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="16-23":::
 
 The application would write the following sample output:
 
@@ -74,7 +74,7 @@ The <xref:Microsoft.Extensions.Configuration.Xml.XmlConfigurationProvider> class
 
 The following code demonstrates configuration of XML files using the XML configuration provider.
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-32,50,58-59" highlight="21-32":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-18,36-41" highlight="7-18":::
 
 The preceding code:
 
@@ -97,7 +97,7 @@ In .NET 5 and earlier versions, add the `name` attribute to distinguish repeatin
 
 The following code reads the previous configuration file and displays the keys and values:
 
-:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="34-49":::
+:::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="20-35":::
 
 The application would write the following sample output:
 
@@ -126,7 +126,7 @@ The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> class
 
 The following code clears all the configuration providers and adds the `IniConfigurationProvider` with two INI files as the source:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-34,43-44" highlight="21-27":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-13,20-25" highlight="7-13":::
 
 An example *appsettings.ini* file with various configuration settings follows:
 
@@ -134,7 +134,7 @@ An example *appsettings.ini* file with various configuration settings follows:
 
 The following code displays the preceding configuration settings by writing them to the console window:
 
-:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="29-33":::
+:::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="15-19":::
 
 The application would write the following sample output:
 
@@ -185,7 +185,7 @@ To test that the preceding commands override *appsettings.json* and *appsettings
 
 Call <xref:Microsoft.Extensions.Configuration.EnvironmentVariablesExtensions.AddEnvironmentVariables%2A> with a string to specify a prefix for environment variables:
 
-:::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="20-21":::
+:::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="6-7":::
 
 In the preceding code:
 
@@ -312,7 +312,7 @@ The <xref:Microsoft.Extensions.Configuration.Memory.MemoryConfigurationProvider>
 
 The following code adds a memory collection to the configuration system:
 
-:::code language="csharp" source="snippets/configuration/console-memory/Program.cs" highlight="20-27":::
+:::code language="csharp" source="snippets/configuration/console-memory/Program.cs" highlight="6-13":::
 
 In the preceding code, <xref:Microsoft.Extensions.Configuration.MemoryConfigurationBuilderExtensions.AddInMemoryCollection(Microsoft.Extensions.Configuration.IConfigurationBuilder,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}})?displayProperty=nameWithType> adds the memory provider after the default configuration providers. For an example of ordering the configuration providers, see [XML configuration provider](#xml-configuration-provider).
 

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -38,7 +38,7 @@ The following code:
 * Calls [ConfigurationBinder.Bind](xref:Microsoft.Extensions.Configuration.ConfigurationBinder.Bind%2A) to bind the `TransientFaultHandlingOptions` class to the `"TransientFaultHandlingOptions"` section.
 * Displays the configuration data.
 
-:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="29-36":::
+:::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="16-23":::
 
 In the preceding code, changes to the JSON configuration file after the app has started are read.
 

--- a/docs/core/extensions/snippets/configuration/console-env/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-env/Program.cs
@@ -1,22 +1,12 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleEnvironment.Example;
+using IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((hostingContext, configuration) =>
+        configuration.AddEnvironmentVariables(
+            prefix: "CustomPrefix_"))
+    .Build();
 
-class Program
-{
-    static async Task Main(string[] args)
-    {
-        using IHost host = CreateHostBuilder(args).Build();
+// Application code should start here.
 
-        // Application code should start here.
-
-        await host.RunAsync();
-    }
-
-    static IHostBuilder CreateHostBuilder(string[] args) =>
-        Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((hostingContext, configuration) =>
-                configuration.AddEnvironmentVariables(
-                    prefix: "CustomPrefix_"));
-}
+await host.RunAsync();

--- a/docs/core/extensions/snippets/configuration/console-ini/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-ini/Program.cs
@@ -1,43 +1,34 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleIni.Example;
-
-class Program
-{
-    static async Task Main(string[] args)
+using IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((hostingContext, configuration) =>
     {
-        using IHost host = CreateHostBuilder(args).Build();
+        configuration.Sources.Clear();
 
-        // Application code should start here.
+        IHostEnvironment env = hostingContext.HostingEnvironment;
 
-        await host.RunAsync();
-    }
+        configuration
+            .AddIniFile("appsettings.ini", optional: true, reloadOnChange: true)
+            .AddIniFile($"appsettings.{env.EnvironmentName}.ini", true, true);
 
-    static IHostBuilder CreateHostBuilder(string[] args) =>
-        Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((hostingContext, configuration) =>
-            {
-                configuration.Sources.Clear();
+        foreach ((string key, string value) in
+            configuration.Build().AsEnumerable().Where(t => t.Value is not null))
+        {
+            Console.WriteLine($"{key}={value}");
+        }
+    })
+    .Build();
 
-                IHostEnvironment env = hostingContext.HostingEnvironment;
+// Application code should start here.
 
-                configuration
-                    .AddIniFile("appsettings.ini", optional: true, reloadOnChange: true)
-                    .AddIniFile($"appsettings.{env.EnvironmentName}.ini", true, true);
+await host.RunAsync();
 
-                foreach ((string key, string value) in
-                    configuration.Build().AsEnumerable().Where(t => t.Value is not null))
-                {
-                    Console.WriteLine($"{key}={value}");
-                }
-            });
-    // <Output>
-    // Sample output:
-    //    TransientFaultHandlingOptions:Enabled=True
-    //    TransientFaultHandlingOptions:AutoRetryDelay=00:00:07
-    //    SecretKey=Secret key value
-    //    Logging:LogLevel:Microsoft=Warning
-    //    Logging:LogLevel:Default=Information
-    // </Output>
-}
+// <Output>
+// Sample output:
+//    TransientFaultHandlingOptions:Enabled=True
+//    TransientFaultHandlingOptions:AutoRetryDelay=00:00:07
+//    SecretKey=Secret key value
+//    Logging:LogLevel:Microsoft=Warning
+//    Logging:LogLevel:Default=Information
+// </Output>

--- a/docs/core/extensions/snippets/configuration/console-memory/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-memory/Program.cs
@@ -1,28 +1,18 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleMemory.Example;
+using IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((_, configuration) =>
+        configuration.AddInMemoryCollection(
+            new Dictionary<string, string>
+            {
+                ["SecretKey"] = "Dictionary MyKey Value",
+                ["TransientFaultHandlingOptions:Enabled"] = bool.TrueString,
+                ["TransientFaultHandlingOptions:AutoRetryDelay"] = "00:00:07",
+                ["Logging:LogLevel:Default"] = "Warning"
+            }))
+    .Build();
 
-class Program
-{
-    static async Task Main(string[] args)
-    {
-        using IHost host = CreateHostBuilder(args).Build();
+// Application code should start here.
 
-        // Application code should start here.
-
-        await host.RunAsync();
-    }
-
-    static IHostBuilder CreateHostBuilder(string[] args) =>
-        Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((_, configuration) =>
-                configuration.AddInMemoryCollection(
-                    new Dictionary<string, string>
-                    {
-                        ["SecretKey"] = "Dictionary MyKey Value",
-                        ["TransientFaultHandlingOptions:Enabled"] = bool.TrueString,
-                        ["TransientFaultHandlingOptions:AutoRetryDelay"] = "00:00:07",
-                        ["Logging:LogLevel:Default"] = "Warning"
-                    }));
-}
+await host.RunAsync();

--- a/docs/core/extensions/snippets/configuration/console-xml/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-xml/Program.cs
@@ -1,58 +1,49 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ConsoleXml.Example;
-
-class Program
-{
-    static async Task Main(string[] args)
+using IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((hostingContext, configuration) =>
     {
-        using IHost host = CreateHostBuilder(args).Build();
+        configuration.Sources.Clear();
 
-        // Application code should start here.
+        configuration
+            .AddXmlFile("appsettings.xml", optional: true, reloadOnChange: true)
+            .AddXmlFile("repeating-example.xml", optional: true, reloadOnChange: true);
 
-        await host.RunAsync();
-    }
+        configuration.AddEnvironmentVariables();
 
-    static IHostBuilder CreateHostBuilder(string[] args) =>
-        Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((hostingContext, configuration) =>
-            {
-                configuration.Sources.Clear();
+        if (args is { Length: > 0 })
+        {
+            configuration.AddCommandLine(args);
+        }
 
-                configuration
-                    .AddXmlFile("appsettings.xml", optional: true, reloadOnChange: true)
-                    .AddXmlFile("repeating-example.xml", optional: true, reloadOnChange: true);
+        IConfigurationRoot configurationRoot = configuration.Build();
 
-                configuration.AddEnvironmentVariables();
+        string key00 = "section:section0:key:key0";
+        string key01 = "section:section0:key:key1";
+        string key10 = "section:section1:key:key0";
+        string key11 = "section:section1:key:key1";
 
-                if (args is { Length: > 0 })
-                {
-                    configuration.AddCommandLine(args);
-                }
+        string val00 = configurationRoot[key00];
+        string val01 = configurationRoot[key01];
+        string val10 = configurationRoot[key10];
+        string val11 = configurationRoot[key11];
 
-                IConfigurationRoot configurationRoot = configuration.Build();
+        Console.WriteLine($"{key00} = {val00}");
+        Console.WriteLine($"{key01} = {val01}");
+        Console.WriteLine($"{key10} = {val10}");
+        Console.WriteLine($"{key10} = {val11}");
+    })
+    .Build();
 
-                string key00 = "section:section0:key:key0";
-                string key01 = "section:section0:key:key1";
-                string key10 = "section:section1:key:key0";
-                string key11 = "section:section1:key:key1";
+// Application code should start here.
 
-                string val00 = configurationRoot[key00];
-                string val01 = configurationRoot[key01];
-                string val10 = configurationRoot[key10];
-                string val11 = configurationRoot[key11];
+await host.RunAsync();
 
-                Console.WriteLine($"{key00} = {val00}");
-                Console.WriteLine($"{key01} = {val01}");
-                Console.WriteLine($"{key10} = {val10}");
-                Console.WriteLine($"{key10} = {val11}");
-            });
-    // <Output>
-    // Sample output:
-    //    section:section0:key:key0 = value 00
-    //    section:section0:key:key1 = value 01
-    //    section:section1:key:key0 = value 10
-    //    section:section1:key:key0 = value 11
-    // </Output>
-}
+// <Output>
+// Sample output:
+//    section:section0:key:key0 = value 00
+//    section:section0:key:key1 = value 01
+//    section:section1:key:key0 = value 10
+//    section:section1:key:key0 = value 11
+// </Output>


### PR DESCRIPTION
## Summary

Use top-level programs for config provider article

Fixes #27666

✔️ [Preview: Configuration providers in .NET](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/configuration-providers?branch=pr-en-us-27755)