### PR TITLE
Add {} and {||} to symbol page type section

### DIFF
--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -115,8 +115,8 @@ The following table describes symbols related to type annotation and type tests.
 |`'`|[Automatic Generalization](../generics/automatic-generalization.md)|Indicates a generic type parameter.|
 |`<...>`|[Automatic Generalization](../generics/automatic-generalization.md)|Delimits type parameters.|
 |`^`|[Statically Resolved Type Parameters](../generics/statically-resolved-type-parameters.md)<br /><br />[Strings](../strings.md)|<ul><li>Specifies type parameters that must be resolved at compile time, not at run time.</li><li>Concatenates strings.</li></ul>|
-| `{}`|[Class](classes.md) or [Record](records.md)|When used with the `type` keyword, delimits a class or record. The type is a class members are declared or the `class` keyword is used. Otherwise, it is a record. |
-| `{\|\|}`|[Anonymous record](anonymous-records.md)|Denotes an anonymous record|
+| `{}`|[Class](../classes.md) or [Record](../records.md)|When used with the `type` keyword, delimits a class or record. The type is a class members are declared or the `class` keyword is used. Otherwise, it is a record. |
+| `{\|\|}`|[Anonymous record](../anonymous-records.md)|Denotes an anonymous record|
 
 ## Symbols used in member lookup and slice expressions
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -115,6 +115,8 @@ The following table describes symbols related to type annotation and type tests.
 |`'`|[Automatic Generalization](../generics/automatic-generalization.md)|Indicates a generic type parameter.|
 |`<...>`|[Automatic Generalization](../generics/automatic-generalization.md)|Delimits type parameters.|
 |`^`|[Statically Resolved Type Parameters](../generics/statically-resolved-type-parameters.md)<br /><br />[Strings](../strings.md)|<ul><li>Specifies type parameters that must be resolved at compile time, not at run time.</li><li>Concatenates strings.</li></ul>|
+| `{}`|[Class](https://docs.microsoft.com/dotnet/fsharp/language-reference/classes) or [Record](https://docs.microsoft.com/dotnet/fsharp/language-reference/records)|When used with the `type` keyword, delimits a class or record. The type is a class members are declared or the `class` keyword is used. Otherwise, it is a record. |
+| `{\|\|}`|[Anonymous record](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/anonymous-records)|Denotes an anonymous record|
 
 ## Symbols used in member lookup and slice expressions
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -115,8 +115,8 @@ The following table describes symbols related to type annotation and type tests.
 |`'`|[Automatic Generalization](../generics/automatic-generalization.md)|Indicates a generic type parameter.|
 |`<...>`|[Automatic Generalization](../generics/automatic-generalization.md)|Delimits type parameters.|
 |`^`|[Statically Resolved Type Parameters](../generics/statically-resolved-type-parameters.md)<br /><br />[Strings](../strings.md)|<ul><li>Specifies type parameters that must be resolved at compile time, not at run time.</li><li>Concatenates strings.</li></ul>|
-| `{}`|[Class](https://docs.microsoft.com/dotnet/fsharp/language-reference/classes) or [Record](https://docs.microsoft.com/dotnet/fsharp/language-reference/records)|When used with the `type` keyword, delimits a class or record. The type is a class members are declared or the `class` keyword is used. Otherwise, it is a record. |
-| `{\|\|}`|[Anonymous record](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/anonymous-records)|Denotes an anonymous record|
+| `{}`|[Class](classes.md) or [Record](records.md)|When used with the `type` keyword, delimits a class or record. The type is a class members are declared or the `class` keyword is used. Otherwise, it is a record. |
+| `{\|\|}`|[Anonymous record](anonymous-records.md)|Denotes an anonymous record|
 
 ## Symbols used in member lookup and slice expressions
 


### PR DESCRIPTION
## Summary

Added more symbol information. 

Fixes #28391
