### PR TITLE
Setup for C# 11

### DIFF
--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -147,8 +147,10 @@ items:
       href: fundamentals/exceptions/how-to-execute-cleanup-code-using-finally.md
 - name: What's new in C#
   items:
-  - name: C# 10
+  - name: C# 11
     displayName: what's new
+    href: whats-new/csharp-11.md
+  - name: C# 10
     href: whats-new/csharp-10.md
   - name: C# 9.0
     href: whats-new/csharp-9.md

--- a/docs/csharp/whats-new/breaking-changes.md
+++ b/docs/csharp/whats-new/breaking-changes.md
@@ -40,7 +40,7 @@ using System;
 
 F(var () => default);  // error: 'var' cannot be used as an explicit lambda return type
 F(@var () => default); // ok
-f(() => default);      // OK: return type is inferred from the parameter to F().
+F(() => default);      // ok: return type is inferred from the parameter to F()
 
 static void F(Func<var> f) { }
 
@@ -133,7 +133,6 @@ string SampleSizeMessage<T>(IList<T> samples)
         { Count: < 100 }  => "reasonable",
         { Count: >= 100 } => "fine",
     };
-
 }
 ```
 
@@ -147,9 +146,9 @@ The workaround is to remove the switch arms with unreachable conditions.
 
 ***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
 
-There are two ways to initialize a variable to its default value in C#: `new()` and `default`. For classes, the difference is evident since `new` creates a new instance and `default` returns `null`. The difference is more subtle for structs, since for `default` structs return an instance with each field/property set to its own default. We added field initializers for structs in C# 10. Field initializers are executed only when an explicitly declared constructor runs. Significantly, they don't execute when you use `default` or create an array of any `struct` type.
+There are two ways to initialize a variable to its default value in C#: `new()` and `default`. For classes, the difference is evident since `new` creates a new instance and `default` returns `null`. The difference is more subtle for structs, since for `default`, structs return an instance with each field/property set to its own default. We added field initializers for structs in C# 10. Field initializers are executed only when an explicitly declared constructor runs. Significantly, they don't execute when you use `default` or create an array of any `struct` type.
 
-In earlier versions, if there are field initializers but no declared constructors, a parameterless constructor is synthesized and runs field initializers. However, that meant adding or removing a constructor declaration may affect whether a parameterless constructor is synthesized, and as a result, may change the behavior of `new()`.
+In earlier versions, if there are field initializers but no declared constructors, a parameterless constructor is synthesized that runs field initializers. However, that meant adding or removing a constructor declaration may affect whether a parameterless constructor is synthesized, and as a result, may change the behavior of `new()`.
 
 To address the issue, in .NET SDK 6.0.200 (VS 17.1) the compiler no longer synthesizes a parameterless constructor. If a `struct` contains field initializers and no explicit constructors, the compiler generates an error. If a `struct` has field initializers it must declare a constructor, because otherwise the field initializers are never executed.
 

--- a/docs/csharp/whats-new/breaking-changes.md
+++ b/docs/csharp/whats-new/breaking-changes.md
@@ -165,7 +165,7 @@ struct S
 
 Read more about this change in the proposal [Avoid synthesizing parameterless struct constructors #5552](https://github.com/dotnet/csharplang/issues/5552).
 
-## default arguments involving conversion of literal string constant
+## Default arguments involving conversion of literal string constant
 
 ***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
 

--- a/docs/csharp/whats-new/breaking-changes.md
+++ b/docs/csharp/whats-new/breaking-changes.md
@@ -38,7 +38,7 @@ You can encounter this error if you have a type named `var` and define a lambda 
 ```csharp
 using System;
 
-F(var () => default);  // error: 'var' cannot be used as an explicit lambda return type
+F(var () => default);  // error CS8975: The contextual keyword 'var' cannot be used as an explicit lambda return type
 F(@var () => default); // ok
 F(() => default);      // ok: return type is inferred from the parameter to F()
 
@@ -152,7 +152,7 @@ In earlier versions, if there are field initializers but no declared constructor
 
 To address the issue, in .NET SDK 6.0.200 (VS 17.1) the compiler no longer synthesizes a parameterless constructor. If a `struct` contains field initializers and no explicit constructors, the compiler generates an error. If a `struct` has field initializers it must declare a constructor, because otherwise the field initializers are never executed.
 
-Additionally, all fields must be definitely assigned in `struct` constructors that do not have a `: this()` initializer, so any previously unassigned fields must be assigned from the constructor or from field initializers.
+Additionally, all fields that do not have field initializers must be assigned in each `struct` constructor unless the constructor has a `: this()` initializer.
 
 For instance:
 

--- a/docs/csharp/whats-new/breaking-changes.md
+++ b/docs/csharp/whats-new/breaking-changes.md
@@ -153,13 +153,27 @@ In earlier versions, if there are field initializers but no declared constructor
 
 To address the issue, in .NET SDK 6.0.200 (VS 17.1) the compiler no longer synthesizes a parameterless constructor. If a `struct` contains field initializers and no explicit constructors, the compiler generates an error. If a `struct` has field initializers it must declare a constructor, because otherwise the field initializers are never executed.
 
-The workaround is to declare a constructor. This constructor can, and often will, be an empty parameterless constructor:
+Additionally, all fields must be definitely assigned in `struct` constructors that do not have a `: this()` initializer, so any previously unassigned fields must be assigned from the constructor or from field initializers.
 
-```c#
+For instance:
+
+```csharp
+struct S // error CS8983: A 'struct' with field initializers must include an explicitly declared constructor.
+{
+    int X = 1; 
+    int Y;
+}
+```
+
+The workaround is to declare a constructor. Unless fields were previously unassigned, this constructor can, and often will, be an empty parameterless constructor:
+
+```csharp
 struct S
 {
-    public S() { }
-    // remainder of struct code
+    int X = 1;
+    int Y;
+
+    public S() { Y = 0; } // ok
 }
 ```
 

--- a/docs/csharp/whats-new/breaking-changes.md
+++ b/docs/csharp/whats-new/breaking-changes.md
@@ -1,12 +1,189 @@
 ---
 title: Breaking changes in the C# compiler
-description: Find any breaking changes in the C# compiler that you are using.
+description: Find any breaking changes in the C# compiler that you're using.
 ms.topic: troubleshooting
 ms.custom: updateeachrelease
-ms.date: 03/09/2021
+ms.date: 03/04/2022
 ---
 
 # Learn about any breaking changes in the C# compiler
+
+This section explains the breaking changes since C# 10 (.NET 6) general release, including the reason and how to work around the change.
+
+## Disallow converted strings as a default argument
+
+***Introduced in .NET SDK 6.0.300, Visual Studio 2022 version 17.2.***
+
+This change fixes a spec violation in the compiler. Default arguments must be compile time constants. Previous versions allowed the following code:
+
+```csharp
+void M(IEnumerable<char> s = "hello")
+```
+
+The preceding declaration required a conversion from `string` to `IEnumerable<char>`. The compiler allowed this construct, and would emit `null` as the value of the argument.
+
+To work around this change, you can make one of the following changes:
+
+1. Change the parameter type so a conversion isn't required.
+1. Change the value of the default argument to `null` to restore the previous behavior.
+
+## The contextual keyword `var` as an explicit lambda return type
+
+***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
+
+This change enables [potential future features](https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-06-02.md#lambda-return-type-parsing) by ensuring that the `var` remains the natural type for the return type of a lambda expression.
+
+You can encounter this error if you have a type named `var` and define a lambda expression using an explicit return type of `var` (the type).
+
+```csharp
+using System;
+
+F(var () => default);  // error: 'var' cannot be used as an explicit lambda return type
+F(@var () => default); // ok
+f(() => default);      // OK: return type is inferred from the parameter to F().
+
+static void F(Func<var> f) { }
+
+public class var
+{
+}
+```
+
+Workarounds include the following changes:
+
+1. Use `@var` as the return type.
+1. Remove the explicit return type so that the compiler determines the return type.
+
+## Interpolated string handlers and indexer initialization
+
+***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
+
+This change disallows an edge case scenario where indexer initializers use an interpolated string handler and that interpolated string handler takes the receiver of the indexer as a parameter of the constructor. The reason for this change is that this scenario could result in accessing variables that haven't yet been initialized. Consider this example:
+
+```csharp
+using System.Runtime.CompilerServices;
+
+// error: Interpolated string handler conversions that reference
+// the instance being indexed cannot be used in indexer member initializers.
+var c = new C { [$""] = 1 }; 
+
+class C
+{
+    public int this[[InterpolatedStringHandlerArgument("")] CustomHandler c]
+    {
+        get => ...;
+        set => ...;
+    }
+}
+
+[InterpolatedStringHandler]
+class CustomHandler
+{
+    // The constructor of the string handler takes a "C" instance:
+    public CustomHandler(int literalLength, int formattedCount, C c) {}
+}
+```
+
+Workarounds include the following changes:
+
+1. Remove the receiver type from the interpolated string handler.
+1. Change the argument to the indexer to be a `string`
+
+## ref, readonly ref, in, out not allowed as parameters or return on methods with Unmanaged callers only
+
+***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
+
+This change is a bug fix. Return values and parameters aren't blittable. Passing arguments or return values by reference can cause undefined behavior. None of the following declarations will compile:
+
+```csharp
+using System.Runtime.InteropServices;
+[UnmanagedCallersOnly]
+static ref int M1() => throw null; // error CS8977: Cannot use 'ref', 'in', or 'out' in a method attributed with 'UnmanagedCallersOnly'.
+
+[UnmanagedCallersOnly]
+static ref readonly int M2() => throw null; // error CS8977: Cannot use 'ref', 'in', or 'out' in a method attributed with 'UnmanagedCallersOnly'.
+
+[UnmanagedCallersOnly]
+static void M3(ref int o) => throw null; // error CS8977: Cannot use 'ref', 'in', or 'out' in a method attributed with 'UnmanagedCallersOnly'.
+
+[UnmanagedCallersOnly]
+static void M4(in int o) => throw null; // error CS8977: Cannot use 'ref', 'in', or 'out' in a method attributed with 'UnmanagedCallersOnly'.
+
+[UnmanagedCallersOnly]
+static void M5(out int o) => throw null; // error CS8977: Cannot use 'ref', 'in', or 'out' in a method attributed with 'UnmanagedCallersOnly'.
+```
+
+The workaround is to remove the by reference modifier.
+
+## Length, Count assumed to be non-negative in patterns
+
+***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
+
+The `Length` and `Count` properties, even though typed as `int`, are assumed to be non-negative when analyzing patterns. Consider this sample method:
+
+```csharp
+string SampleSizeMessage<T>(IList<T> samples)
+{
+    return samples switch
+    {
+        { Count: < 0 }    => throw new InvalidOperationException(), // Can't happen!
+        { Count:  0 }     => "Empty collection",
+        { Count: < 5 }    => "Too small",
+        { Count: < 20 }   => "reasonable for the first pass",
+        { Count: < 100 }  => "reasonable",
+        { Count: >= 100 } => "fine",
+    };
+
+}
+```
+
+Prior to 17.1, The first switch arm, testing that `Count` is negative was necessary to avoid a warning that all possible values weren't covered. Starting with 17.1, the first switch arm generates a compiler error. The workaround is to remove the switch arms added for the invalid cases.
+
+This change was added as part of adding list patterns. The processing rules are more consistent if every use of a `Length` or `Count` property on a collection are considered non-negative. You can read more details about the change in the [language design issue](https://github.com/dotnet/csharplang/issues/5226).
+
+The workaround is to remove the switch arms with unreachable conditions.
+
+## Adding field initializers to a struct requires an explicitly declared constructor
+
+***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
+
+There are two ways to initialize a variable to its default value in C#: `new()` and `default`. For classes, the difference is evident since `new` creates a new instance and `default` returns `null`. The difference is more subtle for structs, since for `default` structs return an instance with each field/property set to its own default. We added field initializers for structs in C# 10. Field initializers are executed only when an explicitly declared constructor runs. Significantly, they don't execute when you use `default` or create an array of any `struct` type.
+
+In earlier versions, if there are field initializers but no declared constructors, a parameterless constructor is synthesized and runs field initializers. However, that meant adding or removing a constructor declaration may affect whether a parameterless constructor is synthesized, and as a result, may change the behavior of `new()`.
+
+To address the issue, in .NET SDK 6.0.200 (VS 17.1) the compiler no longer synthesizes a parameterless constructor. If a `struct` contains field initializers and no explicit constructors, the compiler generates an error. If a `struct` has field initializers it must declare a constructor, because otherwise the field initializers are never executed.
+
+The workaround is to declare a constructor. This constructor can, and often will, be an empty parameterless constructor:
+
+```c#
+struct S
+{
+    public S() { }
+    // remainder of struct code
+}
+```
+
+Read more about this change in the proposal [Avoid synthesizing parameterless struct constructors #5552](https://github.com/dotnet/csharplang/issues/5552).
+
+## default arguments involving conversion of literal string constant
+
+***Introduced in .NET SDK 6.0.200, Visual Studio 2022 version 17.1.***
+
+Format specifiers in interpolated strings can’t contain curly braces (either `{` or `}`). In previous versions `{{` was interpreted as an escaped `{` and `}}` was interpreted as an escaped `}` char in the format specifier. Now the first `}` char in a format specifier ends the interpolation, and any `{` char is an error:
+
+```c#
+using System;
+Console.WriteLine($"{{{12:X}}}");
+//prints now: "{C}" - not "{X}}"
+```
+
+`X` is the format for uppercase hexadecimal and `C` is the hexadecimal value for 12.
+
+The workaround is to remove the extra braces in the format string.
+
+You can learn more about this change in the associated [roslyn issue](https://github.com/dotnet/roslyn/issues/57750).
+
+## Links to breaking changes documents
 
 The [Roslyn](https://github.com/dotnet/roslyn) team maintains a list of breaking changes in the C# and Visual Basic compilers. You can find information on those changes at these links on their GitHub repository:
 

--- a/docs/csharp/whats-new/csharp-10.md
+++ b/docs/csharp/whats-new/csharp-10.md
@@ -22,11 +22,6 @@ C# 10 adds the following features and enhancements to the C# language:
 - [CallerArgumentExpression attribute](#callerargumentexpression-attribute-diagnostics)
 - [Enhanced `#line` pragma](#enhanced-line-pragma)
 
-Additional features are available in *preview* mode. You're encouraged to try these features and provide feedback on them. They may change before their final release. In order to use these features, you must [set `<LangVersion>` to `Preview`](../language-reference/compiler-options/language.md#langversion) in your project:
-
-- [Generic attributes](#generic-attributes) later in this article.
-- [static abstract members in interfaces](#static-abstract-members-in-interfaces)
-
 C# 10 is supported on **.NET 6**. For more information, see [C# language versioning](../language-reference/configure-language-version.md).
 
 You can download the latest .NET 6 SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), which includes the .NET 6 SDK.
@@ -168,72 +163,3 @@ You can learn more about this feature in the article on [Caller information attr
 ## Enhanced #line pragma
 
 C# 10 supports a new format for the `#line` pragma. You likely won't use the new format, but you'll see its effects. The enhancements enable more fine-grained output in domain-specific languages (DSLs) like Razor. The Razor engine uses these enhancements to improve the debugging experience. You'll find debuggers can highlight your Razor source more accurately. To learn more about the new syntax, see the article on [Preprocessor directives](../language-reference/preprocessor-directives.md#error-and-warning-information) in the language reference. You can also read the [feature specification](~/_csharplang/proposals/csharp-10.0/enhanced-line-directives.md#examples) for Razor based examples.
-
-## Generic attributes
-
-> [!IMPORTANT]
-> *Generic attributes* is a preview feature. You must [set `<LangVersion>` to `Preview`](../language-reference/compiler-options/language.md#langversion) to enable this feature. This feature may change before its final release.
-
-You can declare a [generic class](../programming-guide/generics/generic-classes.md) whose base class is <xref:System.Attribute?displayProperty=fullName>. This provides a more convenient syntax for attributes that require a <xref:System.Type?displayProperty=nameWithType> parameter. Previously, you'd need to create an attribute that takes a `Type` as its constructor parameter:
-
-```csharp
-public class TypeAttribute : Attribute
-{
-   public TypeAttribute(Type t) => ParamType = t;
-
-   public Type ParamType { get; }
-}
-```
-
-And to apply the attribute, you use the [`typeof`](../language-reference/operators/type-testing-and-cast.md#typeof-operator) operator:
-
-```csharp
-[TypeAttribute(typeof(string))]
-public string Method() => default;
-```
-
-Using this new feature, you can create a generic attribute instead:
-
-```csharp
-public class GenericAttribute<T> : Attribute { }
-```
-
-Then, specify the type parameter to use the attribute:
-
-```csharp
-[GenericAttribute<string>()]
-public string Method() => default;
-```
-
-You can apply a fully closed constructed generic attribute. In other words, all type parameters must be specified. For example, the following is not allowed:
-
-```csharp
-public class GenericType<T>
-{
-   [GenericAttribute<T>()] // Not allowed! generic attributes must be fully closed types.
-   public string Method() => default;
-}
-```
-
-The type arguments must satisfy the same restrictions as the [`typeof`](../language-reference/operators/type-testing-and-cast.md#typeof-operator) operator. Types that require metadata annotations aren't allowed. Examples include the following:
-
-- `dynamic`
-- `nint`, `nuint`
-- `string?` (or any nullable reference type)
-- `(int X, int Y)` (or any other tuple types using C# tuple syntax).
-
-These types aren't directly represented in metadata. They include annotations that describe the type. In all cases, you can use the underlying type instead:
-
-- `object` for `dynamic`.
-- <xref:System.IntPtr> instead of `nint` or `unint`.
-- `string` instead of `string?`.
-- `ValueTuple<int, int>` instead of `(int X, int Y)`.
-
-## Static abstract members in interfaces
-
-> [!IMPORTANT]
-> *static abstract members in interfaces* is a preview feature. You must add the `<EnablePreviewFeatures>True</EnablePreviewFeatures>` in your project file. See [Preview features](https://aka.ms/dotnet-warnings/preview-features) for more information. You can experiment with this feature, and the experimental libraries that use it. We will use feedback from the preview cycles to improve the feature before its general release.
-
-You can add *static abstract members* in interfaces to define interfaces that include overloadable operators, other static members, and static properties. The primary scenario for this feature is to use mathematical operators in generic types. The .NET runtime team has included interfaces for mathematical operations in the [System.Runtime.Experimental](https://www.nuget.org/packages/System.Runtime.Experimental/) NuGet package. For example, you can implement the `System.IAdditionOperators<TSelf, TOther, TResult>` in a type that implements `operator +`. Other interfaces define other mathematical operations or well-defined values.
-
-You can learn more and try the feature yourself in the tutorial [Explore static abstract interface members](./tutorials/static-abstract-interface-methods.md), or the [Preview features in .NET 6 – generic math](https://devblogs.microsoft.com/dotnet/preview-features-in-net-6-generic-math/) blog post.

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -22,6 +22,7 @@ You can download the latest .NET 6 SDK from the [.NET downloads page](https://do
 You can declare a [generic class](../programming-guide/generics/generic-classes.md) whose base class is <xref:System.Attribute?displayProperty=fullName>. This provides a more convenient syntax for attributes that require a <xref:System.Type?displayProperty=nameWithType> parameter. Previously, you'd need to create an attribute that takes a `Type` as its constructor parameter:
 
 ```csharp
+// Before C# 11:
 public class TypeAttribute : Attribute
 {
    public TypeAttribute(Type t) => ParamType = t;
@@ -33,6 +34,7 @@ public class TypeAttribute : Attribute
 And to apply the attribute, you use the [`typeof`](../language-reference/operators/type-testing-and-cast.md#typeof-operator) operator:
 
 ```csharp
+// C# 11 feature:
 [TypeAttribute(typeof(string))]
 public string Method() => default;
 ```
@@ -50,12 +52,12 @@ Then, specify the type parameter to use the attribute:
 public string Method() => default;
 ```
 
-You can apply a fully closed constructed generic attribute. In other words, all type parameters must be specified. For example, the following is not allowed:
+You must supply all type parameters when you apply the attribute. In other words, the generic type must [fully constructed](~/_csharpstandard/standard/types.md#84-constructed-types).
 
 ```csharp
 public class GenericType<T>
 {
-   [GenericAttribute<T>()] // Not allowed! generic attributes must be fully closed types.
+   [GenericAttribute<T>()] // Not allowed! generic attributes must be fully constructed types.
    public string Method() => default;
 }
 ```

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -1,0 +1,84 @@
+---
+title: What's new in C# 11 - C# Guide
+description: Get an overview of the new features coming in C# 11.
+ms.date: 03/04/2022
+---
+# What's new in C# 11
+
+Beginning with the .NET 6.0.200 SDK or Visual Studio 2022 version 17.1, preview features in C# are available for you to try.
+
+> [!IMPORTANT]
+> These are currently preview features. You must [set `<LangVersion>` to `Preview`](../language-reference/compiler-options/language.md#langversion) to enable these features. Any feature may change before its final release. These features may not all be released in C# 11. Some may remain in a preview phase for longer based on feedback on the feature.
+
+The following features are available in the 6.0.200 version of the .NET SDK. They are available in Visual Studio 2022 version 17.1.
+
+- [Generic attributes](#generic-attributes).
+- [static abstract members in interfaces](#static-abstract-members-in-interfaces).
+
+You can download the latest .NET 6 SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), which includes the .NET 6 SDK.
+
+## Generic attributes
+
+You can declare a [generic class](../programming-guide/generics/generic-classes.md) whose base class is <xref:System.Attribute?displayProperty=fullName>. This provides a more convenient syntax for attributes that require a <xref:System.Type?displayProperty=nameWithType> parameter. Previously, you'd need to create an attribute that takes a `Type` as its constructor parameter:
+
+```csharp
+public class TypeAttribute : Attribute
+{
+   public TypeAttribute(Type t) => ParamType = t;
+
+   public Type ParamType { get; }
+}
+```
+
+And to apply the attribute, you use the [`typeof`](../language-reference/operators/type-testing-and-cast.md#typeof-operator) operator:
+
+```csharp
+[TypeAttribute(typeof(string))]
+public string Method() => default;
+```
+
+Using this new feature, you can create a generic attribute instead:
+
+```csharp
+public class GenericAttribute<T> : Attribute { }
+```
+
+Then, specify the type parameter to use the attribute:
+
+```csharp
+[GenericAttribute<string>()]
+public string Method() => default;
+```
+
+You can apply a fully closed constructed generic attribute. In other words, all type parameters must be specified. For example, the following is not allowed:
+
+```csharp
+public class GenericType<T>
+{
+   [GenericAttribute<T>()] // Not allowed! generic attributes must be fully closed types.
+   public string Method() => default;
+}
+```
+
+The type arguments must satisfy the same restrictions as the [`typeof`](../language-reference/operators/type-testing-and-cast.md#typeof-operator) operator. Types that require metadata annotations aren't allowed. Examples include the following:
+
+- `dynamic`
+- `nint`, `nuint`
+- `string?` (or any nullable reference type)
+- `(int X, int Y)` (or any other tuple types using C# tuple syntax).
+
+These types aren't directly represented in metadata. They include annotations that describe the type. In all cases, you can use the underlying type instead:
+
+- `object` for `dynamic`.
+- <xref:System.IntPtr> instead of `nint` or `unint`.
+- `string` instead of `string?`.
+- `ValueTuple<int, int>` instead of `(int X, int Y)`.
+
+## Static abstract members in interfaces
+
+> [!IMPORTANT]
+> *static abstract members in interfaces* is a runtime preview feature. You must add the `<EnablePreviewFeatures>True</EnablePreviewFeatures>` in your project file. See [Preview features](https://aka.ms/dotnet-warnings/preview-features) for more information. You can experiment with this feature, and the experimental libraries that use it. We will use feedback from the preview cycles to improve the feature before its general release.
+
+You can add *static abstract members* in interfaces to define interfaces that include overloadable operators, other static members, and static properties. The primary scenario for this feature is to use mathematical operators in generic types. The .NET runtime team has included interfaces for mathematical operations in the [System.Runtime.Experimental](https://www.nuget.org/packages/System.Runtime.Experimental/) NuGet package. For example, you can implement the `System.IAdditionOperators<TSelf, TOther, TResult>` in a type that implements `operator +`. Other interfaces define other mathematical operations or well-defined values.
+
+You can learn more and try the feature yourself in the tutorial [Explore static abstract interface members](./tutorials/static-abstract-interface-methods.md), or the [Preview features in .NET 6 – generic math](https://devblogs.microsoft.com/dotnet/preview-features-in-net-6-generic-math/) blog post.

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -8,7 +8,7 @@ ms.date: 03/04/2022
 Beginning with the .NET 6.0.200 SDK or Visual Studio 2022 version 17.1, preview features in C# are available for you to try.
 
 > [!IMPORTANT]
-> These are currently preview features. You must [set `<LangVersion>` to `Preview`](../language-reference/compiler-options/language.md#langversion) to enable these features. Any feature may change before its final release. These features may not all be released in C# 11. Some may remain in a preview phase for longer based on feedback on the feature.
+> These are currently preview features. You must [set `<LangVersion>` to `preview`](../language-reference/compiler-options/language.md#langversion) to enable these features. Any feature may change before its final release. These features may not all be released in C# 11. Some may remain in a preview phase for longer based on feedback on the feature.
 
 The following features are available in the 6.0.200 version of the .NET SDK. They are available in Visual Studio 2022 version 17.1.
 

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -324,8 +324,8 @@ C# 10 adds the following features and enhancements to the C# language:
 
 Additional features are available in *preview* mode. You're encouraged to try these features and [provide feedback](https://github.com/dotnet/roslyn/issues/new/choose) on them. They may change before their final release. In order to use these features, you must [set `<LangVersion>` to `Preview`](../language-reference/compiler-options/language.md#langversion) in your project:
 
-- [Generic attributes](./csharp-10.md#generic-attributes) later in this article.
-- [static abstract members in interfaces](./csharp-10.md#static-abstract-members-in-interfaces)
+- [Generic attributes](./csharp-11.md#generic-attributes) later in this article.
+- [static abstract members in interfaces](./csharp-11.md#static-abstract-members-in-interfaces)
 
 C# 10 continues work on themes of removing ceremony, separating data from algorithms, and improved performance for the .NET Runtime.
 


### PR DESCRIPTION
Fixes #28442 
Fixes #28446 

Two sets of changes to improve adoption of new features.

First move features currently in preview from the C# 10 what's new page to the C# 11 what's new page.

Second, add details on the latest (and upcoming) breaking changes in the compiler

Internal Preview links:

[Breaking changes](https://review.docs.microsoft.com/en-us/dotnet/csharp/whats-new/breaking-changes?branch=pr-en-us-28498)
[C# 10](https://review.docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10?branch=pr-en-us-28498)
[C# 11](https://review.docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-11?branch=pr-en-us-28498)
