### PR TITLE
Remove confusing text in code sample

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-find-the-set-difference-between-two-lists-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-find-the-set-difference-between-two-lists-linq.md
@@ -33,7 +33,7 @@ class CompareLists
         foreach (string s in differenceQuery)  
             Console.WriteLine(s);  
   
-        // Keep the console window open in debug mode.  
+        // Keep the console window open until the user presses a key.
         Console.WriteLine("Press any key to exit");  
         Console.ReadKey();  
     }  


### PR DESCRIPTION
"Debug mode" doesn't make any sense and adds unnecessary confusion in this code sample.
