### PR TITLE
Document `DisableImplicitFrameworkDefines` from the .NET SDK

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -366,7 +366,7 @@ The `DisableImplicitFrameworkDefines` property controls whether or not the SDK g
 * Framework with version (`NET48`, `NETSTANDARD2_0`, `NET6_0`)
 * Framework with version minimum bound (`NET48_OR_GREATER`, `NETSTANDARD2_0_OR_GREATER`, `NET6_0_OR_GREATER`)
 
-For more information on Target Framework Monikers and these implicit compiler define symbols, see the [Target frameworks](../../standard/frameworks.md) documentation.
+For more information on target framework monikers and these implicit compiler define symbols, see [Target frameworks](../../standard/frameworks.md).
 
 Additionally, if an operating system-specific Target Framework is specified in the project (for example `net6.0-android`), the following compiler define symbols are generated:
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -376,7 +376,7 @@ Additionally, if you specify an operating system-specific target framework in th
 
 For more information on operating system-specific target framework monikers, see [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
 
-Finally, if your target framework implies support for older target frameworks, preprocessor symbols for those older frameworks are emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `netcoreapp1.0`. So for each of these target frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
+Finally, if your target framework implies support for older target frameworks, preprocessor symbols for those older frameworks are emitted. For example, `net6.0` **implies** support for `net5.0` and so on all the way back to `.netcoreapp1.0`. So for each of these target frameworks, the _Framework with version minimum bound_ symbol will be defined.
 
 ### DocumentationFile
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -368,7 +368,7 @@ The `DisableImplicitFrameworkDefines` property controls whether or not the SDK g
 
 For more information on target framework monikers and these implicit compiler define symbols, see [Target frameworks](../../standard/frameworks.md).
 
-Additionally, if an operating system-specific Target Framework is specified in the project (for example `net6.0-android`), the following compiler define symbols are generated:
+Additionally, if you specify an operating system-specific target framework in the project (for example `net6.0-android`), the following compiler define symbols are generated:
 
 * Platform without version (`ANDROID`, `IOS`, `WINDOWS`)
 * Platform with version (`IOS15_1`)

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -360,15 +360,15 @@ C# compiler options, such as `LangVersion` and `Nullable`, can also be specified
 
 ### DisableImplicitFrameworkDefines
 
-The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates compiler define symbols for the target framework and platform for the .NET project. When this property is set to `true`, compiler define symbols are generated for:
+The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates preprocessor symbols for the target framework and platform for the .NET project. When this property is set to `true`, preprocessor symbols are generated for:
 
 * Framework without version (`NETFRAMEWORK`, `NETSTANDARD`, `NET`)
 * Framework with version (`NET48`, `NETSTANDARD2_0`, `NET6_0`)
 * Framework with version minimum bound (`NET48_OR_GREATER`, `NETSTANDARD2_0_OR_GREATER`, `NET6_0_OR_GREATER`)
 
-For more information on target framework monikers and these implicit compiler define symbols, see [Target frameworks](../../standard/frameworks.md).
+For more information on target framework monikers and these implicit preprocessor symbols, see [Target frameworks](../../standard/frameworks.md).
 
-Additionally, if you specify an operating system-specific target framework in the project (for example `net6.0-android`), the following compiler define symbols are generated:
+Additionally, if you specify an operating system-specific target framework in the project (for example `net6.0-android`), the following preprocessor symbols are generated:
 
 * Platform without version (`ANDROID`, `IOS`, `WINDOWS`)
 * Platform with version (`IOS15_1`)
@@ -376,7 +376,7 @@ Additionally, if you specify an operating system-specific target framework in th
 
 For more information on operating system-specific target framework monikers, see [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
 
-Finally, if your target framework implies support for older target frameworks, compiler define symbols for those older frameworks are emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`. So for each of these target frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
+Finally, if your target framework implies support for older target frameworks, preprocessor symbols for those older frameworks are emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`. So for each of these target frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
 
 ### DocumentationFile
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -360,7 +360,7 @@ C# compiler options, such as `LangVersion` and `Nullable`, can also be specified
 
 ### DisableImplicitFrameworkDefines
 
-The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates compiler define symbols for the Target Framework and Platform for the .NET project. When this property is set to `true`, compiler define symbols are generated for
+The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates compiler define symbols for the target framework and platform for the .NET project. When this property is set to `true`, compiler define symbols are generated for:
 
 * Framework without version (`NETFRAMEWORK`, `NETSTANDARD`, `NET`)
 * Framework with version (`NET48`, `NETSTANDARD2_0`, `NET6_0`)

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -376,7 +376,7 @@ Additionally, if you specify an operating system-specific target framework in th
 
 For more information on operating system-specific target framework monikers, see [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
 
-Finally, if your Target Framework implies support for older Target Frameworks, compiler define symbols for those older frameworks will be emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`, and so for each of these Target Frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
+Finally, if your target framework implies support for older target frameworks, compiler define symbols for those older frameworks are emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`. So for each of these target frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
 
 ### DocumentationFile
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1,7 +1,7 @@
 ---
 title: MSBuild properties for Microsoft.NET.Sdk
 description: Reference for the MSBuild properties and items that are understood by the .NET SDK.
-ms.date: 11/22/2021
+ms.date: 01/13/2022
 ms.topic: reference
 ms.custom: updateeachrelease
 ---
@@ -357,6 +357,18 @@ The following MSBuild properties are documented in this section:
 
 C# compiler options, such as `LangVersion` and `Nullable`, can also be specified as MSBuild properties in your project file. For more information, see [C# compiler options](../../csharp/language-reference/compiler-options/index.md).
 
+### DocumentationFile
+
+The `DocumentationFile` property lets you specify a file name for the XML file that contains the documentation for your library. For IntelliSense to function correctly with your documentation, the file name must be the same as the assembly name and must be in the same directory as the assembly. If you don't specify this property but you do set [GenerateDocumentationFile](#generatedocumentationfile) to `true`, the name of the documentation file defaults to the name of your assembly but with an *.xml* file extension. For this reason, it's often easier to omit this property and use the [GenerateDocumentationFile property](#generatedocumentationfile) instead.
+
+If you specify this property but you set [GenerateDocumentationFile](#generatedocumentationfile) to `false`, the compiler *does not* generate a documentation file. If you specify this property and omit the [GenerateDocumentationFile property](#generatedocumentationfile), the compiler *does* generate a documentation file.
+
+```xml
+<PropertyGroup>
+  <DocumentationFile>path/to/file.xml</DocumentationFile>
+</PropertyGroup>
+```
+
 ### EmbeddedResourceUseDependentUponConvention
 
 The `EmbeddedResourceUseDependentUponConvention` property defines whether resource manifest file names are generated from type information in source files that are co-located with resource files. For example, if *Form1.resx* is in the same folder as *Form1.cs*, and `EmbeddedResourceUseDependentUponConvention` is set to `true`, the generated *.resources* file takes its name from the first type that's defined in *Form1.cs*. For example, if `MyNamespace.Form1` is the first type defined in *Form1.cs*, the generated file name is *MyNamespace.Form1.resources*.
@@ -391,18 +403,6 @@ When a project contains this property set to `True`, the following assembly-leve
 An analyzer warns if this attribute is present on dependencies for projects where `EnablePreviewFeatures` is not set to `True`.
 
 Library authors who intend to ship preview assemblies should set this property to `True`. If an assembly needs to ship with a mixture of preview and non-preview APIs, see the [GenerateRequiresPreviewFeaturesAttribute](#generaterequirespreviewfeaturesattribute) section below.
-
-### DocumentationFile
-
-The `DocumentationFile` property lets you specify a file name for the XML file that contains the documentation for your library. For IntelliSense to function correctly with your documentation, the file name must be the same as the assembly name and must be in the same directory as the assembly. If you don't specify this property but you do set [GenerateDocumentationFile](#generatedocumentationfile) to `true`, the name of the documentation file defaults to the name of your assembly but with an *.xml* file extension. For this reason, it's often easier to omit this property and use the [GenerateDocumentationFile property](#generatedocumentationfile) instead.
-
-If you specify this property but you set [GenerateDocumentationFile](#generatedocumentationfile) to `false`, the compiler *does not* generate a documentation file. If you specify this property and omit the [GenerateDocumentationFile property](#generatedocumentationfile), the compiler *does* generate a documentation file.
-
-```xml
-<PropertyGroup>
-  <DocumentationFile>path/to/file.xml</DocumentationFile>
-</PropertyGroup>
-```
 
 ### GenerateDocumentationFile
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -360,7 +360,7 @@ C# compiler options, such as `LangVersion` and `Nullable`, can also be specified
 
 ### DisableImplicitFrameworkDefines
 
-The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates preprocessor symbols for the target framework and platform for the .NET project. When this property is set to `true`, preprocessor symbols are generated for:
+The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates preprocessor symbols for the target framework and platform for the .NET project. When this property is set to `false` or is unset (which is the default value) preprocessor symbols are generated for:
 
 * Framework without version (`NETFRAMEWORK`, `NETSTANDARD`, `NET`)
 * Framework with version (`NET48`, `NETSTANDARD2_0`, `NET6_0`)

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -376,7 +376,7 @@ Additionally, if you specify an operating system-specific target framework in th
 
 For more information on operating system-specific target framework monikers, see [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
 
-Finally, if your target framework implies support for older target frameworks, preprocessor symbols for those older frameworks are emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`. So for each of these target frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
+Finally, if your target framework implies support for older target frameworks, preprocessor symbols for those older frameworks are emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `netcoreapp1.0`. So for each of these target frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
 
 ### DocumentationFile
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -374,7 +374,7 @@ Additionally, if you specify an operating system-specific target framework in th
 * Platform with version (`IOS15_1`)
 * Platform with version minimum bound (`IOS15_1_OR_GREATER`)
 
-For more information on operating system-specific Target Framework Monikers, see the documentation on [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
+For more information on operating system-specific target framework monikers, see [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
 
 Finally, if your Target Framework implies support for older Target Frameworks, compiler define symbols for those older frameworks will be emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`, and so for each of these Target Frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -348,6 +348,7 @@ For more information about deployment, see [.NET application deployment](../depl
 
 The following MSBuild properties are documented in this section:
 
+- [DisableImplicitFrameworkDefines](#disableimplicitframeworkdefines)
 - [DocumentationFile](#documentationfile)
 - [EmbeddedResourceUseDependentUponConvention](#embeddedresourceusedependentuponconvention)
 - [EnablePreviewFeatures](#enablepreviewfeatures)
@@ -356,6 +357,26 @@ The following MSBuild properties are documented in this section:
 - [OptimizeImplicitlyTriggeredBuild](#optimizeimplicitlytriggeredbuild)
 
 C# compiler options, such as `LangVersion` and `Nullable`, can also be specified as MSBuild properties in your project file. For more information, see [C# compiler options](../../csharp/language-reference/compiler-options/index.md).
+
+### DisableImplicitFrameworkDefines
+
+The `DisableImplicitFrameworkDefines` property controls whether or not the SDK generates compiler define symbols for the Target Framework and Platform for the .NET project. When this property is set to `true`, compiler define symbols are generated for
+
+* Framework without version (`NETFRAMEWORK`, `NETSTANDARD`, `NET`)
+* Framework with version (`NET48`, `NETSTANDARD2_0`, `NET6_0`)
+* Framework with version minimum bound (`NET48_OR_GREATER`, `NETSTANDARD2_0_OR_GREATER`, `NET6_0_OR_GREATER`)
+
+For more information on Target Framework Monikers and these implicit compiler define symbols, see the [Target frameworks](../../standard/frameworks.md) documentation.
+
+Additionally, if an operating system-specific Target Framework is specified in the project (for example `net6.0-android`), the following compiler define symbols are generated:
+
+* Platform without version (`ANDROID`, `IOS`, `WINDOWS`)
+* Platform with version (`IOS15_1`)
+* Platform with version minimum bound (`IOS15_1_OR_GREATER`)
+
+For more information on operating system-specific Target Framework Monikers, see the documentation on [OS-specific TFMs](../../standard/frameworks.md#net-5-os-specific-tfms).
+
+Finally, if your Target Framework implies support for older Target Frameworks, compiler define symbols for those older frameworks will be emitted. For example, `net6.0` implies support for `net5.0` and so on all the way back to `.netcoreapp1.0`, and so for each of these Target Frameworks, the _Framework with version_ and _Framework with version minimum bound_ symbols will be defined.
 
 ### DocumentationFile
 

--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -168,7 +168,7 @@ public class MyClass
 }
 ```
 
-The build system is aware of preprocessor symbols representing the target frameworks shown in the [Supported target framework versions](#supported-target-frameworks) table when you're using SDK-style projects. When using a symbol that represents a .NET Standard, .NET Core, or .NET 5 TFM, replace dots and hyphens with an underscore and change lowercase letters to uppercase (for example, the symbol for `netstandard1.4` is `NETSTANDARD1_4`). Generation of these symbols can be disabled via the `DisableImplicitFrameworkDefines` property. For more information about this property, see the [documentation](../../docs/core/project-sdk/msbuild-props.md#disableimplicitframeworkdefines).
+The build system is aware of preprocessor symbols representing the target frameworks shown in the [Supported target framework versions](#supported-target-frameworks) table when you're using SDK-style projects. When using a symbol that represents a .NET Standard, .NET Core, or .NET 5+ TFM, replace dots and hyphens with an underscore, and change lowercase letters to uppercase (for example, the symbol for `netstandard1.4` is `NETSTANDARD1_4`). You can disable generation of these symbols via the `DisableImplicitFrameworkDefines` property. For more information about this property, see [DisableImplicitFrameworkDefines](../core/project-sdk/msbuild-props.md#disableimplicitframeworkdefines).
 
 The complete list of preprocessor symbols for .NET target frameworks is:
 

--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -168,7 +168,7 @@ public class MyClass
 }
 ```
 
-The build system is aware of preprocessor symbols representing the target frameworks shown in the [Supported target framework versions](#supported-target-frameworks) table when you're using SDK-style projects. When using a symbol that represents a .NET Standard, .NET Core, or .NET 5 TFM, replace dots and hyphens with an underscore and change lowercase letters to uppercase (for example, the symbol for `netstandard1.4` is `NETSTANDARD1_4`).
+The build system is aware of preprocessor symbols representing the target frameworks shown in the [Supported target framework versions](#supported-target-frameworks) table when you're using SDK-style projects. When using a symbol that represents a .NET Standard, .NET Core, or .NET 5 TFM, replace dots and hyphens with an underscore and change lowercase letters to uppercase (for example, the symbol for `netstandard1.4` is `NETSTANDARD1_4`). Generation of these symbols can be disabled via the `DisableImplicitFrameworkDefines` property. For more information about this property, see the [documentation](../../docs/core/project-sdk/msbuild-props.md#disableimplicitframeworkdefines).
 
 The complete list of preprocessor symbols for .NET target frameworks is:
 


### PR DESCRIPTION
## Summary

Covers the logic of the property with examples, linking to relevant documentation of the Target Framework concept.

Fixes #27821 
