### PR TITLE
Updated Event Keyword for R2R events

### DIFF
--- a/docs/fundamentals/diagnostics/runtime-method-events.md
+++ b/docs/fundamentals/diagnostics/runtime-method-events.md
@@ -113,8 +113,7 @@ The following table shows the event information:
 
 |Keyword for raising the event|Level|
 |-----------------------------------|-----------|
-|`JITKeyword` (0x10) |Informational (4)|
-|`NGenKeyword` (0x20) |Informational (4)|
+|`CompilationDiagnosticKeyword` (0x2000000000) |Informational (4)|
 
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|
@@ -133,8 +132,7 @@ The following table shows the event information:
 
 |Keyword for raising the event|Level|
 |-----------------------------------|-----------|
-|`JITKeyword` (0x10) |Informational (4)|
-|`NGenKeyword` (0x20) |Informational (4)|
+|`CompilationDiagnosticKeyword` (0x2000000000) |Informational (4)|
 
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|


### PR DESCRIPTION
## Summary

R2R event keyword was changed in https://github.com/dotnet/runtime/commit/0e43cb9f0e3df7c58c8a9d386bfd572383e1b5e2, but not in docs. This PR fixes it.