### PR TITLE
Fix code format in AppDomain_Setup

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/AppDomain_Setup/CS/Test.csproj
+++ b/samples/snippets/csharp/VS_Snippets_CLR/AppDomain_Setup/CS/Test.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net45</TargetFramework>
+    <StartupObject>Test</StartupObject>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_CLR/AppDomain_Setup/CS/setup.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/AppDomain_Setup/CS/setup.cs
@@ -1,23 +1,24 @@
 ﻿using System;
 using System.Security.Policy;
 
-class Test {
+class Test
+{
+    public static void Main()
+    {
+        // <Snippet1>
+        // Set up the AppDomainSetup
+        AppDomainSetup setup = new AppDomainSetup();
+        setup.ApplicationBase = "(some directory)";
+        setup.ConfigurationFile = "(some file)";
 
-   public static void Main() {
-      // <Snippet1>
-      // Set up the AppDomainSetup
-      AppDomainSetup setup = new AppDomainSetup();
-      setup.ApplicationBase = "(some directory)";
-      setup.ConfigurationFile = "(some file)";
+        // Set up the Evidence
+        Evidence baseEvidence = AppDomain.CurrentDomain.Evidence;
+        Evidence evidence = new Evidence(baseEvidence);
+        evidence.AddAssembly("(some assembly)");
+        evidence.AddHost("(some host)");
 
-      // Set up the Evidence
-      Evidence baseEvidence = AppDomain.CurrentDomain.Evidence;
-      Evidence evidence = new Evidence(baseEvidence);
-      evidence.AddAssembly("(some assembly)");
-      evidence.AddHost("(some host)");
-
-      // Create the AppDomain
-      AppDomain newDomain = AppDomain.CreateDomain("newDomain", evidence, setup);
-      // </Snippet1>
-   }
+        // Create the AppDomain
+        AppDomain newDomain = AppDomain.CreateDomain("newDomain", evidence, setup);
+        // </Snippet1>
+    }
 }


### PR DESCRIPTION
## Summary

Fix the code format by `dotnet-format`.

Why I should the .NET Framework 4.5 TargetFramework? Because the `samples\snippets\csharp\VS_Snippets_CLR\AppDomain_Setup\CS\source2.cs` file use the [`CreateDomain(String, Evidence)`](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.createdomain?view=netframework-4.5#system-appdomain-createdomain(system-string-system-security-policy-evidence)) method which removed in .NET 6.

https://github.com/dotnet/docs/blob/75b439071165d3790521f027e0caaeedfffeb1df/samples/snippets/csharp/VS_Snippets_CLR/AppDomain_Setup/CS/source2.cs#L10