### PR TITLE
Fixed `new Guid()` in Orleans code sample

### DIFF
--- a/docs/orleans/grains/request-context.md
+++ b/docs/orleans/grains/request-context.md
@@ -30,7 +30,7 @@ Application metadata also is maintained when you schedule a future computation u
 For example, to set a trace id in the client to a new `Guid`, one would simply call:
 
 ```csharp
-RequestContext.Set("TraceId", new Guid());
+RequestContext.Set("TraceId", Guid.NewGuid());
 ```
 
 Within grain code (or other code that runs within Orleans on a scheduler thread), the trace id of the original client request could be used, for instance, when writing a log:


### PR DESCRIPTION
## Summary

Calling `new Guid()` returns the default guid (all zeros), which is not a very helpful trace id :¬)
