### PR TITLE
Document change to ref assembly output directory

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -127,6 +127,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | | RC 1 |
 | [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ | RC 1 |
 | [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ | RC 1 |
+| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ | 6.0.200 |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -5,7 +5,7 @@ ms.date: 07/13/2021
 ---
 # Write reference assemblies to intermediate output
 
-The .NET SDK now writes [reference assemblies](https://docs.microsoft.com/dotnet/standard/assembly/reference-assemblies) to the `IntermediateOutputPath` instead of the `OutDir` by default. This removes these build-time-only artifacts from your runtime-required outputs.
+The .NET SDK now writes [reference assemblies](../../../../standard/assembly/reference-assemblies.md) to the `IntermediateOutputPath` instead of the `OutDir` by default. This change removes these build-time-only artifacts from outputs that you require at run time.
 
 ## Version **introduced**
 

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -1,0 +1,28 @@
+---
+title: "Breaking change: Write reference assemblies to IntermediateOutputPath"
+description: Learn about the breaking change in .NET 6 where reference assemblies are written to the IntermediateOutputPath by default.
+ms.date: 07/13/2021
+---
+# Write reference assemblies to intermediate output
+
+The .NET SDK now writes [reference assemblies](https://docs.microsoft.com/dotnet/standard/assembly/reference-assemblies) to the `IntermediateOutputPath` instead of the `OutDir` by default. This removes these build-time-only artifacts from your runtime-required outputs.
+
+## Version **introduced**
+
+.NET SDK 6.0.200
+
+## Old behavior
+
+Since reference assemblies were added, the .NET SDK has written reference assemblies to the `ref` directory in the `OutDir` of the compilation.
+
+## New behavior
+
+Now, reference assemblies will be written to the `refint` directory of the `IntermediateOutputPath` by default, like many other intermediate artifacts.
+
+## Reason for change
+
+Reference assemblies are not runtime assets, and so don't belong in the `OutDir` directory by default.
+
+## Recommended action
+
+If you have custom build logic and you need to manipulate the reference assemblies, use the `TargetRefPath` property to get the correct path.

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -13,7 +13,7 @@ The .NET SDK now writes [reference assemblies](../../../../standard/assembly/ref
 
 ## Old behavior
 
-Since reference assemblies were added, the .NET SDK has written reference assemblies to the `ref` directory in the `OutDir` of the compilation.
+Since reference assemblies were added, the .NET SDK has written reference assemblies to the `ref` directory in the `OutDir` directory of the compilation.
 
 ## New behavior
 

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -17,7 +17,7 @@ Since reference assemblies were added, the .NET SDK has written reference assemb
 
 ## New behavior
 
-Now, reference assemblies will be written to the `refint` directory of the `IntermediateOutputPath` by default, like many other intermediate artifacts.
+Now, reference assemblies are written to the `refint` directory of the `IntermediateOutputPath` directory by default, like many other intermediate artifacts.
 
 ## Reason for change
 

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -21,7 +21,7 @@ Now, reference assemblies are written to the `refint` directory of the `Intermed
 
 ## Reason for change
 
-Reference assemblies are not run-time assets, and so don't belong in the `OutDir` directory by default.
+Reference assemblies are generally not run-time assets, and so don't belong in the `OutDir` directory by default.
 
 ## Recommended action
 

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -26,3 +26,5 @@ Reference assemblies are not run-time assets, and so don't belong in the `OutDir
 ## Recommended action
 
 If you have custom build logic and you need to manipulate the reference assemblies, use the `TargetRefPath` property to get the correct path.
+
+If an external system requires the reference assembly in `OutDir`, set the property `<ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>`.

--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -21,7 +21,7 @@ Now, reference assemblies are written to the `refint` directory of the `Intermed
 
 ## Reason for change
 
-Reference assemblies are not runtime assets, and so don't belong in the `OutDir` directory by default.
+Reference assemblies are not run-time assets, and so don't belong in the `OutDir` directory by default.
 
 ## Recommended action
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -199,6 +199,8 @@ items:
           href: sdk/6.0/outputtype-not-set-automatically.md
         - name: RuntimeIdentifier warning if self-contained is unspecified
           href: sdk/6.0/runtimeidentifier-self-contained.md
+        - name: Write reference assemblies to IntermediateOutputPath
+          href: sdk/6.0/write-reference-assemblies-to-obj.md
       - name: Serialization
         items:
         - name: Default serialization format for TimeSpan
@@ -893,6 +895,8 @@ items:
           href: sdk/6.0/outputtype-not-set-automatically.md
         - name: RuntimeIdentifier warning if self-contained is unspecified
           href: sdk/6.0/runtimeidentifier-self-contained.md
+        - name: Write reference assemblies to IntermediateOutputPath
+          href: sdk/6.0/write-reference-assemblies-to-obj.md
       - name: .NET 5
         items:
         - name: Directory.Packages.props files imported by default


### PR DESCRIPTION
## Summary

This is a follow up from https://github.com/dotnet/msbuild/issues/7355 about documenting a change to the SDK coming in 6.0.2xx

Paging @rainersigwald for content verification, as I was kind of stitching together context from issue/PR linkages.


