### PR TITLE
Clean up logging guidance

### DIFF
--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -19,7 +19,7 @@ This article helps you find the various tools you need.
 
 [Unit testing](../testing/index.md) is a key component of continuous integration and deployment of high-quality software. Unit tests are designed to give you an early warning when you break something.
 
-## Instrumentation for Observability
+## Instrumentation for observability
 
 .NET supports industry standard instrumentation techniques using metrics, logs, and distributed traces. Instrumentation is code that is added to a software project to record what it is doing. This information can then be collected in files, databases, or in-memory and analyzed to understand how a software program is operating. This is often used in production environments to monitor for problems and diagnose them. The .NET runtime has built-in instrumentation that can be optionally enabled and APIs that allow you to add custom instrumentation specialized for your application.
 
@@ -31,7 +31,7 @@ This article helps you find the various tools you need.
 
 [Logging](logging-tracing.md) is a technique where code is instrumented to produce a log, a record of interesting events that occured while the program was running. Often a baseline set of log events are configured on by default and more extensive logging can be enabled on-demand to diagnose particular problems. Performance overhead is variable depending on how much data is being logged.
 
-### Distributed Traces
+### Distributed traces
 
 [Distributed Tracing](./distributed-tracing.md) is a specialized form of logging that helps you localize failures and performance issues within applications distributed across multiple machines or processes. This technique tracks requests through an application correlating together work done by different application components and separating it from other work the application may be doing for concurrent requests. It is possible to trace every request and sampling can be optionally employed to bound the performance overhead.
 

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -11,23 +11,29 @@ Software doesn't always behave as you would expect, but .NET Core has tools and 
 
 This article helps you find the various tools you need.
 
-## Managed debuggers
+## Debuggers
 
-[Managed debuggers](managed-debuggers.md) allow you to interact with your program. Pausing, incrementally executing, examining,  and resuming gives you insight into the behavior of your code. A debugger is the first choice for diagnosing functional problems that can be easily reproduced.
-
-## Logging and tracing
-
-[Logging and tracing](logging-tracing.md) are related techniques. They refer to instrumenting code to create log files. The files record the details of what a program does. These details can be used to diagnose the most complex problems. When combined with time stamps, these techniques are also valuable in performance investigations.
-
-## Metrics
-
-[Metrics](metrics.md) are numerical measurements recorded over time to monitor application performance and health. Metrics are often used to
-generate alerts when potential problems are detected. In normal use, metrics have very low performance overhead and are configured as
-'always-on' telemetry. The .NET runtime and libraries publish many built-in metrics, and you can create new ones using metric APIs.
+[Debuggers](managed-debuggers.md) allow you to interact with your program. Pausing, incrementally executing, examining,  and resuming gives you insight into the behavior of your code. A debugger is a good choice for diagnosing functional problems that can be easily reproduced.
 
 ## Unit testing
 
 [Unit testing](../testing/index.md) is a key component of continuous integration and deployment of high-quality software. Unit tests are designed to give you an early warning when you break something.
+
+## Instrumentation for Observability
+
+.NET supports industry standard instrumentation techniques using metrics, logs, and distributed traces. Instrumentation is code that is added to a software project to record what it is doing. This information can then be collected in files, databases, or in-memory and analyzed to understand how a software program is operating. This is often used in production environments to monitor for problems and diagnose them. The .NET runtime has built-in instrumentation that can be optionally enabled and APIs that allow you to add custom instrumentation specialized for your application.
+
+### Metrics
+
+[Metrics](metrics.md) are numerical measurements recorded over time to monitor application performance and health. Metrics are often used to generate alerts when potential problems are detected. Metrics have very low performance overhead and many services configure them as always-on telemetry.
+
+### Logs
+
+[Logging](logging-tracing.md) is a technique where code is instrumented to produce a log, a record of interesting events that occured while the program was running. Often a baseline set of log events are configured on by default and more extensive logging can be enabled on-demand to diagnose particular problems. Performance overhead is variable depending on how much data is being logged.
+
+### Distributed Traces
+
+[Distributed Tracing](./distributed-tracing.md) is a specialized form of logging that helps you localize failures and performance issues within applications distributed across multiple machines or processes. This technique tracks requests through an application correlating together work done by different application components and separating it from other work the application may be doing for concurrent requests. It is possible to trace every request and sampling can be optionally employed to bound the performance overhead.
 
 ## Dumps
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -30,7 +30,7 @@ Most logging APIs allow log messages to be sent to different destinations called
 
 ### ILogger
 
-For most cases, whether adding logging to an existing project or creating a new project, [ILogger](../extensions/logging.md) is a good default choice for logging API. ILogger supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers). ILogger can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer much more functionality and extensibility.
+For most cases, whether adding logging to an existing project or creating a new project, the [ILogger](../extensions/logging.md) interface is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers). Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer more functionality and extensibility.
 
 ### EventSource
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -1,110 +1,55 @@
 ---
-title: Logging and tracing - .NET Core
-description: An introduction to .NET Core logging and tracing.
-ms.date: 10/12/2020
+title: Logging and tracing - .NET
+description: An introduction to .NET logging and tracing.
+ms.date: 4/29/2022
 ---
-# .NET Core logging and tracing
+# .NET logging and tracing
 
-Logging and tracing are really two names for the same technique. The simple technique has been used since the early days of computers. It simply involves instrumenting an application to write output to be consumed later.
+Code can be instrumented to produce a log, a record of interesting events that occured while the program was running. Then the log can be reviewed later to understand the application's behavior. Logging and tracing are different names for this same technique. .NET has accumulated several different logging APIs over its history and this page will help you understand what options are available.
 
-## Reasons to use logging and tracing
+## Key Distinctions in Logging APIs
 
-This simple technique is surprisingly powerful. It can be used in situations where a debugger fails:
+### Structured logging
 
-- Issues occurring over long periods of time, can be difficult to debug with a traditional debugger. Logs allow for detailed post-mortem review spanning long periods of time. In contrast, debuggers are constrained to real-time analysis.
-- Multi-threaded applications and distributed applications are often difficult to debug.  Attaching a debugger tends to modify behaviors. Detailed logs can be analyzed as needed to understand complex systems.
-- Issues in distributed applications may arise from a complex interaction between many components and it may not be reasonable to connect a debugger to every part of the system.
-- Many services shouldn't be stalled. Attaching a debugger often causes timeout failures.
-- Issues aren't always foreseen. Logging and tracing are designed for low overhead so that programs can always be recording in case an issue occurs.
+Logging APIs can either be structured or unstructured:
 
-## .NET Core APIs
+- Unstructured: Log entries have free-form text content that is intended to be viewed by humans
+- Structured: Log entries have a well defined schema and can be encoded in different binary and textual formats. These logs are designed to be machine translatable and queryable so that both humans and automated systems can work with them easily.
 
-### Print-style APIs
+APIs that support structured logging are preferable for non-trivial usage. They can offer more functionality, flexibility, and performance with little difference in usability.
 
-The <xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> classes each provide similar print-style APIs that are convenient for logging.
+### Configuration
 
-The choice of which print-style API to use is up to you. The key differences are:
+For very simple use-cases you might want to use APIs that directly write messages to the console or a file, but most software projects will find it useful to configure which log events get recorded and how they are persisted. For example, when running in a local dev environment you might want to output plain text to the console for easy readability. Then when the application is deployed to a production environment you might switch to have the logs stored in a dedicated database or a set of rolling files. APIs with good configuration options will make these transitions easy whereas less configurable options would require updating the instrumentation code everywhere to make changes.
 
-- <xref:System.Console?displayProperty=nameWithType>
-  - Always enabled and always writes to the console.
-  - Useful for information that your customer may need to see in the release.
-  - Because it's the simplest approach, it's often used for ad-hoc temporary debugging. This debug code is often never checked in to source control.
-- <xref:System.Diagnostics.Trace?displayProperty=nameWithType>
-  - Only enabled when `TRACE` is defined by adding `#define TRACE` to your source or specifying the option `/d:TRACE` when compiling.
-  - Writes to attached <xref:System.Diagnostics.Trace.Listeners>, by default the <xref:System.Diagnostics.DefaultTraceListener>.
-  - Use this API when creating logs that will be enabled in most builds.
-- <xref:System.Diagnostics.Debug?displayProperty=nameWithType>
-  - Only enabled when `DEBUG` is defined by adding `#define DEBUG` to your source or specifying the option `/d:DEBUG` when compiling.
-  - Writes to an attached debugger.
-  - On `*nix` writes to stderr if `DOTNET_DebugWriteToStdErr` or `COMPlus_DebugWriteToStdErr` is set.
-  - Use this API when creating logs that will be enabled only in debug builds.
+### Sinks
 
-### Logging events
+Most logging APIs allow log messages to be sent to different destinations called sinks. Some APIs have a large number of pre-made sinks whereas others only have a few. If no pre-made sink exists there is usually an extensibility API that will let you author a custom sink but this will take a little extra effort.
 
-The following APIs are more event oriented. Rather than logging simple strings they log event objects.
+## .NET logging APIs
 
-- [System.Diagnostics.Tracing.EventSource](./eventsource.md)
-  - EventSource is the primary root .NET Core tracing API.
-  - Available in all .NET Standard versions.
-  - Only allows tracing serializable objects.
-  - Can be consumed in-process via any [EventListener](xref:System.Diagnostics.Tracing.EventListener) instances configured to consume the EventSource.
-  - Can be consumed out-of-process via:
-    - [.NET Core's EventPipe](./eventpipe.md) on all platforms
-    - [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal)
+### ILogger
 
-- <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType>
-  - Included in .NET Core and as a [NuGet package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) for .NET Framework.
-  - Allows in-process tracing of non-serializable objects.
-  - Includes a bridge to allow selected fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
+For most cases, whether adding logging to an existing project or creating a new project, [ILogger](../extensions/logging.md) is a good default choice for logging API. ILogger supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers). ILogger can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer much more functionality and extensibility.
 
-- <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
-  - Windows only.
-  - Writes messages to the Windows Event Log.
-  - System administrators expect fatal application error messages to appear in the Windows Event Log.
+### EventSource
 
-## Distributed Tracing
+[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to ILogger, EventSource has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. EventSource is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging most projects will likely find ILogger more flexible and easier to use.
 
-[Distributed Tracing](./distributed-tracing.md) is a diagnostic technique that helps engineers
-localize failures and performance issues within applications, especially those that may be
-distributed across multiple machines or processes. This technique tracks requests through an
-application correlating together work done by different application components and separating
-it from other work the application may be doing for concurrent requests.
+### Trace
 
-## ILogger and logging frameworks
+<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file but in .NET Core there is no built-in file-based configuration mechanism. The .NET team continues to support these APIs for back-compat purposes but there is no plan to add new functionality. These are a fine choice for applications that are already using them. For newer apps that haven't already commited to a logging API, ILogger may offer better functionality.
 
-The low-level APIs may not be the right choice for your logging needs. You may want to consider a logging framework.
+## Specialized logging APIs
 
-The <xref:Microsoft.Extensions.Logging.ILogger> interface has been used to create a common logging interface where the loggers can be inserted through dependency injection.
+### Console
 
-For instance, to allow you to make the best choice for your application .NET offers support for a selection of built-in and third-party frameworks:
+The <xref:System.Console?displayProperty=nameWithType> class has the <xref:System.Console.Write%2A> and <xref:System.Console.WriteLine%2A> methods that can be used in simple logging scenarios. These APIs are very easy to get started with but the solution won't be as flexible as a general purpose logging API. Console only allows unstructured logging and there is no configuration support to select which log messages are enabled or to retarget to a different sink. Using the ILogger or Trace APIs with a console sink doesn't take much additional effort and keeps the logging configurable.
 
-- [.NET Built-in logging providers](../extensions/logging-providers.md#built-in-logging-providers)
-- [.NET Third-party logging providers](../extensions/logging-providers.md#third-party-logging-providers)
+### DiagnosticSource
 
-## Logging-related references
+<xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> is intended for logging where the log messages will be analyzed synchronously in-process rather than serialized to any storage. This allows the source and listener to exchange arbitrary .NET objects as messages whereas most logging APIs require the log event to be serializable. This technique can also be extremely fast, handling log events in 10s of nanoseconds if the listener is implemented efficiently. Tools that use these APIs often act more like in-process profilers though the API doesn't impose any constraint here.
 
-- [How to: Compile Conditionally with Trace and Debug](../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug.md)
+### EventLog
 
-- [How to: Add Trace Statements to Application Code](../../framework/debug-trace-profile/how-to-add-trace-statements-to-application-code.md)
-
-- [Logging in .NET](../extensions/logging.md) provides an overview of the logging techniques it supports.
-
-- [C# string interpolation](../../csharp/language-reference/tokens/interpolated.md) can simplify writing logging code.
-
-- [Runtime Provider Event List](../../fundamentals/diagnostics/runtime-events.md)
-
-- [Well-known Event Providers in .NET](well-known-event-providers.md)
-
-- The <xref:System.Exception.Message?displayProperty=nameWithType> property is useful for logging exceptions.
-
-- The <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType> class can be useful to provide stack info in your logs.
-
-## Performance considerations
-
-String formatting can take noticeable CPU processing time.
-
-In performance-critical applications, it's recommended that you:
-
-- Avoid lots of logging when no one is listening. Avoid constructing costly logging messages by checking if logging is enabled first.
-- Only log what's useful.
-- Defer fancy formatting to the analysis stage.
+<xref:System.Diagnostics.EventLog?displayProperty=nameWithType> is a Windows only API that writes messages to the Windows EventLog. In many cases using ILogger with an optional EventLog sink when running on Windows may give similar functionality without coupling the app tightly to the Windows OS.

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -13,18 +13,18 @@ Code can be instrumented to produce a log, which serves as a record of interesti
 
 Logging APIs can either be structured or unstructured:
 
-- Unstructured: Log entries have free-form text content that is intended to be viewed by humans
+- Unstructured: Log entries have free-form text content that is intended to be viewed by humans.
 - Structured: Log entries have a well defined schema and can be encoded in different binary and textual formats. These logs are designed to be machine translatable and queryable so that both humans and automated systems can work with them easily.
 
 APIs that support structured logging are preferable for non-trivial usage. They offer more functionality, flexibility, and performance with little difference in usability.
 
 ### Configuration
 
-For very simple use-cases you might want to use APIs that directly write messages to the console or a file, but most software projects will find it useful to configure which log events get recorded and how they are persisted. For example, when running in a local dev environment you might want to output plain text to the console for easy readability. Then when the application is deployed to a production environment you might switch to have the logs stored in a dedicated database or a set of rolling files. APIs with good configuration options will make these transitions easy whereas less configurable options would require updating the instrumentation code everywhere to make changes.
+For simple use cases, you might want to use APIs that directly write messages to the console or a file. But most software projects will find it useful to configure which log events get recorded and how they are persisted. For example, when running in a local dev environment, you might want to output plain text to the console for easy readability. Then when the application is deployed to a production environment, you might switch to have the logs stored in a dedicated database or a set of rolling files. APIs with good configuration options will make these transitions easy, whereas less configurable options would require updating the instrumentation code everywhere to make changes.
 
 ### Sinks
 
-Most logging APIs allow log messages to be sent to different destinations called sinks. Some APIs have a large number of pre-made sinks whereas others only have a few. If no pre-made sink exists there is usually an extensibility API that will let you author a custom sink, although this requires writing a bit more code.
+Most logging APIs allow log messages to be sent to different destinations called sinks. Some APIs have a large number of pre-made sinks, whereas others only have a few. If no pre-made sink exists, there's usually an extensibility API that will let you author a custom sink, although this requires writing a bit more code.
 
 ## .NET logging APIs
 
@@ -34,11 +34,11 @@ For most cases, whether adding logging to an existing project or creating a new 
 
 ### EventSource
 
-[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging most projects will likely find `ILogger` more flexible and easier to use.
+[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
 
 ### Trace
 
-<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file but in .NET Core there is no built-in file-based configuration mechanism. The .NET team continues to support these APIs for backward-compatability purposes but there is no plan to add new functionality. These are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
+<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
 
 ## Specialized logging APIs
 
@@ -48,7 +48,7 @@ The <xref:System.Console?displayProperty=nameWithType> class has the <xref:Syste
 
 ### DiagnosticSource
 
-<xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> is intended for logging where the log messages will be analyzed synchronously in-process rather than serialized to any storage. This allows the source and listener to exchange arbitrary .NET objects as messages whereas most logging APIs require the log event to be serializable. This technique can also be extremely fast, handling log events in 10s of nanoseconds if the listener is implemented efficiently. Tools that use these APIs often act more like in-process profilers though the API doesn't impose any constraint here.
+<xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> is intended for logging where the log messages will be analyzed synchronously in-process rather than serialized to any storage. This allows the source and listener to exchange arbitrary .NET objects as messages, whereas most logging APIs require the log event to be serializable. This technique can also be extremely fast, handling log events in tens of nanoseconds if the listener is implemented efficiently. Tools that use these APIs often act more like in-process profilers, though the API doesn't impose any constraint here.
 
 ### EventLog
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -5,9 +5,9 @@ ms.date: 4/29/2022
 ---
 # .NET logging and tracing
 
-Code can be instrumented to produce a log, a record of interesting events that occured while the program was running. Then the log can be reviewed later to understand the application's behavior. Logging and tracing are different names for this same technique. .NET has accumulated several different logging APIs over its history and this page will help you understand what options are available.
+Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs are reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
 
-## Key Distinctions in Logging APIs
+## Key distinctions in logging APIs
 
 ### Structured logging
 
@@ -16,7 +16,7 @@ Logging APIs can either be structured or unstructured:
 - Unstructured: Log entries have free-form text content that is intended to be viewed by humans
 - Structured: Log entries have a well defined schema and can be encoded in different binary and textual formats. These logs are designed to be machine translatable and queryable so that both humans and automated systems can work with them easily.
 
-APIs that support structured logging are preferable for non-trivial usage. They can offer more functionality, flexibility, and performance with little difference in usability.
+APIs that support structured logging are preferable for non-trivial usage. They offer more functionality, flexibility, and performance with little difference in usability.
 
 ### Configuration
 
@@ -24,7 +24,7 @@ For very simple use-cases you might want to use APIs that directly write message
 
 ### Sinks
 
-Most logging APIs allow log messages to be sent to different destinations called sinks. Some APIs have a large number of pre-made sinks whereas others only have a few. If no pre-made sink exists there is usually an extensibility API that will let you author a custom sink but this will take a little extra effort.
+Most logging APIs allow log messages to be sent to different destinations called sinks. Some APIs have a large number of pre-made sinks whereas others only have a few. If no pre-made sink exists there is usually an extensibility API that will let you author a custom sink, although this requires writing a bit more code.
 
 ## .NET logging APIs
 
@@ -34,11 +34,11 @@ For most cases, whether adding logging to an existing project or creating a new 
 
 ### EventSource
 
-[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to ILogger, EventSource has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. EventSource is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging most projects will likely find ILogger more flexible and easier to use.
+[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging most projects will likely find `ILogger` more flexible and easier to use.
 
 ### Trace
 
-<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file but in .NET Core there is no built-in file-based configuration mechanism. The .NET team continues to support these APIs for back-compat purposes but there is no plan to add new functionality. These are a fine choice for applications that are already using them. For newer apps that haven't already commited to a logging API, ILogger may offer better functionality.
+<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file but in .NET Core there is no built-in file-based configuration mechanism. The .NET team continues to support these APIs for backward-compatability purposes but there is no plan to add new functionality. These are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
 
 ## Specialized logging APIs
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -630,8 +630,6 @@ items:
         href: ../core/diagnostics/debug-linux-dumps.md
       - name: SOS debugger extension
         href: ../core/diagnostics/sos-debugging-extension.md
-    - name: EventPipe
-      href: ../core/diagnostics/eventpipe.md
     - name: Logging and tracing
       items:
       - name: Overview
@@ -639,16 +637,6 @@ items:
         href: ../core/diagnostics/logging-tracing.md
       - name: Well-known event providers
         href: ../core/diagnostics/well-known-event-providers.md
-      - name: Distributed tracing
-        items:
-        - name: Overview
-          href: ../core/diagnostics/distributed-tracing.md
-        - name: Concepts
-          href: ../core/diagnostics/distributed-tracing-concepts.md
-        - name: Instrumentation
-          href: ../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
-        - name: Collection
-          href: ../core/diagnostics/distributed-tracing-collection-walkthroughs.md
       - name: Event Source
         items:
         - name: Overview
@@ -661,6 +649,8 @@ items:
           href: ../core/diagnostics/eventsource-collect-and-view-traces.md
         - name: Activity IDs
           href: ../core/diagnostics/eventsource-activity-ids.md
+      - name: EventPipe
+        href: ../core/diagnostics/eventpipe.md
     - name: Metrics
       items:
       - name: Overview
@@ -681,6 +671,16 @@ items:
           href: ../core/diagnostics/event-counter-perf.md
       - name: Compare metric APIs
         href: ../core/diagnostics/compare-metric-apis.md
+    - name: Distributed tracing
+      items:
+      - name: Overview
+        href: ../core/diagnostics/distributed-tracing.md
+      - name: Concepts
+        href: ../core/diagnostics/distributed-tracing-concepts.md
+      - name: Instrumentation
+        href: ../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+      - name: Collection
+        href: ../core/diagnostics/distributed-tracing-collection-walkthroughs.md
     - name: Symbols
       href: ../core/diagnostics/symbols.md
     - name: Microsoft.Diagnostics.NETCore.Client library


### PR DESCRIPTION
- Make the suggestion to use ILogger more prominent
- Re-focus the logging landing page on understanding the differences between logging APIs,
remove extraneous comments/links that I expect are less relevant to people who browse to this page,
and make the text sound less like an outline.