### PR TITLE
Add ref assemblies property

### DIFF
--- a/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
+++ b/docs/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md
@@ -27,4 +27,4 @@ Reference assemblies are generally not run-time assets, and so don't belong in t
 
 If you have custom build logic and you need to manipulate the reference assemblies, use the `TargetRefPath` property to get the correct path.
 
-If an external system requires the reference assembly in `OutDir`, set the property `<ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>`.
+If an external system requires the reference assembly in `OutDir`, set the MSBuild property [ProduceReferenceAssemblyInOutDir](../../../project-sdk/msbuild-props.md#producereferenceassemblyinoutdir) to `true` in your project file.

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -266,6 +266,18 @@ The `PreserveCompilationReferences` property is similar to the [PreserveCompilat
 
 For more information, see [Razor SDK properties](/aspnet/core/razor-pages/sdk#properties).
 
+### ProduceReferenceAssemblyInOutDir
+
+The `ProduceReferenceAssemblyInOutDir` property controls whether reference assemblies are written to the `OutDir` directory. Staring in .NET 6, the default value is `false`, and reference assemblies are only written to the `IntermediateOutputPath` directory. Set the value to `true` to write reference assemblies to the `OutDir` directory.
+
+```xml
+<PropertyGroup>
+  <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+</PropertyGroup>
+```
+
+For more information, see [Write reference assemblies to intermediate output](../compatibility/sdk/6.0/write-reference-assemblies-to-obj.md).
+
 ### RollForward
 
 The `RollForward` property controls how the application chooses a runtime when multiple runtime versions are available. This value is output to the *.runtimeconfig.json* as the `rollForward` setting.

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -152,6 +152,7 @@ The following MSBuild properties are documented in this section:
 - [IsPublishable](#ispublishable)
 - [PreserveCompilationContext](#preservecompilationcontext)
 - [PreserveCompilationReferences](#preservecompilationreferences)
+- [ProduceReferenceAssemblyInOutDir](#producereferenceassemblyinoutdir)
 - [RollForward](#rollforward)
 - [RuntimeFrameworkVersion](#runtimeframeworkversion)
 - [RuntimeIdentifier](#runtimeidentifier)
@@ -268,7 +269,7 @@ For more information, see [Razor SDK properties](/aspnet/core/razor-pages/sdk#pr
 
 ### ProduceReferenceAssemblyInOutDir
 
-The `ProduceReferenceAssemblyInOutDir` property controls whether reference assemblies are written to the `OutDir` directory. Staring in .NET 6, the default value is `false`, and reference assemblies are only written to the `IntermediateOutputPath` directory. Set the value to `true` to write reference assemblies to the `OutDir` directory.
+In .NET 5 and earlier versions, reference assemblies are always written to the `OutDir` directory. In .NET 6 and later versions, you can use the `ProduceReferenceAssemblyInOutDir` property to control whether reference assemblies are written to the `OutDir` directory. The default value is `false`, and reference assemblies are only written to the `IntermediateOutputPath` directory. Set the value to `true` to write reference assemblies to the `OutDir` directory.
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
Follow up to #28057. 

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-28059#producereferenceassemblyinoutdir).