### PR TITLE
fix sample so it adheres to naming conventions

### DIFF
--- a/samples/snippets/csharp/objectoriented/accessmodifiers.cs
+++ b/samples/snippets/csharp/objectoriented/accessmodifiers.cs
@@ -15,12 +15,12 @@
         protected void Pedal() { }
 
         // private field:
-        private int wheels = 3;
+        private int _wheels = 3;
 
         // protected internal property:
         protected internal int Wheels
         {
-            get { return wheels; }
+            get { return _wheels; }
         }
     }
     //</SnippetMethodAccess>


### PR DESCRIPTION
## Summary

prefix private variable with a `_` so it adheres to [coding conventions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#camel-case).

Fixes #28014 
