### PR TITLE
fsharp/style/formatting: space (many curried args)

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -213,6 +213,7 @@ someFunction3 z (convertVolumeUSPint z)
 someFunction1(convertVolumeToLiter x)(convertVolumeUSPint x)
 someFunction2(convertVolumeToLiter y) y
 someFunction3 z(convertVolumeUSPint z)
+```
 
 In default formatting conventions, a space is added when applying lower-case functions to tupled or parenthesized arguments (even when a single argument is used):
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -195,10 +195,26 @@ Parentheses should be omitted unless arguments require them:
 someFunction1 x.IngredientName
 
 // ❌ Not preferred - parentheses should be omitted unless required
-someFunction1(x.IngredientName)
+someFunction1 (x.IngredientName)
+
+// ✔️ OK - parentheses are required
+someFunction1 (convertVolumeToLiter x)
 ```
 
-In default formatting conventions, a space is added when applying lower-case functions to tupled or parenthesized arguments:
+Spaces should not be omitted when invoking with multiple curried arguments:
+
+```fsharp
+// ✔️ OK
+someFunction1 (convertVolumeToLiter x) (convertVolumeUSPint x)
+someFunction2 (convertVolumeToLiter y) y
+someFunction3 z (convertVolumeUSPint z)
+
+// ❌ Not preferred - spaces should be not omitted between arguments
+someFunction1(convertVolumeToLiter x)(convertVolumeUSPint x)
+someFunction2(convertVolumeToLiter y) y
+someFunction3 z(convertVolumeUSPint z)
+
+In default formatting conventions, a space is added when applying lower-case functions to tupled or parenthesized arguments (even when a single argument is used):
 
 ```fsharp
 // ✔️ OK

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -209,7 +209,7 @@ someFunction1 (convertVolumeToLiter x) (convertVolumeUSPint x)
 someFunction2 (convertVolumeToLiter y) y
 someFunction3 z (convertVolumeUSPint z)
 
-// ❌ Not preferred - spaces should be not omitted between arguments
+// ❌ Not preferred - spaces should not be omitted between arguments
 someFunction1(convertVolumeToLiter x)(convertVolumeUSPint x)
 someFunction2(convertVolumeToLiter y) y
 someFunction3 z(convertVolumeUSPint z)


### PR DESCRIPTION
## Summary

Makes it explicit to require spaces between function and args, and in between args, when invocation is curried.

Fixes https://github.com/fsharp/fslang-design/issues/643
