### PR TITLE
In .NET 6.0 IndexOf behavior changed with the \n.

### DIFF
--- a/docs/standard/base-types/string-comparison-net-5-plus.md
+++ b/docs/standard/base-types/string-comparison-net-5-plus.md
@@ -1,5 +1,5 @@
 ---
-title: Behavior changes when comparing strings on .NET 5+
+title: Behavior changes when comparing strings on .NET 5
 description: Learn about string-comparison behavior changes in .NET 5 and later versions on Windows.
 ms.topic: conceptual
 ms.date: 12/07/2020
@@ -31,6 +31,7 @@ Console.WriteLine(idx);
 // '-1' when running on .NET 5 (Windows)
 // '-1' when running on .NET Core 2.x - 3.x or .NET 5 (non-Windows)
 // '6' when running on .NET Core 2.x or .NET 5 (in invariant mode)
+// '6' when running on .NET 6
 ```
 
 ## Guard against unexpected behavior


### PR DESCRIPTION
See this issue https://github.com/dotnet/docs/issues/28218 and this pr https://github.com/dotnet/docs/pull/28250

## Summary
A small text update for wegpage https://docs.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus.

IndexOf method should not be used as an example to test if ICU is being used. In .NET 6 it is used by default, but as the treatment of the character \n has been changed in .NET 6 (in comparison to .NET 5) it should be noted in this example. 

Somebody else (who isnt a junior dev like me) add more changes to this page so it becomes logical.

Fixes #Issue_Number (if available)

