### PR TITLE
Update dotnet-stack.md

### DIFF
--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -140,7 +140,7 @@ To report managed stacks using `dotnet-stack`:
   ```
   
 > [!NOTE]
-> Stopping the process may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured.
+> Stopping the process can take a long time (up to serveral minutes) for very large applications. The runtime needs to send over the type and method information for all managed code that was captured to resolve function names.
   
 ## Next steps
   

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -139,8 +139,8 @@ To report managed stacks using `dotnet-stack`:
     Module!Method
   ```
   
-[!NOTE]
-Stopping the process may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured.
+> [!NOTE]
+> Stopping the process may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured.
   
 ## Next steps
   

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -139,6 +139,9 @@ To report managed stacks using `dotnet-stack`:
     Module!Method
   ```
   
+[!NOTE]
+Stopping the process may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured.
+  
 ## Next steps
   
 - [Use dotnet-trace to collect CPU samples of a .NET application](dotnet-trace.md)


### PR DESCRIPTION
## Summary

Add note to notify users that rundown can take a while for large apps. 

Fixes dotnet/diagnostics#1737
