### PR TITLE
ASP.NET Core 7 breaking change for MVC Logger Event IDs

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -17,6 +17,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ | Preview 2 |
+| [Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed](aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md) | ❌ | ✔️ | Preview 3 |
 | [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed](aspnet-core/7.0/libuv-transport-dll-removed.md) | ❌ | ❌ | Preview 1 |
 | [Microsoft.Data.SqlClient updated to 4.0.1](aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md) | ✔️ | ❌ | Preview 2 |
 | [SignalR Hub methods try to resolve parameters from DI](aspnet-core/7.0/signalr-hub-method-parameters-di.md) | ✔️ | ❌ | Preview 2 |

--- a/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
+++ b/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
@@ -14,7 +14,7 @@ ASP.NET Core 7.0 Preview 3
 
 ## Previous behavior
 
-Some logger event IDs in `Microsoft.AspNetCore.Mvc.Core` were reused within a single log category.
+Some logger event IDs within the `Microsoft.AspNetCore.Mvc.Core` assembly were reused within a single log category.
 
 ## New behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
+++ b/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
@@ -1,0 +1,37 @@
+---
+title: "Breaking change: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed"
+description: Learn about the breaking change in ASP.NET Core 7.0 event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed.
+ms.date: 03/23/2022
+---
+
+# Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed
+
+As part of updating the `Microsoft.AspNetcore.Mvc.Core` assembly to use <xref:Microsoft.Extensions.Logging.LoggerMessageAttribute>, the ASP.NET Core team discovered logger event IDs that were reused within a single log category. Event IDs and names should be unique so that different message types can be identified. These IDs have been updated to ensure that they're unique within a single log category.
+
+## Version introduced
+
+ASP.NET Core 7.0 Preview 3
+
+## Previous behavior
+
+Some logger event IDs in `Microsoft.AspNetCore.Mvc.Core` were reused within a single log category.
+
+## New behavior
+
+Duplicate logger event IDs within a single log category within the `Microsoft.AspNetCore.Mvc.Core` assembly have been updated.
+
+## Type of breaking change
+
+This change affects [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+Logger event IDs and names should be unique so that different message types can be identified.
+
+## Recommended action
+
+If you have code or configuration that references the old logger event IDs, update those references to use the new IDs.
+
+## Affected APIs
+
+Not detectable via API analysis.

--- a/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
+++ b/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
@@ -1,6 +1,6 @@
 ---
 title: "Breaking change: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed"
-description: Learn about the breaking change in ASP.NET Core 7.0 event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed.
+description: Learn about the breaking change in ASP.NET Core 7.0 where event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed.
 ms.date: 03/23/2022
 ---
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -27,7 +27,7 @@ items:
         items:
         - name: API controller actions try to infer parameters from DI
           href: aspnet-core/7.0/api-controller-action-parameters-di.md
-        - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed]
+        - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed
           href: aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
         - name: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed
           href: aspnet-core/7.0/libuv-transport-dll-removed.md
@@ -533,7 +533,7 @@ items:
         items:
           - name: API controller actions try to infer parameters from DI
             href: aspnet-core/7.0/api-controller-action-parameters-di.md
-          - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed]
+          - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed
             href: aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
           - name: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed
             href: aspnet-core/7.0/libuv-transport-dll-removed.md

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -27,6 +27,8 @@ items:
         items:
         - name: API controller actions try to infer parameters from DI
           href: aspnet-core/7.0/api-controller-action-parameters-di.md
+        - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed]
+          href: aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
         - name: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed
           href: aspnet-core/7.0/libuv-transport-dll-removed.md
         - name: Microsoft.Data.SqlClient updated to 4.0.1
@@ -531,6 +533,8 @@ items:
         items:
           - name: API controller actions try to infer parameters from DI
             href: aspnet-core/7.0/api-controller-action-parameters-di.md
+          - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed]
+            href: aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
           - name: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed
             href: aspnet-core/7.0/libuv-transport-dll-removed.md
           - name: Microsoft.Data.SqlClient updated to 4.0.1


### PR DESCRIPTION
Documents https://github.com/aspnet/Announcements/issues/483.

[Internal Review](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids?branch=pr-en-us-28776).