### PR TITLE
add documentation for new CLI telemetry in .NET 6.0.300

### DIFF
--- a/docs/core/tools/telemetry.md
+++ b/docs/core/tools/telemetry.md
@@ -83,6 +83,7 @@ The telemetry feature collects the following data:
 | >=5.0.202     | Elapsed time for generating ASP.NET Certificate on first run. |
 | >=5.0.202     | Elapsed time to parse the CLI input. |
 | >=6.0.100     | OS architecture |
+| >=6.0.300     | If the CLI was invoked from a Continuous Integration environment. For more information, see [Continuous Integration Detection](#continuous-integration-detection).|
 
 ### Collected options
 
@@ -144,6 +145,26 @@ at Microsoft.DotNet.Tools.Run.RunCommand.Run(String[] args)
 at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
 at Microsoft.DotNet.Cli.Program.Main(String[] args)
 ```
+
+## Continuous Integration Detection
+
+In order to detect if the .NET CLI is running in a Continuous Integration environment, the .NET CLI probes for the presence and values of several well-known environment variables that common CI providers set.
+
+The full list of environment variables, and what is done with their values, is shown below.  Note that in every case, the value of the environment variable is never collected, only used to set a boolean flag.
+
+| Variable(s) | Provider | Action |
+| ----------- | -------- | ------ |
+| TF_BUILD    | Azure Pipelines | Parse boolean value |
+| GITHUB_ACTIONS | GitHub Actions | Parse boolean value |
+| APPVEYOR | Appveyor | Parse boolean value |
+| CI | Many/Most | Parse boolean value |
+| TRAVIS | Travis CI | Parse boolean value |
+| CIRCLECI | Circle CI | Parse boolean value |
+| CODEBUILD_BUILD_ID, AWS_REGION | Amazon Web Services CodeBuild | Check if all are present and non-null |
+| BUILD_ID, BUILD_URL | Jenkins | Check if all are present and non-null |
+| BUILD_ID, PROJECT_ID | Google Cloud Build | Check if all are present and non-null |
+| TEAMCITY_VERSION | TeamCity | Check if present and non-null |
+| JB_SPACE_API_URL | JetBrains Space | Check if present and non-null |
 
 ## Avoid inadvertent disclosure of information
 


### PR DESCRIPTION
## Summary

With https://github.com/dotnet/sdk/pull/24166 the .NET CLI added the ability to detect the presence of CI systems during invocation. We need to document the data checked accordingly.
