### PR TITLE
Adjust tryfix permissions

### DIFF
--- a/.github/workflows/docs-verifier-tryfix.yml
+++ b/.github/workflows/docs-verifier-tryfix.yml
@@ -8,8 +8,7 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/tryfix')
     name: Try fix build
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+    permissions: write-all
     env:
       IS_TRY_FIX: true # differentiates /tryfix from the validation-only run.
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There is `fatal: unable to access 'https://github.com/dotnet/docs/': The requested URL returned error: 403`. Hopefully this can fix it. @IEvangelist sorry for the series of PR for this GH Action