### PR TITLE
Update system-text-json-migrate-from-newtonsoft-how-to.md

### DIFF
--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 ms.topic: how-to
 ---
 
-# How to migrate from Newtonsoft.Json to System.Text.Json
+# Compare and migrate from Newtonsoft.Json to System.Text.Json
 
 This article shows how to migrate from [Newtonsoft.Json](https://www.newtonsoft.com/json) to <xref:System.Text.Json>.
 
@@ -24,7 +24,7 @@ The `System.Text.Json` namespace provides functionality for serializing to and d
 * .NET Framework 4.7.2 and later versions
 * .NET Core 2.0, 2.1, and 2.2
 
-## System.Text.Json and Newtonsoft.Json comparison
+
 
 `System.Text.Json` focuses primarily on performance, security, and standards compliance. It has some key differences in default behavior and doesn't aim to have feature parity with `Newtonsoft.Json`. For some scenarios, `System.Text.Json` currently has no built-in functionality, but there are recommended workarounds. For other scenarios, workarounds are impractical.
 

--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 ms.topic: how-to
 ---
 
-# Compare and migrate from Newtonsoft.Json to System.Text.Json
+# Compare and migrate Newtonsoft.Json to System.Text.Json
 
 This article shows how to migrate from [Newtonsoft.Json](https://www.newtonsoft.com/json) to <xref:System.Text.Json>.
 

--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 ms.topic: how-to
 ---
 
-# Compare and migrate Newtonsoft.Json to System.Text.Json
+# Compare Newtonsoft.Json to System.Text.Json, and migrate to System.Text.Json
 
 This article shows how to migrate from [Newtonsoft.Json](https://www.newtonsoft.com/json) to <xref:System.Text.Json>.
 

--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -24,8 +24,6 @@ The `System.Text.Json` namespace provides functionality for serializing to and d
 * .NET Framework 4.7.2 and later versions
 * .NET Core 2.0, 2.1, and 2.2
 
-
-
 `System.Text.Json` focuses primarily on performance, security, and standards compliance. It has some key differences in default behavior and doesn't aim to have feature parity with `Newtonsoft.Json`. For some scenarios, `System.Text.Json` currently has no built-in functionality, but there are recommended workarounds. For other scenarios, workarounds are impractical.
 
 We're investing in adding the features that have most often been requested. If your application depends on a missing feature, consider [filing an issue](https://github.com/dotnet/runtime/issues/new) in the dotnet/runtime GitHub repository to find out if support for your scenario can be added. See [epic issue #43620](https://github.com/dotnet/runtime/issues/43620) to find out what is already planned.

--- a/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
+++ b/docs/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.md
@@ -24,6 +24,8 @@ The `System.Text.Json` namespace provides functionality for serializing to and d
 * .NET Framework 4.7.2 and later versions
 * .NET Core 2.0, 2.1, and 2.2
 
+## System.Text.Json and Newtonsoft.Json comparison
+
 `System.Text.Json` focuses primarily on performance, security, and standards compliance. It has some key differences in default behavior and doesn't aim to have feature parity with `Newtonsoft.Json`. For some scenarios, `System.Text.Json` currently has no built-in functionality, but there are recommended workarounds. For other scenarios, workarounds are impractical.
 
 We're investing in adding the features that have most often been requested. If your application depends on a missing feature, consider [filing an issue](https://github.com/dotnet/runtime/issues/new) in the dotnet/runtime GitHub repository to find out if support for your scenario can be added. See [epic issue #43620](https://github.com/dotnet/runtime/issues/43620) to find out what is already planned.


### PR DESCRIPTION
Folks reporting having trouble finding Newtonsoft.Json vs System.Text.Json so make this H2 explicit. See https://github.com/dotnet/AspNetCore.Docs/issues/25100

Once this is merged, I can link to it in several places.
