### PR TITLE
SEO OKR

### DIFF
--- a/docs/architecture/dapr-for-net-developers/index.md
+++ b/docs/architecture/dapr-for-net-developers/index.md
@@ -2,7 +2,7 @@
 title: Dapr for .NET Developers
 description: A guide for .NET developers to understand and leverage the full power of Microsoft's open source Distributed Application Runtime.
 author: robvet
-ms.date: 01/10/2022
+ms.date: 03/11/2022
 ---
 
 # Dapr for .NET Developers

--- a/docs/architecture/dapr-for-net-developers/index.md
+++ b/docs/architecture/dapr-for-net-developers/index.md
@@ -2,7 +2,7 @@
 title: Dapr for .NET Developers
 description: A guide for .NET developers to understand and leverage the full power of Microsoft's open source Distributed Application Runtime.
 author: robvet
-ms.date: 03/11/2022
+ms.date: 01/10/2022
 ---
 
 # Dapr for .NET Developers

--- a/docs/core/tutorials/top-level-templates.md
+++ b/docs/core/tutorials/top-level-templates.md
@@ -1,6 +1,7 @@
 ---
 title: "C# console app template changes in .NET 6"
 description: The .NET 6 project template for C# console apps uses top-level statements. Understand what's changed and how to use existing learning materials with the new syntax.
+ms.custom: updateeachrelease
 ms.date: 03/14/2022
 ---
 # .NET 6 C# console app template generates top-level statements
@@ -29,7 +30,7 @@ namespace MyApp // Note: actual namespace depends on the project name.
 }
 ```
 
-These two forms represent the same program. Both are valid with C# 10.0. When you use the newer version, you only need to write the body of the `Main` method. You don't need to include the other program elements. You have two options to work with tutorials that haven't been updated yet for .NET 6:
+These two forms represent the same program. Both are valid with C# 10.0. When you use the newer version, you only need to write the body of the `Main` method. You don't need to include the other program elements. You have two options to work with tutorials that haven't been updated to use .NET 6+ templates:
 
 - Use the new program style, adding new top-level statements as you add features.
 - Convert the new program style to the older style, with a `Program` class and a `Main` method.

--- a/docs/core/tutorials/top-level-templates.md
+++ b/docs/core/tutorials/top-level-templates.md
@@ -1,18 +1,18 @@
 ---
-title: "C# template changes in .NET 6"
-description: The C# console app template now uses top-level statements. Understand what's changed and how to use existing learning materials with the new syntax.
-ms.date: 03/11/2022
+title: "C# console app template changes in .NET 6"
+description: The .NET 6 project template for C# console apps uses top-level statements. Understand what's changed and how to use existing learning materials with the new syntax.
+ms.date: 03/14/2022
 ---
-# New C# templates generate top-level statements
+# .NET 6 C# console app template generates top-level statements
 
-Starting with .NET 6, new C# projects using the `console` template generate different code than previous versions:
+Starting with .NET 6, the project template for new C# console apps generates the following code in the *Program.cs* file:
 
 ```csharp
 // See https://aka.ms/new-console-template for more information
 Console.WriteLine("Hello, World!");
 ```
 
-The new output uses recent C# features that simplify the code you need to write for a program. Traditionally, the console app template generated the following code:
+The new output uses recent C# features that simplify the code you need to write for a program. For .NET 5 and earlier versions, the console app template generates the following code:
 
 ```csharp
 using System;
@@ -29,12 +29,12 @@ namespace MyApp // Note: actual namespace depends on the project name.
 }
 ```
 
-These two forms represent the same program. Both are valid with C# 10.0. When you use the newer version, you only need to write the body of the `Main` method. You don't need to include the other program elements. You have two options to work with existing tutorials:
+These two forms represent the same program. Both are valid with C# 10.0. When you use the newer version, you only need to write the body of the `Main` method. You don't need to include the other program elements. You have two options to work with tutorials that haven't been updated yet for .NET 6:
 
 - Use the new program style, adding new top-level statements as you add features.
 - Convert the new program style to the older style, with a `Program` class and a `Main` method.
 
-If you want to use the old templates, see the [Use the old program style](#use-the-old-program-style) section.
+If you want to use the old templates, see [Use the old program style](#use-the-old-program-style) later in this article.
 
 ## Use the new program style
 

--- a/docs/core/tutorials/top-level-templates.md
+++ b/docs/core/tutorials/top-level-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "C# template changes in .NET 6"
 description: The C# console app template now uses top-level statements. Understand what's changed and how to use existing learning materials with the new syntax.
-ms.date: 02/28/2022
+ms.date: 03/11/2022
 ---
 # New C# templates generate top-level statements
 

--- a/docs/csharp/fundamentals/program-structure/index.md
+++ b/docs/csharp/fundamentals/program-structure/index.md
@@ -1,7 +1,7 @@
 ---
 title: "General Structure of a C# Program"
 description: Learn about the structure of a C# program by using a skeleton program that contains all the required elements for a program.
-ms.date: 05/14/2021
+ms.date: 03/11/2022
 helpviewer_keywords: 
   - "C# language, program structure"
 ms.assetid: 5ae964a5-0ef0-40fe-88fb-6d1793371d0d

--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -1,9 +1,11 @@
 ---
-title: A Tour of C# - Major language areas
+title: A tour of C# - Major language areas
 description: New to C#? Learn the basics of the language. This article contains a survey of major language features.
 ms.date: 03/14/2022
 ---
 # C# major language areas
+
+This article introduces the main features of the C# language.
 
 ## Arrays, collections, and LINQ
 

--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -1,9 +1,9 @@
 ---
 title: A Tour of C# - Major language areas
 description: New to C#? Learn the basics of the language. This article contains a survey of major language features.
-ms.date: 08/23/2021
+ms.date: 03/14/2022
 ---
-# Major language areas
+# C# major language areas
 
 ## Arrays, collections, and LINQ
 
@@ -98,7 +98,7 @@ The following example declares a `HelpAttribute` attribute that can be placed on
 
 :::code language="csharp" source="./snippets/shared/Features.cs" ID="DefineAttribute":::
 
-All attribute classes derive from the <xref:System.Attribute> base class provided by the .NET library. Attributes can be applied by giving their name, along with any arguments, inside square brackets just before the associated declaration. If an attribute’s name ends in `Attribute`, that part of the name can be omitted when the attribute is referenced. For example, the `HelpAttribute` can be used as follows.
+All attribute classes derive from the <xref:System.Attribute> base class provided by the .NET library. Attributes can be applied by giving their name, along with any arguments, inside square brackets just before the associated declaration. If an attribute's name ends in `Attribute`, that part of the name can be omitted when the attribute is referenced. For example, the `HelpAttribute` can be used as follows.
 
 :::code language="csharp" source="./snippets/shared/Features.cs" ID="UseAttributes":::
 

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -1,5 +1,5 @@
 ---
-title: A Tour of C# - C# Guide
+title: A tour of C# - Overview
 description: New to C#? Learn the basics of the language. Start with this overview.
 ms.date: 03/14/2022
 ---

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -1,7 +1,7 @@
 ---
 title: A Tour of C# - C# Guide
 description: New to C#? Learn the basics of the language. Start with this overview.
-ms.date: 09/30/2021
+ms.date: 03/14/2022
 ---
 
 # A tour of the C# language

--- a/docs/csharp/tour-of-csharp/program-building-blocks.md
+++ b/docs/csharp/tour-of-csharp/program-building-blocks.md
@@ -1,9 +1,9 @@
 ---
-title: The building blocks of C# programs
+title: A Tour of C# - The building blocks of C# programs
 description: Learn about C# members, expressions, and statements. Types contain members you write. Those members are built from statements and expressions.
-ms.date: 03/11/2022
+ms.date: 03/14/2022
 ---
-# Program building blocks
+# C# program building blocks
 
 The types described in the previous article are built using these building blocks: [***members***](../programming-guide/classes-and-structs/members.md), [***expressions***, and ***statements***](../programming-guide/statements-expressions-operators/index.md).
 

--- a/docs/csharp/tour-of-csharp/program-building-blocks.md
+++ b/docs/csharp/tour-of-csharp/program-building-blocks.md
@@ -1,11 +1,15 @@
 ---
-title: A Tour of C# - The building blocks of C# programs
-description: Learn about C# members, expressions, and statements. Types contain members you write. Those members are built from statements and expressions.
+title: A tour of C# - The building blocks of C# programs
+description: Learn about C# members, expressions, and statements. Members include properties, fields, events, operators, nested types, and more.
 ms.date: 03/14/2022
 ---
 # C# program building blocks
 
-The types described in the previous article are built using these building blocks: [***members***](../programming-guide/classes-and-structs/members.md), [***expressions***, and ***statements***](../programming-guide/statements-expressions-operators/index.md).
+The types described in [the previous article](types.md) are built by using these building blocks:
+
+* [Members](#members), such as properties, fields, methods, and events.
+* [Expressions](#expressions)
+* [Statements](#statements)
 
 ## Members
 
@@ -24,7 +28,7 @@ The following list provides an overview of the kinds of members a class can cont
 - **Finalizers**: Actions done before instances of the class are permanently discarded
 - **Types**: Nested types declared by the class
 
-## Accessibility
+### Accessibility
 
 Each member of a class has an associated accessibility, which controls the regions of program text that can access the member. There are six possible forms of accessibility. The access modifiers are summarized below.
 

--- a/docs/csharp/tour-of-csharp/program-building-blocks.md
+++ b/docs/csharp/tour-of-csharp/program-building-blocks.md
@@ -1,7 +1,7 @@
 ---
 title: The building blocks of C# programs
 description: Learn about C# members, expressions, and statements. Types contain members you write. Those members are built from statements and expressions.
-ms.date: 08/23/2021
+ms.date: 03/11/2022
 ---
 # Program building blocks
 
@@ -47,13 +47,13 @@ In the following example, each instance of the `Color` class has a separate copy
 
 :::code language="csharp" source="./snippets/shared/ClassesObjects.cs" ID="ColorClassDefinition":::
 
-As shown in the previous example, *read-only fields* may be declared with a `readonly` modifier. Assignment to a read-only field can only occur as part of the field’s declaration or in a constructor in the same class.
+As shown in the previous example, *read-only fields* may be declared with a `readonly` modifier. Assignment to a read-only field can only occur as part of the field's declaration or in a constructor in the same class.
 
 ## Methods
 
 A *method* is a member that implements a computation or action that can be performed by an object or class. *Static methods* are accessed through the class. *Instance methods* are accessed through instances of the class.
 
-Methods may have a list of *parameters*, which represent values or variable references passed to the method. Methods have a *return type*, which specifies the type of the value computed and returned by the method. A method’s return type is `void` if it doesn't return a value.
+Methods may have a list of *parameters*, which represent values or variable references passed to the method. Methods have a *return type*, which specifies the type of the value computed and returned by the method. A method's return type is `void` if it doesn't return a value.
 
 Like types, methods may also have a set of type parameters, for which type arguments must be specified when the method is called. Unlike types, the type arguments can often be inferred from the arguments of a method call and need not be explicitly given.
 
@@ -95,7 +95,7 @@ is equivalent to writing the following.
 
 ### Method body and local variables
 
-A method’s body specifies the statements to execute when the method is invoked.
+A method's body specifies the statements to execute when the method is invoked.
 
 A method body can declare variables that are specific to the invocation of the method. Such variables are called *local variables*. A local variable declaration specifies a type name, a variable name, and possibly an initial value. The following example declares a local variable `i` with an initial value of zero and a local variable `j` with no initial value.
 

--- a/docs/csharp/tour-of-csharp/program-building-blocks.md
+++ b/docs/csharp/tour-of-csharp/program-building-blocks.md
@@ -1,11 +1,11 @@
 ---
 title: A tour of C# - The building blocks of C# programs
-description: Learn about C# members, expressions, and statements. Members include properties, fields, events, operators, nested types, and more.
+description: Learn about C# members, expressions, and statements. Members include properties, fields, methods, events, operators, nested types, and more.
 ms.date: 03/14/2022
 ---
 # C# program building blocks
 
-The types described in [the previous article](types.md) are built by using these building blocks:
+The types described in [the previous article in this Tour of C# series](types.md) are built by using these building blocks:
 
 * [Members](#members), such as properties, fields, methods, and events.
 * [Expressions](#expressions)

--- a/docs/csharp/tour-of-csharp/types.md
+++ b/docs/csharp/tour-of-csharp/types.md
@@ -1,5 +1,5 @@
 ---
-title: A Tour of C# - Types and their members
+title: A tour of C# - Types and their members
 description: The building blocks of programs are types. Learn how to create classes, structs, interfaces, and more in C#.
 ms.date: 03/14/2022
 ---

--- a/docs/csharp/tour-of-csharp/types.md
+++ b/docs/csharp/tour-of-csharp/types.md
@@ -5,7 +5,7 @@ ms.date: 03/14/2022
 ---
 # C# types and members
 
-As an object-oriented language, C# supports the concepts of encapsulation, inheritance, and polymorphism. A class may inherit directly from one parent class, and it may implement any number of interfaces. Methods that override virtual methods in a parent class require the `override` keyword as a way to avoid accidental redefinition. In C#, a struct is like a lightweight class; it's a stack-allocated type that can implement interfaces but doesn't support inheritance. C# provides `record class`, and `record struct` types, which are types whose purpose is primarily storing data values.
+As an object-oriented language, C# supports the concepts of encapsulation, inheritance, and polymorphism. A class may inherit directly from one parent class, and it may implement any number of interfaces. Methods that override virtual methods in a parent class require the `override` keyword as a way to avoid accidental redefinition. In C#, a struct is like a lightweight class; it's a stack-allocated type that can implement interfaces but doesn't support inheritance. C# provides `record class` and `record struct` types, which are types whose purpose is primarily storing data values.
 
 ## Classes and objects
 

--- a/docs/csharp/tour-of-csharp/types.md
+++ b/docs/csharp/tour-of-csharp/types.md
@@ -1,15 +1,15 @@
 ---
-title: Define types and their members - A tour of C#
+title: A Tour of C# - Types and their members
 description: The building blocks of programs are types. Learn how to create classes, structs, interfaces, and more in C#.
-ms.date: 08/23/2021
+ms.date: 03/14/2022
 ---
-# Types and members
+# C# types and members
 
-As an object-oriented language, C# supports the concepts of encapsulation, inheritance, and polymorphism. A class may inherit directly from one parent class, and it may implement any number of interfaces. Methods that override virtual methods in a parent class require the `override` keyword as a way to avoid accidental redefinition. In C#, a struct is like a lightweight class; it's a stack-allocated type that can implement interfaces but doesn't support inheritance. C# provides `record class`, and `record struct` types which are types whose purpose is primarily storing data values.
+As an object-oriented language, C# supports the concepts of encapsulation, inheritance, and polymorphism. A class may inherit directly from one parent class, and it may implement any number of interfaces. Methods that override virtual methods in a parent class require the `override` keyword as a way to avoid accidental redefinition. In C#, a struct is like a lightweight class; it's a stack-allocated type that can implement interfaces but doesn't support inheritance. C# provides `record class`, and `record struct` types, which are types whose purpose is primarily storing data values.
 
 ## Classes and objects
 
-*Classes* are the most fundamental of C#’s types. A class is a data structure that combines state (fields) and actions (methods and other function members) in a single unit. A class provides a definition for *instances* of the class, also known as *objects*. Classes support *inheritance* and *polymorphism*, mechanisms whereby *derived classes* can extend and specialize *base classes*.
+*Classes* are the most fundamental of C#'s types. A class is a data structure that combines state (fields) and actions (methods and other function members) in a single unit. A class provides a definition for *instances* of the class, also known as *objects*. Classes support *inheritance* and *polymorphism*, mechanisms whereby *derived classes* can extend and specialize *base classes*.
 
 New classes are created using class declarations. A class declaration starts with a header. The header specifies:
 

--- a/docs/standard/native-interop/cross-platform.md
+++ b/docs/standard/native-interop/cross-platform.md
@@ -2,7 +2,7 @@
 title: Cross Platform P/Invoke
 description: Learn which paths the runtime will search when loading native libraries via P/Invoke. Also learn how to use SetDllImportResolver.
 author: saul
-ms.date: 01/31/2021
+ms.date: 03/11/2022
 ---
 
 # Writing cross platform P/Invoke code

--- a/docs/standard/native-interop/cross-platform.md
+++ b/docs/standard/native-interop/cross-platform.md
@@ -2,14 +2,17 @@
 title: Cross Platform P/Invoke
 description: Learn which paths the runtime will search when loading native libraries via P/Invoke. Also learn how to use SetDllImportResolver.
 author: saul
-ms.date: 03/11/2022
+ms.date: 03/14/2022
 ---
 
 # Writing cross platform P/Invoke code
 
+This article explains which paths the runtime searches when loading native libraries via P/Invoke. It also shows how to use
+<xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver%2A>.
+
 ## Library name variations
 
-To facilitate simpler cross platform P/Invoke code, the runtime adds the canonical shared library extension (`.dll`, `.so` or `.dylib`) to native library names. On Linux and macOS, the runtime will also try prepending `lib`. These library names variations are automatically searched when you use APIs that load unmanaged libraries (e.g., <xref:System.Runtime.InteropServices.DllImportAttribute>).
+To facilitate simpler cross platform P/Invoke code, the runtime adds the canonical shared library extension (`.dll`, `.so` or `.dylib`) to native library names. On Linux and macOS, the runtime will also try prepending `lib`. These library names variations are automatically searched when you use APIs that load unmanaged libraries, such as <xref:System.Runtime.InteropServices.DllImportAttribute>.
 
 > [!NOTE]
 > Absolute paths in library names (e.g., `/usr/lib/libc`) are treated as-is and no variations will be searched.


### PR DESCRIPTION
Contributes to #28383 

* Cross Platform P/Invoke

  Organic search January: 17%, February: 63%. The February rate is the norm for this article.  It normally gets around 1,000 PV/month, but on one day, January 13, it got 2,585 PV from Microsoft referrals, skewing the organic search percentage down to 17%. Number of visitors stayed low at 34 for the day, so all of the extra traffic came from one or a few visitors. So 63% is the accurate organic search rate and there is not necessarily an SEO problem, but I added an intro paragraph with the keywords that were provided in the meta description.

* Dapr for .NET Developers

  Organic search 16%. This is the cover page for an e-book. Most of the traffic comes from hub and landing pages, and other pages from the same e-book. A change that might improve SEO would be to spell out the name Distributed Application Runtime somewhere besides just the meta description, but the page can't be modified without getting out of sync with the e-book.

* Architectural principles

  This is an e-book chapter, so any changes to the article would make it out of sync with the e-book it's a copy of.

* C# template changes in .NET 6

  Organic search 18%. Direct traffic rate is 75% due to an aka.ms link included in a code comment in the Program.cs file created by the .NET 6 C# console application project template (aka.ms/new-console-template). I changed title, h1, and first paragraph to emphasize the top keywords -- .NET 6, console app, and program.cs.

* Define types and their members - A tour of C#

  Organic search 15%. This is part of the "tour of C#" series, and most of the traffic comes from "next" and "previous" buttons and menu selections -- 70% of traffic is Microsoft. All of the top keywords include C#, but that was missing from the h1, so I added it. There are similar C# pages competing for the same keywords as this article, for example, "define C# classes" leads to the [C# fundamentals article on classes](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/types/classes), which is actually a better result than this article would be for that search.

* General Structure of a C# Program

  Organic search 16%. This is part of a series in the C# fundamentals section, and Microsoft traffic is 83%, mostly from other fundamentals pages, tour of C# pages, and the C# landing page. A search for "C# program structure" produces this article as the first result and highlights the first paragraph as the quick question answer. No changes needed.

* The building blocks of C# programs

  Organic search 7%. This is a Tour of C# article and most of its traffic comes from those pages and other C# pages. Few searches look for "building blocks", so I revised the first paragraph to specify some of the names most likely to be searched for.

The Tour of C# articles were inconsistent in how they included the series title in the article title -- one had "A tour of C#" in front of the article title, two had it after the article title, and one didn't have it at all.  I made all use the prefix arrangement.