### PR TITLE
Fix usage of EmitCompilerGeneratedFiles

### DIFF
--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -137,7 +137,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
     :::image type="content" source="media/source-generators/source-generated-program.png" lightbox="media/source-generators/source-generated-program.png" alt-text="Visual Studio: Auto-generated Program.g.cs file.":::
 
-1. You can also set build properties to save the generated file and control where the generated files are stored. In the console application's project file, add the `<EmitCompilerGeneratedFiles>` element to an `<ItemGroup>`, and set its value to `true`. Build your project again. Now, the generated files are created under *obj/Debug/net6.0/generated/SourceGenerator/SourceGenerator.HelloSourceGenerator*. The components of the path map to the build configuration, target framework, source generator project name, and fully qualified type name of the generator. You can choose a more convenient output folder by adding the `<CompilerGeneratedFilesOutputPath>` element to the application's project file.
+1. You can also set build properties to save the generated file and control where the generated files are stored. In the console application's project file, add the `<EmitCompilerGeneratedFiles>` element to a `<PropertyGroup>`, and set its value to `true`. Build your project again. Now, the generated files are created under *obj/Debug/net6.0/generated/SourceGenerator/SourceGenerator.HelloSourceGenerator*. The components of the path map to the build configuration, target framework, source generator project name, and fully qualified type name of the generator. You can choose a more convenient output folder by adding the `<CompilerGeneratedFilesOutputPath>` element to the application's project file.
 
 ## Next steps
 


### PR DESCRIPTION
must be in a PropertyGroup, not an ItemGroup

## Summary

`EmitCompilerGeneratedFiles` is not a _vector_ but a _scalar_.

The suggested usage causes the containing project to fail to load (in _Visual Studio 17.1.3_):
```xml
<Project>
  <ItemGroup>
    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
  </ItemGroup>
</Project>
```

The correct usage is:
```xml
<Project>
  <PropertyGroup>
    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
  </PropertyGroup>
</Project>
```

Here are two working examples:
- https://github.com/Flash0ver/F0.Generators/blob/main/source/example/F0.Generators.Examples/F0.Generators.Examples.csproj
- https://github.com/Flash0ver/F0.Compatibility/blob/main/src/samples/F0.Compatibility.Examples/F0.Compatibility.Examples.csproj
