### PR TITLE
Update struct.md

### DIFF
--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -67,7 +67,7 @@ Typically, you apply the `readonly` modifier to the following kinds of instance 
 
   :::code language="csharp" source="snippets/shared/StructType.cs" id="ReadonlyWithInit":::
 
-You can apply the `readonly` modifier to static members of a structure type excluding static members able to modify the structure instance.
+You can apply the `readonly` modifier to static fields of a structure type, but not any other static members, such as properties or methods.
 
 The compiler may make use of the `readonly` modifier for performance optimizations. For more information, see [Write safe and efficient C# code](../../write-safe-efficient-code.md).
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -67,7 +67,7 @@ Typically, you apply the `readonly` modifier to the following kinds of instance 
 
   :::code language="csharp" source="snippets/shared/StructType.cs" id="ReadonlyWithInit":::
 
-You can apply the `readonly` modifier to static members of a structure type excluding methods.
+You can apply the `readonly` modifier to static members of a structure type excluding members able to modify the structure instance.
 
 The compiler may make use of the `readonly` modifier for performance optimizations. For more information, see [Write safe and efficient C# code](../../write-safe-efficient-code.md).
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -67,7 +67,7 @@ Typically, you apply the `readonly` modifier to the following kinds of instance 
 
   :::code language="csharp" source="snippets/shared/StructType.cs" id="ReadonlyWithInit":::
 
-You can apply the `readonly` modifier to static members of a structure type excluding members able to modify the structure instance.
+You can apply the `readonly` modifier to static members of a structure type excluding static members able to modify the structure instance.
 
 The compiler may make use of the `readonly` modifier for performance optimizations. For more information, see [Write safe and efficient C# code](../../write-safe-efficient-code.md).
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -67,7 +67,7 @@ Typically, you apply the `readonly` modifier to the following kinds of instance 
 
   :::code language="csharp" source="snippets/shared/StructType.cs" id="ReadonlyWithInit":::
 
-You can't apply the `readonly` modifier to static members of a structure type.
+You can apply the `readonly` modifier to static members of a structure type excluding methods.
 
 The compiler may make use of the `readonly` modifier for performance optimizations. For more information, see [Write safe and efficient C# code](../../write-safe-efficient-code.md).
 


### PR DESCRIPTION
Readonly static members are possible. I may have not exhausted the list of members excluded from being applicable to both readonly and static (those that can modify the structure instance), so further edits may be necessary.

## Summary

Fixes unclear and misleading information regarding the usage of static readonly members.
