### PR TITLE
Checkout head from forks properly

### DIFF
--- a/.github/workflows/docs-verifier-tryfix.yml
+++ b/.github/workflows/docs-verifier-tryfix.yml
@@ -15,14 +15,9 @@ jobs:
     steps:
     - name: Checkout the repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
-    - name: Checkout Pull Request
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        PR_URL="${{ github.event.issue.pull_request.url }}"
-        PR_NUM=${PR_URL##*/}
-        echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
-        hub pr checkout $PR_NUM
+      with:
+        ref: ${{ github.event.issue.pull_request.head.sha }}
+
     - name: Tryfix
       uses: dotnet/docs-actions/actions/docs-verifier@youssef-testing
 

--- a/.github/workflows/docs-verifier-tryfix.yml
+++ b/.github/workflows/docs-verifier-tryfix.yml
@@ -26,4 +26,4 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git commit -am "Automated: Fix links"
-          hub push origin
+          git push


### PR DESCRIPTION
`on: issue_comment` workflows doesn't checkout the head of the PR, it checkouts the default branch. This attempts to checkout the head of the PR so that push can work.