### PR TITLE
Document crossgen/ReadyToRun break in the 6.0 SDK

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -126,6 +126,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Install location for x64 emulated on ARM64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ | RC 2 |
 | [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | | RC 1 |
 | [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ | RC 1 |
+| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ | 6.0.100 |
 | [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ | RC 1 |
 | [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ | 6.0.200 |
 

--- a/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
+++ b/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
@@ -25,5 +25,5 @@ The crossgen binary is not required for many workloads, so it was split out from
 
 ## Recommended action
 
-- If you want to maintain a hermetic publish experience, you need to tell the restore step that you'll be publishing ReadyToRun. Add `-p:ReadyToRun=true` to your restore command line as well.
+- If you want to maintain an isolated publish experience, you need to tell the restore step that you'll be publishing ReadyToRun. Add `-p:ReadyToRun=true` to your restore command line as well.
 - Or, remove `--no-restore` from your publish command line to allow the publish command to restore crossgen as well.

--- a/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
+++ b/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
@@ -17,7 +17,7 @@ In previous versions, the crossgen application was packaged with the runtime. As
 
 ## New behavior
 
-In .NET 6, `dotnet restore` followed by `dotnet publish -p:ReadyToRun=true --no-restore` will fail with the NETSDK1095 error. This is because the crossgen binary is now shipped as a separate NuGet package, and so needs to be part of the restore operation in order for publishing to succeed.
+In .NET 6, `dotnet restore` followed by `dotnet publish -p:ReadyToRun=true --no-restore` will fail with the NETSDK1095 error. This is because the crossgen binary is now shipped as a separate NuGet package, and so needs to be part of the restore operation for publishing to succeed.
 
 ## Reason for change
 

--- a/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
+++ b/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
@@ -1,6 +1,6 @@
 ---
 title: "Breaking change: Publish ReadyToRun with --no-restore requires changes"
-description: Learn about the breaking change in .NET 6 where publishing a project with ReadyToRun requires changes to the way the project is restore.
+description: Learn about the breaking change in .NET 6 where publishing a project with ReadyToRun requires changes to the way the project is restored.
 ms.date: 02/01/2022
 ---
 # Publishing a ReadyToRun project with --no-restore requires changes to the restore

--- a/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
+++ b/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
@@ -1,0 +1,29 @@
+---
+title: "Breaking change: Publishing a ReadyToRun project with --no-restore requires changes to the restore"
+description: Learn about the breaking change in .NET 6 where publishing a project with ReadyToRun requires changes to the way the project is restore.
+ms.date: 02/01/2022
+---
+# Publishing a ReadyToRun project with --no-restore requires changes to the restore
+
+If you publish a project with `-p:ReadyToRun=true` in addition to `--no-restore`, the project will only build with packages that were restored in a prior `dotnet restore` operation. In .NET 5, this process worked and resulted in a crossgen'd binary. In .NET 6, this same process will fail with the NETSDK1095 error.
+
+## Version introduced
+
+.NET 6
+
+## Previous behavior
+
+In previous versions, the crossgen application was packaged with the runtime. As a result, the crossgen process was able to run on your application regardless of if the project had been restored or not. It was a common practice to separate `dotnet restore` from `dotnet publish`, adding `--no-restore` to the publish command to ensure that no additional network accesses occurred.
+
+## New behavior
+
+In .NET 6, `dotnet restore` followed by `dotnet publish -p:ReadyToRun=true --no-restore` will fail with the NETSDK1095 error. This is because the crossgen binary is now shipped as a separate NuGet package, and so needs to be part of the restore operation in order for publishing to succeed.
+
+## Reason for change
+
+The crossgen binary is not required for many workloads, so it was split out from the main SDK.  It it typically acquired on-demand, and the publishing MSBuild targets now handle this acquisition by adding the package to the list of packages to be restored.
+
+## Recommended action
+
+- If you want to maintain a hermetic publish experience, you need to tell the restore step that you'll be publishing ReadyToRun. Add `-p:ReadyToRun=true` to your restore command line as well.
+- Or, remove `--no-restore` from your publish command line to allow the publish command to restore crossgen as well.

--- a/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
+++ b/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
@@ -1,5 +1,5 @@
 ---
-title: "Breaking change: Publishing a ReadyToRun project with --no-restore requires changes to the restore"
+title: "Breaking change: Publish ReadyToRun with --no-restore requires changes"
 description: Learn about the breaking change in .NET 6 where publishing a project with ReadyToRun requires changes to the way the project is restore.
 ms.date: 02/01/2022
 ---

--- a/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
+++ b/docs/core/compatibility/sdk/6.0/publish-readytorun-requires-restore-change.md
@@ -25,5 +25,5 @@ The crossgen binary is not required for many workloads, so it was split out from
 
 ## Recommended action
 
-- If you want to maintain an isolated publish experience, you need to tell the restore step that you'll be publishing ReadyToRun. Add `-p:ReadyToRun=true` to your restore command line as well.
+- If you want to maintain an isolated publish experience, tell the restore step that you'll be publishing ReadyToRun. Add `-p:ReadyToRun=true` to your restore command line as well.
 - Or, remove `--no-restore` from your publish command line to allow the publish command to restore crossgen as well.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -197,6 +197,8 @@ items:
           href: sdk/6.0/calling-gettype-property-functions.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md
+        - name: Publish ReadyToRun with --no-restore requires changes
+          href: sdk/6.0/publish-readytorun-requires-restore-change.md
         - name: RuntimeIdentifier warning if self-contained is unspecified
           href: sdk/6.0/runtimeidentifier-self-contained.md
         - name: Write reference assemblies to IntermediateOutputPath
@@ -893,6 +895,8 @@ items:
           href: sdk/6.0/calling-gettype-property-functions.md
         - name: OutputType not automatically set to WinExe
           href: sdk/6.0/outputtype-not-set-automatically.md
+        - name: Publish ReadyToRun with --no-restore requires changes
+          href: sdk/6.0/publish-readytorun-requires-restore-change.md
         - name: RuntimeIdentifier warning if self-contained is unspecified
           href: sdk/6.0/runtimeidentifier-self-contained.md
         - name: Write reference assemblies to IntermediateOutputPath


### PR DESCRIPTION
## Summary

Document the change to the requirements for the ReadyToRun feature in conjunction with the `publish` command.

Fixes dotnet/sdk#18999 and dotnet/sdk#20701


Tagging @dsplaisted for correctness, as my understanding is secondhand from catching up on issues/PRs.