### PR TITLE
Add note about invalid event name characters

### DIFF
--- a/docs/core/diagnostics/eventsource-instrumentation.md
+++ b/docs/core/diagnostics/eventsource-instrumentation.md
@@ -58,7 +58,7 @@ follow the relatedActivityId. For the WriteEvent\*Core methods, the arguments mu
 `data` parameter.
 8. Event names cannot contain `<` or `>` characters. While user defined methods also cannot contain these characters, `async` methods
 will be rewritten by the compiler to contain them. Mark all non-event methods on an <xref:System.Diagnostics.Tracing.EventSource>
-with the <xref:System.Diagnostics.Tracing.EventSource.NonEventAttribute> to be sure these generated methods don't become events.
+with the <xref:System.Diagnostics.Tracing.NonEventAttribute> to be sure these generated methods don't become events.
 
 ## Best practices
 

--- a/docs/core/diagnostics/eventsource-instrumentation.md
+++ b/docs/core/diagnostics/eventsource-instrumentation.md
@@ -56,6 +56,9 @@ so on.
 to the WriteEvent\* APIs. For WriteEvent the arguments follow the Event ID, for WriteEventWithRelatedActivityId the arguments
 follow the relatedActivityId. For the WriteEvent\*Core methods, the arguments must be serialized manually into the
 `data` parameter.
+8. Event names cannot contain `<` or `>` characters. While user defined methods also cannot contain these characters, `async` methods
+will be rewritten by the compiler to contain them. Mark all non-event methods on an <xref:System.Diagnostics.Tracing.EventSource>
+with the <xref:System.Diagnostics.Tracing.EventSource.NonEventAttribute> to be sure these generated methods don't become events.
 
 ## Best practices
 

--- a/docs/core/diagnostics/eventsource-instrumentation.md
+++ b/docs/core/diagnostics/eventsource-instrumentation.md
@@ -56,9 +56,9 @@ so on.
 to the WriteEvent\* APIs. For WriteEvent the arguments follow the Event ID, for WriteEventWithRelatedActivityId the arguments
 follow the relatedActivityId. For the WriteEvent\*Core methods, the arguments must be serialized manually into the
 `data` parameter.
-8. Event names cannot contain `<` or `>` characters. While user defined methods also cannot contain these characters, `async` methods
-will be rewritten by the compiler to contain them. Mark all non-event methods on an <xref:System.Diagnostics.Tracing.EventSource>
-with the <xref:System.Diagnostics.Tracing.NonEventAttribute> to be sure these generated methods don't become events.
+8. Event names cannot contain `<` or `>` characters. While user-defined methods also cannot contain these characters, `async` methods
+will be rewritten by the compiler to contain them. To be sure these generated methods don't become events, mark all non-event methods on an <xref:System.Diagnostics.Tracing.EventSource>
+with the <xref:System.Diagnostics.Tracing.NonEventAttribute>.
 
 ## Best practices
 


### PR DESCRIPTION
Fixes dotnet/runtime#50892