### PR TITLE
Update environment variable name

### DIFF
--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -30,7 +30,7 @@ There are two main scenarios for populating the properties depending on whether 
 
 Additionally, the *\*.deps.json* files for any referenced frameworks are similarly parsed.
 
-Finally the environment variable `ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an `--additional-deps` optional parameter to set this value on application startup.
+Finally the environment variable `DOTNET_ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an `--additional-deps` optional parameter to set this value on application startup.
 
 The `APP_PATHS` property is not populated by default and is omitted for most applications.
 

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -30,7 +30,7 @@ There are two main scenarios for populating the properties depending on whether 
 
 Additionally, the *\*.deps.json* files for any referenced frameworks are similarly parsed.
 
-Finally the environment variable `DOTNET_ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an `--additional-deps` optional parameter to set this value on application startup.
+The environment variable `DOTNET_ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an optional `--additional-deps` parameter to set this value on application startup.
 
 The `APP_PATHS` property is not populated by default and is omitted for most applications.
 


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_additional_deps the name is DOTNET_ADDITIONAL_DEPS. 

Checked with dotnet 6.0.100, name ADDITIONAL_DEPS doesn't work.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
