### PR TITLE
Added web templates --use-program-main option

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -156,6 +156,10 @@ Each template may have additional options available. The core templates have the
 
   Doesn't execute an implicit restore during project creation.
 
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
+
 ***
 
 ## <a name="test"></a> `mstest`, `xunit`
@@ -307,6 +311,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 
   Port number to use for the HTTPS endpoint in *launchSettings.json*. This option is not applicable when the parameter `no-https` is used (but `no-https` is ignored when an individual or organizational authentication setting is chosen for `--auth`).
 
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
+
 ***
 
 ## `blazorwasm`
@@ -422,6 +430,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 
   Port number to use for the HTTPS endpoint in *launchSettings.json*. This option is not applicable when the parameter `no-https` is used (but `no-https` is ignored when an individual or organizational authentication setting is chosen for `--auth`).
 
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
+
 ***
 
 ## `web`
@@ -461,6 +473,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 - **`--kestrelHttpsPort`**
 
   Port number to use for the HTTPS endpoint in *launchSettings.json*. This option is not applicable when the parameter `no-https` is used (but `no-https` is ignored when an individual or organizational authentication setting is chosen for `--auth`).
+
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
 
 ***
 
@@ -564,6 +580,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 
   Port number to use for the HTTPS endpoint in *launchSettings.json*. This option is not applicable when the parameter `no-https` is used (but `no-https` is ignored when an individual or organizational authentication setting is chosen for `--auth`).
 
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
+
 ***
 
 ## <a name="spa"></a> `angular`, `react`
@@ -616,6 +636,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 - **`--kestrelHttpsPort`**
 
   Port number to use for the HTTPS endpoint in *launchSettings.json*. This option is not applicable when the parameter `no-https` is used (but `no-https` is ignored when an individual or organizational authentication setting is chosen for `--auth`).
+
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
 
 ***
 
@@ -745,6 +769,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 - **`--no-restore`**
 
   Doesn't execute an implicit restore during project creation.
+
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
 
 ***
 

--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -86,6 +86,10 @@ Each template may have additional options available. The core templates have the
 
   If specified, doesn't execute an implicit restore during project creation. Available since .NET Core 2.2 SDK.
 
+- **`--use-program-main`**
+
+  If specified, an explicit `Program` class and `Main` method will be used instead of top-level statements. Available since .NET SDK 6.0.300. Default value: `false`.
+
 ***
 
 ## `classlib`


### PR DESCRIPTION
## Summary
Adds details of the new `--use-program-main` template option to web templates.

**NOTE:** Do not merge until [actual change](https://github.com/dotnet/aspnetcore/pull/40945) is successfully back-ported to SDK 6.0.300
