### PR TITLE
Add missing return from example code

### DIFF
--- a/docs/core/deploying/trimming/trim-warnings/il2078.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2078.md
@@ -22,6 +22,6 @@ Type _typeField;
 Type TestMethod()
 {
     // IL2078 Trim analysis: 'TestMethod' method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The field '_typeField' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-    _typeField;
+    return _typeField;
 }
 ```


### PR DESCRIPTION
Example code was missing a return from a method
