### PR TITLE
Fix fish tab completion command

### DIFF
--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -99,5 +99,5 @@ compctl -K _dotnet_zsh_complete dotnet
 To add tab completion to your **fish** shell for the .NET CLI, add the following code to your `config.fish` file:
 
 ```fish
-complete -f -c dotnet -a "(dotnet complete)"
+complete -f -c dotnet -a "(dotnet complete (commandline -cp))"
 ```


### PR DESCRIPTION
## Summary

The current fish shell completions command doesn't work for me. It calls `dotnet complete` with no arguments, which does make suggestions, but the suggestions are not based on what I've already typed. Adding `commandline -cp` passes the currently typed command to improve suggestion relevancy.