### PR TITLE
Bulk update incorrect or inconsistent slugs.

### DIFF
--- a/docs/architecture/dapr-for-net-developers/secrets-management.md
+++ b/docs/architecture/dapr-for-net-developers/secrets-management.md
@@ -691,7 +691,7 @@ The `CalculateFine` method expects a string containing a `licenseKey` as its fir
 
 The implementation simulates a check on the `licenseKey` that is passed in. The `CollectionController` of the FineCollection service must pass in the correct license key argument when calling the `CalculateFine` method. It retrieves the license key from the Dapr secrets management building block that is exposed by the Dapr client in the Dapr SDK for .NET. If you examine the constructor of the `CollectionController`, you can see the call:
 
-```c#
+```csharp
 // set finecalculator component license-key
 if (_fineCalculatorLicenseKey == null)
 {

--- a/docs/azure/sdk/resource-management.md
+++ b/docs/azure/sdk/resource-management.md
@@ -232,7 +232,7 @@ If you are not sure if a resource you want to get exists, or you just want to ch
 
 In previous versions of packages, you would have to catch the `RequestFailedException` and inspect the status code for 404. With this new API, we hope that this can boost the developer productivity and optimize resource access. .
 
-```C# Snippet:Readme_OldCheckIfExistsRG
+```csharp 
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 Subscription subscription = await armClient.GetDefaultSubscriptionAsync();
 string rgName = "myRgName";
@@ -250,7 +250,7 @@ catch (RequestFailedException ex) when (ex.Status == 404)
 
 Now with these convenience methods we can simply do the following.
 
-```C# Snippet:Readme_CheckIfExistssRG
+```csharp 
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 Subscription subscription = await armClient.GetDefaultSubscriptionAsync();
 string rgName = "myRgName";
@@ -273,7 +273,7 @@ else
 
 Another way to do this is by using `GetIfExists()` which will avoid the race condition mentioned above:
 
-```C# Snippet:Readme_TryGetRG
+```csharp 
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 Subscription subscription = await armClient.GetDefaultSubscriptionAsync();
 string rgName = "myRgName";

--- a/docs/azure/sdk/resource-management.md
+++ b/docs/azure/sdk/resource-management.md
@@ -232,7 +232,7 @@ If you are not sure if a resource you want to get exists, or you just want to ch
 
 In previous versions of packages, you would have to catch the `RequestFailedException` and inspect the status code for 404. With this new API, we hope that this can boost the developer productivity and optimize resource access. .
 
-```csharp 
+```csharp
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 Subscription subscription = await armClient.GetDefaultSubscriptionAsync();
 string rgName = "myRgName";
@@ -250,7 +250,7 @@ catch (RequestFailedException ex) when (ex.Status == 404)
 
 Now with these convenience methods we can simply do the following.
 
-```csharp 
+```csharp
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 Subscription subscription = await armClient.GetDefaultSubscriptionAsync();
 string rgName = "myRgName";
@@ -273,7 +273,7 @@ else
 
 Another way to do this is by using `GetIfExists()` which will avoid the race condition mentioned above:
 
-```csharp 
+```csharp
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 Subscription subscription = await armClient.GetDefaultSubscriptionAsync();
 string rgName = "myRgName";

--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -91,13 +91,13 @@ Users must run the `dotnet <filename.dll>` command to start your app. .NET Core 
 
 Publish an app cross-platform framework-dependent. An executable that targets your current platform is created along with the *dll* file.
 
-```dotnet
+```dotnetcli
 dotnet publish
 ```
 
 Publish an app cross-platform framework-dependent. A Linux 64-bit executable is created along with the *dll* file. This command doesn't work with .NET Core SDK 2.1.
 
-```dotnet
+```dotnetcli
 dotnet publish -r linux-x64 --self-contained false
 ```
 
@@ -135,13 +135,13 @@ Because your app includes the .NET runtime and all of your app dependencies, the
 
 Publish an app self-contained. A macOS 64-bit executable is created.
 
-```dotnet
+```dotnetcli
 dotnet publish -r osx-x64
 ```
 
 Publish an app self-contained. A Windows 64-bit executable is created.
 
-```dotnet
+```dotnetcli
 dotnet publish -r win-x64
 ```
 
@@ -163,13 +163,13 @@ The application will be larger on disk.
 
 Publish an app self-contained and ReadyToRun. A macOS 64-bit executable is created.
 
-```dotnet
+```dotnetcli
 dotnet publish -c Release -r osx-x64 -p:PublishReadyToRun=true
 ```
 
 Publish an app self-contained and ReadyToRun. A Windows 64-bit executable is created.
 
-```dotnet
+```dotnetcli
 dotnet publish -c Release -r win-x64 -p:PublishReadyToRun=true
 ```
 

--- a/docs/core/deploying/single-file/warnings/il3002.md
+++ b/docs/core/deploying/single-file/warnings/il3002.md
@@ -22,7 +22,7 @@ When publishing an app as a single file (for example, by setting the `PublishSin
 
 Example:
 
-```C#
+```csharp
 [RequiresAssemblyFiles(Message="Use 'MethodFriendlyToSingleFile' instead", Url="http://help/assemblyfiles")]
 void MethodWithAssemblyFilesUsage()
 {

--- a/docs/core/deploying/single-file/warnings/il3003.md
+++ b/docs/core/deploying/single-file/warnings/il3003.md
@@ -22,7 +22,7 @@ When publishing as a single file (for example, by setting the `PublishSingleFile
 
 A member of a base class has the attribute but the overriding member of the derived class does not have the attribute:
 
-```C#
+```csharp
 public class Base
 {
     [RequiresAssemblyFiles]
@@ -37,7 +37,7 @@ public class Derived : Base
 
 A member of a base class does not have the attribute but the overriding member of the derived class does have the attribute:
 
-```C#
+```csharp
 public class Base
 {
     public virtual void TestMethod() {}
@@ -52,7 +52,7 @@ public class Derived : Base
 
 An interface member has the attribute but its implementation does not have the attribute:
   
-```C#
+```csharp
 interface IRAF
 {
     [RequiresAssemblyFiles]
@@ -67,7 +67,7 @@ class Implementation : IRAF
 
 An interface member does not have the attribute but its implementation does have the attribute:
 
-```C#
+```csharp
 interface INoRAF
 {
     void TestMethod();

--- a/docs/core/deploying/trimming/trim-warnings/il2001.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2001.md
@@ -22,7 +22,7 @@ preserve members that cannot be found will trigger a warning.
 
 ## Example
 
-```XML
+```xml
 <linker>
   <assembly fullname="test">
     <type fullname="TestType" preserve="fields" />
@@ -30,7 +30,7 @@ preserve members that cannot be found will trigger a warning.
 </linker>
 ```
 
-```C#
+```csharp
 // IL2001: Type 'TestType' has no fields to preserve
 class TestType
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2002.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2002.md
@@ -22,7 +22,7 @@ preserve members that cannot be found will trigger a warning.
 
 ## Example
 
-```XML
+```xml
 <linker>
   <assembly fullname="test">
     <type fullname="TestType" preserve="methods" />
@@ -30,7 +30,7 @@ preserve members that cannot be found will trigger a warning.
 </linker>
 ```
 
-```C#
+```csharp
 // IL2002: Type 'TestType' has no methods to preserve
 struct TestType
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2003.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2003.md
@@ -21,7 +21,7 @@ find the member to preserve.
 
 ## Example
 
-```C#
+```csharp
 // IL2003: Could not resolve dependency assembly 'NonExistentAssembly' specified in a 'PreserveDependency' attribute
 [PreserveDependency("MyMethod", "MyType", "NonExistentAssembly")]
 void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2004.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2004.md
@@ -21,7 +21,7 @@ does not have a way to find the member to preserve.
 
 ## Example
 
-```C#
+```csharp
 // IL2004: Could not resolve dependency type 'NonExistentType' specified in a 'PreserveDependency' attribute
 [PreserveDependency("MyMethod", "NonExistentType", "MyAssembly")]
 void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2005.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2005.md
@@ -15,7 +15,7 @@ The member of a type specified in a `PreserveDependencyAttribute` could not be r
 
 ## Example
 
-```C#
+```csharp
 // IL2005: Could not resolve dependency member 'NonExistentMethod' declared on type 'MyType' specified in a 'PreserveDependency' attribute
 [PreserveDependency("NonExistentMethod", "MyType", "MyAssembly")]
 void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2007.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2007.md
@@ -21,7 +21,7 @@ The assembly specified in the descriptor file by its full name could not be foun
 
 ## Example
 
-```XML
+```xml
 <!-- IL2007: Could not resolve assembly 'NonExistentAssembly' -->
 <linker>
   <assembly fullname="NonExistentAssembly" />

--- a/docs/core/deploying/trimming/trim-warnings/il2008.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2008.md
@@ -24,7 +24,7 @@ A type specified in a descriptor file could not be found in the assembly matchin
 
 ## Example
 
-```XML
+```xml
 <!-- IL2008: Could not resolve type 'NonExistentType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2009.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2009.md
@@ -24,7 +24,7 @@ A method specified in a descriptor file could not be found in the type matching 
 
 ## Example
 
-```XML
+```xml
 <!-- IL2009: Could not find method 'NonExistentMethod' on type 'MyType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2010.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2010.md
@@ -25,7 +25,7 @@ the trimmer to a type matching the return type of the specified method.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2010: Invalid value for 'MyType.MyMethodReturningInt()' stub -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2011.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2011.md
@@ -24,7 +24,7 @@ supported options for this argument are `remove` and `stub`.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2011: Unknown body modification 'nonaction' for 'MyType.MyMethod()' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2012.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2012.md
@@ -24,7 +24,7 @@ A field specified in a substitution file could not be found in the type matching
 
 ## Example
 
-```XML
+```xml
 <!-- IL2012: Could not find field 'NonExistentField' on type 'MyType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2013.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2013.md
@@ -23,7 +23,7 @@ Trimmer cannot substitute non-static or constant fields.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2013: Substituted field 'MyType.InstanceField' needs to be static field -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2014.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2014.md
@@ -25,7 +25,7 @@ A `field` element specified in the substitution file does not specify the requir
 
 ## Example
 
-```XML
+```xml
 <!-- IL2014: Missing 'value' attribute for field 'MyType.MyField' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2015.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2015.md
@@ -25,7 +25,7 @@ the trimmer to a type matching the return type of the specified field.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2015: Invalid value 'NonNumber' for 'MyType.IntField' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2016.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2016.md
@@ -21,7 +21,7 @@ the parent of the `event` element.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2016: Could not find event 'NonExistentEvent' on type 'MyType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2017.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2017.md
@@ -21,7 +21,7 @@ the parent of the `property` element.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2017: Could not find property 'NonExistentProperty' on type 'MyType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2018.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2018.md
@@ -24,7 +24,7 @@ the `signature` argument that was passed to the `property` element.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2018: Could not find the get accessor of property 'SetOnlyProperty' on type 'MyType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2019.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2019.md
@@ -24,7 +24,7 @@ the `signature` argument that was passed to the `property` element.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2019: Could not find the set accessor of property 'GetOnlyProperty' on type 'MyType' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2022.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2022.md
@@ -28,7 +28,7 @@ the trimmer to a type matching the attribute's constructor argument type.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2022: Could not find matching constructor for custom attribute 'attribute-type' arguments -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2023.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2023.md
@@ -26,7 +26,7 @@ A `method` element has more than one `return` element specified. Trimmer only al
 
 ## Example
 
-```XML
+```xml
 <!-- IL2023: There is more than one 'return' child element specified for method 'method' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2024.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2024.md
@@ -28,7 +28,7 @@ There is more than one `parameter` element with the same `name` value in a given
 
 ## Example
 
-```XML
+```xml
 <!-- IL2024: More than one value specified for parameter 'parameter' of method 'method' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2025.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2025.md
@@ -23,7 +23,7 @@ Members in this file should only appear once.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2025: Duplicate preserve of 'method' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2026.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2026.md
@@ -18,7 +18,7 @@ Calling (or accessing via reflection) a member annotated with
 
 For example:
 
-```C#
+```csharp
 [RequiresUnreferencedCode("Use 'MethodFriendlyToTrimming' instead", Url="http://help/unreferencedcode")]
 void MethodWithUnreferencedCodeUsage()
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2029.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2029.md
@@ -26,7 +26,7 @@ All `attribute` elements must have the required `fullname` argument and its valu
 
 ## Example
 
-```XML
+```xml
 <!-- IL2029: 'attribute' element does not contain required attribute 'fullname' or it's empty -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2030.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2030.md
@@ -28,7 +28,7 @@ assemblies seen by the trimmer.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2030: Could not resolve assembly 'NonExistentAssembly' for attribute 'MyAttribute' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2031.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2031.md
@@ -29,7 +29,7 @@ assembly matching the `fullname` argument that was passed to the parent of the
 
 ## Example
 
-```XML
+```xml
 <!-- IL2031: Attribute type 'NonExistentTypeAttribute' could not be found -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2032.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2032.md
@@ -17,7 +17,7 @@ the target type.
 
 ## Example
 
-```C#
+```csharp
 void TestMethod(string assemblyName, string typeName)
 {
     // IL2032 Trim analysis: Unrecognized value passed to the parameter 'typeName' of method 'System.Activator.CreateInstance(string, string)'. It's not possible to guarantee the availability of the target type.

--- a/docs/core/deploying/trimming/trim-warnings/il2033.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2033.md
@@ -16,7 +16,7 @@ supported. Use <xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute>
 
 ## Example
 
-```C#
+```csharp
 // IL2033: 'PreserveDependencyAttribute' is deprecated. Use 'DynamicDependencyAttribute' instead.
 [PreserveDependency("OtherMethod")]
 public void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2035.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2035.md
@@ -16,7 +16,7 @@ could not be resolved.
 
 ## Example
 
-```C#
+```csharp
 // IL2035: Unresolved assembly 'NonExistentAssembly' in 'DynamicDependencyAttribute'
 [DynamicDependency("Method", "Type", "NonExistentAssembly")]
 public void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2036.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2036.md
@@ -16,7 +16,7 @@ could not be resolved.
 
 ## Example
 
-```C#
+```csharp
 // IL2036: Unresolved type 'NonExistentType' in 'DynamicDependencyAttribute'
 [DynamicDependency("Method", "NonExistentType", "MyAssembly")]
 public void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2037.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2037.md
@@ -17,7 +17,7 @@ member and that it uses the correct [ID string format](https://github.com/dotnet
 
 ## Example
 
-```C#
+```csharp
 // IL2037: Unresolved type 'NonExistentType' in 'DynamicDependencyAttribute'
 [DynamicDependency("Method", "NonExistentType", "MyAssembly")]
 public void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2038.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2038.md
@@ -24,7 +24,7 @@ specifying the resource to remove.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2038: Missing 'name' attribute for resource. -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2039.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2039.md
@@ -24,7 +24,7 @@ supported value for this argument is `remove`.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2039: Invalid value 'NonExistentAction' for attribute 'action' for resource 'MyResource'. -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2040.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2040.md
@@ -26,7 +26,7 @@ assembly.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2040: Could not find embedded resource 'NonExistentResource' to remove in assembly 'MyAssembly'. -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2041.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2041.md
@@ -17,7 +17,7 @@ should usually be placed on the return value of the method or one of the paramet
 
 ## Example
 
-```C#
+```csharp
 // IL2041: The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters though.
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicMethods)]
 

--- a/docs/core/deploying/trimming/trim-warnings/il2042.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2042.md
@@ -16,7 +16,7 @@ The trimmer could not determine the backing field of a property annotated with
 
 ## Example
 
-```C#
+```csharp
 // IL2042: Could not find a unique backing field for property 'MyProperty' to propagate 'DynamicallyAccessedMembersAttribute'
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicMethods)]
 public Type MyProperty

--- a/docs/core/deploying/trimming/trim-warnings/il2043.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2043.md
@@ -17,7 +17,7 @@ already has such an attribute. Only the existing attribute will be used.
 
 ## Example
 
-```C#
+```csharp
 // IL2043: 'DynamicallyAccessedMembersAttribute' on property 'MyProperty' conflicts with the same attribute on its accessor 'get_MyProperty'.
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicMethods)]
 public Type MyProperty

--- a/docs/core/deploying/trimming/trim-warnings/il2044.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2044.md
@@ -24,7 +24,7 @@ the `fullname` argument that was passed to the parent of the `namespace` element
 
 ## Example
 
-```XML
+```xml
 <!-- IL2044: Could not find any type in namespace 'NonExistentNamespace' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2045.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2045.md
@@ -17,7 +17,7 @@ custom attribute's type is being used.
 
 ## Example
 
-```XML
+```xml
 <linker>
   <assembly fullname="MyAssembly">
     <type fullname="MyAttribute">
@@ -27,7 +27,7 @@ custom attribute's type is being used.
 </linker>
 ```
 
-```C#
+```csharp
 // This attribute instance will be removed
 [MyAttribute]
 class MyType

--- a/docs/core/deploying/trimming/trim-warnings/il2046.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2046.md
@@ -19,7 +19,7 @@ override.
 
 A base member has the attribute but the derived member does not have the attribute.
 
-```C#
+```csharp
 public class Base
 {
   [RequiresUnreferencedCode("Message")]
@@ -36,7 +36,7 @@ public class Derived : Base
 A derived member has the attribute but the overriden base member does not have the
 attribute.
 
-```C#
+```csharp
 public class Base
 {
   public virtual void TestMethod() {}
@@ -52,7 +52,7 @@ public class Derived : Base
 
 An interface member has the attribute but its implementation does not have the attribute.
 
-```C#
+```csharp
 interface IRUC
 {
   [RequiresUnreferencedCode("Message")]
@@ -69,7 +69,7 @@ class Implementation : IRUC
 An implementation member has the attribute but the interface that it implements does not
 have the attribute.
 
-```C#
+```csharp
 interface IRUC
 {
   void TestMethod();

--- a/docs/core/deploying/trimming/trim-warnings/il2048.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2048.md
@@ -16,7 +16,7 @@ can only be used on a type.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2048: Internal attribute 'RemoveAttributeInstances' can only be used on a type, but is being used on 'MyMethod' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2049.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2049.md
@@ -16,7 +16,7 @@ supported by the trimmer.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2049: Unrecognized internal attribute 'InvalidInternalAttributeName' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2050.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2050.md
@@ -16,7 +16,7 @@ Correctness of COM interop cannot be guaranteed after trimming.
 
 ## Example
 
-```C#
+```csharp
 // IL2050: M1(): P/invoke method 'M2(C)' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
 static void M1 ()
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2051.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2051.md
@@ -16,7 +16,7 @@ argument `name`.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2051: Property element does not contain attribute 'name' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2052.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2052.md
@@ -16,7 +16,7 @@ Could not find a property matching the value of the `name` argument specified in
 
 ## Example
 
-```XML
+```xml
 <!-- IL2052: Property 'NonExistentPropertyName' could not be found -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2053.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2053.md
@@ -15,7 +15,7 @@ Value used in a `property` element in a custom attribute annotations file does n
 
 ## Example
 
-```XML
+```xml
 <!-- IL2053: Invalid value 'StringValue' for property 'IntProperty' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2054.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2054.md
@@ -15,7 +15,7 @@ Value used in an `argument` element in a custom attribute annotations file does 
 
 ## Example
 
-```XML
+```xml
 <!-- IL2054: Invalid argument value 'NonExistentEnumValue' for parameter of type 'MyEnumType' of attribute 'AttributeWithEnumParameterAttribute' -->
 <linker>
   <assembly fullname="MyAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2055.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2055.md
@@ -22,7 +22,7 @@ the trimmer currently cannot validate that the requirements are fulfilled by the
 
 ## Example
 
-```C#
+```csharp
 class Lazy<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType.PublicParameterlessConstructor)] T>
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2056.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2056.md
@@ -23,7 +23,7 @@ explicitly annotated with <xref:System.Runtime.CompilerServices.CompilerGenerate
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 [CompilerGenerated]
 Type backingField;

--- a/docs/core/deploying/trimming/trim-warnings/il2057.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2057.md
@@ -21,7 +21,7 @@ the type being used anywhere else, the trimmer might end up removing it from the
 
 ## Example
 
-```C#
+```csharp
 void TestMethod()
 {
     string typeName = ReadName();

--- a/docs/core/deploying/trimming/trim-warnings/il2058.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2058.md
@@ -19,7 +19,7 @@ Trimmer does not analyze assembly instances and thus does not know on which asse
 
 ## Example
 
-```C#
+```csharp
 void TestMethod()
 {
     // IL2058 Trim analysis: Parameters passed to method 'Assembly.CreateInstance(string)' cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.

--- a/docs/core/deploying/trimming/trim-warnings/il2059.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2059.md
@@ -20,7 +20,7 @@ cannot guarantee the availability of the target static constructor.
 
 ## Example
 
-```C#
+```csharp
 void TestMethod(Type type)
 {
     // IL2059 Trim analysis: Unrecognized value passed to the parameter 'type' of method 'System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle type)'.

--- a/docs/core/deploying/trimming/trim-warnings/il2060.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2060.md
@@ -23,7 +23,7 @@ calling method.
 
 ## Example
 
-```C#
+```csharp
 class Test
 {
   public static void TestGenericMethod<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>()

--- a/docs/core/deploying/trimming/trim-warnings/il2061.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2061.md
@@ -15,7 +15,7 @@ A call to <xref:System.Activator.CreateInstance%2A> had an assembly that could n
 
 ## Example
 
-```C#
+```csharp
 void TestMethod()
 {
     // IL2061 Trim analysis: The assembly name 'NonExistentAssembly' passed to method 'System.Activator.CreateInstance(string, string)' references assembly which is not available.

--- a/docs/core/deploying/trimming/trim-warnings/il2062.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2062.md
@@ -15,7 +15,7 @@ The parameter 'parameter' of method 'method' has a <xref:System.Diagnostics.Code
 
 ## Example
 
-```C#
+```csharp
 void NeedsPublicConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2063.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2063.md
@@ -15,7 +15,7 @@ The return value of method 'method' has a <xref:System.Diagnostics.CodeAnalysis.
 
 ## Example
 
-```C#
+```csharp
 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type TestMethod(Type[] types)
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2064.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2064.md
@@ -15,7 +15,7 @@ The field 'field' has a <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccesse
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type _typeField;
 

--- a/docs/core/deploying/trimming/trim-warnings/il2065.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2065.md
@@ -15,7 +15,7 @@ The method 'method' has a <xref:System.Diagnostics.CodeAnalysis.DynamicallyAcces
 
 ## Example
 
-```C#
+```csharp
 void TestMethod(Type[] types)
 {
     // IL2065 Trim analysis: Value passed to implicit 'this' parameter of method 'Type.GetMethods()' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.

--- a/docs/core/deploying/trimming/trim-warnings/il2066.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2066.md
@@ -15,7 +15,7 @@ The generic parameter 'parameter' of 'type' (or 'method') is annotated with <xre
 
 ## Example
 
-```C#
+```csharp
 static void MethodWithUnresolvedGenericArgument<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T>()
 {
 }

--- a/docs/core/deploying/trimming/trim-warnings/il2067.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2067.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void NeedsPublicConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2068.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2068.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type TestMethod(Type type)
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2069.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2069.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type _typeField;
 

--- a/docs/core/deploying/trimming/trim-warnings/il2070.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2070.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void GenericWithAnnotation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>()
 {
 }

--- a/docs/core/deploying/trimming/trim-warnings/il2072.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2072.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 Type GetCustomType() { return typeof(CustomType); }
 
 void NeedsPublicConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)

--- a/docs/core/deploying/trimming/trim-warnings/il2073.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2073.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 Type GetCustomType() { return typeof(CustomType); }
 
 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/docs/core/deploying/trimming/trim-warnings/il2074.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2074.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 Type GetCustomType() { return typeof(CustomType); }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/docs/core/deploying/trimming/trim-warnings/il2075.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2075.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 Type GetCustomType() { return typeof(CustomType); }
 
 void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2077.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2077.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void NeedsPublicConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2078.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2078.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 Type _typeField;
 
 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/docs/core/deploying/trimming/trim-warnings/il2079.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2079.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 Type _typeField;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/docs/core/deploying/trimming/trim-warnings/il2080.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2080.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type _typeFieldWithRequirements;
 

--- a/docs/core/deploying/trimming/trim-warnings/il2082.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2082.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void NeedsPublicConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2083.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2083.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 // This can only happen within methods of System.Type type (or derived types). Assume the below method is declared on System.Type
 [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/docs/core/deploying/trimming/trim-warnings/il2084.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2084.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type _typeFieldWithRequirements;
 

--- a/docs/core/deploying/trimming/trim-warnings/il2085.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2085.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 // This can only happen within methods of System.Type type (or derived types). Assume the below method is declared on System.Type
 void TestMethod()
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2087.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2087.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void NeedsPublicConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2088.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2088.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type TestMethod<TSource>()

--- a/docs/core/deploying/trimming/trim-warnings/il2089.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2089.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 Type _typeFieldWithRequirements;
 

--- a/docs/core/deploying/trimming/trim-warnings/il2090.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2090.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void TestMethod<TSource>()
 {
     // IL2090 Trim analysis: 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'GetMethods'. The generic parameter 'TSource' of 'TestMethod' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

--- a/docs/core/deploying/trimming/trim-warnings/il2091.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2091.md
@@ -15,7 +15,7 @@ The target location declares some requirements on the type value via its <xref:S
 
 ## Example
 
-```C#
+```csharp
 void NeedsPublicConstructors<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTarget>()
 {
     // ...

--- a/docs/core/deploying/trimming/trim-warnings/il2092.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2092.md
@@ -15,7 +15,7 @@ All overrides of a virtual method, including the base method, must have the same
 
 ## Example
 
-```C#
+```csharp
 public class Base
 {
   public virtual void TestMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type) {}

--- a/docs/core/deploying/trimming/trim-warnings/il2093.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2093.md
@@ -15,7 +15,7 @@ All overrides of a virtual method including the base method must have the same <
 
 ## Example
 
-```C#
+```csharp
 public class Base
 {
   [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]

--- a/docs/core/deploying/trimming/trim-warnings/il2094.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2094.md
@@ -15,7 +15,7 @@ All overrides of a virtual method including the base method must have the same <
 
 ## Example
 
-```C#
+```csharp
 // This only works on methods in System.Type and derived classes - this is just an example
 public class Type
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2095.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2095.md
@@ -15,7 +15,7 @@ All overrides of a virtual method including the base method must have the same <
 
 ## Example
 
-```C#
+```csharp
 public class Base
 {
   public virtual void TestMethod<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>() {}

--- a/docs/core/deploying/trimming/trim-warnings/il2096.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2096.md
@@ -15,7 +15,7 @@ Specifying a case-insensitive search on an overload of <xref:System.Type.GetType
 
 ## Example
 
-```C#
+```csharp
 void TestMethod()
 {
     // IL2096 Trim analysis: Call to 'System.Type.GetType(String,Boolean,Boolean)' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types

--- a/docs/core/deploying/trimming/trim-warnings/il2097.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2097.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Example
 
-```C#
+```csharp
 // IL2097: Field '_valueField' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 object _valueField;

--- a/docs/core/deploying/trimming/trim-warnings/il2098.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2098.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Example
 
-```C#
+```csharp
 // IL2098: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'
 void TestMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] object param)
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2099.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2099.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Example
 
-```C#
+```csharp
 // IL2099: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 object TestProperty { get; set; }

--- a/docs/core/deploying/trimming/trim-warnings/il2100.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2100.md
@@ -16,7 +16,7 @@ Trimmer XML. Use a specific assembly name instead.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2100: XML contains unsupported wildcard for assembly "fullname" attribute -->
 <linker>
   <assembly fullname="*">

--- a/docs/core/deploying/trimming/trim-warnings/il2101.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2101.md
@@ -16,7 +16,7 @@ containing assembly. Attempting to modify another assembly will not have any eff
 
 ## Example
 
-```XML
+```xml
 <!-- IL2101: Embedded XML in assembly 'ContainingAssembly' contains assembly "fullname" attribute for another assembly 'OtherAssembly' -->
 <linker>
   <assembly fullname="OtherAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2102.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2102.md
@@ -17,7 +17,7 @@ contains an unsupported value. The only supported value is `True`.
 
 ## Example
 
-```XML
+```xml
 <!-- IL2102: Embedded XML in assembly 'ContainingAssembly' contains assembly "fullname" attribute for another assembly 'OtherAssembly' -->
 <linker>
   <assembly fullname="OtherAssembly">

--- a/docs/core/deploying/trimming/trim-warnings/il2103.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2103.md
@@ -15,7 +15,7 @@ The value passed to the `propertyAccessor` parameter of <xref:System.Linq.Expres
 
 ## Example
 
-```C#
+```csharp
 void TestMethod(MethodInfo methodInfo)
 {
   // IL2103: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor.

--- a/docs/core/deploying/trimming/trim-warnings/il2105.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2105.md
@@ -15,7 +15,7 @@ Type name strings representing dynamically accessed types must be assembly quali
 
 ## Example
 
-```C#
+```csharp
 void TestInvalidTypeName()
 {
     RequirePublicMethodOnAType("Foo.Unqualified.TypeName");

--- a/docs/core/deploying/trimming/trim-warnings/il2106.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2106.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Example
 
-```C#
+```csharp
 // IL2106: Return type of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] object TestMethod()
 {

--- a/docs/core/deploying/trimming/trim-warnings/il2107.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2107.md
@@ -15,7 +15,7 @@ The trimmer cannot correctly handle if the same compiler-generated state machine
 
 ## Example
 
-```C#
+```csharp
 class <compiler_generated_state_machine>_type {
     void MoveNext()
     {

--- a/docs/core/deploying/trimming/trim-warnings/il2108.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2108.md
@@ -15,7 +15,7 @@ The only scopes supported on global unconditional suppressions are `module`, `ty
 
 ## Example
 
-```C#
+```csharp
 // IL2108: Invalid scope 'method' used in 'UnconditionalSuppressMessageAttribute' on module 'Warning' with target 'MyTarget'.
 [module: UnconditionalSuppressMessage ("Test suppression with invalid scope", "IL2026", Scope = "method", Target = "MyTarget")]
 

--- a/docs/core/deploying/trimming/trim-warnings/il2109.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2109.md
@@ -15,7 +15,7 @@ A type is referenced in code, and this type derives from a base type with <xref:
 
 ## Example
 
-```C#
+```csharp
 [RequiresUnreferencedCode("Using any of the members inside this class is trim unsafe", Url="http://help/unreferencedcode")]
 public class UnsafeClass {
    public UnsafeClass () {}

--- a/docs/core/deploying/trimming/trim-warnings/il2110.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2110.md
@@ -15,7 +15,7 @@ The trimmer can't guarantee that all requirements of the <xref:System.Diagnostic
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemeberTypes.PublicMethods)]
 Type _field;
 

--- a/docs/core/deploying/trimming/trim-warnings/il2111.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2111.md
@@ -15,7 +15,7 @@ The trimmer can't guarantee that all requirements of the <xref:System.Diagnostic
 
 ## Example
 
-```C#
+```csharp
 void MethodWithRequirements([DynamicallyAccessedMembers(DynamicallyAccessedMemeberTypes.PublicMethods)] Type type)
 {
 }

--- a/docs/core/deploying/trimming/trim-warnings/il2112.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2112.md
@@ -15,7 +15,7 @@ A type is annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccess
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 public class AnnotatedType {
     // Trim analysis warning IL2112: AnnotatedType.Method(): 'DynamicallyAccessedMembersAttribute' on 'AnnotatedType' or one of its

--- a/docs/core/deploying/trimming/trim-warnings/il2113.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2113.md
@@ -15,7 +15,7 @@ A type is annotated with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferen
 
 ## Example
 
-```C#
+```csharp
 public class BaseType {
     [RequiresUnreferencedCode("Using this member is trim unsafe")]
     public static void Method() { }

--- a/docs/core/deploying/trimming/trim-warnings/il2114.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2114.md
@@ -15,7 +15,7 @@ A type is annotated with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferen
 
 ## Example
 
-```C#
+```csharp
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
 public class AnnotatedType {
     // Trim analysis warning IL2114: System.Type AnnotatedType::Field: 'DynamicallyAccessedMembersAttribute' on 'AnnotatedType' or one of its

--- a/docs/core/deploying/trimming/trim-warnings/il2115.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2115.md
@@ -15,7 +15,7 @@ A type is annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccess
 
 ## Example
 
-```C#
+```csharp
 public class BaseType {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
     public static Type Field;

--- a/docs/core/deploying/trimming/trim-warnings/il2116.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2116.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Example
 
-```C#
+```csharp
 public class MyClass {
     // Trim analysis warning IL2116: 'RequiresUnreferencedCodeAttribute' cannot be placed directly on static constructor 'MyClass..cctor()', consider placing 'RequiresUnreferencedCodeAttribute' on the type declaration instead.
     [RequiresUnreferencedCode("Dangerous")]

--- a/docs/core/diagnostics/distributed-tracing-collection-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-collection-walkthroughs.md
@@ -43,7 +43,7 @@ dotnet add package System.Diagnostics.DiagnosticSource
 
 Replace the contents of the generated Program.cs with this example source:
 
-```C#
+```csharp
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -111,7 +111,7 @@ dotnet add package OpenTelemetry.Exporter.Console
 
 Update Program.cs with additional OpenTelemetry `using` directives:
 
-```C#
+```csharp
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -122,7 +122,7 @@ using System.Threading.Tasks;
 
 Update `Main()` to create the OpenTelemetry TracerProvider:
 
-```C#
+```csharp
         public static async Task Main()
         {
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -230,7 +230,7 @@ dotnet add package System.Diagnostics.DiagnosticSource
 
 Replace the contents of the generated Program.cs with this example source:
 
-```C#
+```csharp
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -286,7 +286,7 @@ Example work done
 
 Update Main() with this code:
 
-```C#
+```csharp
         static async Task Main(string[] args)
         {
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;

--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -45,7 +45,7 @@ dotnet add package OpenTelemetry.Exporter.Console
 
 Replace the contents of the generated Program.cs with this example source:
 
-```C#
+```csharp
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;

--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -35,7 +35,7 @@ dotnet add package System.Diagnostics.DiagnosticSource
 
 Replace the code of `Program.cs` with:
 
-```C#
+```csharp
 using System;
 using System.Diagnostics.Metrics;
 using System.Threading;
@@ -173,7 +173,7 @@ dotnet add package OpenTelemetry.Exporter.Prometheus --version 1.2.0-beta1
 
 Modify the code of `Program.cs` so that it contains the extra code to configure OpenTelemetry at the beginning of Main():
 
-```C#
+```csharp
 using System;
 using System.Diagnostics.Metrics;
 using System.Threading;
@@ -292,7 +292,7 @@ logic compatible with the older EventCounters instrumentation, see [EventCounter
 
 Modify the code of `Program.cs` to use <xref:System.Diagnostics.Metrics.MeterListener> like this:
 
-```C#
+```csharp
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
@@ -348,13 +348,13 @@ hats-sold recorded measurement 4
 
 Let's break down what happens in the example above.
 
-```C#
+```csharp
 using MeterListener meterListener = new MeterListener();
 ```
 
 First we created an instance of the <xref:System.Diagnostics.Metrics.MeterListener>, which we will use to receive measurements.
 
-```C#
+```csharp
 meterListener.InstrumentPublished = (instrument, listener) =>
 {
     if(instrument.Meter.Name == "HatCo.HatStore")
@@ -372,7 +372,7 @@ public property to decide whether to subscribe. If we do want to receive measure
 to obtain a reference to an instrument, it's legal to invoke `EnableMeasurementEvents()` at any time with that reference, but this is
 probably uncommon.
 
-```C#
+```csharp
 meterListener.SetMeasurementEventCallback<int>(OnMeasurementRecorded);
 ...
 static void OnMeasurementRecorded<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string,object>> tags, object state)
@@ -397,7 +397,7 @@ store measurements in memory and have code to do calculations on those measureme
 that maps from the instrument to the storage object and look it up on every measurement, that would be much slower than
 accessing it from `state`.
 
-```C#
+```csharp
 meterListener.Start();
 ```
 
@@ -405,7 +405,7 @@ Once the `MeterListener` is configured, we need to start it to trigger callbacks
 delegate will be invoked for every pre-existing Instrument in the process. In the future, any newly created Instrument
 will also trigger `InstrumentPublished` to be invoked.
 
-```C#
+```csharp
 using MeterListener meterListener = new MeterListener();
 ```
 

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -29,7 +29,7 @@ version 6 or greater. Applications that target .NET 6+ include this reference by
 > dotnet add package System.Diagnostics.DiagnosticSource
 ```
 
-```C#
+```csharp
 using System;
 using System.Diagnostics.Metrics;
 using System.Threading;
@@ -179,7 +179,7 @@ Types of instruments currently available:
 
 Stop the example process started previously, and replace the example code in `Program.cs` with:
 
-```C#
+```csharp
 using System;
 using System.Diagnostics.Metrics;
 using System.Threading;
@@ -260,7 +260,7 @@ summarize the distribution differently or offer more configuration options.
   as we did for the other instruments is legal but error prone, because C# static initialization is lazy and the variable is usually never referenced. Here is an example
   of the problem:
 
-```C#
+```csharp
 using System;
 using System.Diagnostics.Metrics;
 
@@ -285,7 +285,7 @@ class Program
 Instruments can specify optional descriptions and units. These values are opaque to all metric calculations but can be shown in collection tool UI
 to help engineers understand how to interpret the data. Stop the example process you started previously, and replace the example code in `Program.cs` with:
 
-```C#
+```csharp
 using System;
 using System.Diagnostics.Metrics;
 using System.Threading;
@@ -336,7 +336,7 @@ size, color, or any combination of both.
 Counter and Histogram tags can be specified in overloads of the <xref:System.Diagnostics.Metrics.Counter%601.Add%2A> and
 <xref:System.Diagnostics.Metrics.Histogram%601.Record%2A> that take one or more `KeyValuePair` arguments. For example:
 
-```C#
+```csharp
 s_hatsSold.Add(2,
                new KeyValuePair<string, object>("Color", "Red"),
                new KeyValuePair<string, object>("Size", 12));
@@ -345,7 +345,7 @@ s_hatsSold.Add(2,
 
 Replace the code of `Program.cs` and rerun the app and dotnet-counters as before:
 
-```C#
+```csharp
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
@@ -389,7 +389,7 @@ Press p to pause, r to resume, q to quit.
 
 For ObservableCounter and ObservableGauge, tagged measurements can be provided in the callback passed to the constructor:
 
-```C#
+```csharp
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;

--- a/docs/core/porting/upgrade-assistant-overview.md
+++ b/docs/core/porting/upgrade-assistant-overview.md
@@ -44,13 +44,13 @@ This section describes how to install the .NET Upgrade Assistant. You can also f
 
 The .NET Upgrade Assistant is a .NET tool that is installed globally with the following command:
 
-```dotnet
+```dotnetcli
 dotnet tool install -g upgrade-assistant
 ```
 
 Similarly, because the .NET Upgrade Assistant is installed as a .NET tool, it can be easily updated by running:
 
-```dotnet
+```dotnetcli
 dotnet tool update -g upgrade-assistant
 ```
 

--- a/docs/core/tools/troubleshoot-usage-issues.md
+++ b/docs/core/tools/troubleshoot-usage-issues.md
@@ -184,7 +184,7 @@ Most likely you've specified an alternative NuGet feed, and that feed requires a
 
   Create a local _nuget.config_ file with just the public Microsoft NuGet feed, and reference it with the `--configfile` parameter:
 
-  ```dotnet
+  ```dotnetcli
   dotnet tool install -g --configfile "./nuget.config" <toolName>
   ```
 

--- a/docs/core/tutorials/top-level-templates.md
+++ b/docs/core/tutorials/top-level-templates.md
@@ -91,7 +91,7 @@ While a .NET 6 console app template generates the new style of top-level stateme
 
 01. Create a new project that targets .NET 5.
 
-    ```dotnet
+    ```dotnetcli
     dotnet new console --framework net5.0
     ```
 

--- a/docs/core/versions/selection.md
+++ b/docs/core/versions/selection.md
@@ -131,7 +131,7 @@ The roll-forward behavior for an application can be configured in four different
 
     When you run an application, you can control the roll-forward behavior through the command line:
 
-    ```dotnet
+    ```dotnetcli
     dotnet run --roll-forward LatestMinor
     dotnet myapp.dll --roll-forward LatestMinor
     myapp.exe --roll-forward LatestMinor

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -208,7 +208,7 @@ for arg in args do
 
 When evaluated, it prints all arguments. The first argument is always the name of the script that is evaluated:
 
-```dotnet
+```dotnetcli
 dotnet fsi Script1.fsx hello world from fsi
 Script1.fsx
 hello

--- a/docs/fundamentals/code-analysis/quality-rules/ca1416.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1416.md
@@ -103,7 +103,7 @@ The analyzer does not check target framework moniker (TFM) target platforms from
   > - The `platformName` is included in the default [MSBuild `<SupportedPlatform>`](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props) items group.
   > - `platformName` is manually included in the MSBuild `<SupportedPlatform>` items group.
   >
-  >  ```XML
+  >  ```xml
   >  <ItemGroup>
   >      <SupportedPlatform Include="platformName" />
   >  </ItemGroup>

--- a/docs/fundamentals/code-analysis/quality-rules/ca1418.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1418.md
@@ -33,7 +33,7 @@ The known platform names list is populated from two places:
 - The `PlatformName` part of <xref:System.OperatingSystem> guard methods named `OperatingSystem.Is<PlatformName>[VersionAtLeast]()`. For example, guard method <xref:System.OperatingSystem.IsWindows?displayProperty=nameWithType> adds `Windows` to the known platform names list.
 - The project's MSBuild item group of `SupportedPlatform` items, including the default [MSBuild SupportedPlatforms list](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props). This is the project specific knowledge of known platforms. It allows class library authors to add more platforms into the known platforms list. For example:
 
-   ```XML
+   ```xml
     <ItemGroup>
       <SupportedPlatform Include="PlatformName" />
     </ItemGroup>
@@ -70,7 +70,7 @@ If the platform string contains a *version* part, it should be a valid <xref:Sys
 
 - If the platform name is correct and you want to make it a known platform, then add it to the MSBuild SupportedPlatforms list in your project file:
 
-  ```XML
+  ```xml
     <ItemGroup>
       <SupportedPlatform Include="Solaris" />
     </ItemGroup>

--- a/docs/standard/analyzers/platform-compat-analyzer.md
+++ b/docs/standard/analyzers/platform-compat-analyzer.md
@@ -39,7 +39,7 @@ The platform compatibility analyzer is one of the Roslyn code quality analyzers.
     - **Warns** if the project targets the platform that's attributed as unsupported (for example, if the API is attributed with `[UnsupportedOSPlatform("windows")]` and the call site targets `<TargetFramework>net5.0-windows</TargetFramework>`).
     - **Warns** if the project is multi-targeted and the `platform` is included in the default [MSBuild `<SupportedPlatform>`](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props) items group, or the `platform` is manually included within the `MSBuild` \<SupportedPlatform> items group:
 
-      ```XML
+      ```xml
       <ItemGroup>
           <SupportedPlatform Include="platform" />
       </ItemGroup>


### PR DESCRIPTION
Bulk update to fix incorrect or inconsistent language identifier (slugs) for triple backtick code blocks.

- `C#` or `c#` should be `csharp`.
- `XML` should be `xml`.
- `dotnet` should be `dotnetcli`.
