### PR TITLE
Add links to null safety learn module

### DIFF
--- a/docs/csharp/nullable-migration-strategies.md
+++ b/docs/csharp/nullable-migration-strategies.md
@@ -76,3 +76,5 @@ Several attributes have been added to express additional information about the n
 ## Next steps
 
 Once you've addressed all warnings after enabling annotations, you can set the default context for your project to *enabled*. If you added any pragmas in your code for the nullable annotation or warning context, you can remove them. Over time, you may see new warnings. You may write code that introduces warnings. A library dependency may be  updated for nullable reference types. Those updates will change the types in that library from *nullable oblivious* to either *nonnullable* or *nullable*.
+
+You can also explore these concepts in our learn module on [Nullable safety in C#](https://docs.microsoft.com/learn/modules/csharp-null-safety).

--- a/docs/csharp/nullable-migration-strategies.md
+++ b/docs/csharp/nullable-migration-strategies.md
@@ -77,4 +77,4 @@ Several attributes have been added to express additional information about the n
 
 Once you've addressed all warnings after enabling annotations, you can set the default context for your project to *enabled*. If you added any pragmas in your code for the nullable annotation or warning context, you can remove them. Over time, you may see new warnings. You may write code that introduces warnings. A library dependency may be  updated for nullable reference types. Those updates will change the types in that library from *nullable oblivious* to either *nonnullable* or *nullable*.
 
-You can also explore these concepts in our learn module on [Nullable safety in C#](https://docs.microsoft.com/learn/modules/csharp-null-safety).
+You can also explore these concepts in our learn module on [Nullable safety in C#](/learn/modules/csharp-null-safety).

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -23,6 +23,8 @@ int length = message.Length; // dereferencing "message"
 
 When you dereference a variable whose value is `null`, the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>.
 
+You can also explore these concepts in our learn module on [Nullable safety in C#](https://docs.microsoft.com/learn/modules/csharp-null-safety).
+
 ## Null state analysis
 
 ***Null-state analysis*** tracks the *null-state* of references. This static analysis emits warnings when your code may dereference `null`. You can address these warnings to minimize incidences when the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>. The compiler uses static analysis to determine the *null-state* of a variable. A variable is either *not-null* or *maybe-null*. The compiler determines that a variable is *not-null* in two ways:

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -23,7 +23,7 @@ int length = message.Length; // dereferencing "message"
 
 When you dereference a variable whose value is `null`, the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>.
 
-You can also explore these concepts in our learn module on [Nullable safety in C#](https://docs.microsoft.com/learn/modules/csharp-null-safety).
+You can also explore these concepts in our learn module on [Nullable safety in C#](/learn/modules/csharp-null-safety).
 
 ## Null state analysis
 


### PR DESCRIPTION
Add links from the conceptual null reference types articles to the new null safety in C# learn module.
