### PR TITLE
Add reference to MMLib.SwaggerForOcelot package

### DIFF
--- a/docs/architecture/microservices/multi-container-microservice-net-applications/implement-api-gateways-with-ocelot.md
+++ b/docs/architecture/microservices/multi-container-microservice-net-applications/implement-api-gateways-with-ocelot.md
@@ -570,6 +570,9 @@ There are other important features to research and use, when using an Ocelot API
 
 - **Rate limiting** \
   [https://ocelot.readthedocs.io/en/latest/features/ratelimiting.html](https://ocelot.readthedocs.io/en/latest/features/ratelimiting.html )
+  
+- **Swagger for Ocelot** \
+  [https://github.com/Burgyn/MMLib.SwaggerForOcelot](https://github.com/Burgyn/MMLib.SwaggerForOcelot)
 
 > [!div class="step-by-step"]
 > [Previous](background-tasks-with-ihostedservice.md)


### PR DESCRIPTION
## Summary

Hi,

Many developers are looking for how to generate documentation for the microservices that Ocelot Api Gateway covers. [MMLib.SwaggerForOcelot](https://github.com/Burgyn/MMLib.SwaggerForOcelot) is a popular nugget package that solves this. 

I would like to add it to this documentation to make it easier for developers to find a solution.
