### PR TITLE
Update suboptimal stackalloc behavior

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
@@ -66,7 +66,7 @@ namespace operators
         {
             // <SnippetLimitStackalloc>
             const int MaxStackLimit = 1024;
-            Span<byte> buffer = inputLength <= MaxStackLimit ? stackalloc byte[inputLength] : new byte[inputLength];
+            Span<byte> buffer = inputLength <= MaxStackLimit ? stackalloc byte[MaxStackLimit] : new byte[inputLength];
             // </SnippetLimitStackalloc>
         }
     }


### PR DESCRIPTION
## Suboptimal stackalloc behavior in code-snippet

Referencing [this Twitter thread](https://twitter.com/EgorBo/status/1508069816275513344) one of the code-snippets within the [stackalloc docs](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc) shows suboptimal behavior. The [link](https://vcsjones.dev/stackalloc/) found on the bottom of the docs site does also use the same pattern as the thread suggests.

Would probably also be nice to add some information why the constant size is used referencing e.g. [this answer on the thread](https://twitter.com/scalablecory/status/1508073921790156802), but I'm not sure about the perfect wording.