### PR TITLE
Update versioning-sdk-msbuild-vs.md

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -39,7 +39,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 > \* MSbuild/Visual Studio supported for longer
 >
 > \*\* When .NET 6 releases, the goal is for the .NET SDK to be functional in version 16.11 for **downlevel** targeting. This means that you're not forced to update your SDK and Visual Studio versions simultaneously. However, you won't be able to target .NET 6 because of limitations in 6.0 features and C#10 features in version 16.11. This compatibility is specifically for targeting 5.0 and below.
-
+>
 > ^ 6.0.300 and newer SDKs require a minimum Visual Studio version of 17.0.
 
 Expect breaking changes that require a new MSBuild and Visual Studio version at least once a year, for each major SDK release. All versions of 5.0.Nxx SDK will load on all versions of Visual Studio and MSBuild from 16.8 - 16.11, as no breaking changes were made during that time. There shouldn't be breaking changes in SDK feature (patch) updates.

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -29,7 +29,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 5.0.2xx          | 16.9               | March '21    | Aug '22   |
 | 5.0.3xx          | 16.10              | May '21      | Aug '21   |
 | 5.0.4xx          | 16.11              | Aug '21      | Feb '22*  |
-| 6.0.100          | 17.0**             | Nov '21      | tbd       |
+| 6.0.100          | 17.0**             | Nov '21      | TBD       |
 | 6.0.200          | 17.1               | Feb '22      | tbd       |
 | 6.0.300          | 17.2^              | tbd          | tbd       |
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -31,7 +31,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 5.0.4xx          | 16.11              | Aug '21      | Feb '22*  |
 | 6.0.100          | 17.0**             | Nov '21      | TBD       |
 | 6.0.200          | 17.1               | Feb '22      | tbd       |
-| 6.0.300          | 17.2^              | tbd          | tbd       |
+| 6.0.300          | 17.2^              | TBD          | TBD       |
 
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -25,13 +25,14 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 2.1.8xx          | 16.2 (No VS)       | July '19     | Aug '21   |
 | 3.1.1xx          | 16.4               | Dec '19      | Oct '21   |
 | 3.1.4xx          | 16.7               | Aug '20      | Dec '22   |
-| 5.0.1xx          | 16.8               | November '20 | Mar '21   |
+| 5.0.1xx          | 16.8               | Nov '20      | Mar '21   |
 | 5.0.2xx          | 16.9               | March '21    | Aug '22   |
 | 5.0.3xx          | 16.10              | May '21      | Aug '21   |
 | 5.0.4xx          | 16.11              | Aug '21      | Feb '22*  |
-| 6.0.1xx          | 17.0**             | Nov. '21     | Jul '23   |
-| 6.0.2xx          | 17.1               |  '21         |           |
-| 6.0.3xx          | 17.2               |  '21         |           |
+| 6.0.100-rc1      | 17.0-preview 4     | Sep '21      | N/A       |
+| 6.0.100          | 17.0**             | Nov '21      | May '23   |
+| 6.0.200          | 17.1               | Feb '22      | May '22   |
+| 6.0.300          | 17.2^              | May '22      | -         |
 
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.
@@ -39,6 +40,8 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 > \* MSbuild/Visual Studio supported for longer
 >
 > \*\* When .NET 6 releases, the goal is for the .NET SDK to be functional in version 16.11 for **downlevel** targeting. This means that you're not forced to update your SDK and Visual Studio versions simultaneously. However, you won't be able to target .NET 6 because of limitations in 6.0 features and C#10 features in version 16.11. This compatibility is specifically for targeting 5.0 and below.
+
+^6.0.300 and newer SDKs will require a minimum VS version of 17.0
 
 Expect breaking changes that require a new MSBuild and Visual Studio version at least once a year, for each major SDK release. All versions of 5.0.Nxx SDK will load on all versions of Visual Studio and MSBuild from 16.8 - 16.11, as no breaking changes were made during that time. There shouldn't be breaking changes in SDK feature (patch) updates.
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -29,10 +29,9 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 5.0.2xx          | 16.9               | March '21    | Aug '22   |
 | 5.0.3xx          | 16.10              | May '21      | Aug '21   |
 | 5.0.4xx          | 16.11              | Aug '21      | Feb '22*  |
-| 6.0.100-rc1      | 17.0-preview 4     | Sep '21      | N/A       |
-| 6.0.100          | 17.0**             | Nov '21      | May '23   |
-| 6.0.200          | 17.1               | Feb '22      | May '22   |
-| 6.0.300          | 17.2^              | May '22      | -         |
+| 6.0.100          | 17.0**             | Nov '21      | tbd       |
+| 6.0.200          | 17.1               | Feb '22      | tbd       |
+| 6.0.300          | 17.2^              | tbd          | tbd       |
 
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -40,7 +40,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 >
 > \*\* When .NET 6 releases, the goal is for the .NET SDK to be functional in version 16.11 for **downlevel** targeting. This means that you're not forced to update your SDK and Visual Studio versions simultaneously. However, you won't be able to target .NET 6 because of limitations in 6.0 features and C#10 features in version 16.11. This compatibility is specifically for targeting 5.0 and below.
 
-^6.0.300 and newer SDKs will require a minimum VS version of 17.0
+> ^ 6.0.300 and newer SDKs require a minimum Visual Studio version of 17.0.
 
 Expect breaking changes that require a new MSBuild and Visual Studio version at least once a year, for each major SDK release. All versions of 5.0.Nxx SDK will load on all versions of Visual Studio and MSBuild from 16.8 - 16.11, as no breaking changes were made during that time. There shouldn't be breaking changes in SDK feature (patch) updates.
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -30,7 +30,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 5.0.3xx          | 16.10              | May '21      | Aug '21   |
 | 5.0.4xx          | 16.11              | Aug '21      | Feb '22*  |
 | 6.0.100          | 17.0**             | Nov '21      | TBD       |
-| 6.0.200          | 17.1               | Feb '22      | tbd       |
+| 6.0.200          | 17.1               | Feb '22      | TBD       |
 | 6.0.300          | 17.2^              | TBD          | TBD       |
 
 > [!NOTE]


### PR DESCRIPTION
Updating this page per changes made by Marc to the version of this doc in the first party wiki...
https://devdiv.visualstudio.com/FirstPartyEngagements/_wiki/wikis/FirstPartyEngagements.wiki?wikiVersion=GBwikiMaster&pagePath=/NET%20Core%20Adoption%20Guide/NET%20Core%20Adoption%20Resources/Guides/MSBuild%2C%20VS%2C%20.NET%20SDK%20Versioning&_a=compare&version=4e1d045532d3fa77cb1a6ffb39b533bb158e89b4
