### PR TITLE
Update how-to-count-occurrences-of-a-word-in-a-string-linq.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
@@ -32,7 +32,7 @@ class CountWords
         //Convert the string into an array of words  
         string[] source = text.Split(new char[] { '.', '?', '!', ' ', ';', ':', ',' }, StringSplitOptions.RemoveEmptyEntries);  
   
-        // Create the query.  Use ToLowerInvariant to match "data" and "Data"
+        // Create the query.  Use the InvariantCultureIgnoreCase comparision to match "data" and "Data"
         var matchQuery = from word in source  
                          where word.Equals(searchTerm, StringComparison.InvariantCultureIgnoreCase)  
                          select word;  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
@@ -34,7 +34,7 @@ class CountWords
   
         // Create the query.  Use ToLowerInvariant to match "data" and "Data"
         var matchQuery = from word in source  
-                         where word.ToLowerInvariant() == searchTerm.ToLowerInvariant()  
+                         where word.Equals(searchTerm, StringComparison.InvariantCultureIgnoreCase)  
                          select word;  
   
         // Count the matches, which executes the query.  


### PR DESCRIPTION
Use of ToLowerInvariant leads to lot of garbage and also serves as a bad example for junior developers. Let's give them a better example with string.Equals and StringComparison enumeration.