### PR TITLE
Consistency fix : remove using static Console

### DIFF
--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/base-and-derived.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/base-and-derived.cs
@@ -38,7 +38,7 @@ public abstract class Publication
      set
      {
          if (value <= 0)
-            throw new ArgumentOutOfRangeException("The number of pages cannot be zero or negative.");
+            throw new ArgumentOutOfRangeException(nameof(value), "The number of pages cannot be zero or negative.");
          totalPages = value;
      }
    }
@@ -116,7 +116,7 @@ public sealed class Book : Publication
    public Decimal SetPrice(Decimal price, string currency)
    {
        if (price < 0)
-          throw new ArgumentOutOfRangeException("The price cannot be negative.");
+          throw new ArgumentOutOfRangeException(nameof(price), "The price cannot be negative.");
        Decimal oldValue = Price;
        Price = price;
 

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/is-a.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/is-a.cs
@@ -6,13 +6,13 @@ public class Automobile
     public Automobile(string make, string model, int year)
     {
         if (make == null)
-           throw new ArgumentNullException("The make cannot be null.");
+           throw new ArgumentNullException(nameof(make), "The make cannot be null.");
         else if (String.IsNullOrWhiteSpace(make))
            throw new ArgumentException("make cannot be an empty string or have space characters only.");
         Make = make;
 
         if (model == null)
-           throw new ArgumentNullException("The model cannot be null.");
+           throw new ArgumentNullException(nameof(model), "The model cannot be null.");
         else if (String.IsNullOrWhiteSpace(model))
            throw new ArgumentException("model cannot be an empty string or have space characters only.");
         Model = model;

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/use-publication.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/use-publication.cs
@@ -1,6 +1,5 @@
 ﻿// <Snippet1>
 using System;
-using static System.Console;
 
 public class ClassExample
 {
@@ -13,14 +12,14 @@ public class ClassExample
       ShowPublicationInfo(book);
 
       var book2 = new Book("The Tempest", "Classic Works Press", "Shakespeare, William");
-      Write($"{book.Title} and {book2.Title} are the same publication: " +
+      Console.Write($"{book.Title} and {book2.Title} are the same publication: " +
             $"{((Publication) book).Equals(book2)}");
    }
 
    public static void ShowPublicationInfo(Publication pub)
    {
        string pubDate = pub.GetPublicationDate();
-       WriteLine($"{pub.Title}, " +
+       Console.WriteLine($"{pub.Title}, " +
                  $"{(pubDate == "NYP" ? "Not Yet Published" : "published on " + pubDate):d} by {pub.Publisher}");
    }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/use-publication.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/use-publication.cs
@@ -67,7 +67,7 @@ public sealed class Book : Publication
    public Decimal SetPrice(Decimal price, string currency)
    {
        if (price < 0)
-          throw new ArgumentOutOfRangeException("The price cannot be negative.");
+          throw new ArgumentOutOfRangeException(nameof(price), "The price cannot be negative.");
        Decimal oldValue = Price;
        Price = price;
 


### PR DESCRIPTION
## Summary

Remove a `a using static System.Console` to improve consistency

Fixes #27793 
