### PR TITLE
IndexOf method changed again in .NET 6.

### DIFF
--- a/docs/core/compatibility/globalization/5.0/icu-globalization-api.md
+++ b/docs/core/compatibility/globalization/5.0/icu-globalization-api.md
@@ -31,7 +31,8 @@ Console.WriteLine(idx);
 ```
 
 - In previous versions of .NET on Windows, the snippet prints `6`.
-- In .NET 5 and later versions on Windows 19H1 and later versions, the snippet prints `-1`.
+- Only in .NET 5 and on Windows 19H1 and later versions, the snippet prints `-1`.
+- In .NET 6 this snippet prints `6`, even though ICU is used.
 
 To fix this code by conducting an ordinal search instead of a culture-sensitive search, call the <xref:System.String.IndexOf(System.String,System.StringComparison)> overload and pass in <xref:System.StringComparison.Ordinal?displayProperty=nameWithType> as an argument.
 

--- a/docs/core/compatibility/globalization/5.0/icu-globalization-api.md
+++ b/docs/core/compatibility/globalization/5.0/icu-globalization-api.md
@@ -31,8 +31,8 @@ Console.WriteLine(idx);
 ```
 
 - In previous versions of .NET on Windows, the snippet prints `6`.
-- Only in .NET 5 and on Windows 19H1 and later versions, the snippet prints `-1`.
-- In .NET 6 this snippet prints `6`, even though ICU is used.
+- In .NET 5 and on Windows 19H1 and later versions, the snippet prints `-1`.
+- In .NET 6 and later versions, the snippet prints `6`, however, ICU libraries are still used.
 
 To fix this code by conducting an ordinal search instead of a culture-sensitive search, call the <xref:System.String.IndexOf(System.String,System.StringComparison)> overload and pass in <xref:System.StringComparison.Ordinal?displayProperty=nameWithType> as an argument.
 


### PR DESCRIPTION
See issues: https://github.com/dotnet/docs/issues/28218
and https://github.com/dotnet/runtime/pull/57078

## Summary

Changes for webpage https://docs.microsoft.com/en-us/dotnet/core/compatibility/globalization/5.0/icu-globalization-api as of IndexOf method change in .NET 6

Fixes #Issue_Number (if available)
