### PR TITLE
move comment to correct block

### DIFF
--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -37,7 +37,6 @@ public class TypeAttribute : Attribute
 And to apply the attribute, you use the [`typeof`](../language-reference/operators/type-testing-and-cast.md#typeof-operator) operator:
 
 ```csharp
-// C# 11 feature:
 [TypeAttribute(typeof(string))]
 public string Method() => default;
 ```
@@ -45,6 +44,7 @@ public string Method() => default;
 Using this new feature, you can create a generic attribute instead:
 
 ```csharp
+// C# 11 feature:
 public class GenericAttribute<T> : Attribute { }
 ```
 


### PR DESCRIPTION
## Summary

If I understand the explanation correctly, the third (and fourth) code block uses the feature, not the second.
This tiny PR fixes this error.