### PR TITLE
Replace hyphen-link characer with hyphen

### DIFF
--- a/docs/standard/assembly/delay-sign.md
+++ b/docs/standard/assembly/delay-sign.md
@@ -49,21 +49,21 @@ To delay-sign an assembly:
 
 3. The compiler inserts the public key into the assembly manifest and reserves space in the PE file for the full strong name signature. The real public key must be stored while the assembly is built so that other assemblies that reference this assembly can obtain the key to store in their own assembly reference.
 
-4. Because the assembly does not have a valid strong name signature, the verification of that signature must be turned off. You can do this by using the **–Vr** option with the Strong Name tool.
+4. Because the assembly does not have a valid strong name signature, the verification of that signature must be turned off. You can do this by using the **-Vr** option with the Strong Name tool.
 
      The following example turns off verification for an assembly called *myAssembly.dll*.
 
    ```console
-   sn –Vr myAssembly.dll
+   sn -Vr myAssembly.dll
    ```
 
-   To turn off verification on platforms where you can't run the Strong Name tool, such as Advanced RISC Machine (ARM) microprocessors, use the **–Vk** option to create a registry file. Import the registry file into the registry on the computer where you want to turn off verification. The following example creates a registry file for `myAssembly.dll`.
+   To turn off verification on platforms where you can't run the Strong Name tool, such as Advanced RISC Machine (ARM) microprocessors, use the **-Vk** option to create a registry file. Import the registry file into the registry on the computer where you want to turn off verification. The following example creates a registry file for `myAssembly.dll`.
 
    ```console
-   sn –Vk myRegFile.reg myAssembly.dll
+   sn -Vk myRegFile.reg myAssembly.dll
    ```
 
-   With either the **–Vr** or **–Vk** option, you can optionally include an *.snk* file for test key signing.
+   With either the **-Vr** or **-Vk** option, you can optionally include an *.snk* file for test key signing.
 
    > [!WARNING]
    > Do not rely on strong names for security. They provide a unique identity only.
@@ -71,7 +71,7 @@ To delay-sign an assembly:
    > [!NOTE]
    > If you use delay signing during development with Visual Studio on a 64-bit computer, and you compile an assembly for **Any CPU**, you might have to apply the **-Vr** option twice. (In Visual Studio, **Any CPU** is a value of the **Platform Target** build property; when you compile from the command line, it is the default.) To run your application from the command line or from File Explorer, use the 64-bit version of the [Sn.exe (Strong Name tool)](../../framework/tools/sn-exe-strong-name-tool.md) to apply the **-Vr** option to the assembly. To load the assembly into Visual Studio at design time (for example, if the assembly contains components that are used by other assemblies in your application), use the 32-bit version of the strong-name tool. This is because the just-in-time (JIT) compiler compiles the assembly to 64-bit native code when the assembly is run from the command line, and to 32-bit native code when the assembly is loaded into the design-time environment.
 
-5. Later, usually just before shipping, you submit the assembly to your organization's signing authority for the actual strong name signing using the **–R** option with the Strong Name tool.
+5. Later, usually just before shipping, you submit the assembly to your organization's signing authority for the actual strong name signing using the **-R** option with the Strong Name tool.
 
    The following example signs an assembly called *myAssembly.dll* with a strong name using the *sgKey.snk* key pair.
 


### PR DESCRIPTION
## Summary

In the code samples, the hyphen used is `–` which is U+2013 instead of the real hyphen character `-` which is U+002D. This causes copying the code samples to fail when executing them via CLI
