### PR TITLE
Timestamp breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -59,6 +59,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ | Preview 1 |
 | [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ | Preview 1 |
 | [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ | Preview 6 |
+| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ | Servicing 6.0.2 |
 | [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
 | [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
 | [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |

--- a/docs/core/compatibility/core-libraries/6.0/set-timestamp-readonly-file.md
+++ b/docs/core/compatibility/core-libraries/6.0/set-timestamp-readonly-file.md
@@ -1,0 +1,41 @@
+---
+title: "Breaking change: Set timestamp on read-only file on Windows"
+description: Learn about the .NET 6 servicing release breaking change where you can now set the timestamp on a read-only file on Windows.
+ms.date: 01/11/2022
+---
+# Set timestamp on read-only file on Windows
+
+Setting the timestamp on a file with the read-only attribute now succeeds on Windows and no longer throws an exception.
+
+## Old behavior
+
+Prior to .NET 6 servicing releases, setting the timestamp on a read-only file on Windows resulted in an <xref:System.UnauthorizedAccessException>.
+
+## New behavior
+
+Starting in .NET 6.0.2, setting the timestamp on a read-only file on Windows succeeds.
+
+## Version introduced
+
+.NET 6.0.2 (servicing release)
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+Customers gave feedback that they expected setting the timestamp on a read-only file to succeed. This change also makes the Windows behavior consistent with Linux. Finally, the behavior was unintentional, caused by a bug.
+
+## Recommended action
+
+It is unlikely that existing code expects setting the timestamp on a read-only file to fail. However, if your code expects it to fail, add a check for the read-only attribute using <xref:System.IO.File.GetAttributes(System.String)?displayProperty=nameWithType> before attempting to set the timestamp.
+
+## Affected APIs
+
+- <xref:System.IO.File.SetCreationTime(System.String,System.DateTime)?displayProperty=fullName>
+- <xref:System.IO.File.SetCreationTimeUtc(System.String,System.DateTime)?displayProperty=fullName>
+- <xref:System.IO.File.SetLastAccessTime(System.String,System.DateTime)?displayProperty=fullName>
+- <xref:System.IO.File.SetLastAccessTimeUtc(System.String,System.DateTime)?displayProperty=fullName>
+- <xref:System.IO.File.SetLastWriteTime(System.String,System.DateTime)?displayProperty=fullName>
+- <xref:System.IO.File.SetLastWriteTimeUtc(System.String,System.DateTime)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -111,6 +111,8 @@ items:
           href: core-libraries/6.0/parameters-renamed-on-stream-derived-types.md
         - name: Partial and zero-byte reads in streams
           href: core-libraries/6.0/partial-byte-reads-in-streams.md
+        - name: Set timestamp on read-only file on Windows
+          href: core-libraries/6.0/set-timestamp-readonly-file.md
         - name: Standard numeric format parsing precision
           href: core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
         - name: Static abstract members in interfaces
@@ -669,6 +671,8 @@ items:
           href: core-libraries/6.0/parameters-renamed-on-stream-derived-types.md
         - name: Partial and zero-byte reads in streams
           href: core-libraries/6.0/partial-byte-reads-in-streams.md
+        - name: Set timestamp on read-only file on Windows
+          href: core-libraries/6.0/set-timestamp-readonly-file.md
         - name: Standard numeric format parsing precision
           href: core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md
         - name: Static abstract members in interfaces


### PR DESCRIPTION
Fixes #27757.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/set-timestamp-readonly-file?branch=pr-en-us-27808)