### PR TITLE
Refactor out dependency on unreliable HTTP endpoint

### DIFF
--- a/docs/core/compatibility/serialization/6.0/timespan-serialization-format.md
+++ b/docs/core/compatibility/serialization/6.0/timespan-serialization-format.md
@@ -50,7 +50,7 @@ public class TimeSpanConverter : JsonConverter<TimeSpan>
         writer.WriteNumber("days", value.Days);
         writer.WriteNumber("hours", value.Hours);
         /* insert any needed properties here */
-        writer.WriteEndObject();    
+        writer.WriteEndObject();
     }
 }
 ```

--- a/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
+++ b/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
@@ -27,7 +27,7 @@ public DiagnosticsClient
         DumpType dumpType,
         string dumpPath,
         bool logDumpGeneration = false);
-        
+
     public async Task WriteDumpAsync(
         DumpType dumpType,
         string dumpPath,
@@ -39,17 +39,17 @@ public DiagnosticsClient
         Guid profilerGuid,
         string profilerPath,
         byte[] additionalData = null);
-        
+
     public void SetStartupProfiler(
         Guid profilerGuid,
         string profilerPath);
-        
+
     public void ResumeRuntime();
-    
+
     public void SetEnvironmentVariable(
         string name,
         string value);
-        
+
     public Dictionary<string, string> GetProcessEnvironment();
 
     public static IEnumerable<int> GetPublishedProcesses();
@@ -98,8 +98,8 @@ public EventPipeSession StartEventPipeSession(EventPipeProvider providers, bool 
 
 ```csharp
 public void WriteDump(
-    DumpType dumpType, 
-    string dumpPath, 
+    DumpType dumpType,
+    string dumpPath,
     bool logDumpGeneration=false);
 ```
 
@@ -145,9 +145,9 @@ Request a dump for post-mortem debugging of the target application. The type of 
 
 ```csharp
 public void AttachProfiler(
-    TimeSpan attachTimeout, 
-    Guid profilerGuid, 
-    string profilerPath, 
+    TimeSpan attachTimeout,
+    Guid profilerGuid,
+    string profilerPath,
     byte[] additionalData=null);
 ```
 
@@ -183,7 +183,7 @@ Tell the runtime to resume execution after being paused at startup.
 
 ```csharp
 public void SetEnvironmentVariable(
-    string name, 
+    string name,
     string value);
 ```
 

--- a/docs/core/extensions/snippets/workers/windows-service/JokeService.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/JokeService.cs
@@ -1,40 +1,43 @@
-﻿using System.Net.Http.Json;
-using System.Text.Json;
-
-namespace App.WindowsService;
+﻿namespace App.WindowsService;
 
 public class JokeService
 {
-    private readonly HttpClient _httpClient;
-    private readonly JsonSerializerOptions _options = new()
+    public string GetJoke()
     {
-        PropertyNameCaseInsensitive = true
-    };
+        Joke joke = _jokes.ElementAt(
+            Random.Shared.Next(_jokes.Count));
 
-    private const string JokeApiUrl =
-        "https://karljoke.herokuapp.com/jokes/programming/random";
-
-    public JokeService(HttpClient httpClient) => _httpClient = httpClient;
-
-    public async Task<string> GetJokeAsync()
-    {
-        try
-        {
-            // The API returns an array with a single entry.
-            Joke[]? jokes = await _httpClient.GetFromJsonAsync<Joke[]>(
-                JokeApiUrl, _options);
-
-            Joke? joke = jokes?[0];
-
-            return joke is not null
-                ? $"{joke.Setup}{Environment.NewLine}{joke.Punchline}"
-                : "No joke here...";
-        }
-        catch (Exception ex)
-        {
-            return $"That's not funny! {ex}";
-        }
+        return $"{joke.Setup}{Environment.NewLine}{joke.Punchline}";
     }
+
+    // Programming jokes borrowed from:
+    // https://github.com/eklavyadev/karljoke/blob/main/source/jokes.json
+    readonly HashSet<Joke> _jokes = new()
+    {
+        new Joke("What's the best thing about a Boolean?", "Even if you're wrong, you're only off by a bit."),
+        new Joke("What's the object-oriented way to become wealthy?", "Inheritance"),
+        new Joke("Why did the programmer quit their job?", "Because they didn't get arrays."),
+        new Joke("Why do programmers always mix up Halloween and Christmas?", "Because Oct 31 == Dec 25"),
+        new Joke("How many programmers does it take to change a lightbulb?", "None that's a hardware problem"),
+        new Joke("If you put a million monkeys at a million keyboards, one of them will eventually write a Java program", "the rest of them will write Perl"),
+        new Joke("['hip', 'hip']", "(hip hip array)"),
+        new Joke("To understand what recursion is...", "You must first understand what recursion is"),
+        new Joke("There are 10 types of people in this world...", "Those who understand binary and those who don't"),
+        new Joke("Which song would an exception sing?", "Can't catch me - Avicii"),
+        new Joke("Why do Java programmers wear glasses?", "Because they don't C#"),
+        new Joke("How do you check if a webpage is HTML5?", "Try it out on Internet Explorer"),
+        new Joke("A user interface is like a joke.", "If you have to explain it then it is not that good."),
+        new Joke("I was gonna tell you a joke about UDP...", "...but you might not get it."),
+        new Joke("The punchline often arrives before the set-up.", "Do you know the problem with UDP jokes?"),
+        new Joke("Why do C# and Java developers keep breaking their keyboards?", "Because they use a strongly typed language."),
+        new Joke("Knock-knock.", "A race condition. Who is there?"),
+        new Joke("What's the best part about TCP jokes?", "I get to keep telling them until you get them."),
+        new Joke("A programmer puts two glasses on their bedside table before going to sleep.", "A full one, in case they gets thirsty, and an empty one, in case they don’t."),
+        new Joke("There are 10 kinds of people in this world.", "Those who understand binary, those who don't, and those who weren't expecting a base 3 joke."),
+        new Joke("What did the router say to the doctor?", "It hurts when IP."),
+        new Joke("An IPv6 packet is walking out of the house.", "He goes nowhere."),
+        new Joke("3 SQL statements walk into a NoSQL bar. Soon, they walk out", "They couldn't find a table.")
+    };
 }
 
-public record Joke(int Id, string Type, string Setup, string Punchline);
+public record Joke(string Setup, string Punchline);

--- a/docs/core/extensions/snippets/workers/windows-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/Program.cs
@@ -8,7 +8,6 @@ using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {
         services.AddHostedService<WindowsBackgroundService>();
-        services.AddHttpClient<JokeService>();
     })
     .Build();
 

--- a/docs/core/extensions/snippets/workers/windows-service/WindowsBackgroundService.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/WindowsBackgroundService.cs
@@ -14,7 +14,7 @@ public sealed class WindowsBackgroundService : BackgroundService
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            string joke = await _jokeService.GetJokeAsync();
+            string joke = _jokeService.GetJoke();
             _logger.LogWarning(joke);
 
             await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);

--- a/docs/core/extensions/windows-service.md
+++ b/docs/core/extensions/windows-service.md
@@ -3,7 +3,7 @@ title: Create a Windows Service using BackgroundService
 description: Learn how to create a Windows Service using the BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 12/03/2021
+ms.date: 03/01/2022
 ms.topic: tutorial
 ---
 
@@ -26,7 +26,7 @@ In this tutorial, you'll learn how to:
 
 ## Prerequisites
 
-- The [.NET 5.0 SDK or later](https://dotnet.microsoft.com/download/dotnet)
+- The [.NET 6.0 SDK or later](https://dotnet.microsoft.com/download/dotnet)
 - A Windows OS
 - A .NET integrated development environment (IDE)
   - Feel free to use [Visual Studio](https://visualstudio.microsoft.com)
@@ -70,14 +70,7 @@ Add a new class to the project named *JokeService.cs*, and replace its contents 
 
 :::code source="snippets/workers/windows-service/JokeService.cs":::
 
-The preceding joke service source code exposes a single functionality, the `GetJokeAsync` method. This is a <xref:System.Threading.Tasks.Task%601> returning method where `T` is a `string`, and it represents a random programming joke. The <xref:System.Net.Http.HttpClient> is injected into the constructor and assigned to a class-scope `_httpClient` variable.
-
-> [!TIP]
-> The joke API is from an [open source project on GitHub](https://github.com/eklavyadev/karljoke). It is used for demonstration purposes, and we make no guarantee that it will be available in the future. To quickly test the API, open the following URL in a browser:
->
-> ```http
-> https://karljoke.herokuapp.com/jokes/programming/random.
-> ```
+The preceding joke service source code exposes a single piece of functionality, the `GetJoke` method. This is a `string` returning method that represents a random programming joke. The class-scoped `_jokes` field is used to store the list of jokes. A random joke is selected from the list and returned.
 
 ## Rewrite the `Worker` class
 
@@ -106,9 +99,9 @@ In the preceding code, the `JokeService` is injected along with an `ILogger`. Bo
 
 Replace the template *Program.cs* file contents with the following C# code:
 
-:::code source="snippets/workers/windows-service/Program.cs" highlight="4-7,10-11":::
+:::code source="snippets/workers/windows-service/Program.cs" highlight="4-7,10":::
 
-The <xref:Microsoft.Extensions.Hosting.WindowsServiceLifetimeHostBuilderExtensions.UseWindowsService%2A> extension method configures the app to work as a Windows Service. The service name is set to `".NET Joke Service"`. The hosted service is registered, and the `HttpClient` is registered to the `JokeService` for dependency injection.
+The <xref:Microsoft.Extensions.Hosting.WindowsServiceLifetimeHostBuilderExtensions.UseWindowsService%2A> extension method configures the app to work as a Windows Service. The service name is set to `".NET Joke Service"`. The hosted service is registered for dependency injection.
 
 For more information on registering services, see [Dependency injection in .NET](dependency-injection.md).
 
@@ -198,7 +191,7 @@ SERVICE_NAME: .NET Joke Service
         COMMAND_LINE                 :
 ```
 
-The command will output the recovery configuration, which are the default values&mdash;since they've not yet been configured.
+The command will output the recovery configuration, which is the default values&mdash;since they've not yet been configured.
 
 :::image type="content" source="media/windows-service-recovery-properties.png" alt-text="The Windows Service recovery configuration properties dialog.":::
 

--- a/docs/core/porting/upgrade-assistant-wpf-framework.md
+++ b/docs/core/porting/upgrade-assistant-wpf-framework.md
@@ -379,7 +379,7 @@ With the WPF example app upgraded in the preceding section, we can remove the de
         <Content Include="appsettings.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-      </ItemGroup>    
+      </ItemGroup>
     ```
 
 01. Edit the _App.xaml.cs_ file, setting up a configuration object that loads the _appsettings.json_ file, the added lines are highlighted:

--- a/docs/csharp/whats-new/tutorials/static-abstract-interface-methods.md
+++ b/docs/csharp/whats-new/tutorials/static-abstract-interface-methods.md
@@ -131,7 +131,7 @@ Finally, when you're performing addition, it's useful to have a property that de
 There are a few changes here, so let's walk through them one by one. First, you declare that the `Translation` type implements the `IAdditiveIdentity` interface:
 
 ```csharp
-public record Translation<T>(T XOffset, T YOffset) : IAdditiveIdentity<Translation<T>, Translation<T>> 
+public record Translation<T>(T XOffset, T YOffset) : IAdditiveIdentity<Translation<T>, Translation<T>>
 ```
 
 You next might try implementing the interface member as shown in the following code:

--- a/docs/fsharp/language-reference/plaintext-formatting.md
+++ b/docs/fsharp/language-reference/plaintext-formatting.md
@@ -428,7 +428,7 @@ To achieve consistent formatting for `%A` and `%O` format specifiers, combine th
 type MyRecord =
     {
         a: int
-    } 
+    }
     member this.DisplayText = this.ToString()
 
     override _.ToString() = "Custom ToString"

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1701,7 +1701,7 @@ val SampleMixedFunction:
         arg4: string *
         arg5: TType ->
             arg6: TType *
-            arg7: TType -> 
+            arg7: TType ->
                 arg8: TType *
                 arg9: TType *
                 arg10: TType ->
@@ -1713,7 +1713,7 @@ The same rules apply for members in type signatures:
 ```fsharp
 type SampleTypeName =
     member ResolveDependencies:
-        arg1: string * 
+        arg1: string *
         arg2: string ->
             string
 ```
@@ -1775,7 +1775,7 @@ myObj
     {| child: {| displayName: string; kind: string |}
        newParent: {| id: string; displayName: string |}
        requiresApproval: bool |}>
-       
+
 // ✔️ OK
 Json.serialize<
     {| child: {| displayName: string; kind: string |}

--- a/docs/orleans/deployment/consul-deployment.md
+++ b/docs/orleans/deployment/consul-deployment.md
@@ -57,7 +57,7 @@ There is currently a known issue with the "Custom" membership provider _OrleansC
     <Defaults>
         <Networking Address="localhost" Port="22222" />
         <ProxyingGateway Address="localhost" Port="30000" />
-    </Defaults>    
+    </Defaults>
 </OrleansConfiguration>
 ```
 

--- a/docs/orleans/deployment/docker-deployment.md
+++ b/docs/orleans/deployment/docker-deployment.md
@@ -340,7 +340,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg 
+    && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
 WORKDIR /app
 ENTRYPOINT ["tail", "-f", "/dev/null"]
 ```
@@ -380,17 +380,17 @@ services:
     build:
       context: ./src/OrleansClient/bin/PublishOutput/
       dockerfile: Dockerfile.Debug
-    volumes: 
+    volumes:
       - ./src/OrleansClient/bin/PublishOutput/:/app
       - ~/.nuget/packages:/root/.nuget/packages:ro
-    depends_on: 
+    depends_on:
       - orleans-silo
   orleans-silo:
     image: orleans-silo:debug
     build:
       context: ./src/OrleansSilo/bin/PublishOutput/
       dockerfile: Dockerfile.Debug
-    volumes: 
+    volumes:
       - ./src/OrleansSilo/bin/PublishOutput/:/app
       - ~/.nuget/packages:/root/.nuget/packages:ro
 ```
@@ -403,7 +403,7 @@ version: '3.1'
 services:
   orleans-client:
     image: orleans-client
-    depends_on: 
+    depends_on:
       - orleans-silo
   orleans-silo:
     image: orleans-silo
@@ -446,9 +446,9 @@ Now, let's run it!
 ```shell
 # docker-compose up -d
 Creating network "orleansdocker_default" with the default driver
-Creating orleansdocker_orleans-silo_1 ... 
+Creating orleansdocker_orleans-silo_1 ...
 Creating orleansdocker_orleans-silo_1 ... done
-Creating orleansdocker_orleans-client_1 ... 
+Creating orleansdocker_orleans-client_1 ...
 Creating orleansdocker_orleans-client_1 ... done
 #
 ```
@@ -457,10 +457,10 @@ Now if you run a `docker-compose ps`, you will see 2 containers running for the 
 
 ```shell
 # docker-compose ps
-             Name                     Command        State   Ports 
+             Name                     Command        State   Ports
 ------------------------------------------------------------------
-orleansdocker_orleans-client_1   tail -f /dev/null   Up            
-orleansdocker_orleans-silo_1     tail -f /dev/null   Up 
+orleansdocker_orleans-client_1   tail -f /dev/null   Up
+orleansdocker_orleans-silo_1     tail -f /dev/null   Up
 ```
 
 > [!NOTE]
@@ -475,20 +475,20 @@ Once you have your compose project running, you can easily scale up or down your
 ```shell
 # docker-compose scale orleans-silo=15
 Starting orleansdocker_orleans-silo_1 ... done
-Creating orleansdocker_orleans-silo_2 ... 
-Creating orleansdocker_orleans-silo_3 ... 
-Creating orleansdocker_orleans-silo_4 ... 
-Creating orleansdocker_orleans-silo_5 ... 
-Creating orleansdocker_orleans-silo_6 ... 
-Creating orleansdocker_orleans-silo_7 ... 
-Creating orleansdocker_orleans-silo_8 ... 
-Creating orleansdocker_orleans-silo_9 ... 
-Creating orleansdocker_orleans-silo_10 ... 
-Creating orleansdocker_orleans-silo_11 ... 
-Creating orleansdocker_orleans-silo_12 ... 
-Creating orleansdocker_orleans-silo_13 ... 
-Creating orleansdocker_orleans-silo_14 ... 
-Creating orleansdocker_orleans-silo_15 ... 
+Creating orleansdocker_orleans-silo_2 ...
+Creating orleansdocker_orleans-silo_3 ...
+Creating orleansdocker_orleans-silo_4 ...
+Creating orleansdocker_orleans-silo_5 ...
+Creating orleansdocker_orleans-silo_6 ...
+Creating orleansdocker_orleans-silo_7 ...
+Creating orleansdocker_orleans-silo_8 ...
+Creating orleansdocker_orleans-silo_9 ...
+Creating orleansdocker_orleans-silo_10 ...
+Creating orleansdocker_orleans-silo_11 ...
+Creating orleansdocker_orleans-silo_12 ...
+Creating orleansdocker_orleans-silo_13 ...
+Creating orleansdocker_orleans-silo_14 ...
+Creating orleansdocker_orleans-silo_15 ...
 Creating orleansdocker_orleans-silo_6
 Creating orleansdocker_orleans-silo_5
 Creating orleansdocker_orleans-silo_3
@@ -509,24 +509,24 @@ After a few seconds, you will see the services scaled to the specific number of 
 
 ```shell
 # docker-compose ps
-             Name                     Command        State   Ports 
+             Name                     Command        State   Ports
 ------------------------------------------------------------------
-orleansdocker_orleans-client_1   tail -f /dev/null   Up            
-orleansdocker_orleans-silo_1     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_10    tail -f /dev/null   Up            
-orleansdocker_orleans-silo_11    tail -f /dev/null   Up            
-orleansdocker_orleans-silo_12    tail -f /dev/null   Up            
-orleansdocker_orleans-silo_13    tail -f /dev/null   Up            
-orleansdocker_orleans-silo_14    tail -f /dev/null   Up            
-orleansdocker_orleans-silo_15    tail -f /dev/null   Up            
-orleansdocker_orleans-silo_2     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_3     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_4     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_5     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_6     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_7     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_8     tail -f /dev/null   Up            
-orleansdocker_orleans-silo_9     tail -f /dev/null   Up 
+orleansdocker_orleans-client_1   tail -f /dev/null   Up
+orleansdocker_orleans-silo_1     tail -f /dev/null   Up
+orleansdocker_orleans-silo_10    tail -f /dev/null   Up
+orleansdocker_orleans-silo_11    tail -f /dev/null   Up
+orleansdocker_orleans-silo_12    tail -f /dev/null   Up
+orleansdocker_orleans-silo_13    tail -f /dev/null   Up
+orleansdocker_orleans-silo_14    tail -f /dev/null   Up
+orleansdocker_orleans-silo_15    tail -f /dev/null   Up
+orleansdocker_orleans-silo_2     tail -f /dev/null   Up
+orleansdocker_orleans-silo_3     tail -f /dev/null   Up
+orleansdocker_orleans-silo_4     tail -f /dev/null   Up
+orleansdocker_orleans-silo_5     tail -f /dev/null   Up
+orleansdocker_orleans-silo_6     tail -f /dev/null   Up
+orleansdocker_orleans-silo_7     tail -f /dev/null   Up
+orleansdocker_orleans-silo_8     tail -f /dev/null   Up
+orleansdocker_orleans-silo_9     tail -f /dev/null   Up
 ```
 
 > [!IMPORTANT]

--- a/docs/orleans/deployment/index.md
+++ b/docs/orleans/deployment/index.md
@@ -29,7 +29,7 @@ var silo = new SiloHost("Test Silo", siloConfig);
 silo.InitializeOrleansSilo();
 silo.StartOrleansSilo();
 
-Console.WriteLine("Press Enter to close."); 
+Console.WriteLine("Press Enter to close.");
 // wait here
 Console.ReadLine();
 

--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -47,7 +47,7 @@ spec:
         orleans/serviceId: dictionary-app
 
         # This label is used to identify an instance of a cluster to Orleans.
-        # Typically, this will be the same value as the previous label, or any 
+        # Typically, this will be the same value as the previous label, or any
         # fixed value.
         # In cases where you are not using rolling deployments (for example,
         # blue/green deployments),

--- a/docs/orleans/grains/event-sourcing/journaledgrain-basics.md
+++ b/docs/orleans/grains/event-sourcing/journaledgrain-basics.md
@@ -58,7 +58,7 @@ class GrainState
     {
         // code that updates the state
     }
-    
+
     Apply(E2 @event)
     {
         // code that updates the state

--- a/docs/orleans/grains/event-sourcing/journaledgrain-diagnostics.md
+++ b/docs/orleans/grains/event-sourcing/journaledgrain-diagnostics.md
@@ -16,7 +16,7 @@ JournaledGrain subclasses can override the following methods to receive notifica
 protected override void OnConnectionIssue(
     ConnectionIssue issue)
 {
-    /// handle the observed error described by issue 
+    /// handle the observed error described by issue
 }
 
 protected override void OnConnectionIssueResolved(

--- a/docs/orleans/grains/external-tasks-and-grains.md
+++ b/docs/orleans/grains/external-tasks-and-grains.md
@@ -52,7 +52,7 @@ public async Task MyGrainMethod()
 
     await t1;
 
-    // We are back to the Orleans task scheduler. 
+    // We are back to the Orleans task scheduler.
     // Since await was executed in Orleans task scheduler context, we are now back
     // to that context.
     Assert.AreEqual(orleansTS, TaskScheduler.Current);

--- a/docs/orleans/grains/grain-persistence/index.md
+++ b/docs/orleans/grains/grain-persistence/index.md
@@ -51,7 +51,7 @@ public class UserGrain : Grain, IUserGrain
 {
     private readonly IPersistentState<ProfileState> _profile;
     private readonly IPersistentState<CartState> _cart;
-    
+
     public UserGrain(
         [PersistentState("profile", "profileStore")] IPersistentState<ProfileState> profile,
         [PersistentState("cart", "cartStore")] IPersistentState<CartState> cart)
@@ -117,7 +117,7 @@ var host = new HostBuilder()
             {
                 // Use JSON for serializing the state in storage
                 options.UseJson = true;
-            
+
                 // Configure the storage connection key
                 options.ConnectionString =
                     "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1";
@@ -128,7 +128,7 @@ var host = new HostBuilder()
                 {
                     // Use JSON for serializing the state in storage
                     options.UseJson = true;
-            
+
                     // Configure the storage connection key
                     options.ConnectionString =
                         "DefaultEndpointsProtocol=https;AccountName=data2;AccountKey=SOMETHING2";
@@ -153,7 +153,7 @@ Declare a class to hold our grain's state:
 public class ProfileState
 {
     public string Name { get; set; }
-    
+
     public Date DateOfBirth
 }
 ```
@@ -164,7 +164,7 @@ Inject `IPersistentState<ProfileState>` into the grain's constructor:
 public class UserGrain : Grain, IUserGrain
 {
     private readonly IPersistentState<ProfileState> _profile;
-    
+
     public UserGrain(
         [PersistentState("profile", "profileStore")]
         IPersistentState<ProfileState> profile)
@@ -183,16 +183,16 @@ Now that the grain has a persistent state, we can add methods to read and write 
 public class UserGrain : Grain, IUserGrain
     {
     private readonly IPersistentState<ProfileState> _profile;
-    
+
     public UserGrain(
         [PersistentState("profile", "profileStore")]
         IPersistentState<ProfileState> profile)
     {
         _profile = profile;
     }
-    
+
     public Task<string> GetNameAsync() => Task.FromResult(_profile.State.Name);
-    
+
     public async Task SetNameAsync(string name)
     {
         _profile.State.Name = name;
@@ -265,7 +265,7 @@ public interface IGrainStorage
     /// <returns>Completion promise for the Read operation on the specified grain.</returns>
     Task ReadStateAsync(
         string grainType, GrainReference grainReference, IGrainState grainState);
-    
+
     /// <summary>Write data function for this storage instance.</summary>
     /// <param name="grainType">Type of this grain [fully qualified class name]</param>
     /// <param name="grainReference">Grain reference object for this grain.</param>
@@ -273,7 +273,7 @@ public interface IGrainStorage
     /// <returns>Completion promise for the Write operation on the specified grain.</returns>
     Task WriteStateAsync(
         string grainType, GrainReference grainReference, IGrainState grainState);
-    
+
     /// <summary>Delete / Clear data function for this storage instance.</summary>
     /// <param name="grainType">Type of this grain [fully qualified class name]</param>
     /// <param name="grainReference">Grain reference object for this grain.</param>
@@ -316,7 +316,7 @@ public class InconsistentStateException : OrleansException
 
     /// <summary>The Etag value currently held in persistent storage.</summary>
     public string StoredEtag { get; }
-    
+
     /// <summary>The Etag value currently held in memory, and attempting to be updated.</summary>
     public string CurrentEtag { get; }
 }

--- a/docs/orleans/grains/grain-persistence/relational-storage.md
+++ b/docs/orleans/grains/grain-persistence/relational-storage.md
@@ -54,14 +54,14 @@ You can set the following properties via `AdoNetGrainStorageOptions`:
 public class AdoNetGrainStorageOptions
 {
     /// <summary>
-    /// Define the property of the connection string 
+    /// Define the property of the connection string
     /// for AdoNet storage.
     /// </summary>
     [Redact]
     public string ConnectionString { get; set; }
 
     /// <summary>
-    /// Set the stage of the silo lifecycle where storage should 
+    /// Set the stage of the silo lifecycle where storage should
     /// be initialized.  Storage must be initialized prior to use.
     /// </summary>
     public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
@@ -72,7 +72,7 @@ public class AdoNetGrainStorageOptions
         ServiceLifecycleStage.ApplicationServices;
 
     /// <summary>
-    /// The default ADO.NET invariant will be used for 
+    /// The default ADO.NET invariant will be used for
     /// storage if none is given.
     /// </summary>
     public const string DEFAULT_ADONET_INVARIANT =

--- a/docs/orleans/grains/grain-versioning/backward-compatibility-guidelines.md
+++ b/docs/orleans/grains/grain-versioning/backward-compatibility-guidelines.md
@@ -30,7 +30,7 @@ public interface IMyGrain : IGrainWithIntegerKey
 {
     // Method inherited from V1
     Task MyMethod(int arg);
-    
+
     // New method added in V2
     Task MyNewMethod(int arg, obj o);
 }
@@ -116,7 +116,7 @@ public interface MyGrain : IMyGrain
     {
         SomeSubRoutine(arg);
     }
-    
+
     // New method added in V2
     Task MyNewMethod(int arg)
     {
@@ -149,7 +149,7 @@ If you want to remove methods, this should be done in 2 steps:
         // Method inherited from V1
         [Obsolete]
         Task MyMethod(int arg);
-        
+
         // New method added in V2
         Task MyNewMethod(int arg, obj o);
     }

--- a/docs/orleans/grains/grain-versioning/deploying-new-versions-of-grains.md
+++ b/docs/orleans/grains/grain-versioning/deploying-new-versions-of-grains.md
@@ -48,7 +48,7 @@ Recommended configuration:
 
 ```csharp
 var silo = new SiloHostBuilder()
-    .Configure<GrainVersioningOptions>(options => 
+    .Configure<GrainVersioningOptions>(options =>
     {
         options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
         options.DefaultVersionSelectorStrategy = nameof(MinimumVersion);

--- a/docs/orleans/grains/grain-versioning/grain-versioning.md
+++ b/docs/orleans/grains/grain-versioning/grain-versioning.md
@@ -50,7 +50,7 @@ You can change this default behavior via the option `GrainVersioningOptions`:
 
 ```csharp
 var silo = new SiloHostBuilder()
-    .Configure<GrainVersioningOptions>(options => 
+    .Configure<GrainVersioningOptions>(options =>
     {
         options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
         options.DefaultVersionSelectorStrategy = nameof(MinimumVersion);

--- a/docs/orleans/grains/grainservices.md
+++ b/docs/orleans/grains/grainservices.md
@@ -82,7 +82,7 @@ public class DataService : GrainService, IDataService
     public class MyNormalGrain: Grain<NormalGrainState>, INormalGrain
     {
         readonly IDataServiceClient _dataServiceClient;
-    
+
         public MyNormalGrain(
             IGrainActivationContext grainActivationContext,
             IDataServiceClient dataServiceClient) =>
@@ -122,6 +122,6 @@ var builder = new SiloHostBuilder()
     .ConfigureServices(services =>
     {
         // Register Client of GrainService
-        services.AddSingleton<IDataServiceClient, DataServiceClient>(); 
+        services.AddSingleton<IDataServiceClient, DataServiceClient>();
     })
  ```

--- a/docs/orleans/grains/index.md
+++ b/docs/orleans/grains/index.md
@@ -153,7 +153,7 @@ The Orleans programming model is based on [asynchronous programming](../../cshar
 Task joinGameTask = player.JoinGame(this);
 
 // The await keyword effectively makes the remainder of the
-// method execute asynchronously at a later point 
+// method execute asynchronously at a later point
 // (upon completion of the Task being awaited) without blocking the thread.
 await joinGameTask;
 

--- a/docs/orleans/grains/interceptors.md
+++ b/docs/orleans/grains/interceptors.md
@@ -485,11 +485,11 @@ public async Task Invoke(IIncomingGrainCallContext context)
     {
         var filterGrain = _grainFactory.GetGrain<ICustomFilterGrain>(
             context.Grain.GetPrimaryKeyLong());
-        
+
         // Perform some grain call here.
         await filterGrain.OnReceivedCall();
     }
-    
+
     // Continue invoking the call on the target grain.
     await context.Invoke();
 }

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -69,7 +69,7 @@ SQL:
 const string connectionString = "YOUR_CONNECTION_STRING_HERE";
 const string invariant = "YOUR_INVARIANT";
 var silo = new SiloHostBuilder()
-    .UseAdoNetReminderService(options => 
+    .UseAdoNetReminderService(options =>
     {
         options.ConnectionString = connectionString;
         options.Invariant = invariant;

--- a/docs/orleans/host/client.md
+++ b/docs/orleans/host/client.md
@@ -249,7 +249,7 @@ namespace PlayerWatcher
                     .ConfigureApplicationParts(
                         parts => parts.AddApplicationPart(typeof(IValueGrain).Assembly))
                     .Build();
-    
+
                     // Hardcoded player ID
                     Guid playerId = new("{2349992C-860A-4EDA-9590-000000000006}");
                     IPlayerGrain player = client.GetGrain<IPlayerGrain>(playerId);
@@ -258,7 +258,7 @@ namespace PlayerWatcher
                     {
                         Console.WriteLine(
                             $"Getting current game for player {playerId}...");
-    
+
                         try
                         {
                             game = await player.GetCurrentGame();
@@ -272,15 +272,15 @@ namespace PlayerWatcher
                             Console.WriteLine($"Exception: {ex.GetBaseException()}");
                         }
                     }
-    
+
                     Console.WriteLine(
                         $"Subscribing to updates for game {game.GetPrimaryKey()}...");
-    
+
                     // Subscribe for updates
                     var watcher = new GameObserver();
                     await game.SubscribeForGameUpdates(
                         await client.CreateObjectReference<IGameObserver>(watcher));
-    
+
                     Console.WriteLine(
                         "Subscribed successfully. Press <Enter> to stop.");
                 }
@@ -293,7 +293,7 @@ namespace PlayerWatcher
         }
 
         /// <summary>
-        /// Observer class that implements the observer interface. 
+        /// Observer class that implements the observer interface.
         /// Need to pass a grain reference to an instance of
         /// this class to subscribe for updates.
         /// </summary>

--- a/docs/orleans/host/configuration-guide/local-development-configuration.md
+++ b/docs/orleans/host/configuration-guide/local-development-configuration.md
@@ -56,7 +56,7 @@ static async Task<ISiloHost> BuildAndStartSiloAsync()
         .Configure<EndpointOptions>(
             options => options.AdvertisedIPAddress = IPAddress.Loopback)
         .ConfigureLogging(logging => logging.AddConsole());
-    
+
     var host = builder.Build();
     await host.StartAsync();
 

--- a/docs/orleans/host/configuration-guide/serialization.md
+++ b/docs/orleans/host/configuration-guide/serialization.md
@@ -215,7 +215,7 @@ Implementation of `IExternalSerializer` follows the pattern described for serial
 public interface IExternalSerializer
 {
     /// <summary>
-    /// Initializes the external serializer. Called once when the serialization manager creates 
+    /// Initializes the external serializer. Called once when the serialization manager creates
     /// an instance of this type
     /// </summary>
     void Initialize(Logger logger);
@@ -276,7 +276,7 @@ internal class UserSerializer
         var input = (User)original;
         var result = new User();
 
-        // Record 'result' as a copy of 'input'. Doing this 
+        // Record 'result' as a copy of 'input'. Doing this
         // immediately after construction allows for data
         // structures that have cyclic references or duplicate
         // references. For example, imagine that 'input.BestFriend'

--- a/docs/orleans/host/configuration-guide/typical-configurations.md
+++ b/docs/orleans/host/configuration-guide/typical-configurations.md
@@ -64,7 +64,7 @@ var silo = new SiloHostBuilder()
         options.ServiceId = "MyAwesomeService";
     })
     .UseAdoNetClustering(options =>
-    { 
+    {
       options.ConnectionString = connectionString;
       options.Invariant = "System.Data.SqlClient";
     })
@@ -84,7 +84,7 @@ var client = new ClientBuilder()
         options.ServiceId = "MyAwesomeService";
     })
     .UseAdoNetClustering(options =>
-    { 
+    {
       options.ConnectionString = connectionString;
       options.Invariant = "System.Data.SqlClient";
     })

--- a/docs/orleans/migration/migration-1.5.md
+++ b/docs/orleans/migration/migration-1.5.md
@@ -55,7 +55,7 @@ class Program
 
         var config = ClusterConfiguration.LocalhostPrimarySilo();
         config.AddMemoryStorageProvider();
-            
+
         var builder = new SiloHostBuilder()
             .UseConfiguration(config)
             .ConfigureApplicationParts(parts =>

--- a/docs/orleans/overview.md
+++ b/docs/orleans/overview.md
@@ -70,7 +70,7 @@ public class ThermostatGrain : Grain, IThermostat, IThermostatControl
 {
     private ThermostatStatus _status;
     private List<Command> _commands;
-    
+
     public Task<List<Command>> OnUpdate(ThermostatStatus status)
     {
         _status = status;

--- a/docs/orleans/resources/nuget-packages.md
+++ b/docs/orleans/resources/nuget-packages.md
@@ -78,7 +78,7 @@ Included in Microsoft.Orleans.Client and Microsoft.Orleans.Server meta-packages,
 ### [Microsoft Orleans Runtime](https://www.nuget.org/packages/Microsoft.Orleans.OrleansRuntime/)
 
 ```powershell
-Install-Package Microsoft.Orleans.OrleansRuntime 
+Install-Package Microsoft.Orleans.OrleansRuntime
 ```
 
 Library for configuring and starting a silo. Reference it in your silo host project. Included in Microsoft.Orleans.Server meta-package.
@@ -86,7 +86,7 @@ Library for configuring and starting a silo. Reference it in your silo host proj
 ### [Microsoft Orleans Runtime Abstractions](https://www.nuget.org/packages/Microsoft.Orleans.Runtime.Abstractions/)
 
 ```powershell
-Install-Package Microsoft.Orleans.Runtime.Abstractions 
+Install-Package Microsoft.Orleans.Runtime.Abstractions
 ```
 
 Contains interfaces and abstractions for types implemented in Microsoft.Orleans.OrleansRuntime.
@@ -102,7 +102,7 @@ Contains helper classes for hosting silos and Orleans clients as Azure Cloud Ser
 ### [Microsoft Orleans Service Fabric Hosting Support](https://www.nuget.org/packages/Microsoft.Orleans.Hosting.ServiceFabric/)
 
 ```powershell
-Install-Package Microsoft.Orleans.Hosting.ServiceFabric 
+Install-Package Microsoft.Orleans.Hosting.ServiceFabric
 ```
 
 Contains helper classes for hosting silos as a stateless Service Fabric service.
@@ -256,7 +256,7 @@ Includes the run time code generator.
 ### [Microsoft Orleans Event-Sourcing](https://www.nuget.org/packages/Microsoft.Orleans.EventSourcing/)
 
 ```powershell
-Install-Package Microsoft.Orleans.EventSourcing 
+Install-Package Microsoft.Orleans.EventSourcing
 ```
 
 Contains a set of base types for creating grain classes with event-sourced state.

--- a/docs/orleans/streaming/index.md
+++ b/docs/orleans/streaming/index.md
@@ -38,7 +38,7 @@ public async Task OnHttpCall(DeviceEvent deviceEvent)
      // Post data directly into the device's stream.
      IStreamProvider streamProvider =
         GrainClient.GetStreamProvider("MyStreamProvider");
-     
+
     IAsyncStream<DeviceEventData> deviceStream =
         streamProvider.GetStream<DeviceEventData>(
             deviceEvent.DeviceId, "MyNamespace");

--- a/docs/orleans/streaming/streams-programming-apis.md
+++ b/docs/orleans/streaming/streams-programming-apis.md
@@ -205,7 +205,7 @@ Applications can choose where and how the Pub-Sub data is stored. The Pub-Sub co
 The following configures the Pub-Sub to store its state in Azure tables.
 
 ```csharp
-hostBuilder.AddAzureTableGrainStorage("PubSubStore", 
+hostBuilder.AddAzureTableGrainStorage("PubSubStore",
     options=>{ options.ConnectionString = "Secret"; });
 ```
 

--- a/docs/orleans/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/orleans/tutorials-and-samples/custom-grain-storage.md
@@ -293,7 +293,7 @@ public static class FileSiloBuilderExtensions
         Action<FileGrainStorageOptions> options)
     {
         services.AddOptions<FileGrainStorageOptions>(providerName).Configure(options);
-        
+
         return services.AddSingletonNamedService(providerName, FileGrainStorageFactory.Create)
             .AddSingletonNamedService(
                 providerName,


### PR DESCRIPTION
## Summary

- Refactor out dependency on unreliable HTTP endpoint
- Pre-commit hook, applied automatic markdownlint CLI fixes

## Internal preview

✔️ [Create a Windows Service using `BackgroundService`](https://review.docs.microsoft.com/en-us/dotnet/core/extensions/windows-service?branch=pr-en-us-28434)

Fixes #28004 also related to https://github.com/dotnet/samples/pull/5032