### PR TITLE
Document --configfile option for dotnet nuget verify

### DIFF
--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -106,7 +106,7 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
   dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 --certificate-fingerprint EC10992GG5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E027
   ```
 
-- Verify *foo.nupkg* signature using settings (i.e: `packagesources` , `trustedSigners`) only from specified nuget.config:
+- Verify the signature of *foo.nupkg* by using settings (`packagesources` and `trustedSigners`) only from the specified *nuget.config* file:
 
   ```dotnetcli
   dotnet nuget verify foo.nupkg --configfile ..\Settings\nuget.config

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -19,6 +19,7 @@ dotnet nuget verify [<package-path(s)>]
     [--all]
     [--certificate-fingerprint <FINGERPRINT>]
     [-v|--verbosity <LEVEL>]
+    [--configfile <FILE>]
 
 dotnet nuget verify -h|--help
 ```
@@ -75,6 +76,8 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
 
   ❌ indicates details that are **not** displayed. ✔️ indicates details that are displayed.
 
+[!INCLUDE [configfile](../../../includes/cli-configfile.md)]
+
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
 ## Examples
@@ -101,4 +104,10 @@ The `dotnet nuget verify` command verifies a signed NuGet package.
 
   ```dotnetcli
   dotnet nuget verify foo.nupkg --certificate-fingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 --certificate-fingerprint EC10992GG5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E027
+  ```
+
+- Verify *foo.nupkg* signature using settings (i.e: `packagesources` , `trustedSigners`) only from specified nuget.config:
+
+  ```dotnetcli
+  dotnet nuget verify foo.nupkg --configfile ..\Settings\nuget.config
   ```


### PR DESCRIPTION
## Summary

`nuget.exe verify` has configFile option, to reach parity added `configfile` option for `dotnet nuget verify`.

Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2632
