### PR TITLE
Replace "not unmanaged" with managed.

### DIFF
--- a/docs/csharp/language-reference/builtin-types/unmanaged-types.md
+++ b/docs/csharp/language-reference/builtin-types/unmanaged-types.md
@@ -20,7 +20,7 @@ Beginning with C# 8.0, a *constructed* struct type that contains fields of unman
 
 [!code-csharp[unmanaged constructed types](snippets/shared/UnmanagedTypes.cs#ProgramExample)]
 
-A generic struct may be the source of both unmanaged and not unmanaged constructed types. The preceding example defines a generic struct `Coords<T>` and presents the examples of unmanaged constructed types. The example of not an unmanaged type is `Coords<object>`. It's not unmanaged because it has the fields of the `object` type, which is not unmanaged. If you want *all* constructed types to be unmanaged types, use the `unmanaged` constraint in the definition of a generic struct:
+A generic struct may be the source of both unmanaged and managed constructed types. The preceding example defines a generic struct `Coords<T>` and presents the examples of unmanaged constructed types. The example of a managed type is `Coords<object>`. It's managed because it has the fields of the `object` type, which is managed. If you want *all* constructed types to be unmanaged types, use the `unmanaged` constraint in the definition of a generic struct:
 
 [!code-csharp[unmanaged constraint in type definition](snippets/shared/UnmanagedTypes.cs#AlwaysUnmanaged)]
 


### PR DESCRIPTION
While the C# spec doesn't define "managed type" (The CLI spec does), we use it throughout the .NET docs. This will read better.

Fixes #28799
