### PR TITLE
Fix GitHub Actions typo: `pull_quest` → `pull_request`

### DIFF
--- a/docs/devops/dotnet-build-github-action.md
+++ b/docs/devops/dotnet-build-github-action.md
@@ -30,7 +30,7 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-build-github-action/build-validation.yml" range="3-9":::
 
-  - Triggered when a `push` or `pull_quest` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
+  - Triggered when a `push` or `pull_request` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
 
 - The `env` node defines named environment variables (env var).
 

--- a/docs/devops/dotnet-secure-github-action.md
+++ b/docs/devops/dotnet-secure-github-action.md
@@ -34,7 +34,7 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-secure-github-action/codeql-analysis.yml" range="3-15":::
 
-  - Triggered when a `push` or `pull_quest` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
+  - Triggered when a `push` or `pull_request` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
   - As a cron job (on a schedule) &mdash; to run at 8:00 UTC every Thursday.
 
 - The `jobs` node builds out the steps for the workflow to take.

--- a/docs/devops/dotnet-test-github-action.md
+++ b/docs/devops/dotnet-test-github-action.md
@@ -30,7 +30,7 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-test-github-action/build-and-test.yml" range="3-9":::
 
-  - Triggered when a `push` or `pull_quest` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
+  - Triggered when a `push` or `pull_request` occurs on the `main` branch where any files changed ending with the *.cs* or *.csproj* file extensions.
 
 - The `env` node defines named environment variables (env var).
 


### PR DESCRIPTION
This PR replaces `pull_quest` with `pull_request`, affecting 3 pages:

* https://docs.microsoft.com/en-us/dotnet/devops/dotnet-build-github-action
* https://docs.microsoft.com/en-us/dotnet/devops/dotnet-secure-github-action
* https://docs.microsoft.com/en-us/dotnet/devops/dotnet-test-github-action

To be sure I double-checked and confirmed there is no such thing as a `pull_quest` 
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows