### PR TITLE
remove acronyms clause

### DIFF
--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1301,8 +1301,6 @@ items:
       href: ../../_csharpstandard/standard/normative-references.md
     - name: Terms and definitions
       href: ../../_csharpstandard/standard/terms-and-definitions.md
-    - name: Acronyms and abbreviations
-      href: ../../_csharpstandard/standard/acronyms-and-abbreviations.md
     - name: General description
       href: ../../_csharpstandard/standard/general-description.md
     - name: Conformance


### PR DESCRIPTION
See dotnet/csharpstandard#446

The content has been removed from this clause. The referenced PR will remove the file, which will break our build.
