### PR TITLE
Raise prominence on null warnings for initialization

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -69,7 +69,11 @@ void FindRoot(Node node, Action<Node> processNode)
 
 The previous code doesn't generate any warnings for dereferencing the variable `current`. Static analysis determines that `current` is never dereferenced when it's *maybe-null*. The variable `current` is checked against `null` before `current.Parent` is accessed, and before passing `current` to the `ProcessNode` action. The previous examples show how the compiler determines *null-state* for local variables when initialized, assigned, or compared to `null`.
 
-The null state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by constructors will generate a warning: "Non-nullable property '*name*' must contain a non-null value when exiting constructor.". You can address these warnings in one of two ways: *Constructor chaining*, or *nullable attributes* on the helper method. The following code shows an example of each. The `Person` class uses a common constructor called by all other constructors. The `Student` class has a helper method annotated with the <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?displayProperty=nameWithType> attribute:
+The null state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by constructors will generate a warning with the following template:
+
+> Non-nullable property '*name*' must contain a non-null value when exiting constructor.
+
+You can address these warnings in one of two ways: *Constructor chaining*, or *nullable attributes* on the helper method. The following code shows an example of each. The `Person` class uses a common constructor called by all other constructors. The `Student` class has a helper method annotated with the <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?displayProperty=nameWithType> attribute:
 
 :::code language="csharp" source="./snippets/null-warnings/PersonExamples.cs" id="ConstructorChainingAndMemberNotNull":::
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -69,8 +69,14 @@ void FindRoot(Node node, Action<Node> processNode)
 
 The previous code doesn't generate any warnings for dereferencing the variable `current`. Static analysis determines that `current` is never dereferenced when it's *maybe-null*. The variable `current` is checked against `null` before `current.Parent` is accessed, and before passing `current` to the `ProcessNode` action. The previous examples show how the compiler determines *null-state* for local variables when initialized, assigned, or compared to `null`.
 
+The null state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by constructors will generate a warning: "Non-nullable property '*name*' must contain a non-null value when exiting constructor.". You can address these warnings in one of two ways: *Constructor chaining*, or *nullable attributes* on the helper method. The following code shows an example of each. The `Person` class uses a common constructor called by all other constructors. The `Student` class has a helper method annotated with the <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?displayProperty=nameWithType> attribute:
+
+:::code language="csharp" source="./snippets/null-warnings/PersonExamples.cs" id="ConstructorChainingAndMemberNotNull":::
+
 > [!NOTE]
 > A number of improvements to definite assignment and null state analysis were added in C# 10. When you upgrade to C# 10, you may find fewer nullable warnings that are false positives. You can learn more about the improvements in the [features specification for definite assignment improvements](~/_csharplang/proposals/csharp-10.0/improved-definite-assignment.md).
+
+Nullable state analysis and the warnings the compiler generates help you avoid program errors by dereferencing `null`. The article on [resolving nullable warnings](nullable-warnings.md) provides techniques for correcting the warnings you'll likely see in your code.
 
 ## Attributes on API signatures
 

--- a/docs/csharp/nullable-warnings.md
+++ b/docs/csharp/nullable-warnings.md
@@ -100,7 +100,9 @@ Another alternative may be to change those members to nullable reference types. 
 
 :::code language="csharp" source="./snippets/null-warnings/PersonExamples.cs" id="NullableMember":::
 
-Existing code may require other changes to inform the compiler about the null semantics for those members. You may have created multiple constructors, and your class may have a private helper method that initializes one or more members. The <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?displayProperty=nameWithType> and <xref:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute?displayProperty=nameWithType> attributes inform the compiler that a member is *not-null* after the method has been called.
+Existing code may require other changes to inform the compiler about the null semantics for those members. You may have created multiple constructors, and your class may have a private helper method that initializes one or more members. You can move the initialization code into a single constructor and ensure all constructors call the one with the common initialization code. Or, you can use the <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?displayProperty=nameWithType> and <xref:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute?displayProperty=nameWithType> attributes. These attributes inform the compiler that a member is *not-null* after the method has been called. The following code shows an example of each. The `Person` class uses a common constructor called by all other constructors. The `Student` class has a helper method annotated with the <xref:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?displayProperty=nameWithType> attribute:
+
+:::code language="csharp" source="./snippets/null-warnings/PersonExamples.cs" id="ConstructorChainingAndMemberNotNull":::
 
 Finally, you can use the null forgiving operator to indicate that a member is initialized in other code. For another example, consider the following classes representing an Entity Framework Core model:
 

--- a/docs/csharp/snippets/null-warnings/PersonExamples.cs
+++ b/docs/csharp/snippets/null-warnings/PersonExamples.cs
@@ -51,6 +51,9 @@ namespace fourthExample
 namespace initializationExample
 {
     // <ConstructorChainingAndMemberNotNull>
+
+    using System.Diagnostics.CodeAnalysis;
+
     public class Person
     {
         public string FirstName { get; set; }

--- a/docs/csharp/snippets/null-warnings/PersonExamples.cs
+++ b/docs/csharp/snippets/null-warnings/PersonExamples.cs
@@ -47,3 +47,50 @@ namespace fourthExample
     }
     // </NullableMember>
 }
+
+namespace initializationExample
+{
+    // <ConstructorChainingAndMemberNotNull>
+    public class Person
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+
+        public Person(string firstName, string lastName)
+        {
+            FirstName = firstName;
+            LastName = lastName;
+        }
+
+        public Person() : this("John", "Doe") { }
+    }
+
+    public class Student : Person
+    {
+        public string Major { get; set; }
+
+        public Student(string firstName, string lastName, string major)
+            : base(firstName, lastName)
+        {
+            SetMajor(major);
+        }
+
+        public Student(string firstName, string lastName) :
+            base(firstName, lastName)
+        {
+            SetMajor();
+        }
+
+        public Student()
+        {
+            SetMajor();
+        }
+
+        [MemberNotNull(nameof(Major))]
+        private void SetMajor(string? major = default)
+        {
+            Major = major ?? "Undeclared";
+        }
+    }
+        // </ConstructorChainingAndMemberNotNull>
+}


### PR DESCRIPTION
Fixes #28531

The nullable docs did point to the `MemberNotNull` and `MemberNotNull` attributes for private initialization. But, there weren't clear examples, and a discussion of the alternative of constructor chaining.

Also, from the overview article, link to the article on resolving nullable warnings more prominently.
