### PR TITLE
Publish from the draft v7 branch

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -55,7 +55,7 @@
     {
       "path_to_root": "_csharpstandard",
       "url": "https://github.com/dotnet/csharpstandard",
-      "branch": "draft-v6",
+      "branch": "draft-v7",
       "include_in_build": true,
       "branch_mapping": {}
     },


### PR DESCRIPTION
The committee has finished the C# 6 standard, and submitted the draft to ECMA. It's now turning its focus to the C# 7.x release(s).

The PR changes the branch from which we publish the standard, but doesn't do any further work. The content is at v6, as we haven't started accepting any V7 PRs.
