### PR TITLE
Update task-based-asynchronous-programming.md

### DIFF
--- a/docs/standard/parallel-programming/task-based-asynchronous-programming.md
+++ b/docs/standard/parallel-programming/task-based-asynchronous-programming.md
@@ -66,7 +66,7 @@ You can also use the <xref:System.Threading.Tasks.TaskFactory.StartNew%2A?displa
 
 For more information, see [How to: Return a Value from a Task](how-to-return-a-value-from-a-task.md).
 
-When you use a lambda expression to create a delegate, you have access to all the variables that are visible at that point in your source code. However, in some cases, most notably within loops, a lambda doesn't capture the variable as expected. It only captures the final value, not the value as it mutates after each iteration. The following example illustrates the problem. It passes a loop counter to a lambda expression that instantiates a `CustomData` object and uses the loop counter as the object's identifier. As the output from the example shows, each `CustomData` object has an identical identifier.
+When you use a lambda expression to create a delegate, you have access to all the variables that are visible at that point in your source code. However, in some cases, most notably within loops, a lambda doesn't capture the variable as expected. It only captures the reference of variable, not the value as it mutates after each iteration. The following example illustrates the problem. It passes a loop counter to a lambda expression that instantiates a `CustomData` object and uses the loop counter as the object's identifier. As the output from the example shows, each `CustomData` object has an identical identifier.
 
 [!code-csharp[TPL_TaskIntro#22](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_taskintro/cs/iteration1b.cs#22)]
 [!code-vb[TPL_TaskIntro#22](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_taskintro/vb/iteration1b.vb#22)]


### PR DESCRIPTION
Lamda expression captures reference of a variable not the last value of variable in the loop.
