### PR TITLE
Clarify format specifiers in interpolated-strings.md

### DIFF
--- a/docs/fsharp/language-reference/interpolated-strings.md
+++ b/docs/fsharp/language-reference/interpolated-strings.md
@@ -53,8 +53,6 @@ printfn $"Name: %s{age}, Age: %d{name}"
 
 In the previous example, the code mistakenly passes the `age` value where `name` should be, and vice/versa. Because the interpolated strings use format specifiers, this is a compile error instead of a subtle runtime bug.
 
-All format specifiers covered in [plaintext formatting](plaintext-formatting.md) are valid inside of an interpolated string.
-
 ## Verbatim interpolated strings
 
 F# supports verbatim interpolated strings with triple quotes so that you can embed string literals.
@@ -63,6 +61,35 @@ F# supports verbatim interpolated strings with triple quotes so that you can emb
 let age = 30
 
 printfn $"""Name: {"Phillip"}, Age: %d{age}"""
+```
+
+## Format specifiers
+
+Format specifiers can either be printf-style or .NET-style. Printf-style specifiers are those covered in [plaintext formatting](plaintext-formatting.md), placed before the braces. For example:
+
+```fsharp
+let pi = $"%0.3f{System.Math.PI}"  // "3.142"
+let code = $"0x%08x{43962}"  // "0x0000abba"
+```
+
+The format specifier `%A` is particularly useful for producing diagnostic output of structured F# data.
+
+```fsharp
+let data = [0..4]
+let output = $"The data is %A{data}"  // "The data is [0; 1; 2; 3; 4]"
+```
+
+.NET-style specifiers are those usable with [String.Format](https://docs.microsoft.com/dotnet/api/system.string.format), placed after a `:` within the braces. For example:
+
+```fsharp
+let pi = $"{System.Math.PI:N4}"  // "3.1416"
+let now = $"{System.DateTime.UtcNow:``yyyyMMdd``}" // e.g. "20220210"
+```
+
+If a .NET alignment contains an unusual character, then it can be escaped using double-backticks:
+
+```fsharp
+let nowDashes = $"{System.DateTime.UtcNow:``yyyy-MM-dd``}" // e.g. "2022-02-10"
 ```
 
 ## Aligning expressions in interpolated strings
@@ -97,3 +124,4 @@ Note that the type annotation must be on the interpolated string expression itse
 ## See also
 
 * [Strings](strings.md)
+* [F# RFC FS-1001 - Interpolated strings](https://github.com/fsharp/fslang-design/blob/main/FSharp-5.0/FS-1001-StringInterpolation.md)


### PR DESCRIPTION
General clarifications and links for format specifiers, plus specific clarification for https://github.com/dotnet/fsharp/issues/10449
