### PR TITLE
Unity 2021.2 supports .NET Standard 2.1

### DIFF
--- a/includes/net-standard-2.1.md
+++ b/includes/net-standard-2.1.md
@@ -9,7 +9,7 @@
 | Xamarin.Mac                 | 5.16               |
 | Xamarin.Android             | 10.0               |
 | Universal Windows Platform  | TBD                |
-| Unity                       | N/A                |
+| Unity                       | 2021.2             |
 
 <sup>1</sup> The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/main/release-notes/download-archives) if you cannot upgrade to Visual Studio 2017 or a later version.
 


### PR DESCRIPTION
See also #25496.