### PR TITLE
Update Snippet for the event pattern documentation

### DIFF
--- a/samples/snippets/csharp/events/Program.cs
+++ b/samples/snippets/csharp/events/Program.cs
@@ -12,10 +12,10 @@ namespace EventSampleCode
     {
         static void Main(string[] args)
         {
+            // <SnippetDeclareEventHandler>
             var fileLister = new FileSearcher();
             int filesFound = 0;
-
-            // <SnippetDeclareEventHandler>
+            
             EventHandler<FileFoundArgs> onFileFound = (sender, eventArgs) =>
             {
                 Console.WriteLine(eventArgs.FoundFile);


### PR DESCRIPTION
Moved \<SnippetDeclareEventHandler\> to include the instantiation of the FileSearcher class as 'fileLister'. 
As it stands the documentation shows 'fileLister' being referred to with no explanation where it originated, making it ambiguous.