### PR TITLE
Don't mix index and element

### DIFF
--- a/docs/csharp/whats-new/tutorials/ranges-indexes.md
+++ b/docs/csharp/whats-new/tutorials/ranges-indexes.md
@@ -26,7 +26,7 @@ This language support relies on two new types and two new operators:
 - <xref:System.Range?displayProperty=nameWithType> represents a sub range of a sequence.
 - The range operator `..`, which specifies the start and end of a range as its operands.
 
-Let's start with the rules for indices. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. The expression `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence[sequence.Length - n]`.
+Let's start with the rules for indices. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. The expression `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
 
 ```csharp
 string[] words = new string[]


### PR DESCRIPTION
The text reerring to the *Index* compared the index to the element expression. 

Fixes #28292
