### PR TITLE
Remove ref to JSON DOM as read-only

### DIFF
--- a/docs/standard/serialization/system-text-json-overview.md
+++ b/docs/standard/serialization/system-text-json-overview.md
@@ -17,7 +17,7 @@ The `System.Text.Json` namespace provides functionality for serializing to and d
 
 The library design emphasizes high performance and low memory allocation over an extensive feature set. Built-in UTF-8 support optimizes the process of reading and writing JSON text encoded as UTF-8, which is the most prevalent encoding for data on the web and files on disk.
 
-The library also provides classes for working with an in-memory document object model (DOM). This feature enables random read-only access of the elements in a JSON file or string.
+The library also provides classes for working with an in-memory [document object model (DOM)](system-text-json-use-dom-utf8jsonreader-utf8jsonwriter.md#json-dom-choices). This feature enables random access to the elements in a JSON file or string.
 
 There are some limitations on what parts of the library that you can use from Visual Basic code. For more information, see [Visual Basic support](system-text-json-how-to.md#visual-basic-support).
 


### PR DESCRIPTION
In .NET 6 a mutable DOM is available in System.Text.Json.
