### PR TITLE
Document new method group conversion

### DIFF
--- a/docs/csharp/language-reference/operators/delegate-operator.md
+++ b/docs/csharp/language-reference/operators/delegate-operator.md
@@ -39,6 +39,24 @@ A static anonymous method can't capture local variables or instance state from e
 
 You also use the `delegate` keyword to declare a [delegate type](../builtin-types/reference-types.md#the-delegate-type).
 
+Beginning with C# 11, the compiler may cache the delegate object created from a method group. Consider the following method:
+
+```csharp
+static void StaticFunction() { }
+```
+
+When you assign the method group to a delegate, the compiler will cache the delegate:
+
+```csharp
+Action a = StaticFunction;
+```
+
+Before C# 11, you'd need to use a lambda expression to reuse a single delegate object:
+
+```csharp
+Action a = () = StaticFunction;
+```
+
 ## C# language specification
 
 For more information, see the [Anonymous function expressions](~/_csharpstandard/standard/expressions.md#1116-anonymous-function-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md).

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -16,6 +16,7 @@ The following features are available in the 6.0.200 version of the .NET SDK. The
 - [static abstract members in interfaces](#static-abstract-members-in-interfaces).
 - [Newlines in string interpolation expressions](#newlines-in-string-interpolations).
 - [Simplified parameter null checks](#simplified-parameter-null-checks).
+- [Improved method group conversion to delegate](#improved-method-group-conversion-to-delegate)
 
 You can download the latest .NET 6 SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), which includes the .NET 6 SDK.
 You can also try all these features with the preview release of the .NET 7 SDK, which can be downloaded from the [all .NET downloads](https://dotnet.microsoft.com/download/dotnet) page.
@@ -119,3 +120,11 @@ void Method(string name)
 ```
 
 This feature provides a concise syntax for runtime null parameter checking. It's intended for library authors to provide runtime checks even when APIs have been annotated for nullable reference types. These checks can simplify the necessary validation. You can learn more in the language reference article on [null parameter checks](../language-reference/operators/null-parameter-check.md).
+
+## Improved method group conversion to delegate
+
+The C# standard on [Method group conversions](~/_csharpstandard/standard/conversions.md#108-method-group-conversions) now includes the following item:
+
+> - The conversion is permitted (but not required) to use an existing delegate instance that already contains these references.
+
+Previous versions of the standard prohibited the compiler from reusing the delegate object created for a method group conversion. The C# 11 compiler caches the delegate object created from a method group conversion and reuses that single delegate object. This feature is first available in Visual Studio 17.2 as a preview feature. It is first available in .NET 7 preview 2.


### PR DESCRIPTION
Fixes #28942

Beginning in C# 11, the compiler is allowed to cache the delegate created from a method group conversion. The compiler now does this.
