### PR TITLE
Updated broken links when accessing previous relative paths for nuget documentation

### DIFF
--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -40,7 +40,7 @@ Starting with .NET SDK 6.0.100, installed template packages will available in la
 - **`--nuget-source <SOURCE>`**
   
   By default, `dotnet new --install` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
-  To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior)
+  To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior)
 
 ## Examples
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -40,7 +40,7 @@ Starting with .NET SDK 6.0.100, installed template packages will available in la
 - **`--nuget-source <SOURCE>`**
   
   By default, `dotnet new --install` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
-  To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
+  To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior)
 
 ## Examples
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -26,7 +26,7 @@ dotnet nuget push -h|--help
 
 ## Description
 
-The `dotnet nuget push` command pushes a package to the server and publishes it. The push command uses server and credential details found in the system's NuGet config file or chain of config files. For more information on config files, see [Configuring NuGet Behavior](/nuget/consume-packages/configuring-nuget-behavior). NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.nuget/NuGet/NuGet.Config* (Linux/macOS), then loading any *nuget.config* or *.nuget\nuget.config* starting from the root of drive and ending in the current directory.
+The `dotnet nuget push` command pushes a package to the server and publishes it. The push command uses server and credential details found in the system's NuGet config file or chain of config files. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior). NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.nuget/NuGet/NuGet.Config* (Linux/macOS), then loading any *nuget.config* or *.nuget\nuget.config* starting from the root of drive and ending in the current directory.
 
 The command pushes an existing package. It doesn't create a package. To create a package, use [`dotnet pack`](dotnet-pack.md).
 
@@ -68,7 +68,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 
   Specifies the server URL. NuGet identifies a UNC or local folder source and simply copies the file there instead of pushing it using HTTP.
   > [!IMPORTANT]
-  > Starting with NuGet 3.4.2, this is a mandatory parameter unless the NuGet config file specifies a `DefaultPushSource` value. For more information, see [Configuring NuGet behavior](/nuget/consume-packages/configuring-nuget-behavior).
+  > Starting with NuGet 3.4.2, this is a mandatory parameter unless the NuGet config file specifies a `DefaultPushSource` value. For more information, see [Configuring NuGet behavior](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior).
 
 - **`--skip-duplicate`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -26,7 +26,7 @@ dotnet nuget push -h|--help
 
 ## Description
 
-The `dotnet nuget push` command pushes a package to the server and publishes it. The push command uses server and credential details found in the system's NuGet config file or chain of config files. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior). NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.nuget/NuGet/NuGet.Config* (Linux/macOS), then loading any *nuget.config* or *.nuget\nuget.config* starting from the root of drive and ending in the current directory.
+The `dotnet nuget push` command pushes a package to the server and publishes it. The push command uses server and credential details found in the system's NuGet config file or chain of config files. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior). NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.nuget/NuGet/NuGet.Config* (Linux/macOS), then loading any *nuget.config* or *.nuget\nuget.config* starting from the root of drive and ending in the current directory.
 
 The command pushes an existing package. It doesn't create a package. To create a package, use [`dotnet pack`](dotnet-pack.md).
 
@@ -68,7 +68,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 
   Specifies the server URL. NuGet identifies a UNC or local folder source and simply copies the file there instead of pushing it using HTTP.
   > [!IMPORTANT]
-  > Starting with NuGet 3.4.2, this is a mandatory parameter unless the NuGet config file specifies a `DefaultPushSource` value. For more information, see [Configuring NuGet behavior](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior).
+  > Starting with NuGet 3.4.2, this is a mandatory parameter unless the NuGet config file specifies a `DefaultPushSource` value. For more information, see [Configuring NuGet behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 - **`--skip-duplicate`**
 

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -22,7 +22,7 @@ dotnet nuget trust -h|--help
 
 ## Description
 
-The `dotnet nuget trust` command manages the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For more information, see [Common NuGet configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior). For details on what the nuget.config schema looks like, refer to the [NuGet config file reference](https://docs.microsoft.com/en-gb/nuget/reference/nuget-config-file).
+The `dotnet nuget trust` command manages the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For more information, see [Common NuGet configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior). For details on what the nuget.config schema looks like, refer to the [NuGet config file reference](https://docs.microsoft.com/nuget/reference/nuget-config-file).
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -22,7 +22,7 @@ dotnet nuget trust -h|--help
 
 ## Description
 
-The `dotnet nuget trust` command manages the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For more information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior). For details on what the nuget.config schema looks like, refer to the [NuGet config file reference](/nuget/reference/nuget-config-file).
+The `dotnet nuget trust` command manages the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For more information, see [Common NuGet configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior). For details on what the nuget.config schema looks like, refer to the [NuGet config file reference](https://docs.microsoft.com/en-gb/nuget/reference/nuget-config-file).
 
 ## Options
 

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -42,12 +42,12 @@ Sometimes, it might be inconvenient to run the implicit NuGet restore with these
 
 To restore the dependencies, NuGet needs the feeds where the packages are located. Feeds are usually provided via the *nuget.config* configuration file. A default configuration file is provided when the .NET SDK is installed. To specify additional feeds, do one of the following:
 
-- Create your own *nuget.config* file in the project directory. For more information, see [Common NuGet configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior) and [nuget.config differences](#nugetconfig-differences) later in this article.
+- Create your own *nuget.config* file in the project directory. For more information, see [Common NuGet configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior) and [nuget.config differences](#nugetconfig-differences) later in this article.
 - Use `dotnet nuget` commands such as [`dotnet nuget add source`](dotnet-nuget-add-source.md).
 
 You can override the *nuget.config* feeds with the `-s` option.
 
-For information about how to use authenticated feeds, see [Consuming packages from authenticated feeds](https://docs.microsoft.com/en-gb/nuget/consume-packages/consuming-packages-authenticated-feeds).
+For information about how to use authenticated feeds, see [Consuming packages from authenticated feeds](https://docs.microsoft.com/nuget/consume-packages/consuming-packages-authenticated-feeds).
 
 ### Global packages folder
 
@@ -59,19 +59,19 @@ For project-specific tooling, `dotnet restore` first restores the package in whi
 
 ### nuget.config differences
 
-The behavior of the `dotnet restore` command is affected by the settings in the *nuget.config* file, if present. For example, setting the `globalPackagesFolder` in *nuget.config* places the restored NuGet packages in the specified folder. This is an alternative to specifying the `--packages` option on the `dotnet restore` command. For more information, see the [nuget.config reference](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file).
+The behavior of the `dotnet restore` command is affected by the settings in the *nuget.config* file, if present. For example, setting the `globalPackagesFolder` in *nuget.config* places the restored NuGet packages in the specified folder. This is an alternative to specifying the `--packages` option on the `dotnet restore` command. For more information, see the [nuget.config reference](https://docs.microsoft.com/nuget/schema/nuget-config-file).
 
 There are three specific settings that `dotnet restore` ignores:
 
-- [bindingRedirects](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file#bindingredirects-section)
+- [bindingRedirects](https://docs.microsoft.com/nuget/schema/nuget-config-file#bindingredirects-section)
 
   Binding redirects don't work with `<PackageReference>` elements and .NET only supports `<PackageReference>` elements for NuGet packages.
 
-- [solution](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file#solution-section)
+- [solution](https://docs.microsoft.com/nuget/schema/nuget-config-file#solution-section)
 
   This setting is Visual Studio specific and doesn't apply to .NET. .NET doesn't use a `packages.config` file and instead uses `<PackageReference>` elements for NuGet packages.
 
-- [trustedSigners](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file#trustedsigners-section)
+- [trustedSigners](https://docs.microsoft.com/nuget/schema/nuget-config-file#trustedsigners-section)
 
   Support for cross-platform package signature verification was added in the .NET 5.0.100 SDK.
 

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -42,12 +42,12 @@ Sometimes, it might be inconvenient to run the implicit NuGet restore with these
 
 To restore the dependencies, NuGet needs the feeds where the packages are located. Feeds are usually provided via the *nuget.config* configuration file. A default configuration file is provided when the .NET SDK is installed. To specify additional feeds, do one of the following:
 
-- Create your own *nuget.config* file in the project directory. For more information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior) and [nuget.config differences](#nugetconfig-differences) later in this article.
+- Create your own *nuget.config* file in the project directory. For more information, see [Common NuGet configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior) and [nuget.config differences](#nugetconfig-differences) later in this article.
 - Use `dotnet nuget` commands such as [`dotnet nuget add source`](dotnet-nuget-add-source.md).
 
 You can override the *nuget.config* feeds with the `-s` option.
 
-For information about how to use authenticated feeds, see [Consuming packages from authenticated feeds](/nuget/consume-packages/consuming-packages-authenticated-feeds).
+For information about how to use authenticated feeds, see [Consuming packages from authenticated feeds](https://docs.microsoft.com/en-gb/nuget/consume-packages/consuming-packages-authenticated-feeds).
 
 ### Global packages folder
 
@@ -59,19 +59,19 @@ For project-specific tooling, `dotnet restore` first restores the package in whi
 
 ### nuget.config differences
 
-The behavior of the `dotnet restore` command is affected by the settings in the *nuget.config* file, if present. For example, setting the `globalPackagesFolder` in *nuget.config* places the restored NuGet packages in the specified folder. This is an alternative to specifying the `--packages` option on the `dotnet restore` command. For more information, see the [nuget.config reference](/nuget/schema/nuget-config-file).
+The behavior of the `dotnet restore` command is affected by the settings in the *nuget.config* file, if present. For example, setting the `globalPackagesFolder` in *nuget.config* places the restored NuGet packages in the specified folder. This is an alternative to specifying the `--packages` option on the `dotnet restore` command. For more information, see the [nuget.config reference](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file).
 
 There are three specific settings that `dotnet restore` ignores:
 
-- [bindingRedirects](/nuget/schema/nuget-config-file#bindingredirects-section)
+- [bindingRedirects](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file#bindingredirects-section)
 
   Binding redirects don't work with `<PackageReference>` elements and .NET only supports `<PackageReference>` elements for NuGet packages.
 
-- [solution](/nuget/schema/nuget-config-file#solution-section)
+- [solution](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file#solution-section)
 
   This setting is Visual Studio specific and doesn't apply to .NET. .NET doesn't use a `packages.config` file and instead uses `<PackageReference>` elements for NuGet packages.
 
-- [trustedSigners](/nuget/schema/nuget-config-file#trustedsigners-section)
+- [trustedSigners](https://docs.microsoft.com/en-gb/nuget/schema/nuget-config-file#trustedsigners-section)
 
   Support for cross-platform package signature verification was added in the .NET 5.0.100 SDK.
 

--- a/includes/cli-configfile.md
+++ b/includes/cli-configfile.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 - **`--configfile <FILE>`**
 
-  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior).
+  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).

--- a/includes/cli-configfile.md
+++ b/includes/cli-configfile.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 - **`--configfile <FILE>`**
 
-  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior).
+  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/en-gb/nuget/consume-packages/configuring-nuget-behavior).


### PR DESCRIPTION
## Summary

Updated broken links with absolute paths to nuget pages so they work when accessed from GitHub documentation.

Fixes #28683
