### PR TITLE
fix HeapAffinitizeRanges name

### DIFF
--- a/docs/core/run-time-config/garbage-collector.md
+++ b/docs/core/run-time-config/garbage-collector.md
@@ -192,7 +192,7 @@ Example:
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
-| **runtimeconfig.json** | `System.GC.GCHeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:70" | .NET Core 3.0 |
+| **runtimeconfig.json** | `System.GC.HeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:70" | .NET Core 3.0 |
 | **Environment variable** | `COMPlus_GCHeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:70" | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCHeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:70" | .NET 6 |
 
@@ -202,7 +202,7 @@ Example:
 {
    "runtimeOptions": {
       "configProperties": {
-         "System.GC.GCHeapAffinitizeRanges": "0:1-10,0:12,1:50-52,1:70"
+         "System.GC.HeapAffinitizeRanges": "0:1-10,0:12,1:50-52,1:70"
       }
    }
 }


### PR DESCRIPTION
## Summary
fix HeapAffinitizeRanges name in runtimeconfig.json, as noted here: https://github.com/dotnet/runtime/blob/158b26e68681c3b28c6abeb3c9828506222f18fd/src/coreclr/gc/gcconfig.h#L95