### PR TITLE
Add missing forward slash on windows install command line switch

### DIFF
--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -341,7 +341,7 @@ Installs .NET.
 - `/quiet`\
 Prevents any UI and prompts from displaying.
 
-- `norestart`\
+- `/norestart`\
 Suppresses any attempts to restart.
 
 ```console


### PR DESCRIPTION
## Summary

Add missing `/` on command line switch

Fixes #27662

@luisquintanilla 
