### PR TITLE
Fix documention on specifying connection pooling settings

### DIFF
--- a/docs/framework/data/adonet/sql-server-connection-pooling.md
+++ b/docs/framework/data/adonet/sql-server-connection-pooling.md
@@ -51,7 +51,7 @@ using (SqlConnection connection = new SqlConnection(
     }  
 ```  
   
- If `MinPoolSize` is either not specified in the connection string or is specified as zero, the connections in the pool will be closed after a period of inactivity. However, if the specified `MinPoolSize` is greater than zero, the connection pool is not destroyed until the `AppDomain` is unloaded and the process ends. Maintenance of inactive or empty pools involves minimal system overhead.  
+ If `Min Pool Size` is either not specified in the connection string or is specified as zero, the connections in the pool will be closed after a period of inactivity. However, if the specified `Min Pool Size` is greater than zero, the connection pool is not destroyed until the `AppDomain` is unloaded and the process ends. Maintenance of inactive or empty pools involves minimal system overhead.  
   
 > [!NOTE]
 > The pool is automatically cleared when a fatal error occurs, such as a failover.  


### PR DESCRIPTION
## Summary

Describe your changes here.
The documentation specifies that a developer must specify minimum connections in a pool as "MinPoolSize", this is incorrect. There needs to be some spaces in between for it to work correctly
Fixes #Issue_Number (if available)
