### PR TITLE
Add Win10 21H2 in installation requirements

### DIFF
--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -47,6 +47,7 @@ For information on the support lifecycle of .NET Framework versions, see [Micros
 | Operating system | Supported editions | Preinstalled with the OS | Installable separately |
 | ---------------- | ------------------ | ------------------------ | ---------------------- |
 | Windows 11<br/> (version 21H2) | 64-bit | .NET Framework 4.8 | -- |
+| Windows 10 November 2021 Update<br/> (version 21H2) | 32-bit and 64-bit | .NET Framework 4.8 | -- |
 | Windows 10 May 2021 Update<br/> (version 21H1) | 32-bit and 64-bit | .NET Framework 4.8 | -- |
 | Windows 10 October 2020 Update<br/> (version 20H2) | 32-bit and 64-bit | .NET Framework 4.8 | -- |
 | Windows 10 May 2020 Update<br/> (version 2004) | 32-bit and 64-bit | .NET Framework 4.8 | -- |


### PR DESCRIPTION
## Summary

.NET Framework can be used in Windows 10 21H2, but this document doesn't discribe that.
So, I added new row in Installation requirements.