### PR TITLE
SEO OKR

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -1,6 +1,6 @@
 ---
-title: .NET and .NET Core - introduction and overview
-description: Learn about .NET and .NET Core. .NET is a free, open-source development platform for building many kinds of apps.
+title: .NET (and .NET Core) - introduction and overview
+description: Learn about .NET (and .NET Core). .NET is a free, open-source development platform for building many kinds of apps.
 author: tdykstra
 ms.date: 02/24/2022
 ms.custom: "updateeachrelease"

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -2,7 +2,7 @@
 title: .NET introduction and overview
 description: Learn about .NET, a free, open-source development platform for building many kinds of apps.
 author: tdykstra
-ms.date: 11/30/2021
+ms.date: 02/24/2022
 ms.custom: "updateeachrelease"
 recommendations: false
 ---

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -1,12 +1,12 @@
 ---
-title: .NET introduction and overview
-description: Learn about .NET, a free, open-source development platform for building many kinds of apps.
+title: .NET and .NET Core - introduction and overview
+description: Learn about .NET and .NET Core. .NET is a free, open-source development platform for building many kinds of apps.
 author: tdykstra
 ms.date: 02/24/2022
 ms.custom: "updateeachrelease"
 recommendations: false
 ---
-# Introduction to .NET
+# What is .NET? Introduction and overview
 
 .NET is a free, open-source development platform for building many kinds of apps, such as:
 
@@ -51,9 +51,9 @@ Supported processor architectures include:
 
 For more information, see [Supported OS lifecycle policy](https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md) and [.NET RID Catalog](rid-catalog.md).
 
-## Open source
+## Free and open source
 
-.NET is open source, using [MIT and Apache 2 licenses](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT). .NET is a project of the [.NET Foundation](https://dotnetfoundation.org/).
+.NET is free and open source, using [MIT and Apache 2 licenses](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT). .NET is a project of the [.NET Foundation](https://dotnetfoundation.org/).
 
 For more information, see the [list of project repositories on GitHub.com](https://github.com/dotnet/core/blob/main/Documentation/core-repos.md).
 
@@ -69,9 +69,9 @@ For more information, see the [list of project repositories on GitHub.com](https
 
 For more information, see [Releases and support for .NET Core and .NET 5](releases-and-support.md).
 
-## Implementations
+## .NET Core, .NET Framework, Mono, UWP
 
-.NET comes in different flavors, more formally known as *implementations*. .NET 5+ (including .NET Core) is the latest implementation and runs on any platform. .NET Framework is the original implementation of .NET, and runs only on Windows. Mono is used when a small runtime is required. Universal Windows Platform (UWP) is used to build modern Windows apps.
+.NET comes in different flavors, more formally known as *implementations*. .NET 5+ (including .NET Core) is the latest implementation and runs on any platform. .NET Framework is the original implementation of .NET, and runs only on Windows. [Mono](../standard/glossary.md#mono) is used when a small runtime is required. [Universal Windows Platform (UWP)](../standard/glossary.md#uwp) is used to build modern Windows apps.
 
 Each implementation includes a runtime and a class library. It may also include application frameworks and development tools.
 
@@ -407,14 +407,7 @@ For more information, see [Unsafe code and pointers](../csharp/language-referenc
 
 ## Next steps
 
-> [!div class="nextstepaction"]
-> [Choose a .NET tutorial](tutorials/index.md)
-
-> [!div class="nextstepaction"]
-> [Try .NET in your browser](../csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml)
-
-> [!div class="nextstepaction"]
-> [Take a tour of C#](../csharp/tour-of-csharp/index.md)
-
-> [!div class="nextstepaction"]
-> [Take a tour of F#](../fsharp/tour.md)
+* [Choose a .NET tutorial](tutorials/index.md)
+* [Try .NET in your browser](../csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml)
+* [Take a tour of C#](../csharp/tour-of-csharp/index.md)
+* [Take a tour of F#](../fsharp/tour.md)

--- a/docs/core/sdk.md
+++ b/docs/core/sdk.md
@@ -1,25 +1,25 @@
 ---
 title: .NET SDK overview
-description: Find out about the .NET SDK, which is a set of libraries and tools used to create .NET projects.
+description: Learn about the .NET SDK (formerly known as the .NET Core SDK), which is a set of libraries and tools used to create .NET projects.
 ms.date: 02/24/2022
 ms.technology: dotnet-cli
 ---
-# .NET SDK overview
+# What is the .NET SDK?
 
 The .NET SDK is a set of libraries and tools that allow developers to create .NET applications and libraries. It contains the following components that are used to build and run applications:
 
-- The .NET CLI.
-- .NET libraries and runtime.
+- The [.NET CLI](tools/index.md).
+- The .NET  [runtime](introduction.md#sdk-and-runtimes)and [libraries](introduction.md#runtime-libraries).
 - The `dotnet` [driver](tools/index.md#driver).
 
-## Acquiring the .NET SDK
+## How to install the .NET SDK
 
-As with any tooling, the first thing is to get the tools to your machine. Depending on your scenario, you can install the SDK using one of the following methods:
+As with any tooling, the first thing is to get the tools on your machine. Depending on your scenario, you can install the SDK using one of the following methods:
 
 - Use the native installers.
 - Use the installation shell script.
 
-The native installers are primarily meant for developer's machines. The SDK is distributed using each supported platform's
+The native installers are primarily meant for developers' machines. The SDK is distributed using each supported platform's
 native install mechanism, such as DEB packages on Ubuntu or MSI bundles on Windows. These installers install
 and set up the environment as needed for the user to use the SDK immediately after the install. However, they also
 require administrative privileges on the machine. You can find the SDK to install on the
@@ -32,10 +32,11 @@ caveat above). You can find more information in the [install script reference](t
 interested in how to set up the SDK on your CI build server, see the [Using .NET SDK and tools in Continuous Integration (CI)](tools/using-ci-with-cli.md) article.
 
 By default, the SDK installs in a "side-by-side" (SxS) manner, which means multiple versions
-can coexist at any given time on a single machine. How the version gets picked when you're running CLI commands is explained in more detail in the [Select the .NET version to use](versions/selection.md) article.
+can coexist at any given time on a single machine. For information about how the version gets picked when you're running CLI commands, see [Select the .NET version to use](versions/selection.md).
 
 ## See also
 
+- [.NET downloads](https://dotnet.microsoft.com/download)
 - [.NET CLI overview](tools/index.md)
 - [.NET versioning overview](versions/index.md)
 - [How to remove the .NET runtime and SDK](install/remove-runtime-sdk-versions.md)

--- a/docs/core/sdk.md
+++ b/docs/core/sdk.md
@@ -1,7 +1,7 @@
 ---
 title: .NET SDK overview
 description: Find out about the .NET SDK, which is a set of libraries and tools used to create .NET projects.
-ms.date: 07/31/2019
+ms.date: 02/24/2022
 ms.technology: dotnet-cli
 ---
 # .NET SDK overview

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -71,7 +71,7 @@ The telemetry feature collects the following data:
 | >=2.1.300     | Kernel version. |
 | >=2.1.300     | Libc release/version. |
 | >=3.0.100     | Whether the output was redirected (true or false). |
-| >=3.0.100     | On a CLI/SDK crash, the exception type and its stack trace (only CLI/SDK code is included in the stack trace sent). For more information, see [.NET CLI/SDK crash exception telemetry collected](#net-clisdk-crash-exception-telemetry-collected). |
+| >=3.0.100     | On a CLI/SDK crash, the exception type and its stack trace (only CLI/SDK code is included in the stack trace sent). For more information, see [Crash exception telemetry](#crash-exception-telemetry). |
 | >=5.0.100     | Hashed TargetFrameworkVersion used for build (MSBuild property) |
 | >=5.0.100     | Hashed RuntimeIdentifier used for build (MSBuild property) |
 | >=5.0.100     | Hashed SelfContained used for build  (MSBuild property) |
@@ -152,6 +152,11 @@ at Microsoft.DotNet.Cli.Program.Main(String[] args)
 Because of this, custom builds of the .NET SDK shouldn't be located in directories whose path names expose personal or sensitive information.
 
 ## See also
+
+|Column1  |Column2  |
+|---------|---------|
+|Row1     |         |
+|Row2     |         |
 
 - [.NET CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry)
 - [Telemetry reference source (dotnet/sdk repository)](https://github.com/dotnet/sdk/tree/main/src/Cli/dotnet/Telemetry)

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -2,7 +2,7 @@
 title: .NET SDK telemetry
 description: Discover the .NET SDK telemetry features that collect usage information for analysis, which data is collected, and how to disable it.
 author: KathleenDollard
-ms.date: 08/27/2019
+ms.date: 02/24/2022
 ---
 # .NET SDK telemetry
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -1,18 +1,18 @@
 ---
-title: .NET SDK telemetry
-description: Discover the .NET SDK telemetry features that collect usage information for analysis, which data is collected, and how to disable it.
+title: .NET SDK and .NET CLI telemetry
+description: The .NET SDK and the .NET CLI collect usage information and send it to Microsoft. Learn what data is collected and how to opt out.
 author: KathleenDollard
 ms.date: 02/24/2022
 ---
-# .NET SDK telemetry
+# .NET SDK and .NET CLI telemetry
 
-The [.NET SDK](index.md) includes a telemetry feature that collects usage data and exception information when the .NET CLI crashes. The .NET CLI comes with the .NET SDK and is the set of verbs that enable you to build, test, and publish your .NET apps. It's important that the .NET team understands how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
+The [.NET SDK](index.md) includes a telemetry feature that collects usage data and sends it to Microsoft. The usage data includes exception information when the .NET CLI crashes. The .NET CLI comes with the .NET SDK and is the set of verbs that enable you to build, test, and publish your .NET apps. Telemetry data helps the .NET team understand how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
 
-The collected data is published in aggregate under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/).
+The collected data is published in aggregate under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/). Some of the collected data is published at [.NET CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry).
 
 ## Scope
 
-`dotnet` has two functions: to run apps, and to execute CLI commands. Telemetry *isn't collected* when using `dotnet` to start an application in the following format:
+`dotnet` has two functions: to run apps and to execute CLI commands. Telemetry *isn't collected* when using `dotnet` to start an application in the following format:
 
 - `dotnet [path-to-app].dll`
 
@@ -122,13 +122,11 @@ The `dotnet new` template instantiation command collects additional data for Mic
 * `--framework`
 * `--auth`
 
-## .NET CLI/SDK crash exception telemetry collected
+## Crash exception telemetry
 
 If the .NET CLI/SDK crashes, it collects the name of the exception and stack trace of the CLI/SDK code. This information is collected to assess problems and improve the quality of the .NET SDK and CLI. This article provides information about the data we collect. It also provides tips on how users building their own version of the .NET SDK can avoid inadvertent disclosure of personal or sensitive information.
 
-### Types of collected data
-
-.NET CLI collects information for CLI/SDK exceptions only, not exceptions in your application. The collected data contains the name of the exception and the stack trace. This stack trace is of CLI/SDK code.
+The .NET CLI collects information for CLI/SDK exceptions only, not exceptions in your application. The collected data contains the name of the exception and the stack trace. This stack trace is of CLI/SDK code.
 
 The following example shows the kind of data that is collected:
 
@@ -147,7 +145,7 @@ at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryC
 at Microsoft.DotNet.Cli.Program.Main(String[] args)
 ```
 
-### Avoid inadvertent disclosure of information
+## Avoid inadvertent disclosure of information
 
 .NET contributors and anyone else running a version of the .NET SDK that they built themselves should consider the path to their SDK source code. If a crash occurs while using a .NET SDK that is a custom debug build or configured with custom build symbol files, the SDK source file path from the build machine is collected as part of the stack trace and isn't hashed.
 

--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -6,7 +6,7 @@ ms.date: 02/24/2022
 ---
 # .NET SDK and .NET CLI telemetry
 
-The [.NET SDK](index.md) includes a telemetry feature that collects usage data and sends it to Microsoft. The usage data includes exception information when the .NET CLI crashes. The .NET CLI comes with the .NET SDK and is the set of verbs that enable you to build, test, and publish your .NET apps. Telemetry data helps the .NET team understand how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
+The [.NET SDK](index.md) includes a telemetry feature that collects usage data and sends it to Microsoft when you use [.NET CLI](index.md) commands. The usage data includes exception information when the .NET CLI crashes. The .NET CLI comes with the .NET SDK and is the set of verbs that enable you to build, test, and publish your .NET apps. Telemetry data helps the .NET team understand how the tools are used so they can be improved. Information on failures helps the team resolve problems and fix bugs.
 
 The collected data is published in aggregate under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/). Some of the collected data is published at [.NET CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry).
 
@@ -153,10 +153,5 @@ Because of this, custom builds of the .NET SDK shouldn't be located in directori
 
 ## See also
 
-|Column1  |Column2  |
-|---------|---------|
-|Row1     |         |
-|Row2     |         |
-
-- [.NET CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry)
+- [.NET CLI telemetry data](https://dotnet.microsoft.com/platform/telemetry)
 - [Telemetry reference source (dotnet/sdk repository)](https://github.com/dotnet/sdk/tree/main/src/Cli/dotnet/Telemetry)

--- a/docs/standard/base-types/formatting-types.md
+++ b/docs/standard/base-types/formatting-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Overview: How to format numbers, dates, enums, and other types in .NET"
-description: "Introduction to converting instances of .NET types to formatted strings. Override the ToString method, make formatting culture-sensitive, and use ICustomFormatter."
+description: "Learn how to convert instances of .NET types to formatted strings. Override the ToString method, make formatting culture-sensitive, and use ICustomFormatter."
 ms.date: 02/25/2022
 dev_langs:
   - "csharp"
@@ -27,22 +27,10 @@ helpviewer_keywords:
 ---
 # Overview: How to format numbers, dates, enums, and other types in .NET
 
-Formatting is the process of converting an instance of a class, structure, or enumeration value to its string representation, often so that the resulting string can be displayed to users or deserialized to restore the original data type. This conversion can pose a number of challenges:
-
-- The way that values are stored internally does not necessarily reflect the way that users want to view them. For example, a telephone number might be stored in the form 8009999999, which is not user-friendly. It should instead be displayed as 800-999-9999. See the [Custom Format Strings](#custom-format-strings) section for an example that formats a number in this way.
-
-- Sometimes the conversion of an object to its string representation is not intuitive. For example, it is not clear how the string representation of a Temperature object or a Person object should appear. For an example that formats a Temperature object in a variety of ways, see the [Standard Format Strings](#standard-format-strings) section.
-
-- Values often require culture-sensitive formatting. For example, in an application that uses numbers to reflect monetary values, numeric strings should include the current culture's currency symbol, group separator (which, in most cultures, is the thousands separator), and decimal symbol. For an example, see the [Culture-sensitive formatting with format providers](#culture-sensitive-formatting-with-format-providers) section.
-
-- An application may have to display the same value in different ways. For example, an application may represent an enumeration member by displaying a string representation of its name or by displaying its underlying value. For an example that formats a member of the <xref:System.DayOfWeek> enumeration in different ways, see the [Standard Format Strings](#standard-format-strings) section.
+Formatting is the process of converting an instance of a class or structure, or an enumeration value, to a string representation. The purpose is to display the resulting string to users or to deserialize it later to restore the original data type. This article introduces the formatting mechanisms that .NET provides.
 
 > [!NOTE]
-> Formatting converts the value of a type into a string representation. Parsing is the inverse of formatting. A parsing operation creates an instance of a data type from its string representation. For information about converting strings to other data types, see [Parsing Strings](parsing-strings.md).
-
-.NET provides rich formatting support that enables developers to address these requirements.
-
-## Formatting in .NET
+> Parsing is the inverse of formatting. A parsing operation creates an instance of a data type from its string representation. For more information, see [Parsing Strings](parsing-strings.md). For information about serialization and deserialization, see [Serialization in .NET](../serialization/index.md).
 
 The basic mechanism for formatting is the default implementation of the <xref:System.Object.ToString%2A?displayProperty=nameWithType> method, which is discussed in the [Default Formatting Using the ToString Method](#default-formatting-using-the-tostring-method) section later in this topic. However, .NET provides several ways to modify and extend its default formatting support. These include the following:
 
@@ -55,7 +43,7 @@ The basic mechanism for formatting is the default implementation of the <xref:Sy
 
      For more information about format specifiers, see the [ToString Method and Format Strings](#the-tostring-method-and-format-strings) section.
 
-- Using format providers to take advantage of the formatting conventions of a specific culture. For example, the following statement displays a currency value by using the formatting conventions of the en-US culture.
+- Using format providers to implement the formatting conventions of a specific culture. For example, the following statement displays a currency value by using the formatting conventions of the en-US culture.
 
      [!code-csharp[Conceptual.Formatting.Overview#10](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.formatting.overview/cs/specifier1.cs#10)]
      [!code-vb[Conceptual.Formatting.Overview#10](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.formatting.overview/vb/specifier1.vb#10)]
@@ -65,6 +53,8 @@ The basic mechanism for formatting is the default implementation of the <xref:Sy
 - Implementing the <xref:System.IFormattable> interface to support both string conversion with the <xref:System.Convert> class and composite formatting. For more information, see the [IFormattable Interface](#the-iformattable-interface) section.
 
 - Using composite formatting to embed the string representation of a value in a larger string. For more information, see the [Composite Formatting](#composite-formatting) section.
+
+- Using string interpolation, a more readable syntax to embed the string representation of a value in a larger string. For more information, see [String interpolation](../../csharp/language-reference/tokens/interpolated.md).
 
 - Implementing <xref:System.ICustomFormatter> and <xref:System.IFormatProvider> to provide a complete custom formatting solution. For more information, see the [Custom Formatting with ICustomFormatter](#custom-formatting-with-icustomformatter) section.
 
@@ -324,6 +314,11 @@ In addition to replacing a format item with the string representation of its cor
 
 For more information about composite formatting, see [Composite Formatting](composite-formatting.md).
 
+## String interpolation
+
+The `$` special character identifies a string literal as an *interpolated string*. An interpolated string is a string literal that might contain *interpolation expressions*. When an interpolated string is resolved to a result string, items with interpolation expressions are replaced by the string representations of the expression results.
+
+
 ## Custom formatting with ICustomFormatter
 
 Two composite formatting methods, <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType> and <xref:System.Text.StringBuilder.AppendFormat%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType>, include a format provider parameter that supports custom formatting. When either of these formatting methods is called, it passes a <xref:System.Type> object that represents an <xref:System.ICustomFormatter> interface to the format provider's <xref:System.IFormatProvider.GetFormat%2A> method. The <xref:System.IFormatProvider.GetFormat%2A> method is then responsible for returning the <xref:System.ICustomFormatter> implementation that provides custom formatting.
@@ -340,7 +335,7 @@ The following example uses the `ByteByByteFormatter` class to format integer val
 [!code-csharp[Conceptual.Formatting.Overview#16](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.formatting.overview/cs/icustomformatter1.cs#16)]
 [!code-vb[Conceptual.Formatting.Overview#16](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.formatting.overview/vb/icustomformatter1.vb#16)]
 
-## Related topics
+## See also
 
 |Title|Definition|
 |-----------|----------------|

--- a/docs/standard/base-types/formatting-types.md
+++ b/docs/standard/base-types/formatting-types.md
@@ -1,7 +1,7 @@
 ---
-title: "Formatting types in .NET"
-description: Learn how to format types in .NET. Understand how to use or override the ToString method. Learn about culture-sensitive, composite, and custom formatting.
-ms.date: "03/30/2017"
+title: "Overview: How to format numbers, dates, enums, and other types in .NET"
+description: "Introduction to converting instances of .NET types to formatted strings. Override the ToString method, make formatting culture-sensitive, and use ICustomFormatter."
+ms.date: 02/25/2022
 dev_langs:
   - "csharp"
   - "vb"
@@ -24,9 +24,8 @@ helpviewer_keywords:
   - "base types [.NET], formatting"
   - "custom formatting [.NET]"
   - "strings [.NET], formatting"
-ms.assetid: 0d1364da-5b30-4d42-8e6b-03378343343f
 ---
-# Format types in .NET
+# Overview: How to format numbers, dates, enums, and other types in .NET
 
 Formatting is the process of converting an instance of a class, structure, or enumeration value to its string representation, often so that the resulting string can be displayed to users or deserialized to restore the original data type. This conversion can pose a number of challenges:
 

--- a/docs/standard/base-types/formatting-types.md
+++ b/docs/standard/base-types/formatting-types.md
@@ -314,11 +314,6 @@ In addition to replacing a format item with the string representation of its cor
 
 For more information about composite formatting, see [Composite Formatting](composite-formatting.md).
 
-## String interpolation
-
-The `$` special character identifies a string literal as an *interpolated string*. An interpolated string is a string literal that might contain *interpolation expressions*. When an interpolated string is resolved to a result string, items with interpolation expressions are replaced by the string representations of the expression results.
-
-
 ## Custom formatting with ICustomFormatter
 
 Two composite formatting methods, <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType> and <xref:System.Text.StringBuilder.AppendFormat%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType>, include a format provider parameter that supports custom formatting. When either of these formatting methods is called, it passes a <xref:System.Type> object that represents an <xref:System.ICustomFormatter> interface to the format provider's <xref:System.IFormatProvider.GetFormat%2A> method. The <xref:System.IFormatProvider.GetFormat%2A> method is then responsible for returning the <xref:System.ICustomFormatter> implementation that provides custom formatting.


### PR DESCRIPTION
Contributes to #28383 

* Intro to .NET

  Organic search 21.61%. It turns out that many people still include ".net core" in their search strings, so I added that to the title and description. Also changed h1 to "What is ...".

* .NET telemetry

  Organic search 5.10%. The reason for low organic search volume is that almost all traffic comes from an aka.ms link that is displayed by the CLI the first time a CLI command is used after installation (aka.ms/dotnet-cli-telemetry). It probably won't be possible to get the organic search rate up much higher for this article, as most traffic will always be from that aka.ms link. But since the telemetry is more closely related to the CLI in particular than to the SDK in general, I added "CLI" in a couple of places.

* SDK overview

  Organic search 16.19%. Since people are still searching for .NET Core SDK I added "formerly known as the .NET Core SDK" to the meta description. Also changed title to "What is ...".

* Formatting types

  Organic search 17.95%. Some of this article is high-level intro to topics covered in detail in separate articles (standard and custom format strings, composite formatting), other topics are covered in adequate detail in this article. I changed metadata and h1 to emphasize the overview/intro character of the article, to explain better what is meant by "formatting types", and to call out in the description the topics covered in detail in this article. Also removed some superfluous material that interrupted the article introduction.
