### PR TITLE
Fix typo - "sybte"

### DIFF
--- a/docs/core/diagnostics/eventsource-instrumentation.md
+++ b/docs/core/diagnostics/eventsource-instrumentation.md
@@ -156,7 +156,7 @@ Events that are triggered more than 1,000/sec are good candidates for a unique k
 
 EventSource requires that all event parameters can be serialized so it only accepts a limited set of types. These are:
 
-- Primitives: bool, byte, sybte, char, short, ushort, int, uint, long, ulong, float, double, IntPtr, and UIntPtr, Guid
+- Primitives: bool, byte, sbyte, char, short, ushort, int, uint, long, ulong, float, double, IntPtr, and UIntPtr, Guid
   decimal, string,  DateTime, DateTimeOffset, TimeSpan
 - Enums
 - Structures attributed with <xref:System.Diagnostics.Tracing.EventDataAttribute?displayProperty=nameWithType>. Only


### PR DESCRIPTION
The data type `sybte` appears to be misspelt here and it should be [`sbyte`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types), I suppose.