### PR TITLE
Discovery OKR

### DIFF
--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -1,7 +1,7 @@
 ---
 title: "Identifier names"
 description: "Learn the rules for valid identifier names in the C# programming language."
-ms.date: 08/21/2018
+ms.date: 03/23/2022
 ---
 # Identifier names
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -3,7 +3,7 @@ title: "C# identifier names"
 description: "Learn the rules for valid identifier names in the C# programming language."
 ms.date: 03/23/2022
 ---
-# C# identifier names - rules and conventions
+# C# identifier naming rules and conventions
 
 An **identifier** is the name you assign to a type (class, interface, struct, delegate, or enum), member, variable, or namespace.
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -5,7 +5,7 @@ ms.date: 03/23/2022
 ---
 # C# identifier naming rules and conventions
 
-An **identifier** is the name you assign to a type (class, interface, struct, delegate, or enum), member, variable, or namespace.
+An **identifier** is the name you assign to a type (class, interface, struct, record, delegate, or enum), member, variable, or namespace.
 
 ## Naming rules
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -1,13 +1,17 @@
 ---
-title: "Identifier names"
+title: "C# identifier names"
 description: "Learn the rules for valid identifier names in the C# programming language."
 ms.date: 03/23/2022
 ---
-# Identifier names
+# C# identifier names - rules and conventions
 
-An **identifier** is the name you assign to a type (class, interface, struct, delegate, or enum), member, variable, or namespace. Valid identifiers must follow these rules:
+An **identifier** is the name you assign to a type (class, interface, struct, delegate, or enum), member, variable, or namespace.
 
-- Identifiers must start with a letter, or `_`.
+## Naming rules
+
+Valid identifiers must follow these rules:
+
+- Identifiers must start with a letter or underscore (`_`).
 - Identifiers may contain Unicode letter characters, decimal digit characters, Unicode connecting characters, Unicode combining characters, or Unicode formatting characters. For more information on Unicode categories, see the [Unicode Category Database](https://www.unicode.org/reports/tr44/).
 You can declare identifiers that match C# keywords by using the `@` prefix on the identifier. The `@` is not part of the identifier name. For example, `@if` declares an identifier named `if`. These [verbatim identifiers](../../language-reference/tokens/verbatim.md) are primarily for interoperability with identifiers declared in other languages.
 
@@ -20,7 +24,9 @@ In addition to the rules, there are many identifier [naming conventions](../../.
 - Interface names start with a capital `I`.
 - Attribute types end with the word `Attribute`.
 - Enum types use a singular noun for non-flags, and a plural noun for flags.
-- Identifiers shouldn't contain two consecutive `_` characters. Those names are reserved for compiler-generated identifiers.
+- Identifiers shouldn't contain two consecutive underscore (`_`) characters. Those names are reserved for compiler-generated identifiers.
+
+For more information, see [Naming conventions](coding-conventions.md#naming-conventions).
 
 ## C# Language Specification
 

--- a/docs/csharp/fundamentals/object-oriented/index.md
+++ b/docs/csharp/fundamentals/object-oriented/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Classes, structs, and records"
+title: "Classes, structs, and records in C#"
 description: Describes the use of classes, structures (structs), and records in C#.
 ms.date: 03/23/2022
 helpviewer_keywords: 
@@ -12,11 +12,13 @@ helpviewer_keywords:
   - "objects [C#]"
   - "C# language, classes"
 ---
-# Object-oriented programming
+# Overview of classes, structs, and records in C\#
+
+In C#, the definition of a type&mdash;a class, struct, or record&mdashis like a blueprint that specifies what the type can do. An object is basically a block of memory that has been allocated and configured according to the blueprint. This article provides an overview of these blueprints and their features. The [next article in this series](objects.md) introduces objects.
 
 ## Encapsulation  
 
- *Encapsulation* is sometimes referred to as the first pillar or principle of object-oriented programming. A class or struct can specify how accessible each of its members is to code outside of the class or struct. Methods and variables that aren't intended to be used from outside of the class or assembly can be hidden to limit the potential for coding errors or malicious exploits. For more information, see [Object-oriented programming](../tutorials/oop.md).
+ *Encapsulation* is sometimes referred to as the first pillar or principle of object-oriented programming. A class or struct can specify how accessible each of its members is to code outside of the class or struct. Methods and variables that aren't intended to be used from outside of the class or assembly can be hidden to limit the potential for coding errors or malicious exploits. For more information, see the [Object-oriented programming](../tutorials/oop.md) tutorial.
 
 ## Members
 
@@ -34,7 +36,9 @@ The following list includes all the various kinds of members that may be declare
 - Indexers
 - Operators
 - Nested Types
-  
+
+For more information, see [Members](../../programming-guide/classes-and-structs/members.md).
+
 ## Accessibility  
 
  Some methods and properties are meant to be called or accessed from code outside a class or struct, known as *client code*. Other methods and properties might be only for use in the class or struct itself. It's important to limit the accessibility of your code so that only the intended client code can reach it. You specify how accessible your types and their members are to client code by using the following access modifiers:
@@ -50,9 +54,11 @@ The default accessibility is `private`.
   
 ## Inheritance  
 
-Classes (but not structs) support the concept of inheritance. A class that derives from another class, called the *base class*, automatically contains all the public, protected, and internal members of the base class except its constructors and finalizers. For more information, see [Inheritance](./inheritance.md) and [Polymorphism](./polymorphism.md).
+Classes (but not structs) support the concept of inheritance. A class that derives from another class, called the *base class*, automatically contains all the public, protected, and internal members of the base class except its constructors and finalizers.
   
 Classes may be declared as [abstract](../../language-reference/keywords/abstract.md), which means that one or more of their methods have no implementation. Although abstract classes cannot be instantiated directly, they can serve as base classes for other classes that provide the missing implementation. Classes can also be declared as [sealed](../../language-reference/keywords/sealed.md) to prevent other classes from inheriting from them.
+
+For more information, see [Inheritance](./inheritance.md) and [Polymorphism](./polymorphism.md).
   
 ## Interfaces  
 
@@ -64,31 +70,31 @@ Classes, structs, and records can be defined with one or more type parameters. C
   
 ## Static Types  
 
-Classes (but not structs or records) can be declared as `static`. A static class can contain only static members and can't be instantiated with the `new` keyword. One copy of the class is loaded into memory when the program loads, and its members are accessed through the class name. Classes, structs, and records can contain static members.
+Classes (but not structs or records) can be declared as `static`. A static class can contain only static members and can't be instantiated with the `new` keyword. One copy of the class is loaded into memory when the program loads, and its members are accessed through the class name. Classes, structs, and records can contain static members. For more information, see [Static classes and static class members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md).
   
 ## Nested Types
 
-A class, struct, or record can be nested within another class, struct, or record.
+A class, struct, or record can be nested within another class, struct, or record. For more information, see [Nested Types](../../programming-guide/classes-and-structs/nested-types.md).
   
 ## Partial Types  
 
-You can define part of a class, struct, or method in one code file and another part in a separate code file.
+You can define part of a class, struct, or method in one code file and another part in a separate code file. For more information, see [Partial Classes and Methods](../../programming-guide/classes-and-structs/partial-classes-and-methods.md).
   
 ## Object Initializers  
 
-You can instantiate and initialize class or struct objects, and collections of objects, by assigning values to its properties.
+You can instantiate and initialize class or struct objects, and collections of objects, by assigning values to its properties. For more information, see [How to initialize objects by using an object initializer](../../programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md).
   
 ## Anonymous Types  
 
-In situations where it isn't convenient or necessary to create a named class you use anonymous types. Anonymous types are defined by their named data members.
+In situations where it isn't convenient or necessary to create a named class you use anonymous types. Anonymous types are defined by their named data members. For more information, see [Anonymous types](../types/anonymous-types.md).
   
 ## Extension Methods  
 
-You can "extend" a class without creating a derived class by creating a separate type. That type contains methods that can be called as if they belonged to the original type.
+You can "extend" a class without creating a derived class by creating a separate type. That type contains methods that can be called as if they belonged to the original type. For more information, see [Extension methods)](../../programming-guide/classes-and-structs/extension-methods.md).
   
 ## Implicitly Typed Local Variables  
 
-Within a class or struct method, you can use implicit typing to instruct the compiler to determine a variable's type at compile time.
+Within a class or struct method, you can use implicit typing to instruct the compiler to determine a variable's type at compile time. For more information, see [var (C# reference)](../../language-reference/keywords/var.md).
 
 ## Records
 

--- a/docs/csharp/fundamentals/object-oriented/index.md
+++ b/docs/csharp/fundamentals/object-oriented/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Classes, structs, and records"
 description: Describes the use of classes, structures (structs), and records in C#.
-ms.date: 09/30/2021
+ms.date: 03/23/2022
 helpviewer_keywords: 
   - "structs [C#], about structs"
   - "records [C#], about records"

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -69,8 +69,7 @@ items:
     # TODO: Delegates, lambdas and events
   - name: Object Oriented programming
     items:
-    - name: Overview
-      displayName: classes, structs, records
+    - name: Classes, structs, and records
       href: fundamentals/object-oriented/index.md
     - name: Objects
       href: fundamentals/object-oriented/objects.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -110,7 +110,7 @@ items:
       href: fundamentals/exceptions/compiler-generated-exceptions.md
   - name: Coding style
     items:
-    - name: Identifier names
+    - name: C# identifier names
       href: fundamentals/coding-style/identifier-names.md
     - name: C# coding conventions
       href: fundamentals/coding-style/coding-conventions.md

--- a/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
+++ b/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
@@ -1,6 +1,6 @@
 ---
 title: Work with List\<T> - Introduction to C# tutorial
-description: Learn C# by exploring the generic List collection in this tutorial.
+description: Learn C# by exploring the generic List collection type in this tutorial.
 ms.date: 03/23/2022
 ---
 # Learn to manage data collections using List\<T> in C\#

--- a/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
+++ b/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
@@ -1,15 +1,17 @@
 ---
-title: Work with collections - Introduction to C# tutorial
-description: Learn C# by exploring the List collection in this tutorial.
+title: Work with List\<T> - Introduction to C# tutorial
+description: Learn C# by exploring the generic List collection in this tutorial.
 ms.date: 02/05/2021
 ---
-# Learn to manage data collections using the generic list type
+# Learn to manage data collections using List\<T> in C\#
 
 This introductory tutorial provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601> class.
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Mac and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macOS and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+
+If you prefer to run the code without having to set up a local environment, see the [interactive-in-browser version of this tutorial](list-collections.yml).
 
 ## A basic list example
 

--- a/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
+++ b/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
@@ -1,7 +1,7 @@
 ---
 title: Work with List\<T> - Introduction to C# tutorial
 description: Learn C# by exploring the generic List collection in this tutorial.
-ms.date: 02/05/2021
+ms.date: 03/23/2022
 ---
 # Learn to manage data collections using List\<T> in C\#
 
@@ -11,7 +11,7 @@ This introductory tutorial provides an introduction to the C# language and the b
 
 The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macOS and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
 
-If you prefer to run the code without having to set up a local environment, see the [interactive-in-browser version of this tutorial](list-collections.yml).
+If you prefer to run the code without having to set up a local environment, see the [interactive-in-browser version of this tutorial](list-collection.yml).
 
 ## A basic list example
 

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
@@ -1,16 +1,18 @@
 ---
 title: Branches and loops - Introduction to C# tutorial
 description: In this tutorial about branches and loops, you write C# code to explore the language syntax that supports conditional branches and loops to execute statements repeatedly.
-ms.date: 02/05/2021
+ms.date: 03/23/2022
 ---
 
-# Learn conditional logic with branch and loop statements
+# C# `if` statements and loops - conditional logic tutorial
 
-This tutorial teaches you how to write code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
+This tutorial teaches you how to write C# code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Mac and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macoS and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+
+If you prefer to run the code without having to set up a local environment, see the [interactive-in-browser version of this tutorial](branches-and-loops.yml).
 
 ## Make decisions using the `if` statement
 

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
@@ -6,7 +6,7 @@ metadata:
   audience: Developer
   level: Beginner
   ms.custom: mvc
-  ms.date: 08/24/2018
+  ms.date: 03/23/2022
   ms.topic: interactive-tutorial
   displayType: two-column
   interactive: csharp

--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
@@ -6,7 +6,7 @@ metadata:
   audience: Developer
   ms.custom: mvc
   ms.topic: interactive-tutorial
-  ms.date: 10/23/2018
+  ms.date: 03/23/2022
   level: Beginner
   displayType: two-column
   interactive: csharp

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -1,16 +1,18 @@
 ---
 title: Numbers in C# - Introduction to C# tutorial
 description: Learn C# by exploring numeric types, their uses, properties, and methods.
-ms.date: 02/05/2021
+ms.date: 03/23/2022
 ---
 
 # Manipulate integral and floating point numbers in C\#
 
-This tutorial teaches you about the numeric types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
+This tutorial teaches you about the numeric types in C#. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Mac or Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macOS or Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+
+If you don't want to set up a local environment, see the [interactive-in-browser version of this tutorial](numbers-in-csharp.yml).
 
 ## Explore integer math
 

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -4,7 +4,7 @@ description: Learn C# by exploring numeric types, their uses, properties, and me
 ms.date: 03/23/2022
 ---
 
-# Manipulate integral and floating point numbers in C\#
+# How to use integer and floating point numbers in C\#
 
 This tutorial teaches you about the numeric types in C#. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
@@ -5,7 +5,7 @@ metadata:
   description: In this tutorial about numeric types, you'll use your browser to learn C# interactively. You're going to write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   ms.custom: mvc
-  ms.date: 08/24/2018
+  ms.date: 03/23/2022
   ms.topic: interactive-tutorial
   level: Beginner
   nextTutorialHref: branches-and-loops.yml


### PR DESCRIPTION
Contributes to https://github.com/dotnet/docs/issues/28383

* [Classes, structs, and records](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/object-oriented/)

  Organic search 15% PV 7K. This article doesn't have a clear intended purpose. Its title is "classes, structs, and records", but its h1 is "object-oriented programming" and it's the overview node in the toc "object-oriented programming" section.  The next article in the TOC section is about "objects" as class/struct/record instances. Only 2 of 14 h2s are relevant to the object-oriented title.  Just one h2 talks about records. Most of the remaining h2s are about types or topics related to types (like the Members h2), mentioning classes and structs in the text. As a whole, the article seems most like an overview of classes, structs, and records, so that's what I'm making the title, h1, and intro paragraph consistently represent. Longer term, an overhaul of this TOC section will be worthwhile.

* [Numbers in C# - Introduction to C# interactive tutorial](https://docs.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/numbers-in-csharp) Organic search .4% PV 6K.
* [Branches and loops - Introduction to C# interactive tutorial](https://docs.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/branches-and-loops) Organic search .7% PV 5K.
* [Data collections - Introduction to C# interactive tutorial](https://docs.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/list-collection) Organic search 1.4% PV 4K.

  The interactive tutorials get almost no organic search traffic because all the search engine bots see is the first page, which only has an intro paragraph. The best way to increase organic search traffic for these tutorials is to focus on the corresponding local-environment tutorials and make sure that those feature prominent links to their interactive counterparts. However, any traffic increase will show up in the interactive tutorial's stats as Microsoft traffic, not organic search.

* [Identifier names](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names)

  Organic search 19% PV 4K. Added "C#" to title, h1, and toc node that links to the article. This article already shows up in the first page of results for searches such as c# names and variants like c# variable names, but not for c# naming and variants. Made "naming" more prominent by putting it in a new h2.
