### PR TITLE
Add a link to the RidGraph tool

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -63,6 +63,8 @@ The following example shows a slightly bigger RID graph also defined in the *run
             any
 ```
 
+Alternatively, you can use the [RidGraph](https://github.com/0xced/RidGraph) tool to easily visualize the RID graph (or any subset of the graph).
+
 All RIDs eventually map back to the root `any` RID.
 
 There are some considerations about RIDs that you have to keep in mind when working with them:


### PR DESCRIPTION
The RidGraph tool generates visualizable .NET runtime identifier graphs in SVG

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/rid-catalog.md](https://github.com/dotnet/docs/blob/656d7c88e500e334bd04c02f8b839af342103a7d/docs/core/rid-catalog.md) | [.NET RID Catalog](https://review.learn.microsoft.com/en-us/dotnet/core/rid-catalog?branch=pr-en-us-29230) |


<!-- PREVIEW-TABLE-END -->