### PR TITLE
Fix IL2115

### DIFF
--- a/docs/core/deploying/trimming/trim-warnings/il2115.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2115.md
@@ -11,7 +11,7 @@ f1_keywords:
 
 ## Cause
 
-A type is annotated with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> indicating that the type may dynamically access some members declared on one of the derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> which cannot be statically verified. The <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> requirements.
+A type is annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> indicating that the type may dynamically access some members declared on one of the derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> which cannot be statically verified. The <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> requirements.
 
 ## Example
 


### PR DESCRIPTION
The warning was talking in terms of RequiresUnreferencedCodeAttribute instead of DynamicallyAccessedMembersAttribute

## Summary

Change documentation to talk about DynamicallyAccessedMembersAttribute
