### PR TITLE
The correct values for System.GC.CpuGroup in runtimeconfig.json should be true/false

### DIFF
--- a/docs/core/run-time-config/garbage-collector.md
+++ b/docs/core/run-time-config/garbage-collector.md
@@ -220,7 +220,7 @@ Example:
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
-| **runtimeconfig.json** | `System.GC.CpuGroup` | `0` - disabled<br/>`1` - enabled | .NET 5 |
+| **runtimeconfig.json** | `System.GC.CpuGroup` | `false` - disabled<br/>`true` - enabled | .NET 5 |
 | **Environment variable** | `COMPlus_GCCpuGroup` | `0` - disabled<br/>`1` - enabled | .NET Core 1.0 |
 | **Environment variable** | `DOTNET_GCCpuGroup` | `0` - disabled<br/>`1` - enabled | .NET 6 |
 | **app.config for .NET Framework** | [GCCpuGroup](../../framework/configure-apps/file-schema/runtime/gccpugroup-element.md) | `false` - disabled<br/>`true` - enabled |  |


### PR DESCRIPTION
## Summary

The correct values for `System.GC.CpuGroup` in runtimeconfig.json should be true/false instead of 1/0.

As indicated [here](https://github.com/dotnet/runtime/blob/1d751ba8563fc099c6a75c41687d2f282a05f916/src/coreclr/gc/gcconfig.h#L78), `System.GC.CpuGroup` is a `BOOL_CONFIG`, and therefore it should be written as `true` or `false` in `runtimeconfig.json`. We did the same with `System.GC.Server`.

@dickens-code 