### PR TITLE
Fix indenting on closing brace

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -207,34 +207,6 @@ namespace builtin_types
         }
     }
 
-    namespace field_initializer_no_constructor
-    {
-        public static class Example
-        {
-            // <FieldInitializerNoConstructor>
-            public struct Coords
-            {
-                public double X = double.NaN;
-                public double Y = double.NaN;
-            
-                public override string ToString() => $"({X}, {Y})";
-            }
-
-            public static void Main()
-            {
-                var p1 = new Coords();
-                Console.WriteLine(p1);  // output: (NaN, NaN)
-
-                var p2 = default(Coords);
-                Console.WriteLine(p2);  // output: (0, 0)
-
-                var ps = new Coords[3];
-                Console.WriteLine(string.Join(", ", ps));  // output: (0, 0), (0, 0), (0, 0)
-            }
-            // </FieldInitializerNoConstructor>
-        }
-    }
-
     namespace with_expression
     {
         public static class Example

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -9,7 +9,6 @@ namespace builtin_types
             without_new.StructWithoutNew.Main();
             parameterless_constructor.Example.Main();
             field_initializer.Example.Main();
-            field_initializer_no_constructor.Example.Main();
             with_expression.Example.Main();
         }
 

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -202,7 +202,7 @@ namespace builtin_types
 
                 var m3 = default(Measurement);
                 Console.WriteLine(m3);  // output: 0 ()
-}
+            }
             // </FieldInitializer>
         }
     }

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -115,15 +115,8 @@ Beginning with C# 10, you can also initialize an instance field or property at i
 
 If you don't declare a parameterless constructor explicitly, a structure type provides a parameterless constructor whose behavior is as follows:
 
-- If a structure type has explicit instance constructors or has no field initializers, an implicit parameterless constructor produces the default value of a structure type, regardless of field initializers, as the preceding example shows.
-- If a structure type has no explicit instance constructors and has field initializers, the compiler synthesizes a public parameterless constructor that performs the specified field initializations, as the following example shows:
-
-  :::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializerNoConstructor":::
-
-As the preceding example shows, the default value expression and array instantiation ignore field initializers.
-
-> [!IMPORTANT]
-> When a `struct` includes field initializers, but doesn't include any explicit instance constructors, the synthesized public parameterless constructor performs the specified field initializers. If that `struct` includes an explicit instance constructor, the synthesized parameterless constructor produces the same value as the `default` expression.
+- If a structure type has no field initializers, an implicit parameterless constructor produces the default value of a structure type, regardless of field initializers, as the preceding example shows.
+- If a structure type has field initializers, you must write an explicit parameterless constructor for the struct. It can, and often will, have an empty body.
 
 For more information, see the [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md) feature proposal note.
 


### PR DESCRIPTION
Fixes #28594 

The closing brace was in the wrong column, which indented the entire sample.
