### PR TITLE
Add conceptual documentation for "disabled runtime marshalling"

### DIFF
--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -84,6 +84,8 @@ GUIDs are usable directly in signatures. Many Windows APIs take `GUID&` type ali
 
 Blittable types are types that have the same bit-level representation in managed and native code. As such they do not need to be converted to another format to be marshaled to and from native code, and as this improves performance they should be preferred. Some types are not blittable but are known to contain blittable contents. These types have similar optimizations as blittable types when they are not contained in another type, but are not considered blittable when in fields of structs or for the purposes of [`UnmanagedCallersOnlyAttribute`](xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute).
 
+### Blittable types when runtime marshalling is enabled
+
 **Blittable types:**
 
 - `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `single`, `double`
@@ -125,6 +127,10 @@ public struct UnicodeCharStruct
 `string` contains blittable contents if it isn't contained in another type and it's being passed as an argument that is marked with `[MarshalAs(UnmanagedType.LPWStr)]` or the `[DllImport]` has `CharSet = CharSet.Unicode` set.
 
 You can see if a type is blittable or contains blittable contents by attempting to create a pinned `GCHandle`. If the type isn't a string or considered blittable, `GCHandle.Alloc` will throw an `ArgumentException`.
+
+### Blittable types when runtime marshalling is disabled
+
+When [runtime marshalling is disabled](disabled-marshalling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of "types with blittable contents" does not apply when runtime marshalling is disabled.
 
 ✔️ DO make your structures blittable when possible.
 

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -54,7 +54,7 @@ If you *do* use `StringBuilder`, one last gotcha is that the capacity does **not
 
 ✔️ CONSIDER using `char[]`s from an `ArrayPool`.
 
-For more information on string marshalling, see [Default Marshalling for Strings](../../framework/interop/default-marshalling-for-strings.md) and [Customizing string marshalling](customize-parameter-marshalling.md#customizing-string-parameters).
+For more information on string marshalling, see [Default Marshalling for Strings](../../framework/interop/default-marshaling-for-strings.md) and [Customizing string marshalling](customize-parameter-marshalling.md#customizing-string-parameters).
 
 > __Windows Specific__
 > For `[Out]` strings the CLR will use `CoTaskMemFree` by default to free strings or `SysStringFree` for strings that are marked

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -25,7 +25,7 @@ The guidance in this section applies to all interop scenarios.
 |---------|---------|----------------|---------|
 | <xref:System.Runtime.InteropServices.DllImportAttribute.PreserveSig>   | `true` |  keep default  | When this is explicitly set to false, failed HRESULT return values will be turned into exceptions (and the return value in the definition becomes null as a result).|
 | <xref:System.Runtime.InteropServices.DllImportAttribute.SetLastError> | `false`  | depends on the API  | Set this to true if the API uses GetLastError and use Marshal.GetLastWin32Error to get the value. If the API sets a condition that says it has an error, get the error before making other calls to avoid inadvertently having it overwritten.|
-| <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet> | Compiler-defined (specified in the [charset documentation](./charset.md))  | Explicitly  use `CharSet.Unicode` or `CharSet.Ansi` when strings or characters are present in the definition | This specifies marshaling behavior of strings and what `ExactSpelling` does when `false`. Note that `CharSet.Ansi` is actually UTF8 on Unix. _Most_ of the time Windows uses Unicode while Unix uses UTF8. See more information on the [documentation on charsets](./charset.md). |
+| <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet> | Compiler-defined (specified in the [charset documentation](./charset.md))  | Explicitly  use `CharSet.Unicode` or `CharSet.Ansi` when strings or characters are present in the definition | This specifies marshalling behavior of strings and what `ExactSpelling` does when `false`. Note that `CharSet.Ansi` is actually UTF8 on Unix. _Most_ of the time Windows uses Unicode while Unix uses UTF8. See more information on the [documentation on charsets](./charset.md). |
 | <xref:System.Runtime.InteropServices.DllImportAttribute.ExactSpelling> | `false` | `true`             | Set this to true and gain a slight perf benefit as the runtime will not look for alternate function names with either an "A" or "W" suffix depending on the value of the `CharSet` setting ("A" for `CharSet.Ansi` and "W" for `CharSet.Unicode`). |
 
 ## String parameters
@@ -36,7 +36,7 @@ Remember to mark the `[DllImport]` as `Charset.Unicode` unless you explicitly wa
 
 ❌ DO NOT use `[Out] string` parameters. String parameters passed by value with the `[Out]` attribute can destabilize the runtime if the string is an interned string. See more information about string interning in the documentation for <xref:System.String.Intern%2A?displayProperty=nameWithType>.
 
-❌ AVOID `StringBuilder` parameters. `StringBuilder` marshaling *always* creates a native buffer copy. As such, it can be extremely inefficient. Take the typical scenario of calling a Windows API that takes a string:
+❌ AVOID `StringBuilder` parameters. `StringBuilder` marshalling *always* creates a native buffer copy. As such, it can be extremely inefficient. Take the typical scenario of calling a Windows API that takes a string:
 
 1. Create a `StringBuilder` of the desired capacity (allocates managed capacity) **{1}**.
 2. Invoke:
@@ -50,11 +50,11 @@ in another call, but this still only saves *1* allocation. It's much better to u
 
 The other issue with `StringBuilder` is that it always copies the return buffer back up to the first null. If the passed back string isn't terminated or is a double-null-terminated string, your P/Invoke is incorrect at best.
 
-If you *do* use `StringBuilder`, one last gotcha is that the capacity does **not** include a hidden null, which is always accounted for in interop. It's common for people to get this wrong as most APIs want the size of the buffer *including* the null. This can result in wasted/unnecessary allocations. Additionally, this gotcha prevents the runtime from optimizing `StringBuilder` marshaling to minimize copies.
+If you *do* use `StringBuilder`, one last gotcha is that the capacity does **not** include a hidden null, which is always accounted for in interop. It's common for people to get this wrong as most APIs want the size of the buffer *including* the null. This can result in wasted/unnecessary allocations. Additionally, this gotcha prevents the runtime from optimizing `StringBuilder` marshalling to minimize copies.
 
 ✔️ CONSIDER using `char[]`s from an `ArrayPool`.
 
-For more information on string marshaling, see [Default Marshaling for Strings](../../framework/interop/default-marshaling-for-strings.md) and [Customizing string marshaling](customize-parameter-marshaling.md#customizing-string-parameters).
+For more information on string marshalling, see [Default Marshalling for Strings](../../framework/interop/default-marshalling-for-strings.md) and [Customizing string marshalling](customize-parameter-marshalling.md#customizing-string-parameters).
 
 > __Windows Specific__
 > For `[Out]` strings the CLR will use `CoTaskMemFree` by default to free strings or `SysStringFree` for strings that are marked
@@ -68,7 +68,7 @@ as `UnmanagedType.BSTR`.
 
 ## Boolean parameters and fields
 
-Booleans are easy to mess up. By default, a .NET `bool` is marshaled to a Windows `BOOL`, where it's a 4-byte value. However, the `_Bool`, and `bool` types in C and C++ are a *single* byte. This can lead to hard to track down bugs as half the return value will be discarded, which will only *potentially* change the result. For more for information on marshaling .NET `bool` values to C or C++ `bool` types, see the documentation on [customizing boolean field marshaling](customize-struct-marshaling.md#customizing-boolean-field-marshaling).
+Booleans are easy to mess up. By default, a .NET `bool` is marshalled to a Windows `BOOL`, where it's a 4-byte value. However, the `_Bool`, and `bool` types in C and C++ are a *single* byte. This can lead to hard to track down bugs as half the return value will be discarded, which will only *potentially* change the result. For more for information on marshalling .NET `bool` values to C or C++ `bool` types, see the documentation on [customizing boolean field marshalling](customize-struct-marshalling.md#customizing-boolean-field-marshalling).
 
 ## GUIDs
 
@@ -82,7 +82,7 @@ GUIDs are usable directly in signatures. Many Windows APIs take `GUID&` type ali
 
 ## Blittable types
 
-Blittable types are types that have the same bit-level representation in managed and native code. As such they do not need to be converted to another format to be marshaled to and from native code, and as this improves performance they should be preferred. Some types are not blittable but are known to contain blittable contents. These types have similar optimizations as blittable types when they are not contained in another type, but are not considered blittable when in fields of structs or for the purposes of [`UnmanagedCallersOnlyAttribute`](xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute).
+Blittable types are types that have the same bit-level representation in managed and native code. As such they do not need to be converted to another format to be marshalled to and from native code, and as this improves performance they should be preferred. Some types are not blittable but are known to contain blittable contents. These types have similar optimizations as blittable types when they are not contained in another type, but are not considered blittable when in fields of structs or for the purposes of [`UnmanagedCallersOnlyAttribute`](xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute).
 
 ### Blittable types when runtime marshalling is enabled
 
@@ -130,7 +130,7 @@ You can see if a type is blittable or contains blittable contents by attempting 
 
 ### Blittable types when runtime marshalling is disabled
 
-When [runtime marshalling is disabled](disabled-marshaling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types and do not have any fields that are marked with `[StructLayout(LayoutKind.Auto)]` are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of types with blittable contents, such as arrays or strings, does not apply when runtime marshalling is disabled. Any type that is not considered blittable by the aforementioned rule is unsupported when runtime marshalling is disabled.
+When [runtime marshalling is disabled](disabled-marshalling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types and do not have any fields that are marked with `[StructLayout(LayoutKind.Auto)]` are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of types with blittable contents, such as arrays or strings, does not apply when runtime marshalling is disabled. Any type that is not considered blittable by the aforementioned rule is unsupported when runtime marshalling is disabled.
 
 These rules differ from the built-in system primarily in situations where `bool` and `char` are used. When marshalling is disabled, `bool` is passed as a 1-byte value and not normalized and `char` is always passed as a 2-byte value. When runtime marshalling is enabled, `bool` can map to a 1, 2, or 4-byte value and is always normalized, and `char` maps to either a 1 or 2-byte value depending on the [`CharSet`](charset.md).
 
@@ -139,7 +139,7 @@ These rules differ from the built-in system primarily in situations where `bool`
 For more information, see:
 
 - [Blittable and Non-Blittable Types](../../framework/interop/blittable-and-non-blittable-types.md)
-- [Type Marshaling](type-marshaling.md)
+- [Type Marshalling](type-marshalling.md)
 
 ## Keeping managed objects alive
 
@@ -213,7 +213,7 @@ The following types, being pointers, do follow the width of the platform. Use `I
 | `LONG_PTR`                          |                                        |
 | `INT_PTR`                           |                                        |
 
-A Windows `PVOID`, which is a C `void*`, can be marshaled as either `IntPtr` or `UIntPtr`, but prefer `void*` when possible.
+A Windows `PVOID`, which is a C `void*`, can be marshalled as either `IntPtr` or `UIntPtr`, but prefer `void*` when possible.
 
 [Windows Data Types](/windows/desktop/WinProg/windows-data-types)
 
@@ -223,7 +223,7 @@ A Windows `PVOID`, which is a C `void*`, can be marshaled as either `IntPtr` or 
 
 There are rare instances when built-in support for a type is removed.
 
-The [`UnmanagedType.HString`](xref:System.Runtime.InteropServices.UnmanagedType) built-in marshal support was removed in the .NET 5 release. You must recompile binaries that use this marshaling type and that target a previous framework. It's still possible to marshal this type, but you must marshal it manually, as the following code example shows. This code will work moving forward and is also compatible with previous frameworks.
+The [`UnmanagedType.HString`](xref:System.Runtime.InteropServices.UnmanagedType) built-in marshal support was removed in the .NET 5 release. You must recompile binaries that use this marshalling type and that target a previous framework. It's still possible to marshal this type, but you must marshal it manually, as the following code example shows. This code will work moving forward and is also compatible with previous frameworks.
 
 ```csharp
 static class HSTRING
@@ -318,7 +318,7 @@ else
 
 Managed structs are created on the stack and aren't removed until the method returns. By definition then, they are "pinned" (it won't get moved by the GC). You can also simply take the address in unsafe code blocks if native code won't use the pointer past the end of the current method.
 
-Blittable structs are much more performant as they can simply be used directly by the marshaling layer. Try to make structs blittable (for example, avoid `bool`). For more information, see the [Blittable Types](#blittable-types) section.
+Blittable structs are much more performant as they can simply be used directly by the marshalling layer. Try to make structs blittable (for example, avoid `bool`). For more information, see the [Blittable Types](#blittable-types) section.
 
 *If* the struct is blittable, use `sizeof()` instead of `Marshal.SizeOf<MyStruct>()` for better performance. As mentioned above, you can validate that the type is blittable by attempting to create a pinned `GCHandle`. If the type is not a string or considered blittable, `GCHandle.Alloc` will throw an `ArgumentException`.
 
@@ -330,11 +330,11 @@ Pointers to structs in definitions must either be passed by `ref` or use `unsafe
 
 ❌ AVOID using `System.Delegate` or `System.MulticastDelegate` fields to represent function pointer fields in structures.
 
-Since <xref:System.Delegate?displayProperty=fullName> and <xref:System.MulticastDelegate?displayProperty=fullName> don't have a required signature, they don't guarantee that the delegate passed in will match the signature the native code expects. Additionally, in .NET Framework and .NET Core, marshaling a struct containing a `System.Delegate` or `System.MulticastDelegate` from its native representation to a managed object can destabilize the runtime if the value of the field in the native representation isn't a function pointer that wraps a managed delegate. In .NET 5 and later versions, marshaling a `System.Delegate` or `System.MulticastDelegate` field from a native representation to a managed object is not supported. Use a specific delegate type instead of `System.Delegate` or `System.MulticastDelegate`.
+Since <xref:System.Delegate?displayProperty=fullName> and <xref:System.MulticastDelegate?displayProperty=fullName> don't have a required signature, they don't guarantee that the delegate passed in will match the signature the native code expects. Additionally, in .NET Framework and .NET Core, marshalling a struct containing a `System.Delegate` or `System.MulticastDelegate` from its native representation to a managed object can destabilize the runtime if the value of the field in the native representation isn't a function pointer that wraps a managed delegate. In .NET 5 and later versions, marshalling a `System.Delegate` or `System.MulticastDelegate` field from a native representation to a managed object is not supported. Use a specific delegate type instead of `System.Delegate` or `System.MulticastDelegate`.
 
 ### Fixed Buffers
 
-An array like `INT_PTR Reserved1[2]` has to be marshaled to two `IntPtr` fields, `Reserved1a` and `Reserved1b`. When the native array is a primitive type, we can use the `fixed` keyword to write it a little more cleanly. For example, `SYSTEM_PROCESS_INFORMATION` looks like this in the native header:
+An array like `INT_PTR Reserved1[2]` has to be marshalled to two `IntPtr` fields, `Reserved1a` and `Reserved1b`. When the native array is a primitive type, we can use the `fixed` keyword to write it a little more cleanly. For example, `SYSTEM_PROCESS_INFORMATION` looks like this in the native header:
 
 ```c
 typedef struct _SYSTEM_PROCESS_INFORMATION {
@@ -359,4 +359,4 @@ internal unsafe struct SYSTEM_PROCESS_INFORMATION
 }
 ```
 
-However, there are some gotchas with fixed buffers. Fixed buffers of non-blittable types won't be correctly marshaled, so the in-place array needs to be expanded out to multiple individual fields. Additionally, in .NET Framework and .NET Core before 3.0, if a struct containing a fixed buffer field is nested within a non-blittable struct, the fixed buffer field won't be correctly marshaled to native code.
+However, there are some gotchas with fixed buffers. Fixed buffers of non-blittable types won't be correctly marshalled, so the in-place array needs to be expanded out to multiple individual fields. Additionally, in .NET Framework and .NET Core before 3.0, if a struct containing a fixed buffer field is nested within a non-blittable struct, the fixed buffer field won't be correctly marshalled to native code.

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -130,7 +130,9 @@ You can see if a type is blittable or contains blittable contents by attempting 
 
 ### Blittable types when runtime marshalling is disabled
 
-When [runtime marshalling is disabled](disabled-marshaling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of "types with blittable contents" does not apply when runtime marshalling is disabled.
+When [runtime marshalling is disabled](disabled-marshaling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types and do not have any fields that are marked with `[StructLayout(LayoutKind.Auto)]` are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of types with blittable contents, such as arrays or strings, does not apply when runtime marshalling is disabled. Any type that is not considered blittable by the aforementioned rule is unsupported when runtime marshalling is disabled.
+
+These rules differ from the built-in system primarily in situations where `bool` and `char` are used. When marshalling is disabled, `bool` is passed as a 1-byte value and not normalized and `char` is always passed as a 2-byte value. When runtime marshalling is enabled, `bool` can map to a 1, 2, or 4-byte value and is always normalized, and `char` maps to either a 1 or 2-byte value depending on the [`CharSet`](charset.md).
 
 ✔️ DO make your structures blittable when possible.
 

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -130,7 +130,7 @@ You can see if a type is blittable or contains blittable contents by attempting 
 
 ### Blittable types when runtime marshalling is disabled
 
-When [runtime marshalling is disabled](disabled-marshalling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of "types with blittable contents" does not apply when runtime marshalling is disabled.
+When [runtime marshalling is disabled](disabled-marshaling.md), the rules for which types are blittable are significantly simpler. All types that are [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) types are blittable. All types that are not C# `unmanaged` types are not blittable. The concept of "types with blittable contents" does not apply when runtime marshalling is disabled.
 
 ✔️ DO make your structures blittable when possible.
 

--- a/docs/standard/native-interop/customize-parameter-marshaling.md
+++ b/docs/standard/native-interop/customize-parameter-marshaling.md
@@ -1,17 +1,17 @@
 ---
-title: Customizing parameter marshaling - .NET
+title: Customizing parameter marshalling - .NET
 description: Learn how to customize how .NET marshals your parameters to a native representation.
 ms.date: 01/18/2019
 ms.topic: how-to
 ---
 
-# Customizing parameter marshaling
+# Customizing parameter marshalling
 
-When the .NET runtime's default parameter marshaling behavior doesn't do what you want, use can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute?displayProperty=nameWithType> attribute to customize how your parameters are marshaled. These customization features do not apply when [runtime marshaling is disabled](disabled-marshaling.md).
+When the .NET runtime's default parameter marshalling behavior doesn't do what you want, use can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute?displayProperty=nameWithType> attribute to customize how your parameters are marshalled. These customization features do not apply when [runtime marshalling is disabled](disabled-marshalling.md).
 
 ## Customizing string parameters
 
-.NET has a variety of formats for marshaling strings. These methods are split into distinct sections on C-style strings and Windows-centric string formats.
+.NET has a variety of formats for marshalling strings. These methods are split into distinct sections on C-style strings and Windows-centric string formats.
 
 ### C-Style strings
 
@@ -34,19 +34,19 @@ If you're interacting with WinRT APIs, you can use the <xref:System.Runtime.Inte
 
 ## Customizing array parameters
 
-.NET also provides you multiple ways to marshal array parameters. If you're calling an API that takes a C-style array, use the <xref:System.Runtime.InteropServices.UnmanagedType.LPArray?displayProperty=nameWithType> unmanaged type. If the values in the array need customized marshaling, you can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute.ArraySubType> field on the `[MarshalAs]` attribute for that.
+.NET also provides you multiple ways to marshal array parameters. If you're calling an API that takes a C-style array, use the <xref:System.Runtime.InteropServices.UnmanagedType.LPArray?displayProperty=nameWithType> unmanaged type. If the values in the array need customized marshalling, you can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute.ArraySubType> field on the `[MarshalAs]` attribute for that.
 
-If you're using COM APIs, you'll likely have to marshal your array parameters as `SAFEARRAY*`s. To do so, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.SafeArray?displayProperty=nameWithType> unmanaged type. The default type of the elements of the `SAFEARRAY` can be seen in the table on [customizing `object` fields](./customize-struct-marshaling.md#marshal-systemobject). You can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SafeArraySubType?displayProperty=nameWithType> and <xref:System.Runtime.InteropServices.MarshalAsAttribute.SafeArrayUserDefinedSubType?displayProperty=nameWithType> fields to customize the exact element type of the `SAFEARRAY`.
+If you're using COM APIs, you'll likely have to marshal your array parameters as `SAFEARRAY*`s. To do so, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.SafeArray?displayProperty=nameWithType> unmanaged type. The default type of the elements of the `SAFEARRAY` can be seen in the table on [customizing `object` fields](./customize-struct-marshalling.md#marshal-systemobject). You can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SafeArraySubType?displayProperty=nameWithType> and <xref:System.Runtime.InteropServices.MarshalAsAttribute.SafeArrayUserDefinedSubType?displayProperty=nameWithType> fields to customize the exact element type of the `SAFEARRAY`.
 
 ## Customizing boolean or decimal parameters
 
-For information on marshaling boolean or decimal parameters, see [Customizing structure marshaling](customize-struct-marshaling.md).
+For information on marshalling boolean or decimal parameters, see [Customizing structure marshalling](customize-struct-marshalling.md).
 
 ## Customizing object parameters (Windows-only)
 
 On Windows, the .NET runtime provides a number of different ways to marshal object parameters to native code.
 
-### Marshaling as specific COM interfaces
+### Marshalling as specific COM interfaces
 
 If your API takes a pointer to a COM object, you can use any of the following `UnmanagedType` formats on an `object`-typed parameter to tell .NET to marshal as these specific interfaces:
 
@@ -54,12 +54,12 @@ If your API takes a pointer to a COM object, you can use any of the following `U
 - `IDispatch`
 - `IInspectable`
 
-Additionally, if your type is marked `[ComVisible(true)]` or you're marshaling the `object` type, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.Interface?displayProperty=nameWithType> format to marshal your object as a COM callable wrapper for the COM view of your type.
+Additionally, if your type is marked `[ComVisible(true)]` or you're marshalling the `object` type, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.Interface?displayProperty=nameWithType> format to marshal your object as a COM callable wrapper for the COM view of your type.
 
-### Marshaling to a `VARIANT`
+### Marshalling to a `VARIANT`
 
-If your native API takes a Win32 `VARIANT`, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.Struct?displayProperty=nameWithType> format on your `object` parameter to marshal your objects as `VARIANT`s. See the documentation on [customizing `object` fields](customize-struct-marshaling.md#marshal-systemobject) for a mapping between .NET types and `VARIANT` types.
+If your native API takes a Win32 `VARIANT`, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.Struct?displayProperty=nameWithType> format on your `object` parameter to marshal your objects as `VARIANT`s. See the documentation on [customizing `object` fields](customize-struct-marshalling.md#marshal-systemobject) for a mapping between .NET types and `VARIANT` types.
 
-### Custom marshalers
+### Custom marshallers
 
-If you want to project a native COM interface into a different managed type, you can use the `UnmanagedType.CustomMarshaler` format and an implementation of <xref:System.Runtime.InteropServices.ICustomMarshaler> to provide your own custom marshaling code.
+If you want to project a native COM interface into a different managed type, you can use the `UnmanagedType.CustomMarshaler` format and an implementation of <xref:System.Runtime.InteropServices.ICustomMarshaler> to provide your own custom marshalling code.

--- a/docs/standard/native-interop/customize-parameter-marshaling.md
+++ b/docs/standard/native-interop/customize-parameter-marshaling.md
@@ -7,7 +7,7 @@ ms.topic: how-to
 
 # Customizing parameter marshaling
 
-When the .NET runtime's default parameter marshaling behavior doesn't do what you want, use can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute?displayProperty=nameWithType> attribute to customize how your parameters are marshaled.
+When the .NET runtime's default parameter marshaling behavior doesn't do what you want, use can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute?displayProperty=nameWithType> attribute to customize how your parameters are marshaled. These customization features do not apply when [runtime marshaling is disabled](disabled-marshaling.md).
 
 ## Customizing string parameters
 

--- a/docs/standard/native-interop/customize-struct-marshaling.md
+++ b/docs/standard/native-interop/customize-struct-marshaling.md
@@ -1,5 +1,5 @@
 ---
-title: Customizing structure marshaling - .NET
+title: Customizing structure marshalling - .NET
 description: Learn how to customize how .NET marshals structures to a native representation.
 ms.date: 01/18/2019
 dev_langs:
@@ -7,9 +7,9 @@ dev_langs:
   - "cpp"
 ms.topic: how-to
 ---
-# Customize structure marshaling
+# Customize structure marshalling
 
-Sometimes the default marshaling rules for structures aren't exactly what you need. The .NET runtimes provide a few extension points for you to customize your structure's layout and how fields are marshaled. Customizing structure layout is supported for all scenarios, but customizing field marshalling is only supported for scenarios where runtime marshalling is enabled. If [runtime marshaling is disabled](disabled-marshaling.md), then any field marshalling must be done manually.
+Sometimes the default marshalling rules for structures aren't exactly what you need. The .NET runtimes provide a few extension points for you to customize your structure's layout and how fields are marshalled. Customizing structure layout is supported for all scenarios, but customizing field marshalling is only supported for scenarios where runtime marshalling is enabled. If [runtime marshalling is disabled](disabled-marshalling.md), then any field marshalling must be done manually.
 
 ## Customizing structure layout
 
@@ -17,15 +17,15 @@ Sometimes the default marshaling rules for structures aren't exactly what you ne
 
 ✔️ CONSIDER using `LayoutKind.Sequential` whenever possible.
 
-✔️ DO only use `LayoutKind.Explicit` in marshaling when your native struct also has an explicit layout, such as a union.
+✔️ DO only use `LayoutKind.Explicit` in marshalling when your native struct also has an explicit layout, such as a union.
 
-❌ AVOID using `LayoutKind.Explicit` when marshaling structures on non-Windows platforms if you need to target runtimes before .NET Core 3.0. The .NET Core runtime before 3.0 doesn't support passing explicit structures by value to native functions on Intel or AMD 64-bit non-Windows systems. However, the runtime supports passing explicit structures by reference on all platforms.
+❌ AVOID using `LayoutKind.Explicit` when marshalling structures on non-Windows platforms if you need to target runtimes before .NET Core 3.0. The .NET Core runtime before 3.0 doesn't support passing explicit structures by value to native functions on Intel or AMD 64-bit non-Windows systems. However, the runtime supports passing explicit structures by reference on all platforms.
 
-## Customizing boolean field marshaling
+## Customizing boolean field marshalling
 
 Native code has many different boolean representations. On Windows alone, there are three ways to represent boolean values. The runtime doesn't know the native definition of your structure, so the best it can do is make a guess on how to marshal your boolean values. The .NET runtime provides a way to indicate how to marshal your boolean field. The following examples show how to marshal .NET `bool` to different native boolean types.
 
-Boolean values default to marshaling as a native 4-byte Win32 [`BOOL`](/windows/desktop/winprog/windows-data-types#BOOL) value as shown in the following example:
+Boolean values default to marshalling as a native 4-byte Win32 [`BOOL`](/windows/desktop/winprog/windows-data-types#BOOL) value as shown in the following example:
 
 ```csharp
 public struct WinBool
@@ -95,9 +95,9 @@ struct VariantBool
 > [!NOTE]
 > `VARIANT_BOOL` is different than most bool types in that `VARIANT_TRUE = -1` and `VARIANT_FALSE = 0`. Additionally, all values that aren't equal to `VARIANT_TRUE` are considered false.
 
-## Customizing array field marshaling
+## Customizing array field marshalling
 
-.NET also includes a few ways to customize array marshaling.
+.NET also includes a few ways to customize array marshalling.
 
 By default, .NET marshals arrays as a pointer to a contiguous list of the elements:
 
@@ -134,7 +134,7 @@ struct SafeArrayExample
 
 If you need to customize what type of element is in the `SAFEARRAY`, then you can use the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SafeArraySubType?displayProperty=nameWithType> and <xref:System.Runtime.InteropServices.MarshalAsAttribute.SafeArrayUserDefinedSubType?displayProperty=nameWithType> fields to customize the exact element type of the `SAFEARRAY`.
 
-If you need to marshal the array in-place, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.ByValArray?displayProperty=nameWithType> value to tell the marshaler to marshal the array in-place. When you're using this marshaling, you also must supply a value to the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SizeConst?displayProperty=nameWithType> field  for the number of elements in the array so the runtime can correctly allocate space for the structure.
+If you need to marshal the array in-place, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.ByValArray?displayProperty=nameWithType> value to tell the marshaller to marshal the array in-place. When you're using this marshalling, you also must supply a value to the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SizeConst?displayProperty=nameWithType> field  for the number of elements in the array so the runtime can correctly allocate space for the structure.
 
 ```csharp
 public struct InPlaceArray
@@ -152,11 +152,11 @@ struct InPlaceArray
 ```
 
 > [!NOTE]
-> .NET doesn't support marshaling a variable length array field as a C99 Flexible Array Member.
+> .NET doesn't support marshalling a variable length array field as a C99 Flexible Array Member.
 
-## Customizing string field marshaling
+## Customizing string field marshalling
 
-.NET also provides a wide variety of customizations for marshaling string fields.
+.NET also provides a wide variety of customizations for marshalling string fields.
 
 By default, .NET marshals a string as a pointer to a null-terminated string. The encoding depends on the value of the <xref:System.Runtime.InteropServices.StructLayoutAttribute.CharSet?displayProperty=nameWithType> field in the <xref:System.Runtime.InteropServices.StructLayoutAttribute?displayProperty=nameWithType>. If no attribute is specified, the encoding defaults to an ANSI encoding.
 
@@ -276,7 +276,7 @@ struct BString
 };
 ```
 
-If your API requires you to pass the string in-place in the structure, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.ByValTStr?displayProperty=nameWithType> value. Do note that the encoding for a string marshaled by `ByValTStr` is determined from the `CharSet` attribute. Additionally, it requires that a string length is passed by the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SizeConst?displayProperty=nameWithType> field.
+If your API requires you to pass the string in-place in the structure, you can use the <xref:System.Runtime.InteropServices.UnmanagedType.ByValTStr?displayProperty=nameWithType> value. Do note that the encoding for a string marshalled by `ByValTStr` is determined from the `CharSet` attribute. Additionally, it requires that a string length is passed by the <xref:System.Runtime.InteropServices.MarshalAsAttribute.SizeConst?displayProperty=nameWithType> field.
 
 ```csharp
 [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
@@ -310,9 +310,9 @@ struct DefaultString
 };
 ```
 
-## Customizing decimal field marshaling
+## Customizing decimal field marshalling
 
-If you're working on Windows, you might encounter some APIs that use the native [`CY` or `CURRENCY`](/windows/win32/api/wtypes/ns-wtypes-cy-r1) structure. By default, the .NET `decimal` type marshals to the native [`DECIMAL`](/windows/win32/api/wtypes/ns-wtypes-decimal-r1) structure. However, you can use a <xref:System.Runtime.InteropServices.MarshalAsAttribute> with the <xref:System.Runtime.InteropServices.UnmanagedType.Currency?displayProperty=nameWithType> value to instruct the marshaler to convert a `decimal` value to a native `CY` value.
+If you're working on Windows, you might encounter some APIs that use the native [`CY` or `CURRENCY`](/windows/win32/api/wtypes/ns-wtypes-cy-r1) structure. By default, the .NET `decimal` type marshals to the native [`DECIMAL`](/windows/win32/api/wtypes/ns-wtypes-decimal-r1) structure. However, you can use a <xref:System.Runtime.InteropServices.MarshalAsAttribute> with the <xref:System.Runtime.InteropServices.UnmanagedType.Currency?displayProperty=nameWithType> value to instruct the marshaller to convert a `decimal` value to a native `CY` value.
 
 ```csharp
 public struct Currency
@@ -337,7 +337,7 @@ On Windows, you can marshal `object`-typed fields to native code. You can marsha
 - [`IUnknown*`](/windows/desktop/api/unknwn/nn-unknwn-iunknown)
 - [`IDispatch*`](/windows/desktop/api/oaidl/nn-oaidl-idispatch)
 
-By default, an `object`-typed field will be marshaled to an `IUnknown*` that wraps the object.
+By default, an `object`-typed field will be marshalled to an `IUnknown*` that wraps the object.
 
 ```csharp
 public struct ObjectDefault

--- a/docs/standard/native-interop/customize-struct-marshaling.md
+++ b/docs/standard/native-interop/customize-struct-marshaling.md
@@ -9,7 +9,7 @@ ms.topic: how-to
 ---
 # Customize structure marshaling
 
-Sometimes the default marshaling rules for structures aren't exactly what you need. The .NET runtimes provide a few extension points for you to customize your structure's layout and how fields are marshaled.
+Sometimes the default marshaling rules for structures aren't exactly what you need. The .NET runtimes provide a few extension points for you to customize your structure's layout and how fields are marshaled. Customizing structure layout is supported for all scenarios, but customizing field marshalling is only supported for scenarios where runtime marshalling is enabled. If [runtime marshaling is disabled](disabled-marshaling.md), then any field marshalling must be done manually.
 
 ## Customizing structure layout
 
@@ -259,7 +259,7 @@ struct BString
 };
 ```
 
-When using a WinRT-based API, you may need to marshal a string as an `HSTRING`. Using the <xref:System.Runtime.InteropServices.UnmanagedType.HString?displayProperty=nameWithType> value, you can marshal a string as a `HSTRING`.
+When using a WinRT-based API, you may need to marshal a string as an `HSTRING`. Using the <xref:System.Runtime.InteropServices.UnmanagedType.HString?displayProperty=nameWithType> value, you can marshal a string as a `HSTRING`. `HSTRING` marshalling is only suppported on runtimes with built-in WinRT support. WinRT support was [removed in .NET 5](/core/compatibility/interop/5.0/built-in-support-for-winrt-removed.md), so `HSTRING` marshalling is not supported in .NET 5.0 or newer.
 
 ```csharp
 public struct HString

--- a/docs/standard/native-interop/customize-struct-marshaling.md
+++ b/docs/standard/native-interop/customize-struct-marshaling.md
@@ -259,7 +259,7 @@ struct BString
 };
 ```
 
-When using a WinRT-based API, you may need to marshal a string as an `HSTRING`. Using the <xref:System.Runtime.InteropServices.UnmanagedType.HString?displayProperty=nameWithType> value, you can marshal a string as a `HSTRING`. `HSTRING` marshalling is only suppported on runtimes with built-in WinRT support. WinRT support was [removed in .NET 5](/core/compatibility/interop/5.0/built-in-support-for-winrt-removed.md), so `HSTRING` marshalling is not supported in .NET 5.0 or newer.
+When using a WinRT-based API, you may need to marshal a string as an `HSTRING`. Using the <xref:System.Runtime.InteropServices.UnmanagedType.HString?displayProperty=nameWithType> value, you can marshal a string as a `HSTRING`. `HSTRING` marshalling is only suppported on runtimes with built-in WinRT support. WinRT support was [removed in .NET 5](../../core/compatibility/interop/5.0/built-in-support-for-winrt-removed.md), so `HSTRING` marshalling is not supported in .NET 5.0 or newer.
 
 ```csharp
 public struct HString

--- a/docs/standard/native-interop/disabled-marshaling.md
+++ b/docs/standard/native-interop/disabled-marshaling.md
@@ -25,7 +25,7 @@ When the `DisableRuntimeMarshallingAttribute` is applied to an assembly, the fol
 
 ## Default rules for marshaling common types
 
-When marshalling is disabled, the rules for default marshalling change to much simpler rules. These rules are described below. As mentioned in the [interop best practices documentation](best-practices.md#Blittable-types), blittable types are types with the same layout in managed and native code and as such do not require any marshalling.
+When marshalling is disabled, the rules for default marshalling change to much simpler rules. These rules are described below. As mentioned in the [interop best practices documentation](best-practices.md#blittable-types), blittable types are types with the same layout in managed and native code and as such do not require any marshalling.
 
 | .NET Type | Native Type        |
 |-----------|--------------------|

--- a/docs/standard/native-interop/disabled-marshaling.md
+++ b/docs/standard/native-interop/disabled-marshaling.md
@@ -1,0 +1,45 @@
+---
+title: Disabled runtime marshalling - .NET
+description: Learn how .NET marshals your types to a native representation when runtime marshalling is disabled.
+ms.date: 01/12/2022
+---
+
+# Disabled runtime marshalling
+
+When the [`System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`](xref:System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute) attribute is applied to an assembly, the runtime disables most built-in support for data marshalling between managed and native representations. This document describes the features that are disabled and how .NET types map to native types when marshalling is disabled.
+
+## Scenarios where marshalling is disabled
+
+When the `DisableRuntimeMarshallingAttribute` is applied to an assembly, it affects P/Invokes and Delegate types in the assembly, as well as any calls to unmanaged function pointers in the assembly. It does not affect any P/Invoke or interop delegate types defined in other assemblies. It also does not disable marshalling for the runtime's built-in COM interop support. The built-in COM interop support can be enabled or disabled through a [feature switch](https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md).
+
+### Disabled features
+
+When the `DisableRuntimeMarshallingAttribute` is applied to an assembly, the following attributes will have no effect or throw an exception:
+
+- [`LCIDConversionAttribute`](xref:System.Runtime.InteropServices.LCIDConversionAttribute) on a P/Invoke or a delegate
+- `SetLastError=true` on a P/Invoke
+- `ThrowOnUnmappableChar=true` on a P/Invoke
+- `BestFitMapping=true` on a P/Invoke
+- .NET variadic argument method signatures (varargs)
+- `in`, `ref`, `out` parameters
+
+## Default rules for marshaling common types
+
+When marshalling is disabled, the rules for default marshalling change to much simpler rules. These rules are described below. As mentioned in the [interop best practices documentation](best-practices.md#Blittable-types), blittable types are types with the same layout in managed and native code and as such do not require any marshalling.
+
+| .NET Type | Native Type        |
+|-----------|--------------------|
+| `byte`    | `uint8_t`          |
+| `sbyte`   | `int8_t`           |
+| `short`   | `int16_t`          |
+| `ushort`  | `uint16_t`         |
+| `int`     | `int32_t`          |
+| `uint`    | `uint32_t`         |
+| `long`    | `int64_t`          |
+| `ulong`   | `uint64_t`         |
+| `char`    | `char16_t` (`CharSet` on the P/Invoke has no effect) |
+| `System.IntPtr` | `intptr_t`   |
+| `System.UIntPtr` | `uintptr_t` |
+| `bool`    | `bool`             |
+| User-defined [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) type | Treated as a blittable type |
+| All other types | unsupported  |

--- a/docs/standard/native-interop/disabled-marshalling.md
+++ b/docs/standard/native-interop/disabled-marshalling.md
@@ -23,9 +23,9 @@ When the `DisableRuntimeMarshallingAttribute` is applied to an assembly, the fol
 - .NET variadic argument method signatures (varargs)
 - `in`, `ref`, `out` parameters
 
-## Default rules for marshaling common types
+## Default rules for marshalling common types
 
-When marshalling is disabled, the rules for default marshalling change to much simpler rules. These rules are described below. As mentioned in the [interop best practices documentation](best-practices.md#blittable-types), blittable types are types with the same layout in managed and native code and as such do not require any marshalling. Additionally, these rules cannot be customized with the tools mentioned in [the documentation on customizing parameter marshaling](customize-parameter-marshaling.md).
+When marshalling is disabled, the rules for default marshalling change to much simpler rules. These rules are described below. As mentioned in the [interop best practices documentation](best-practices.md#blittable-types), blittable types are types with the same layout in managed and native code and as such do not require any marshalling. Additionally, these rules cannot be customized with the tools mentioned in [the documentation on customizing parameter marshalling](customize-parameter-marshalling.md).
 
 | C# keyword | .NET Type        | Native Type        |
 |------------|------------------|--------------------|
@@ -41,7 +41,7 @@ When marshalling is disabled, the rules for default marshalling change to much s
 | `nint`     | `System.IntPtr`  | `intptr_t`         |
 | `nuint`    | `System.UIntPtr` | `uintptr_t`        |
 |            | `System.Boolean` | `bool`             |
-|            | User-defined [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) type with no fields with `LayoutKind.Auto` | Treated as a blittable type. All [customized struct marshalling](customize-struct-marshaling.md) is ignored. |
+|            | User-defined [C# `unmanaged`](../../csharp/language-reference/builtin-types/unmanaged-types.md) type with no fields with `LayoutKind.Auto` | Treated as a blittable type. All [customized struct marshalling](customize-struct-marshalling.md) is ignored. |
 |            | All other types  | unsupported        |
 
 ## Examples

--- a/docs/standard/native-interop/index.md
+++ b/docs/standard/native-interop/index.md
@@ -21,6 +21,6 @@ The previous list doesn't cover all of the potential situations and scenarios in
 ## See also
 
 - [Platform Invoke (P/Invoke)](pinvoke.md)
-- [Type marshaling](type-marshaling.md)
+- [Type marshalling](type-marshalling.md)
 - [Native interoperability best practices](best-practices.md)
-- [Disabled runtime marshalling](disabled-marshaling.md)
+- [Disabled runtime marshalling](disabled-marshalling.md)

--- a/docs/standard/native-interop/index.md
+++ b/docs/standard/native-interop/index.md
@@ -23,3 +23,4 @@ The previous list doesn't cover all of the potential situations and scenarios in
 - [Platform Invoke (P/Invoke)](pinvoke.md)
 - [Type marshaling](type-marshaling.md)
 - [Native interoperability best practices](best-practices.md)
+- [Disabled runtime marshalling](disabled-runtime-marshaling.md)

--- a/docs/standard/native-interop/index.md
+++ b/docs/standard/native-interop/index.md
@@ -23,4 +23,4 @@ The previous list doesn't cover all of the potential situations and scenarios in
 - [Platform Invoke (P/Invoke)](pinvoke.md)
 - [Type marshaling](type-marshaling.md)
 - [Native interoperability best practices](best-practices.md)
-- [Disabled runtime marshalling](disabled-runtime-marshaling.md)
+- [Disabled runtime marshalling](disabled-marshaling.md)

--- a/docs/standard/native-interop/type-marshaling.md
+++ b/docs/standard/native-interop/type-marshaling.md
@@ -1,27 +1,27 @@
 ---
-title: Type marshaling - .NET
+title: Type marshalling - .NET
 description: Learn how .NET marshals your types to a native representation.
 ms.date: 01/18/2019
 ---
 
-# Type marshaling
+# Type marshalling
 
-**Marshaling** is the process of transforming types when they need to cross between managed and native code.
+**Marshalling** is the process of transforming types when they need to cross between managed and native code.
 
-Marshaling is needed because the types in the managed and unmanaged code are different. In managed code, for instance, you have a `String`, while in the unmanaged world strings can be Unicode ("wide"), non-Unicode, null-terminated, ASCII, etc. By default, the P/Invoke subsystem tries to do the right thing based on the default behavior, described on this article. However, for those situations where you need extra control, you can employ the [MarshalAs](xref:System.Runtime.InteropServices.MarshalAsAttribute) attribute to specify what is the expected type on the unmanaged side. For instance, if you want the string to be sent as a null-terminated ANSI string, you could do it like this:
+Marshalling is needed because the types in the managed and unmanaged code are different. In managed code, for instance, you have a `String`, while in the unmanaged world strings can be Unicode ("wide"), non-Unicode, null-terminated, ASCII, etc. By default, the P/Invoke subsystem tries to do the right thing based on the default behavior, described on this article. However, for those situations where you need extra control, you can employ the [MarshalAs](xref:System.Runtime.InteropServices.MarshalAsAttribute) attribute to specify what is the expected type on the unmanaged side. For instance, if you want the string to be sent as a null-terminated ANSI string, you could do it like this:
 
 ```csharp
 [DllImport("somenativelibrary.dll")]
 static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);
 ```
 
-If the [`System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`](xref:System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute) attribute is applied to the assembly, the below rules do not apply. See the documentation on [disabled runtime marshalling](disabled-marshaling.md) for information on how .NET values are exposed to native code when this attribute is applied.
+If the [`System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`](xref:System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute) attribute is applied to the assembly, the below rules do not apply. See the documentation on [disabled runtime marshalling](disabled-marshalling.md) for information on how .NET values are exposed to native code when this attribute is applied.
 
-## Default rules for marshaling common types
+## Default rules for marshalling common types
 
-Generally, the runtime tries to do the "right thing" when marshaling to require the least amount of work from you. The following tables describe how each type is marshaled by default when used in a parameter or field. The C99/C++11 fixed-width integer and character types are used to ensure that the following table is correct for all platforms. You can use any native type that has the same alignment and size requirements as these types.
+Generally, the runtime tries to do the "right thing" when marshalling to require the least amount of work from you. The following tables describe how each type is marshalled by default when used in a parameter or field. The C99/C++11 fixed-width integer and character types are used to ensure that the following table is correct for all platforms. You can use any native type that has the same alignment and size requirements as these types.
 
-This first table describes the mappings for various types for whom the marshaling is the same for both P/Invoke and field marshaling.
+This first table describes the mappings for various types for whom the marshalling is the same for both P/Invoke and field marshalling.
 
 | C# keyword  | .NET Type        | Native Type             |
 |-------------|------------------|-------------------------|
@@ -46,14 +46,14 @@ This first table describes the mappings for various types for whom the marshalin
 |             | `System.DateTime` | Win32 `DATE` type |
 |             | `System.Guid` | Win32 `GUID` type |
 
-A few categories of marshaling have different defaults if you're marshaling as a parameter or structure.
+A few categories of marshalling have different defaults if you're marshalling as a parameter or structure.
 
 | .NET Type | Native Type (Parameter) | Native Type (Field) |
 |-----------|-------------------------|---------------------|
 | .NET array | A pointer to the start of an array of native representations of the array elements. | Not allowed without a `[MarshalAs]` attribute|
 | A class with a `LayoutKind` of `Sequential` or `Explicit` | A pointer to the native representation of the class | The native representation of the class |
 
-The following table includes the default marshaling rules that are Windows-only. On non-Windows platforms, you cannot marshal these types.
+The following table includes the default marshalling rules that are Windows-only. On non-Windows platforms, you cannot marshal these types.
 
 | .NET Type | Native Type (Parameter) | Native Type (Field) |
 |-----------|-------------------------|---------------------|
@@ -64,7 +64,7 @@ The following table includes the default marshaling rules that are Windows-only.
 | `System.Collections.IEnumerable` | `IDispatch*` | Not allowed |
 | `System.DateTimeOffset` | `int64_t` representing the number of ticks since midnight on January 1, 1601 | `int64_t` representing the number of ticks since midnight on January 1, 1601 |
 
-Some types can only be marshaled as parameters and not as fields. These types are listed in the following table:
+Some types can only be marshalled as parameters and not as fields. These types are listed in the following table:
 
 | .NET Type | Native Type (Parameter Only) |
 |-----------|------------------------------|
@@ -73,11 +73,11 @@ Some types can only be marshaled as parameters and not as fields. These types ar
 | `System.Runtime.InteropServices.ArrayWithOffset` | `void*` |
 | `System.Runtime.InteropServices.HandleRef` | `void*` |
 
-If these defaults don't do exactly what you want, you can customize how parameters are marshaled. The [parameter marshaling](customize-parameter-marshaling.md) article walks you through how to customize how different parameter types are marshaled.
+If these defaults don't do exactly what you want, you can customize how parameters are marshalled. The [parameter marshalling](customize-parameter-marshalling.md) article walks you through how to customize how different parameter types are marshalled.
 
-## Default marshaling in COM scenarios
+## Default marshalling in COM scenarios
 
-When you are calling methods on COM objects in .NET, the .NET runtime changes the default marshaling rules to match common COM semantics. The following table lists the rules that .NET runtimes uses in COM scenarios:
+When you are calling methods on COM objects in .NET, the .NET runtime changes the default marshalling rules to match common COM semantics. The following table lists the rules that .NET runtimes uses in COM scenarios:
 
 | .NET Type | Native Type (COM method calls) |
 |-----------|--------------------------------|
@@ -89,9 +89,9 @@ When you are calling methods on COM objects in .NET, the .NET runtime changes th
 | .NET array | `SAFEARRAY`                   |
 | `System.String[]` | `SAFEARRAY` of `BSTR`s        |
 
-## Marshaling classes and structs
+## Marshalling classes and structs
 
-Another aspect of type marshaling is how to pass in a struct to an unmanaged method. For instance, some of the unmanaged methods require a struct as a parameter. In these cases, you need to create a corresponding struct or a class in managed part of the world to use it as a parameter. However, just defining the class isn't enough, you also need to instruct the marshaler how to map fields in the class to the unmanaged struct. Here the `StructLayout` attribute becomes useful.
+Another aspect of type marshalling is how to pass in a struct to an unmanaged method. For instance, some of the unmanaged methods require a struct as a parameter. In these cases, you need to create a corresponding struct or a class in managed part of the world to use it as a parameter. However, just defining the class isn't enough, you also need to instruct the marshaller how to map fields in the class to the unmanaged struct. Here the `StructLayout` attribute becomes useful.
 
 ```csharp
 [DllImport("kernel32.dll")]
@@ -131,4 +131,4 @@ typedef struct _SYSTEMTIME {
 } SYSTEMTIME, *PSYSTEMTIME;
 ```
 
-Sometimes the default marshaling for your structure doesn't do what you need. The [Customizing structure marshaling](./customize-struct-marshaling.md) article teaches you how to customize how your structure is marshaled.
+Sometimes the default marshalling for your structure doesn't do what you need. The [Customizing structure marshalling](./customize-struct-marshalling.md) article teaches you how to customize how your structure is marshalled.

--- a/docs/standard/native-interop/type-marshaling.md
+++ b/docs/standard/native-interop/type-marshaling.md
@@ -15,7 +15,7 @@ Marshaling is needed because the types in the managed and unmanaged code are dif
 static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);
 ```
 
-If the [`System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`](xref:System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute) attribute is applied to the assembly, the below rules do not apply. See the documentation on [disabled runtime marshalling](disabled-marshalling.md) for information on how .NET values are exposed to native code when this attribute is applied.
+If the [`System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`](xref:System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute) attribute is applied to the assembly, the below rules do not apply. See the documentation on [disabled runtime marshalling](disabled-marshaling.md) for information on how .NET values are exposed to native code when this attribute is applied.
 
 ## Default rules for marshaling common types
 

--- a/docs/standard/native-interop/type-marshaling.md
+++ b/docs/standard/native-interop/type-marshaling.md
@@ -23,28 +23,28 @@ Generally, the runtime tries to do the "right thing" when marshaling to require 
 
 This first table describes the mappings for various types for whom the marshaling is the same for both P/Invoke and field marshaling.
 
-| .NET Type | Native Type  |
-|-----------|-------------------------|
-| `byte`    | `uint8_t`               |
-| `sbyte`   | `int8_t`                |
-| `short`   | `int16_t`               |
-| `ushort`  | `uint16_t`              |
-| `int`     | `int32_t`               |
-| `uint`    | `uint32_t`              |
-| `long`    | `int64_t`               |
-| `ulong`   | `uint64_t`              |
-| `char`    | Either `char` or `char16_t` depending on the `CharSet` of the P/Invoke or structure. See the [charset documentation](charset.md). |
-| `string`  | Either `char*` or `char16_t*` depending on the `CharSet` of the P/Invoke or structure. See the [charset documentation](charset.md). |
-| `System.IntPtr` | `intptr_t`        |
-| `System.UIntPtr` | `uintptr_t`      |
-| .NET Pointer types (ex. `void*`)  | `void*` |
-| Type derived from `System.Runtime.InteropServices.SafeHandle` | `void*` |
-| Type derived from `System.Runtime.InteropServices.CriticalHandle` | `void*`          |
-| `bool`    | Win32 `BOOL` type       |
-| `decimal` | COM `DECIMAL` struct |
-| .NET Delegate | Native function pointer |
-| `System.DateTime` | Win32 `DATE` type |
-| `System.Guid` | Win32 `GUID` type |
+| C# keyword  | .NET Type        | Native Type             |
+|-------------|------------------|-------------------------|
+| `byte`      | `System.Byte`    | `uint8_t`               |
+| `sbyte`     | `System.SByte`   | `int8_t`                |
+| `short`     | `System.Int16`   | `int16_t`               |
+| `ushort`    | `System.UInt16`  | `uint16_t`              |
+| `int`       | `System.Int32`   | `int32_t`               |
+| `uint`      | `System.UInt32`  | `uint32_t`              |
+| `long`      | `System.Int64`   | `int64_t`               |
+| `ulong`     | `System.UInt64`  | `uint64_t`              |
+| `char`      | `System.Char`    | Either `char` or `char16_t` depending on the `CharSet` of the P/Invoke or structure. See the [charset documentation](charset.md). |
+|             | `System.Char`    | Either `char*` or `char16_t*` depending on the `CharSet` of the P/Invoke or structure. See the [charset documentation](charset.md). |
+| `nint`      | `System.IntPtr`  | `intptr_t`        |
+| `nuint`     | `System.UIntPtr` | `uintptr_t`      |
+|             | .NET Pointer types (ex. `void*`)  | `void*` |
+|             | Type derived from `System.Runtime.InteropServices.SafeHandle` | `void*` |
+|             | Type derived from `System.Runtime.InteropServices.CriticalHandle` | `void*`          |
+|             | `System.Boolean` | Win32 `BOOL` type       |
+| `decimal`   | `System.Decimal` | COM `DECIMAL` struct |
+|             | .NET Delegate | Native function pointer |
+|             | `System.DateTime` | Win32 `DATE` type |
+|             | `System.Guid` | Win32 `GUID` type |
 
 A few categories of marshaling have different defaults if you're marshaling as a parameter or structure.
 
@@ -57,7 +57,7 @@ The following table includes the default marshaling rules that are Windows-only.
 
 | .NET Type | Native Type (Parameter) | Native Type (Field) |
 |-----------|-------------------------|---------------------|
-| `object`  | `VARIANT`               | `IUnknown*`         |
+| `System.Object`  | `VARIANT`               | `IUnknown*`         |
 | `System.Array` | COM interface | Not allowed without a `[MarshalAs]` attribute |
 | `System.ArgIterator` | `va_list` | Not allowed |
 | `System.Collections.IEnumerator` | `IEnumVARIANT*` | Not allowed |
@@ -81,13 +81,13 @@ When you are calling methods on COM objects in .NET, the .NET runtime changes th
 
 | .NET Type | Native Type (COM method calls) |
 |-----------|--------------------------------|
-| `bool`    | `VARIANT_BOOL`                 |
+| `System.Boolean`    | `VARIANT_BOOL`                 |
 | `StringBuilder` | `LPWSTR`                 |
-| `string`  | `BSTR`                         |
+| `System.String`  | `BSTR`                         |
 | Delegate types | `_Delegate*` in .NET Framework. Disallowed in .NET Core and .NET 5+. |
 | `System.Drawing.Color` | `OLECOLOR`        |
 | .NET array | `SAFEARRAY`                   |
-| `string[]` | `SAFEARRAY` of `BSTR`s        |
+| `System.String[]` | `SAFEARRAY` of `BSTR`s        |
 
 ## Marshaling classes and structs
 

--- a/docs/standard/native-interop/type-marshaling.md
+++ b/docs/standard/native-interop/type-marshaling.md
@@ -15,6 +15,8 @@ Marshaling is needed because the types in the managed and unmanaged code are dif
 static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);
 ```
 
+If the [`System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`](xref:System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute) attribute is applied to the assembly, the below rules do not apply. See the documentation on [disabled runtime marshalling](disabled-marshalling.md) for information on how .NET values are exposed to native code when this attribute is applied.
+
 ## Default rules for marshaling common types
 
 Generally, the runtime tries to do the "right thing" when marshaling to require the least amount of work from you. The following tables describe how each type is marshaled by default when used in a parameter or field. The C99/C++11 fixed-width integer and character types are used to ensure that the following table is correct for all platforms. You can use any native type that has the same alignment and size requirements as these types.


### PR DESCRIPTION
## Summary

Add some conceptual documentation for the upcoming `System.Runtime.InteropServices.DisableRuntimeMarshallingAttribute` in our new interop documentation.

This PR is expected to fail until after dotnet/runtime#63320 is merged and dotnet/dotnet-api-docs is updated with API docs including the new attribute.

cc: @dotnet/interop-contrib 