### PR TITLE
Breaking changes for SDK version compatibility

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -129,6 +129,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ | RC 1 |
 | [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ | 6.0.100 |
 | [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ | RC 1 |
+| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ | 6.0.300 |
 | [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ | 6.0.200 |
 
 ## Serialization

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -39,6 +39,12 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [AllowRenegotiation default is false](networking/7.0/allowrenegotiation-default.md) | ❌ | ❌ | Preview 3 |
 | [Custom ping payloads on Linux](networking/7.0/ping-custom-payload-linux.md) | ❌ | ✔️ | Preview 2 |
 
+## SDK
+
+| Title | Binary compatible | Source compatible | Introduced |
+| - | :-: | :-: | - |
+| [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
+
 ## Serialization
 
 | Title | Binary compatible | Source compatible | Introduced |

--- a/docs/core/compatibility/sdk/6.0/vs-msbuild-version.md
+++ b/docs/core/compatibility/sdk/6.0/vs-msbuild-version.md
@@ -1,0 +1,32 @@
+---
+title: "Breaking change: Version requirements for .NET 6 SDK"
+description: Learn about the breaking change in the .NET 6 SDK where version 17.0 or newer of Visual Studio and MSBuild is required.
+ms.date: 03/25/2022
+---
+# Version requirements for .NET 6 SDK
+
+The NET 6.0.300 SDK no longer loads in version 16.11 or earlier of Visual Studio or MSBuild.
+
+## Version introduced
+
+.NET SDK 6.0.300
+
+## Old behavior
+
+.NET SDK 6.0.300 would load in the 16.10 and 16.11 versions of Visual Studio and MSBuild.
+
+## New behavior
+
+.NET SDK 6.0.300 can only be used with version 17.0 or later of Visual Studio and MSBuild. In addition, any scenarios that use a source generator could fail when using a Visual Studio or MSBuild version earlier than version 17.2.
+
+## Reason for change
+
+Changes were made to features within the SDK that aren't compatible with Visual Studio version 16.11.
+
+## Recommended action
+
+Upgrade to Visual Studio 2022 version 17.0 or later. It's recommended that you use version 17.2 preview builds.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/sdk/7.0/vs-msbuild-version.md
+++ b/docs/core/compatibility/sdk/7.0/vs-msbuild-version.md
@@ -1,0 +1,32 @@
+---
+title: "Breaking change: Version requirements for .NET 7 SDK"
+description: Learn about the breaking change in the .NET 7 SDK where version 17.0 or newer of Visual Studio and MSBuild is required.
+ms.date: 03/25/2022
+---
+# Version requirements for .NET 7 SDK
+
+The NET 7.0.100 SDK no longer loads in version 16.11 or earlier of Visual Studio or MSBuild.
+
+## Version introduced
+
+.NET SDK 7.0.100 (.NET 7 Preview 3)
+
+## Old behavior
+
+.NET SDK 7.0.100 would load in the 16.10 and 16.11 versions of Visual Studio and MSBuild.
+
+## New behavior
+
+.NET SDK 7.0.100 can only be used with version 17.0 or later of Visual Studio and MSBuild. In addition, any scenarios that use a source generator could fail when using a Visual Studio or MSBuild version earlier than version 17.2.
+
+## Reason for change
+
+Changes were made to features within the SDK that aren't compatible with Visual Studio version 16.11.
+
+## Recommended action
+
+Upgrade to Visual Studio 2022 version 17.0 or later. It's recommended that you use version 17.2 preview builds.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -53,6 +53,10 @@ items:
           href: networking/7.0/allowrenegotiation-default.md
         - name: Custom ping payloads on Linux
           href: networking/7.0/ping-custom-payload-linux.md
+      - name: SDK
+        items:
+        - name: Version requirements for .NET 7 SDK
+          href: sdk/7.0/vs-msbuild-version.md
       - name: Serialization
         items:
         - name: Deserialize Version type with leading or trailing whitespace
@@ -223,6 +227,8 @@ items:
           href: sdk/6.0/publish-readytorun-requires-restore-change.md
         - name: RuntimeIdentifier warning if self-contained is unspecified
           href: sdk/6.0/runtimeidentifier-self-contained.md
+        - name: Version requirements for .NET 6 SDK
+          href: sdk/6.0/vs-msbuild-version.md
         - name: Write reference assemblies to IntermediateOutputPath
           href: sdk/6.0/write-reference-assemblies-to-obj.md
       - name: Serialization
@@ -921,6 +927,10 @@ items:
         href: networking.md
     - name: SDK and MSBuild
       items:
+      - name: .NET 7
+        items:
+        - name: Version requirements for .NET 7 SDK
+          href: sdk/7.0/vs-msbuild-version.md
       - name: .NET 6
         items:
         - name: -p option for `dotnet run` is deprecated
@@ -945,6 +955,8 @@ items:
           href: sdk/6.0/publish-readytorun-requires-restore-change.md
         - name: RuntimeIdentifier warning if self-contained is unspecified
           href: sdk/6.0/runtimeidentifier-self-contained.md
+        - name: Version requirements for .NET 6 SDK
+          href: sdk/6.0/vs-msbuild-version.md
         - name: Write reference assemblies to IntermediateOutputPath
           href: sdk/6.0/write-reference-assemblies-to-obj.md
       - name: .NET 5


### PR DESCRIPTION
Fixes #28642 
Fixes #28641 

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/vs-msbuild-version?branch=pr-en-us-28809).