### PR TITLE
Typo "**-out **"→"-out "

### DIFF
--- a/docs/csharp/misc/cs2022.md
+++ b/docs/csharp/misc/cs2022.md
@@ -12,4 +12,4 @@ ms.assetid: d22de497-c4ef-466f-8fbc-6faba7ba5ad0
 
 Options '/out' and '/target' must appear before source file names  
   
- The [/out (Set Output Filename)](../language-reference/compiler-options/output.md#outputassembly) and [/target (Specify Output File Format)](../language-reference/compiler-options/output.md#targettype) compiler options, when specified on the command line, must precede the source code files.
+ The [**-out** (Set Output Filename)](../language-reference/compiler-options/output.md#outputassembly) and [-target (Specify Output File Format)](../language-reference/compiler-options/output.md#targettype) compiler options, when specified on the command line, must precede the source code files.

--- a/docs/csharp/misc/cs2022.md
+++ b/docs/csharp/misc/cs2022.md
@@ -12,4 +12,4 @@ ms.assetid: d22de497-c4ef-466f-8fbc-6faba7ba5ad0
 
 Options '/out' and '/target' must appear before source file names  
   
- The [-out (Set Output Filename)](../language-reference/compiler-options/output.md#outputassembly) and [-target (Specify Output File Format)](../language-reference/compiler-options/output.md#targettype) compiler options, when specified on the command line, must precede the source code files.
+ The [/out (Set Output Filename)](../language-reference/compiler-options/output.md#outputassembly) and [/target (Specify Output File Format)](../language-reference/compiler-options/output.md#targettype) compiler options, when specified on the command line, must precede the source code files.

--- a/docs/csharp/misc/cs2022.md
+++ b/docs/csharp/misc/cs2022.md
@@ -12,4 +12,4 @@ ms.assetid: d22de497-c4ef-466f-8fbc-6faba7ba5ad0
 
 Options '/out' and '/target' must appear before source file names  
   
- The [**-out **(Set Output Filename)](../language-reference/compiler-options/output.md#outputassembly) and [-target (Specify Output File Format)](../language-reference/compiler-options/output.md#targettype) compiler options, when specified on the command line, must precede the source code files.
+ The [-out (Set Output Filename)](../language-reference/compiler-options/output.md#outputassembly) and [-target (Specify Output File Format)](../language-reference/compiler-options/output.md#targettype) compiler options, when specified on the command line, must precede the source code files.


### PR DESCRIPTION
## Summary
Typo "**-out **"→"-out "
https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs2022
https://github.com/dotnet/docs/blob/main/docs/csharp/misc/cs2022.md
#PingMSFTDocs

Describe your changes here.
Typo "**-out **"→"-out "

Fixes #Issue_Number (if available)
