### PR TITLE
C# example used a VB.NET style variable name

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Data/XmlSchemaReadWriteExample/CS/XmlSchemaReadWriteExample.cs
+++ b/samples/snippets/csharp/VS_Snippets_Data/XmlSchemaReadWriteExample/CS/XmlSchemaReadWriteExample.cs
@@ -12,12 +12,12 @@ class XmlSchemaReadWriteExample
         try
         {
             XmlTextReader reader = new XmlTextReader("example.xsd");
-            XmlSchema myschema = XmlSchema.Read(reader, ValidationCallback);
-            myschema.Write(Console.Out);
+            XmlSchema schema = XmlSchema.Read(reader, ValidationCallback);
+            schema.Write(Console.Out);
             FileStream file = new FileStream("new.xsd", FileMode.Create, FileAccess.ReadWrite);
             XmlTextWriter xwriter = new XmlTextWriter(file, new UTF8Encoding());
             xwriter.Formatting = Formatting.Indented;
-            myschema.Write(xwriter);
+            schema.Write(xwriter);
         }
         catch(Exception e)
         {


### PR DESCRIPTION
This main page for XmlSchema contains C++, C#, and VB.NET examples. Someone ported the VB.NET example to C# and used the variable name "mySchema" (VB.NET style) versus C# which does not prefix variables with the term "my."

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
