### PR TITLE
HostBuilder is now the preferred way to build a silo.

### DIFF
--- a/docs/orleans/deployment/multi-cluster-support/gossip-channels.md
+++ b/docs/orleans/deployment/multi-cluster-support/gossip-channels.md
@@ -52,15 +52,18 @@ When a silo is first started, or when it is restarted after a failure, it needs 
 We have already implemented a gossip channel based on Azure Tables. The configuration specifies standard connection strings used for Azure accounts. For example, a configuration could specify two gossip channels with separate Azure storage accounts `usa` and `europe` as follows:
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<MultiClusterOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.GossipChannels.Add(
-            "AzureTable",
-            "DefaultEndpointsProtocol=https;AccountName=usa;AccountKey=...");
-        options.GossipChannels.Add(
-            "AzureTable",
-            "DefaultEndpointsProtocol=https;AccountName=europe;AccountKey=...")
+        builder.Configure<MultiClusterOptions>(options =>
+        {
+            options.GossipChannels.Add(
+                "AzureTable",
+                "DefaultEndpointsProtocol=https;AccountName=usa;AccountKey=...");
+            options.GossipChannels.Add(
+                "AzureTable",
+                "DefaultEndpointsProtocol=https;AccountName=europe;AccountKey=...")
+        });
     })
 ```
 

--- a/docs/orleans/deployment/multi-cluster-support/multi-cluster-configuration.md
+++ b/docs/orleans/deployment/multi-cluster-support/multi-cluster-configuration.md
@@ -50,11 +50,15 @@ There is an optional third argument, a boolean called `checkForLaggingSilosFirst
 In situations where the multi-cluster configuration is known in advance and the deployment is fresh every time (for testing), we may want to supply a default configuration. The global configuration supports an optional attribute `DefaultMultiCluster` which takes a comma-separated list of cluster ids:
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<MultiClusterOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.DefaultMultiCluster = new[] { "us1", "eu1", "us2" };
+        builder.Configure<MultiClusterOptions>(options =>
+        {
+            options.DefaultMultiCluster = new[] { "us1", "eu1", "us2" };
+        })
     })
+    .Build();
 ```
 
 After a silo is started with this setting, it checks to see if the current multi-cluster configuration is null, and if so, injects the given configuration with the current UTC timestamp.

--- a/docs/orleans/deployment/multi-cluster-support/silo-configuration.md
+++ b/docs/orleans/deployment/multi-cluster-support/silo-configuration.md
@@ -29,28 +29,31 @@ To get a quick overview, we show all relevant configuration parameters (includin
 ```
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<ClusterInfo>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builer =>
     {
-        options.ClusterId = "us3";
-        options.ServiceId = "myawesomeservice";
-    })
-    .Configure<MultiClusterOptions>(options =>
-    {
-        options.HasMultiClusterNetwork = true;
-        options.DefaultMultiCluster = new[] { "us1", "eu1", "us2" };
-        options.BackgroundGossipInterval = TimeSpan.FromSeconds(30);
-        options.UseGlobalSingleInstanceByDefault = false;
-        options.GlobalSingleInstanceRetryInterval = TimeSpan.FromSeconds(30);
-        options.GlobalSingleInstanceNumberRetries = 3;
-        options.MaxMultiClusterGateways = 10;
-        options.GossipChannels.Add(
-            "AzureTable",
-            "DefaultEndpointsProtocol=https;AccountName=usa;AccountKey=...");
-        options.GossipChannels.Add(
-            "AzureTable",
-            "DefaultEndpointsProtocol=https;AccountName=europe;AccountKey=...")
-    })
+        builder.Configure<ClusterInfo>(options =>
+        {
+            options.ClusterId = "us3";
+            options.ServiceId = "myawesomeservice";
+        })
+        .Configure<MultiClusterOptions>(options =>
+        {
+            options.HasMultiClusterNetwork = true;
+            options.DefaultMultiCluster = new[] { "us1", "eu1", "us2" };
+            options.BackgroundGossipInterval = TimeSpan.FromSeconds(30);
+            options.UseGlobalSingleInstanceByDefault = false;
+            options.GlobalSingleInstanceRetryInterval = TimeSpan.FromSeconds(30);
+            options.GlobalSingleInstanceNumberRetries = 3;
+            options.MaxMultiClusterGateways = 10;
+            options.GossipChannels.Add(
+                "AzureTable",
+                "DefaultEndpointsProtocol=https;AccountName=usa;AccountKey=...");
+            options.GossipChannels.Add(
+                "AzureTable",
+                "DefaultEndpointsProtocol=https;AccountName=europe;AccountKey=...")
+        });
+    });
 ```
 
 As usual, all configuration settings can also be read and written programmatically, via the respective members of the `GlobalConfiguration` class.

--- a/docs/orleans/grains/grain-persistence/relational-storage.md
+++ b/docs/orleans/grains/grain-persistence/relational-storage.md
@@ -33,12 +33,15 @@ Read the [ADO.NET configuration](../../host/configuration-guide/adonet-configura
 The following is an example of how to configure an ADO.NET storage provider via `ISiloHostBuilder`:
 
 ```csharp
-var siloHostBuilder = new SiloHostBuilder()
-    .AddAdoNetGrainStorage("OrleansStorage", options =>
+var siloHostBuilder = new HostBuilder()
+    .UseOrleans(c =>
     {
-        options.Invariant = "<Invariant>";
-        options.ConnectionString = "<ConnectionString>";
-        options.UseJsonFormat = true;
+        c.AddAdoNetGrainStorage("OrleansStorage", options =>
+        {
+            options.Invariant = "<Invariant>";
+            options.ConnectionString = "<ConnectionString>";
+            options.UseJsonFormat = true;
+        });
     });
 ```
 

--- a/docs/orleans/grains/grain-placement.md
+++ b/docs/orleans/grains/grain-placement.md
@@ -109,9 +109,11 @@ And finally, register the strategy when you build the `SiloHost`:
 ```csharp
 private static async Task<ISiloHost> StartSilo()
 {
-    ISiloHostBuilder builder = new SiloHostBuilder()
+    var builder = new HostBuilder(c =>
+    {
         // normal configuration methods omitted for brevity
-        .ConfigureServices(ConfigureServices);
+        c.ConfigureServices(ConfigureServices);
+    });
 
     var host = builder.Build();
     await host.StartAsync();

--- a/docs/orleans/grains/grain-versioning/deploying-new-versions-of-grains.md
+++ b/docs/orleans/grains/grain-versioning/deploying-new-versions-of-grains.md
@@ -20,12 +20,16 @@ Recommended configuration:
 - `DefaultVersionSelectorStrategy` set to `AllCompatibleVersions`
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<GrainVersioningOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
-        options.DefaultVersionSelectorStrategy = nameof(AllCompatibleVersions);
+        builder.Configure<GrainVersioningOptions>(options =>
+        {
+            options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
+            options.DefaultVersionSelectorStrategy = nameof(AllCompatibleVersions);
+        })
     })
+    .Build();
 ```
 
 When using this configuration, "old" clients will be able to talk to activations
@@ -47,12 +51,17 @@ Recommended configuration:
 - `DefaultVersionSelectorStrategy` set to `MinimumVersion`
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<GrainVersioningOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
-        options.DefaultVersionSelectorStrategy = nameof(MinimumVersion);
+        builder.Configure<GrainVersioningOptions>(options =>
+        {
+            options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
+            options.DefaultVersionSelectorStrategy = nameof(MinimumVersion);
+        })
     })
+    .Build();
+    
 ```
 
 Suggested deployment steps:

--- a/docs/orleans/grains/grain-versioning/grain-versioning.md
+++ b/docs/orleans/grains/grain-versioning/grain-versioning.md
@@ -49,10 +49,13 @@ By default:
 You can change this default behavior via the option `GrainVersioningOptions`:
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<GrainVersioningOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(c =>
     {
-        options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
-        options.DefaultVersionSelectorStrategy = nameof(MinimumVersion);
-    })
+        c.Configure<GrainVersioningOptions>(options =>
+        {
+            options.DefaultCompatibilityStrategy = nameof(BackwardCompatible);
+            options.DefaultVersionSelectorStrategy = nameof(MinimumVersion);
+        });
+    });
 ```

--- a/docs/orleans/grains/grainservices.md
+++ b/docs/orleans/grains/grainservices.md
@@ -117,11 +117,14 @@ The `Microsoft.Orleans.OrleansRuntime` NuGet package should be referenced by the
 In order for this to work you have to register both the service and its client. The code looks something like this:
 
 ```csharp
-var builder = new SiloHostBuilder()
-    .AddGrainService<DataService>()  // Register GrainService
-    .ConfigureServices(services =>
+var builder = new HostBuilder()
+    .UseOrleans(c =>
     {
-        // Register Client of GrainService
-        services.AddSingleton<IDataServiceClient, DataServiceClient>();
+        c.AddGrainService<DataService>()  // Register GrainService
+        .ConfigureServices(services =>
+        {
+            // Register Client of GrainService
+            services.AddSingleton<IDataServiceClient, DataServiceClient>();
+        });
     })
  ```

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -59,8 +59,12 @@ Azure Table configuration:
 ```csharp
 // TODO replace with your connection string
 const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-var silo = new SiloHostBuilder()
-    .UseAzureTableReminderService(options => options.ConnectionString = connectionString)
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
+    {
+        builder.UseAzureTableReminderService(options => options.ConnectionString = connectionString)
+    })
+    .Build();
 ```
 
 SQL:
@@ -68,19 +72,27 @@ SQL:
 ```csharp
 const string connectionString = "YOUR_CONNECTION_STRING_HERE";
 const string invariant = "YOUR_INVARIANT";
-var silo = new SiloHostBuilder()
-    .UseAdoNetReminderService(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.ConnectionString = connectionString;
-        options.Invariant = invariant;
+        builder.UseAdoNetReminderService(options =>
+        {
+            options.ConnectionString = connectionString;
+            options.Invariant = invariant;
+        });
     })
+    .Build();
 ```
 
  If you just want a placeholder implementation of reminders to work without needing to set up an Azure account or SQL database, then this will give you a development-only implementation of the reminder system:
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .UseInMemoryReminderService()
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
+    {
+        builder.UseInMemoryReminderService();
+    })
+    .Build();
 ```
 
 ## Reminder usage

--- a/docs/orleans/grains/transactions.md
+++ b/docs/orleans/grains/transactions.md
@@ -16,7 +16,11 @@ If it is not, any calls to transactional methods on grains will receive an `Orle
 To enable transactions on a silo, call `UseTransactions()` on the silo host builder.
 
 ```csharp
-var builder = new SiloHostBuilder().UseTransactions();
+var builder = new HostBuilder()
+    UseOrleans(c =>
+    {
+        c.UseTransactions();
+    });
 ```
 
 ### Transactional state storage
@@ -30,12 +34,16 @@ Example:
 
 ```csharp
 
-var builder = new SiloHostBuilder()
-    .AddAzureTableTransactionalStateStorage("TransactionStore", options =>
+new HostBuilder()
+    UseOrleans(builder =>
     {
-        options.ConnectionString = "YOUR_STORAGE_CONNECTION_STRING");
+        builder.AddAzureTableTransactionalStateStorage("TransactionStore", options =>
+        {
+            options.ConnectionString = "YOUR_STORAGE_CONNECTION_STRING");
+        })
+        .UseTransactions();
     })
-    .UseTransactions();
+    .Build();
 ```
 
 For development purposes, if transaction-specific storage is not available for the data store you need, an `IGrainStorage` implementation may be used instead.

--- a/docs/orleans/host/configuration-guide/local-development-configuration.md
+++ b/docs/orleans/host/configuration-guide/local-development-configuration.md
@@ -46,18 +46,21 @@ catch (Exception ex)
 
 static async Task<ISiloHost> BuildAndStartSiloAsync()
 {
-    var builder = new SiloHostBuilder()
-        .UseLocalhostClustering()
-        .Configure<ClusterOptions>(options =>
-        {
-            options.ClusterId = "dev";
-            options.ServiceId = "MyAwesomeService";
-        })
-        .Configure<EndpointOptions>(
-            options => options.AdvertisedIPAddress = IPAddress.Loopback)
-        .ConfigureLogging(logging => logging.AddConsole());
+    var host = new HostBuilder()
+      .UseOrleans(builder =>
+      {
+          .UseLocalhostClustering()
+          .Configure<ClusterOptions>(options =>
+          {
+              options.ClusterId = "dev";
+              options.ServiceId = "MyAwesomeService";
+          })
+          .Configure<EndpointOptions>(
+              options => options.AdvertisedIPAddress = IPAddress.Loopback)
+          .ConfigureLogging(logging => logging.AddConsole());
+      })
+      .Build();
 
-    var host = builder.Build();
     await host.StartAsync();
 
     return host;

--- a/docs/orleans/host/configuration-guide/server-configuration.md
+++ b/docs/orleans/host/configuration-guide/server-configuration.md
@@ -19,17 +19,20 @@ There are several key aspects of silo configuration:
 This is an example of a silo configuration that defines cluster information, uses Azure clustering, and configures the application parts:
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .Configure<ClusterOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.ClusterId = "my-first-cluster";
-        options.ServiceId = "AspNetSampleApp";
+        .Configure<ClusterOptions>(options =>
+        {
+            options.ClusterId = "my-first-cluster";
+            options.ServiceId = "AspNetSampleApp";
+        })
+        .UseAzureStorageClustering(
+            options => options.ConnectionString = connectionString)
+        .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
+        .ConfigureApplicationParts(
+            parts => parts.AddApplicationPart(typeof(ValueGrain).Assembly).WithReferences())
     })
-    .UseAzureStorageClustering(
-        options => options.ConnectionString = connectionString)
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
-    .ConfigureApplicationParts(
-        parts => parts.AddApplicationPart(typeof(ValueGrain).Assembly).WithReferences())
     .Build();
 ```
 

--- a/docs/orleans/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/orleans/host/configuration-guide/shutting-down-orleans.md
@@ -54,11 +54,14 @@ static void SetupApplicationShutdown()
     };
 }
 
-static ISiloHost CreateSilo() => new SiloHostBuilder()
-    .Configure(options => options.ClusterId = "MyTestCluster")
-    .UseDevelopmentClustering(
-        options => options.PrimarySiloEndpoint = new IPEndPoint(IPAddress.Loopback, 11111))
-    .ConfigureLogging(b => b.SetMinimumLevel(LogLevel.Debug).AddConsole())
+static ISiloHost CreateSilo() => new HostBuilder()
+    .UseOrleans(builder =>
+    {
+        .Configure(options => options.ClusterId = "MyTestCluster")
+        .UseDevelopmentClustering(
+            options => options.PrimarySiloEndpoint = new IPEndPoint(IPAddress.Loopback, 11111))
+        .ConfigureLogging(b => b.SetMinimumLevel(LogLevel.Debug).AddConsole())
+    })
     .Build();
 
 static async Task StopSiloAsync() {

--- a/docs/orleans/host/configuration-guide/typical-configurations.md
+++ b/docs/orleans/host/configuration-guide/typical-configurations.md
@@ -22,15 +22,18 @@ Silo configuration:
 
 ```csharp
 const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-var silo = new SiloHostBuilder()
-    .Configure<ClusterOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
+        .Configure<ClusterOptions>(options =>
+        {
+            options.ClusterId = "Cluster42";
+            options.ServiceId = "MyAwesomeService";
+        })
+        .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
+        .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
+        .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
     })
-    .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
-    .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
     .Build();
 ```
 
@@ -57,19 +60,22 @@ Silo configuration:
 
 ```csharp
 const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-var silo = new SiloHostBuilder()
-    .Configure<ClusterOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
+        .Configure<ClusterOptions>(options =>
+        {
+            options.ClusterId = "Cluster42";
+            options.ServiceId = "MyAwesomeService";
+        })
+        .UseAdoNetClustering(options =>
+        {
+          options.ConnectionString = connectionString;
+          options.Invariant = "System.Data.SqlClient";
+        })
+        .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
+        .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
     })
-    .UseAdoNetClustering(options =>
-    {
-      options.ConnectionString = connectionString;
-      options.Invariant = "System.Data.SqlClient";
-    })
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
-    .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
     .Build();
 ```
 
@@ -100,15 +106,18 @@ On the silos:
 
 ```csharp
 var primarySiloEndpoint = new IPEndpoint(PRIMARY_SILO_IP_ADDRESS, 11111);
-var silo = new SiloHostBuilder()
-    .UseDevelopmentClustering(primarySiloEndpoint)
-    .Configure<ClusterOptions>(options =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
+        .UseDevelopmentClustering(primarySiloEndpoint)
+        .Configure<ClusterOptions>(options =>
+        {
+            options.ClusterId = "Cluster42";
+            options.ServiceId = "MyAwesomeService";
+        })
+        .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
+        .ConfigureLogging(logging => logging.AddConsole())
     })
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
-    .ConfigureLogging(logging => logging.AddConsole())
     .Build();
 ```
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -24,8 +24,12 @@ The Orleans runtime continually updates a number of them. The _CounterControl.ex
 To configure your silo and client to use telemetry consumers, silo configuration code looks like this:
 
 ```csharp
-var siloHostBuilder = new SiloHostBuilder();
-siloHostBuilder.AddApplicationInsightsTelemetryConsumer("INSTRUMENTATION_KEY");
+var siloHostBuilder = new HostBuilder()
+    .UseOrleans(c =>
+    {
+        c.AddApplicationInsightsTelemetryConsumer("INSTRUMENTATION_KEY");      
+    });
+
 ```
 
 Client configuration code look like this:
@@ -38,9 +42,13 @@ clientBuilder.AddApplicationInsightsTelemetryConsumer("INSTRUMENTATION_KEY");
 To use a custom defined TelemetryConfiguration (which may have `TelemetryProcessors`, `TelemetrySinks`, and so on), silo configuration code looks like this:
 
 ```csharp
-var siloHostBuilder = new SiloHostBuilder();
 var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
-siloHostBuilder.AddApplicationInsightsTelemetryConsumer(telemetryConfiguration);
+var siloHostBuilder = new HostBuilder()
+    .UseOrleans(c =>
+    {
+        c.AddApplicationInsightsTelemetryConsumer(telemetryConfiguration);  
+    });
+
 ```
 
 Client configuration code look like this:

--- a/docs/orleans/migration/migration-1.5.md
+++ b/docs/orleans/migration/migration-1.5.md
@@ -56,12 +56,15 @@ class Program
         var config = ClusterConfiguration.LocalhostPrimarySilo();
         config.AddMemoryStorageProvider();
 
-        var builder = new SiloHostBuilder()
-            .UseConfiguration(config)
-            .ConfigureApplicationParts(parts =>
-                parts.AddApplicationPart(typeof(HelloGrain).Assembly)
-                     .WithReferences())
-            .ConfigureLogging(logging => logging.AddConsole());
+        var builder = new HostBuilder()
+            .UseOrleans(c =>
+            {
+                c.UseConfiguration(config)
+                .ConfigureApplicationParts(parts =>
+                    parts.AddApplicationPart(typeof(HelloGrain).Assembly)
+                        .WithReferences())
+                .ConfigureLogging(logging => logging.AddConsole());
+            });
 
         var host = builder.Build();
         await host.StartAsync();

--- a/docs/orleans/migration/migration-azure-2.0.md
+++ b/docs/orleans/migration/migration-azure-2.0.md
@@ -39,23 +39,26 @@ var connectionString =
     RoleEnvironment.GetConfigurationSettingValue("DataConnectionString");
 var deploymentId = RoleEnvironment.DeploymentId;
 
-var builder = new SiloHostBuilder()
-    .Configure<ClusterOptions>(options =>
-        {
-            options.ClusterId = deploymentId;
-            options.ServiceIs = "my-app";
-        })
-    .Configure<SiloOptions>(options => options.SiloName = Name)
-    .ConfigureEndpoints(siloEndpoint.Address, siloEndpoint.Port, proxyPort)
-    .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
-    .UseAzureTableReminderService(connectionString)
-    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(
-        "StreamProvider",
-        configurator => configurator.Configure(configure =>
-        {
-            configure.ConnectionString = connectionString;
-        }))
-    .AddAzureTableGrainStorage("AzureTableStore");
+var builder = new HostBuilder()
+    .UseOrleans(c =>
+    {
+        c.Configure<ClusterOptions>(options =>
+            {
+                options.ClusterId = deploymentId;
+                options.ServiceIs = "my-app";
+            })
+        .Configure<SiloOptions>(options => options.SiloName = Name)
+        .ConfigureEndpoints(siloEndpoint.Address, siloEndpoint.Port, proxyPort)
+        .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
+        .UseAzureTableReminderService(connectionString)
+        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(
+            "StreamProvider",
+            configurator => configurator.Configure(configure =>
+            {
+                configure.ConnectionString = connectionString;
+            }))
+        .AddAzureTableGrainStorage("AzureTableStore");
+    });
 ```
 
 ## Migrate from `AzureSilo` to `ISiloHost`

--- a/docs/orleans/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/orleans/tutorials-and-samples/custom-grain-storage.md
@@ -314,11 +314,14 @@ return services.AddSingletonNamedService(providerName, FileGrainStorageFactory.C
 This enables us to add the file storage using the extension on the `ISiloHostBuilder`:
 
 ```csharp
-var silo = new SiloHostBuilder()
-    .UseLocalhostClustering()
-    .AddFileGrainStorage("File", opts =>
+var silo = new HostBuilder()
+    .UseOrleans(builder =>
     {
-        opts.RootDirectory = "C:/TestFiles";
+        builder.UseLocalhostClustering()
+            .AddFileGrainStorage("File", opts =>
+            {
+                opts.RootDirectory = "C:/TestFiles";
+            });
     })
     .Build();
 ```

--- a/docs/orleans/tutorials-and-samples/overview-helloworld.md
+++ b/docs/orleans/tutorials-and-samples/overview-helloworld.md
@@ -19,18 +19,21 @@ A list of all of the options can be found [here.](../host/configuration-guide/li
 ```csharp
 static async Task<ISiloHost> StartSilo()
 {
-    var builder = new SiloHostBuilder()
-        .UseLocalhostClustering()
-        .Configure<ClusterOptions>(options =>
+    var builder = new HostBuilder()
+        UseOrleans(c =>
         {
-            options.ClusterId = "dev";
-            options.ServiceId = "HelloWorldApp";
-        })
-        .Configure<EndpointOptions>(
-            options => options.AdvertisedIPAddress = IPAddress.Loopback)
-        .ConfigureApplicationParts(
-            parts => parts.AddApplicationPart(typeof(HelloGrain).Assembly).WithReferences())
-        .ConfigureLogging(logging => logging.AddConsole());
+            c.UseLocalhostClustering()
+                .Configure<ClusterOptions>(options =>
+                {
+                    options.ClusterId = "dev";
+                    options.ServiceId = "HelloWorldApp";
+                })
+                .Configure<EndpointOptions>(
+                    options => options.AdvertisedIPAddress = IPAddress.Loopback)
+                .ConfigureApplicationParts(
+                    parts => parts.AddApplicationPart(typeof(HelloGrain).Assembly).WithReferences())
+                .ConfigureLogging(logging => logging.AddConsole());
+        });
 
     var host = builder.Build();
     await host.StartAsync();

--- a/docs/orleans/tutorials-and-samples/tutorial-1.md
+++ b/docs/orleans/tutorials-and-samples/tutorial-1.md
@@ -143,16 +143,19 @@ catch (Exception ex)
 
 static async Task<ISiloHost> StartSiloAsync()
 {
-    var builder = new SiloHostBuilder()
-        .UseLocalhostClustering()
-        .Configure<ClusterOptions>(options =>
+    var builder = new HostBuilder()
+        .UseOrleans(c =>
         {
-            options.ClusterId = "dev";
-            options.ServiceId = "OrleansBasics";
-        })
-        .ConfigureApplicationParts(
-            parts => parts.AddApplicationPart(typeof(HelloGrain).Assembly).WithReferences())
-        .ConfigureLogging(logging => logging.AddConsole());
+            c.UseLocalhostClustering()
+            .Configure<ClusterOptions>(options =>
+            {
+                options.ClusterId = "dev";
+                options.ServiceId = "OrleansBasics";
+            })
+            .ConfigureApplicationParts(
+                parts => parts.AddApplicationPart(typeof(HelloGrain).Assembly).WithReferences())
+            .ConfigureLogging(logging => logging.AddConsole());
+        });
 
     var host = builder.Build();
     await host.StartAsync();


### PR DESCRIPTION
## Summary

in the Orleans documentation the code snippets used for creating a silo host are out of date. The preferred technique is to use a HostBuilder rather than a SiloHostBuilder.
