### PR TITLE
Breaking change for ScaleControl

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -149,6 +149,6 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ | Preview 4 |
 | [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ | RC 2 |
 | [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ | Preview 1 |
-| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing |
+| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing 6.0.101 |
 | [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1-4 |
 | [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ | Preview 1 |

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -149,5 +149,6 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ | Preview 4 |
 | [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ | RC 2 |
 | [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ | Preview 1 |
+| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing |
 | [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1-4 |
 | [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ | Preview 1 |

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -227,6 +227,8 @@ items:
           href: windows-forms/6.0/listview-invalidoperationexception.md
         - name: NotifyIcon.Text maximum text length increased
           href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
+        - name: ScaleControl called only when needed
+          href: windows-forms/6.0/optimize-scalecontrol-calls.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
         - name: TreeNodeCollection.Item throws exception if node is assigned elsewhere
@@ -985,6 +987,8 @@ items:
           href: windows-forms/6.0/listview-invalidoperationexception.md
         - name: NotifyIcon.Text maximum text length increased
           href: windows-forms/6.0/notifyicon-text-max-text-length-increased.md
+        - name: ScaleControl called only when needed
+          href: windows-forms/6.0/optimize-scalecontrol-calls.md
         - name: TableLayoutSettings properties throw InvalidEnumArgumentException
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
         - name: TreeNodeCollection.Item throws exception if node is assigned elsewhere

--- a/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
+++ b/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
@@ -13,7 +13,7 @@ Scaling is usually needed only when an application is running in <xref:System.Wi
 
 ## Old behavior
 
-In .NET 6 GA release and earlier versions, the virtual, public API <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called every time <xref:System.Windows.Forms.ContainerControl.PerformAutoScale> was called on the container control of the application. That is, the method was called every time there way a layout or font change, regardless of whether scaling was needed.
+In .NET 6 GA release and earlier versions, the virtual, public API <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called every time <xref:System.Windows.Forms.ContainerControl.PerformAutoScale> was called on the container control of the application. That is, the method was called every time there is a layout or font change, regardless of whether scaling was needed.
 
 ## New behavior
 

--- a/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
+++ b/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: Virtual method call optimized"
+description: Learn about the breaking change in .NET 6 for Windows Forms where ScaleControl is only called if scaling is needed.
+ms.date: 02/08/2022
+---
+# ScaleControl called only when needed
+
+Scaling is usually needed only when an application is running in `SystemAware /PermonitorV2` modes, and the monitor where the app is going to render has custom DPI settings that differ from the machine where the app was designed. In these scenarios, the Windows Forms runtime calculates the scale factor, based on custom DPI settings of the monitor, and calls <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> with the new scale factor. To improve performance, `ScaleControl` is now called only when the calculated scale factor is other than 1.0F (that is, scaling is needed).
+
+## Version introduced
+
+.NET 6 servicing
+
+## Old behavior
+
+In .NET 6 GA release and earlier versions, the virtual, public API <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called every time <xref:System.Windows.Forms.ContainerControl.PerformAutoScale> was called on the container control of the application. That is, the method was called every time there way a layout or font change. <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called regardless of whether scaling was needed.
+
+## New behavior
+
+Starting in .NET 6 servicing releases, <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> is called only when there's a need to scale the form or control. The Windows Forms runtime calculates the scale factor based on the custom DPI settings of the monitor and the DPI settings of the monitor on which the application was designed. <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> is called only if the scale factor indicates that scaling is required.
+
+## Change category
+
+This change affects [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change was made to improve performance and avoid unnecessary layouts.
+
+## Recommended action
+
+Revisit your code and use alternative if they are performing any non scaling custom actions in these overridable methods.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
+++ b/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
@@ -5,7 +5,7 @@ ms.date: 02/08/2022
 ---
 # ScaleControl called only when needed
 
-Scaling is usually needed only when an application is running in `SystemAware /PermonitorV2` modes, and the monitor where the app is going to render has custom DPI settings that differ from the machine where the app was designed. In these scenarios, the Windows Forms runtime calculates the scale factor, based on custom DPI settings of the monitor, and calls <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> with the new scale factor. To improve performance, `ScaleControl` is now called only when the calculated scale factor is other than 1.0F (that is, scaling is needed). This change can break your app if it overrides `ScaleControl` and performs any custom actions in the override.
+Scaling is usually needed only when an application is running in <xref:System.Windows.Forms.HighDpiMode.SystemAware> or <xref:System.Windows.Forms.HighDpiMode.PerMonitorV2> mode and the monitor has custom DPI settings that differ from the machine where the app was designed. In these scenarios, the Windows Forms runtime calculates the scale factor, based on custom DPI settings of the monitor, and calls <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> with the new scale factor. To improve performance, `ScaleControl` is now called only when the calculated scale factor is something other than 1.0F (that is, scaling is needed). This change can break your app if it overrides `ScaleControl` and performs any custom actions in the override.
 
 ## Version introduced
 
@@ -13,7 +13,7 @@ Scaling is usually needed only when an application is running in `SystemAware /P
 
 ## Old behavior
 
-In .NET 6 GA release and earlier versions, the virtual, public API <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called every time <xref:System.Windows.Forms.ContainerControl.PerformAutoScale> was called on the container control of the application. That is, the method was called every time there way a layout or font change. <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called regardless of whether scaling was needed.
+In .NET 6 GA release and earlier versions, the virtual, public API <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> was called every time <xref:System.Windows.Forms.ContainerControl.PerformAutoScale> was called on the container control of the application. That is, the method was called every time there way a layout or font change, regardless of whether scaling was needed.
 
 ## New behavior
 

--- a/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
+++ b/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
@@ -5,7 +5,7 @@ ms.date: 02/08/2022
 ---
 # ScaleControl called only when needed
 
-Scaling is usually needed only when an application is running in `SystemAware /PermonitorV2` modes, and the monitor where the app is going to render has custom DPI settings that differ from the machine where the app was designed. In these scenarios, the Windows Forms runtime calculates the scale factor, based on custom DPI settings of the monitor, and calls <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> with the new scale factor. To improve performance, `ScaleControl` is now called only when the calculated scale factor is other than 1.0F (that is, scaling is needed).
+Scaling is usually needed only when an application is running in `SystemAware /PermonitorV2` modes, and the monitor where the app is going to render has custom DPI settings that differ from the machine where the app was designed. In these scenarios, the Windows Forms runtime calculates the scale factor, based on custom DPI settings of the monitor, and calls <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)> with the new scale factor. To improve performance, `ScaleControl` is now called only when the calculated scale factor is other than 1.0F (that is, scaling is needed). This change can break your app if it overrides `ScaleControl` and performs any custom actions in the override.
 
 ## Version introduced
 
@@ -29,8 +29,8 @@ This change was made to improve performance and avoid unnecessary layouts.
 
 ## Recommended action
 
-Revisit your code and use alternative if they are performing any non scaling custom actions in these overridable methods.
+Check if your code performs any custom, non-scaling actions in these overridable methods.
 
 ## Affected APIs
 
-N/A
+- <xref:System.Windows.Forms.Form.ScaleControl(System.Drawing.SizeF,System.Windows.Forms.BoundsSpecified)?displayProperty=fullName>

--- a/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
+++ b/docs/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls.md
@@ -9,7 +9,7 @@ Scaling is usually needed only when an application is running in <xref:System.Wi
 
 ## Version introduced
 
-.NET 6 servicing
+.NET 6 servicing 6.0.101
 
 ## Old behavior
 


### PR DESCRIPTION
Fixes #28115.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/6.0/optimize-scalecontrol-calls?branch=pr-en-us-28142).