### PR TITLE
Add section for telemetry gathered by the Templating Engine

### DIFF
--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -117,7 +117,7 @@ Except for `--verbosity` and `--sdk-package-version`, all the other values are h
 
 ### Template engine telemetry
 
-In addition to the options listed above, the `dotnet new` template instantiation command collects additional data for Microsoft-authored templates (after 2.1.100):
+The `dotnet new` template instantiation command collects additional data for Microsoft-authored templates, starting with .NET Core 2.1.100 SDK:
 
 * `--framework`
 * `--auth`

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -115,6 +115,13 @@ A subset of commands sends selected options if they're used, along with their va
 
 Except for `--verbosity` and `--sdk-package-version`, all the other values are hashed starting with .NET Core 2.1.100 SDK.
 
+### Template Engine telemetry
+
+In addition to the options listed above, the `dotnet new` template instantiation command collects additional data for Microsoft-authored templates (after 2.1.100):
+
+* `--framework`
+* `--auth`
+
 ## .NET CLI/SDK crash exception telemetry collected
 
 If the .NET CLI/SDK crashes, it collects the name of the exception and stack trace of the CLI/SDK code. This information is collected to assess problems and improve the quality of the .NET SDK and CLI. This article provides information about the data we collect. It also provides tips on how users building their own version of the .NET SDK can avoid inadvertent disclosure of personal or sensitive information.

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -115,7 +115,7 @@ A subset of commands sends selected options if they're used, along with their va
 
 Except for `--verbosity` and `--sdk-package-version`, all the other values are hashed starting with .NET Core 2.1.100 SDK.
 
-### Template Engine telemetry
+### Template engine telemetry
 
 In addition to the options listed above, the `dotnet new` template instantiation command collects additional data for Microsoft-authored templates (after 2.1.100):
 


### PR DESCRIPTION
## Summary

After doing some planning about telemetry for the template engine, I realized that we did in fact collect telemetry from users instantiating templates, and we should declare that in the docs alongside the rest of the declarations.