### PR TITLE
Fix compile in 3DSnippetGallery.

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Wpf/3DGallery_procedural_snip/CSharp/Viewport3DVisualExample.cs
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/3DGallery_procedural_snip/CSharp/Viewport3DVisualExample.cs
@@ -180,7 +180,7 @@ namespace SDKSample
         {
             if (index < 0 || index > _children.Count)
             {
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             return (Visual)_children[index];


### PR DESCRIPTION
## Summary

See [CA2208: Instantiate argument exceptions correctly (code analysis) - .NET | Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2208 )
