### PR TITLE
Incorrect output in example

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/LiteralsEx2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/LiteralsEx2.cs
@@ -22,6 +22,6 @@ public class Example
    }
 }
 // The example displays the following output:
-//       18 Aug 2016 04:50 PM PDT
+//       18 Aug 2016 04:50 PM pst
 //       12/25/2016 12:00:00 PM
 // </Snippet21>

--- a/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/LiteralsEx3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/LiteralsEx3.cs
@@ -22,6 +22,6 @@ public class Example
    }
 }
 // The example displays the following output:
-//       18 Aug 2016 04:50 PM PDT
+//       18 Aug 2016 04:50 PM pst
 //       12/25/2016 12:00:00 PM
 // </Snippet22>


### PR DESCRIPTION
When running this code the output comment does not match the actual output. 
It actually outputs `pst` where as the comment said it output `PDT`

## Summary

I updated the comment to show the correct expected output.

