### PR TITLE
Update code example on runes and text elements to be clearer

### DIFF
--- a/docs/standard/base-types/snippets/character-encoding-introduction/csharp/CountTextElements.cs
+++ b/docs/standard/base-types/snippets/character-encoding-introduction/csharp/CountTextElements.cs
@@ -9,7 +9,7 @@ namespace RuneSamples
         public static void Run()
         {
             // <SnippetCallCountMethod>
-            PrintTextElementCount("á");
+            PrintTextElementCount("a");
             // Number of chars: 1
             // Number of runes: 1
             // Number of text elements: 1
@@ -41,8 +41,8 @@ namespace RuneSamples
                 }
 
                 Console.WriteLine($"Number of text elements: {textElementCount}");
-                // </SnippetCountMethod>
             }
+            // </SnippetCountMethod>
         }
     }
 }


### PR DESCRIPTION
## Summary

It's a bit confusing to see two types of `á` characters in the example and have different output results. I've changed the first example to be a single `a`.

I also fixed the snippet tag position.

Fixes #29075
