### PR TITLE
Adressed an IDE0049 in code sample

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2013.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2013.md
@@ -41,7 +41,7 @@ To fix the violation, replace it with a more appropriate equality check such as 
 
     // Use appropriate equality operator or method instead
     Console.WriteLine(int1 == int2);                        // true
-    Console.WriteLine(Object.Equals(int1, int2));           // true
+    Console.WriteLine(object.Equals(int1, int2));           // true
 ```
 
 ## When to suppress warnings


### PR DESCRIPTION
## Summary

"Use language keywords instead of framework type names for type references"
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049

Fixes IDE0049 in code sample
