### PR TITLE
Update numbers-in-csharp-local.md

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -266,7 +266,7 @@ double third = 1.0 / 3.0;
 Console.WriteLine(third);
 ```
 
-You know that `0.3` repeating isn't exactly the same as `1/3`.
+You know that `0.3` repeating finite number of times isn't exactly the same as `1/3`.
 
 ***Challenge***
 


### PR DESCRIPTION
## Summary
Fixes misleading statement. 0.3 repeating forever is exactly equal to 1/3 however floating-point types don't support representing repeating decimals and rounds to a finite number of digits instead.