### PR TITLE
Recommend using the 0x prefix in App.config

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -1,39 +1,35 @@
 ---
 title: Garbage collector config settings
 description: Learn about run-time settings for configuring how the garbage collector manages memory for .NET Core apps.
-ms.date: 07/10/2020
+ms.date: 04/20/2022
 ms.topic: reference
 ---
 # Runtime configuration options for garbage collection
 
-This page contains information about garbage collector (GC) settings that can be changed at run time. If you're trying to achieve peak performance of a running app, consider using these settings. However, the defaults provide optimum performance for most applications in typical situations.
+This page contains information about settings for the .NET runtime garbage collector (GC). If you're trying to achieve peak performance of a running app, consider using these settings. However, the defaults provide optimum performance for most applications in typical situations.
 
 Settings are arranged into groups on this page. The settings within each group are commonly used in conjunction with each other to achieve a specific result.
 
 > [!NOTE]
 >
-> - These settings can also be changed dynamically by the app as it's running, so any run-time settings you set may be overridden.
+> - These settings can also be changed dynamically by the app as it's running, so any configuration options you set may be overridden.
 > - Some settings, such as [latency level](../../standard/garbage-collection/latency.md), are typically set only through the API at design time. Such settings are omitted from this page.
 > - For number values, use decimal notation for settings in the *runtimeconfig.json* file and hexadecimal notation for environment variable settings. For hexadecimal values, you can specify them with or without the "0x" prefix.
 > - If you're using the environment variables, .NET 6 standardizes on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.
 
 ## Ways to specify the configuration
 
-For different versions of the the .NET runtime, there are different ways to specify the configuration values, here is a summary:
+For different versions of the the .NET runtime, there are different ways to specify the configuration values. The following table shows a summary.
 
-| config location      | .net versions this location applies to | formats  | how it's interpreted                                         |
+| Config location      | .NET versions this location applies to | Formats  | How it's interpreted                                         |
 | -------------------- | -------------------------------------- | -------- | ------------------------------------------------------------ |
-| app.config           | .NET Framework                         | 0xn      | n is interpreted as a hex value  (also see note below)       |
-| environment variable | .NET Framework, .NET Core              | 0xn or n | n is interpreted as a hex value in either format             |
-| runtimeconfig.json   | .NET Core                              | n        | n is interpreted as a decimal value.                         |
+| runtimeconfig.json file | .NET Core                           | n        | n is interpreted as a decimal value.                         |
+| Environment variable | .NET Framework, .NET Core              | 0xn or n | n is interpreted as a hex value in either format             |
+| app.config file      | .NET Framework                         | 0xn      | n is interpreted as a hex value<sup>1</sup>                  |
 
-> [!NOTE]
->
-> - Note that you could specify a value without the 0x prefix for app.config but we do not recommend that. Due to an unfortunate bug, on .NET Framework 4.8+ it's interpreted as hex but on previous versions of .NET Framework it's interpreted as decimal. To avoid having to change your config please always use the 0x prefix when specifying a value in your app.config.
+<sup>1</sup> You can specify a value without the `0x` prefix for an app.config file setting, but it's not recommended. On .NET Framework 4.8+, due to a bug, a value specified without the `0x` prefix is interpreted as hexadecimal, but on previous versions of .NET Framework, it's interpreted as decimal. To avoid having to change your config, use the `0x` prefix when specifying a value in your app.config file.
 
-An example, if I want to specify 12 heaps for GCHeapCount, this is how I would specify it for an executable named `A.exe`
-
-For .NET Framework only, we can use A.exe.config
+For example, to specify 12 heaps for `GCHeapCount` for a .NET Framework app named *A.exe*, add the following XML to the *A.exe.config* file.
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -46,41 +42,39 @@ For .NET Framework only, we can use A.exe.config
 </configuration>
 ```
 
-For both .NET Core or .NET Framework, we can use environment variables:
+For both .NET Core and .NET Framework, you can use environment variables.
 
-On Windows
-
-For .NET 5 or above
+On Windows using .NET 5 or a later version:
 
 ```cmd
 SET DOTNET_gcServer=1
 SET DOTNET_GCHeapCount=c
 ```
 
-otherwise
+On Windows using .NET Core 3.1 or earlier:
 
 ```cmd
 SET COMPlus_gcServer=1
 SET COMPlus_GCHeapCount=c
 ```
 
-On Other OSes:
+On other operating systems:
 
-For .NET 5 or above
+For .NET 5 or later versions:
 
 ```bash
 export DOTNET_gcServer=1
 export DOTNET_GCHeapCount=c
 ```
 
-otherwise
+For .NET Core 3.1 and earlier versions:
 
 ```bash
 export COMPlus_gcServer=1
 export COMPlus_GCHeapCount=c
 ```
 
-For .NET Core only, we can use `runtimeconfig.json`
+For .NET Core only, you can set the value in the *runtimeconfig.json* file.
 
 ```json
 {

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -33,30 +33,32 @@ For different versions of the the .NET runtime, there are different ways to spec
 
 An example, if I want to specify 12 heaps for GCHeapCount, this is how I would specify it for an executable named `A.exe`
 
-
 For .NET Framework only, we can use A.exe.config
+
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-	...
-	<runtime>
-		<gcServer enabled="true"/>
-		<GCHeapCount>0xc</GCHeapCount>
-	</runtime>
+    ...
+    <runtime>
+        <gcServer enabled="true"/>
+        <GCHeapCount>0xc</GCHeapCount>
+    </runtime>
 </configuration>
 ```
 
 For both .NET Core or .NET Framework, we can use environment variables:
 
-On Windows 
+On Windows
 
 For .NET 5 or above
+
 ```cmd
 SET DOTNET_gcServer=1
 SET DOTNET_GCHeapCount=c
 ```
 
 otherwise
+
 ```cmd
 SET COMPlus_gcServer=1
 SET COMPlus_GCHeapCount=c
@@ -65,12 +67,14 @@ SET COMPlus_GCHeapCount=c
 On Other OSes:
 
 For .NET 5 or above
+
 ```bash
 export DOTNET_gcServer=1
 export DOTNET_GCHeapCount=c
 ```
 
 otherwise
+
 ```bash
 export COMPlus_gcServer=1
 export COMPlus_GCHeapCount=c

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -17,6 +17,78 @@ Settings are arranged into groups on this page. The settings within each group a
 > - For number values, use decimal notation for settings in the *runtimeconfig.json* file and hexadecimal notation for environment variable settings. For hexadecimal values, you can specify them with or without the "0x" prefix.
 > - If you're using the environment variables, .NET 6 standardizes on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.
 
+## Ways to specify the configuration
+
+For different versions of the the .NET runtime, there are different ways to specify the configuration values, here is a summary:
+
+| config location      | .net versions this location applies to | formats  | how it's interpreted                                         |
+| -------------------- | -------------------------------------- | -------- | ------------------------------------------------------------ |
+| app.config           | .NET Framework                         | 0xn      | n is interpreted as a hex value  (also see note below)       |
+| environment variable | .NET Framework, .NET Core              | 0xn or n | n is interpreted as a hex value in either format             |
+| runtimeconfig.json   | .NET Core                              | n        | n is interpreted as a decimal value.                         |
+
+> [!NOTE]
+>
+> - Note that you could specify a value without the 0x prefix for app.config but we do not recommend that. Due to an unfortunate bug, on .NET Framework 4.8+ it's interpreted as hex but on previous versions of .NET Framework it's interpreted as decimal. To avoid having to change your config please always use the 0x prefix when specifying a value in your app.config.
+
+An example, if I want to specify 12 heaps for GCHeapCount, this is how I would specify it for an executable named `A.exe`
+
+
+For .NET Framework only, we can use A.exe.config
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	...
+	<runtime>
+		<gcServer enabled="true"/>
+		<GCHeapCount>0xc</GCHeapCount>
+	</runtime>
+</configuration>
+```
+
+For both .NET Core or .NET Framework, we can use environment variables:
+
+On Windows 
+
+For .NET 5 or above
+```cmd
+SET DOTNET_gcServer=1
+SET DOTNET_GCHeapCount=c
+```
+
+otherwise
+```cmd
+SET COMPlus_gcServer=1
+SET COMPlus_GCHeapCount=c
+```
+
+On Other OSes:
+
+For .NET 5 or above
+```bash
+export DOTNET_gcServer=1
+export DOTNET_GCHeapCount=c
+```
+
+otherwise
+```bash
+export COMPlus_gcServer=1
+export COMPlus_GCHeapCount=c
+```
+
+For .NET Core only, we can use `runtimeconfig.json`
+
+```json
+{
+  "runtimeOptions": {
+   "configProperties": {
+      "System.GC.Server": true,
+      "System.GC.HeapCount": 12
+   }
+  }
+}
+```
+
 ## Flavors of garbage collection
 
 The two main flavors of garbage collection are workstation GC and server GC. For more information about differences between the two, see [Workstation and server garbage collection](../../standard/garbage-collection/workstation-server-gc.md).


### PR DESCRIPTION
## Summary

Update the GC Configuration page to recommend using 0x prefix in `App.config` to avoid a known unfortunate bug.

@dotnet/gc 