### PR TITLE
Logging bugs should be created in the runtime-repo

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -601,4 +601,4 @@ class Program
 - [Implement a custom logging provider in .NET](custom-logging-provider.md)
 - [Console log formatting](console-log-formatter.md)
 - [High-performance logging in .NET](high-performance-logging.md)
-- Logging bugs should be created in the [github.com/dotnet/extensions](https://github.com/dotnet/extensions/issues) repo
+- Logging bugs should be created in the [github.com/dotnet/runtime](https://github.com/dotnet/runtime//issues) repo


### PR DESCRIPTION
The extensions-repo is kind of "archived".