### PR TITLE
Typo "Azure Pipeline"→"Azure Pipelines"

### DIFF
--- a/docs/architecture/devops-for-aspnet-developers/actions-vs-pipelines.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-vs-pipelines.md
@@ -39,7 +39,7 @@ GitHub Workflows execute on *runners*. The runner code is essentially a fork of 
 Hosted agents (Azure Pipelines) and hosted runners (GitHub) are agents that are spun up and managed by Azure DevOps or GitHub respectively. You don't need to maintain any build infrastructure. When a pipeline triggers that targets a hosted agent, an instance of the specified agent image is created. The job is run by the agent on the instance, and once the job completes, the instance is destroyed. The same applies for hosted runners running GitHub workflows.
 
 > [!NOTE]
-> The list of software installed on Azure Pipeline images is listed in [this repository](https://github.com/actions/virtual-environments/tree/main/images). You can select the platform folder and examine the *README.md* files. You can find information on [GitHub hosted runners](https://docs.github.com/actions/reference/specifications-for-github-hosted-runners).
+> The list of software installed on Azure Pipelines images is listed in [this repository](https://github.com/actions/virtual-environments/tree/main/images). You can select the platform folder and examine the *README.md* files. You can find information on [GitHub hosted runners](https://docs.github.com/actions/reference/specifications-for-github-hosted-runners).
 
 ### Private agents and self-hosted runners
 


### PR DESCRIPTION
## Summary
Typo "Azure Pipeline"→"Azure Pipelines"

Describe your changes here.
Typo "Azure Pipeline"→"Azure Pipelines"
https://docs.microsoft.com/en-us/dotnet/architecture/devops-for-aspnet-developers/actions-vs-pipelines
https://github.com/dotnet/docs/blob/main/docs/architecture/devops-for-aspnet-developers/actions-vs-pipelines.md
#PingMSFTDocs

Fixes #Issue_Number (if available)
