### PR TITLE
Update version text in Porting eBook intro

### DIFF
--- a/docs/architecture/porting-existing-aspnet-apps/index.md
+++ b/docs/architecture/porting-existing-aspnet-apps/index.md
@@ -51,7 +51,7 @@ Participants and Reviewers:
 
 ## Version
 
-This guide covers **.NET Core 3.1** and updates related to the same technology "wave" (that is, Azure and other third-party technologies) coinciding in time with the .NET Core 3.1 release. Updating from .NET Core 3.1 to .NET 6 (the current LTS version) is relatively straightforward and certainly will require substantially less effort than porting from .NET Framework to .NET Core. Migrating from .NET Framework 4.x to .NET 6 will be similar to migrating to .NET Core 3.1. For more information, see [choosing the right .NET Core version](choose-net-core-version.md).
+This guide covers **.NET 6* and updates related to the same technology "wave" (that is, Azure and other third-party technologies) coinciding in time with the .NET 6 release. This book covers migration of apps that are currently running on .NET Framework 4.x. Migrating from .NET Framework 4.x to .NET 6 is similar to migrating to .NET Core 3.1, which is discussed as a potential intermediate step later in the book. For more information, see [choosing the right .NET Core version](choose-net-core-version.md).
 
 ## Who should use this guide
 


### PR DESCRIPTION
Refer to .NET 6 instead of .NET Core 3.1.
