### PR TITLE
Remove extra "the" from link

### DIFF
--- a/docs/standard/base-types/parsing-other.md
+++ b/docs/standard/base-types/parsing-other.md
@@ -50,4 +50,4 @@ In addition to numeric and <xref:System.DateTime> strings, you can also parse st
 
 - [Parsing Strings](parsing-strings.md)
 - [Formatting Types](formatting-types.md)
-- [Type Conversion in the .NET](type-conversion.md)
+- [Type Conversion in .NET](type-conversion.md)


### PR DESCRIPTION
## Summary

Fixes #28507
