### PR TITLE
Refine code generator overview

### DIFF
--- a/docs/csharp/roslyn-sdk/snippets/source-generators/SourceGenerator/SourceGenerator.csproj
+++ b/docs/csharp/roslyn-sdk/snippets/source-generators/SourceGenerator/SourceGenerator.csproj
@@ -5,7 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/docs/csharp/roslyn-sdk/snippets/source-generators/SourceGenerator/SourceGenerator.csproj
+++ b/docs/csharp/roslyn-sdk/snippets/source-generators/SourceGenerator/SourceGenerator.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -57,7 +57,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
 1. Create a .NET console application. This example uses .NET 6.
 
-1. Replace the `Program` class with the following:
+1. Replace the `Program` class with the following code. The following code doesn't use top level statements. That's because this first source generator writes a partial method in that `Program` class:
 
     :::code source="snippets/source-generators/ConsoleApp/Program.cs":::
 

--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -137,6 +137,8 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
     :::image type="content" source="media/source-generators/source-generated-program.png" lightbox="media/source-generators/source-generated-program.png" alt-text="Visual Studio: Auto-generated Program.g.cs file.":::
 
+1. You can also set build properties to save the generated file and control where the generated files are stored. In the console application's project file, add the `<EmitCompilerGeneratedFiles>` element to an `<ItemGroup>`, and set its value to `true`. Build your project again. Now, the generated files are created under *obj/Debug/net6.0/generated/SourceGenerator/SourceGenerator.HelloSourceGenerator*. The components of the path map to the build configuration, target framework, source generator project name, and fully qualified type name of the generator. You can choose a more convenient output folder by adding the `<CompilerGeneratedFilesOutputPath>` element to the application's project fie.
+
 ## Next steps
 
 The [Source Generators Cookbook](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.cookbook.md) goes over some of these examples with some recommended approaches to solving them. Additionally, we have a [set of samples available on GitHub](https://github.com/dotnet/roslyn-sdk/tree/main/samples/CSharp/SourceGenerators) that you can try on your own.

--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -133,7 +133,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
     :::image type="content" source="media/source-generators/solution-explorer-program.png" lightbox="media/source-generators/solution-explorer-program.png" alt-text="Visual Studio: Solution Explorer source generated files.":::
 
-    When you open this generated file, Visual Studio will indicate that the file is auto-generated and that it can’t be edited.
+    When you open this generated file, Visual Studio will indicate that the file is auto-generated and that it can't be edited.
 
     :::image type="content" source="media/source-generators/source-generated-program.png" lightbox="media/source-generators/source-generated-program.png" alt-text="Visual Studio: Auto-generated Program.g.cs file.":::
 

--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -1,28 +1,28 @@
 ---
 title: Source Generators
-description: Source Generators is a C# compiler feature that lets C# developers inspect user code as it is being compiled and generates new C# source files on the fly that are added to the user's compilation.
-ms.date: 12/15/2021
+description: Source Generators is a C# compiler feature that lets C# developers inspect user code as it is being compiled. Source generators create new C# source files on the fly that are added to the user's compilation.
+ms.date: 03/02/2022
 ms.topic: tutorial
 ms.custom: mvc, vs-dotnet, source-generators
 ---
 
 # Source Generators
 
-This article provides an overview of Source Generators that ships as part of the .NET Compiler Platform ("Roslyn") SDK. Source Generators are a C# compiler feature that lets C# developers inspect user code as it is being compiled and generate new C# source files on the fly that are added to the user's compilation. In this way, you can have code that runs during compilation and inspects your program to produce additional source files that are compiled together with the rest of your code.
+This article provides an overview of Source Generators that ships as part of the .NET Compiler Platform ("Roslyn") SDK. Source Generators let C# developers inspect user code as it is being compiled. The generator can create new C# source files on the fly that are added to the user's compilation. In this way, you have code that runs during compilation. It inspects your program to produce additional source files that are compiled together with the rest of your code.
 
 A Source Generator is a new kind of component that C# developers can write that lets you do two major things:
 
 1. Retrieve a *compilation object* that represents all user code that is being compiled. This object can be inspected, and you can write code that works with the syntax and semantic models for the code being compiled, just like with analyzers today.
 
-1. Generate C# source files that can be added to a compilation object during the course of compilation. In other words, you can provide additional source code as input to a compilation while the code is being compiled.
+1. Generate C# source files that can be added to a compilation object during compilation. In other words, you can provide additional source code as input to a compilation while the code is being compiled.
 
-When combined, these two things are what make Source Generators so useful. You can inspect user code with all of the rich metadata that the compiler builds up during compilation, then emit C# code back into the same compilation that is based on the data you've analyzed. If you're familiar with Roslyn Analyzers, you can think of Source Generators as analyzers that can emit C# source code.
+When combined, these two things are what make Source Generators so useful. You can inspect user code with all of the rich metadata that the compiler builds up during compilation. Your generator then emits C# code back into the same compilation that is based on the data you've analyzed. If you're familiar with Roslyn Analyzers, you can think of Source Generators as analyzers that can emit C# source code.
 
 Source generators run as a phase of compilation visualized below:
 
 :::image type="content" source="media/source-generators/source-generator-visualization.png" lightbox="media/source-generators/source-generator-visualization.png" alt-text="Graphic describing the different parts of source generation":::
 
-A Source Generator is a .NET Standard 2.0 assembly that is loaded by the compiler along with any analyzers. It is usable in environments where .NET Standard components can be loaded and run.
+A Source Generator is a .NET Standard 2.0 assembly that is loaded by the compiler along with any analyzers. It's usable in environments where .NET Standard components can be loaded and run.
 
 > [!IMPORTANT]
 > Currently only .NET Standard 2.0 assemblies can be used as Source Generators.
@@ -39,17 +39,17 @@ Source Generators can be an improvement over each approach.
 
 ### Runtime reflection
 
-Runtime reflection is a powerful technology that was added to .NET a long time ago. There are countless scenarios for using it. A very common scenario is to perform some analysis of user code when an app starts up and use that data to generate things.
+Runtime reflection is a powerful technology that was added to .NET a long time ago. There are countless scenarios for using it. A common scenario is to perform some analysis of user code when an app starts up and use that data to generate things.
 
-For example, ASP.NET Core uses reflection when your web service first runs to discover constructs you've defined so that it can "wire up" things like controllers and razor pages. Although this enables you to write straightforward code with powerful abstractions, it comes with a performance penalty at run time: when your web service or app first starts up, it cannot accept any requests until all the runtime reflection code that discovers information about your code is finished running. Although this performance penalty is not enormous, it is somewhat of a fixed cost that you cannot improve yourself in your own app.
+For example, ASP.NET Core uses reflection when your web service first runs to discover constructs you've defined so that it can "wire up" things like controllers and razor pages. Although this enables you to write straightforward code with powerful abstractions, it comes with a performance penalty at run time: when your web service or app first starts up, it can’t accept any requests until all the runtime reflection code that discovers information about your code is finished running. Although this performance penalty isn't enormous, it's somewhat of a fixed cost that you can’t improve yourself in your own app.
 
-With a Source Generator, the controller discovery phase of startup could instead happen at compile time by analyzing your source code and emitting the code it needs to "wire up" your app. This could result in some faster startup times, since an action happening at run time today could get pushed into compile time.
+With a Source Generator, the controller discovery phase of startup could instead happen at compile time. A generator can analyze your source code and emit the code it needs to "wire up" your app. Using source generators could result in some faster startup times, since an action happening at run time today could get pushed into compile time.
 
 ### Juggling MSBuild tasks
 
 Source Generators can improve performance in ways that aren't limited to reflection at run time to discover types as well. Some scenarios involve calling the MSBuild C# task (called CSC) multiple times so they can inspect data from a compilation. As you might imagine, calling the compiler more than once affects the total time it takes to build your app. We're investigating how Source Generators can be used to obviate the need for juggling MSBuild tasks like this, since Source generators don't just offer some performance benefits, but also allows tools to operate at the right level of abstraction.
 
-Another capability Source Generators can offer is obviating the use of some "stringly-typed" APIs, such as how ASP.NET Core routing between controllers and razor pages work. With a Source Generator, routing can be strongly typed with the necessary strings being generated as a compile-time detail. This would reduce the amount of times a mistyped string literal leads to a request not hitting the correct controller.
+Another capability Source Generators can offer is obviating the use of some "stringly typed" APIs, such as how ASP.NET Core routing between controllers and razor pages work. With a Source Generator, routing can be strongly typed with the necessary strings being generated as a compile-time detail. This would reduce the number of times a mistyped string literal leads to a request not hitting the correct controller.
 
 ## Get started with source generators
 
@@ -57,7 +57,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
 1. Create a .NET console application. This example uses .NET 6.
 
-1. Replace the `Program` class with the following code. The following code doesn't use top level statements. That's because this first source generator writes a partial method in that `Program` class:
+1. Replace the `Program` class with the following code. The following code doesn't use top level statements. The classic form is required because this first source generator writes a partial method in that `Program` class:
 
     :::code source="snippets/source-generators/ConsoleApp/Program.cs":::
 
@@ -96,13 +96,13 @@ In this guide, you'll explore the creation of a source generator using the <xref
     }
     ```
 
-    A source generator needs to both implement the <xref:Microsoft.CodeAnalysis.ISourceGenerator?displayProperty=nameWithType> interface, and have the <xref:Microsoft.CodeAnalysis.GeneratorAttribute?displayProperty=nameWithType>. Not all source generators require initialization, and that is the case with this example implementation &mdash; where <xref:Microsoft.CodeAnalysis.ISourceGenerator.Initialize%2A?displayProperty=nameWithType> is empty.
+    A source generator needs to both implement the <xref:Microsoft.CodeAnalysis.ISourceGenerator?displayProperty=nameWithType> interface, and have the <xref:Microsoft.CodeAnalysis.GeneratorAttribute?displayProperty=nameWithType>. Not all source generators require initialization, and that is the case with this example implementation—where <xref:Microsoft.CodeAnalysis.ISourceGenerator.Initialize%2A?displayProperty=nameWithType> is empty.
 
 1. Replace the contents of the <xref:Microsoft.CodeAnalysis.ISourceGenerator.Execute%2A?displayProperty=nameWithType> method, with the following implementation:
 
     :::code source="snippets/source-generators/SourceGenerator/HelloSourceGenerator.cs":::
 
-    From the `context` object we can access the compilations' entry point, or `Main` method. The `mainMethod` instance is an <xref:Microsoft.CodeAnalysis.IMethodSymbol>, and it represents a method or method-like symbol (including constructor, destructor, operator, or property/event accessor). The <xref:Microsoft.CodeAnalysis.Compilation.GetEntryPoint%2A?displayProperty=fullName> method returns the <xref:Microsoft.CodeAnalysis.IMethodSymbol> for the program's entry point. Other methods enable you to find any method symbol in a project. From this object we can reason about the containing namespace (if one is present) and the type. The `source` in this example is an interpolated string that templates the source code to be generated, where the interpolated wholes are filled with the containing namespace and type information. The `source` is added to the `context` with a hint name. For this example, the generator creates a new generated source file that contains an implementation of the `partial` method in the console application. You can write source generators to add any source you'd like.
+    From the `context` object we can access the compilations' entry point, or `Main` method. The `mainMethod` instance is an <xref:Microsoft.CodeAnalysis.IMethodSymbol>, and it represents a method or method-like symbol (including constructor, destructor, operator, or property/event accessor). The <xref:Microsoft.CodeAnalysis.Compilation.GetEntryPoint%2A?displayProperty=fullName> method returns the <xref:Microsoft.CodeAnalysis.IMethodSymbol> for the program's entry point. Other methods enable you to find any method symbol in a project. From this object, we can reason about the containing namespace (if one is present) and the type. The `source` in this example is an interpolated string that templates the source code to be generated, where the interpolated wholes are filled with the containing namespace and type information. The `source` is added to the `context` with a hint name. For this example, the generator creates a new generated source file that contains an implementation of the `partial` method in the console application. You can write source generators to add any source you'd like.
 
     > [!TIP]
     > The `hintName` parameter from the <xref:Microsoft.CodeAnalysis.GeneratorExecutionContext.AddSource%2A?displayProperty=nameWithType> method can be any unique name. It's common to provide an explicit C# file extension such as `".g.cs"` or `".generated.cs"` for the name. The file name helps identify the file as being source generated.
@@ -118,9 +118,9 @@ In this guide, you'll explore the creation of a source generator using the <xref
     </ItemGroup>
     ```
 
-    This is not a traditional project reference, and has to be manually edited to include the `OutputItemType` and `ReferenceOutputAssembly` attributes. For additional information on the `OutputItemType` and `ReferenceOutputAssembly` attributes of `ProjectReference`, see [Common MSBuild project items: ProjectReference](/visualstudio/msbuild/common-msbuild-project-items#projectreference).
+    This new reference isn't a traditional project reference, and has to be manually edited to include the `OutputItemType` and `ReferenceOutputAssembly` attributes. For more information on the `OutputItemType` and `ReferenceOutputAssembly` attributes of `ProjectReference`, see [Common MSBuild project items: ProjectReference](/visualstudio/msbuild/common-msbuild-project-items#projectreference).
 
-1. Now, when you run the console application, you should see that the generated code gets run and prints to the screen. The console application itself doesn't implement the `HelloFrom` method, instead it is source generated during compilation from the Source Generator project. The following is an example output from the application:
+1. Now, when you run the console application, you should see that the generated code gets run and prints to the screen. The console application itself doesn't implement the `HelloFrom` method, instead it's source generated during compilation from the Source Generator project. The following text is an example output from the application:
 
     ```console
     Generator says: Hi from 'Generated Code'
@@ -129,21 +129,21 @@ In this guide, you'll explore the creation of a source generator using the <xref
     > [!NOTE]
     > You might need to restart Visual Studio to see IntelliSense and get rid of errors as the tooling experience is actively being improved.
 
-1. If you're using Visual Studio, you can see the source generated files. From the **Solution Explorer** window expand the **Dependencies** > **Analyzers** > **SourceGenerator** > **SourceGenerator.HelloSourceGenerator**, and double-click the _Program.g.cs_ file.
+1. If you're using Visual Studio, you can see the source generated files. From the **Solution Explorer** window, expand the **Dependencies** > **Analyzers** > **SourceGenerator** > **SourceGenerator.HelloSourceGenerator**, and double-click the _Program.g.cs_ file.
 
     :::image type="content" source="media/source-generators/solution-explorer-program.png" lightbox="media/source-generators/solution-explorer-program.png" alt-text="Visual Studio: Solution Explorer source generated files.":::
 
-    When you open this generated file, Visual Studio will indicate that the file is auto-generated and that it cannot be edited.
+    When you open this generated file, Visual Studio will indicate that the file is auto-generated and that it can’t be edited.
 
     :::image type="content" source="media/source-generators/source-generated-program.png" lightbox="media/source-generators/source-generated-program.png" alt-text="Visual Studio: Auto-generated Program.g.cs file.":::
 
-1. You can also set build properties to save the generated file and control where the generated files are stored. In the console application's project file, add the `<EmitCompilerGeneratedFiles>` element to an `<ItemGroup>`, and set its value to `true`. Build your project again. Now, the generated files are created under *obj/Debug/net6.0/generated/SourceGenerator/SourceGenerator.HelloSourceGenerator*. The components of the path map to the build configuration, target framework, source generator project name, and fully qualified type name of the generator. You can choose a more convenient output folder by adding the `<CompilerGeneratedFilesOutputPath>` element to the application's project fie.
+1. You can also set build properties to save the generated file and control where the generated files are stored. In the console application's project file, add the `<EmitCompilerGeneratedFiles>` element to an `<ItemGroup>`, and set its value to `true`. Build your project again. Now, the generated files are created under *obj/Debug/net6.0/generated/SourceGenerator/SourceGenerator.HelloSourceGenerator*. The components of the path map to the build configuration, target framework, source generator project name, and fully qualified type name of the generator. You can choose a more convenient output folder by adding the `<CompilerGeneratedFilesOutputPath>` element to the application's project file.
 
 ## Next steps
 
 The [Source Generators Cookbook](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.cookbook.md) goes over some of these examples with some recommended approaches to solving them. Additionally, we have a [set of samples available on GitHub](https://github.com/dotnet/roslyn-sdk/tree/main/samples/CSharp/SourceGenerators) that you can try on your own.
 
-You can learn more about Source Generators in these topics:
+You can learn more about Source Generators in these articles:
 
 - [Source Generators design document](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.md)
 - [Source Generators cookbook](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.cookbook.md)

--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -66,7 +66,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
 1. Next, we'll create a source generator project that will implement the `partial void HelloFrom` method counterpart.
 
-1. Create a .NET standard library project that targets the `netstandard2.0` target framework moniker (TFM):
+1. Create a .NET standard library project that targets the `netstandard2.0` target framework moniker (TFM). Add the NuGet packages *Microsoft.CodeAnalysis.Analyzers* and *Microsoft.CodeAnalysis.CSharp*:
 
     :::code language="xml" source="snippets/source-generators/SourceGenerator/SourceGenerator.csproj":::
 
@@ -102,7 +102,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
     :::code source="snippets/source-generators/SourceGenerator/HelloSourceGenerator.cs":::
 
-    From the `context` object we can access the compilations' entry point, or `Main` method. The `mainMethod` instance is an <xref:Microsoft.CodeAnalysis.IMethodSymbol>, and it represents a method or method-like symbol (including constructor, destructor, operator, or property/event accessor). From this object we can reason about the containing namespace (if one is present) and the type. The `source` in this example is an interpolated string that templates the source code to be generated, where the interpolated wholes are filled with the containing namespace and type information. The `source` is added to the `context` with a hint name.
+    From the `context` object we can access the compilations' entry point, or `Main` method. The `mainMethod` instance is an <xref:Microsoft.CodeAnalysis.IMethodSymbol>, and it represents a method or method-like symbol (including constructor, destructor, operator, or property/event accessor). The <xref:Microsoft.CodeAnalysis.Compilation.GetEntryPoint%2A?displayProperty=fullName> method returns the <xref:Microsoft.CodeAnalysis.IMethodSymbol> for the program's entry point. Other methods enable you to find any method symbol in a project. From this object we can reason about the containing namespace (if one is present) and the type. The `source` in this example is an interpolated string that templates the source code to be generated, where the interpolated wholes are filled with the containing namespace and type information. The `source` is added to the `context` with a hint name. For this example, the generator creates a new generated source file that contains an implementation of the `partial` method in the console application. You can write source generators to add any source you'd like.
 
     > [!TIP]
     > The `hintName` parameter from the <xref:Microsoft.CodeAnalysis.GeneratorExecutionContext.AddSource%2A?displayProperty=nameWithType> method can be any unique name. It's common to provide an explicit C# file extension such as `".g.cs"` or `".generated.cs"` for the name. The file name helps identify the file as being source generated.


### PR DESCRIPTION
Fixes #24690

- Once of the concerns had already been addressed. Update for the others.

Fixes #24752

- Explain how to save the output from your source generator.

Fixes #27407

This source generator writes a partial method in the main program class. Therefore it requires the traditional template.

Fixes #25924

- Fixed by updating the dependencies.

