### PR TITLE
Fix a typo

### DIFF
--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -197,7 +197,7 @@ For more information, see [Top-level statements](../fundamentals/program-structu
 
 C# 9 includes new pattern matching improvements:
 
-- ***Type patterns*** match a variable is a type
+- ***Type patterns*** match a variable that is a type
 - ***Parenthesized patterns*** enforce or emphasize the precedence of pattern combinations
 - ***Conjunctive `and` patterns*** require both patterns to match
 - ***Disjunctive `or` patterns*** require either pattern to match

--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -197,7 +197,7 @@ For more information, see [Top-level statements](../fundamentals/program-structu
 
 C# 9 includes new pattern matching improvements:
 
-- ***Type patterns*** match a variable that is a type
+- ***Type patterns*** match a variable that is a particular type
 - ***Parenthesized patterns*** enforce or emphasize the precedence of pattern combinations
 - ***Conjunctive `and` patterns*** require both patterns to match
 - ***Disjunctive `or` patterns*** require either pattern to match

--- a/docs/csharp/whats-new/csharp-9.md
+++ b/docs/csharp/whats-new/csharp-9.md
@@ -197,7 +197,7 @@ For more information, see [Top-level statements](../fundamentals/program-structu
 
 C# 9 includes new pattern matching improvements:
 
-- ***Type patterns*** match a variable that is a particular type
+- ***Type patterns*** match an object matches a particular type
 - ***Parenthesized patterns*** enforce or emphasize the precedence of pattern combinations
 - ***Conjunctive `and` patterns*** require both patterns to match
 - ***Disjunctive `or` patterns*** require either pattern to match


### PR DESCRIPTION
## Summary

Fix a grammar typo in the explanation of Type patterns in the **Pattern matching enhancements** section of the _What's new in C# 9.0_ article.

Fixes #Issue_Number (if available)
