### PR TITLE
Added a link to usage examples

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -31,7 +31,7 @@ The logging message template should not vary between calls.
 
 Update the message template to be a constant expression.
 
-See the [LoggerExtensions.LogInformation Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggerextensions.loginformation) for usage examples.
+See the [LoggerExtensions.LogInformation Method](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.loggerextensions.loginformation) for usage examples.
 
 ## When to suppress errors
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -31,6 +31,8 @@ The logging message template should not vary between calls.
 
 Update the message template to be a constant expression.
 
+See the [LoggerExtensions.LogInformation Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggerextensions.loginformation) for usage examples.
+
 ## When to suppress errors
 
 Do not suppress a warning from this rule.

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -31,7 +31,7 @@ The logging message template should not vary between calls.
 
 Update the message template to be a constant expression.
 
-See the [LoggerExtensions.LogInformation Method](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.loggerextensions.loginformation) for usage examples.
+For usage examples, see the <xref:Microsoft.Extensions.Logging.LoggerExtensions.LogInformation%2A?displayProperty=nameWithType> method.
 
 ## When to suppress errors
 


### PR DESCRIPTION
Added a link to the LoggerExtensions.LogInformation Method to see usage examples

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2254.md](https://github.com/dotnet/docs/blob/c0ba3ce38218fca9e0a8f7266285ddda940a1b39/docs/fundamentals/code-analysis/quality-rules/ca2254.md) | [docs/fundamentals/code-analysis/quality-rules/ca2254](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254?branch=pr-en-us-28493) |

<!-- PREVIEW-TABLE-END -->