### PR TITLE
Perf map docs

### DIFF
--- a/docs/core/diagnostics/debug-highcpu.md
+++ b/docs/core/diagnostics/debug-highcpu.md
@@ -114,7 +114,7 @@ When analyzing a slow request, you need a diagnostics tool that can provide insi
 
 The `perf` tool can be used to generate .NET Core app profiles. Exit the previous instance of the [sample debug target](/samples/dotnet/samples/diagnostic-scenarios).
 
-Set the `DOTNET_PerfMapEnabled` environment variable to cause the .NET Core app to create a `map` file in the `/tmp` directory. This `map` file is used by `perf` to map CPU address to JIT-generated functions by name. For more information, see [Write perf map](../runtime-config/debugging-profiling.md#write-perf-map).
+Set the `DOTNET_PerfMapEnabled` environment variable to cause the .NET Core app to create a `map` file in the `/tmp` directory. This `map` file is used by `perf` to map CPU address to JIT-generated functions by name. For more information, see [Export perf maps](../runtime-config/debugging-profiling.md#export-perf-maps).
 
 [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -53,7 +53,7 @@ This article details the settings you can use to configure .NET debugging and pr
 
 ## Export perf maps
 
-- Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Perf maps allow 3rd party tools, such as perf, to identify call sites from pre-compiled R2R modules.
+- Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Perf maps allow third party tools, such as perf, to identify call sites from precompiled ReadyToRun (R2R) modules.
 - If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
 - Without perf maps enabled you will not see all managed callsites properly resolved.
 - Enabling causes a 10-20% overhead.

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -74,4 +74,4 @@ This article details the settings you can use to configure .NET debugging and pr
 | **Environment variable** | `COMPlus_PerfMapIgnoreSignal` or `DOTNET_PerfMapIgnoreSignal` | `0` - disabled<br/>`1` - enabled |
 
 > [!NOTE]
-> This setting is ignored if [DOTNET_PerfMapEnabled](#write-perf-map) is omitted or set to `0` (that is, disabled).
+> This setting is ignored if [DOTNET_PerfMapEnabled](#export-perf-map) is omitted or set to `0` (that is, disabled).

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -74,4 +74,4 @@ This article details the settings you can use to configure .NET debugging and pr
 | **Environment variable** | `COMPlus_PerfMapIgnoreSignal` or `DOTNET_PerfMapIgnoreSignal` | `0` - disabled<br/>`1` - enabled |
 
 > [!NOTE]
-> This setting is ignored if [DOTNET_PerfMapEnabled](#export-perf-map) is omitted or set to `0` (that is, disabled).
+> This setting is ignored if [DOTNET_PerfMapEnabled](#export-perf-maps) is omitted or set to `0` (that is, disabled).

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -56,7 +56,7 @@ This article details the settings you can use to configure .NET debugging and pr
 - Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Perf maps allow third party tools, such as perf, to identify call sites from precompiled ReadyToRun (R2R) modules.
 - If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
 - When perf maps are disabled, not all managed callsites will be properly resolved.
-- Enabling causes a 10-20% overhead.
+- Enabling perf maps causes a 10-20% overhead.
 
 | | Setting name | Values |
 | - | - | - |

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -51,15 +51,17 @@ This article details the settings you can use to configure .NET debugging and pr
 | **Environment variable** | `CORECLR_PROFILER_PATH_32` | *string-path* |
 | **Environment variable** | `CORECLR_PROFILER_PATH_64` | *string-path* |
 
-## Write perf map
+## Export perf maps
 
-- Enables or disables writing */tmp/perf-$pid.map* on Linux systems.
+- Controls whether the runtime emits perf maps to */tmp/perf-$pid.map*. Perf maps allow 3rd party tools, such as perf, to identify call sites from pre-compiled R2R modules.
 - If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
+- Without perf maps enabled you will not see all managed callsites properly resolved.
+- Enabling causes a 10-20% overhead.
 
 | | Setting name | Values |
 | - | - | - |
 | **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - enabled |
+| **Environment variable** | `COMPlus_PerfMapEnabled` | `0` - disabled<br/>`1` - enabled |
 
 ## Perf log markers
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -55,7 +55,7 @@ This article details the settings you can use to configure .NET debugging and pr
 
 - Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Perf maps allow third party tools, such as perf, to identify call sites from precompiled ReadyToRun (R2R) modules.
 - If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
-- Without perf maps enabled you will not see all managed callsites properly resolved.
+- When perf maps are disabled, not all managed callsites will be properly resolved.
 - Enabling causes a 10-20% overhead.
 
 | | Setting name | Values |

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -61,7 +61,7 @@ This article details the settings you can use to configure .NET debugging and pr
 | | Setting name | Values |
 | - | - | - |
 | **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_PerfMapEnabled` | `0` - disabled<br/>`1` - enabled |
+| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - enabled |
 
 ## Perf log markers
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -53,7 +53,7 @@ This article details the settings you can use to configure .NET debugging and pr
 
 ## Export perf maps
 
-- Controls whether the runtime emits perf maps to */tmp/perf-$pid.map*. Perf maps allow 3rd party tools, such as perf, to identify call sites from pre-compiled R2R modules.
+- Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Perf maps allow 3rd party tools, such as perf, to identify call sites from pre-compiled R2R modules.
 - If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
 - Without perf maps enabled you will not see all managed callsites properly resolved.
 - Enabling causes a 10-20% overhead.


### PR DESCRIPTION
## Summary

Expand on what perf maps are and mention that they cause a large overhead.

Fixes https://github.com/dotnet/diagnostics/issues/2155
