### PR TITLE
Update code-style-rule-options.md

### DIFF
--- a/docs/fundamentals/code-analysis/code-style-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-style-rule-options.md
@@ -94,11 +94,11 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 # Naming Conventions          #
 ###############################
 # Style Definitions
-dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+dotnet_naming_style.pascal_case.capitalization             = pascal_case
 # Use PascalCase for constant fields  
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const

--- a/docs/fundamentals/code-analysis/code-style-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-style-rule-options.md
@@ -94,7 +94,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 # Naming Conventions          #
 ###############################
 # Style Definitions
-dotnet_naming_style.pascal_case.capitalization             = pascal_case
+dotnet_naming_style.pascal_case.capitalization                    = pascal_case
 # Use PascalCase for constant fields  
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields


### PR DESCRIPTION
## Summary

Describe your changes here.

Pascal Case rules for editorconfig were not working, because `pascal_case_style` was used instead of `pascal_case`

Fixes #29332
