### PR TITLE
Update tutorials to .NET 6

### DIFF
--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -20,7 +20,7 @@ Using a terminal window, create a directory named *classes*. You'll build your a
 Console.WriteLine("Hello, World!");
 ```
 
-In this tutorial, you're going to create new types that represent a bank account. Typically developers define each class in a different text file. That makes it easier to manage as a program grows in size. Create a new file named *BankAccount.cs* in the *classes* directory.
+In this tutorial, you're going to create new types that represent a bank account. Typically developers define each class in a different text file. That makes it easier to manage as a program grows in size. Create a new file named *BankAccount.cs* in the *Classes* directory.
 
 This file will contain the definition of a ***bank account***. Object Oriented programming organizes code by creating types in the form of ***classes***. These classes contain the code that represents a specific entity. The `BankAccount` class represents a bank account. The code implements specific operations through methods and properties. In this tutorial, the bank account supports this behavior:
 
@@ -37,7 +37,8 @@ This file will contain the definition of a ***bank account***. Object Oriented p
 You can start by creating the basics of a class that defines that behavior. Create a new file using the **File:New** command. Name it *BankAccount.cs*. Add the following code to your *BankAccount.cs* file:
 
 ```csharp
-namespace classes;
+namespace Classes;
+
 public class BankAccount
 {
     public string Number { get; }
@@ -75,7 +76,7 @@ public BankAccount(string name, decimal initialBalance)
 Constructors are called when you create an object using [`new`](../../language-reference/operators/new-operator.md). Replace the line `Console.WriteLine("Hello World!");` in *Program.cs* with the following code (replace `<name>` with your name):
 
 ```csharp
-using classes;
+using Classes;
 
 var account = new BankAccount("<name>", 1000);
 Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} initial balance.");

--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -1,7 +1,7 @@
 ---
 title: Classes and objects  - C# Fundamentals tutorial
 description: Create your first C# program and explore object oriented concepts
-ms.date: 05/14/2021
+ms.date: 02/25/2022
 ---
 # Explore object oriented programming with classes and objects
 
@@ -16,18 +16,8 @@ The tutorial expects that you have a machine set up for local development. On Wi
 Using a terminal window, create a directory named *classes*. You'll build your application there. Change to that directory and type `dotnet new console` in the console window. This command creates your application. Open *Program.cs*. It should look like this:
 
 ```csharp
-using System;
-
-namespace classes
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Console.WriteLine("Hello World!");
-        }
-    }
-}
+// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");
 ```
 
 In this tutorial, you're going to create new types that represent a bank account. Typically developers define each class in a different text file. That makes it easier to manage as a program grows in size. Create a new file named *BankAccount.cs* in the *classes* directory.
@@ -47,23 +37,19 @@ This file will contain the definition of a ***bank account***. Object Oriented p
 You can start by creating the basics of a class that defines that behavior. Create a new file using the **File:New** command. Name it *BankAccount.cs*. Add the following code to your *BankAccount.cs* file:
 
 ```csharp
-using System;
-
-namespace classes
+namespace classes;
+public class BankAccount
 {
-    public class BankAccount
+    public string Number { get; }
+    public string Owner { get; set; }
+    public decimal Balance { get; }
+
+    public void MakeDeposit(decimal amount, DateTime date, string note)
     {
-        public string Number { get; }
-        public string Owner { get; set; }
-        public decimal Balance { get; }
+    }
 
-        public void MakeDeposit(decimal amount, DateTime date, string note)
-        {
-        }
-
-        public void MakeWithdrawal(decimal amount, DateTime date, string note)
-        {
-        }
+    public void MakeWithdrawal(decimal amount, DateTime date, string note)
+    {
     }
 }
 ```
@@ -89,6 +75,8 @@ public BankAccount(string name, decimal initialBalance)
 Constructors are called when you create an object using [`new`](../../language-reference/operators/new-operator.md). Replace the line `Console.WriteLine("Hello World!");` in *Program.cs* with the following code (replace `<name>` with your name):
 
 ```csharp
+using classes;
+
 var account = new BankAccount("<name>", 1000);
 Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} initial balance.");
 ```
@@ -123,12 +111,6 @@ Let's start by creating a new type to represent a transaction. This is a simple 
 Now, let's add a <xref:System.Collections.Generic.List%601> of `Transaction` objects to the `BankAccount` class. Add the following declaration after the constructor in your *BankAccount.cs* file:
 
 :::code language="csharp" source="./snippets/introduction-to-classes/BankAccount.cs" id="TransactionDeclaration":::
-
-The <xref:System.Collections.Generic.List%601> class requires you to import a different namespace. Add the following at the beginning of *BankAccount.cs*:
-
-```csharp
-using System.Collections.Generic;
-```
 
 Now, let's correctly compute the `Balance`. The current balance can be found by summing the values of all transactions. As the code is currently, you can only get the initial balance of the account, so you'll have to update the `Balance` property. Replace the line `public decimal Balance { get; }` in *BankAccount.cs* with the following code:
 

--- a/docs/csharp/fundamentals/tutorials/how-to-display-command-line-arguments.md
+++ b/docs/csharp/fundamentals/tutorials/how-to-display-command-line-arguments.md
@@ -1,7 +1,7 @@
 ---
 title: "How to display command-line arguments"
 description: Learn how to display command-line arguments. See a code example and view additional available resources.
-ms.date: 03/08/2021
+ms.date: 02/25/2022
 ms.topic: how-to
 helpviewer_keywords: 
   - "command-line arguments [C#], displaying"

--- a/docs/csharp/fundamentals/tutorials/inheritance.md
+++ b/docs/csharp/fundamentals/tutorials/inheritance.md
@@ -1,7 +1,7 @@
 ---
 title: Inheritance in C#
 description: Learn to use inheritance in C# libraries and applications.
-ms.date: 07/05/2018
+ms.date: 02/25/2022
 ms.assetid: aeb68c74-0ea0-406f-9fbe-2ce02d47ef31
 ---
 # Inheritance in C# and .NET
@@ -93,8 +93,6 @@ public class B : A // Generates CS0534.
 Inheritance applies only to classes and interfaces. Other type categories (structs, delegates, and enums) do not support inheritance. Because of these rules, attempting to compile code like the following example produces compiler error CS0527: "Type 'ValueType' in interface list is not an interface." The error message indicates that, although you can define the interfaces that a struct implements, inheritance is not supported.
 
 ```csharp
-using System;
-
 public struct ValueStructure : ValueType // Generates CS0527.
 {
 }

--- a/docs/csharp/fundamentals/tutorials/oop.md
+++ b/docs/csharp/fundamentals/tutorials/oop.md
@@ -1,7 +1,7 @@
 ---
 title: "Object-Oriented Programming (C#)"
 description: C# provides full support for object-oriented programming including abstraction, encapsulation, inheritance, and polymorphism.
-ms.date: 05/14/2021
+ms.date: 02/25/2022
 ---
 # Object-Oriented programming (C#)
 

--- a/docs/csharp/fundamentals/tutorials/pattern-matching.md
+++ b/docs/csharp/fundamentals/tutorials/pattern-matching.md
@@ -64,7 +64,7 @@ using CommercialRegistration;
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator;
+namespace Calculators;
 
 public class TollCalculator
 {

--- a/docs/csharp/fundamentals/tutorials/pattern-matching.md
+++ b/docs/csharp/fundamentals/tutorials/pattern-matching.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Build algorithms with pattern matching"
 description: This advanced tutorial demonstrates how to use pattern matching techniques to create functionality using data and algorithms that are created separately.
-ms.date: 10/01/2021
+ms.date: 02/25/2022
 ms.custom: contperf-fy21q1
 ---
 # Tutorial: Use pattern matching to build type-driven and data-driven algorithms
@@ -64,21 +64,20 @@ using CommercialRegistration;
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator
+namespace toll_calculator;
+
+public class TollCalculator
 {
-    public class TollCalculator
+    public decimal CalculateToll(object vehicle) =>
+        vehicle switch
     {
-        public decimal CalculateToll(object vehicle) =>
-            vehicle switch
-        {
-            Car c           => 2.00m,
-            Taxi t          => 3.50m,
-            Bus b           => 5.00m,
-            DeliveryTruck t => 10.00m,
-            { }             => throw new ArgumentException(message: "Not a known vehicle type", paramName: nameof(vehicle)),
-            null            => throw new ArgumentNullException(nameof(vehicle))
-        };
-    }
+        Car c           => 2.00m,
+        Taxi t          => 3.50m,
+        Bus b           => 5.00m,
+        DeliveryTruck t => 10.00m,
+        { }             => throw new ArgumentException(message: "Not a known vehicle type", paramName: nameof(vehicle)),
+        null            => throw new ArgumentNullException(nameof(vehicle))
+    };
 }
 ```
 
@@ -92,42 +91,35 @@ using CommercialRegistration;
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator
+using toll_calculator;
+
+var tollCalc = new TollCalculator();
+
+var car = new Car();
+var taxi = new Taxi();
+var bus = new Bus();
+var truck = new DeliveryTruck();
+
+Console.WriteLine($"The toll for a car is {tollCalc.CalculateToll(car)}");
+Console.WriteLine($"The toll for a taxi is {tollCalc.CalculateToll(taxi)}");
+Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(bus)}");
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
+
+try
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var tollCalc = new TollCalculator();
-
-            var car = new Car();
-            var taxi = new Taxi();
-            var bus = new Bus();
-            var truck = new DeliveryTruck();
-
-            Console.WriteLine($"The toll for a car is {tollCalc.CalculateToll(car)}");
-            Console.WriteLine($"The toll for a taxi is {tollCalc.CalculateToll(taxi)}");
-            Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(bus)}");
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
-
-            try
-            {
-                tollCalc.CalculateToll("this will fail");
-            }
-            catch (ArgumentException e)
-            {
-                Console.WriteLine("Caught an argument exception when using the wrong type");
-            }
-            try
-            {
-                tollCalc.CalculateToll(null!);
-            }
-            catch (ArgumentNullException e)
-            {
-                Console.WriteLine("Caught an argument exception when using null");
-            }
-        }
-    }
+    tollCalc.CalculateToll("this will fail");
+}
+catch (ArgumentException e)
+{
+    Console.WriteLine("Caught an argument exception when using the wrong type");
+}
+try
+{
+    tollCalc.CalculateToll(null!);
+}
+catch (ArgumentNullException e)
+{
+    Console.WriteLine("Caught an argument exception when using null");
 }
 ```
 

--- a/docs/csharp/fundamentals/tutorials/safely-cast-using-pattern-matching-is-and-as-operators.md
+++ b/docs/csharp/fundamentals/tutorials/safely-cast-using-pattern-matching-is-and-as-operators.md
@@ -1,7 +1,7 @@
 ---
 title: "How to safely cast by using pattern matching and the is and as operators"
 description: Learn to use pattern matching techniques to safely cast variables to a different type. You can use pattern matching as well as the is and as operators to safely convert types.
-ms.date: 05/14/2021
+ms.date: 02/25/2022
 helpviewer_keywords: 
   - "cast operators [C#], as and is operators"
   - "as operator [C#]"

--- a/docs/csharp/fundamentals/tutorials/snippets/command-line-arguments/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/command-line-arguments/Program.cs
@@ -1,18 +1,11 @@
-﻿using System;
+﻿// The Length property provides the number of array elements.
+Console.WriteLine($"parameter count = {args.Length}");
 
-class CommandLine
+for (int i = 0; i < args.Length; i++)
 {
-    static void Main(string[] args)
-    {
-        // The Length property provides the number of array elements.
-        Console.WriteLine($"parameter count = {args.Length}");
-
-        for (int i = 0; i < args.Length; i++)
-        {
-            Console.WriteLine($"Arg[{i}] = [{args[i]}]");
-        }
-    }
+    Console.WriteLine($"Arg[{i}] = [{args[i]}]");
 }
+
 /* Output (assumes 3 cmd line args):
     parameter count = 3
     Arg[0] = [a]

--- a/docs/csharp/fundamentals/tutorials/snippets/command-line-arguments/command-line-arguments.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/command-line-arguments/command-line-arguments.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>command_line_arguments</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace inheritance;
+namespace Inheritance;
 
 class Program
 {

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/Program.cs
@@ -1,17 +1,14 @@
-﻿using System;
+﻿namespace inheritance;
 
-namespace inheritance
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            Basic.Example.Main();
-            IsA_Namespace.Example.Main();
-            AccessExample.Main(args);
-            Example.Example.Main();
-            ClassNameExample.Main();
-            ClassExample.Main();
-        }
+        Basic.Example.Main();
+        IsA_Namespace.Example.Main();
+        AccessExample.Main(args);
+        Example.Example.Main();
+        ClassNameExample.Main();
+        ClassExample.Main();
     }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/base-and-derived.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/base-and-derived.cs
@@ -1,144 +1,142 @@
 ﻿// <Snippet1>
-using System;
 
 public enum PublicationType { Misc, Book, Magazine, Article };
 
 public abstract class Publication
 {
-   private bool published = false;
-   private DateTime datePublished;
-   private int totalPages;
+    private bool _published = false;
+    private DateTime _datePublished;
+    private int _totalPages;
 
-   public Publication(string title, string publisher, PublicationType type)
-   {
-      if (String.IsNullOrWhiteSpace(publisher))
-         throw new ArgumentException("The publisher is required.");
-      Publisher = publisher;
+    public Publication(string title, string publisher, PublicationType type)
+    {
+        if (string.IsNullOrWhiteSpace(publisher))
+            throw new ArgumentException("The publisher is required.");
+        Publisher = publisher;
 
-      if (String.IsNullOrWhiteSpace(title))
-         throw new ArgumentException("The title is required.");
-      Title = title;
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("The title is required.");
+        Title = title;
 
-      Type = type;
-   }
+        Type = type;
+    }
 
-   public string Publisher { get; }
+    public string Publisher { get; }
 
-   public string Title { get; }
+    public string Title { get; }
 
-   public PublicationType Type { get; }
+    public PublicationType Type { get; }
 
-   public string CopyrightName { get; private set; }
+    public string? CopyrightName { get; private set; }
 
-   public int CopyrightDate { get; private set; }
+    public int CopyrightDate { get; private set; }
 
-   public int Pages
-   {
-     get { return totalPages; }
-     set
-     {
-         if (value <= 0)
-            throw new ArgumentOutOfRangeException(nameof(value), "The number of pages cannot be zero or negative.");
-         totalPages = value;
-     }
-   }
+    public int Pages
+    {
+        get { return _totalPages; }
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(value), "The number of pages cannot be zero or negative.");
+            _totalPages = value;
+        }
+    }
 
-   public string GetPublicationDate()
-   {
-      if (!published)
-         return "NYP";
-      else
-         return datePublished.ToString("d");
-   }
+    public string GetPublicationDate()
+    {
+        if (!_published)
+            return "NYP";
+        else
+            return _datePublished.ToString("d");
+    }
 
-   public void Publish(DateTime datePublished)
-   {
-      published = true;
-      this.datePublished = datePublished;
-   }
+    public void Publish(DateTime datePublished)
+    {
+        _published = true;
+        _datePublished = datePublished;
+    }
 
-   public void Copyright(string copyrightName, int copyrightDate)
-   {
-      if (String.IsNullOrWhiteSpace(copyrightName))
-         throw new ArgumentException("The name of the copyright holder is required.");
-      CopyrightName = copyrightName;
+    public void Copyright(string copyrightName, int copyrightDate)
+    {
+        if (string.IsNullOrWhiteSpace(copyrightName))
+            throw new ArgumentException("The name of the copyright holder is required.");
+        CopyrightName = copyrightName;
 
-      int currentYear = DateTime.Now.Year;
-      if (copyrightDate < currentYear - 10 || copyrightDate > currentYear + 2)
-         throw new ArgumentOutOfRangeException($"The copyright year must be between {currentYear - 10} and {currentYear + 1}");
-      CopyrightDate = copyrightDate;
-   }
+        int currentYear = DateTime.Now.Year;
+        if (copyrightDate < currentYear - 10 || copyrightDate > currentYear + 2)
+            throw new ArgumentOutOfRangeException($"The copyright year must be between {currentYear - 10} and {currentYear + 1}");
+        CopyrightDate = copyrightDate;
+    }
 
-   public override string ToString() => Title;
+    public override string ToString() => Title;
 }
 // </Snippet1>
 
 namespace DerivedClasses
 {
-// <Snippet2>
-using System;
+    // <Snippet2>
+    using System;
 
-public sealed class Book : Publication
-{
-   public Book(string title, string author, string publisher) :
-          this(title, String.Empty, author, publisher)
-   { }
+    public sealed class Book : Publication
+    {
+        public Book(string title, string author, string publisher) :
+               this(title, string.Empty, author, publisher)
+        { }
 
-   public Book(string title, string isbn, string author, string publisher) : base(title, publisher, PublicationType.Book)
-   {
-      // isbn argument must be a 10- or 13-character numeric string without "-" characters.
-      // We could also determine whether the ISBN is valid by comparing its checksum digit
-      // with a computed checksum.
-      //
-      if (! String.IsNullOrEmpty(isbn)) {
-        // Determine if ISBN length is correct.
-        if (! (isbn.Length == 10 | isbn.Length == 13))
-            throw new ArgumentException("The ISBN must be a 10- or 13-character numeric string.");
-        ulong nISBN = 0;
-        if (! UInt64.TryParse(isbn, out nISBN))
-            throw new ArgumentException("The ISBN can consist of numeric characters only.");
-      }
-      ISBN = isbn;
+        public Book(string title, string isbn, string author, string publisher) : base(title, publisher, PublicationType.Book)
+        {
+            // isbn argument must be a 10- or 13-character numeric string without "-" characters.
+            // We could also determine whether the ISBN is valid by comparing its checksum digit
+            // with a computed checksum.
+            //
+            if (!string.IsNullOrEmpty(isbn))
+            {
+                // Determine if ISBN length is correct.
+                if (!(isbn.Length == 10 | isbn.Length == 13))
+                    throw new ArgumentException("The ISBN must be a 10- or 13-character numeric string.");
+                if (!ulong.TryParse(isbn, out _))
+                    throw new ArgumentException("The ISBN can consist of numeric characters only.");
+            }
+            ISBN = isbn;
 
-      Author = author;
-   }
+            Author = author;
+        }
 
-   public string ISBN { get; }
+        public string ISBN { get; }
 
-   public string Author { get; }
+        public string Author { get; }
 
-   public Decimal Price { get; private set; }
+        public decimal Price { get; private set; }
 
-   // A three-digit ISO currency symbol.
-   public string Currency { get; private set; }
+        // A three-digit ISO currency symbol.
+        public string? Currency { get; private set; }
 
-   // Returns the old price, and sets a new price.
-   public Decimal SetPrice(Decimal price, string currency)
-   {
-       if (price < 0)
-          throw new ArgumentOutOfRangeException(nameof(price), "The price cannot be negative.");
-       Decimal oldValue = Price;
-       Price = price;
+        // Returns the old price, and sets a new price.
+        public decimal SetPrice(decimal price, string currency)
+        {
+            if (price < 0)
+                throw new ArgumentOutOfRangeException(nameof(price), "The price cannot be negative.");
+            decimal oldValue = Price;
+            Price = price;
 
-       if (currency.Length != 3)
-          throw new ArgumentException("The ISO currency symbol is a 3-character string.");
-       Currency = currency;
+            if (currency.Length != 3)
+                throw new ArgumentException("The ISO currency symbol is a 3-character string.");
+            Currency = currency;
 
-       return oldValue;
-   }
+            return oldValue;
+        }
 
-   public override bool Equals(object obj)
-   {
-      Book book = obj as Book;
-      if (book == null)
-         return false;
-      else
-         return ISBN == book.ISBN;
-   }
+        public override bool Equals(object? obj)
+        {
+            if (obj is not Book book)
+                return false;
+            else
+                return ISBN == book.ISBN;
+        }
 
-   public override int GetHashCode() => ISBN.GetHashCode();
+        public override int GetHashCode() => ISBN.GetHashCode();
 
-   public override string ToString() => $"{(String.IsNullOrEmpty(Author) ? "" : Author + ", ")}{Title}";
-}
-// </Snippet2>
+        public override string ToString() => $"{(string.IsNullOrEmpty(Author) ? "" : Author + ", ")}{Title}";
+    }
+    // </Snippet2>
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/basics.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/basics.cs
@@ -1,26 +1,23 @@
-﻿using System;
+﻿namespace Basic;
 
-namespace Basic
+// <Snippet1>
+public class A
 {
-    // <Snippet1>
-    public class A
+    public void Method1()
     {
-        public void Method1()
-        {
-            // Method implementation.
-        }
+        // Method implementation.
     }
-
-    public class B : A
-    { }
-
-    public class Example
-    {
-        public static void Main()
-        {
-            B b = new B();
-            b.Method1();
-        }
-    }
-    // </Snippet1>
 }
+
+public class B : A
+{ }
+
+public class Example
+{
+    public static void Main()
+    {
+        B b = new ();
+        b.Method1();
+    }
+}
+// </Snippet1>

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/inheritance.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/inheritance.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <StartupObject>inheritance.Program</StartupObject>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/inheritance.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/inheritance.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <StartupObject>inheritance.Program</StartupObject>
+    <StartupObject>Inheritance.Program</StartupObject>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/is-a.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/is-a.cs
@@ -1,24 +1,22 @@
 ﻿// <Snippet1>
-using System;
-
 public class Automobile
 {
     public Automobile(string make, string model, int year)
     {
         if (make == null)
-           throw new ArgumentNullException(nameof(make), "The make cannot be null.");
-        else if (String.IsNullOrWhiteSpace(make))
-           throw new ArgumentException("make cannot be an empty string or have space characters only.");
+            throw new ArgumentNullException(nameof(make), "The make cannot be null.");
+        else if (string.IsNullOrWhiteSpace(make))
+            throw new ArgumentException("make cannot be an empty string or have space characters only.");
         Make = make;
 
         if (model == null)
-           throw new ArgumentNullException(nameof(model), "The model cannot be null.");
-        else if (String.IsNullOrWhiteSpace(model))
-           throw new ArgumentException("model cannot be an empty string or have space characters only.");
+            throw new ArgumentNullException(nameof(model), "The model cannot be null.");
+        else if (string.IsNullOrWhiteSpace(model))
+            throw new ArgumentException("model cannot be an empty string or have space characters only.");
         Model = model;
 
         if (year < 1857 || year > DateTime.Now.Year + 2)
-           throw new ArgumentException("The year is out of range.");
+            throw new ArgumentException("The year is out of range.");
         Year = year;
     }
 

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/private.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/private.cs
@@ -1,25 +1,23 @@
 ﻿// <Snippet1>
-using System;
-
 public class A
 {
-   private int value = 10;
+    private int _value = 10;
 
-   public class B : A
-   {
-       public int GetValue()
-       {
-           return this.value;
-       }
-   }
+    public class B : A
+    {
+        public int GetValue()
+        {
+            return _value;
+        }
+    }
 }
 
 public class C : A
 {
-//    public int GetValue()
-//    {
-//        return this.value;
-//    }
+    //    public int GetValue()
+    //    {
+    //        return this.value;
+    //    }
 }
 
 public class AccessExample

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/shape.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/shape.cs
@@ -1,117 +1,116 @@
 ﻿// <Snippet1>
-using System;
-
 public abstract class Shape
 {
-   public abstract double Area { get; }
+    public abstract double Area { get; }
 
-   public abstract double Perimeter { get; }
+    public abstract double Perimeter { get; }
 
-   public override string ToString() => GetType().Name;
+    public override string ToString() => GetType().Name;
 
-   public static double GetArea(Shape shape) => shape.Area;
+    public static double GetArea(Shape shape) => shape.Area;
 
-   public static double GetPerimeter(Shape shape) => shape.Perimeter;
+    public static double GetPerimeter(Shape shape) => shape.Perimeter;
 }
 // </Snippet1>
 
 namespace DerivedClasses
 {
-// <Snippet2>
-using System;
+    // <Snippet2>
+    using System;
 
-public class Square : Shape
-{
-   public Square(double length)
-   {
-      Side = length;
-   }
+    public class Square : Shape
+    {
+        public Square(double length)
+        {
+            Side = length;
+        }
 
-   public double Side { get; }
+        public double Side { get; }
 
-   public override double Area => Math.Pow(Side, 2);
+        public override double Area => Math.Pow(Side, 2);
 
-   public override double Perimeter => Side * 4;
+        public override double Perimeter => Side * 4;
 
-   public double Diagonal => Math.Round(Math.Sqrt(2) * Side, 2);
-}
+        public double Diagonal => Math.Round(Math.Sqrt(2) * Side, 2);
+    }
 
-public class Rectangle : Shape
-{
-   public Rectangle(double length, double width)
-   {
-      Length = length;
-      Width = width;
-   }
+    public class Rectangle : Shape
+    {
+        public Rectangle(double length, double width)
+        {
+            Length = length;
+            Width = width;
+        }
 
-   public double Length { get; }
+        public double Length { get; }
 
-   public double Width { get; }
+        public double Width { get; }
 
-   public override double Area => Length * Width;
+        public override double Area => Length * Width;
 
-   public override double Perimeter => 2 * Length + 2 * Width;
+        public override double Perimeter => 2 * Length + 2 * Width;
 
-   public bool IsSquare() => Length == Width;
+        public bool IsSquare() => Length == Width;
 
-   public double Diagonal => Math.Round(Math.Sqrt(Math.Pow(Length, 2) + Math.Pow(Width, 2)), 2);
-}
+        public double Diagonal => Math.Round(Math.Sqrt(Math.Pow(Length, 2) + Math.Pow(Width, 2)), 2);
+    }
 
-public class Circle : Shape
-{
-   public Circle(double radius)
-   {
-      Radius = radius;
-   }
+    public class Circle : Shape
+    {
+        public Circle(double radius)
+        {
+            Radius = radius;
+        }
 
-   public override double Area => Math.Round(Math.PI * Math.Pow(Radius, 2), 2);
+        public override double Area => Math.Round(Math.PI * Math.Pow(Radius, 2), 2);
 
-   public override double Perimeter => Math.Round(Math.PI * 2 * Radius, 2);
+        public override double Perimeter => Math.Round(Math.PI * 2 * Radius, 2);
 
-   // Define a circumference, since it's the more familiar term.
-   public double Circumference => Perimeter;
+        // Define a circumference, since it's the more familiar term.
+        public double Circumference => Perimeter;
 
-   public double Radius { get; }
+        public double Radius { get; }
 
-   public double Diameter => Radius * 2;
-}
-// </Snippet2>
+        public double Diameter => Radius * 2;
+    }
+    // </Snippet2>
 } // Namespace definition
 
 namespace Example
 {
 
-using DerivedClasses;
-// <Snippet3>
-using System;
+    using DerivedClasses;
+    // <Snippet3>
+    using System;
 
-public class Example
-{
-   public static void Main()
-   {
-      Shape[] shapes = { new Rectangle(10, 12), new Square(5),
+    public class Example
+    {
+        public static void Main()
+        {
+            Shape[] shapes = { new Rectangle(10, 12), new Square(5),
                         new Circle(3) };
-      foreach (var shape in shapes) {
-         Console.WriteLine($"{shape}: area, {Shape.GetArea(shape)}; " +
-                           $"perimeter, {Shape.GetPerimeter(shape)}");
-         var rect = shape as Rectangle;
-         if (rect != null) {
-            Console.WriteLine($"   Is Square: {rect.IsSquare()}, Diagonal: {rect.Diagonal}");
-            continue;
-         }
-         var sq = shape as Square;
-         if (sq != null) {
-            Console.WriteLine($"   Diagonal: {sq.Diagonal}");
-            continue;
-         }
-      }
-   }
-}
-// The example displays the following output:
-//         Rectangle: area, 120; perimeter, 44
-//            Is Square: False, Diagonal: 15.62
-//         Square: area, 25; perimeter, 20
-//            Diagonal: 7.07
-//         Circle: area, 28.27; perimeter, 18.85
-// </Snippet3>
+            foreach (Shape shape in shapes)
+            {
+                Console.WriteLine($"{shape}: area, {Shape.GetArea(shape)}; " +
+                                  $"perimeter, {Shape.GetPerimeter(shape)}");
+                if (shape is Rectangle rect)
+                {
+                    Console.WriteLine($"   Is Square: {rect.IsSquare()}, Diagonal: {rect.Diagonal}");
+                    continue;
+                }
+                if (shape is Square sq)
+                {
+                    Console.WriteLine($"   Diagonal: {sq.Diagonal}");
+                    continue;
+                }
+            }
+        }
+    }
+    // The example displays the following output:
+    //         Rectangle: area, 120; perimeter, 44
+    //            Is Square: False, Diagonal: 15.62
+    //         Square: area, 25; perimeter, 20
+    //            Diagonal: 7.07
+    //         Circle: area, 28.27; perimeter, 18.85
+    // </Snippet3>
 } // Namespace definition.

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/simpleclass.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/simpleclass.cs
@@ -1,5 +1,4 @@
 ﻿// <Snippet2>
-using System;
 using System.Reflection;
 
 public class SimpleClassExample
@@ -11,7 +10,7 @@ public class SimpleClassExample
                              BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
         MemberInfo[] members = t.GetMembers(flags);
         Console.WriteLine($"Type {t.Name} has {members.Length} members: ");
-        foreach (var member in members)
+        foreach (MemberInfo member in members)
         {
             string access = "";
             string stat = "";
@@ -31,7 +30,7 @@ public class SimpleClassExample
                 if (method.IsStatic)
                     stat = " Static";
             }
-            var output = $"{member.Name} ({member.MemberType}): {access}{stat}, Declared by {member.DeclaringType}";
+            string output = $"{member.Name} ({member.MemberType}): {access}{stat}, Declared by {member.DeclaringType}";
             Console.WriteLine(output);
         }
     }

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/simpleclass2.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/simpleclass2.cs
@@ -1,14 +1,12 @@
 ﻿// <Snippet1>
-using System;
-
 public class EmptyClass
-{}
+{ }
 
 public class ClassNameExample
 {
     public static void Main()
     {
-        EmptyClass sc = new EmptyClass();
+        EmptyClass sc = new();
         Console.WriteLine(sc.ToString());
     }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/inheritance/use-publication.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/inheritance/use-publication.cs
@@ -1,27 +1,25 @@
 ﻿// <Snippet1>
-using System;
-
 public class ClassExample
 {
-   public static void Main()
-   {
-      var book = new Book("The Tempest",  "0971655819", "Shakespeare, William",
-                          "Public Domain Press");
-      ShowPublicationInfo(book);
-      book.Publish(new DateTime(2016, 8, 18));
-      ShowPublicationInfo(book);
+    public static void Main()
+    {
+        var book = new Book("The Tempest", "0971655819", "Shakespeare, William",
+                            "Public Domain Press");
+        ShowPublicationInfo(book);
+        book.Publish(new DateTime(2016, 8, 18));
+        ShowPublicationInfo(book);
 
-      var book2 = new Book("The Tempest", "Classic Works Press", "Shakespeare, William");
-      Console.Write($"{book.Title} and {book2.Title} are the same publication: " +
-            $"{((Publication) book).Equals(book2)}");
-   }
+        var book2 = new Book("The Tempest", "Classic Works Press", "Shakespeare, William");
+        Console.Write($"{book.Title} and {book2.Title} are the same publication: " +
+              $"{((Publication)book).Equals(book2)}");
+    }
 
-   public static void ShowPublicationInfo(Publication pub)
-   {
-       string pubDate = pub.GetPublicationDate();
-       Console.WriteLine($"{pub.Title}, " +
-                 $"{(pubDate == "NYP" ? "Not Yet Published" : "published on " + pubDate):d} by {pub.Publisher}");
-   }
+    public static void ShowPublicationInfo(Publication pub)
+    {
+        string pubDate = pub.GetPublicationDate();
+        Console.WriteLine($"{pub.Title}, " +
+                  $"{(pubDate == "NYP" ? "Not Yet Published" : "published on " + pubDate):d} by {pub.Publisher}");
+    }
 }
 // The example displays the following output:
 //        The Tempest, Not Yet Published by Public Domain Press
@@ -31,63 +29,62 @@ public class ClassExample
 
 public sealed class Book : Publication
 {
-   public Book(string title, string author, string publisher) :
-          this(title, String.Empty, author, publisher)
-   { }
+    public Book(string title, string author, string publisher) :
+           this(title, string.Empty, author, publisher)
+    { }
 
-   public Book(string title, string isbn, string author, string publisher) : base(title, publisher, PublicationType.Book)
-   {
-      // isbn argument must be a 10- or 13-character numeric string without "-" characters.
-      // We could also determine whether the ISBN is valid by comparing its checksum digit
-      // with a computed checksum.
-      //
-      if (! String.IsNullOrEmpty(isbn)) {
-        // Determine if ISBN length is correct.
-        if (! (isbn.Length == 10 | isbn.Length == 13))
-            throw new ArgumentException("The ISBN must be a 10- or 13-character numeric string.");
-        ulong nISBN = 0;
-        if (! UInt64.TryParse(isbn, out nISBN))
-            throw new ArgumentException("The ISBN can consist of numeric characters only.");
-      }
-      ISBN = isbn;
+    public Book(string title, string isbn, string author, string publisher) : base(title, publisher, PublicationType.Book)
+    {
+        // isbn argument must be a 10- or 13-character numeric string without "-" characters.
+        // We could also determine whether the ISBN is valid by comparing its checksum digit
+        // with a computed checksum.
+        //
+        if (!string.IsNullOrEmpty(isbn))
+        {
+            // Determine if ISBN length is correct.
+            if (!(isbn.Length == 10 | isbn.Length == 13))
+                throw new ArgumentException("The ISBN must be a 10- or 13-character numeric string.");
+            if (!ulong.TryParse(isbn, out _))
+                throw new ArgumentException("The ISBN can consist of numeric characters only.");
+        }
+        ISBN = isbn;
 
-      Author = author;
-   }
+        Author = author;
+    }
 
-   public string ISBN { get; }
+    public string ISBN { get; }
 
-   public string Author { get; }
+    public string Author { get; }
 
-   public Decimal Price { get; private set; }
+    public decimal Price { get; private set; }
 
-   // A three-digit ISO currency symbol.
-   public string Currency { get; private set; }
+    // A three-digit ISO currency symbol.
+    public string? Currency { get; private set; }
 
-   // Returns the old price, and sets a new price.
-   public Decimal SetPrice(Decimal price, string currency)
-   {
-       if (price < 0)
-          throw new ArgumentOutOfRangeException(nameof(price), "The price cannot be negative.");
-       Decimal oldValue = Price;
-       Price = price;
+    // Returns the old price, and sets a new price.
+    public decimal SetPrice(decimal price, string currency)
+    {
+        if (price < 0)
+            throw new ArgumentOutOfRangeException(nameof(price), "The price cannot be negative.");
+        decimal oldValue = Price;
+        Price = price;
 
-       if (currency.Length != 3)
-          throw new ArgumentException("The ISO currency symbol is a 3-character string.");
-       Currency = currency;
+        if (currency.Length != 3)
+            throw new ArgumentException("The ISO currency symbol is a 3-character string.");
+        Currency = currency;
 
-       return oldValue;
-   }
+        return oldValue;
+    }
 
-   public override bool Equals(object obj)
-   {
-      Book book = obj as Book;
-      if (book == null)
-         return false;
-      else
-         return ISBN == book.ISBN;
-   }
+    public override bool Equals(object? obj)
+    {
+        if (obj is not Book book)
+            return false;
+        else
+            return ISBN == book.ISBN;
+    }
 
-   public override int GetHashCode() => ISBN.GetHashCode();
+    public override int GetHashCode() => ISBN.GetHashCode();
 
-   public override string ToString() => $"{(String.IsNullOrEmpty(Author) ? "" : Author + ", ")}{Title}";
+    public override string ToString() => $"{(string.IsNullOrEmpty(Author) ? "" : Author + ", ")}{Title}";
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/BankAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/BankAccount.cs
@@ -1,85 +1,84 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace classes
+namespace classes;
+
+public class BankAccount
 {
-    public class BankAccount
-    {
-        public string Number { get; }
-        public string Owner { get; set; }
+    public string Number { get; }
+    public string Owner { get; set; }
 #region BalanceComputation
-        public decimal Balance
+    public decimal Balance
+    {
+        get
         {
-            get
-            {
-                decimal balance = 0;
-                foreach (var item in allTransactions)
-                {
-                    balance += item.Amount;
-                }
-
-                return balance;
-            }
-        }
-#endregion
-
-        private static int accountNumberSeed = 1234567890;
-#region Constructor
-        public BankAccount(string name, decimal initialBalance)
-        {
-            this.Number = accountNumberSeed.ToString();
-            accountNumberSeed++;
-
-            this.Owner = name;
-            MakeDeposit(initialBalance, DateTime.Now, "Initial balance");
-        }
-#endregion
-
-#region TransactionDeclaration
-        private List<Transaction> allTransactions = new List<Transaction>();
-#endregion
-
-#region DepositAndWithdrawal
-        public void MakeDeposit(decimal amount, DateTime date, string note)
-        {
-            if (amount <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(amount), "Amount of deposit must be positive");
-            }
-            var deposit = new Transaction(amount, date, note);
-            allTransactions.Add(deposit);
-        }
-
-        public void MakeWithdrawal(decimal amount, DateTime date, string note)
-        {
-            if (amount <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(amount), "Amount of withdrawal must be positive");
-            }
-            if (Balance - amount < 0)
-            {
-                throw new InvalidOperationException("Not sufficient funds for this withdrawal");
-            }
-            var withdrawal = new Transaction(-amount, date, note);
-            allTransactions.Add(withdrawal);
-        }
-#endregion
-
-#region History
-        public string GetAccountHistory()
-        {
-            var report = new System.Text.StringBuilder();
-
             decimal balance = 0;
-            report.AppendLine("Date\t\tAmount\tBalance\tNote");
             foreach (var item in allTransactions)
             {
                 balance += item.Amount;
-                report.AppendLine($"{item.Date.ToShortDateString()}\t{item.Amount}\t{balance}\t{item.Notes}");
             }
 
-            return report.ToString();
+            return balance;
         }
-#endregion
     }
+#endregion
+
+    private static int accountNumberSeed = 1234567890;
+#region Constructor
+    public BankAccount(string name, decimal initialBalance)
+    {
+        this.Number = accountNumberSeed.ToString();
+        accountNumberSeed++;
+
+        this.Owner = name;
+        MakeDeposit(initialBalance, DateTime.Now, "Initial balance");
+    }
+#endregion
+
+#region TransactionDeclaration
+    private List<Transaction> allTransactions = new List<Transaction>();
+#endregion
+
+#region DepositAndWithdrawal
+    public void MakeDeposit(decimal amount, DateTime date, string note)
+    {
+        if (amount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount), "Amount of deposit must be positive");
+        }
+        var deposit = new Transaction(amount, date, note);
+        allTransactions.Add(deposit);
+    }
+
+    public void MakeWithdrawal(decimal amount, DateTime date, string note)
+    {
+        if (amount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount), "Amount of withdrawal must be positive");
+        }
+        if (Balance - amount < 0)
+        {
+            throw new InvalidOperationException("Not sufficient funds for this withdrawal");
+        }
+        var withdrawal = new Transaction(-amount, date, note);
+        allTransactions.Add(withdrawal);
+    }
+#endregion
+
+#region History
+    public string GetAccountHistory()
+    {
+        var report = new System.Text.StringBuilder();
+
+        decimal balance = 0;
+        report.AppendLine("Date\t\tAmount\tBalance\tNote");
+        foreach (var item in allTransactions)
+        {
+            balance += item.Amount;
+            report.AppendLine($"{item.Date.ToShortDateString()}\t{item.Amount}\t{balance}\t{item.Notes}");
+        }
+
+        return report.ToString();
+    }
+#endregion
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/BankAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/BankAccount.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace classes;
+namespace Classes;
 
 public class BankAccount
 {
@@ -27,10 +27,10 @@ public class BankAccount
 #region Constructor
     public BankAccount(string name, decimal initialBalance)
     {
-        this.Number = accountNumberSeed.ToString();
+        Number = accountNumberSeed.ToString();
         accountNumberSeed++;
 
-        this.Owner = name;
+        Owner = name;
         MakeDeposit(initialBalance, DateTime.Now, "Initial balance");
     }
 #endregion

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/Program.cs
@@ -1,42 +1,33 @@
-﻿using System;
+﻿using classes;
 
-namespace classes
+var account = new BankAccount("<name>", 1000);
+Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} balance.");
+
+account.MakeWithdrawal(500, DateTime.Now, "Rent payment");
+Console.WriteLine(account.Balance);
+account.MakeDeposit(100, DateTime.Now, "friend paid me back");
+Console.WriteLine(account.Balance);
+
+Console.WriteLine(account.GetAccountHistory());
+
+// Test that the initial balances must be positive:
+try
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var account = new BankAccount("<name>", 1000);
-            Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} balance.");
+    var invalidAccount = new BankAccount("invalid", -55);
+}
+catch (ArgumentOutOfRangeException e)
+{
+    Console.WriteLine("Exception caught creating account with negative balance");
+    Console.WriteLine(e.ToString());
+}
 
-            account.MakeWithdrawal(500, DateTime.Now, "Rent payment");
-            Console.WriteLine(account.Balance);
-            account.MakeDeposit(100, DateTime.Now, "friend paid me back");
-            Console.WriteLine(account.Balance);
-
-            Console.WriteLine(account.GetAccountHistory());
-
-            // Test that the initial balances must be positive:
-            try
-            {
-                var invalidAccount = new BankAccount("invalid", -55);
-            }
-            catch (ArgumentOutOfRangeException e)
-            {
-                Console.WriteLine("Exception caught creating account with negative balance");
-                Console.WriteLine(e.ToString());
-            }
-
-            // Test for a negative balance
-            try
-            {
-                account.MakeWithdrawal(750, DateTime.Now, "Attempt to overdraw");
-            }
-            catch (InvalidOperationException e)
-            {
-                Console.WriteLine("Exception caught trying to overdraw");
-                Console.WriteLine(e.ToString());
-            }
-        }
-    }
+// Test for a negative balance
+try
+{
+    account.MakeWithdrawal(750, DateTime.Now, "Attempt to overdraw");
+}
+catch (InvalidOperationException e)
+{
+    Console.WriteLine("Exception caught trying to overdraw");
+    Console.WriteLine(e.ToString());
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/Program.cs
@@ -1,4 +1,4 @@
-﻿using classes;
+using Classes;
 
 var account = new BankAccount("<name>", 1000);
 Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} balance.");

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/classes.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/classes.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <nullable>enable</nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/transaction.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/transaction.cs
@@ -1,4 +1,5 @@
-﻿namespace classes;
+namespace Classes;
+
 public class Transaction
 {
     public decimal Amount { get; }
@@ -7,8 +8,8 @@ public class Transaction
 
     public Transaction(decimal amount, DateTime date, string note)
     {
-        this.Amount = amount;
-        this.Date = date;
-        this.Notes = note;
+        Amount = amount;
+        Date = date;
+        Notes = note;
     }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/transaction.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/introduction-to-classes/transaction.cs
@@ -1,18 +1,14 @@
-﻿using System;
-
-namespace classes
+﻿namespace classes;
+public class Transaction
 {
-    public class Transaction
-    {
-        public decimal Amount { get; }
-        public DateTime Date { get; }
-        public string Notes { get; }
+    public decimal Amount { get; }
+    public DateTime Date { get; }
+    public string Notes { get; }
 
-        public Transaction(decimal amount, DateTime date, string note)
-        {
-            this.Amount = amount;
-            this.Date = date;
-            this.Notes = note;
-        }
+    public Transaction(decimal amount, DateTime date, string note)
+    {
+        this.Amount = amount;
+        this.Date = date;
+        this.Notes = note;
     }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/BankAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/BankAccount.cs
@@ -9,7 +9,7 @@ public class BankAccount
         get
         {
             decimal balance = 0;
-            foreach (var item in allTransactions)
+            foreach (var item in _allTransactions)
             {
                 balance += item.Amount;
             }
@@ -18,26 +18,26 @@ public class BankAccount
         }
     }
 
-    private static int accountNumberSeed = 1234567890;
+    private static int s_accountNumberSeed = 1234567890;
 
     // <ConstructorModifications>
-    private readonly decimal minimumBalance;
+    private readonly decimal _minimumBalance;
 
     public BankAccount(string name, decimal initialBalance) : this(name, initialBalance, 0) { }
 
     public BankAccount(string name, decimal initialBalance, decimal minimumBalance)
     {
-        this.Number = accountNumberSeed.ToString();
-        accountNumberSeed++;
+        Number = s_accountNumberSeed.ToString();
+        s_accountNumberSeed++;
 
-        this.Owner = name;
-        this.minimumBalance = minimumBalance;
+        Owner = name;
+        _minimumBalance = minimumBalance;
         if (initialBalance > 0)
             MakeDeposit(initialBalance, DateTime.Now, "Initial balance");
     }
     // </ConstructorModifications>
 
-    private List<Transaction> allTransactions = new List<Transaction>();
+    private readonly List<Transaction> _allTransactions = new();
 
     public void MakeDeposit(decimal amount, DateTime date, string note)
     {
@@ -46,7 +46,7 @@ public class BankAccount
             throw new ArgumentOutOfRangeException(nameof(amount), "Amount of deposit must be positive");
         }
         var deposit = new Transaction(amount, date, note);
-        allTransactions.Add(deposit);
+        _allTransactions.Add(deposit);
     }
 
     // <RefactoredMakeWithdrawal>
@@ -56,11 +56,11 @@ public class BankAccount
         {
             throw new ArgumentOutOfRangeException(nameof(amount), "Amount of withdrawal must be positive");
         }
-        var overdraftTransaction = CheckWithdrawalLimit(Balance - amount < minimumBalance);
-        var withdrawal = new Transaction(-amount, date, note);
-        allTransactions.Add(withdrawal);
+        Transaction? overdraftTransaction = CheckWithdrawalLimit(Balance - amount < _minimumBalance);
+        Transaction? withdrawal = new(-amount, date, note);
+        _allTransactions.Add(withdrawal);
         if (overdraftTransaction != null)
-            allTransactions.Add(overdraftTransaction);
+            _allTransactions.Add(overdraftTransaction);
     }
 
     protected virtual Transaction? CheckWithdrawalLimit(bool isOverdrawn)
@@ -82,7 +82,7 @@ public class BankAccount
 
         decimal balance = 0;
         report.AppendLine("Date\t\tAmount\tBalance\tNote");
-        foreach (var item in allTransactions)
+        foreach (var item in _allTransactions)
         {
             balance += item.Amount;
             report.AppendLine($"{item.Date.ToShortDateString()}\t{item.Amount}\t{balance}\t{item.Notes}");

--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/GiftCardAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/GiftCardAccount.cs
@@ -3,7 +3,7 @@
 public class GiftCardAccount : BankAccount
 {
     // <GiftCardAccountConstruction>
-    private decimal _monthlyDeposit = 0m;
+    private readonly decimal _monthlyDeposit = 0m;
 
     public GiftCardAccount(string name, decimal initialBalance, decimal monthlyDeposit = 0) : base(name, initialBalance)
         => _monthlyDeposit = monthlyDeposit;

--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/InterestEarningAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/InterestEarningAccount.cs
@@ -3,8 +3,8 @@
 public class InterestEarningAccount : BankAccount
 {
     // <DerivedConstructor>
-    public InterestEarningAccount(string name, decimal initialBalance) : base(name, initialBalance) 
-    { 
+    public InterestEarningAccount(string name, decimal initialBalance) : base(name, initialBalance)
+    {
     }
     // </DerivedConstructor>
 
@@ -13,7 +13,7 @@ public class InterestEarningAccount : BankAccount
     {
         if (Balance > 500m)
         {
-            var interest = Balance * 0.05m;
+            decimal interest = Balance * 0.05m;
             MakeDeposit(interest, DateTime.Now, "apply monthly interest");
         }
     }

--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/LineOfCreditAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/LineOfCreditAccount.cs
@@ -14,7 +14,7 @@ class LineOfCreditAccount : BankAccount
         if (Balance < 0)
         {
             // Negate the balance to get a positive interest charge:
-            var interest = -Balance * 0.07m;
+            decimal interest = -Balance * 0.07m;
             MakeWithdrawal(interest, DateTime.Now, "Charge monthly interest");
         }
     }

--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/Program.cs
@@ -1,72 +1,65 @@
-﻿namespace OOProgramming;
+﻿using OOProgramming;
 
-class Program
+IntroToClasses();
+
+// <FirstTests>
+var giftCard = new GiftCardAccount("gift card", 100, 50);
+giftCard.MakeWithdrawal(20, DateTime.Now, "get expensive coffee");
+giftCard.MakeWithdrawal(50, DateTime.Now, "buy groceries");
+giftCard.PerformMonthEndTransactions();
+// can make additional deposits:
+giftCard.MakeDeposit(27.50m, DateTime.Now, "add some additional spending money");
+Console.WriteLine(giftCard.GetAccountHistory());
+
+var savings = new InterestEarningAccount("savings account", 10000);
+savings.MakeDeposit(750, DateTime.Now, "save some money");
+savings.MakeDeposit(1250, DateTime.Now, "Add more savings");
+savings.MakeWithdrawal(250, DateTime.Now, "Needed to pay monthly bills");
+savings.PerformMonthEndTransactions();
+Console.WriteLine(savings.GetAccountHistory());
+// </FirstTests>
+
+// <TestLineOfCredit>
+var lineOfCredit = new LineOfCreditAccount("line of credit", 0, 2000);
+// How much is too much to borrow?
+lineOfCredit.MakeWithdrawal(1000m, DateTime.Now, "Take out monthly advance");
+lineOfCredit.MakeDeposit(50m, DateTime.Now, "Pay back small amount");
+lineOfCredit.MakeWithdrawal(5000m, DateTime.Now, "Emergency funds for repairs");
+lineOfCredit.MakeDeposit(150m, DateTime.Now, "Partial restoration on repairs");
+lineOfCredit.PerformMonthEndTransactions();
+Console.WriteLine(lineOfCredit.GetAccountHistory());
+// </TestLineOfCredit>
+static void IntroToClasses()
 {
-    static void Main(string[] args)
+    var account = new BankAccount("<name>", 1000);
+    Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} balance.");
+
+    account.MakeWithdrawal(500, DateTime.Now, "Rent payment");
+    Console.WriteLine(account.Balance);
+    account.MakeDeposit(100, DateTime.Now, "friend paid me back");
+    Console.WriteLine(account.Balance);
+
+    Console.WriteLine(account.GetAccountHistory());
+
+    // Test that the initial balances must be positive:
+    try
     {
-        IntroToClasses();
-
-        // <FirstTests>
-        var giftCard = new GiftCardAccount("gift card", 100, 50);
-        giftCard.MakeWithdrawal(20, DateTime.Now, "get expensive coffee");
-        giftCard.MakeWithdrawal(50, DateTime.Now, "buy groceries");
-        giftCard.PerformMonthEndTransactions();
-        // can make additional deposits:
-        giftCard.MakeDeposit(27.50m, DateTime.Now, "add some additional spending money");
-        Console.WriteLine(giftCard.GetAccountHistory());
-
-        var savings = new InterestEarningAccount("savings account", 10000);
-        savings.MakeDeposit(750, DateTime.Now, "save some money");
-        savings.MakeDeposit(1250, DateTime.Now, "Add more savings");
-        savings.MakeWithdrawal(250, DateTime.Now, "Needed to pay monthly bills");
-        savings.PerformMonthEndTransactions();
-        Console.WriteLine(savings.GetAccountHistory());
-        // </FirstTests>
-
-        // <TestLineOfCredit>
-        var lineOfCredit = new LineOfCreditAccount("line of credit", 0, 2000);
-        // How much is too much to borrow?
-        lineOfCredit.MakeWithdrawal(1000m, DateTime.Now, "Take out monthly advance");
-        lineOfCredit.MakeDeposit(50m, DateTime.Now, "Pay back small amount");
-        lineOfCredit.MakeWithdrawal(5000m, DateTime.Now, "Emergency funds for repairs");
-        lineOfCredit.MakeDeposit(150m, DateTime.Now, "Partial restoration on repairs");
-        lineOfCredit.PerformMonthEndTransactions();
-        Console.WriteLine(lineOfCredit.GetAccountHistory());
-        // </TestLineOfCredit>
+        var invalidAccount = new BankAccount("invalid", -55);
+    }
+    catch (ArgumentOutOfRangeException e)
+    {
+        Console.WriteLine("Exception caught creating account with negative balance");
+        Console.WriteLine(e.ToString());
     }
 
-    private static void IntroToClasses()
+    // Test for a negative balance
+    try
     {
-        var account = new BankAccount("<name>", 1000);
-        Console.WriteLine($"Account {account.Number} was created for {account.Owner} with {account.Balance} balance.");
-
-        account.MakeWithdrawal(500, DateTime.Now, "Rent payment");
-        Console.WriteLine(account.Balance);
-        account.MakeDeposit(100, DateTime.Now, "friend paid me back");
-        Console.WriteLine(account.Balance);
-
-        Console.WriteLine(account.GetAccountHistory());
-
-        // Test that the initial balances must be positive:
-        try
-        {
-            var invalidAccount = new BankAccount("invalid", -55);
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            Console.WriteLine("Exception caught creating account with negative balance");
-            Console.WriteLine(e.ToString());
-        }
-
-        // Test for a negative balance
-        try
-        {
-            account.MakeWithdrawal(750, DateTime.Now, "Attempt to overdraw");
-        }
-        catch (InvalidOperationException e)
-        {
-            Console.WriteLine("Exception caught trying to overdraw");
-            Console.WriteLine(e.ToString());
-        }
+        account.MakeWithdrawal(750, DateTime.Now, "Attempt to overdraw");
+    }
+    catch (InvalidOperationException e)
+    {
+        Console.WriteLine("Exception caught trying to overdraw");
+        Console.WriteLine(e.ToString());
     }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/transaction.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/transaction.cs
@@ -8,8 +8,8 @@ public class Transaction
 
     public Transaction(decimal amount, DateTime date, string note)
     {
-        this.Amount = amount;
-        this.Date = date;
-        this.Notes = note;
+        Amount = amount;
+        Date = date;
+        Notes = note;
     }
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/Program.cs
@@ -2,7 +2,7 @@
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-using toll_calculator;
+using TollCalculator;
 
 var tollCalc = new TollCalculator();
 

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/Program.cs
@@ -1,99 +1,91 @@
-﻿using System;
-using CommercialRegistration;
+﻿using CommercialRegistration;
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator
+using toll_calculator;
+
+var tollCalc = new TollCalculator();
+
+var soloDriver = new Car();
+var twoRideShare = new Car { Passengers = 1 };
+var threeRideShare = new Car { Passengers = 2 };
+var fullVan = new Car { Passengers = 5 };
+var emptyTaxi = new Taxi();
+var singleFare = new Taxi { Fares = 1 };
+var doubleFare = new Taxi { Fares = 2 };
+var fullVanPool = new Taxi { Fares = 5 };
+var lowOccupantBus = new Bus { Capacity = 90, Riders = 15 };
+var normalBus = new Bus { Capacity = 90, Riders = 75 };
+var fullBus = new Bus { Capacity = 90, Riders = 85 };
+
+var heavyTruck = new DeliveryTruck { GrossWeightClass = 7500 };
+var truck = new DeliveryTruck { GrossWeightClass = 4000 };
+var lightTruck = new DeliveryTruck { GrossWeightClass = 2500 };
+
+Console.WriteLine($"The toll for a solo driver is {tollCalc.CalculateToll(soloDriver)}");
+Console.WriteLine($"The toll for a two ride share is {tollCalc.CalculateToll(twoRideShare)}");
+Console.WriteLine($"The toll for a three ride share is {tollCalc.CalculateToll(threeRideShare)}");
+Console.WriteLine($"The toll for a fullVan is {tollCalc.CalculateToll(fullVan)}");
+
+Console.WriteLine($"The toll for an empty taxi is {tollCalc.CalculateToll(emptyTaxi)}");
+Console.WriteLine($"The toll for a single fare taxi is {tollCalc.CalculateToll(singleFare)}");
+Console.WriteLine($"The toll for a double fare taxi is {tollCalc.CalculateToll(doubleFare)}");
+Console.WriteLine($"The toll for a full van taxi is {tollCalc.CalculateToll(fullVanPool)}");
+
+Console.WriteLine($"The toll for a low-occupant bus is {tollCalc.CalculateToll(lowOccupantBus)}");
+Console.WriteLine($"The toll for a regular bus is {tollCalc.CalculateToll(normalBus)}");
+Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(fullBus)}");
+
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(heavyTruck)}");
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(lightTruck)}");
+
+try
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var tollCalc = new TollCalculator();
+    tollCalc.CalculateToll("this will fail");
+}
+catch (ArgumentException)
+{
+    Console.WriteLine("Caught an argument exception when using the wrong type");
+}
+try
+{
+    tollCalc.CalculateToll(null!);
+}
+catch (ArgumentNullException)
+{
+    Console.WriteLine("Caught an argument exception when using null");
+}
 
-            var soloDriver = new Car();
-            var twoRideShare = new Car { Passengers = 1 };
-            var threeRideShare = new Car { Passengers = 2 };
-            var fullVan = new Car { Passengers = 5 };
-            var emptyTaxi = new Taxi();
-            var singleFare = new Taxi { Fares = 1 };
-            var doubleFare = new Taxi { Fares = 2 };
-            var fullVanPool = new Taxi { Fares = 5 };
-            var lowOccupantBus = new Bus { Capacity = 90, Riders = 15 };
-            var normalBus = new Bus { Capacity = 90, Riders = 75 };
-            var fullBus = new Bus { Capacity = 90, Riders = 85 };
+Console.WriteLine("Testing the time premiums");
 
-            var heavyTruck = new DeliveryTruck { GrossWeightClass = 7500 };
-            var truck = new DeliveryTruck { GrossWeightClass = 4000 };
-            var lightTruck = new DeliveryTruck { GrossWeightClass = 2500 };
+var testTimes = new DateTime[]
+{
+    new DateTime(2019, 3, 4, 8, 0, 0), // morning rush
+    new DateTime(2019, 3, 6, 11, 30, 0), // daytime
+    new DateTime(2019, 3, 7, 17, 15, 0), // evening rush
+    new DateTime(2019, 3, 14, 03, 30, 0), // overnight
 
-            Console.WriteLine($"The toll for a solo driver is {tollCalc.CalculateToll(soloDriver)}");
-            Console.WriteLine($"The toll for a two ride share is {tollCalc.CalculateToll(twoRideShare)}");
-            Console.WriteLine($"The toll for a three ride share is {tollCalc.CalculateToll(threeRideShare)}");
-            Console.WriteLine($"The toll for a fullVan is {tollCalc.CalculateToll(fullVan)}");
+    new DateTime(2019, 3, 16, 8, 30, 0), // weekend morning rush
+    new DateTime(2019, 3, 17, 14, 30, 0), // weekend daytime
+    new DateTime(2019, 3, 17, 18, 05, 0), // weekend evening rush
+    new DateTime(2019, 3, 16, 01, 30, 0), // weekend overnight
+};
 
-            Console.WriteLine($"The toll for an empty taxi is {tollCalc.CalculateToll(emptyTaxi)}");
-            Console.WriteLine($"The toll for a single fare taxi is {tollCalc.CalculateToll(singleFare)}");
-            Console.WriteLine($"The toll for a double fare taxi is {tollCalc.CalculateToll(doubleFare)}");
-            Console.WriteLine($"The toll for a full van taxi is {tollCalc.CalculateToll(fullVanPool)}");
-
-            Console.WriteLine($"The toll for a low-occupant bus is {tollCalc.CalculateToll(lowOccupantBus)}");
-            Console.WriteLine($"The toll for a regular bus is {tollCalc.CalculateToll(normalBus)}");
-            Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(fullBus)}");
-
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(heavyTruck)}");
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(lightTruck)}");
-
-            try
-            {
-                tollCalc.CalculateToll("this will fail");
-            }
-            catch (ArgumentException)
-            {
-                Console.WriteLine("Caught an argument exception when using the wrong type");
-            }
-            try
-            {
-                tollCalc.CalculateToll(null!);
-            }
-            catch (ArgumentNullException)
-            {
-                Console.WriteLine("Caught an argument exception when using null");
-            }
-
-            Console.WriteLine("Testing the time premiums");
-
-            var testTimes = new DateTime[]
-            {
-                new DateTime(2019, 3, 4, 8, 0, 0), // morning rush
-                new DateTime(2019, 3, 6, 11, 30, 0), // daytime
-                new DateTime(2019, 3, 7, 17, 15, 0), // evening rush
-                new DateTime(2019, 3, 14, 03, 30, 0), // overnight
-
-                new DateTime(2019, 3, 16, 8, 30, 0), // weekend morning rush
-                new DateTime(2019, 3, 17, 14, 30, 0), // weekend daytime
-                new DateTime(2019, 3, 17, 18, 05, 0), // weekend evening rush
-                new DateTime(2019, 3, 16, 01, 30, 0), // weekend overnight
-            };
-
-            foreach (var time in testTimes)
-            {
-                Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremiumIfElse(time, true)}");
-                Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremiumIfElse(time, false)}");
-            }
-            Console.WriteLine("====================================================");
-            foreach (var time in testTimes)
-            {
-                Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, true)}");
-                Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, false)}");
-            }
-            Console.WriteLine("====================================================");
-            foreach (var time in testTimes)
-            {
-                Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremium(time, true)}");
-                Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremium(time, false)}");
-            }
-        }
-    }
+foreach (var time in testTimes)
+{
+    Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremiumIfElse(time, true)}");
+    Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremiumIfElse(time, false)}");
+}
+Console.WriteLine("====================================================");
+foreach (var time in testTimes)
+{
+    Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, true)}");
+    Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, false)}");
+}
+Console.WriteLine("====================================================");
+foreach (var time in testTimes)
+{
+    Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremium(time, true)}");
+    Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremium(time, false)}");
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/Program.cs
@@ -2,7 +2,7 @@
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-using TollCalculator;
+using Calculators;
 
 var tollCalc = new TollCalculator();
 

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/TollCalculator.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/TollCalculator.cs
@@ -1,154 +1,152 @@
-﻿using System;
-using CommercialRegistration;
+﻿using CommercialRegistration;
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator
+namespace toll_calculator;
+
+public class TollCalculator
 {
-    public class TollCalculator
+    public decimal CalculateToll(object vehicle) =>
+        vehicle switch
+        {
+            Car c => c.Passengers switch
+            {
+                0 => 2.00m + 0.5m,
+                1 => 2.0m,
+                2 => 2.0m - 0.5m,
+                _ => 2.00m - 1.0m
+            },
+
+            Taxi t => t.Fares switch
+            {
+                0 => 3.50m + 1.00m,
+                1 => 3.50m,
+                2 => 3.50m - 0.50m,
+                _ => 3.50m - 1.00m
+            },
+
+            Bus b when ((double)b.Riders / (double)b.Capacity) < 0.50 => 5.00m + 2.00m,
+            Bus b when ((double)b.Riders / (double)b.Capacity) > 0.90 => 5.00m - 1.00m,
+            Bus => 5.00m,
+
+            DeliveryTruck t when (t.GrossWeightClass > 5000) => 10.00m + 5.00m,
+            DeliveryTruck t when (t.GrossWeightClass < 3000) => 10.00m - 2.00m,
+            DeliveryTruck => 10.00m,
+
+            { } => throw new ArgumentException(message: "Not a known vehicle type", paramName: nameof(vehicle)),
+            null => throw new ArgumentNullException(nameof(vehicle))
+        };
+
+    // <SnippetFinalTuplePattern>
+    public decimal PeakTimePremium(DateTime timeOfToll, bool inbound) =>
+        (IsWeekDay(timeOfToll), GetTimeBand(timeOfToll), inbound) switch
+        {
+            (true, TimeBand.Overnight, _) => 0.75m,
+            (true, TimeBand.Daytime, _) => 1.5m,
+            (true, TimeBand.MorningRush, true) => 2.0m,
+            (true, TimeBand.EveningRush, false) => 2.0m,
+            _ => 1.0m,
+        };
+    // </SnippetFinalTuplePattern>
+
+    // <SnippetPremiumWithoutPattern>
+    public decimal PeakTimePremiumIfElse(DateTime timeOfToll, bool inbound)
     {
-        public decimal CalculateToll(object vehicle) =>
-            vehicle switch
-            {
-                Car c => c.Passengers switch
-                {
-                    0 => 2.00m + 0.5m,
-                    1 => 2.0m,
-                    2 => 2.0m - 0.5m,
-                    _ => 2.00m - 1.0m
-                },
-
-                Taxi t => t.Fares switch
-                {
-                    0 => 3.50m + 1.00m,
-                    1 => 3.50m,
-                    2 => 3.50m - 0.50m,
-                    _ => 3.50m - 1.00m
-                },
-
-                Bus b when ((double)b.Riders / (double)b.Capacity) < 0.50 => 5.00m + 2.00m,
-                Bus b when ((double)b.Riders / (double)b.Capacity) > 0.90 => 5.00m - 1.00m,
-                Bus b => 5.00m,
-
-                DeliveryTruck t when (t.GrossWeightClass > 5000) => 10.00m + 5.00m,
-                DeliveryTruck t when (t.GrossWeightClass < 3000) => 10.00m - 2.00m,
-                DeliveryTruck t => 10.00m,
-
-                { } => throw new ArgumentException(message: "Not a known vehicle type", paramName: nameof(vehicle)),
-                null => throw new ArgumentNullException(nameof(vehicle))
-            };
-
-        // <SnippetFinalTuplePattern>
-        public decimal PeakTimePremium(DateTime timeOfToll, bool inbound) =>
-            (IsWeekDay(timeOfToll), GetTimeBand(timeOfToll), inbound) switch
-            {
-                (true, TimeBand.Overnight, _) => 0.75m,
-                (true, TimeBand.Daytime, _) => 1.5m,
-                (true, TimeBand.MorningRush, true) => 2.0m,
-                (true, TimeBand.EveningRush, false) => 2.0m,
-                _ => 1.0m,
-            };
-        // </SnippetFinalTuplePattern>
-
-        // <SnippetPremiumWithoutPattern>
-        public decimal PeakTimePremiumIfElse(DateTime timeOfToll, bool inbound)
+        if ((timeOfToll.DayOfWeek == DayOfWeek.Saturday) ||
+            (timeOfToll.DayOfWeek == DayOfWeek.Sunday))
         {
-            if ((timeOfToll.DayOfWeek == DayOfWeek.Saturday) ||
-                (timeOfToll.DayOfWeek == DayOfWeek.Sunday))
+            return 1.0m;
+        }
+        else
+        {
+            int hour = timeOfToll.Hour;
+            if (hour < 6)
             {
-                return 1.0m;
+                return 0.75m;
             }
-            else
+            else if (hour < 10)
             {
-                int hour = timeOfToll.Hour;
-                if (hour < 6)
+                if (inbound)
                 {
-                    return 0.75m;
+                    return 2.0m;
                 }
-                else if (hour < 10)
+                else
                 {
-                    if (inbound)
-                    {
-                        return 2.0m;
-                    }
-                    else
-                    {
-                        return 1.0m;
-                    }
-                }
-                else if (hour < 16)
-                {
-                    return 1.5m;
-                }
-                else if (hour < 20)
-                {
-                    if (inbound)
-                    {
-                        return 1.0m;
-                    }
-                    else
-                    {
-                        return 2.0m;
-                    }
-                }
-                else // Overnight
-                {
-                    return 0.75m;
+                    return 1.0m;
                 }
             }
+            else if (hour < 16)
+            {
+                return 1.5m;
+            }
+            else if (hour < 20)
+            {
+                if (inbound)
+                {
+                    return 1.0m;
+                }
+                else
+                {
+                    return 2.0m;
+                }
+            }
+            else // Overnight
+            {
+                return 0.75m;
+            }
         }
-        // </SnippetPremiumWithoutPattern>
-
-        // <SnippetTuplePatternOne>
-        public decimal PeakTimePremiumFull(DateTime timeOfToll, bool inbound) =>
-            (IsWeekDay(timeOfToll), GetTimeBand(timeOfToll), inbound) switch
-            {
-                (true, TimeBand.MorningRush, true) => 2.00m,
-                (true, TimeBand.MorningRush, false) => 1.00m,
-                (true, TimeBand.Daytime, true) => 1.50m,
-                (true, TimeBand.Daytime, false) => 1.50m,
-                (true, TimeBand.EveningRush, true) => 1.00m,
-                (true, TimeBand.EveningRush, false) => 2.00m,
-                (true, TimeBand.Overnight, true) => 0.75m,
-                (true, TimeBand.Overnight, false) => 0.75m,
-                (false, TimeBand.MorningRush, true) => 1.00m,
-                (false, TimeBand.MorningRush, false) => 1.00m,
-                (false, TimeBand.Daytime, true) => 1.00m,
-                (false, TimeBand.Daytime, false) => 1.00m,
-                (false, TimeBand.EveningRush, true) => 1.00m,
-                (false, TimeBand.EveningRush, false) => 1.00m,
-                (false, TimeBand.Overnight, true) => 1.00m,
-                (false, TimeBand.Overnight, false) => 1.00m,
-            };
-        // </SnippetTuplePatternOne>
-
-        // <SnippetIsWeekDay>
-        private static bool IsWeekDay(DateTime timeOfToll) =>
-            timeOfToll.DayOfWeek switch
-            {
-                DayOfWeek.Saturday => false,
-                DayOfWeek.Sunday => false,
-                _ => true
-            };
-        // </SnippetIsWeekDay>
-
-        // <SnippetGetTimeBand>
-        private enum TimeBand
-        {
-            MorningRush,
-            Daytime,
-            EveningRush,
-            Overnight
-        }
-
-        private static TimeBand GetTimeBand(DateTime timeOfToll) =>
-            timeOfToll.Hour switch
-            {
-                < 6 or > 19 => TimeBand.Overnight,
-                < 10 => TimeBand.MorningRush,
-                < 16 => TimeBand.Daytime,
-                _ => TimeBand.EveningRush,
-            };
-        // </SnippetGetTimeBand>
     }
+    // </SnippetPremiumWithoutPattern>
+
+    // <SnippetTuplePatternOne>
+    public decimal PeakTimePremiumFull(DateTime timeOfToll, bool inbound) =>
+        (IsWeekDay(timeOfToll), GetTimeBand(timeOfToll), inbound) switch
+        {
+            (true, TimeBand.MorningRush, true) => 2.00m,
+            (true, TimeBand.MorningRush, false) => 1.00m,
+            (true, TimeBand.Daytime, true) => 1.50m,
+            (true, TimeBand.Daytime, false) => 1.50m,
+            (true, TimeBand.EveningRush, true) => 1.00m,
+            (true, TimeBand.EveningRush, false) => 2.00m,
+            (true, TimeBand.Overnight, true) => 0.75m,
+            (true, TimeBand.Overnight, false) => 0.75m,
+            (false, TimeBand.MorningRush, true) => 1.00m,
+            (false, TimeBand.MorningRush, false) => 1.00m,
+            (false, TimeBand.Daytime, true) => 1.00m,
+            (false, TimeBand.Daytime, false) => 1.00m,
+            (false, TimeBand.EveningRush, true) => 1.00m,
+            (false, TimeBand.EveningRush, false) => 1.00m,
+            (false, TimeBand.Overnight, true) => 1.00m,
+            (false, TimeBand.Overnight, false) => 1.00m,
+        };
+    // </SnippetTuplePatternOne>
+
+    // <SnippetIsWeekDay>
+    private static bool IsWeekDay(DateTime timeOfToll) =>
+        timeOfToll.DayOfWeek switch
+        {
+            DayOfWeek.Saturday => false,
+            DayOfWeek.Sunday => false,
+            _ => true
+        };
+    // </SnippetIsWeekDay>
+
+    // <SnippetGetTimeBand>
+    private enum TimeBand
+    {
+        MorningRush,
+        Daytime,
+        EveningRush,
+        Overnight
+    }
+
+    private static TimeBand GetTimeBand(DateTime timeOfToll) =>
+        timeOfToll.Hour switch
+        {
+            < 6 or > 19 => TimeBand.Overnight,
+            < 10 => TimeBand.MorningRush,
+            < 16 => TimeBand.Daytime,
+            _ => TimeBand.EveningRush,
+        };
+    // </SnippetGetTimeBand>
 }

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/TollCalculator.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/TollCalculator.cs
@@ -2,7 +2,7 @@
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator;
+namespace Calculators;
 
 public class TollCalculator
 {

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/toll-calculator.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/finished/toll-calculator/toll-calculator.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>toll_calculator</RootNamespace>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/start/toll-calculator/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/start/toll-calculator/Program.cs
@@ -3,126 +3,121 @@ using CommercialRegistration;
 using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
-namespace toll_calculator
+/*   First set of test code
+using toll_calculator;
+
+var tollCalc = new TollCalculator();
+
+var car = new Car();
+var taxi = new Taxi();
+var bus = new Bus();
+var truck = new DeliveryTruck();
+
+Console.WriteLine($"The toll for a car is {tollCalc.CalculateToll(car)}");
+Console.WriteLine($"The toll for a taxi is {tollCalc.CalculateToll(taxi)}");
+Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(bus)}");
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
+
+try
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            /*   First set of test code
-            var tollCalc = new TollCalculator();
-
-            var car = new Car();
-            var taxi = new Taxi();
-            var bus = new Bus();
-            var truck = new DeliveryTruck();
-
-            Console.WriteLine($"The toll for a car is {tollCalc.CalculateToll(car)}");
-            Console.WriteLine($"The toll for a taxi is {tollCalc.CalculateToll(taxi)}");
-            Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(bus)}");
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
-
-            try
-            {
-                tollCalc.CalculateToll("this will fail");
-            }
-            catch (ArgumentException e)
-            {
-                Console.WriteLine("Caught an argument exception when using the wrong type");
-            }
-            try
-            {
-                tollCalc.CalculateToll(null!);
-            }
-            catch (ArgumentNullException e)
-            {
-                Console.WriteLine("Caught an argument exception when using null");
-            }
-            */
-
-            /*  2nd test (after adding for occupants)
-            var tollCalc = new TollCalculator();
-
-            var soloDriver = new Car();
-            var twoRideShare = new Car { Passengers = 1 };
-            var threeRideShare = new Car { Passengers = 2 };
-            var fullVan = new Car { Passengers = 5 };
-            var emptyTaxi = new Taxi();
-            var singleFare = new Taxi { Fares = 1 };
-            var doubleFare = new Taxi { Fares = 2 };
-            var fullVanPool = new Taxi { Fares = 5 };
-            var lowOccupantBus = new Bus { Capacity = 90, Riders = 15 };
-            var normalBus = new Bus { Capacity = 90, Riders = 75 };
-            var fullBus = new Bus { Capacity = 90, Riders = 85 };
-
-            var heavyTruck = new DeliveryTruck { GrossWeightClass = 7500 };
-            var truck = new DeliveryTruck { GrossWeightClass = 4000 };
-            var lightTruck = new DeliveryTruck { GrossWeightClass = 2500 };
-
-            Console.WriteLine($"The toll for a solo driver is {tollCalc.CalculateToll(soloDriver)}");
-            Console.WriteLine($"The toll for a two ride share is {tollCalc.CalculateToll(twoRideShare)}");
-            Console.WriteLine($"The toll for a three ride share is {tollCalc.CalculateToll(threeRideShare)}");
-            Console.WriteLine($"The toll for a fullVan is {tollCalc.CalculateToll(fullVan)}");
-
-            Console.WriteLine($"The toll for an empty taxi is {tollCalc.CalculateToll(emptyTaxi)}");
-            Console.WriteLine($"The toll for a single fare taxi is {tollCalc.CalculateToll(singleFare)}");
-            Console.WriteLine($"The toll for a double fare taxi is {tollCalc.CalculateToll(doubleFare)}");
-            Console.WriteLine($"The toll for a full van taxi is {tollCalc.CalculateToll(fullVanPool)}");
-
-            Console.WriteLine($"The toll for a low-occupant bus is {tollCalc.CalculateToll(lowOccupantBus)}");
-            Console.WriteLine($"The toll for a regular bus is {tollCalc.CalculateToll(normalBus)}");
-            Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(fullBus)}");
-
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(heavyTruck)}");
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
-            Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(lightTruck)}");
-
-            try
-            {
-                tollCalc.CalculateToll("this will fail");
-            }
-            catch (ArgumentException e)
-            {
-                Console.WriteLine("Caught an argument exception when using the wrong type");
-            }
-            try
-            {
-                tollCalc.CalculateToll(null);
-            }
-            catch (ArgumentNullException e)
-            {
-                Console.WriteLine("Caught an argument exception when using null");
-            }
-            */
-
-            /*
-            Console.WriteLine("Testing the time premiums");
-
-            var testTimes = new DateTime[]
-            {
-                new DateTime(2019, 3, 4, 8, 0, 0), // morning rush
-                new DateTime(2019, 3, 6, 11, 30, 0), // daytime
-                new DateTime(2019, 3, 7, 17, 15, 0), // evening rush
-                new DateTime(2019, 3, 14, 03, 30, 0), // overnight
-
-                new DateTime(2019, 3, 16, 8, 30, 0), // weekend morning rush
-                new DateTime(2019, 3, 17, 14, 30, 0), // weekend daytime
-                new DateTime(2019, 3, 17, 18, 05, 0), // weekend evening rush
-                new DateTime(2019, 3, 16, 01, 30, 0), // weekend overnight
-            };
-
-            foreach (var time in testTimes)
-            {
-                Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, true)}");
-                Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, false)}");
-            }
-            Console.WriteLine("====================================================");
-            foreach (var time in testTimes)
-            {
-                Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremium(time, true)}");
-                Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremium(time, false)}");
-            }
-            */
-        }
-    }
+    tollCalc.CalculateToll("this will fail");
 }
+catch (ArgumentException e)
+{
+    Console.WriteLine("Caught an argument exception when using the wrong type");
+}
+try
+{
+    tollCalc.CalculateToll(null!);
+}
+catch (ArgumentNullException e)
+{
+    Console.WriteLine("Caught an argument exception when using null");
+}
+*/
+
+/*  2nd test (after adding for occupants)
+var tollCalc = new TollCalculator();
+
+var soloDriver = new Car();
+var twoRideShare = new Car { Passengers = 1 };
+var threeRideShare = new Car { Passengers = 2 };
+var fullVan = new Car { Passengers = 5 };
+var emptyTaxi = new Taxi();
+var singleFare = new Taxi { Fares = 1 };
+var doubleFare = new Taxi { Fares = 2 };
+var fullVanPool = new Taxi { Fares = 5 };
+var lowOccupantBus = new Bus { Capacity = 90, Riders = 15 };
+var normalBus = new Bus { Capacity = 90, Riders = 75 };
+var fullBus = new Bus { Capacity = 90, Riders = 85 };
+
+var heavyTruck = new DeliveryTruck { GrossWeightClass = 7500 };
+var truck = new DeliveryTruck { GrossWeightClass = 4000 };
+var lightTruck = new DeliveryTruck { GrossWeightClass = 2500 };
+
+Console.WriteLine($"The toll for a solo driver is {tollCalc.CalculateToll(soloDriver)}");
+Console.WriteLine($"The toll for a two ride share is {tollCalc.CalculateToll(twoRideShare)}");
+Console.WriteLine($"The toll for a three ride share is {tollCalc.CalculateToll(threeRideShare)}");
+Console.WriteLine($"The toll for a fullVan is {tollCalc.CalculateToll(fullVan)}");
+
+Console.WriteLine($"The toll for an empty taxi is {tollCalc.CalculateToll(emptyTaxi)}");
+Console.WriteLine($"The toll for a single fare taxi is {tollCalc.CalculateToll(singleFare)}");
+Console.WriteLine($"The toll for a double fare taxi is {tollCalc.CalculateToll(doubleFare)}");
+Console.WriteLine($"The toll for a full van taxi is {tollCalc.CalculateToll(fullVanPool)}");
+
+Console.WriteLine($"The toll for a low-occupant bus is {tollCalc.CalculateToll(lowOccupantBus)}");
+Console.WriteLine($"The toll for a regular bus is {tollCalc.CalculateToll(normalBus)}");
+Console.WriteLine($"The toll for a bus is {tollCalc.CalculateToll(fullBus)}");
+
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(heavyTruck)}");
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(truck)}");
+Console.WriteLine($"The toll for a truck is {tollCalc.CalculateToll(lightTruck)}");
+
+try
+{
+    tollCalc.CalculateToll("this will fail");
+}
+catch (ArgumentException e)
+{
+    Console.WriteLine("Caught an argument exception when using the wrong type");
+}
+try
+{
+    tollCalc.CalculateToll(null);
+}
+catch (ArgumentNullException e)
+{
+    Console.WriteLine("Caught an argument exception when using null");
+}
+*/
+
+/*
+Console.WriteLine("Testing the time premiums");
+
+var testTimes = new DateTime[]
+{
+    new DateTime(2019, 3, 4, 8, 0, 0), // morning rush
+    new DateTime(2019, 3, 6, 11, 30, 0), // daytime
+    new DateTime(2019, 3, 7, 17, 15, 0), // evening rush
+    new DateTime(2019, 3, 14, 03, 30, 0), // overnight
+
+    new DateTime(2019, 3, 16, 8, 30, 0), // weekend morning rush
+    new DateTime(2019, 3, 17, 14, 30, 0), // weekend daytime
+    new DateTime(2019, 3, 17, 18, 05, 0), // weekend evening rush
+    new DateTime(2019, 3, 16, 01, 30, 0), // weekend overnight
+};
+
+foreach (var time in testTimes)
+{
+    Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, true)}");
+    Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremiumFull(time, false)}");
+}
+Console.WriteLine("====================================================");
+foreach (var time in testTimes)
+{
+    Console.WriteLine($"Inbound premium at {time} is {tollCalc.PeakTimePremium(time, true)}");
+    Console.WriteLine($"Outbound premium at {time} is {tollCalc.PeakTimePremium(time, false)}");
+}
+*/
+
+Console.WriteLine();

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/start/toll-calculator/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/start/toll-calculator/Program.cs
@@ -4,7 +4,7 @@ using ConsumerVehicleRegistration;
 using LiveryRegistration;
 
 /*   First set of test code
-using toll_calculator;
+using Calculators;
 
 var tollCalc = new TollCalculator();
 

--- a/docs/csharp/fundamentals/tutorials/snippets/patterns/start/toll-calculator/toll-calculator.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/patterns/start/toll-calculator/toll-calculator.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>toll_calculator</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/csharp/fundamentals/tutorials/snippets/safelycast/asandis/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/safelycast/asandis/Program.cs
@@ -1,91 +1,80 @@
-﻿using System;
+﻿// <SnippetIsAndAs>
+// Use the is operator to verify the type.
+// before performing a cast.
+Giraffe g = new();
+UseIsOperator(g);
 
-namespace asandis
+// Use the as operator and test for null
+// before referencing the variable.
+UseAsOperator(g);
+
+// Use pattern matching to test for null
+// before referencing the variable
+UsePatternMatchingIs(g);
+
+// Use the as operator to test
+// an incompatible type.
+SuperNova sn = new();
+UseAsOperator(sn);
+
+// Use the as operator with a value type.
+// Note the implicit conversion to int? in
+// the method body.
+int i = 5;
+UseAsWithNullable(i);
+
+double d = 9.78654;
+UseAsWithNullable(d);
+
+static void UseIsOperator(Animal a)
 {
-    // <SnippetIsAndAs>
-    class Animal
+    if (a is Mammal)
     {
-        public void Eat() { Console.WriteLine("Eating."); }
-        public override string ToString()
-        {
-            return "I am an animal.";
-        }
+        Mammal m = (Mammal)a;
+        m.Eat();
     }
-    class Mammal : Animal { }
-    class Giraffe : Mammal { }
-
-    class SuperNova { }
-
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            // Use the is operator to verify the type.
-            // before performing a cast.
-            Giraffe g = new Giraffe();
-            UseIsOperator(g);
-
-            // Use the as operator and test for null
-            // before referencing the variable.
-            UseAsOperator(g);
-
-            // Use the as operator to test
-            // an incompatible type.
-            SuperNova sn = new SuperNova();
-            UseAsOperator(sn);
-
-            // Use the as operator with a value type.
-            // Note the implicit conversion to int? in
-            // the method body.
-            int i = 5;
-            UseAsWithNullable(i);
-
-            double d = 9.78654;
-            UseAsWithNullable(d);
-        }
-
-        static void UseIsOperator(Animal a)
-        {
-            if (a is Mammal)
-            {
-                Mammal m = (Mammal)a;
-                m.Eat();
-            }
-        }
-
-        static void UsePatternMatchingIs(Animal a)
-        {
-            if (a is Mammal m)
-            {
-                m.Eat();
-            }
-        }
-
-        static void UseAsOperator(object o)
-        {
-            Mammal m = o as Mammal;
-            if (m != null)
-            {
-                Console.WriteLine(m.ToString());
-            }
-            else
-            {
-                Console.WriteLine($"{o.GetType().Name} is not a Mammal");
-            }
-        }
-
-        static void UseAsWithNullable(System.ValueType val)
-        {
-            int? j = val as int?;
-            if (j != null)
-            {
-                Console.WriteLine(j);
-            }
-            else
-            {
-                Console.WriteLine("Could not convert " + val.ToString());
-            }
-        }
-    }
-    // </SnippetIsAndAs>
 }
+
+static void UsePatternMatchingIs(Animal a)
+{
+    if (a is Mammal m)
+    {
+        m.Eat();
+    }
+}
+
+static void UseAsOperator(object o)
+{
+    Mammal? m = o as Mammal;
+    if (m is not null)
+    {
+        Console.WriteLine(m.ToString());
+    }
+    else
+    {
+        Console.WriteLine($"{o.GetType().Name} is not a Mammal");
+    }
+}
+
+static void UseAsWithNullable(System.ValueType val)
+{
+    int? j = val as int?;
+    if (j is not null)
+    {
+        Console.WriteLine(j);
+    }
+    else
+    {
+        Console.WriteLine("Could not convert " + val.ToString());
+    }
+}
+class Animal
+{
+    public void Eat() => Console.WriteLine("Eating.");
+    public override string ToString() => "I am an animal.";
+}
+class Mammal : Animal { }
+class Giraffe : Mammal { }
+
+class SuperNova { }
+// </SnippetIsAndAs>

--- a/docs/csharp/fundamentals/tutorials/snippets/safelycast/asandis/asandis.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/safelycast/asandis/asandis.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/tutorials/snippets/safelycast/nullablepatternmatching/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/safelycast/nullablepatternmatching/Program.cs
@@ -1,69 +1,58 @@
-﻿using System;
+﻿// <SnippetPatternMatchingNullable>
+int i = 5;
+PatternMatchingNullable(i);
 
-namespace nullablepatternmatching
+int? j = null;
+PatternMatchingNullable(j);
+
+double d = 9.78654;
+PatternMatchingNullable(d);
+
+PatternMatchingSwitch(i);
+PatternMatchingSwitch(j);
+PatternMatchingSwitch(d);
+
+static void PatternMatchingNullable(ValueType? val)
 {
-    // <SnippetPatternMatchingNullable>
-    class Program
+    if (val is int j) // Nullable types are not allowed in patterns
     {
-        static void Main(string[] args)
-        {
-            int i = 5;
-            PatternMatchingNullable(i);
-
-            int? j = null;
-            PatternMatchingNullable(j);
-
-            double d = 9.78654;
-            PatternMatchingNullable(d);
-
-            PatternMatchingSwitch(i);
-            PatternMatchingSwitch(j);
-            PatternMatchingSwitch(d);
-        }
-
-        static void PatternMatchingNullable(System.ValueType val)
-        {
-            if (val is int j) // Nullable types are not allowed in patterns
-            {
-                Console.WriteLine(j);
-            }
-            else if (val is null) // If val is a nullable type with no value, this expression is true
-            {
-                Console.WriteLine("val is a nullable type with the null value");
-            }
-            else
-            {
-                Console.WriteLine("Could not convert " + val.ToString());
-            }
-        }
-
-        static void PatternMatchingSwitch(System.ValueType val)
-        {
-            switch (val)
-            {
-                case int number:
-                    Console.WriteLine(number);
-                    break;
-                case long number:
-                    Console.WriteLine(number);
-                    break;
-                case decimal number:
-                    Console.WriteLine(number);
-                    break;
-                case float number:
-                    Console.WriteLine(number);
-                    break;
-                case double number:
-                    Console.WriteLine(number);
-                    break;
-                case null:
-                    Console.WriteLine("val is a nullable type with the null value");
-                    break;
-                default:
-                    Console.WriteLine("Could not convert " + val.ToString());
-                    break;
-            }
-        }
+        Console.WriteLine(j);
     }
-    // </SnippetPatternMatchingNullable>
+    else if (val is null) // If val is a nullable type with no value, this expression is true
+    {
+        Console.WriteLine("val is a nullable type with the null value");
+    }
+    else
+    {
+        Console.WriteLine("Could not convert " + val.ToString());
+    }
 }
+
+static void PatternMatchingSwitch(ValueType? val)
+{
+    switch (val)
+    {
+        case int number:
+            Console.WriteLine(number);
+            break;
+        case long number:
+            Console.WriteLine(number);
+            break;
+        case decimal number:
+            Console.WriteLine(number);
+            break;
+        case float number:
+            Console.WriteLine(number);
+            break;
+        case double number:
+            Console.WriteLine(number);
+            break;
+        case null:
+            Console.WriteLine("val is a nullable type with the null value");
+            break;
+        default:
+            Console.WriteLine("Could not convert " + val.ToString());
+            break;
+    }
+}
+// </SnippetPatternMatchingNullable>

--- a/docs/csharp/fundamentals/tutorials/snippets/safelycast/nullablepatternmatching/nullablepatternmatching.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/safelycast/nullablepatternmatching/nullablepatternmatching.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/tutorials/snippets/safelycast/patternmatching/Program.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/safelycast/patternmatching/Program.cs
@@ -1,68 +1,58 @@
-﻿using System;
+﻿// <SnippetPatternMatchingIs>
+var g = new Giraffe();
+var a = new Animal();
+FeedMammals(g);
+FeedMammals(a);
+// Output:
+// Eating.
+// Animal is not a Mammal
 
-namespace patternmatching
+SuperNova sn = new SuperNova();
+TestForMammals(g);
+TestForMammals(sn);
+
+static void FeedMammals(Animal a)
 {
-    // <SnippetPatternMatchingIs>
-    class Animal
+    if (a is Mammal m)
     {
-        public void Eat() { Console.WriteLine("Eating."); }
-        public override string ToString()
-        {
-            return "I am an animal.";
-        }
+        m.Eat();
     }
-    class Mammal : Animal { }
-    class Giraffe : Mammal { }
-
-    class SuperNova { }
-
-    class Program
+    else
     {
-        static void Main(string[] args)
-        {
-            var g = new Giraffe();
-            var a = new Animal();
-            FeedMammals(g);
-            FeedMammals(a);
-            // Output:
-            // Eating.
-            // Animal is not a Mammal
-
-            SuperNova sn = new SuperNova();
-            TestForMammals(g);
-            TestForMammals(sn);
-            // Output:
-            // I am an animal.
-            // SuperNova is not a Mammal
-        }
-
-        static void FeedMammals(Animal a)
-        {
-            if (a is Mammal m)
-            {
-                m.Eat();
-            }
-            else
-            {
-                // variable 'm' is not in scope here, and can't be used.
-                Console.WriteLine($"{a.GetType().Name} is not a Mammal");
-            }
-        }
-
-        static void TestForMammals(object o)
-        {
-            // You also can use the as operator and test for null
-            // before referencing the variable.
-            var m = o as Mammal;
-            if (m != null)
-            {
-                Console.WriteLine(m.ToString());
-            }
-            else
-            {
-                Console.WriteLine($"{o.GetType().Name} is not a Mammal");
-            }
-        }
+        // variable 'm' is not in scope here, and can't be used.
+        Console.WriteLine($"{a.GetType().Name} is not a Mammal");
     }
-    // </SnippetPatternMatchingIs>
 }
+
+static void TestForMammals(object o)
+{
+    // You also can use the as operator and test for null
+    // before referencing the variable.
+    var m = o as Mammal;
+    if (m != null)
+    {
+        Console.WriteLine(m.ToString());
+    }
+    else
+    {
+        Console.WriteLine($"{o.GetType().Name} is not a Mammal");
+    }
+}
+// Output:
+// I am an animal.
+// SuperNova is not a Mammal
+
+class Animal
+{
+    public void Eat() { Console.WriteLine("Eating."); }
+    public override string ToString()
+    {
+        return "I am an animal.";
+    }
+}
+class Mammal : Animal { }
+class Giraffe : Mammal { }
+
+class SuperNova { }
+
+// </SnippetPatternMatchingIs>

--- a/docs/csharp/fundamentals/tutorials/snippets/safelycast/patternmatching/patternmatching.csproj
+++ b/docs/csharp/fundamentals/tutorials/snippets/safelycast/patternmatching/patternmatching.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
+++ b/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
@@ -20,9 +20,6 @@ Create a directory named *list-tutorial*. Make that the current directory and ru
 Open *Program.cs* in your favorite editor, and replace the existing code with the following:
 
 ```csharp
-using System;
-using System.Collections.Generic;
-
 var names = new List<string> { "<name>", "Ana", "Felipe" };
 foreach (var name in names)
 {
@@ -114,9 +111,6 @@ Save the file and type `dotnet run` to try this latest version.
 Before you start the next section, let's move the current code into a separate method. That makes it easier to start working with a new example. Place all the code you've written in a new method called `WorkWithStrings()`. Call that method at the top of your program. When you finish, your code should look like this:
 
 ```csharp
-using System;
-using System.Collections.Generic;
-
 WorkWithString();
 
 void WorkWithString()

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
@@ -25,8 +25,6 @@ dotnet new console -n BranchesAndLoops -o .
 This command creates a new .NET console application in the current directory. Open *Program.cs* in your favorite editor, and replace the contents with the following code:
 
 ```csharp
-using System;
-
 int a = 5;
 int b = 6;
 if (a + b > 10)
@@ -120,8 +118,6 @@ Modify the values of `a`, `b`, and `c` and switch between `&&` and `||` to explo
 You've finished the first step. Before you start the next section, let's move the current code into a separate method. That makes it easier to start working with a new example. Put the existing code in a method called `ExploreIf()`. Call it from the top of your program. When you finished those changes, your code should look like the following:
 
 ```csharp
-using System;
-
 ExploreIf();
 
 void ExploreIf()

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -25,8 +25,6 @@ dotnet new console -n NumbersInCSharp -o .
 Open *Program.cs* in your favorite editor, and replace the contents of the file with the following code:
 
 ```csharp
-using System;
-
 int a = 18;
 int b = 6;
 int c = a + b;
@@ -67,8 +65,6 @@ You can also experiment by writing multiple mathematics operations in the same l
 You've finished the first step. Before you start the next section, let's move the current code into a separate *method*. A method is a series of statements grouped together and given a name. You call a method by writing the method's name followed by `()`. Organizing your code into methods makes it easier to start working with a new example. When you finish, your code should look like this:
 
 ```csharp
-using System;
-
 WorkWithIntegers();
 
 void WorkWithIntegers()
@@ -148,8 +144,6 @@ Type `dotnet run` again to see the results.
 Before moving on, let's take all the code you've written in this section and put it in a new method. Call that new method `OrderPrecedence`. Your code should look something like this:
 
 ```csharp
-using System;
-
 // WorkWithIntegers();
 OrderPrecedence();
 


### PR DESCRIPTION
Fixes [#27896](https://github.com/dotnet/docs/issues/27896)

Also, in this PR, update all the tutorials in the Get Started and Tutorials section to .NET 6. That includes using top-level statements, implicit usings, and following other conventions.

Because I changed so much of the included code, I updated the date on the associated articles even though the text didn't change as much.