### PR TITLE
Docs: Fix typo in NullParameterCheck snippet

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/NullParameterCheck.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullParameterCheck.cs
@@ -73,7 +73,7 @@ public interface IInterfaceMethods
     // Simplified null parameter check not allowed:
     void Method(string name);
 
-    // !! allowed because an implementation is suppolied:
+    // !! allowed because an implementation is supplied:
     public static void SetDefaultName(string name!!)
     {
         defaultName = name;


### PR DESCRIPTION
## Summary

This change corrects a typo in one of the comments of the NullParameterCheck code snippet. A word was spelled incorrectly. I've been reading these docs today, otherwise they look great!

This was in a recent addition for a c#11 feature, see PR #28890