### PR TITLE
Document some internal SQL type ctors as additional-apis

### DIFF
--- a/docs/framework/additional-apis/index.md
+++ b/docs/framework/additional-apis/index.md
@@ -39,7 +39,10 @@ These APIs support the product infrastructure and are not intended or supported 
 
 * [Microsoft.SqlServer.Server.SmiOrderProperty.Item property](microsoft.sqlserver.server.smiorderproperty.item.md)
 * [System.Exception.PrepForRemoting method](system.exception.prepforremoting.md)
+* [System.Data.SqlTypes.SqlBinary Constructor](system.data.sqltypes.sqlbinary.-ctor.md)
 * [System.Data.SqlTypes.SqlChars.Stream property](system.data.sqltypes.sqlchars.stream.md)
+* [System.Data.SqlTypes.SqlGuid Constructor](system.data.sqltypes.sqlguid.-ctor.md)
+* [System.Data.SqlTypes.SqlMoney Constructor](system.data.sqltypes.sqlmoney.-ctor.md)
 * [System.Data.SqlTypes.SqlStreamChars Constructor](system.data.sqltypes.sqlstreamchars.-ctor.md)
 * [System.Data.SqlTypes.SqlStreamChars.CanSeek property](system.data.sqltypes.sqlstreamchars.canseek.md)
 * [System.Data.SqlTypes.SqlStreamChars.IsNull property](system.data.sqltypes.sqlstreamchars.isnull.md)

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlbinary.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlbinary.-ctor.md
@@ -15,9 +15,9 @@ api_type:
 ---
 # SqlBinary Constructor
 
-Initializes a new instance of the `SqlBinary` struct without making a copy of the `byte[]` passed via the _value_ parameter. Future mutations to this array may cause the resulting `SqlBinary` instance to change its value.
+Initializes a new instance of the `SqlBinary` struct without making a copy of the `byte` array passed via the `value` parameter. Future mutations to this array may cause the resulting `SqlBinary` instance to change its value.
 
-The _ignored_ parameter is ignored.
+The `ignored` parameter is ignored.
 
 ```csharp
 internal SqlBinary(byte[] value, bool ignored);

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlbinary.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlbinary.-ctor.md
@@ -1,0 +1,39 @@
+---
+description: "Learn more about: SqlBinary Constructor"
+title: SqlBinary Constructor (System.Data.SqlTypes)
+author: grabyourpitchforks
+ms.date: 04/04/2022
+ms.technology: "dotnet-data"
+topic_type:
+  - "apiref"
+api_name:
+  - "System.Data.SqlTypes.SqlBinary..ctor"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlBinary Constructor
+
+Initializes a new instance of the `SqlBinary` struct without making a copy of the `byte[]` passed via the _value_ parameter. Future mutations to this array may cause the resulting `SqlBinary` instance to change its value.
+
+The _ignored_ parameter is ignored.
+
+```csharp
+internal SqlBinary(byte[] value, bool ignored);
+```
+
+## Remarks
+
+> [!WARNING]
+> This overload of the `SqlBinary` constructor is internal and is not meant to be used directly in your code. This API may not be available in future versions of .NET.
+>
+> Microsoft does not support the use of this constructor in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlguid.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlguid.-ctor.md
@@ -15,9 +15,9 @@ api_type:
 ---
 # SqlGuid Constructor
 
-Initializes a new instance of the `SqlGuid` struct without making a copy of the `byte[]` passed via the _value_ parameter. Future mutations to this array may cause the resulting `SqlGuid` instance to change its value.
+Initializes a new instance of the `SqlGuid` struct without making a copy of the `byte` array passed via the `value` parameter. Future mutations to this array may cause the resulting `SqlGuid` instance to change its value.
 
-The _ignored_ parameter is ignored.
+The `ignored` parameter is ignored.
 
 ```csharp
 internal SqlGuid(byte[] value, bool ignored);

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlguid.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlguid.-ctor.md
@@ -1,0 +1,39 @@
+---
+description: "Learn more about: SqlGuid Constructor"
+title: SqlGuid Constructor (System.Data.SqlTypes)
+author: grabyourpitchforks
+ms.date: 04/04/2022
+ms.technology: "dotnet-data"
+topic_type:
+  - "apiref"
+api_name:
+  - "System.Data.SqlTypes.SqlGuid..ctor"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlGuid Constructor
+
+Initializes a new instance of the `SqlGuid` struct without making a copy of the `byte[]` passed via the _value_ parameter. Future mutations to this array may cause the resulting `SqlGuid` instance to change its value.
+
+The _ignored_ parameter is ignored.
+
+```csharp
+internal SqlGuid(byte[] value, bool ignored);
+```
+
+## Remarks
+
+> [!WARNING]
+> This overload of the `SqlGuid` constructor is internal and is not meant to be used directly in your code. This API may not be available in future versions of .NET.
+>
+> Microsoft does not support the use of this constructor in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlmoney.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlmoney.-ctor.md
@@ -1,0 +1,39 @@
+---
+description: "Learn more about: SqlMoney Constructor"
+title: SqlMoney Constructor (System.Data.SqlTypes)
+author: grabyourpitchforks
+ms.date: 04/04/2022
+ms.technology: "dotnet-data"
+topic_type:
+  - "apiref"
+api_name:
+  - "System.Data.SqlTypes.SqlMoney..ctor"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlMoney Constructor
+
+Initializes a new instance of the `SqlMoney` struct, where _value_ has already been scaled by a ten-thousandth of a currency unit. For example, if __20000__ is provided for the _value_ parameter, this `SqlMoney` instance will represent __2__ currency units.
+
+The _ignored_ parameter is ignored.
+
+```csharp
+internal SqlMoney(long value, int ignored);
+```
+
+## Remarks
+
+> [!WARNING]
+> This overload of the `SqlMoney` constructor is internal and is not meant to be used directly in your code. This API may not be available in future versions of .NET.
+>
+> Microsoft does not support the use of this constructor in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlmoney.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlmoney.-ctor.md
@@ -15,9 +15,9 @@ api_type:
 ---
 # SqlMoney Constructor
 
-Initializes a new instance of the `SqlMoney` struct, where _value_ has already been scaled by a ten-thousandth of a currency unit. For example, if __20000__ is provided for the _value_ parameter, this `SqlMoney` instance will represent __2__ currency units.
+Initializes a new instance of the `SqlMoney` struct, where `value` has already been scaled by a ten-thousandth of a currency unit. For example, if __20000__ is provided for the `value` parameter, this `SqlMoney` instance will represent __2__ currency units.
 
-The _ignored_ parameter is ignored.
+The `ignored` parameter is ignored.
 
 ```csharp
 internal SqlMoney(long value, int ignored);

--- a/docs/framework/toc.yml
+++ b/docs/framework/toc.yml
@@ -463,10 +463,22 @@ items:
         href: additional-apis/system.exception.prepforremoting.md
   - name: System.Data.SqlTypes
     items:
+    - name: SqlBinary structure
+      items:
+      - name: SqlBinary constructor
+        href: additional-apis/system.data.sqltypes.sqlbinary.-ctor.md
     - name: SqlChars class
       items:
       - name: Stream property
         href: additional-apis/system.data.sqltypes.sqlchars.stream.md
+    - name: SqlGuid structure
+      items:
+      - name: SqlGuid constructor
+        href: additional-apis/system.data.sqltypes.sqlguid.-ctor.md
+    - name: SqlMoney structure
+      items:
+      - name: SqlMoney constructor
+        href: additional-apis/system.data.sqltypes.sqlmoney.-ctor.md
     - name: SqlStreamChars class
       items:
       - name: SqlStreamChars constructor


### PR DESCRIPTION
## Summary

Documents internal ctors for three SQL-related types: `SqlGuid`, `SqlBinary`, and `SqlDecimal`. The out-of-band package _Microsoft.Data.SqlClient_ currently uses unsupported union overlays to access these types (see https://github.com/dotnet/runtime/issues/51836). We can update the code to use a less fragile private reflection pattern, but it first requires properly documenting these APIs under the _additional-apis_ subfolder.