### PR TITLE
Disambiguate TFMs from Preprocessor Symbols

### DIFF
--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -121,6 +121,8 @@ You'll notice three major changes here:
 1. There is an `<ItemGroup>` node for the `net40` target pulling in one .NET Framework reference.
 1. There is an `<ItemGroup>` node for the `net45` target pulling in two .NET Framework references.
 
+### Preprocessor Symbols
+
 The build system is aware of the following preprocessor symbols used in `#if` directives:
 
 [!INCLUDE [Preprocessor symbols](../../../includes/preprocessor-symbols.md)]

--- a/includes/preprocessor-symbols.md
+++ b/includes/preprocessor-symbols.md
@@ -12,3 +12,4 @@ ms.custom: "updateeachrelease"
 > * Versionless symbols are defined regardless of the version you're targeting.
 > * Version-specific symbols are only defined for the version you're targeting.
 > * The `<framework>_OR_GREATER` symbols are defined for the version you're targeting and all earlier versions. For example, if you're targeting .NET Framework 2.0, the following symbols are defined: `NET_2_0`, `NET_2_0_OR_GREATER`, `NET_1_1_OR_GREATER`, and `NET_1_0_OR_GREATER`.
+> * These are different from [target framework monikers (TFMs)](../docs/standard/frameworks.md#how-to-specify-a-target-framework), such as those used by the TargetFramework MSBuild property.

--- a/includes/preprocessor-symbols.md
+++ b/includes/preprocessor-symbols.md
@@ -12,4 +12,4 @@ ms.custom: "updateeachrelease"
 > * Versionless symbols are defined regardless of the version you're targeting.
 > * Version-specific symbols are only defined for the version you're targeting.
 > * The `<framework>_OR_GREATER` symbols are defined for the version you're targeting and all earlier versions. For example, if you're targeting .NET Framework 2.0, the following symbols are defined: `NET_2_0`, `NET_2_0_OR_GREATER`, `NET_1_1_OR_GREATER`, and `NET_1_0_OR_GREATER`.
-> * These are different from [target framework monikers (TFMs)](../docs/standard/frameworks.md#how-to-specify-a-target-framework), such as those used by the TargetFramework MSBuild property.
+> * These are different from the target framework monikers (TFMs) used by [the MSBuild `TargetFramework` property](../docs/standard/frameworks.md#supported-target-frameworks) and [NuGet](/nuget/reference/target-frameworks).


### PR DESCRIPTION
## Summary

This confused me for a while trying to work on as it's included right under the project file section of https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-a-target-framework.

Ps. I *think* the link URLs are correct as per [Use links in documentation](https://docs.microsoft.com/en-us/contribute/how-to-write-links), but it seems like GitHub doesn't like cross-repo links.