### PR TITLE
add docs for MSBuild breaking change around serialization of certain types

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -47,11 +47,12 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [AllowRenegotiation default is false](networking/7.0/allowrenegotiation-default.md) | ❌ | ❌ | Preview 3 |
 | [Custom ping payloads on Linux](networking/7.0/ping-custom-payload-linux.md) | ❌ | ✔️ | Preview 2 |
 
-## SDK
+## SDK and MSBuild
 
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
+| [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/7.0/custom-serialization.md
+++ b/docs/core/compatibility/sdk/7.0/custom-serialization.md
@@ -17,7 +17,7 @@ MSBuild 17.4 (.NET SDK 7.0.100)
 
 MSBuild used BinaryFormatter via the `TranslateDotNet` method to translate custom BuildEventArgs and ITaskItems that users could define in their own Tasks.
 
-## New Behavior
+## New behavior
 
 MSBuild will no longer support this mechanism, so code that used `TranslateDotNet` will fail to compile.
 

--- a/docs/core/compatibility/sdk/7.0/custom-serialization.md
+++ b/docs/core/compatibility/sdk/7.0/custom-serialization.md
@@ -15,11 +15,11 @@ MSBuild 17.4 (.NET SDK 7.0.100)
 
 ## Old behavior
 
-MSBuild used BinaryFormatter via the `TranslateDotNet` method to translate custom BuildEventArgs and ITaskItems that users could define in their own Tasks.
+MSBuild used BinaryFormatter to preserve custom types that derived from BuildEventArgs and ITaskItem across certain boundaries, most notably when running in a multi-process environment.
 
 ## New behavior
 
-MSBuild will no longer support this mechanism, so code that used `TranslateDotNet` will fail to compile.
+MSBuild will no longer support this mechanism, so code that used custom types derived from BuildEventArgs and ITaskItem directly may fail unexpectedly.
 
 ## Reason for change
 

--- a/docs/core/compatibility/sdk/7.0/custom-serialization.md
+++ b/docs/core/compatibility/sdk/7.0/custom-serialization.md
@@ -7,13 +7,13 @@ ms.date: 05/06/2022
 
 # BinaryFormatter serialization of custom BuildEventArgs and ITaskItems removed for .NET 7
 
-MSBuild in .NET 7 doesn't support serialization of custom `BuildEventArgs`- and `ITaskItem`-derived types via the BinaryFormatter serializer.
+MSBuild in .NET 7 doesn't support serialization of custom `BuildEventArgs`-derived and `ITaskItem`-derived types via the `BinaryFormatter` serializer.
 
-## Version Introduced
+## Version introduced
 
 MSBuild 17.4 (.NET SDK 7.0.100)
 
-## Old Behavior
+## Old behavior
 
 MSBuild used BinaryFormatter via the `TranslateDotNet` method to translate custom BuildEventArgs and ITaskItems that users could define in their own Tasks.
 
@@ -23,7 +23,7 @@ MSBuild will no longer support this mechanism, so code that used `TranslateDotNe
 
 ## Reason for change
 
-BinaryFormatter was [made obsolete in .NET 5](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md). Per this plan, all first-party code in the dotnet org must migrate away from its use by .NET 7. This change impacts user-exposed functionality of MSBuild.
+BinaryFormatter was [made obsolete in .NET 5](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md). Per this plan, all first-party code in the dotnet GitHub organization must migrate away from its use by .NET 7. This change impacts user-exposed functionality of MSBuild.
 
 ## Recommended action
 

--- a/docs/core/compatibility/sdk/7.0/custom-serialization.md
+++ b/docs/core/compatibility/sdk/7.0/custom-serialization.md
@@ -1,0 +1,32 @@
+---
+title: "Breaking change: Serialization of custom types in .NET 7"
+description: Learn about a breaking change in MSBuild for .NET 7 where serialization using BinaryFormatter of certain user-defined types is removed.
+author: baronfel
+ms.date: 05/06/2022
+---
+
+# BinaryFormatter serialization of custom BuildEventArgs and ITaskItems removed for .NET 7
+
+MSBuild in .NET 7 doesn't support serialization of custom BuildEventArgs and ITaskItems via the BinaryFormatter serializer.
+
+## Version Introduced
+
+MSBuild 17.4 (.NET SDK 7.0.100)
+
+## Old Behavior
+
+MSBuild used BinaryFormatter via the `TranslateDotNet` method to translate custom BuildEventArgs and ITaskItems that users could define in their own Tasks.
+
+## New Behavior
+
+MSBuild will no longer support this mechanism, so code that used `TranslateDotNet` will fail to compile.
+
+## Reason for change
+
+BinaryFormatter was [obsoleted in .NET 5](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md). Per this plan, all first-party dotnet org code bases must migrate away from its use by .NET 7. This change specifically impacts user-exposed functionality of MSBuild, which is why this breaking change notice is separate from the original deprecation notice.
+
+## Recommended action
+
+* Engage with the MSBuild team on [this GitHub discussion](https://github.com/dotnet/msbuild/discussions/7582) about your specific use cases and how you can migrate away from the `TranslateDotNet` mechanism.
+
+* Update your Tasks to use a different serialization mechanism.

--- a/docs/core/compatibility/sdk/7.0/custom-serialization.md
+++ b/docs/core/compatibility/sdk/7.0/custom-serialization.md
@@ -7,7 +7,7 @@ ms.date: 05/06/2022
 
 # BinaryFormatter serialization of custom BuildEventArgs and ITaskItems removed for .NET 7
 
-MSBuild in .NET 7 doesn't support serialization of custom BuildEventArgs and ITaskItems via the BinaryFormatter serializer.
+MSBuild in .NET 7 doesn't support serialization of custom `BuildEventArgs`- and `ITaskItem`-derived types via the BinaryFormatter serializer.
 
 ## Version Introduced
 
@@ -23,10 +23,10 @@ MSBuild will no longer support this mechanism, so code that used `TranslateDotNe
 
 ## Reason for change
 
-BinaryFormatter was [obsoleted in .NET 5](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md). Per this plan, all first-party dotnet org code bases must migrate away from its use by .NET 7. This change specifically impacts user-exposed functionality of MSBuild, which is why this breaking change notice is separate from the original deprecation notice.
+BinaryFormatter was [made obsolete in .NET 5](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md). Per this plan, all first-party code in the dotnet org must migrate away from its use by .NET 7. This change impacts user-exposed functionality of MSBuild.
 
 ## Recommended action
 
 * Engage with the MSBuild team on [this GitHub discussion](https://github.com/dotnet/msbuild/discussions/7582) about your specific use cases and how you can migrate away from the `TranslateDotNet` mechanism.
 
-* Update your Tasks to use a different serialization mechanism.
+* Avoid returning custom derived types from tasks or when logging.

--- a/docs/core/compatibility/sdk/7.0/custom-serialization.md
+++ b/docs/core/compatibility/sdk/7.0/custom-serialization.md
@@ -19,7 +19,7 @@ MSBuild used BinaryFormatter to preserve custom types that derived from BuildEve
 
 ## New behavior
 
-MSBuild will no longer support this mechanism, so code that used custom types derived from BuildEventArgs and ITaskItem directly may fail unexpectedly.
+MSBuild will no longer support this mechanism, so code that used custom types derived from BuildEventArgs and ITaskItem may fail.
 
 ## Reason for change
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -61,10 +61,12 @@ items:
           href: networking/7.0/allowrenegotiation-default.md
         - name: Custom ping payloads on Linux
           href: networking/7.0/ping-custom-payload-linux.md
-      - name: SDK
+      - name: SDK and MSBuild
         items:
         - name: Version requirements for .NET 7 SDK
           href: sdk/7.0/vs-msbuild-version.md
+        - name: Serialization of custom types in .NET 7
+          href: sdk/7.0/custom-serialization.md
       - name: Serialization
         items:
         - name: Deserialize Version type with leading or trailing whitespace
@@ -965,6 +967,8 @@ items:
         items:
         - name: Version requirements for .NET 7 SDK
           href: sdk/7.0/vs-msbuild-version.md
+        - name: Serialization of custom types in .NET 7
+          href: sdk/7.0/custom-serialization.md
       - name: .NET 6
         items:
         - name: -p option for `dotnet run` is deprecated


### PR DESCRIPTION
## Summary

This is a preemptive breaking-change notice for [this](https://github.com/dotnet/msbuild/issues/7583) linked MSBuild issue/discussion, because we want to get this announcement out with the Preview 4 blog post.

Details are still slightly fuzzy about the action items for this particular breakage, because there will be no replacement, but as that discussion goes on I'll be sure to keep this document updated.