### PR TITLE
Update trim warnings IL2000-IL2037

### DIFF
--- a/docs/core/deploying/trimming/trim-warnings/il2003.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2003.md
@@ -19,7 +19,8 @@ Trimmer keeps a cache with the assemblies that it has seen. If the assembly spec
 `PreserveDependencyAttribute` is not found in this cache, the trimmer does not have a way to
 find the member to preserve.
 
-> [!NOTE] PreserveDependencyAttribute is deprecated
+> [!NOTE]
+> PreserveDependencyAttribute is deprecated
 
 ## Example
 

--- a/docs/core/deploying/trimming/trim-warnings/il2003.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2003.md
@@ -7,7 +7,7 @@ author: mateoatr
 f1_keywords:
   - "IL2003"
 ---
-# IL2003: Could not resolve dependency assembly specified in a 'PreserveDependency' attribute
+# IL2003: The assembly in 'PreserveDependency' attribute could not be resolved
 
 ## Cause
 
@@ -18,6 +18,8 @@ The assembly specified in a `PreserveDependencyAttribute` could not be resolved.
 Trimmer keeps a cache with the assemblies that it has seen. If the assembly specified in the
 `PreserveDependencyAttribute` is not found in this cache, the trimmer does not have a way to
 find the member to preserve.
+
+> [!NOTE] PreserveDependencyAttribute is deprecated
 
 ## Example
 

--- a/docs/core/deploying/trimming/trim-warnings/il2004.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2004.md
@@ -19,6 +19,8 @@ Trimmer keeps a cache with the assemblies that it has seen. If the type specifie
 `PreserveDependencyAttribute` is not found inside an assembly in this cache, the trimmer
 does not have a way to find the member to preserve.
 
+> [!NOTE] PreserveDependencyAttribute is deprecated
+
 ## Example
 
 ```C#

--- a/docs/core/deploying/trimming/trim-warnings/il2004.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2004.md
@@ -19,7 +19,8 @@ Trimmer keeps a cache with the assemblies that it has seen. If the type specifie
 `PreserveDependencyAttribute` is not found inside an assembly in this cache, the trimmer
 does not have a way to find the member to preserve.
 
-> [!NOTE] PreserveDependencyAttribute is deprecated
+> [!NOTE]
+> PreserveDependencyAttribute is deprecated
 
 ## Example
 

--- a/docs/core/deploying/trimming/trim-warnings/il2005.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2005.md
@@ -13,8 +13,8 @@ f1_keywords:
 
 The member of a type specified in a `PreserveDependencyAttribute` could not be resolved.
 
-
-> [!NOTE] PreserveDependencyAttribute is deprecated
+> [!NOTE]
+> PreserveDependencyAttribute is deprecated
 
 ## Example
 

--- a/docs/core/deploying/trimming/trim-warnings/il2005.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2005.md
@@ -13,6 +13,9 @@ f1_keywords:
 
 The member of a type specified in a `PreserveDependencyAttribute` could not be resolved.
 
+
+> [!NOTE] PreserveDependencyAttribute is deprecated
+
 ## Example
 
 ```C#

--- a/docs/core/deploying/trimming/trim-warnings/il2026.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2026.md
@@ -9,14 +9,14 @@ f1_keywords:
   - "IL2026"
   - "RequiresUnreferencedCode"
 ---
-# IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
+# IL2026: Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code.
 
 ## Cause
 
 Calling (or accessing via reflection) a member annotated with
 <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute>.
 
-For example:
+## Example
 
 ```C#
 [RequiresUnreferencedCode("Use 'MethodFriendlyToTrimming' instead", Url="http://help/unreferencedcode")]
@@ -26,7 +26,7 @@ void MethodWithUnreferencedCodeUsage()
 
 void TestMethod()
 {
-    // IL2026: Using method 'MethodWithUnreferencedCodeUsage' which has 'RequiresUnreferencedCodeAttribute'
+    // IL2026: Using member 'MethodWithUnreferencedCodeUsage' which has 'RequiresUnreferencedCodeAttribute'
     // can break functionality when trimming application code. Use 'MethodFriendlyToTrimming' instead. http://help/unreferencedcode
     MethodWithUnreferencedCodeUsage();
 }

--- a/docs/core/deploying/trimming/trim-warnings/il2027.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2027.md
@@ -1,5 +1,5 @@
 ---
-title: "IL2027: Known trimmer attribute used more than once on a single member"
+title: "IL2027: The linker found multiple instances of attribute on a member. This attribute is only allowed to have one instance."
 description: "Learn about trim warning IL2027: TrimmerAttributeUsedMoreThanOnce"
 ms.date: 08/25/2021
 ms.topic: reference
@@ -7,9 +7,40 @@ author: mateoatr
 f1_keywords:
   - "IL2027"
 ---
-# IL2027: Known trimmer attribute used more than once on a single member
+# IL2027: The linker found multiple instances of attribute on a member. This attribute is only allowed to have one instance.
 
 ## Cause
 
 Trimmer found multiple instances of the same trimmer-supported attribute on a single
-member.
+member, for example `RequiresUnreferencedCodeAttribute`. Since C# does not allow multiple attributes of the same type on a member, this can only happen if a LinkAttributes.xml file applies an attribute to a member which has the attribute in the source code.
+
+## Example
+
+MyType.cs:
+
+```C#
+class MyType
+{
+    // IL2027: Attribute 'RequiresUnreferencedCodeAttribute' should only be used once on 'MethodWithUnreferencedCodeUsage()'.
+    [RequiresUnreferencedCode("Use A instead")]
+    void MethodWithUnreferencedCodeUsage()
+    {
+    }
+}
+```
+
+ILLink.LinkAttributes.xml:
+
+```XML
+<linker>
+    <assembly fullname="MyAssembly">
+      <type fullname="MyType">
+        <method name="MethodWithUnreferencedCodeUsage">
+            <attribute fullname="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute">
+                <argument>Use A instead</argument>
+            </attribute>
+        </method>
+      </type>
+    </assembly>
+  </linker>
+```

--- a/docs/core/deploying/trimming/trim-warnings/il2028.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2028.md
@@ -15,3 +15,32 @@ Trimmer found an instance of a known attribute that lacks the required construct
 parameters or has more than the accepted parameters. This can happen if a custom assembly
 defines a custom attribute whose full name conflicts with the trimmer-known attributes,
 since the trimmer recognizes custom attributes by matching namespace and type name.
+For example a custom definition for `RequiresUnreferencedCodeAttribute` with a
+parameterless constructor would cause this warning.
+
+## Example
+
+Compiling with `/nostdlib`
+
+```C#
+namespace System.Diagnostics.CodeAnalysis
+{
+    class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public RequiresUnreferencedCodeAttribute()
+        {
+        }
+    }
+}
+
+namespace Program
+{
+    class Program
+    {
+        [RequiresUnreferencedCode]
+        int Method()
+        {
+        }
+    }
+}
+```

--- a/docs/core/deploying/trimming/trim-warnings/il2032.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2032.md
@@ -7,7 +7,7 @@ author: mateoatr
 f1_keywords:
   - "IL2032"
 ---
-# IL2032: Unrecognized value passed to the parameter 'parameter' of 'System.Activator.CreateInstance' method
+# IL2032: The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
 
 ## Cause
 

--- a/docs/core/deploying/trimming/trim-warnings/il2033.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2033.md
@@ -7,7 +7,7 @@ author: mateoatr
 f1_keywords:
   - "IL2033"
 ---
-# IL2033: 'PreserveDependencyAttribute' is deprecated
+# IL2033: 'PreserveDependencyAttribute' is deprecated. Use 'DynamicDependencyAttribute' instead.
 
 ## Cause
 

--- a/docs/core/deploying/trimming/trim-warnings/il2034.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2034.md
@@ -1,6 +1,6 @@
 ---
 title: "IL2034: 'DynamicDependencyAttribute' could not be analyzed"
-description: "Learn about trim warning IL2034: CouldNotAnalyzeDynamicDependency"
+description: "Learn about trim warning IL2034: The 'DynamicDependencyAttribute' could not be analyzed"
 ms.date: 08/25/2021
 ms.topic: reference
 author: mateoatr
@@ -13,3 +13,7 @@ f1_keywords:
 
 Application contains an invalid use of <xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute>.
 Ensure that you are using one of the officially supported constructors.
+This is possible if a custom assembly defines a custom `System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute`
+with a different constructor than the one the trimmer recognizes. The trimmer will recognize the attribute as the
+one defined in the standard library because it only does a namespace and type name match, but the actual
+constructor used was not recognized.

--- a/docs/core/deploying/trimming/trim-warnings/il2035.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2035.md
@@ -1,18 +1,18 @@
 ---
 title: "IL2035: Unresolved assembly in 'DynamicDependencyAttribute'"
-description: "Learn about trim warning IL2035: DynamicDependencyUnresolvedAssembly"
+description: "Learn about trim warning IL2035: Unresolved assembly name in 'DynamicDependencyAttribute"
 ms.date: 08/25/2021
 ms.topic: reference
 author: mateoatr
 f1_keywords:
   - "IL2035"
 ---
-# IL2035: Unresolved assembly in 'DynamicDependencyAttribute'
+# IL2035: Unresolved assembly name in 'DynamicDependencyAttribute'
 
 ## Cause
 
 The value passed to the `assemblyName` parameter of a <xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute>
-could not be resolved.
+could not be resolved. Ensure that the argument specifies a valid assembly name, and that the assembly is available to the linker.
 
 ## Example
 

--- a/docs/core/deploying/trimming/trim-warnings/il2036.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2036.md
@@ -1,6 +1,6 @@
 ---
 title: "IL2036: Unresolved type in 'DynamicDependencyAttribute'"
-description: "Learn about trim warning IL2036: DynamicDependencyUnresolvedType"
+description: "Learn about trim warning IL2036: Unresolved type name in 'DynamicDependencyAttribute"
 ms.date: 08/25/2021
 ms.topic: reference
 author: mateoatr
@@ -12,7 +12,7 @@ f1_keywords:
 ## Cause
 
 The value passed to the `typeName` parameter of a <xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute>
-could not be resolved.
+could not be resolved. Ensure that the argument specifies a valid type name or type reference, that the type exists in the specified assembly, and that the assembly is available to the linker.
 
 ## Example
 

--- a/docs/core/deploying/trimming/trim-warnings/il2037.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2037.md
@@ -1,6 +1,6 @@
 ---
 title: "IL2037: Unresolved member in 'DynamicDependencyAttribute'"
-description: "Learn about trim warning IL2037: DynamicDependencyUnresolvedMember"
+description: "Learn about trim warning IL2037: Unresolved member in 'DynamicDependencyAttribute'"
 ms.date: 08/25/2021
 ms.topic: reference
 author: mateoatr


### PR DESCRIPTION
## Summary

Updates the trim warnings to align with the current trimmer behavior. Warning titles and messages should match linker's `sharedstrings.resx`, and some additional details are added. Disregards pages about XML descriptors / link attributes.