### PR TITLE
Fix required TFM for Source Generator runtime

### DIFF
--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -71,7 +71,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
     :::code language="xml" source="snippets/source-generators/SourceGenerator/SourceGenerator.csproj":::
 
     > [!TIP]
-    > The source generator project needs to target the `netstandard2.0` TFM, otherwise it will not work.
+    > The source generator project needs to target the `netstandard2.0` TFM for Visual Studio, for `dotnet` CLI with relative SDK it can work for any TFM.
 
 1. Create a new C# file named _HelloSourceGenerator.cs_ that specifies your own Source Generator like so:
 


### PR DESCRIPTION
## Summary

For Source Generator to work in Visual Studio TFM has to be targeted to `.netstandard 2.0` but for `dotnet` CLI it can be targeted to any TFM.

Changes:

Corrected misleading TIP regarding Source Generator not working with higher TFM than `.netstandard 2.0`