### PR TITLE
Doc: Unescape XML attribute value delimiters

### DIFF
--- a/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md
+++ b/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md
@@ -11,7 +11,7 @@ If you run into compatibility issues with this change on the .NET Framework 4.7.
 ```xml
 <configuration>
   <runtime>
-    <AppContextSwitchOverrides value=&quot;Switch.System.ServiceModel.UseSha1InMsmqEncryptionAlgorithm=true&quot; />
+    <AppContextSwitchOverrides value="Switch.System.ServiceModel.UseSha1InMsmqEncryptionAlgorithm=true" />
   </runtime>
 </configuration>
 ```


### PR DESCRIPTION
XML block had `&quot;` around attribute value [here](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/runtime/4.7-4.7.2#suggestion).

Now it matches 
[wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md](https://github.com/dotnet/docs/blob/5ddef8f95b071caa8f428b1d04a8026a8a72adc3/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)
