### PR TITLE
Explicitly state lambda right-associativity

### DIFF
--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -94,7 +94,7 @@ The following table lists the C# operators starting with the highest precedence 
 When operators have the same precedence, associativity of the operators determines the order in which the operations are performed:
 
 - *Left-associative* operators are evaluated in order from left to right. Except for the [assignment operators](assignment-operator.md) and the [null-coalescing operators](null-coalescing-operator.md), all binary operators are left-associative. For example, `a + b - c` is evaluated as `(a + b) - c`.
-- *Right-associative* operators are evaluated in order from right to left. The assignment operators, the null-coalescing operators, and the [conditional operator `?:`](conditional-operator.md) are right-associative. For example, `x = y = z` is evaluated as `x = (y = z)`.
+- *Right-associative* operators are evaluated in order from right to left. The assignment operators, the null-coalescing operators, lambdas, and the [conditional operator `?:`](conditional-operator.md) are right-associative. For example, `x = y = z` is evaluated as `x = (y = z)`.
 
 Use parentheses to change the order of evaluation imposed by operator associativity:
 


### PR DESCRIPTION
## Summary

Adding lambdas to the list of right-associative operators here

Fixes #28998
