### PR TITLE
Breaking change for FullPath

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -23,6 +23,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
+| [FullPath and OldFullPath return fully qualified path](core-libraries/7.0/filesystemeventargs-fullpath.md) | ✔️ | ❌ | Preview 1 |
 | [Validate CompressionLevel for BrotliStream](core-libraries/7.0/compressionlevel-validation.md) | ❌ | ✔️ | Preview 1 |
 
 ## Serialization

--- a/docs/core/compatibility/core-libraries/7.0/filesystemeventargs-fullpath.md
+++ b/docs/core/compatibility/core-libraries/7.0/filesystemeventargs-fullpath.md
@@ -1,0 +1,37 @@
+---
+title: ".NET 7 breaking change: FullPath and OldFullPath return fully qualified path"
+description: Learn about the .NET 7 breaking change in core .NET libraries where the FileSystemEventArgs.FullPath and RenamedEventArgs.OldFullPath properties return fully qualified paths.
+ms.date: 02/08/2022
+---
+# FullPath and OldFullPath return fully qualified path
+
+<xref:System.IO.FileSystemEventArgs.FullPath?displayProperty=nameWithType> and <xref:System.IO.RenamedEventArgs.OldFullPath?displayProperty=nameWithType> return a fully qualified path, even when <xref:System.IO.FileSystemWatcher> is initialized with a relative path. This matches the true intent of these properties.
+
+## Previous behavior
+
+In .NET 6 and previous versions, <xref:System.IO.FileSystemEventArgs.FullPath?displayProperty=nameWithType> and <xref:System.IO.RenamedEventArgs.OldFullPath?displayProperty=nameWithType> mirror what was passed into <xref:System.IO.FileSystemWatcher> initially, which can include a relative path.
+
+## New behavior
+
+Starting in .NET 7, <xref:System.IO.FileSystemEventArgs.FullPath?displayProperty=nameWithType> and <xref:System.IO.RenamedEventArgs.OldFullPath?displayProperty=nameWithType> return a fully qualified path, even when <xref:System.IO.FileSystemWatcher> is initialized with a relative path.
+
+## Version introduced
+
+.NET 7 Preview 1
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change was introduced to align the actual result with the intent and name of the `FullPath` and `OldFullPath` properties from the event arguments.
+
+## Recommended action
+
+Check your usage of <xref:System.IO.FileSystemEventArgs.FullPath?displayProperty=nameWithType> and <xref:System.IO.RenamedEventArgs.OldFullPath?displayProperty=nameWithType> and make sure to account for the path change if necessary.
+
+## Affected APIs
+
+- <xref:System.IO.FileSystemEventArgs.FullPath?displayProperty=fullName>
+- <xref:System.IO.RenamedEventArgs.OldFullPath?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -31,6 +31,8 @@ items:
         items:
         - name: API obsoletions with non-default diagnostic IDs
           href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+        - name: FullPath and OldFullPath return fully qualified path
+          href: core-libraries/7.0/filesystemeventargs-fullpath.md
         - name: Validate CompressionLevel for BrotliStream
           href: core-libraries/7.0/compressionlevel-validation.md
       - name: Serialization
@@ -661,6 +663,8 @@ items:
         items:
         - name: API obsoletions with non-default diagnostic IDs
           href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+        - name: FullPath and OldFullPath return fully qualified path
+          href: core-libraries/7.0/filesystemeventargs-fullpath.md
         - name: Validate CompressionLevel for BrotliStream
           href: core-libraries/7.0/compressionlevel-validation.md
       - name: .NET 6


### PR DESCRIPTION
Fixes #27916.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/filesystemeventargs-fullpath?branch=pr-en-us-28138).

cc @slask