### PR TITLE
Remove Channel 9

### DIFF
--- a/docs/architecture/microservices/index.md
+++ b/docs/architecture/microservices/index.md
@@ -21,7 +21,7 @@ To make it easier to get started, the guide focuses on a reference containerized
 
 - Clone/Fork the reference application [eShopOnContainers on GitHub](https://github.com/dotnet-architecture/eShopOnContainers)
 
-- Watch the [introductory video on Channel 9](https://aka.ms/microservices-video)
+- Watch the [introductory video](https://aka.ms/microservices-video)
 
 - Get to know the [Microservices Architecture](https://aka.ms/MicroservicesArchitecture) right away
 


### PR DESCRIPTION
Updates as part of the fix https://github.com/dotnet/docs/issues/29222. Updated aka.ms link to redirect to the most recent video. This PR removes the Channel 9 text.