### PR TITLE
Fix table cell entry for anonymous records

### DIFF
--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -116,7 +116,7 @@ The following table describes symbols related to type annotation and type tests.
 |`<...>`|[Automatic Generalization](../generics/automatic-generalization.md)|Delimits type parameters.|
 |`^`|[Statically Resolved Type Parameters](../generics/statically-resolved-type-parameters.md)<br /><br />[Strings](../strings.md)|<ul><li>Specifies type parameters that must be resolved at compile time, not at run time.</li><li>Concatenates strings.</li></ul>|
 | `{}`|[Class](../classes.md) or [Record](../records.md)|When used with the `type` keyword, delimits a class or record. The type is a class when members are declared or the `class` keyword is used. Otherwise, it's a record. |
-| `{\|\|}`|[Anonymous record](../anonymous-records.md)|Denotes an anonymous record|
+| <code>{&#124;&#124;}</code> |[Anonymous record](../anonymous-records.md)|Denotes an anonymous record|
 
 ## Symbols used in member lookup and slice expressions
 


### PR DESCRIPTION
At the moment table cell entry with a code snippet for anonymous records is being rendered in HTML on the Microsoft Docs site as:

`{\|\|}` and not like `{||}`

That's because the current Markdown engine considers pipes even inside the backticked blocks as column delimiters while rendering a table :pensive:.

## Summary

Use HTML `<code>...</code>` block instead.
