### PR TITLE
Fix protocolMapping ex. to refer to correct config

### DIFF
--- a/docs/framework/wcf/simplified-configuration.md
+++ b/docs/framework/wcf/simplified-configuration.md
@@ -53,7 +53,7 @@ Configuring Windows Communication Foundation (WCF) services can be a complex tas
   
 ```xml  
 <protocolMapping>  
-  <add scheme="http"     binding="basicHttpBinding" bindingConfiguration="MyBindingConfiguration"/>  
+  <add scheme="http"     binding="basicHttpBinding" bindingConfiguration="MyBindingConfig"/>  
   <add scheme="net.tcp"  binding="netTcpBinding"/>  
   <add scheme="net.pipe" binding="netNamedPipeBinding"/>  
   <add scheme="net.msmq" binding="netMSMQBinding"/>  


### PR DESCRIPTION
Fix bindingConfiguration reference in ProtocolMapping example so that it correctly references previous code example.

## Summary

The protocolMapping example refers to a bindingConfiguration mentioned earlier in this document. The current bindingConfiguration value is "MyBindingConfiguration", which is incorrect; the previous example specifies this value as "MyBindingConfig". This fix makes them match, so that the example is clear and correct.

Fixes #Issue_Number (if available)
