### PR TITLE
Clarify behavior with examples

### DIFF
--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -1,7 +1,7 @@
 ---
 description: "Checked and Unchecked - C# Reference"
 title: "Checked and Unchecked - C# Reference"
-ms.date: 05/15/2018
+ms.date: 04/26/2022
 helpviewer_keywords: 
   - "operators [C#], checked and unchecked"
   - "exceptions [C#], overflow checking"
@@ -9,28 +9,30 @@ helpviewer_keywords:
   - "overflow checking [C#]"
   - "unchecked statement [C#]"
   - "statements [C#], checked and unchecked"
-ms.assetid: a84bc877-2c7f-4396-8735-1ce97c42f35e
 ---
-# Checked and Unchecked (C# Reference)
+# Checked and unchecked (C# Reference)
 
-C# statements can execute in either checked or unchecked context. In a checked context, arithmetic overflow raises an exception. In an unchecked context, arithmetic overflow is ignored and the result is truncated by discarding any high-order bits that don't fit in the destination type.  
-  
-- [checked](checked.md) Specify checked context.  
-  
-- [unchecked](unchecked.md) Specify unchecked context.  
-  
- The following operations are affected by the overflow checking:  
-  
-- Expressions using the following predefined operators on integral types:  
-  
-     `++`, `--`, unary `-`, `+`, `-`, `*`, `/`  
-  
-- Explicit numeric conversions between integral types, or from `float` or `double` to an integral type.  
-  
- If neither `checked` nor `unchecked` is specified, the default context for non-constant expressions (expressions that are evaluated at run time) is defined by the value of the [**CheckForOverflowUnderflow**](../compiler-options/language.md#checkforoverflowunderflow) compiler option. By default the value of that option is unset and arithmetic operations are executed in an unchecked context.
+C# statements can execute in either checked or unchecked context. In a checked context, arithmetic overflow raises an exception. In an unchecked context, arithmetic overflow is ignored and the result is truncated by discarding any high-order bits that don't fit in the destination type.
 
- For constant expressions (expressions that can be fully evaluated at compile time), the default context is always checked. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
+:::code language="csharp" interactive="try-dotnet-method" source="./snippets/CheckedUnchecked.cs" id="CheckedAndUnchecked":::
+
+In checked mode, any constant expression that overflows or underflows generates a compiler error. Any expression that overflows at runtime throws an <xref:System.OverflowException?displayProperty=nameWithType>.  In unchecked mode, it wraps from the maximum value to the minimum value.
   
+- [checked](checked.md) Specify checked context.
+- [unchecked](unchecked.md) Specify unchecked context.
+
+The following operations are affected by the overflow checking:
+
+- Expressions using the following predefined operators on integral types:
+
+    `++`, `--`, unary `-`, `+`, `-`, `*`, `/`
+
+- Explicit numeric conversions between integral types, or from `float` or `double` to an integral type.
+
+If neither `checked` nor `unchecked` is specified, the default context for non-constant expressions (expressions that are evaluated at run time) is defined by the value of the [**CheckForOverflowUnderflow**](../compiler-options/language.md#checkforoverflowunderflow) compiler option. By default the value of that option is unset and arithmetic operations are executed in an unchecked context.
+
+For constant expressions (expressions that can be fully evaluated at compile time), the default context is always checked. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
+
 ## See also
 
 - [C# Reference](../index.md)

--- a/docs/csharp/language-reference/keywords/snippets/CheckedUnchecked.cs
+++ b/docs/csharp/language-reference/keywords/snippets/CheckedUnchecked.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace keywords;
+
+public static class CheckedAndUnchecked
+{
+    public static void Examples()
+    {
+        // <CheckedAndUnchecked>
+        Console.WriteLine(int.MaxValue);           // 2147483647
+        Console.WriteLine($"0x{int.MaxValue:X}");  // 0x7FFFFFFF
+        
+        Console.WriteLine(unchecked (int.MaxValue+1));          // -2147483648
+        Console.WriteLine($"0x{unchecked (int.MaxValue+1):X}"); // 0x80000000
+        Console.WriteLine(int.MinValue);                        // -2147483648
+        Console.WriteLine($"0x{int.MinValue:X}");               // 0x80000000
+        
+        // Create overflow using compile-time constants:
+        // CS0220: The operation overflows at compile time in checked mode
+        // Console.WriteLine(checked (int.MaxValue+1));
+
+        try {
+            checked 
+            {
+                var number = 1 + int.MaxValue / 2;
+                number += number;
+            }
+        } catch (OverflowException e)
+        {
+            Console.WriteLine("This operation overflows at runtime in checked mode.");
+        }
+        // </CheckedAndUnchecked>
+
+   }
+}

--- a/docs/csharp/language-reference/keywords/snippets/Program.cs
+++ b/docs/csharp/language-reference/keywords/snippets/Program.cs
@@ -17,6 +17,8 @@ namespace keywords
             UsingStatements.Examples();
             Console.WriteLine("=================    try-catch Keyword Examples ======================");
             await AsyncExceptionExamples.Examples();
+            Console.WriteLine("=================    try-catch Keyword Examples ======================");
+            CheckedAndUnchecked.Examples();
         }
     }
 }


### PR DESCRIPTION
Fixes #29005

Add examples and explanatory text to the checked and unchecked keywords.

[Internal preview link](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked-and-unchecked?branch=pr-en-us-29177)