### PR TITLE
Remove example of checking an instance being of nullable type

### DIFF
--- a/docs/csharp/language-reference/builtin-types/nullable-value-types.md
+++ b/docs/csharp/language-reference/builtin-types/nullable-value-types.md
@@ -109,10 +109,6 @@ Also, don't use the [is](../operators/type-testing-and-cast.md#is-operator) oper
 
 [!code-csharp-interactive[is operator example](snippets/shared/NullableValueTypes.cs#IsOperator)]
 
-You can use the code presented in the following example to determine whether an instance is of a nullable value type:
-
-[!code-csharp-interactive[whether an instance is of a nullable type](snippets/shared/NullableValueTypes.cs#IsInstanceNullable)]
-
 > [!NOTE]
 > The methods described in this section are not applicable in the case of [nullable reference types](nullable-reference-types.md).
 

--- a/docs/csharp/language-reference/builtin-types/nullable-value-types.md
+++ b/docs/csharp/language-reference/builtin-types/nullable-value-types.md
@@ -109,6 +109,8 @@ Also, don't use the [is](../operators/type-testing-and-cast.md#is-operator) oper
 
 [!code-csharp-interactive[is operator example](snippets/shared/NullableValueTypes.cs#IsOperator)]
 
+Instead use the <xref:System.Nullable.GetUnderlyingType%2A?displayProperty=nameWithType> from the first example and [typeof](../operators/type-testing-and-cast.md#typeof-operator) operator to check if an instance is of a nullable value type.
+
 > [!NOTE]
 > The methods described in this section are not applicable in the case of [nullable reference types](nullable-reference-types.md).
 

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/NullableValueTypes.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/NullableValueTypes.cs
@@ -15,7 +15,6 @@ namespace builtin_types
             WhetherTypeIsNullable();
             GetTypeExample();
             IsOperatorExample();
-            WhetherInstanceIsOfNullableType();
         }
 
         private static void DeclareAndAssign()
@@ -199,23 +198,6 @@ namespace builtin_types
             // int? instance is compatible with int
             // int instance is compatible with int?
             // </SnippetIsOperator>
-        }
-
-        private static void WhetherInstanceIsOfNullableType()
-        {
-            // <SnippetIsInstanceNullable>
-            int? a = 14;
-            Console.WriteLine(IsOfNullableType(a));  // output: True
-
-            int b = 17;
-            Console.WriteLine(IsOfNullableType(b));  // output: False
-
-            bool IsOfNullableType<T>(T o)
-            {
-                var type = typeof(T);
-                return Nullable.GetUnderlyingType(type) != null;
-            }
-            // </SnippetIsInstanceNullable>
         }
     }
 }


### PR DESCRIPTION
This pull request fixes #28597 

It removes the last example of checking whether an instance is of nullable type and replaces it with the brief explanation how to achieve that.
This explanation points (without links between sections) to the first example from the same section and mention the `typeof` operator as an additional tool needed if there's an instance to be checked instead of a type.

**NOTE:** The last example has been reported as duplicated, but in fact it is quite different case. The first applies to the type being checked, while the last show the same goal but for instance.
However they are *very* similar so it may introduce some confusions and I decided to go with the short explanation mentioning the way to do such check.
