### PR TITLE
Discovery OKR

### DIFF
--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -3,7 +3,7 @@ title: Install .NET on Debian
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Debian.
 author: adegeo
 ms.author: adegeo
-ms.date: 11/04/2021
+ms.date: 03/25/2022
 ---
 
 # Install the .NET SDK or the .NET Runtime on Debian

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -1,14 +1,14 @@
 ---
-title: Manually install .NET on Linux
-description: Demonstrates how to install the .NET SDK and the .NET Runtime without a package manager on Linux. Use the install script or manually extract the binaries.
+title: Install .NET on Linux without using a package manager 
+description: Demonstrates how to install the .NET SDK and the .NET Runtime on Linux without a package manager. Use the install script or manually extract the binaries.
 author: adegeo
 ms.author: adegeo
 ms.date: 03/25/2022
 ---
 
-# Install the .NET SDK or the .NET Runtime manually
+# Install .NET on Linux by using an install script or by extracting binaries
 
-.NET is supported on Linux and this article describes how to install .NET on Linux using the install script or by extracting the binaries. For a list of distributions that support the built-in package manager, see [Install .NET on Linux](linux.md).
+This article demonstrates how to install the .NET SDK or the .NET Runtime on Linux by using the install script or by extracting the binaries. For a list of distributions that support the built-in package manager, see [Install .NET on Linux](linux.md).
 
 You can also install .NET with snap. For more information, see [Install the .NET SDK or the .NET Runtime with Snap](linux-snap.md).
 

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -3,7 +3,7 @@ title: Manually install .NET on Linux
 description: Demonstrates how to install the .NET SDK and the .NET Runtime without a package manager on Linux. Use the install script or manually extract the binaries.
 author: adegeo
 ms.author: adegeo
-ms.date: 03/21/2022
+ms.date: 03/25/2022
 ---
 
 # Install the .NET SDK or the .NET Runtime manually

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -3,7 +3,7 @@ title: Install .NET on Linux with Snap
 description: Demonstrates how to install either the .NET SDK or the .NET Runtime on Linux with Snap.
 author: adegeo
 ms.author: adegeo
-ms.date: 10/26/2021
+ms.date: 03/25/2022
 ---
 
 # Install the .NET SDK or the .NET Runtime with Snap

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -1,12 +1,12 @@
 ---
-title: Install .NET on Linux Distributions
-description: Learn about what Linux distributions support installing .NET on Linux.
+title: Install .NET on Linux distributions
+description: Learn about which versions of .NET can be installed on which versions of Linux distributions.
 author: adegeo
 ms.author: adegeo
 ms.date: 03/25/2022
 ---
 
-# Install .NET on Linux
+# Install .NET on Linux distributions
 
 > [!div class="op_single_selector"]
 >
@@ -14,11 +14,11 @@ ms.date: 03/25/2022
 > - [Install on macOS](macos.md)
 > - [Install on Linux](linux.md)
 
-.NET is available on different Linux distributions. Most Linux platforms and distributions have a major release each year, and most provide a package manager that is used to install .NET. This article describes what is currently supported and which package manager is used.
+This article details which versions of the .NET SDK or Runtime can be installed on which versions of various Linux distributions. Most Linux platforms and distributions have a major release each year, and most provide a package manager that is used to install .NET.
 
-The rest of this article is a breakdown of each major Linux distribution that .NET supports. All .NET releases remain supported until either the version of [.NET reaches end-of-support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) or the Linux distribution reaches end-of-life.
+All .NET releases remain supported until either the version of [.NET reaches end-of-support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) or the Linux distribution reaches end-of-life.
 
-For the best compatibility, choose a long-term release (LTS) version.
+For the best compatibility, choose a long-term support (LTS) version.
 
 ## Unsupported releases
 

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -3,7 +3,7 @@ title: Install .NET on Linux Distributions
 description: Learn about what Linux distributions support installing .NET on Linux.
 author: adegeo
 ms.author: adegeo
-ms.date: 03/21/2022
+ms.date: 03/25/2022
 ---
 
 # Install .NET on Linux


### PR DESCRIPTION
Fixes #28383 

* [Install .NET on Linux Distributions](https://docs.microsoft.com/en-us/dotnet/core/install/linux)

  Organic search 17%, PV 48K.  Most traffic comes from a direct link on the download .NET pages -- [Package Manager Instructions](https://docs https://dotnet.microsoft.com/en-us/download/dotnet/6.0), 71% of all traffic is from Microsoft. Updated first-paragraph text to more specifically summarize the contents of the article.

* [Manually install .NET on Linux - .NET](https://docs.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual)

  Organic search 13% PV 15k – 83% of traffic is from Microsoft – the other Linux Install pages. Changed h1, title, first paragraph to highlight "without package manager", "extract binaries", and "install script" instead of "manually".

* [Install .NET on Linux with Snap - .NET](https://docs.microsoft.com/en-us/dotnet/core/install/linux-snap) 

  Organic search 7% PV 9k. By far most traffic comes from the main Linux install page and the Ubuntu install page. There doesn't seem to be any way to improve SEO for this page.  Keywords .net linux and snap bring up this page as the first result.

* [Install .NET on Debian - .NET](https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian)

  Organic search 21% PV 8k. Most traffic comes from the main Linux install page. There doesn't seem to be any way to improve SEO for this page.  Keywords .net and debian bring up this page as the first result.