### PR TITLE
Added docs to reflect dotnet/corefx#36085

### DIFF
--- a/docs/core/additional-tools/xml-serializer-generator.md
+++ b/docs/core/additional-tools/xml-serializer-generator.md
@@ -124,7 +124,7 @@ Congratulations! You have just:
 
 ## Further customize XML serialization assembly (optional)
 
-Add this to your *MyApp.csproj* to further customize assembly generation
+Add the following XML to your *MyApp.csproj* to further customize assembly generation:
 
 ```xml
 <PropertyGroup>

--- a/docs/core/additional-tools/xml-serializer-generator.md
+++ b/docs/core/additional-tools/xml-serializer-generator.md
@@ -122,6 +122,21 @@ Congratulations! You have just:
 > - Added a class and an XmlSerializer.
 > - Built and ran the application.
 
+## Further customize XML serialization assembly (optional)
+
+Add this to your *MyApp.csproj* to further customize assembly generation
+
+```xml
+<PropertyGroup>
+    <SGenReferences>C:\myfolder\abc.dll;C:\myfolder\def.dll</SGenReferences>
+    <SGenTypes>MyApp.MyClass;MyApp.MyClass1</SGenTypes>
+    <SGenProxyTypes>false</SGenProxyTypes>
+    <SGenVerbose>true</SGenVerbose>
+    <SGenKeyFile>mykey.snk</SGenKeyFile>
+    <SGenDelaySign>true</SGenDelaySign>
+</PropertyGroup>
+```
+
 ## Related resources
 
 - [Introducing XML Serialization](../../standard/serialization/introducing-xml-serialization.md)


### PR DESCRIPTION
Explaining how to customize assembly generation (for example to only include the specific types you need)

Currently there are no docs on this whatsoever, I only found this info when examining the source codes and commits to the runtime.