### PR TITLE
Improve the Nullable description with the .NET 6 template

### DIFF
--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -121,7 +121,7 @@ The following table lists the minimum versions of the SDK with the C# compiler t
 
 ## Nullable
 
-The **Nullable** option lets you specify the nullable context.  The default value for this option is `disable`.
+The **Nullable** option lets you specify the nullable context. It can be set in the project's configuration using the `<Nullable>` tag:
 
 ```xml
 <Nullable>enable</Nullable>

--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -128,7 +128,9 @@ The **Nullable** option lets you specify the nullable context. It can be set in 
 ```
 
 The argument must be one of `enable`, `disable`, `warnings`, or `annotations`. The `enable` argument enables the nullable context. Specifying `disable` will disable the nullable context. When providing the `warnings` argument the nullable warning context is enabled. When specifying the `annotations` argument, the nullable annotation context is enabled.
-<br/>When there's no value set, the default value `disable` is applied, however **note** that the .NET 6 templates are by default provided with the **Nullable** value set to `enable`.
+
+> [!NOTE]
+> When there's no value set, the default value `disable` is applied, however the .NET 6 templates are by default provided with the **Nullable** value set to `enable`.
 
 Flow analysis is used to infer the nullability of variables within executable code. The inferred nullability of a variable is independent of the variable's declared nullability. Method calls are analyzed even when they're conditionally omitted. For instance, <xref:System.Diagnostics.Debug.Assert%2A?displayProperty=nameWithType> in release mode.
 

--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -128,6 +128,7 @@ The **Nullable** option lets you specify the nullable context. It can be set in 
 ```
 
 The argument must be one of `enable`, `disable`, `warnings`, or `annotations`. The `enable` argument enables the nullable context. Specifying `disable` will disable the nullable context. When providing the `warnings` argument the nullable warning context is enabled. When specifying the `annotations` argument, the nullable annotation context is enabled.
+<br/>When there's no value set, the default value `disable` is applied, however **note** that the .NET 6 templates are by default provided with the **Nullable** value set to `enable`.
 
 Flow analysis is used to infer the nullability of variables within executable code. The inferred nullability of a variable is independent of the variable's declared nullability. Method calls are analyzed even when they're conditionally omitted. For instance, <xref:System.Diagnostics.Debug.Assert%2A?displayProperty=nameWithType> in release mode.
 


### PR DESCRIPTION
This pull request fixes #28578 

It replaces the default value mentioned at the beginning with the explanation about the .NET 6 templates having this value set and mentioning the default value **after** all values listed.
There's also the structure of this article's part changed so that the example is provided with the introduction.