### PR TITLE
ConnectionString is deprecated, use ConfigureTableServiceClient method.

### DIFF
--- a/docs/orleans/grains/grain-persistence/azure-storage.md
+++ b/docs/orleans/grains/grain-persistence/azure-storage.md
@@ -20,7 +20,8 @@ siloBuilder.AddAzureTableGrainStorage(
     configureOptions: options =>
     {
         options.UseJson = true;
-        options.ConfigureTableServiceClient("DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1");
+        options.ConfigureTableServiceClient(
+            "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1");
     });
 ```
 

--- a/docs/orleans/grains/grain-persistence/azure-storage.md
+++ b/docs/orleans/grains/grain-persistence/azure-storage.md
@@ -20,8 +20,7 @@ siloBuilder.AddAzureTableGrainStorage(
     configureOptions: options =>
     {
         options.UseJson = true;
-        options.ConnectionString =
-            "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1";
+        options.ConfigureTableServiceClient("DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1");
     });
 ```
 


### PR DESCRIPTION

## Summary
As the ConnectionString property is marked as deprecated the documentation should not use it either. Switched to the ConfigureTableServiceClient method which is the recommended action in the deprecation notice.

