### PR TITLE
Fix issues on the configure language version page

### DIFF
--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -42,6 +42,8 @@ If you must specify your C# version explicitly, you can do so in several ways:
 - Configure the [**LangVersion** compiler option](compiler-options/language.md#langversion).
 
 > [!TIP]
+> You can see the language version in Visual Studio in the project properties page. Under the *Build* tab, the *Advanced* pane displays the version selected.
+>
 > To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](preprocessor-directives.md#error-and-warning-information) for more information.
 
 ### Edit the project file

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -9,8 +9,6 @@ ms.date: 07/06/2021
 
 The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio doesn't provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensures you don't use a language that requires types or runtime behavior not available in your target framework. Choosing a language version newer than the default can cause hard to diagnose compile-time and runtime errors.
 
-The rules in this article apply to the compiler delivered with Visual Studio 2019 or the .NET SDK. The C# compilers that are part of the Visual Studio 2017 installation or earlier .NET Core SDK versions target C# 7.0 by default.
-
 C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
 
 - [Default interface implementation](../whats-new/csharp-8.md#default-interface-methods) requires new features in the .NET Core 3.0 CLR.
@@ -18,9 +16,9 @@ C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest
 - [Indices and ranges](../whats-new/csharp-8.md#indices-and-ranges) require the new types <xref:System.Index?displayProperty=nameWithType> and <xref:System.Range?displayProperty=nameWithType>.
 - [Nullable reference types](../whats-new/csharp-8.md#nullable-reference-types) make use of several [attributes](attributes/nullable-analysis.md) to provide better warnings. Those attributes were added in .NET Core 3.0. Other target frameworks haven't been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
 
-C# 9 is supported only on .NET 5 and newer versions.
+C# 9 is supported only on .NET 5 and newer versions. C# 10 is supported only on .NET 6 and newer versions.
 
-C# 10 is supported only on .NET 6 and newer versions.
+Check the [Visual Studio platform compatibility](/visualstudio/releases/2022/compatibility#-visual-studio-2022-support-for-net-development) page for details on which .NET versions are supported by versions of Visual Studio. Check the [Visual Studio for Mac platform compatibility](/visualstudio/mac/supported-versions-net) page for details on which .NET versions are support by versions of Visual Studio for Mac.
 
 ## Defaults
 
@@ -84,3 +82,4 @@ Builds in all subdirectories of the directory containing that file will use the 
 The following table shows all current C# language versions. Your compiler may not necessarily understand every value if it's older. If you install the latest .NET SDK, then you have access to everything listed.
 
 [!INCLUDE [langversion-table](includes/langversion-table.md)]
+

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -9,16 +9,9 @@ ms.date: 07/06/2021
 
 The latest C# compiler determines a default language version based on your project's target framework or frameworks. Visual Studio doesn't provide a UI to change the value, but you can change it by editing the *csproj* file. The choice of default ensures that you use the latest language version compatible with your target framework. You benefit from access to the latest language features compatible with your project's target. This default choice also ensures you don't use a language that requires types or runtime behavior not available in your target framework. Choosing a language version newer than the default can cause hard to diagnose compile-time and runtime errors.
 
-C# 8.0 is supported only on .NET Core 3.x and newer versions. Many of the newest features require library and runtime features introduced in .NET Core 3.x:
+[C# 10](../whats-new/csharp-10.md) is supported only on .NET 6 and newer versions. [C# 9](../whats-new/csharp-9.md) is supported only on .NET 5 and newer versions. [C# 8.0](../whats-new/csharp-8.md) is supported only on .NET Core 3.x and newer versions.
 
-- [Default interface implementation](../whats-new/csharp-8.md#default-interface-methods) requires new features in the .NET Core 3.0 CLR.
-- [Async streams](../whats-new/csharp-8.md#asynchronous-streams) require the new types <xref:System.IAsyncDisposable?displayProperty=nameWithType>, <xref:System.Collections.Generic.IAsyncEnumerable%601?displayProperty=nameWithType>, and <xref:System.Collections.Generic.IAsyncEnumerator%601?displayProperty=nameWithType>.
-- [Indices and ranges](../whats-new/csharp-8.md#indices-and-ranges) require the new types <xref:System.Index?displayProperty=nameWithType> and <xref:System.Range?displayProperty=nameWithType>.
-- [Nullable reference types](../whats-new/csharp-8.md#nullable-reference-types) make use of several [attributes](attributes/nullable-analysis.md) to provide better warnings. Those attributes were added in .NET Core 3.0. Other target frameworks haven't been annotated with any of these attributes. That means nullable warnings may not accurately reflect potential issues.
-
-C# 9 is supported only on .NET 5 and newer versions. C# 10 is supported only on .NET 6 and newer versions.
-
-Check the [Visual Studio platform compatibility](/visualstudio/releases/2022/compatibility#-visual-studio-2022-support-for-net-development) page for details on which .NET versions are supported by versions of Visual Studio. Check the [Visual Studio for Mac platform compatibility](/visualstudio/mac/supported-versions-net) page for details on which .NET versions are support by versions of Visual Studio for Mac.
+Check the [Visual Studio platform compatibility](/visualstudio/releases/2022/compatibility#-visual-studio-2022-support-for-net-development) page for details on which .NET versions are supported by versions of Visual Studio. Check the [Visual Studio for Mac platform compatibility](/visualstudio/mac/supported-versions-net) page for details on which .NET versions are support by versions of Visual Studio for Mac. Check the [Mono page for C#](https://www.mono-project.com/docs/about-mono/languages/csharp/) for Mono compatibility with C# versions.
 
 ## Defaults
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -2,7 +2,7 @@
 title: C# language versioning - C# Guide
 description: Learn about how the C# language version is determined based on your project and the reasons behind that choice. Learn how to override the default manually.
 ms.custom: "updateeachrelease"
-ms.date: 07/06/2021
+ms.date: 02/25/2022
 ---
 
 # C# language versioning
@@ -77,4 +77,3 @@ Builds in all subdirectories of the directory containing that file will use the 
 The following table shows all current C# language versions. Your compiler may not necessarily understand every value if it's older. If you install the latest .NET SDK, then you have access to everything listed.
 
 [!INCLUDE [langversion-table](includes/langversion-table.md)]
-


### PR DESCRIPTION
Fixes #25404 - Instead of listing the versions, link to the pages in Visual Studio and Visual Studio for Mac documentation on .NET and C# version support.
Fixes #21287 - Link to the "What's new" pages for C# 8 through C# 10. Instead of repeating the list of features, link to the full list.
Fixes #27301 - Add tip on finding C# version for a given project.
Fixes #21128 - Link to Mono docs for C# version for Mono.
