### PR TITLE
Make installation instructions consistent

### DIFF
--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -9,7 +9,7 @@ In this tutorial, you'll build a console application and see the basic object-or
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](../../tour-of-csharp/tutorials/local-environment.md).
+[!INCLUDE [Prerequisites](../../includes/prerequisites.md)]
 
 ## Create your application
 

--- a/docs/csharp/fundamentals/tutorials/inheritance.md
+++ b/docs/csharp/fundamentals/tutorials/inheritance.md
@@ -10,7 +10,7 @@ This tutorial introduces you to inheritance in C#. Inheritance is a feature of o
 
 ## Prerequisites
 
-This tutorial assumes that you've installed the .NET SDK. Visit the [.NET Downloads](https://dotnet.microsoft.com/download) page to download it. You also need a code editor. This tutorial uses [Visual Studio Code](https://code.visualstudio.com), although you can use any code editor of your choice.
+[!INCLUDE [Prerequisites](../../includes/prerequisites.md)]
 
 ## Running the examples
 

--- a/docs/csharp/fundamentals/tutorials/pattern-matching.md
+++ b/docs/csharp/fundamentals/tutorials/pattern-matching.md
@@ -18,7 +18,7 @@ In this tutorial, you'll learn how to:
 
 ## Prerequisites
 
-You'll need to set up your machine to run .NET 6, which includes the C# 10 compiler. The C# 10 compiler is available starting with [Visual Studio 2022](https://visualstudio.microsoft.com/vs/preview/) or [.NET 6 SDK](https://dotnet.microsoft.com/download).
+[!INCLUDE [Prerequisites](../../includes/prerequisites.md)]
 
 This tutorial assumes you're familiar with C# and .NET, including either Visual Studio or the .NET CLI.
 

--- a/docs/csharp/includes/prerequisites.md
+++ b/docs/csharp/includes/prerequisites.md
@@ -1,0 +1,10 @@
+---
+author: BillWagner
+ms.author: wiwagn
+ms.topic: include
+ms.date: 04/26/2022
+---
+
+- We recommend [Visual Studio](https://visualstudio.com) for Windows or Mac. You can download a free version from the [Visual Studio downloads page](https://visualstudio.microsoft.com/downloads). Visual Studio includes the .NET SDK.
+- You can also use the [Visual Studio Code](https://code.visualstudio.com) editor. You'll need to install the latest [.NET SDK](https://dotnet.microsoft.com/download) separately.
+- If you prefer a different editor, you need to install the latest [.NET SDK](https://dotnet.microsoft.com/download).

--- a/docs/csharp/language-reference/attributes/nullable-analysis.md
+++ b/docs/csharp/language-reference/attributes/nullable-analysis.md
@@ -203,8 +203,6 @@ When the value of the argument matches the value of the `DoesNotReturnIf` constr
 
 ## Summary
 
-[!INCLUDE [C# version alert](../../includes/csharp-version-alert.md)]
-
 Adding nullable reference types provides an initial vocabulary to describe your APIs expectations for variables that could be `null`. The attributes provide a richer vocabulary to describe the null state of variables as preconditions and postconditions. These attributes more clearly describe your expectations and provide a better experience for the developers using your APIs.
 
 As you update libraries for a nullable context, add these attributes to guide users of your APIs to the correct usage. These attributes help you fully describe the null-state of arguments and return values.

--- a/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
+++ b/docs/csharp/tour-of-csharp/tutorials/arrays-and-collections.md
@@ -9,7 +9,7 @@ This introductory tutorial provides an introduction to the C# language and the b
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macOS and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+The tutorial expects that you have a machine set up for local development. See [Set up your local environment](local-environment.md) for installation instructions and an overview of application development in .NET.
 
 If you prefer to run the code without having to set up a local environment, see the [interactive-in-browser version of this tutorial](list-collection.yml).
 

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
@@ -10,7 +10,7 @@ This tutorial teaches you how to write C# code that examines variables and chang
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macoS and Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+The tutorial expects that you have a machine set up for local development. See [Set up your local environment](local-environment.md) for installation instructions and an overview of application development in .NET.
 
 If you prefer to run the code without having to set up a local environment, see the [interactive-in-browser version of this tutorial](branches-and-loops.yml).
 

--- a/docs/csharp/tour-of-csharp/tutorials/local-environment.md
+++ b/docs/csharp/tour-of-csharp/tutorials/local-environment.md
@@ -5,12 +5,9 @@ ms.date: 02/02/2021
 ---
 # Set up your local environment
 
-The first step in running a tutorial on your machine is to set up a development environment. Choose one of the following alternatives:
+The first step in running a tutorial on your machine is to set up a development environment.
 
-* To use the .NET CLI and your choice of text or code editor, see the .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro). The tutorial has instructions for setting up a development environment on Windows, Linux, or macOS.
-* To use the .NET CLI and Visual Studio Code, install the [.NET SDK](https://dotnet.microsoft.com/download) and
-[Visual Studio Code](https://code.visualstudio.com/).
-* To use Visual Studio 2019, see [Tutorial: Create a simple C# console app in Visual Studio](/visualstudio/get-started/csharp/tutorial-console).
+[!INCLUDE [Prerequisites](../../includes/prerequisites.md)]
 
 ## Basic application development flow
 

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -10,7 +10,7 @@ This tutorial teaches you about the numeric types in C#. You'll write small amou
 
 ## Prerequisites
 
-The tutorial expects that you have a machine set up for local development. On Windows, Linux, or macOS, you can use the .NET CLI to create, build, and run applications. On macOS or Windows, you can use Visual Studio 2019. For setup instructions, see [Set up your local environment](local-environment.md).
+The tutorial expects that you have a machine set up for local development. See [Set up your local environment](local-environment.md) for installation instructions and an overview of application development in .NET.
 
 If you don't want to set up a local environment, see the [interactive-in-browser version of this tutorial](numbers-in-csharp.yml).
 


### PR DESCRIPTION
Fixes #28771

- Move installation instructions to a prerequisite document.
Recommend Visual Studio first, followed by VS Code.
- Link to the SDK if users prefer a different editor.
- Remove unused include file.

