### PR TITLE
Allow demo code to compile

### DIFF
--- a/docs/fsharp/language-reference/computation-expressions.md
+++ b/docs/fsharp/language-reference/computation-expressions.md
@@ -309,7 +309,7 @@ module Eventually =
         | Done value -> result (Ok value)
         | NotYetDone work ->
             NotYetDone (fun () ->
-                let res = try Ok(work()) with | exn -> Exception exn
+                let res = try Ok(work()) with | exn -> Error exn
                 match res with
                 | Ok cont -> catch cont // note, a tailcall
                 | Error exn -> result (Error exn))


### PR DESCRIPTION
Function to should return Error not Exception.

## Summary

Fix demo code that has not compiled since it was published five and a half years ago.


