### PR TITLE
Clarify .NET runtime config options

### DIFF
--- a/docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage.md
+++ b/docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage.md
@@ -26,9 +26,10 @@ For example, setting an environment variable `Logging:LogLevel:Default` to `Debu
 }
 ```
 
-To access these values from environment variables, the application just needs to call AddEnvironmentVariables on its ConfigurationBuilder when constructing an IConfigurationRoot object.
+To access these values from environment variables, the application just needs to call `AddEnvironmentVariables` on its `ConfigurationBuilder` when constructing an `IConfigurationRoot` object.
 
-Note that environment variables are commonly stored as plain text, so if the machine or process with the environment variables is compromised, the environment variable values will be visible.
+> [!NOTE]
+> Environment variables are commonly stored as plain text, so if the machine or process with the environment variables is compromised, the environment variable values will be visible.
 
 ## Store secrets with the ASP.NET Core Secret Manager
 
@@ -42,7 +43,7 @@ Secrets set by the Secret Manager tool are organized by the `UserSecretsId` prop
 </PropertyGroup>
 ```
 
-Using secrets stored with Secret Manager in an application is accomplished by calling `AddUserSecrets<T>` on the ConfigurationBuilder instance to include secrets for the application in its configuration. The generic parameter T should be a type from the assembly that the UserSecretId was applied to. Usually using `AddUserSecrets<Startup>` is fine.
+Using secrets stored with Secret Manager in an application is accomplished by calling `AddUserSecrets<T>` on the `ConfigurationBuilder` instance to include secrets for the application in its configuration. The generic parameter `T` should be a type from the assembly that the UserSecretId was applied to. Usually, using `AddUserSecrets<Startup>` is fine.
 
 The `AddUserSecrets<Startup>()` is included in the default options for the Development environment when using the `CreateDefaultBuilder` method in *Program.cs*.
 

--- a/docs/architecture/modernize-desktop/migrate-modern-applications.md
+++ b/docs/architecture/modernize-desktop/migrate-modern-applications.md
@@ -11,26 +11,25 @@ In this chapter, we're exploring the most common issues and challenges you can f
 If you just want to update your application to the latest .NET version using a tool and not get into the details of what's happening behind the scenes, feel free to skip this chapter and find step-by-step instructions in the [Example of migrating to .NET](example-migration.md) chapter.
 
 A complex desktop application doesn't work in isolation and needs some kind of interaction with subsystems that may reside on the local machine or on a remote server. It will probably need some kind of database to connect as a persistence
-storage either locally or remotely. With the raise of Internet and service-oriented architectures, it's common to have your application connected to some sort of service residing on a remote server or in the cloud. You may need to access the machine file system to implement some functionality. Alternatively, maybe you're using a piece of functionality that resides inside a COM object outside your application, which is a common scenario if, for example, you're integrating Office assemblies in your app.
+storage either locally or remotely. With the rise of internet and service-oriented architectures, it's common to have your application connected to some sort of service residing on a remote server or in the cloud. You may need to access the machine file system to implement some functionality. Alternatively, maybe you're using a piece of functionality that resides inside a COM object outside your application, which is a common scenario if, for example, you're integrating Office assemblies in your app.
 
-Besides, there are differences in the API surface that is exposed by .NET Framework and .NET, and some features that are available on .NET Framework aren't available on .NET. So, it's important for you to know and take them into account when planning a migration.
+Besides, there are differences in the API surface that is exposed by .NET Framework and .NET, and some features that are available on .NET Framework aren't available on .NET. It's important for you to know and take them into account when planning a migration.
 
 ## Configuration files
 
-Configuration files offer the possibility to store sets of properties that are read at run time and affect the behavior of our apps, such as where to locate a database or how many times to execute a loop. The beauty of this technique is that you can modify some aspects of the application without the need to recode and recompile. This comes in handy when, for example, the same app code runs on a development environment with a certain set of configuration values and in production with a different one.
+Configuration files offer the possibility to store sets of properties that are read at run time and can affect the behavior of your app, such as where to locate a database or how many times to execute a loop. The beauty of this technique is that you can modify some aspects of the application without the need to recode and recompile. This comes in handy when, for example, the same app code runs on a development environment with a certain set of configuration values and in production environment with a different set.
 
 ### Configuration on .NET Framework
 
 If you have a working .NET Framework desktop application, chances are you have an *app.config* file accessed through the <xref:System.Configuration.AppSettingsSection> class from the `System.Configuration` namespace.
 
-Within the .NET Framework infrastructure, there's a hierarchy of configuration files that inherit properties from its parents. You can find a *machine.config* file that defines many properties and configuration sections that can be used
-or overridden in any descendant configuration file.
+Within the .NET Framework infrastructure, there's a hierarchy of configuration files that inherit properties from its parents. You can find a *machine.config* file that defines many properties and configuration sections that can be used or overridden in any descendant configuration file.
 
 ### Configuration on .NET
 
 In the .NET world, there's no *machine.config* file. And even though you can continue to use the old fashioned <xref:System.Configuration> namespace, you may consider switching to the modern <xref:Microsoft.Extensions.Configuration>, which offers a good number of enhancements.
 
-The configuration API supports the concept of configuration provider, which defines the data source to be used to load the configuration. There are different kinds of built-in providers, such as:
+This configuration API supports the concept of a configuration provider, which defines the data source to be used to load the configuration. There are different kinds of built-in providers, such as:
 
 - In-memory .NET objects
 - INI files
@@ -40,23 +39,23 @@ The configuration API supports the concept of configuration provider, which defi
 - Environment variables
 - Encrypted user store
 
- Or you can build your own.
+Or you can build your own.
 
-The new configuration allows a list of name-value pairs that can be grouped into a multi-level hierarchy. Any stored value maps to a string, and there's built-in binding support that allows you to deserialize settings into a custom plain old CLR object (POCO).
+The new configuration API allows a list of name-value pairs that can be grouped into a multi-level hierarchy. Any stored value maps to a string, and there's built-in binding support that allows you to deserialize settings into a custom plain old CLR object (POCO).
 
-The <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> object lets you add as many configuration providers you may need for your application, using a precedence rule to resolve preference. So, the last provider you add in your code will override the others. This is a great feature for managing different environments for execution since you can define different configurations for development, testing and production environments, and manage them on a single function inside your code.
+The <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> object lets you add as many configuration providers as you may need for your application. A precedence rule to resolve preference. So, the last provider you add in your code overrides the others. This is a great feature for managing different environments for execution since you can define different configurations for development, testing, and production environments. And you can manage them on a single function inside your code.
 
-### Migrating Configuration files
+### Migrating configuration files
 
-You can continue to use your existing app.config XML file. However, you could take this opportunity to migrate your configuration to benefit from the several enhancements made on .NET.
+You can continue to use your existing app.config XML file. However, you could take this opportunity to migrate your configuration to benefit from the several enhancements made in .NET.
 
 To migrate from an old-style *app.config* to a new configuration file, you should choose between an XML format and a JSON format.
 
-If you choose XML, the conversion is straightforward. Since the content is the same, just save the *app.config* file with XML as type. Then, change the code that references AppSettings to use the `ConfigurationBuilder` class. This change should be easy.
+If you choose XML, the conversion is straightforward. Since the content is the same, just save the *app.config* file with XML as type. Then, change the code that references `AppSettings` to use the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> class. This change should be easy.
 
-If you want to use a JSON format and you don't want to migrate by hand, there's a tool called [dotnet-config2json](https://www.nuget.org/packages/dotnet-config2json/) available on .NET that can convert an *app.config* file to a JSON configuration file.
+If you want to use a JSON format and you don't want to migrate by hand, there's a tool called [dotnet-config2json](https://www.nuget.org/packages/dotnet-config2json/) that can convert an *app.config* file to a JSON configuration file.
 
-You may also come across some issues when using configuration sections that were defined in the *machine.config* file. For example, consider the following configuration:
+You may come across some issues when using configuration sections that were defined in the *machine.config* file. For example, consider the following configuration:
 
 ```xml
 <configuration>
@@ -77,7 +76,7 @@ You may also come across some issues when using configuration sections that were
 </configuration>
 ```
 
-If you take this configuration to a .NET, you'll get an exception:
+If you take this configuration to a .NET app, you'll get an exception:
 
 > Unrecognized configuration section System.Diagnostics
 
@@ -107,7 +106,7 @@ You can continue to use ODBC on .NET since Microsoft is providing the `System.Da
 
 ### OLE DB
 
-[OLE DB](/previous-versions/windows/desktop/ms722784(v=vs.85)) has been a great way to access various data sources in a uniform manner. But it was based on COM, which is a Windows-only technology, and as such wasn't the best fit for a cross-platform technology such as .NET. It's also unsupported in SQL Server versions 2014 and later. For those reasons, OLE DB won't be supported by .NET.
+[OLE DB](/previous-versions/windows/desktop/ms722784(v=vs.85)) has been a great way to access various data sources in a uniform manner. But it was based on COM, which is a Windows-only technology, and as such wasn't the best fit for a cross-platform technology such as .NET. It's also unsupported in SQL Server versions 2014 and later. For those reasons, OLE DB won't be supported by .NET.
 
 ### ADO.NET
 
@@ -195,9 +194,9 @@ For more information on API compatibility, you can find documentation about brea
 
 ### AppDomains
 
-Application domains (AppDomains) isolate apps from one another. AppDomains require runtime support and are expensive. Creating additional app domains isn't supported. For code isolation, we recommend separate processes or using containers as an alternative. For the dynamic loading of assemblies, we recommend the new <xref:System.Runtime.Loader.AssemblyLoadContext> class.
+Application domains (AppDomains) isolate apps from one another. AppDomains require runtime support and are expensive. Creating additional app domains isn't supported. For code isolation, we recommend separate processes or using containers as an alternative. For the dynamic loading of assemblies, we recommend the new <xref:System.Runtime.Loader.AssemblyLoadContext> class.
 
-To make code migration from .NET Framework easier, .NET exposes some of the `AppDomain` API surface. Some of the APIs function normally (for example, <xref:System.AppDomain.UnhandledException?displayProperty=nameWithType>), some members do nothing (for example, <xref:System.AppDomain.SetCachePath%2A>), and some of them throw <xref:System.PlatformNotSupportedException> (for example, <xref:System.AppDomain.CreateDomain%2A>).
+To make code migration from .NET Framework easier, .NET exposes some of the `AppDomain` API surface. Some of the APIs function normally (for example, <xref:System.AppDomain.UnhandledException?displayProperty=nameWithType>), some members do nothing (for example, <xref:System.AppDomain.SetCachePath%2A>), and some of them throw <xref:System.PlatformNotSupportedException> (for example, <xref:System.AppDomain.CreateDomain%2A>).
 
 ### Remoting
 
@@ -205,7 +204,7 @@ To make code migration from .NET Framework easier, .NET exposes some of the `Ap
 
 For communication across processes, you should consider inter-process communication (IPC) mechanisms as an alternative to Remoting, such as the <xref:System.IO.Pipes?displayProperty=nameWithType> or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class.
 
-Across machines, use a network-based solution as an alternative. Preferably, use a low-overhead plaintext protocol, such as HTTP. The Kestrel web server, the web server used by ASP.NET Core, is an option here.
+Across machines, use a network-based solution as an alternative. Preferably, use a low-overhead plaintext protocol, such as HTTP. The Kestrel web server, the web server used by ASP.NET Core, is an option here.
 
 ### Code Access Security (CAS)
 
@@ -215,7 +214,7 @@ Use security boundaries that are provided by the operating system, such as virtu
 
 ### Security Transparency
 
-Similar to CAS, Security Transparency separates sandboxed code from security critical code in a declarative fashion but is no longer supported as a security boundary.
+Similar to CAS, Security Transparency separates sandboxed code from security critical code in a declarative fashion but is no longer supported as a security boundary.
 
 Use security boundaries that are provided by the operating system, such as virtualization, containers, or user accounts for running processes with the least set of privileges.
 

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -31,8 +31,8 @@ The <xref:Microsoft.Extensions.Configuration.Json.JsonConfigurationProvider> cla
 
 Overloads can specify:
 
-- Whether the file is optional
-- Whether the configuration is reloaded if the file changes
+- Whether the file is optional.
+- Whether the configuration is reloaded if the file changes.
 
 Consider the following code:
 
@@ -46,16 +46,16 @@ The preceding code:
   - `reloadOnChange: true`: The file is reloaded when changes are saved.
 
 > [!IMPORTANT]
-> When adding configuration providers to a builder using <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Add%2A?displayProperty=nameWithType>, the order in which providers are added matters. Earlier configuration providers are overridden by configuration providers added later.
+> When adding configuration providers to a builder using <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Add%2A?displayProperty=nameWithType>, the order in which you add providers matters. Earlier configuration providers are overridden by configuration providers that are added later.
 
 An example *appsettings.json* file with various configuration settings follows:
 
 :::code language="json" source="snippets/configuration/console-json/appsettings.json":::
 
-From the <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder> instance, after configuration providers have been added you can call <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Build?displayProperty=nameWithType> to get the <xref:Microsoft.Extensions.Configuration.IConfigurationRoot> object. The configuration root represents the root of a configuration hierarchy. Sections from the configuration can be bound to instances of .NET objects, and later provided as <xref:Microsoft.Extensions.Options.IOptions%601> through dependency injection.
+From the <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder> instance, after configuration providers have been added, you can call <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Build?displayProperty=nameWithType> to get the <xref:Microsoft.Extensions.Configuration.IConfigurationRoot> object. The configuration root represents the root of a configuration hierarchy. Sections from the configuration can be bound to instances of .NET objects and later provided as <xref:Microsoft.Extensions.Options.IOptions%601> through dependency injection.
 
 > [!NOTE]
-> The _Build Action_ and Copy to _Output Directory_ properties of the JSON file must be set to _Content_ and _Copy if newer (or Copy always)_, respectively.
+> The _Build Action_ and _Copy to Output Directory_ properties of the JSON file must be set to _Content_ and _Copy if newer (or Copy always)_, respectively.
 
 Consider the `TransientFaultHandlingOptions` class defined as follows:
 
@@ -65,7 +65,7 @@ The following code builds the configuration root, binds a section to the `Transi
 
 :::code language="csharp" source="snippets/configuration/console-json/Program.cs" range="16-23":::
 
-The application would write the following sample output:
+The application writes the following sample output:
 
 :::code language="csharp" source="snippets/configuration/console-json/Program.cs" id="Output":::
 

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -21,6 +21,9 @@ Configuration in .NET is performed using one or more [configuration providers](#
 - In-memory .NET objects
 - Third-party providers
 
+> [!NOTE]
+> For information about configuring the .NET runtime itself, see [.NET Runtime configuration settings](../run-time-config/index.md).
+
 ## Configure console apps
 
 New .NET console applications created using [dotnet new](../tools/dotnet-new.md) or Visual Studio by default *do not* expose configuration capabilities. To add configuration in a new .NET console application, [add a package reference](../tools/dotnet-add-package.md) to [`Microsoft.Extensions.Hosting`](https://www.nuget.org/packages/Microsoft.Extensions.Hosting). Modify the *Program.cs* file to match the following code:
@@ -50,10 +53,10 @@ These abstractions are agnostic to their underlying configuration provider (<xre
 
 ### Basic example
 
-To access configuration values in their basic form, without the assistance of the _generic host_ approach, use the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> directly.
+To access configuration values in their basic form, without the assistance of the _generic host_ approach, use the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> type directly.
 
 > [!TIP]
-> The <xref:System.Configuration.ConfigurationBuilder?displayProperty=fullName> is different than the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder?displayProperty=fullName>. All of this content is specific to the `Microsoft.Extensions.*` NuGet packages and namespaces.
+> The <xref:System.Configuration.ConfigurationBuilder?displayProperty=fullName> type is different to the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder?displayProperty=fullName> type. All of this content is specific to the `Microsoft.Extensions.*` NuGet packages and namespaces.
 
 Consider the following C# project:
 
@@ -78,7 +81,7 @@ The preceding C# code:
 - Instantiates a <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder>.
 - Adds the `"appsettings.json"` file to be recognized by the JSON configuration provider.
 - Adds environment variables as being recognized by the Environment Variable configuration provider.
-- The `config` instance is used to get the required `"Settings"` section and get the corresponding `Settings` instance.
+- Gets the required `"Settings"` section and the corresponding `Settings` instance by using the `config` instance.
 
 The `Settings` object is shaped as follows:
 

--- a/docs/core/run-time-config/index.md
+++ b/docs/core/run-time-config/index.md
@@ -1,29 +1,28 @@
 ---
-title: Runtime config options
-description: Learn how to configure .NET applications by using runtime configuration settings.
+title: .NET Runtime config options
+description: Learn how to configure the .NET runtime using configuration settings.
 ms.date: 07/23/2021
 ---
-# .NET runtime configuration settings
+# .NET Runtime configuration settings
 
-.NET 5+ (including .NET Core versions) supports the use of configuration files and environment variables to configure the behavior of .NET applications at run time. Runtime configuration is an attractive option if:
-
-- You don't own or control the source code for an application and therefore are unable to configure it programmatically.
-
-- Multiple instances of your application run at the same time on a single system, and you want to configure each for optimum performance.
+.NET 5+ (including .NET Core versions) supports the use of configuration files and environment variables to configure the behavior of .NET applications at run time.
 
 > [!NOTE]
-> This documentation is a work in progress. If you notice that the information presented here is either incomplete or inaccurate, either [open an issue](https://github.com/dotnet/docs/issues) to let us know about it, or [submit a pull request](https://github.com/dotnet/docs/pulls) to address the issue. For information about submitting pull requests for the dotnet/docs repository, see the [contributor's guide](/contribute/dotnet/dotnet-contribute).
+> The articles in this section concern configuration of the .NET Runtime itself. If you're migrating to .NET Core 3.1 or later and are looking for a replacement for the *app.config* file, or if you simply want a way to use custom configuration values in your .NET app, see the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder?displayProperty=fullName> class.
 
-.NET provides the following mechanisms for configuring application behavior at run time:
+Using these settings is an attractive option if:
+
+- You don't own or control the source code for an application and therefore are unable to configure it programmatically.
+- Multiple instances of your application run at the same time on a single system, and you want to configure each for optimum performance.
+
+.NET provides the following mechanisms for configuring behavior of the .NET runtime:
 
 - The [runtimeconfig.json file](#runtimeconfigjson)
-
 - [MSBuild properties](#msbuild-properties)
-
 - [Environment variables](#environment-variables)
 
 > [!TIP]
-> Configuring a run-time option by using an environment variable applies the setting to all .NET apps. Configuring a run-time option in the *runtimeconfig.json* or project file applies the setting to that application only.
+> Configuring an option by using an environment variable applies the setting to all .NET apps. Configuring an option in the *runtimeconfig.json* or project file applies the setting to that application only.
 
 Some configuration values can also be set programmatically by calling the <xref:System.AppContext.SetSwitch%2A?displayProperty=nameWithType> method.
 

--- a/docs/core/run-time-config/index.md
+++ b/docs/core/run-time-config/index.md
@@ -8,7 +8,7 @@ ms.date: 07/23/2021
 .NET 5+ (including .NET Core versions) supports the use of configuration files and environment variables to configure the behavior of .NET applications at run time.
 
 > [!NOTE]
-> The articles in this section concern configuration of the .NET Runtime itself. If you're migrating to .NET Core 3.1 or later and are looking for a replacement for the *app.config* file, or if you simply want a way to use custom configuration values in your .NET app, see the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder?displayProperty=fullName> class.
+> The articles in this section concern configuration of the .NET Runtime itself. If you're migrating to .NET Core 3.1 or later and are looking for a replacement for the *app.config* file, or if you simply want a way to use custom configuration values in your .NET app, see the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder?displayProperty=fullName> class and [Configuration in .NET](../extensions/configuration.md).
 
 Using these settings is an attractive option if:
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1633,7 +1633,7 @@ items:
       href: ../core/versions/index.md
     - name: .NET version selection
       href: ../core/versions/selection.md
-  - name: Runtime configuration
+  - name: Configure .NET Runtime
     items:
     - name: Settings
       href: ../core/run-time-config/index.md


### PR DESCRIPTION
Fixes #19585 and fixes #19774.

Add links to configuring apps vs. configuring the .NET runtime.