### PR TITLE
Fixed Compiler Error CS1009 in sample

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -59,7 +59,7 @@ You can use the [`using` statement](../../../csharp/language-reference/keywords/
 - When constructors that are protected by only one exception handler are nested in the [acquisition part of a `using` statement](../../../csharp/language-reference/keywords/using-statement.md), a failure in the outer constructor can result in the object created by the nested constructor never being closed. In the following example, a failure in the <xref:System.IO.StreamReader> constructor can result in the <xref:System.IO.FileStream> object never being closed. CA2000 flags a violation of the rule in this case.
 
    ```csharp
-   using (StreamReader sr = new StreamReader(new FileStream("C:\myfile.txt", FileMode.Create)))
+   using (StreamReader sr = new StreamReader(new FileStream("C:/myfile.txt", FileMode.Create)))
    { ... }
    ```
 


### PR DESCRIPTION
## Summary

The sample code was not valid. A single '\\' needs to be escaped. I changed it to a '/' thats for every os valid.