### PR TITLE
Use language keywords instead of upper case type names

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideExtensionMethods/cs/extensionmethods.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideExtensionMethods/cs/extensionmethods.cs
@@ -11,7 +11,7 @@ namespace CustomExtensions
         // This is the extension method.
         // The first parameter takes the "this" modifier
         // and specifies the type for which the method is defined.
-        public static int WordCount(this String str)
+        public static int WordCount(this string str)
         {
             return str.Split(new char[] {' ', '.','?'}, StringSplitOptions.RemoveEmptyEntries).Length;
         }
@@ -108,7 +108,7 @@ namespace ExtensionMethods
 {
     public static class MyExtensions
     {
-        public static int WordCount(this String str)
+        public static int WordCount(this string str)
         {
             return str.Split(new char[] { ' ', '.', '?' },
                              StringSplitOptions.RemoveEmptyEntries).Length;

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideExtensionMethods/cs/extensionmethods.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideExtensionMethods/cs/extensionmethods.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>ExtensionMethods</AssemblyName>
+    <StartupObject>Extension_Methods_Simple.Program</StartupObject>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
We were inconsistent about `String` (in extension parameters) vs `string` (in the array types). This was confusing to at least one person trying to learn extensions from this tutorial, and using `String` isn't great practice anyway, so I corrected the sample to always use `string` instead.