### PR TITLE
Minor changes to the upgrade intro article

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -1,6 +1,6 @@
 ---
-title: Port from .NET Framework to .NET 5
-description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET 5 (and .NET Core 3.1).
+title: Port from .NET Framework to .NET 6
+description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET 6.
 author: adegeo
 ms.date: 05/04/2021
 no-loc: ["package.config", PackageReference]
@@ -10,6 +10,38 @@ no-loc: ["package.config", PackageReference]
 This article provides an overview of what you should consider when porting your code from .NET Framework to .NET (formerly named .NET Core). Porting to .NET from .NET Framework for many projects is relatively straightforward. The complexity of your projects dictates how much work you'll do after the initial migration of the project files.
 
 Projects where the app-model is available in .NET (such as libraries, console apps, and desktop apps) usually require little change. Projects that require a new app model, such as moving to ASP.NET Core from ASP.NET, require more work. Many patterns from the old app model have equivalents that can be used during the conversion.
+
+## Windows desktop technologies
+
+Many applications created for .NET Framework use a desktop technology such as Windows Forms or Windows Presentation Foundation (WPF). Both Windows Forms and WPF have been ported to .NET, but these remain Windows-only technologies.
+
+Consider the following dependencies before you migrate a Windows Forms or WPF application:
+
+01. Project files for .NET use a different format than .NET Framework.
+01. Your project may use an API that isn't available in .NET.
+01. 3rd-party controls and libraries may not have been ported to .NET and remain only available to .NET Framework.
+01. Your project uses a [technology that is no longer available](net-framework-tech-unavailable.md) in .NET.
+
+.NET uses the open-source versions of Windows Forms and WPF and includes enhancements over .NET Framework.
+
+For tutorials on migrating your desktop application to .NET 6, see one of the following articles:
+
+- [Migrate .NET Framework WPF apps to .NET](/dotnet/desktop/wpf/migration/convert-project-from-net-framework?view=netdesktop-6.0&preserve-view=true)
+- [Migrate .NET Framework Windows Forms apps to .NET](/dotnet/desktop/winforms/migration/?view=netdesktop-6.0&preserve-view=true)
+
+## Windows-specific APIs
+
+Applications can still P/Invoke native libraries on platforms supported by .NET. This technology isn't limited to Windows. However, if the library you're referencing is Windows-specific, such as a _user32.dll_ or _kernel32.dll_, then the code only works on Windows. For each platform you want your app to run on, you'll have to either find platform-specific versions, or make your code generic enough to run on all platforms.
+
+When porting an application from .NET Framework to .NET, your application probably used a library provided distributed with the .NET Framework. Many APIs that were available in .NET Framework weren't ported to .NET because they relied on Windows-specific technology, such as the Windows Registry or the GDI+ drawing model.
+
+The **Windows Compatibility Pack** provides a large portion of the .NET Framework API surface to .NET and is provided via the [Microsoft.Windows.Compatibility NuGet package](https://www.nuget.org/packages/Microsoft.Windows.Compatibility).
+
+For more information, see [Use the Windows Compatibility Pack to port code to .NET](windows-compat-pack.md).
+
+## .NET Framework compatibility mode
+
+The .NET Framework compatibility mode was introduced in .NET Standard 2.0. This compatibility mode allows .NET Standard and .NET 5+ (and .NET Core 3.1) projects to reference .NET Framework libraries on Windows-only. Referencing .NET Framework libraries doesn't work for all projects, such as if the library uses Windows Presentation Foundation (WPF) APIs, but it does unblock many porting scenarios. For more information, see the [Analyze your dependencies to port code from .NET Framework to .NET](third-party-deps.md#net-framework-compatibility-mode).
 
 ## Unavailable technologies
 
@@ -40,38 +72,6 @@ There are a few technologies in .NET Framework that don't exist in .NET:
   WF and WCF aren't supported in .NET 5+ (including .NET Core). For alternatives, see [CoreWF](https://github.com/UiPath/corewf) and [CoreWCF](https://github.com/CoreWCF/CoreWCF).
 
 For more information about these unsupported technologies, see [.NET Framework technologies unavailable on .NET Core and .NET 5+](net-framework-tech-unavailable.md).
-
-## Windows desktop technologies
-
-Many applications created for .NET Framework use a desktop technology such as Windows Forms or Windows Presentation Foundation (WPF). Both Windows Forms and WPF have been ported to .NET, but these remain Windows-only technologies.
-
-Consider the following dependencies before you migrate a Windows Forms or WPF application:
-
-01. Project files for .NET use a different format than .NET Framework.
-01. Your project may use an API that isn't available in .NET.
-01. 3rd-party controls and libraries may not have been ported to .NET and remain only available to .NET Framework.
-01. Your project uses a [technology that is no longer available](net-framework-tech-unavailable.md) in .NET.
-
-.NET uses the open-source versions of Windows Forms and WPF and includes enhancements over .NET Framework.
-
-For tutorials on migrating your desktop application to .NET 5, see one of the following articles:
-
-- [Migrate .NET Framework WPF apps to .NET](/dotnet/desktop/wpf/migration/convert-project-from-net-framework?view=netdesktop-6.0&preserve-view=true)
-- [Migrate .NET Framework Windows Forms apps to .NET](/dotnet/desktop/winforms/migration/?view=netdesktop-6.0&preserve-view=true)
-
-## Windows-specific APIs
-
-Applications can still P/Invoke native libraries on platforms supported by .NET. This technology isn't limited to Windows. However, if the library you're referencing is Windows-specific, such as a _user32.dll_ or _kernel32.dll_, then the code only works on Windows. For each platform you want your app to run on, you'll have to either find platform-specific versions, or make your code generic enough to run on all platforms.
-
-When porting an application from .NET Framework to .NET, your application probably used a library provided distributed with the .NET Framework. Many APIs that were available in .NET Framework weren't ported to .NET because they relied on Windows-specific technology, such as the Windows Registry or the GDI+ drawing model.
-
-The **Windows Compatibility Pack** provides a large portion of the .NET Framework API surface to .NET and is provided via the [Microsoft.Windows.Compatibility NuGet package](https://www.nuget.org/packages/Microsoft.Windows.Compatibility).
-
-For more information, see [Use the Windows Compatibility Pack to port code to .NET](windows-compat-pack.md).
-
-## .NET Framework compatibility mode
-
-The .NET Framework compatibility mode was introduced in .NET Standard 2.0. This compatibility mode allows .NET Standard and .NET 5+ (and .NET Core 3.1) projects to reference .NET Framework libraries on Windows-only. Referencing .NET Framework libraries doesn't work for all projects, such as if the library uses Windows Presentation Foundation (WPF) APIs, but it does unblock many porting scenarios. For more information, see the [Analyze your dependencies to port code from .NET Framework to .NET](third-party-deps.md#net-framework-compatibility-mode).
 
 ## Cross-platform
 


### PR DESCRIPTION
- Moved unavailable technologies a little lower so it's not right in your face.
- Fixed the .NET 5 reference