### PR TITLE
Change sample URL

### DIFF
--- a/docs/visual-basic/programming-guide/concepts/async/control-flow-in-async-programs.md
+++ b/docs/visual-basic/programming-guide/concepts/async/control-flow-in-async-programs.md
@@ -45,7 +45,7 @@ Class MainWindow
         ' TWO
         Dim client As HttpClient = New HttpClient()
         Dim getStringTask As Task(Of String) =
-            client.GetStringAsync("https://msdn.microsoft.com")
+            client.GetStringAsync("https://docs.microsoft.com")
 
         ' THREE
         Dim urlContents As String = Await getStringTask
@@ -189,7 +189,7 @@ To run the project, perform the following steps:
             ResultsTextBox.Text &= vbCrLf & "           Calling HttpClient.GetStringAsync." & vbCrLf
 
             ' GetStringAsync returns a Task(Of String).
-            Dim getStringTask As Task(Of String) = client.GetStringAsync("https://msdn.microsoft.com")
+            Dim getStringTask As Task(Of String) = client.GetStringAsync("https://docs.microsoft.com")
 
             ResultsTextBox.Text &= vbCrLf & "THREE: Back in AccessTheWebAsync." & vbCrLf &
                 "           Task getStringTask is started."
@@ -264,7 +264,7 @@ In `AccessTheWebAsync`, the asynchronous method <xref:System.Net.Http.HttpClient
 The `client.GetStringAsync` method returns a task of string that’s assigned to the `getStringTask` variable in `AccessTheWebAsync`. The following line in the example program shows the call to `client.GetStringAsync` and the assignment.
 
 ```vb
-Dim getStringTask As Task(Of String) = client.GetStringAsync("https://msdn.microsoft.com")
+Dim getStringTask As Task(Of String) = client.GetStringAsync("https://docs.microsoft.com")
 ```
 
 You can think of the task as a promise by `client.GetStringAsync` to produce an actual string eventually. In the meantime, if `AccessTheWebAsync` has work to do that doesn't depend on the promised string from `client.GetStringAsync`, that work can continue while  `client.GetStringAsync` waits. In the example, the following lines of output, which are labeled "THREE," represent the opportunity to do independent work
@@ -288,7 +288,7 @@ The following image shows the flow of control from `client.GetStringAsync` to th
 The await expression suspends `AccessTheWebAsync` until `client.GetStringAsync` returns. In the meantime, control returns to the caller of `AccessTheWebAsync`, `startButton_Click`.
 
 > [!NOTE]
-> Typically, you await the call to an asynchronous method immediately. For example, the following assignment could replace the previous code that creates and then awaits `getStringTask`: `Dim urlContents As String = Await client.GetStringAsync("https://msdn.microsoft.com")`
+> Typically, you await the call to an asynchronous method immediately. For example, the following assignment could replace the previous code that creates and then awaits `getStringTask`: `Dim urlContents As String = Await client.GetStringAsync("https://docs.microsoft.com")`
 >
 > In this topic, the await operator is applied later to accommodate the output lines that mark the flow of control through the program.
 


### PR DESCRIPTION
This sample used `msdn.microsoft.com`, which has been retired. Replace it with `docs.microsoft.com`

Fixes #28591
