### PR TITLE
PatternContext<T> breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -27,6 +27,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | - | :-: | :-: | - |
 | [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
 | [FullPath and OldFullPath return fully qualified path](core-libraries/7.0/filesystemeventargs-fullpath.md) | ✔️ | ❌ | Preview 1 |
+| [Generic type constraint on PatternContext<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ | Preview 3 |
 | [Validate CompressionLevel for BrotliStream](core-libraries/7.0/compressionlevel-validation.md) | ❌ | ✔️ | Preview 1 |
 
 ## Serialization

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -27,7 +27,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | - | :-: | :-: | - |
 | [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
 | [FullPath and OldFullPath return fully qualified path](core-libraries/7.0/filesystemeventargs-fullpath.md) | ✔️ | ❌ | Preview 1 |
-| [Generic type constraint on PatternContext<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ | Preview 3 |
+| [Generic type constraint on PatternContext\<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ | Preview 3 |
 | [Validate CompressionLevel for BrotliStream](core-libraries/7.0/compressionlevel-validation.md) | ❌ | ✔️ | Preview 1 |
 
 ## Serialization

--- a/docs/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint.md
+++ b/docs/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint.md
@@ -3,7 +3,7 @@ title: ".NET 7 breaking change: Generic type constraint on PatternContext<T>"
 description: Learn about the .NET 7 breaking change in core .NET libraries where the generic type parameter on PatternContext<T> is constrained to be a struct type.
 ms.date: 03/16/2022
 ---
-# Generic type constraint on PatternContext<T>
+# Generic type constraint on PatternContext\<T>
 
 As part of annotating the .NET library for nullable, a new generic constraint was added to <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601>. If you're consuming this class directly, your code may break if the `TFrame` type is not a struct.
 

--- a/docs/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint.md
+++ b/docs/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint.md
@@ -1,0 +1,36 @@
+---
+title: ".NET 7 breaking change: Generic type constraint on PatternContext<T>"
+description: Learn about the .NET 7 breaking change in core .NET libraries where the generic type parameter on PatternContext<T> is constrained to be a struct type.
+ms.date: 03/16/2022
+---
+# Generic type constraint on PatternContext<T>
+
+As part of annotating the .NET library for nullable, a new generic constraint was added to <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601>. If you're consuming this class directly, your code may break if the `TFrame` type is not a struct.
+
+## Previous behavior
+
+Previously, <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601> allowed any type to fill the `TFrame` type parameter.
+
+## New behavior
+
+Starting in .NET 7, the generic type parameter on <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601>, `TFrame`, is constrained to be a [struct](../../../../csharp/language-reference/builtin-types/struct.md).
+
+## Version introduced
+
+.NET 7 Preview 3
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility) and [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change was necessary to annotate the type correctly for nullable.
+
+## Recommended action
+
+If you're currently using this type in your code, we recommend that you remove it. This type supports infrastructure and is not intended to be used directly from your code.
+
+## Affected APIs
+
+- <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint.md
+++ b/docs/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint.md
@@ -5,7 +5,7 @@ ms.date: 03/16/2022
 ---
 # Generic type constraint on PatternContext\<T>
 
-As part of annotating the .NET library for nullable, a new generic constraint was added to <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601>. If you're consuming this class directly, your code may break if the `TFrame` type is not a struct.
+As part of annotating the .NET library for nullable reference types, a new generic constraint was added to <xref:Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext%601>. If you're consuming this class directly, your code may break if the `TFrame` type is not a struct.
 
 ## Previous behavior
 
@@ -25,7 +25,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 ## Reason for change
 
-This change was necessary to annotate the type correctly for nullable.
+This change was necessary to annotate the type correctly for nullable contexts.
 
 ## Recommended action
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -39,6 +39,8 @@ items:
           href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
         - name: FullPath and OldFullPath return fully qualified path
           href: core-libraries/7.0/filesystemeventargs-fullpath.md
+        - name: Generic type constraint on PatternContext<T>
+          href: core-libraries/7.0/patterncontext-generic-constraint.md
         - name: Validate CompressionLevel for BrotliStream
           href: core-libraries/7.0/compressionlevel-validation.md
       - name: Serialization
@@ -683,6 +685,8 @@ items:
           href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
         - name: FullPath and OldFullPath return fully qualified path
           href: core-libraries/7.0/filesystemeventargs-fullpath.md
+        - name: Generic type constraint on PatternContext<T>
+          href: core-libraries/7.0/patterncontext-generic-constraint.md
         - name: Validate CompressionLevel for BrotliStream
           href: core-libraries/7.0/compressionlevel-validation.md
       - name: .NET 6


### PR DESCRIPTION
Fixes #28705.

[Preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/patterncontext-generic-constraint?branch=pr-en-us-28709).