### PR TITLE
Add reference links for static abstract interface members

### DIFF
--- a/docs/csharp/fundamentals/types/interfaces.md
+++ b/docs/csharp/fundamentals/types/interfaces.md
@@ -24,7 +24,7 @@ The definition of `IEquatable<T>` doesn't provide an implementation for `Equals`
 
 For more information about abstract classes, see [Abstract and Sealed Classes and Class Members](../../programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md).
 
-Interfaces can contain instance methods, properties, events, indexers, or any combination of those four member types. Interfaces may contain static constructors, fields, constants, or operators. An interface can't contain instance fields, instance constructors, or finalizers. Interface members are public by default, and you can explicitly specify accessibility modifiers, such as `public`, `protected`, `internal`, `private`, `protected internal`, or `private protected`. A `private` member must have a default implementation.
+Interfaces can contain instance methods, properties, events, indexers, or any combination of those four member types. Interfaces may contain static constructors, fields, constants, or operators. Beginning with C# 11, interfaces may contain `static abstract` members other than fields. An interface can't contain instance fields, instance constructors, or finalizers. Interface members are public by default, and you can explicitly specify accessibility modifiers, such as `public`, `protected`, `internal`, `private`, `protected internal`, or `private protected`. A `private` member must have a default implementation.
 
 To implement an interface member, the corresponding member of the implementing class must be public, non-static, and have the same name and signature as the interface member.
 

--- a/docs/csharp/fundamentals/types/interfaces.md
+++ b/docs/csharp/fundamentals/types/interfaces.md
@@ -24,7 +24,7 @@ The definition of `IEquatable<T>` doesn't provide an implementation for `Equals`
 
 For more information about abstract classes, see [Abstract and Sealed Classes and Class Members](../../programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md).
 
-Interfaces can contain instance methods, properties, events, indexers, or any combination of those four member types. Interfaces may contain static constructors, fields, constants, or operators. Beginning with C# 11, interfaces may contain `static abstract` members other than fields. An interface can't contain instance fields, instance constructors, or finalizers. Interface members are public by default, and you can explicitly specify accessibility modifiers, such as `public`, `protected`, `internal`, `private`, `protected internal`, or `private protected`. A `private` member must have a default implementation.
+Interfaces can contain instance methods, properties, events, indexers, or any combination of those four member types. Interfaces may contain static constructors, fields, constants, or operators. Beginning with C# 11, interface members that aren't fields may be `static abstract`. An interface can't contain instance fields, instance constructors, or finalizers. Interface members are public by default, and you can explicitly specify accessibility modifiers, such as `public`, `protected`, `internal`, `private`, `protected internal`, or `private protected`. A `private` member must have a default implementation.
 
 To implement an interface member, the corresponding member of the implementing class must be public, non-static, and have the same name and signature as the interface member.
 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -37,7 +37,7 @@ These preceding member declarations typically do not contain a body. Beginning w
 - Member declarations using the explicit interface implementation syntax.
 - Explicit access modifiers (the default access is [`public`](access-modifiers.md)).
 
-Beginning with C# 11, an interface may declare `static abstract` members for all member types except fields. This feature enables generic algorithms to specify number-like behavior. You can try this feature by working with our tutorial on [static abstract members in interfaces](../../whats-new/tutorials/static-abstract-interface-methods.md).
+Beginning with C# 11, an interface may declare `static abstract` members for all member types except fields. This feature enables generic algorithms to specify number-like behavior. You can try this feature by working with the tutorial on [static abstract members in interfaces](../../whats-new/tutorials/static-abstract-interface-methods.md).
 
 Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field. This rule has a subtle effect on property declarations. In an interface declaration, the following code does not declare an auto-implemented property as it does in a `class` or `struct`. Instead, it declares a property that doesn't have a default implementation but must be implemented in any type that implements the interface:
 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -37,6 +37,8 @@ These preceding member declarations typically do not contain a body. Beginning w
 - Member declarations using the explicit interface implementation syntax.
 - Explicit access modifiers (the default access is [`public`](access-modifiers.md)).
 
+Beginning with C# 11, an interface may declare `static abstract` members for all member types except fields. This feature enables generic algorithms to specify number-like behavior. You can try this feature by working with our tutorial on [static abstract members in interfaces](../../whats-new/tutorials/static-abstract-interface-methods.md).
+
 Interfaces may not contain instance state. While static fields are now permitted, instance fields are not permitted in interfaces. [Instance auto-properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) are not supported in interfaces, as they would implicitly declare a hidden field. This rule has a subtle effect on property declarations. In an interface declaration, the following code does not declare an auto-implemented property as it does in a `class` or `struct`. Instead, it declares a property that doesn't have a default implementation but must be implemented in any type that implements the interface:
 
 ```csharp


### PR DESCRIPTION
Starting with 17.1, developers can turn on this feature.
