### PR TITLE
Container image console formatter

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -41,6 +41,12 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ | Preview 4 |
 | [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ | RC 2 |
 
+## Containers
+
+| Title | Binary compatible | Source compatible | Introduced |
+| - | :-: | :-: | - |
+| [Default console logger formatting in container images](containers/console-formatter-default.md) | ✔️ | ❌ | Servicing 6.0.6 |
+
 ## Core .NET libraries
 
 | Title | Binary compatible | Source compatible | Introduced |

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -45,7 +45,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [Default console logger formatting in container images](containers/console-formatter-default.md) | ✔️ | ❌ | Servicing 6.0.6 |
+| [Default console logger formatting in container images](containers/6.0/console-formatter-default.md) | ✔️ | ❌ | Servicing 6.0.6 |
 
 ## Core .NET libraries
 

--- a/docs/core/compatibility/containers/6.0/console-formatter-default.md
+++ b/docs/core/compatibility/containers/6.0/console-formatter-default.md
@@ -22,7 +22,7 @@ In previous servicing releases of .NET 6, `aspnet` container images were configu
 
 ## New behavior
 
-Starting in .NET 6.0.6, `aspnet` container images have the `Logging__Console__FormatterName` environment variable unset by default. This results in console output formatted similarly to the following:
+Starting in .NET 6.0.6, `aspnet` container images have the `Logging__Console__FormatterName` environment variable unset by default. This results in simple, multiline, human-readable console output similar the following:
 
 ```txt
 warn: Microsoft.AspNetCore.Server.HttpSys.MessagePump[37]
@@ -51,7 +51,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 ## Reason for change
 
-When the change to use JSON formatting was introduced in the .NET 6 GA release, it broke many scenarios that relied on the original, simple formatting as described in <dotnet/dotnet-docker#2725>.
+When the change to use JSON formatting was introduced in the .NET 6 GA release, it broke many scenarios that relied on the original, simple formatting as described in [dotnet/dotnet-docker#2725](dotnet/dotnet-docker#2725).
 
 ## Recommended action
 
@@ -63,4 +63,4 @@ None.
 
 ## See also
 
-- <dotnet/dotnet-docker#3706>
+- [dotnet/dotnet-docker#3706](dotnet/dotnet-docker#3706)

--- a/docs/core/compatibility/containers/6.0/console-formatter-default.md
+++ b/docs/core/compatibility/containers/6.0/console-formatter-default.md
@@ -51,7 +51,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 ## Reason for change
 
-When the change to use JSON formatting was introduced in the .NET 6 GA release, it broke many scenarios that relied on the original, simple formatting as described in [dotnet/dotnet-docker#2725](dotnet/dotnet-docker#2725).
+When the change to use JSON formatting was introduced in the .NET 6 GA release, it broke many scenarios that relied on the original, simple formatting as described in [dotnet/dotnet-docker#2725](https://github.com/dotnet/dotnet-docker#2725).
 
 ## Recommended action
 
@@ -63,4 +63,4 @@ None.
 
 ## See also
 
-- [dotnet/dotnet-docker#3706](dotnet/dotnet-docker#3706)
+- [dotnet/dotnet-docker#3706](https://github.com/dotnet/dotnet-docker#3706)

--- a/docs/core/compatibility/containers/6.0/console-formatter-default.md
+++ b/docs/core/compatibility/containers/6.0/console-formatter-default.md
@@ -22,7 +22,7 @@ In previous servicing releases of .NET 6, `aspnet` container images were configu
 
 ## New behavior
 
-Starting in .NET 6.0.6, `aspnet` container images have the `Logging__Console__FormatterName` environment variable unset by default. This results in simple, multiline, human-readable console output similar the following:
+Starting in .NET 6.0.6, `aspnet` container images have the `Logging__Console__FormatterName` environment variable unset by default. This results in simple, multiline, human-readable console output similar to the following:
 
 ```txt
 warn: Microsoft.AspNetCore.Server.HttpSys.MessagePump[37]

--- a/docs/core/compatibility/containers/console-formatter-default.md
+++ b/docs/core/compatibility/containers/console-formatter-default.md
@@ -1,0 +1,66 @@
+---
+title: ".NET 6 breaking change: Default console logger formatting in container images"
+description: Learn about the .NET 6 breaking change in .NET containers where the default formatting for the console logger in aspnet container images is no longer JSON.
+ms.date: 05/02/2022
+---
+# Default console logger formatting in container images
+
+The default console formatter that's configured in `aspnet` containers has changed.
+
+## Previous behavior
+
+In previous servicing releases of .NET 6, `aspnet` container images were configured with the `Logging__Console__FormatterName` environment variable set to `Json`. This resulted in console output formatted similarly to the following:
+
+```txt
+{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:7000/","State":{"Message":"Now listening on: http://localhost:7000/","address":"http://localhost:7000/","{OriginalFormat}":"Now listening on: {address}"}}
+{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:7001/","State":{"Message":"Now listening on: http://localhost:7001/","address":"http://localhost:7001/","{OriginalFormat}":"Now listening on: {address}"}}
+{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:7002/","State":{"Message":"Now listening on: http://localhost:7002/","address":"http://localhost:7002/","{OriginalFormat}":"Now listening on: {address}"}}
+{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Application started. Press Ctrl\u002BC to shut down.","State":{"Message":"Application started. Press Ctrl\u002BC to shut down.","{OriginalFormat}":"Application started. Press Ctrl\u002BC to shut down."}}
+{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Hosting environment: Development","State":{"Message":"Hosting environment: Development","envName":"Development","{OriginalFormat}":"Hosting environment: {envName}"}}
+{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Content root path: C:\\source\\temp\\web50","State":{"Message":"Content root path: C:\\source\\temp\\web50","contentRoot":"C:\\source\\temp\\web50","{OriginalFormat}":"Content root path: {contentRoot}"}}
+```
+
+## New behavior
+
+Starting in .NET 6.0.6, `aspnet` container images have the `Logging__Console__FormatterName` environment variable unset by default. This results in console output formatted similarly to the following:
+
+```txt
+warn: Microsoft.AspNetCore.Server.HttpSys.MessagePump[37]
+      Overriding address(es) ''. Binding to endpoints added to UrlPrefixes instead.
+info: Microsoft.Hosting.Lifetime[0]
+      Now listening on: http://localhost:7000/
+info: Microsoft.Hosting.Lifetime[0]
+      Now listening on: http://localhost:7001/
+info: Microsoft.Hosting.Lifetime[0]
+      Now listening on: http://localhost:7002/
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+info: Microsoft.Hosting.Lifetime[0]
+      Hosting environment: Development
+info: Microsoft.Hosting.Lifetime[0]
+      Content root path: C:\source\temp\web50
+```
+
+## Version introduced
+
+.NET 6.0.6 (May 2022 servicing)
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+When the change to use JSON formatting was introduced in the .NET 6 GA release, it broke many scenarios that relied on the original, simple formatting as described in <dotnet/dotnet-docker#2725>.
+
+## Recommended action
+
+If you want to continue using the JSON formatting, you can configure your container to use it by setting the `Logging__Console__FormatterName` environment variable value to `Json`.
+
+## Affected APIs
+
+None.
+
+## See also
+
+- <dotnet/dotnet-docker#3706>

--- a/docs/core/compatibility/core-libraries/6.0/file-replace-exceptions-on-unix.md
+++ b/docs/core/compatibility/core-libraries/6.0/file-replace-exceptions-on-unix.md
@@ -7,7 +7,7 @@ ms.date: 10/13/2021
 
 The behavior of <xref:System.IO.File.Replace%2A?displayProperty=nameWithType> on Unix-based operating systems has changed. The exceptions it throws now match those that are thrown by the Windows implementation.
 
-## Previous Behavior
+## Previous behavior
 
 On Unix, with .NET 5, the <xref:System.IO.File.Replace%2A?displayProperty=nameWithType> method:
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -127,6 +127,10 @@ items:
           href: aspnet-core/6.0/signalr-java-client-updated.md
         - name: TryParse and BindAsync methods are validated
           href: aspnet-core/6.0/tryparse-bindasync-validation.md
+      - name: Containers
+        items:
+        - name: Default console logger formatting in container images
+          href: containers/6.0/console-formatter-default.md
       - name: Core .NET libraries
         items:
         - name: API obsoletions with non-default diagnostic IDs
@@ -705,6 +709,14 @@ items:
           href: code-analysis/5.0/ca2200-rethrow-to-preserve-stack-details.md
         - name: CA2247 warning
           href: code-analysis/5.0/ca2247-ctor-arg-should-be-taskcreationoptions.md
+    - name: Containers
+      items:
+      - name: .NET 6
+        items:
+        - name: Default console logger formatting in container images
+          href: containers/6.0/console-formatter-default.md
+        - name: Other breaking changes
+          href: https://github.com/dotnet/dotnet-docker/issues/3276
     - name: Core .NET libraries
       items:
       - name: .NET 7

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -132,7 +132,7 @@ items:
         - name: Default console logger formatting in container images
           href: containers/6.0/console-formatter-default.md
         - name: Other breaking changes
-          href: https://github.com/dotnet/dotnet-docker/issues/3276
+          href: https://github.com/dotnet/dotnet-docker/discussions/3699
       - name: Core .NET libraries
         items:
         - name: API obsoletions with non-default diagnostic IDs
@@ -718,7 +718,7 @@ items:
         - name: Default console logger formatting in container images
           href: containers/6.0/console-formatter-default.md
         - name: Other breaking changes
-          href: https://github.com/dotnet/dotnet-docker/issues/3276
+          href: https://github.com/dotnet/dotnet-docker/discussions/3699
     - name: Core .NET libraries
       items:
       - name: .NET 7

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -131,6 +131,8 @@ items:
         items:
         - name: Default console logger formatting in container images
           href: containers/6.0/console-formatter-default.md
+        - name: Other breaking changes
+          href: https://github.com/dotnet/dotnet-docker/issues/3276
       - name: Core .NET libraries
         items:
         - name: API obsoletions with non-default diagnostic IDs


### PR DESCRIPTION
Fixes #29243.

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/containers/console-formatter-default?branch=pr-en-us-29256).