### PR TITLE
Fix 28117

### DIFF
--- a/docs/standard/parallel-programming/exception-handling-task-parallel-library.md
+++ b/docs/standard/parallel-programming/exception-handling-task-parallel-library.md
@@ -1,7 +1,7 @@
 ---
 title: "Exception handling (Task Parallel Library)"
 description: Explore exception handling using the Task Parallel Library (TPL) in .NET. See nested aggregate exceptions, inner exceptions, unobserved task exceptions, & more.
-ms.date: 04/20/2020
+ms.date: 05/06/2022
 dev_langs: 
   - "csharp"
   - "vb"

--- a/docs/standard/parallel-programming/exception-handling-task-parallel-library.md
+++ b/docs/standard/parallel-programming/exception-handling-task-parallel-library.md
@@ -92,6 +92,12 @@ In a meaningful application, the continuation delegate could log detailed inform
 
 Use a [`try-catch`](../../csharp/language-reference/keywords/try-catch.md) statement to handle and observe thrown exceptions. Alternatively, observe the exception by accessing the <xref:System.Threading.Tasks.Task.Exception%2A?displayProperty=nameWithType> property.
 
+> [!IMPORTANT]
+> The <xref:System.AggregateException> cannot be explicitly caught when using the following expressions:
+>
+> - `await task`
+> - `task.GetAwaiter().GetResult()`
+
 ## UnobservedTaskException event
 
 In some scenarios, such as when hosting untrusted plug-ins, benign exceptions might be common, and it might be too difficult to manually observe them all. In these cases, you can handle the <xref:System.Threading.Tasks.TaskScheduler.UnobservedTaskException?displayProperty=nameWithType> event. The <xref:System.Threading.Tasks.UnobservedTaskExceptionEventArgs?displayProperty=nameWithType> instance that is passed to your handler can be used to prevent the unobserved exception from being propagated back to the joining thread.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/CustomException.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/CustomException.cs
@@ -1,0 +1,9 @@
+﻿// <Snippet23>
+public class CustomException : Exception
+{
+    public CustomException(string message) : base(message)
+    { }
+}
+// The example displays the following output:
+//    Detached child task faulted.
+// </snippet23>

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/CustomException.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/CustomException.cs
@@ -1,9 +1,6 @@
-﻿// <Snippet23>
-public class CustomException : Exception
+﻿public class CustomException : Exception
 {
     public CustomException(string message) : base(message)
-    { }
+    {
+    }
 }
-// The example displays the following output:
-//    Detached child task faulted.
-// </snippet23>

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/Program.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/Program.cs
@@ -1,0 +1,23 @@
+﻿public static partial class Program
+{
+    public static void Main()
+    {
+        //Detached();
+        //DetachedTwo();
+        //ExceptionPropagation();
+        //ExceptionPropagationTwo();
+        //ThrowDemo();
+        //ExceptionTwo();
+        //Flatten();
+        //FlattenTwo();
+        //HandleMethod();
+        //HandleMethodTwo();
+        //HandleMethodThree();
+        //Handle();
+        //HandleTwo();
+        //HandleThree();
+        //HandleFour();
+        //TaskException();
+        //TaskExceptionTwo();
+    }
+}

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached1.cs
@@ -1,38 +1,36 @@
 ﻿// <Snippet3>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run(() => {
-                       var nested1 = Task.Run(() => {
-                                          throw new CustomException("Detached child task faulted.");
-                                     });
+    public static void Detached()
+    {
+        var task1 = Task.Run(() =>
+        {
+            var nested1 = Task.Run(() =>
+            {
+                throw new CustomException("Detached child task faulted.");
+            });
 
-          // Here the exception will be escalated back to the calling thread.
-          // We could use try/catch here to prevent that.
-          nested1.Wait();
-      });
+            // Here the exception will be escalated back to the calling thread.
+            // We could use try/catch here to prevent that.
+            nested1.Wait();
+        });
 
-      try {
-         task1.Wait();
-      }
-      catch (AggregateException ae) {
-         foreach (var e in ae.Flatten().InnerExceptions) {
-            if (e is CustomException) {
-               Console.WriteLine(e.Message);
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.Flatten().InnerExceptions)
+            {
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
             }
-         }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        }
+    }
 }
 // The example displays the following output:
 //    Detached child task faulted.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached1.cs
@@ -4,21 +4,19 @@ public static partial class Program
 {
     public static void Detached()
     {
-        var task1 = Task.Run(() =>
+        var task = Task.Run(() =>
         {
-            var nested1 = Task.Run(() =>
-            {
-                throw new CustomException("Detached child task faulted.");
-            });
+            var nestedTask = Task.Run(
+                () => throw new CustomException("Detached child task faulted."));
 
             // Here the exception will be escalated back to the calling thread.
             // We could use try/catch here to prevent that.
-            nested1.Wait();
+            nestedTask.Wait();
         });
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached21.cs
@@ -1,38 +1,36 @@
 ﻿// <Snippet23>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run(() => {
-                       var nested1 = Task.Run(() => {
-                                          throw new CustomException("Detached child task faulted.");
-                                     });
+    public static void DetachedTwo()
+    {
+        var task1 = Task.Run(() =>
+        {
+            var nested1 = Task.Run(() =>
+            {
+                throw new CustomException("Detached child task faulted.");
+            });
 
-          // Here the exception will be escalated back to the calling thread.
-          // We could use try/catch here to prevent that.
-          nested1.Wait();
-      });
+            // Here the exception will be escalated back to the calling thread.
+            // We could use try/catch here to prevent that.
+            nested1.Wait();
+        });
 
-      try {
-         task1.Wait();
-      }
-      catch (AggregateException ae) {
-         foreach (var e in ae.Flatten().InnerExceptions) {
-            if (e is CustomException) {
-               Console.WriteLine(e.Message);
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.Flatten().InnerExceptions)
+            {
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
             }
-         }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        }
+    }
 }
 // The example displays the following output:
 //    Detached child task faulted.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/detached21.cs
@@ -4,21 +4,19 @@ public static partial class Program
 {
     public static void DetachedTwo()
     {
-        var task1 = Task.Run(() =>
+        var task = Task.Run(() =>
         {
-            var nested1 = Task.Run(() =>
-            {
-                throw new CustomException("Detached child task faulted.");
-            });
+            var nestedTask = Task.Run(
+                () => throw new CustomException("Detached child task faulted."));
 
             // Here the exception will be escalated back to the calling thread.
             // We could use try/catch here to prevent that.
-            nested1.Wait();
+            nestedTask.Wait();
         });
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop1.cs
@@ -4,16 +4,16 @@ public static partial class Program
 {
     public static void ExceptionPropagation()
     {
-        var task1 =
-            Task.Run(() =>
+        _ = Task.Run(
+            () => throw new CustomException("task1 faulted."))
+            .ContinueWith(_ =>
             {
-                throw new CustomException("task1 faulted.");
-            })
-            .ContinueWith(t =>
-            {
-                Console.WriteLine("{0}: {1}",
-                    t.Exception.InnerException.GetType().Name,
-                    t.Exception.InnerException.Message);
+                if (_.Exception?.InnerException is { } inner)
+                {
+                    Console.WriteLine("{0}: {1}",
+                        inner.GetType().Name,
+                        inner.Message);
+                }
             },
             TaskContinuationOptions.OnlyOnFaulted);
 

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop1.cs
@@ -1,27 +1,24 @@
-﻿using System;
+﻿// <Snippet7>
 
-// <Snippet7>
-using System.Threading;
-using System.Threading.Tasks;
-
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run(() =>
-                           { throw new CustomException("task1 faulted.");
-      }).ContinueWith( t => { Console.WriteLine("{0}: {1}",
-                                                t.Exception.InnerException.GetType().Name,
-                                                t.Exception.InnerException.Message);
-                            }, TaskContinuationOptions.OnlyOnFaulted);
-      Thread.Sleep(500);
-   }
-}
+    public static void ExceptionPropagation()
+    {
+        var task1 =
+            Task.Run(() =>
+            {
+                throw new CustomException("task1 faulted.");
+            })
+            .ContinueWith(t =>
+            {
+                Console.WriteLine("{0}: {1}",
+                    t.Exception.InnerException.GetType().Name,
+                    t.Exception.InnerException.Message);
+            },
+            TaskContinuationOptions.OnlyOnFaulted);
 
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        Thread.Sleep(500);
+    }
 }
 // The example displays output like the following:
 //        CustomException: task1 faulted.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop21.cs
@@ -1,27 +1,25 @@
-﻿
-// <Snippet27>
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿// <Snippet27>
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run(() =>
-                           { throw new CustomException("task1 faulted.");
-      }).ContinueWith( t => { Console.WriteLine("{0}: {1}",
-                                                t.Exception.InnerException.GetType().Name,
-                                                t.Exception.InnerException.Message);
-                            }, TaskContinuationOptions.OnlyOnFaulted);
-      Thread.Sleep(500);
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+    public static void ExceptionPropagationTwo()
+    {
+        var task1 =
+            Task.Run(() =>
+            {
+                throw new CustomException("task1 faulted.");
+            })
+            .ContinueWith(t =>
+            {
+                Console.WriteLine(
+                    "{0}: {1}",
+                    t.Exception.InnerException.GetType().Name,
+                    t.Exception.InnerException.Message);
+            }, 
+            TaskContinuationOptions.OnlyOnFaulted);
+        
+        Thread.Sleep(500);
+    }
 }
 // The example displays output like the following:
 //        CustomException: task1 faulted.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptionprop21.cs
@@ -4,17 +4,16 @@ public static partial class Program
 {
     public static void ExceptionPropagationTwo()
     {
-        var task1 =
-            Task.Run(() =>
+        _ = Task.Run(
+            () => throw new CustomException("task1 faulted."))
+            .ContinueWith(_ =>
             {
-                throw new CustomException("task1 faulted.");
-            })
-            .ContinueWith(t =>
-            {
-                Console.WriteLine(
-                    "{0}: {1}",
-                    t.Exception.InnerException.GetType().Name,
-                    t.Exception.InnerException.Message);
+                if (_.Exception?.InnerException is { } inner)
+                {
+                    Console.WriteLine("{0}: {1}",
+                        inner.GetType().Name,
+                        inner.Message);
+                }
             }, 
             TaskContinuationOptions.OnlyOnFaulted);
         

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptions.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptions.cs
@@ -4,14 +4,12 @@ public static partial class Program
 {
     public static void ThrowDemo()
     {
-        var task1 = Task.Factory.StartNew(() =>
-        {
-            throw new CustomException("I'm bad, but not too bad!");
-        });
+        var task = Task.Factory.StartNew(
+            () => throw new CustomException("I'm bad, but not too bad!"));
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {
@@ -19,11 +17,11 @@ public static partial class Program
             // Rethrow anything else. AggregateException.Handle provides
             // another way to express this. See later example.
             //<snippet5>
-            foreach (var e in ae.InnerExceptions)
+            foreach (var ex in ae.InnerExceptions)
             {
-                if (e is CustomException)
+                if (ex is CustomException)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine(ex.Message);
                 }
                 else
                 {
@@ -79,10 +77,8 @@ public static partial class Program
             // This is where you can choose which exceptions to handle.
             foreach (var ex in ae.Flatten().InnerExceptions)
             {
-                if (ex is ArgumentException)
-                    Console.WriteLine(ex.Message);
-                else
-                    ignoredExceptions.Add(ex);
+                if (ex is ArgumentException) Console.WriteLine(ex.Message);
+                else ignoredExceptions.Add(ex);
             }
             if (ignoredExceptions.Count > 0)
             {
@@ -105,11 +101,8 @@ public static partial class Program
             try
             {
                 // Cause a few exceptions, but not too many.
-                if (d < 3)
-                    throw new ArgumentException(
-                        $"Value is {d}. Value must be greater than or equal to 3.");
-                else
-                    Console.Write(d + " ");
+                if (d < 3) throw new ArgumentException($"Value is {d}. Value must be greater than or equal to 3.");
+                else Console.Write(d + " ");
             }
             // Store the exception and continue with the loop.
             catch (Exception e)
@@ -120,7 +113,7 @@ public static partial class Program
         Console.WriteLine();
 
         // Throw the exceptions here after the loop completes.
-        if (exceptions.Count > 0)
+        if (!exceptions.IsEmpty)
         {
             throw new AggregateException(exceptions);
         }

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptions.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/exceptions.cs
@@ -1,137 +1,129 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
-namespace TPL_Exceptions
+public static partial class Program
 {
-    class ExceptionDemoCS
+    public static void ThrowDemo()
     {
-        class MyCustomException : Exception
+        var task1 = Task.Factory.StartNew(() =>
         {
-            public MyCustomException(string s) : base(s) { }
+            throw new CustomException("I'm bad, but not too bad!");
+        });
+
+        try
+        {
+            task1.Wait();
         }
-
-        static void ThrowDemo()
+        catch (AggregateException ae)
         {
-            var task1 = Task.Factory.StartNew(() =>
+            // Assume we know what's going on with this particular exception.
+            // Rethrow anything else. AggregateException.Handle provides
+            // another way to express this. See later example.
+            //<snippet5>
+            foreach (var e in ae.InnerExceptions)
             {
-                throw new MyCustomException("I'm bad, but not too bad!");
-            });
-
-            try
-            {
-                task1.Wait();
-            }
-            catch (AggregateException ae)
-            {
-                // Assume we know what's going on with this particular exception.
-                // Rethrow anything else. AggregateException.Handle provides
-                // another way to express this. See later example.
-                //<snippet5>
-                foreach (var e in ae.InnerExceptions)
+                if (e is CustomException)
                 {
-                    if (e is MyCustomException)
-                    {
-                        Console.WriteLine(e.Message);
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    Console.WriteLine(e.Message);
                 }
-                //</snippet5>
-            }
-        }
-
-        static void CancelDemo()
-        {
-            bool someCondition = true;
-            //<snippet4>
-            var tokenSource = new CancellationTokenSource();
-            var token = tokenSource.Token;
-
-            var task1 = Task.Factory.StartNew(() =>
-            {
-                CancellationToken ct = token;
-                while (someCondition)
+                else
                 {
-                    // Do some work...
-                    Thread.SpinWait(50000);
-                    ct.ThrowIfCancellationRequested();
+                    throw;
                 }
-            },
-            token);
-
-            // No waiting required.
-            tokenSource.Dispose();
-            //</snippet4>
+            }
+            //</snippet5>
         }
     }
 
-    //<snippet08>
-    class ExceptionDemo2
+    static void CancelDemo()
     {
-        static void Main(string[] args)
+        bool someCondition = true;
+        //<snippet4>
+        var tokenSource = new CancellationTokenSource();
+        var token = tokenSource.Token;
+        var task = Task.Factory.StartNew(() =>
         {
-            // Create some random data to process in parallel.
-            // There is a good probability this data will cause some exceptions to be thrown.
-            byte[] data = new byte[5000];
-            Random r = new Random();
-            r.NextBytes(data);
-
-            try
+            CancellationToken ct = token;
+            while (someCondition)
             {
-                ProcessDataInParallel(data);
+                // Do some work...
+                Thread.SpinWait(50_000);
+                ct.ThrowIfCancellationRequested();
             }
-            catch (AggregateException ae)
-            {
-                var ignoredExceptions = new List<Exception>();
-                // This is where you can choose which exceptions to handle.
-                foreach (var ex in ae.Flatten().InnerExceptions)
-                {
-                    if (ex is ArgumentException)
-                        Console.WriteLine(ex.Message);
-                    else
-                        ignoredExceptions.Add(ex);
-                }
-                if (ignoredExceptions.Count > 0) throw new AggregateException(ignoredExceptions);
-            }
+        },
+        token);
 
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-
-        private static void ProcessDataInParallel(byte[] data)
-        {
-            // Use ConcurrentQueue to enable safe enqueueing from multiple threads.
-            var exceptions = new ConcurrentQueue<Exception>();
-
-            // Execute the complete loop and capture all exceptions.
-            Parallel.ForEach(data, d =>
-            {
-                try
-                {
-                    // Cause a few exceptions, but not too many.
-                    if (d < 3)
-                        throw new ArgumentException($"Value is {d}. Value must be greater than or equal to 3.");
-                    else
-                        Console.Write(d + " ");
-                }
-                // Store the exception and continue with the loop.
-                catch (Exception e)
-                {
-                    exceptions.Enqueue(e);
-                }
-            });
-            Console.WriteLine();
-
-            // Throw the exceptions here after the loop completes.
-            if (exceptions.Count > 0) throw new AggregateException(exceptions);
-        }
+        // No waiting required.
+        tokenSource.Dispose();
+        //</snippet4>
     }
-    //</snippet08>
 }
+
+//<snippet08>
+public static partial class Program
+{
+    public static void ExceptionTwo()
+    {
+        // Create some random data to process in parallel.
+        // There is a good probability this data will cause some exceptions to be thrown.
+        byte[] data = new byte[5_000];
+        Random r = Random.Shared;
+        r.NextBytes(data);
+
+        try
+        {
+            ProcessDataInParallel(data);
+        }
+        catch (AggregateException ae)
+        {
+            var ignoredExceptions = new List<Exception>();
+            // This is where you can choose which exceptions to handle.
+            foreach (var ex in ae.Flatten().InnerExceptions)
+            {
+                if (ex is ArgumentException)
+                    Console.WriteLine(ex.Message);
+                else
+                    ignoredExceptions.Add(ex);
+            }
+            if (ignoredExceptions.Count > 0)
+            {
+                throw new AggregateException(ignoredExceptions);
+            }
+        }
+
+        Console.WriteLine("Press any key to exit.");
+        Console.ReadKey();
+    }
+
+    private static void ProcessDataInParallel(byte[] data)
+    {
+        // Use ConcurrentQueue to enable safe enqueueing from multiple threads.
+        var exceptions = new ConcurrentQueue<Exception>();
+
+        // Execute the complete loop and capture all exceptions.
+        Parallel.ForEach(data, d =>
+        {
+            try
+            {
+                // Cause a few exceptions, but not too many.
+                if (d < 3)
+                    throw new ArgumentException(
+                        $"Value is {d}. Value must be greater than or equal to 3.");
+                else
+                    Console.Write(d + " ");
+            }
+            // Store the exception and continue with the loop.
+            catch (Exception e)
+            {
+                exceptions.Enqueue(e);
+            }
+        });
+        Console.WriteLine();
+
+        // Throw the exceptions here after the loop completes.
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException(exceptions);
+        }
+    }
+}
+//</snippet08>

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten1.cs
@@ -1,43 +1,43 @@
 ﻿// <Snippet2>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Factory.StartNew(() => {
-                     var child1 = Task.Factory.StartNew(() => {
-                        var child2 = Task.Factory.StartNew(() => {
-                            // This exception is nested inside three AggregateExceptions.
-                            throw new CustomException("Attached child2 faulted.");
-                        }, TaskCreationOptions.AttachedToParent);
+    public static void Flatten()
+    {
+        var task1 = Task.Factory.StartNew(() =>
+        {
+            var child1 = Task.Factory.StartNew(() =>
+            {
+                var child2 = Task.Factory.StartNew(() =>
+                {
+                    // This exception is nested inside three AggregateExceptions.
+                    throw new CustomException("Attached child2 faulted.");
+                }, TaskCreationOptions.AttachedToParent);
 
-                        // This exception is nested inside two AggregateExceptions.
-                        throw new CustomException("Attached child1 faulted.");
-                     }, TaskCreationOptions.AttachedToParent);
-      });
+                // This exception is nested inside two AggregateExceptions.
+                throw new CustomException("Attached child1 faulted.");
+            }, TaskCreationOptions.AttachedToParent);
+        });
 
-      try {
-         task1.Wait();
-      }
-      catch (AggregateException ae) {
-         foreach (var e in ae.Flatten().InnerExceptions) {
-            if (e is CustomException) {
-               Console.WriteLine(e.Message);
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.Flatten().InnerExceptions)
+            {
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
+                else
+                {
+                    throw;
+                }
             }
-            else {
-               throw;
-            }
-         }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        }
+    }
 }
 // The example displays the following output:
 //    Attached child1 faulted.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten1.cs
@@ -4,11 +4,11 @@ public static partial class Program
 {
     public static void Flatten()
     {
-        var task1 = Task.Factory.StartNew(() =>
+        var task = Task.Factory.StartNew(() =>
         {
-            var child1 = Task.Factory.StartNew(() =>
+            var child = Task.Factory.StartNew(() =>
             {
-                var child2 = Task.Factory.StartNew(() =>
+                var grandChild = Task.Factory.StartNew(() =>
                 {
                     // This exception is nested inside three AggregateExceptions.
                     throw new CustomException("Attached child2 faulted.");
@@ -21,15 +21,15 @@ public static partial class Program
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {
-            foreach (var e in ae.Flatten().InnerExceptions)
+            foreach (var ex in ae.Flatten().InnerExceptions)
             {
-                if (e is CustomException)
+                if (ex is CustomException)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine(ex.Message);
                 }
                 else
                 {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten2.cs
@@ -1,43 +1,43 @@
 ﻿// <Snippet22>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Factory.StartNew(() => {
-                     var child1 = Task.Factory.StartNew(() => {
-                        var child2 = Task.Factory.StartNew(() => {
-                            // This exception is nested inside three AggregateExceptions.
-                            throw new CustomException("Attached child2 faulted.");
-                        }, TaskCreationOptions.AttachedToParent);
+    public static void FlattenTwo()
+    {
+        var task1 = Task.Factory.StartNew(() =>
+        {
+            var child1 = Task.Factory.StartNew(() =>
+            {
+                var child2 = Task.Factory.StartNew(() =>
+                {
+                    // This exception is nested inside three AggregateExceptions.
+                    throw new CustomException("Attached child2 faulted.");
+                }, TaskCreationOptions.AttachedToParent);
 
-                        // This exception is nested inside two AggregateExceptions.
-                        throw new CustomException("Attached child1 faulted.");
-                     }, TaskCreationOptions.AttachedToParent);
-      });
+                // This exception is nested inside two AggregateExceptions.
+                throw new CustomException("Attached child1 faulted.");
+            }, TaskCreationOptions.AttachedToParent);
+        });
 
-      try {
-         task1.Wait();
-      }
-      catch (AggregateException ae) {
-         foreach (var e in ae.Flatten().InnerExceptions) {
-            if (e is CustomException) {
-               Console.WriteLine(e.Message);
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.Flatten().InnerExceptions)
+            {
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
+                else
+                {
+                    throw;
+                }
             }
-            else {
-               throw;
-            }
-         }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        }
+    }
 }
 // The example displays the following output:
 //    Attached child1 faulted.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/flatten2.cs
@@ -4,11 +4,11 @@ public static partial class Program
 {
     public static void FlattenTwo()
     {
-        var task1 = Task.Factory.StartNew(() =>
+        var task = Task.Factory.StartNew(() =>
         {
-            var child1 = Task.Factory.StartNew(() =>
+            var child = Task.Factory.StartNew(() =>
             {
-                var child2 = Task.Factory.StartNew(() =>
+                var grandChild = Task.Factory.StartNew(() =>
                 {
                     // This exception is nested inside three AggregateExceptions.
                     throw new CustomException("Attached child2 faulted.");
@@ -21,15 +21,15 @@ public static partial class Program
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {
-            foreach (var e in ae.Flatten().InnerExceptions)
+            foreach (var ex in ae.Flatten().InnerExceptions)
             {
-                if (e is CustomException)
+                if (ex is CustomException)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine(ex.Message);
                 }
                 else
                 {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod1.cs
@@ -1,32 +1,32 @@
 ﻿// <Snippet6>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void HandleMethod()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      try {
-          task1.Wait();
-      }
-      catch (AggregateException ae)
-      {
-         // Call the Handle method to handle the custom exception,
-         // otherwise rethrow the exception.
-         ae.Handle(ex => { if (ex is CustomException)
-                             Console.WriteLine(ex.Message);
-                          return ex is CustomException;
-                        });
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            // Call the Handle method to handle the custom exception,
+            // otherwise rethrow the exception.
+            ae.Handle(ex =>
+            {
+                if (ex is CustomException)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+                return ex is CustomException;
+            });
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod1.cs
@@ -4,14 +4,12 @@ public static partial class Program
 {
     public static void HandleMethod()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod2.cs
@@ -1,32 +1,32 @@
 ﻿// <Snippet16>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void HandleMethodTwo()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      try {
-          task1.Wait();
-      }
-      catch (AggregateException ae)
-      {
-         // Call the Handle method to handle the custom exception,
-         // otherwise rethrow the exception.
-         ae.Handle(ex => { if (ex is CustomException)
-                             Console.WriteLine(ex.Message);
-                          return ex is CustomException;
-                        });
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            // Call the Handle method to handle the custom exception,
+            // otherwise rethrow the exception.
+            ae.Handle(ex =>
+            {
+                if (ex is CustomException)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+                return ex is CustomException;
+            });
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod2.cs
@@ -4,10 +4,8 @@ public static partial class Program
 {
     public static void HandleMethodTwo()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task1 = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
         try
         {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod21.cs
@@ -4,14 +4,12 @@ public static partial class Program
 {
     public static void HandleMethodThree()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handlemethod21.cs
@@ -1,32 +1,32 @@
 ﻿// <Snippet26>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void HandleMethodThree()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      try {
-          task1.Wait();
-      }
-      catch (AggregateException ae)
-      {
-         // Call the Handle method to handle the custom exception,
-         // otherwise rethrow the exception.
-         ae.Handle(ex => { if (ex is CustomException)
-                             Console.WriteLine(ex.Message);
-                          return ex is CustomException;
-                        });
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            // Call the Handle method to handle the custom exception,
+            // otherwise rethrow the exception.
+            ae.Handle(ex =>
+            {
+                if (ex is CustomException)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+                return ex is CustomException;
+            });
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling-tpl-exceptions.csproj
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling-tpl-exceptions.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling1.cs
@@ -4,23 +4,21 @@ public static partial class Program
 {
     public static void Handle()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {
-            foreach (var e in ae.InnerExceptions)
+            foreach (var ex in ae.InnerExceptions)
             {
                 // Handle the custom exception.
-                if (e is CustomException)
+                if (ex is CustomException)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine(ex.Message);
                 }
                 // Rethrow any other exception.
                 else

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling1.cs
@@ -1,37 +1,35 @@
 ﻿//<snippet1>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void Handle()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      try
-      {
-          task1.Wait();
-      }
-      catch (AggregateException ae)
-      {
-          foreach (var e in ae.InnerExceptions) {
-              // Handle the custom exception.
-              if (e is CustomException) {
-                  Console.WriteLine(e.Message);
-              }
-              // Rethrow any other exception.
-              else {
-                  throw;
-              }
-          }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.InnerExceptions)
+            {
+                // Handle the custom exception.
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
+                // Rethrow any other exception.
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling2.cs
@@ -1,34 +1,33 @@
 ﻿//<snippet9>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void HandleTwo()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      while(! task1.IsCompleted) {}
+        while (!task1.IsCompleted) { }
 
-      if (task1.Status == TaskStatus.Faulted) {
-          foreach (var e in task1.Exception.InnerExceptions) {
-              // Handle the custom exception.
-              if (e is CustomException) {
-                  Console.WriteLine(e.Message);
-              }
-              // Rethrow any other exception.
-              else {
-                  throw e;
-              }
-          }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        if (task1.Status == TaskStatus.Faulted)
+        {
+            foreach (var e in task1.Exception.InnerExceptions)
+            {
+                // Handle the custom exception.
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
+                // Rethrow any other exception.
+                else
+                {
+                    throw e;
+                }
+            }
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling2.cs
@@ -1,29 +1,29 @@
 ﻿//<snippet9>
 
+using System;
+
 public static partial class Program
 {
     public static void HandleTwo()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
-        while (!task1.IsCompleted) { }
+        while (!task.IsCompleted) { }
 
-        if (task1.Status == TaskStatus.Faulted)
+        if (task.Status == TaskStatus.Faulted)
         {
-            foreach (var e in task1.Exception.InnerExceptions)
+            foreach (var ex in task.Exception?.InnerExceptions ?? new(Array.Empty<Exception>()))
             {
                 // Handle the custom exception.
-                if (e is CustomException)
+                if (ex is CustomException)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine(ex.Message);
                 }
                 // Rethrow any other exception.
                 else
                 {
-                    throw e;
+                    throw ex;
                 }
             }
         }

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling21.cs
@@ -4,14 +4,12 @@ public static partial class Program
 {
     public static void HandleThree()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
         try
         {
-            task1.Wait();
+            task.Wait();
         }
         catch (AggregateException ae)
         {

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling21.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling21.cs
@@ -1,37 +1,35 @@
 ﻿//<snippet21>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void HandleThree()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      try
-      {
-          task1.Wait();
-      }
-      catch (AggregateException ae)
-      {
-          foreach (var e in ae.InnerExceptions) {
-              // Handle the custom exception.
-              if (e is CustomException) {
-                  Console.WriteLine(e.Message);
-              }
-              // Rethrow any other exception.
-              else {
-                  throw e;
-              }
-          }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        try
+        {
+            task1.Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var ex in ae.InnerExceptions)
+            {
+                // Handle the custom exception.
+                if (ex is CustomException)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+                // Rethrow any other exception.
+                else
+                {
+                    throw ex;
+                }
+            }
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling22.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling22.cs
@@ -1,34 +1,33 @@
 ﻿//<snippet29>
-using System;
-using System.Threading.Tasks;
 
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-      var task1 = Task.Run( () => { throw new CustomException("This exception is expected!"); } );
+    public static void HandleFour()
+    {
+        var task1 = Task.Run(() =>
+        {
+            throw new CustomException("This exception is expected!");
+        });
 
-      while(! task1.IsCompleted) {}
+        while (!task1.IsCompleted) { }
 
-      if (task1.Status == TaskStatus.Faulted) {
-          foreach (var e in task1.Exception.InnerExceptions) {
-              // Handle the custom exception.
-              if (e is CustomException) {
-                  Console.WriteLine(e.Message);
-              }
-              // Rethrow any other exception.
-              else {
-                  throw e;
-              }
-          }
-      }
-   }
-}
-
-public class CustomException : Exception
-{
-   public CustomException(String message) : base(message)
-   {}
+        if (task1.Status == TaskStatus.Faulted)
+        {
+            foreach (var e in task1.Exception.InnerExceptions)
+            {
+                // Handle the custom exception.
+                if (e is CustomException)
+                {
+                    Console.WriteLine(e.Message);
+                }
+                // Rethrow any other exception.
+                else
+                {
+                    throw e;
+                }
+            }
+        }
+    }
 }
 // The example displays the following output:
 //        This exception is expected!

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling22.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/handling22.cs
@@ -4,26 +4,24 @@ public static partial class Program
 {
     public static void HandleFour()
     {
-        var task1 = Task.Run(() =>
-        {
-            throw new CustomException("This exception is expected!");
-        });
+        var task = Task.Run(
+            () => throw new CustomException("This exception is expected!"));
 
-        while (!task1.IsCompleted) { }
+        while (!task.IsCompleted) { }
 
-        if (task1.Status == TaskStatus.Faulted)
+        if (task.Status == TaskStatus.Faulted)
         {
-            foreach (var e in task1.Exception.InnerExceptions)
+            foreach (var ex in task.Exception?.InnerExceptions ?? new(Array.Empty<Exception>()))
             {
                 // Handle the custom exception.
-                if (e is CustomException)
+                if (ex is CustomException)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine(ex.Message);
                 }
                 // Rethrow any other exception.
                 else
                 {
-                    throw e;
+                    throw ex;
                 }
             }
         }

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions.cs
@@ -54,7 +54,8 @@ public static partial class Program
         catch (AggregateException ae)
         {
             ae.Handle(x =>
-            { // Handle an UnauthorizedAccessException
+            {
+                // Handle an UnauthorizedAccessException
                 if (x is UnauthorizedAccessException)
                 {
                     Console.WriteLine(

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions.cs
@@ -1,55 +1,72 @@
 ﻿// <snippet12>
-using System;
-using System.IO;
-using System.Threading.Tasks;
-
-public class Example
+public static partial class Program
 {
-    public static void Main()
+    public static void TaskException()
     {
         // This should throw an UnauthorizedAccessException.
-       try {
-           var files = GetAllFiles(@"C:\");
-           if (files != null)
-              foreach (var file in files)
-                 Console.WriteLine(file);
+        try
+        {
+            if (GetAllFiles(@"C:\") is { Length: > 0 } files)
+            {
+                foreach (var file in files)
+                {
+                    Console.WriteLine(file);
+                }
+            }
         }
-        catch (AggregateException ae) {
-           foreach (var ex in ae.InnerExceptions)
-               Console.WriteLine("{0}: {1}", ex.GetType().Name, ex.Message);
+        catch (AggregateException ae)
+        {
+            foreach (var ex in ae.InnerExceptions)
+            {
+                Console.WriteLine(
+                    "{0}: {1}", ex.GetType().Name, ex.Message);
+            }
         }
         Console.WriteLine();
 
         // This should throw an ArgumentException.
-        try {
-           foreach (var s in GetAllFiles(""))
-              Console.WriteLine(s);
+        try
+        {
+            foreach (var s in GetAllFiles(""))
+            {
+                Console.WriteLine(s);
+            }
         }
-        catch (AggregateException ae) {
-           foreach (var ex in ae.InnerExceptions)
-               Console.WriteLine("{0}: {1}", ex.GetType().Name, ex.Message);
+        catch (AggregateException ae)
+        {
+            foreach (var ex in ae.InnerExceptions)
+                Console.WriteLine(
+                    "{0}: {1}", ex.GetType().Name, ex.Message);
         }
     }
 
     static string[] GetAllFiles(string path)
     {
-       var task1 = Task.Run( () => Directory.GetFiles(path, "*.txt",
-                                                      SearchOption.AllDirectories));
+        var task1 =
+            Task.Run(() => Directory.GetFiles(
+                path, "*.txt",
+                SearchOption.AllDirectories));
 
-       try {
-          return task1.Result;
-       }
-       catch (AggregateException ae) {
-          ae.Handle( x => { // Handle an UnauthorizedAccessException
-                            if (x is UnauthorizedAccessException) {
-                                Console.WriteLine("You do not have permission to access all folders in this path.");
-                                Console.WriteLine("See your network administrator or try another path.");
-                            }
-                            return x is UnauthorizedAccessException;
-                          });
-          return Array.Empty<String>();
-       }
-   }
+        try
+        {
+            return task1.Result;
+        }
+        catch (AggregateException ae)
+        {
+            ae.Handle(x =>
+            { // Handle an UnauthorizedAccessException
+                if (x is UnauthorizedAccessException)
+                {
+                    Console.WriteLine(
+                        "You do not have permission to access all folders in this path.");
+                    Console.WriteLine(
+                        "See your network administrator or try another path.");
+                }
+                return x is UnauthorizedAccessException;
+            });
+            return Array.Empty<string>();
+        }
+    }
 }
 // The example displays the following output:
 //       You do not have permission to access all folders in this path.

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions2.cs
@@ -1,48 +1,58 @@
 ﻿// <snippet13>
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-public class Example
+public static partial class Program
 {
-   public static void Main()
-   {
-	    try {
-	        ExecuteTasks();
-	    }
-	    catch (AggregateException ae) {
-	        foreach (var e in ae.InnerExceptions) {
-	            Console.WriteLine("{0}:\n   {1}", e.GetType().Name, e.Message);
-	        }
-	    }
-   }
+    public static void TaskExceptionTwo()
+    {
+        try
+        {
+            ExecuteTasks();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.InnerExceptions)
+            {
+                Console.WriteLine(
+                    "{0}:\n   {1}", e.GetType().Name, e.Message);
+            }
+        }
+    }
 
-   static void ExecuteTasks()
-   {
+    static void ExecuteTasks()
+    {
         // Assume this is a user-entered String.
-        String path = @"C:\";
-        List<Task> tasks = new List<Task>();
+        string path = @"C:\";
+        List<Task> tasks = new();
 
-        tasks.Add(Task.Run(() => {
-                             // This should throw an UnauthorizedAccessException.
-                              return Directory.GetFiles(path, "*.txt",
-                                                        SearchOption.AllDirectories);
-                           }));
+        tasks.Add(Task.Run(() =>
+        {
+            // This should throw an UnauthorizedAccessException.
+            return Directory.GetFiles(
+                path, "*.txt",
+                SearchOption.AllDirectories);
+        }));
 
-        tasks.Add(Task.Run(() => {
-                              if (path == @"C:\")
-                                 throw new ArgumentException("The system root is not a valid path.");
-                              return new String[] { ".txt", ".dll", ".exe", ".bin", ".dat" };
-                           }));
+        tasks.Add(Task.Run(() =>
+        {
+            if (path == @"C:\")
+            {
+                throw new ArgumentException(
+                    "The system root is not a valid path.");
+            }
+            return new string[] { ".txt", ".dll", ".exe", ".bin", ".dat" };
+        }));
 
-        tasks.Add(Task.Run(() => {
-                               throw new NotImplementedException("This operation has not been implemented.");
-                           }));
+        tasks.Add(Task.Run(() =>
+        {
+            throw new NotImplementedException(
+                "This operation has not been implemented.");
+        }));
 
-        try {
+        try
+        {
             Task.WaitAll(tasks.ToArray());
         }
-        catch (AggregateException ae) {
+        catch (AggregateException ae)
+        {
             throw ae.Flatten();
         }
     }


### PR DESCRIPTION
## Summary

Clean up and formatting, added callout about various expressions and their expected exception.

Fixes #28117

I had two sandbox Sharplab's going to verify bits, but I also manually verified each update in the newly added `Porgram` file.

- [Sharplab.io: 1](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUKgBgAJVMBWAbjzwDcBDMI4OgZwGsiBeEgNgDoAYnQDGwAPZgAnnwDKzMMAByAUwDuAHgCWUYAD4AFHiLGi+gJRddTABZgxqolDVEAklDjKAHgHkIwbwBmAEp0UADmygCinsLKAA7AmmJQ5mZUuHjAUngA3kYmAPQFRNFxYMosLElQJrV19URBFRAANsD5xkVMrGx8AOp0msDmFA1jncWYfEQAgmFh5WF0wFEx8YnJHURdqACc3eyj42Nd6NNuHj5+gSHhq7EJ1VtdAPpcB71NLK3AR8fbk2mcwWyiWK2iDw2UC2zHYfAA4spgDNVIMVmBzAikV8fiMJkQzq53F5fP5gqEIhD1k9cABfPDCZbCaymYGLZb3anJIh0ZRmXJbUi7fQAEgARFNZvN2eC1o9kiAiDlebSxWk8PTcIzgMzTBcSddyXcqfKakl+bg8rhakLRWLCfqrmTbpS5VDFTkkqr1XSGUyWfoTVCiF4LVabZhheKAMzTIPVD1eb3pWlAA=)
- [Sharplab.io: 2](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUKgBgAJVMBWAbjzwDcBDMI4OgZwGsiBeEgNgDoAYnQDGwAPZgAnnwDKzMMAByAUwDuAHgCWUYAD4AFHiLGi+gJRddTABZgxqolDVEAklDjKAHgHkIwbwBmAEp0UADmygCinsLKAA7AmmJQ5mZUuHjAUngA3kYmAPQFRNFxYMosLElQJrV19fVBFRAANsD5xkVMrGx8AOp0msDmFA1jDV0EHURdqACc3eyj4yuFxTi4tV0A+lyLvU0srcDLq3WT013M7HwA4srAAIKqg8DKYOZ3D4fHI1vreAAvnhhHRgMJrKZHmEwuUwmCojF4olkkQ6GZctNSHN9AASABEBD4RGhsOU8Le0ViCWqICIOTogPxaSBILBENMVOR1SIXgxuDymxM2Lx+MwxK5NOSdJyXiZLKFxk0AVMXiImhYJJhcIRkpRNToyn5tUFYxFBPQxNJOspSKlUBlhvl6TGhr4AAlQnAWspDIrxtonIxOLppmNTWcTMrTIH3urNW4PD4/IEQuFEdT9eqxBI+WHVhHI3VzfiAMzExNeXz+YKhCJ62n0pK5zzOov1fNF1AAdiYkGULvbwP9Z074x7RACdBaLAHY9qgIVC6BQA===)

Internal preview: https://review.docs.microsoft.com/en-us/dotnet/standard/parallel-programming/exception-handling-task-parallel-library?branch=pr-en-us-29315