### PR TITLE
Add CAS deprecation alert

### DIFF
--- a/docs/architecture/modernize-desktop/migrate-modern-applications.md
+++ b/docs/architecture/modernize-desktop/migrate-modern-applications.md
@@ -212,13 +212,13 @@ Across machines, use a network-based solution as an alternative. Preferably, use
 
 Sandboxing, which relies on the runtime or the framework to constrain which resources a managed application or library uses or runs, isn't supported on .NET.
 
-Use security boundaries that are provided by the operating system, such as virtualization, containers, or user accounts for running processes with the minimum set of privileges.
+Use security boundaries that are provided by the operating system, such as virtualization, containers, or user accounts, for running processes with the minimum set of privileges.
 
 ### Security Transparency
 
 Similar to CAS, Security Transparency separates sandboxed code from security critical code in a declarative fashion but is no longer supported as a security boundary.
 
-Use security boundaries that are provided by the operating system, such as virtualization, containers, or user accounts for running processes with the least set of privileges.
+Use security boundaries that are provided by the operating system, such as virtualization, containers, or user accounts, for running processes with the least set of privileges.
 
 >[!div class="step-by-step"]
 >[Previous](whats-new-dotnet.md )

--- a/docs/architecture/porting-existing-aspnet-apps/migration-considerations.md
+++ b/docs/architecture/porting-existing-aspnet-apps/migration-considerations.md
@@ -45,6 +45,8 @@ There are many compelling reasons to consider migrating to .NET Core, which pres
 
 The biggest reason to stay on .NET Framework is when an app isn't under active development and wouldn't benefit substantially from the advantages listed above. In that case, there probably isn't a good business case to incur the cost of porting the app. If your app might benefit from the advantages .NET Core offers, you may still need to stay on .NET Framework if you need certain technologies that are unavailable on .NET Core. There are some [.NET technologies that are unavailable on .NET Core](../../core/porting/net-framework-tech-unavailable.md), including AppDomains, Remoting, Code Access Security (CAS), Security Transparency, and `System.EnterpriseServices`. A brief summary of these technologies and their alternatives is included here. For more detailed guidance, see the documentation.
 
+[!INCLUDE [cas-deprecated](../../../includes/cas-deprecated.md)]
+
 ### Application domains
 
 Application domains (AppDomains) isolate apps from one another. AppDomains require runtime support and can be expensive. Creating additional app domains isn't supported, and there are no plans to add this capability to .NET Core in the future. For code isolation, use separate processes or containers as an alternative. Some customers use AppDomains as a way of unloading assemblies. In .NET Core [AssemblyLoadContext](../../standard/assembly/unloadability.md) provides an alternative way to unload assemblies.

--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -29,7 +29,7 @@ For more messaging options, see [.NET Open Source Developer Projects: Messaging]
 
 ## Code access security (CAS)
 
-Sandboxing, which relies on the runtime or the framework to constrain which resources a managed application or library uses or runs, [isn't supported on .NET Framework](/previous-versions/dotnet/framework/code-access-security/code-access-security) and therefore is also not supported on .NET Core and .NET 5+. There are too many cases in the .NET Framework and the runtime where an elevation of privileges occurs to continue treating CAS as a security boundary. Also, CAS makes the implementation more complicated and often has correctness-performance implications for applications that don't intend to use it.
+Sandboxing, which relies on the runtime or the framework to constrain which resources a managed application or library uses or runs, [isn't supported on .NET Framework](/previous-versions/dotnet/framework/code-access-security/code-access-security) and therefore is also not supported on .NET Core and .NET 5+. CAS is no longer treated as a security boundary, because there are too many cases in .NET Framework and the runtime where an elevation of privileges occurs. Also, CAS makes the implementation more complicated and often has correctness-performance implications for applications that don't intend to use it.
 
 Use security boundaries provided by the operating system, such as virtualization, containers, or user accounts, for running processes with the minimum set of privileges.
 
@@ -37,7 +37,7 @@ Use security boundaries provided by the operating system, such as virtualization
 
 Similar to CAS, security transparency separates sandboxed code from security critical code in a declarative fashion but is [no longer supported as a security boundary](/previous-versions/dotnet/framework/code-access-security/security-transparent-code). This feature is heavily used by Silverlight.
 
-Use security boundaries provided by the operating system, such as virtualization, containers, or user accounts, for running processes with the least set of privileges.
+To run processes with the least set of privileges, use security boundaries provided by the operating system, such as virtualization, containers, or user accounts.
 
 ## System.EnterpriseServices
 

--- a/docs/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element.md
@@ -15,6 +15,8 @@ Specifies whether the runtime creates <xref:System.Security.Policy.Publisher> ev
 &nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;**\<generatePublisherEvidence>**
 
+[!INCLUDE [cas-deprecated](../../../../../includes/cas-deprecated.md)]
+
 ## Syntax
 
 ```xml

--- a/docs/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element.md
@@ -13,7 +13,9 @@ Specifies whether the runtime uses legacy code access security (CAS) policy.
 
 [**\<configuration>**](../configuration-element.md)\
 &nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;**\<NetFx40_LegacySecurityPolicy>**  
+&nbsp;&nbsp;&nbsp;&nbsp;**\<NetFx40_LegacySecurityPolicy>**
+
+[!INCLUDE [cas-deprecated](../../../../../includes/cas-deprecated.md)]
 
 ## Syntax
 

--- a/docs/framework/data/adonet/code-access-security.md
+++ b/docs/framework/data/adonet/code-access-security.md
@@ -9,9 +9,11 @@ ms.assetid: 93e099eb-daa1-4f1e-b031-c1e10a996f88
 ---
 # Code Access Security and ADO.NET
 
-The .NET Framework offers role-based security as well as code access security (CAS), both of which are implemented using a common infrastructure supplied by the common language runtime (CLR). In the world of unmanaged code, most applications execute with the permissions of the user or principal. As a result, computer systems can be damaged and private data compromised when malicious or error-filled software is run by a user with elevated privileges.  
+.NET Framework offers role-based security as well as code access security (CAS), both of which are implemented using a common infrastructure supplied by the common language runtime (CLR). In the world of unmanaged code, most applications execute with the permissions of the user or principal. As a result, computer systems can be damaged and private data compromised when malicious or error-filled software is run by a user with elevated privileges.  
   
- By contrast, managed code executing in the .NET Framework includes code access security, which applies to code alone. Whether the code is allowed to run or not depends on the code's origin or other aspects of the code's identity, not solely the identity of the principal. This reduces the likelihood that managed code can be misused.  
+ By contrast, managed code executing in .NET Framework includes code access security, which applies to code alone. Whether the code is allowed to run or not depends on the code's origin or other aspects of the code's identity, not solely the identity of the principal. This reduces the likelihood that managed code can be misused.
+
+[!INCLUDE [cas-deprecated](../../../../includes/cas-deprecated.md)]
   
 ## Code Access Permissions  
 

--- a/docs/framework/data/adonet/secure-client-applications.md
+++ b/docs/framework/data/adonet/secure-client-applications.md
@@ -28,16 +28,14 @@ Applications typically consist of many parts that must all be protected from vul
  Describes how to use the <xref:System.Text.RegularExpressions.Regex> class to check the validity of user input.  
   
 ## Windows Applications  
-
- In the past, Windows applications generally ran with full permissions. The .NET Framework provides the infrastructure to restrict code executing in a Windows application by using code access security (CAS). However, CAS alone is not enough to protect your application.  
   
- [Windows Forms Security](/dotnet/desktop/winforms/windows-forms-security)  
+ [Windows Forms Security](/dotnet/desktop/winforms/windows-forms-security)\
  Discusses how to secure Windows Forms applications and provides links to related topics.  
   
- [Windows Forms and Unmanaged Applications](/dotnet/desktop/winforms/advanced/windows-forms-and-unmanaged-applications)  
+ [Windows Forms and Unmanaged Applications](/dotnet/desktop/winforms/advanced/windows-forms-and-unmanaged-applications)\
  Describes how to interact with unmanaged applications in a Windows Forms application.  
   
- [ClickOnce Deployment for Windows Forms](/dotnet/desktop/winforms/clickonce-deployment-for-windows-forms)  
+ [ClickOnce Deployment for Windows Forms](/dotnet/desktop/winforms/clickonce-deployment-for-windows-forms)\
  Describes how to use `ClickOnce` deployment in a Windows Forms application and discusses the security implications.  
   
 ## ASP.NET and XML Web Services  

--- a/docs/framework/data/adonet/side-by-side-execution.md
+++ b/docs/framework/data/adonet/side-by-side-execution.md
@@ -30,7 +30,7 @@ Side-by-side execution in the .NET Framework is the ability to execute an applic
   
  If you have an application developed for the .NET Framework version 2.0 or later that uses the data provider to connect to your data source, and you want to run that application on the .NET Framework version 1.0, you must download the data provider and install it on the .NET Framework version 1.0 system.  
   
-## Code Access Security 
+## Code Access Security
   
  Starting with .NET Framework version 2.0, all of the .NET Framework data providers can be used in partially trusted zones. In addition, a new security feature was added to the .NET Framework data providers in .NET Framework version 1.1. This feature enables you to restrict what connection strings can be used in a particular security zone. You can also disable the use of blank passwords for a particular security zone. For more information, see [Code Access Security and ADO.NET](code-access-security.md).  
   

--- a/docs/framework/data/adonet/side-by-side-execution.md
+++ b/docs/framework/data/adonet/side-by-side-execution.md
@@ -30,13 +30,11 @@ Side-by-side execution in the .NET Framework is the ability to execute an applic
   
  If you have an application developed for the .NET Framework version 2.0 or later that uses the data provider to connect to your data source, and you want to run that application on the .NET Framework version 1.0, you must download the data provider and install it on the .NET Framework version 1.0 system.  
   
-## Code Access Security  
-
- The .NET Framework data providers in the .NET Framework version 1.0 (<xref:System.Data.SqlClient>, <xref:System.Data.OleDb>) are required to run with FullTrust permission. Any attempt to use the .NET Framework k data providers from the .NET Framework version 1.0 in a zone with less than FullTrust permission causes a <xref:System.Security.SecurityException>.  
+## Code Access Security 
   
- However, starting with the .NET Framework version 2.0, all of the .NET Framework data providers can be used in partially trusted zones. In addition, a new security feature was added to the .NET Framework data providers in the .NET Framework version 1.1. This feature enables you to restrict what connection strings can be used in a particular security zone. You can also disable the use of blank passwords for a particular security zone. For more information, see [Code Access Security and ADO.NET](code-access-security.md).  
+ Starting with .NET Framework version 2.0, all of the .NET Framework data providers can be used in partially trusted zones. In addition, a new security feature was added to the .NET Framework data providers in .NET Framework version 1.1. This feature enables you to restrict what connection strings can be used in a particular security zone. You can also disable the use of blank passwords for a particular security zone. For more information, see [Code Access Security and ADO.NET](code-access-security.md).  
   
- Because each installation of the .NET Framework has a separate Security.config file, there are no compatibility issues with security settings. However, if your application depends on the additional security capabilities of ADO.NET included in the .NET Framework version 1.1 and later, you will not be able to distribute it to a version 1.0 system.  
+ Because each installation of .NET Framework has a separate Security.config file, there are no compatibility issues with security settings. However, if your application depends on the additional security capabilities of ADO.NET included in .NET Framework version 1.1 and later, you will not be able to distribute it to a version 1.0 system.  
   
 ## SqlCommand Execution  
 

--- a/docs/framework/data/adonet/sql/introduction-to-sql-server-clr-integration.md
+++ b/docs/framework/data/adonet/sql/introduction-to-sql-server-clr-integration.md
@@ -6,11 +6,13 @@ ms.assetid: 551d2290-ed80-49be-b377-44b32444da1c
 ---
 # Introduction to SQL Server CLR Integration
 
-The common language runtime (CLR) is the heart of the Microsoft .NET Framework and provides the execution environment for all .NET Framework code. Code that runs within the CLR is referred to as managed code. The CLR provides various functions and services required for program execution, including just-in-time (JIT) compilation, allocating and managing memory, enforcing type safety, exception handling, thread management, and security.  
+The common language runtime (CLR) is the heart of .NET Framework and provides the execution environment for all .NET Framework code. Code that runs within the CLR is referred to as managed code. The CLR provides various functions and services required for program execution, including just-in-time (JIT) compilation, allocating and managing memory, enforcing type safety, exception handling, thread management, and security.  
   
  With the CLR hosted in Microsoft SQL Server (called CLR integration), you can author stored procedures, triggers, user-defined functions, user-defined types, and user-defined aggregates in managed code. Because managed code compiles to native code prior to execution, you can achieve significant performance increases in some scenarios.  
   
- Managed code uses Code Access Security (CAS), code links, and application domains to prevent assemblies from performing certain operations. SQL Server uses CAS to help secure the managed code and prevent compromise of the operating system or database server.  
+Managed code running on .NET Framework uses Code Access Security (CAS), code links, and application domains to prevent assemblies from performing certain operations. SQL Server uses CAS to help secure the managed code and prevent compromise of the operating system or database server.
+
+[!INCLUDE [cas-deprecated](../../../../../includes/cas-deprecated.md)]
   
  This section is meant to provide only enough information to get started programming with SQL Server CLR integration, and is not meant to be comprehensive. For more detailed information, see [Common Language Runtime (CLR) Integration Overview](/sql/relational-databases/clr-integration/common-language-runtime-integration-overview).
   

--- a/docs/framework/deployment/index.md
+++ b/docs/framework/deployment/index.md
@@ -149,7 +149,7 @@ The .NET Framework provides the following options for distributing applications:
 
 To determine where to deploy your application's assemblies so they can be found by the runtime, see [How the Runtime Locates Assemblies](how-the-runtime-locates-assemblies.md).
 
-Security considerations can also affect how you deploy your application. Security permissions are granted to managed code according to where the code is located. Deploying an application or component to a location where it receives little trust, such as the Internet, limits what the application or component can do. For more information about deployment and security considerations, see [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics).
+Security considerations can also affect how you deploy your application. Security permissions are granted to managed code according to where the code is located. Deploying an application or component to a location where it receives little trust, such as the internet, limits what the application or component can do.
 
 ## Related Topics
 

--- a/docs/framework/performance/sql-server-programming-and-host-protection-attributes.md
+++ b/docs/framework/performance/sql-server-programming-and-host-protection-attributes.md
@@ -16,7 +16,9 @@ ms.assetid: 7dfa36b4-e773-4c75-a3ff-ff1af3ce4c4f
 ---
 # SQL Server Programming and Host Protection Attributes
 
-The ability to load and execute managed code in a SQL Server host requires meeting the host's requirements for both code access security and host resource protection.  The code access security requirements are specified by one of three SQL Server permission sets: SAFE, EXTERNAL-ACCESS, or UNSAFE. Code executing within the SAFE or EXTERNAL-ACCESS permission sets must avoid certain types or members that have the <xref:System.Security.Permissions.HostProtectionAttribute> attribute applied. The <xref:System.Security.Permissions.HostProtectionAttribute> is not a security permission as much as a reliability guarantee in that it identifies specific code constructs, either types or methods, that the host may disallow.  The use of the <xref:System.Security.Permissions.HostProtectionAttribute> enforces a programming model that helps protect the stability of the host.  
+The ability to load and execute managed code in a SQL Server host requires meeting the host's requirements for both code access security and host resource protection.  The code access security requirements are specified by one of three SQL Server permission sets: SAFE, EXTERNAL-ACCESS, or UNSAFE. Code executing within the SAFE or EXTERNAL-ACCESS permission sets must avoid certain types or members that have the <xref:System.Security.Permissions.HostProtectionAttribute> attribute applied. The <xref:System.Security.Permissions.HostProtectionAttribute> is not a security permission as much as a reliability guarantee in that it identifies specific code constructs, either types or methods, that the host may disallow.  The use of the <xref:System.Security.Permissions.HostProtectionAttribute> enforces a programming model that helps protect the stability of the host.
+
+[!INCLUDE [cas-deprecated](../../../includes/cas-deprecated.md)]  
   
 ## Host Protection Attributes  
 

--- a/docs/framework/tools/caspol-exe-code-access-security-policy-tool.md
+++ b/docs/framework/tools/caspol-exe-code-access-security-policy-tool.md
@@ -24,6 +24,8 @@ The Code Access Security (CAS) Policy tool (Caspol.exe) enables users and admini
 > [!IMPORTANT]
 > Starting with .NET Framework 4, Caspol.exe does not affect CAS policy unless the [\<legacyCasPolicy> element](../configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element.md) is set to `true`. Any settings shown or modified by CasPol.exe will only affect applications that opt into using CAS policy.
 
+[!INCLUDE [cas-deprecated](../../../includes/cas-deprecated.md)]
+
 > [!NOTE]
 > 64-bit computers include both 64-bit and 32-bit versions of security policy. To ensure that your policy changes apply to both 32-bit and 64-bit applications, run both the 32-bit and 64-bit versions of Caspol.exe.
 

--- a/docs/framework/tools/ngen-exe-native-image-generator.md
+++ b/docs/framework/tools/ngen-exe-native-image-generator.md
@@ -27,7 +27,7 @@ The Native Image Generator (Ngen.exe) is a tool that improves the performance of
 > [!NOTE]
 > Ngen.exe compiles native images for assemblies that target the .NET Framework only. The equivalent native image generator for .NET Core is [CrossGen](https://github.com/dotnet/runtime/blob/main/docs/workflow/building/coreclr/crossgen.md).
 
-Changes to Ngen.exe in the .NET Framework 4:
+Changes to Ngen.exe in .NET Framework 4:
 
 - Ngen.exe now compiles assemblies with full trust, and code access security (CAS) policy is no longer evaluated.
 
@@ -73,7 +73,7 @@ The following table shows the syntax of each `action`. For descriptions of the i
 |Action|Description|
 |------------|-----------------|
 |`install` [`assemblyName` &#124; `assemblyPath`] [`scenarios`] [`config`] [`/queue`[`:`{`1`&#124;`2`&#124;`3`}]]|Generate native images for an assembly and its dependencies and install the images in the native image cache.<br /><br /> If `/queue` is specified, the action is queued for the native image service. The default priority is 3. See the [Priority Levels](#PriorityTable) table.|
-|`uninstall` [`assemblyName` &#124; `assemblyPath`] [`scenarios`] [`config`]|Delete the native images of an assembly and its dependencies from the native image cache.<br /><br /> To uninstall a single image and its dependencies, use the same command-line arguments that were used to install the image. **Note:**  Starting with the .NET Framework 4, the action `uninstall` * is no longer supported.|
+|`uninstall` [`assemblyName` &#124; `assemblyPath`] [`scenarios`] [`config`]|Delete the native images of an assembly and its dependencies from the native image cache.<br /><br /> To uninstall a single image and its dependencies, use the same command-line arguments that were used to install the image. **Note:**  Starting with .NET Framework 4, the action `uninstall` * is no longer supported.|
 |`update` [`/queue`]|Update native images that have become invalid.<br /><br /> If `/queue` is specified, the updates are queued for the native image service. Updates are always scheduled at priority 3, so they run when the computer is idle.|
 |`display` [`assemblyName` &#124; `assemblyPath`]|Display the state of the native images for an assembly and its dependencies.<br /><br /> If no argument is supplied, everything in the native image cache is displayed.|
 |`executeQueuedItems` [<code>1&#124;2&#124;3</code>]<br /><br /> -or-<br /><br /> `eqi` [1&#124;2&#124;3]|Execute queued compilation jobs.<br /><br /> If a priority is specified, compilation jobs with greater or equal priority are executed. If no priority is specified, all queued compilation jobs are executed.|
@@ -133,9 +133,9 @@ The following table shows the syntax of each `action`. For descriptions of the i
 To run Ngen.exe, you must have administrative privileges.
 
 > [!CAUTION]
-> Do not run Ngen.exe on assemblies that are not fully trusted. Starting with the .NET Framework 4, Ngen.exe compiles assemblies with full trust, and code access security (CAS) policy is no longer evaluated.
+> Do not run Ngen.exe on assemblies that are not fully trusted. Starting with .NET Framework 4, Ngen.exe compiles assemblies with full trust, and code access security (CAS) policy is no longer evaluated.
 
-Starting with the .NET Framework 4, the native images that are generated with Ngen.exe can no longer be loaded into applications that are running in partial trust. Instead, the just-in-time (JIT) compiler is invoked.
+Starting with .NET Framework 4, the native images that are generated with Ngen.exe can no longer be loaded into applications that are running in partial trust. Instead, the just-in-time (JIT) compiler is invoked.
 
 Ngen.exe generates native images for the assembly specified by the `assemblyname` argument to the `install` action and all its dependencies. Dependencies are determined from references in the assembly manifest. The only scenario in which you need to install a dependency separately is when the application loads it using reflection, for example by calling the <xref:System.Reflection.Assembly.Load%2A?displayProperty=nameWithType> method.
 
@@ -558,7 +558,7 @@ The native image task is registered once for each CPU architecture supported on 
 |NET Framework NGEN v4.0.30319|Yes|Yes|
 |NET Framework NGEN v4.0.30319 64|No|Yes|
 
-The native image task is available in the .NET Framework 4.5 and later versions, when running on Windows 8 or later. On earlier versions of Windows, the .NET Framework uses the [Native Image Service](#native-image-service).
+The native image task is available in .NET Framework 4.5 and later versions, when running on Windows 8 or later. On earlier versions of Windows, the .NET Framework uses the [Native Image Service](#native-image-service).
 
 ### Task Lifetime
 

--- a/docs/framework/wcf/deploying-wcf-applications-with-clickonce.md
+++ b/docs/framework/wcf/deploying-wcf-applications-with-clickonce.md
@@ -6,7 +6,9 @@ ms.assetid: 1a11feee-2a47-4d3e-a28a-ad69d5ff93e0
 ---
 # Deploying WCF Applications with ClickOnce
 
-Client applications using Windows Communication Foundation (WCF) may be deployed using ClickOnce technology. This technology allows them to take advantage of the runtime security protections provided by Code Access Security, provided that they are digitally signed with a trusted certificate. The certificate used to sign the ClickOnce application must reside in the Trusted Publisher store, and the local security policy on the client machine must be configured to grant Full Trust permissions to applications signed with the publisher's certificate.  
+Client applications using Windows Communication Foundation (WCF) may be deployed using ClickOnce technology. This technology allows them to take advantage of the runtime security protections provided by Code Access Security, provided that they are digitally signed with a trusted certificate. The certificate used to sign the ClickOnce application must reside in the Trusted Publisher store, and the local security policy on the client machine must be configured to grant Full Trust permissions to applications signed with the publisher's certificate.
+
+[!INCLUDE [cas-deprecated](../../../includes/cas-deprecated.md)]
   
  For information on configuring ClickOnce applications and trusted publishers, see [Configuring ClickOnce Trusted Publishers](/previous-versions/dotnet/articles/ms996418(v=msdn.10)).  
   

--- a/docs/framework/wcf/feature-details/partial-trust-best-practices.md
+++ b/docs/framework/wcf/feature-details/partial-trust-best-practices.md
@@ -46,6 +46,8 @@ The following best practices apply for types that implement <xref:System.Xml.Ser
 
 The WCF partial trust security model assumes that any caller of a WCF public method or property is running in the code access security (CAS) context of the hosting application. WCF also assumes that only one application security context exists for each <xref:System.AppDomain>, and that this context is established at <xref:System.AppDomain> creation time by a trusted host (for example, by a call to <xref:System.AppDomain.CreateDomain%2A> or by the ASP.NET Application Manager).
 
+[!INCLUDE [cas-deprecated](../../../../includes/cas-deprecated.md)]
+
 This security model applies to user-written applications that cannot assert additional CAS permissions, such as user code running in a Medium Trust ASP.NET application. However, fully-trusted platform code (for example, a third-party assembly that is installed in the global assembly cache and accepts calls from partially-trusted code) must take explicit care when calling into WCF on behalf of a partially-trusted application to avoid introducing application-level security vulnerabilities.
 
 Full-trust code should avoid altering the CAS permission set of the current thread (by calling <xref:System.Security.PermissionSet.Assert%2A>, <xref:System.Security.PermissionSet.PermitOnly%2A>, or <xref:System.Security.PermissionSet.Deny%2A>) prior to calling WCF APIs on behalf of partially-trusted code. Asserting, denying, or otherwise creating a thread-specific permission context that is independent of the application-level security context can result in unexpected behavior. Depending on the application, this behavior may result in application-level security vulnerabilities.

--- a/docs/framework/wcf/feature-details/partial-trust.md
+++ b/docs/framework/wcf/feature-details/partial-trust.md
@@ -4,9 +4,11 @@ title: "Partial Trust"
 ms.date: "03/30/2017"
 ms.assetid: 489b1587-9909-4d0e-8c1a-5e83c8f8292b
 ---
-# Partial Trust
+# Partial trust
 
-Starting with the .NET Framework 3.5, partially trusted callers can access public types and methods implemented in <xref:System.ServiceModel>, <xref:System.Runtime.Serialization>, and <xref:System.ServiceModel.Web>. This section describes supported scenarios for using Windows Communication Foundation (WCF) within a partially trusted application as well as the limited subset of WCF functionality available to applications running with reduced code access security (CAS) permissions.  
+Starting with .NET Framework 3.5, partially trusted callers can access public types and methods implemented in <xref:System.ServiceModel>, <xref:System.Runtime.Serialization>, and <xref:System.ServiceModel.Web>. This section describes supported scenarios for using Windows Communication Foundation (WCF) within a partially trusted application as well as the limited subset of WCF functionality available to applications running with reduced code access security (CAS) permissions.
+
+[!INCLUDE [cas-deprecated](../../../../includes/cas-deprecated.md)]
   
 ## In This Section  
 

--- a/docs/framework/wcf/feature-details/security-considerations-for-data.md
+++ b/docs/framework/wcf/feature-details/security-considerations-for-data.md
@@ -36,6 +36,8 @@ You should ensure that no malicious code is plugged in to the various extensibil
 
 Note that when running in partial trust, the data contract serialization infrastructure supports only a limited subset of the data contract programming model - for example, private data members or types using the <xref:System.SerializableAttribute> attribute are not supported. For more information, see [Partial Trust](partial-trust.md).
 
+[!INCLUDE [cas-deprecated](../../../../includes/cas-deprecated.md)]
+
 ## Avoiding Unintentional Information Disclosure
 
 When designing serializable types with security in mind, information disclosure is a possible concern.

--- a/docs/framework/wcf/feature-details/supported-deployment-scenarios.md
+++ b/docs/framework/wcf/feature-details/supported-deployment-scenarios.md
@@ -40,7 +40,6 @@ WCF can be used to communicate with remote servers from within partially trusted
 
 ## See also
 
-- [Code Access Security](/previous-versions/dotnet/framework/code-access-security/code-access-security)
 - [Windows Presentation Foundation Browser-Hosted Applications Overview](/dotnet/desktop/wpf/app-development/wpf-xaml-browser-applications-overview)
 - [Partial Trust](partial-trust.md)
 - [ASP.NET Trust Levels and Policy Files](/previous-versions/wyts434y(v=vs.140))

--- a/docs/orleans/deployment/consul-deployment.md
+++ b/docs/orleans/deployment/consul-deployment.md
@@ -18,7 +18,7 @@ As an [Orleans Membership Provider](../implementation/cluster-management.md), Co
 
 ## Set up Consul
 
-There's extensive documentation available on [Consul.io](https://www.consul.io) about setting up a stable Consul cluster, and it doesn't make sense to repeat that here. However, for your convenience, we include this guide so you can quickly get Orleans running with a standalone Consul agent.
+There is very extensive documentation available on [Consul.io](https://www.consul.io) about setting up a stable Consul cluster and it doesn't make sense to repeat that here; however, for your convenience, we include this guide so you can very quickly get Orleans running with a standalone Consul agent.
 
 1. Create a folder to install Consul into, (for example _C:\Consul_).
 1. Create a subfolder: _C:\Consul\Data_ (Consul will not create this if it doesn't exist).
@@ -43,7 +43,7 @@ There's extensive documentation available on [Consul.io](https://www.consul.io) 
 
 ## Configure Orleans
 
-There is a known issue with the "Custom" membership provider _OrleansConfiguration.xml_ configuration file that will fail to parse correctly. For this reason, you have to provide a placeholder SystemStore in the XML and then configure the provider in code before starting the silo.
+There is currently a known issue with the "Custom" membership provider _OrleansConfiguration.xml_ configuration file that will fail to parse correctly. For this reason, you have to provide a placeholder SystemStore in the XML and then configure the provider in code before starting the silo.
 
 **OrleansConfiguration.xml**
 
@@ -101,11 +101,11 @@ Alternatively, you could configure the silo entirely in code. The client configu
 
 ## Client SDK
 
-If you are interested in using Consul for your service discovery, there are [Client SDKs](https://www.consul.io/downloads_tools.html) for most popular languages.
+If you are interested in using Consul for your service discovery there are [Client SDKs](https://www.consul.io/downloads_tools.html) for most popular languages.
 
 ## Implementation detail
 
-The Membership Table Provider makes use of [Consul's Key/Value store](https://www.consul.io/intro/getting-started/kv.html) functionality with Check-And-Set (CAS) operations. When each Silo starts, it registers two KV entries, one that contains the Silo details and one that holds the last time the Silo reported it was alive (the latter refers to diagnostics "I am alive" entries and not to failure detection heartbeats, which are sent directly between the silos and are not written into the table). All writes to the table are performed with CAS to provide concurrency control, as necessitated by Orleans's [Cluster Management Protocol](../implementation/cluster-management.md).
+The Membership Table Provider makes use of [Consul's Key/Value store](https://www.consul.io/intro/getting-started/kv.html) functionality with CAS. When each Silo starts it registers two KV entries, one which contains the Silo details and one which holds the last time the Silo reported it was alive (the latter refers to diagnostics "I am alive" entries and not to failure detection heartbeats which are sent directly between the silos and are not written into the table). All writes to the table are performed with CAS to provide concurrency control, as necessitated by Orleans's [Cluster Management Protocol](../implementation/cluster-management.md).
 
 Once the Silo is running, you can view these entries in your web browser at `http://localhost:8500/v1/kv/?keys`, which will display something like:
 

--- a/docs/orleans/deployment/consul-deployment.md
+++ b/docs/orleans/deployment/consul-deployment.md
@@ -18,7 +18,7 @@ As an [Orleans Membership Provider](../implementation/cluster-management.md), Co
 
 ## Set up Consul
 
-There is very extensive documentation available on [Consul.io](https://www.consul.io) about setting up a stable Consul cluster and it doesn't make sense to repeat that here; however, for your convenience, we include this guide so you can very quickly get Orleans running with a standalone Consul agent.
+There's extensive documentation available on [Consul.io](https://www.consul.io) about setting up a stable Consul cluster, and it doesn't make sense to repeat that here. However, for your convenience, we include this guide so you can quickly get Orleans running with a standalone Consul agent.
 
 1. Create a folder to install Consul into, (for example _C:\Consul_).
 1. Create a subfolder: _C:\Consul\Data_ (Consul will not create this if it doesn't exist).
@@ -43,7 +43,7 @@ There is very extensive documentation available on [Consul.io](https://www.consu
 
 ## Configure Orleans
 
-There is currently a known issue with the "Custom" membership provider _OrleansConfiguration.xml_ configuration file that will fail to parse correctly. For this reason, you have to provide a placeholder SystemStore in the XML and then configure the provider in code before starting the silo.
+There is a known issue with the "Custom" membership provider _OrleansConfiguration.xml_ configuration file that will fail to parse correctly. For this reason, you have to provide a placeholder SystemStore in the XML and then configure the provider in code before starting the silo.
 
 **OrleansConfiguration.xml**
 
@@ -101,11 +101,11 @@ Alternatively, you could configure the silo entirely in code. The client configu
 
 ## Client SDK
 
-If you are interested in using Consul for your service discovery there are [Client SDKs](https://www.consul.io/downloads_tools.html) for most popular languages.
+If you are interested in using Consul for your service discovery, there are [Client SDKs](https://www.consul.io/downloads_tools.html) for most popular languages.
 
 ## Implementation detail
 
-The Membership Table Provider makes use of [Consul's Key/Value store](https://www.consul.io/intro/getting-started/kv.html) functionality with CAS. When each Silo starts it registers two KV entries, one which contains the Silo details and one which holds the last time the Silo reported it was alive (the latter refers to diagnostics "I am alive" entries and not to failure detection heartbeats which are sent directly between the silos and are not written into the table). All writes to the table are performed with CAS to provide concurrency control, as necessitated by Orleans's [Cluster Management Protocol](../implementation/cluster-management.md).
+The Membership Table Provider makes use of [Consul's Key/Value store](https://www.consul.io/intro/getting-started/kv.html) functionality with Check-And-Set (CAS) operations. When each Silo starts, it registers two KV entries, one that contains the Silo details and one that holds the last time the Silo reported it was alive (the latter refers to diagnostics "I am alive" entries and not to failure detection heartbeats, which are sent directly between the silos and are not written into the table). All writes to the table are performed with CAS to provide concurrency control, as necessitated by Orleans's [Cluster Management Protocol](../implementation/cluster-management.md).
 
 Once the Silo is running, you can view these entries in your web browser at `http://localhost:8500/v1/kv/?keys`, which will display something like:
 

--- a/docs/standard/assembly/security-considerations.md
+++ b/docs/standard/assembly/security-considerations.md
@@ -54,7 +54,7 @@ When you build an assembly, you can specify a set of permissions that the assemb
   
  The common language runtime also performs a hash verification; the assembly manifest contains a list of all files that make up the assembly, including a hash of each file as it existed when the manifest was built. As each file is loaded, its contents are hashed and compared with the hash value stored in the manifest. If the two hashes do not match, the assembly fails to load.  
   
- Because strong naming and signing using [SignTool.exe (Sign Tool)](../../framework/tools/signtool-exe.md) guarantee integrity, you can base code access security policy on these two forms of assembly evidence. Strong naming and signing using [SignTool.exe (Sign Tool)](../../framework/tools/signtool-exe.md) guarantee integrity through digital signatures and certificates. All the technologies mentioned—hash verification, strong naming, and signing using [SignTool.exe (Sign Tool)](../../framework/tools/signtool-exe.md)—work together to ensure that the assembly has not been altered in any way.  
+ Strong naming and signing using [SignTool.exe (Sign Tool)](../../framework/tools/signtool-exe.md) guarantee integrity through digital signatures and certificates. All the technologies mentioned, that is, hash verification, strong naming, and signing using [SignTool.exe (Sign Tool)](../../framework/tools/signtool-exe.md), work together to ensure that the assembly has not been altered in any way.  
   
 ## See also
 

--- a/docs/standard/data/xml/xslt-security-considerations.md
+++ b/docs/standard/data/xml/xslt-security-considerations.md
@@ -59,4 +59,3 @@ The XSLT language has a rich set of features that give you a great deal of power
 
 - [XSLT Transformations](xslt-transformations.md)
 - [Resolving External Resources During XSLT Processing](resolving-external-resources-during-xslt-processing.md)
-- [Code Access Security](/previous-versions/dotnet/framework/code-access-security/code-access-security)

--- a/docs/standard/security/key-security-concepts.md
+++ b/docs/standard/security/key-security-concepts.md
@@ -29,7 +29,7 @@ During just-in-time (JIT) compilation, an optional verification process examines
   
 Although verification of type safety is not mandatory to run managed code, type safety plays a crucial role in assembly isolation and security enforcement. When code is type safe, the common language runtime can completely isolate assemblies from each other. This isolation helps ensure that assemblies cannot adversely affect each other and it increases application reliability. Type-safe components can execute safely in the same process even if they are trusted at different levels. When code is not type safe, unwanted side effects can occur. For example, the runtime cannot prevent managed code from calling into native (unmanaged) code and performing malicious operations. When code is type safe, the runtime's security enforcement mechanism ensures that it does not access native code unless it has permission to do so. All code that is not type safe must have been granted <xref:System.Security.Permissions.SecurityPermission> with the passed enum member <xref:System.Security.Permissions.SecurityPermissionAttribute.SkipVerification%2A> to run.  
   
-For more information, see [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics).  
+[!INCLUDE [cas-deprecated](../../../includes/cas-deprecated.md)]  
   
 ## Principal  
 

--- a/docs/visual-basic/developing-apps/programming/computer-resources/how-to-create-a-registry-key-and-set-its-value.md
+++ b/docs/visual-basic/developing-apps/programming/computer-resources/how-to-create-a-registry-key-and-set-its-value.md
@@ -69,10 +69,11 @@ The following conditions may cause an exception:
 
 To run this process, your assembly requires a privilege level granted by the <xref:System.Security.Permissions.RegistryPermission> class. If you are running in a partial-trust context, the process might throw an exception due to insufficient privileges. Similarly, the user must have the correct ACLs for creating or writing to settings. For example, a local application that has the code access security permission might not have operating system permission. For more information, see [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics).
 
+[!INCLUDE [cas-deprecated](../../../../../includes/cas-deprecated.md)]
+
 ## See also
 
 - <xref:Microsoft.VisualBasic.MyServices.RegistryProxy>
 - <xref:Microsoft.VisualBasic.MyServices.RegistryProxy.CurrentUser%2A>
 - <xref:Microsoft.Win32.RegistryKey.CreateSubKey%2A>
 - [Reading from and Writing to the Registry](reading-from-and-writing-to-the-registry.md)
-- [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics)

--- a/docs/visual-basic/developing-apps/programming/computer-resources/how-to-read-a-value-from-a-registry-key.md
+++ b/docs/visual-basic/developing-apps/programming/computer-resources/how-to-read-a-value-from-a-registry-key.md
@@ -48,7 +48,9 @@ The `GetValue` method of the `My.Computer.Registry` object can be used to read v
   
 ## .NET Framework Security  
 
- To run this process, your assembly requires a privilege level granted by the <xref:System.Security.Permissions.RegistryPermission> class. If you are running in a partial-trust context, the process might throw an exception due to insufficient privileges. Similarly, the user must have the correct ACLs for creating or writing to settings. For example, a local application that has the code access security permission might not have operating system permission. For more information, see [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics).  
+ To run this process, your assembly requires a privilege level granted by the <xref:System.Security.Permissions.RegistryPermission> class. If you are running in a partial-trust context, the process might throw an exception due to insufficient privileges. Similarly, the user must have the correct ACLs for creating or writing to settings. For example, a local application that has the code access security permission might not have operating system permission. For more information, see [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics).
+
+[!INCLUDE [cas-deprecated](../../../../../includes/cas-deprecated.md)]
   
 ## See also
 

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/how-to-create-a-file.md
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/how-to-create-a-file.md
@@ -49,5 +49,3 @@ This example creates an empty text file at the specified path using the <xref:Sy
 
 - <xref:System.IO>
 - <xref:System.IO.File.Create%2A>
-- [Using Libraries from Partially Trusted Code](/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code)
-- [Code Access Security Basics](/previous-versions/dotnet/framework/code-access-security/code-access-security-basics)

--- a/includes/cas-deprecated.md
+++ b/includes/cas-deprecated.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> Code Access Security (CAS) has been deprecated across all versions of .NET Framework and .NET. Recent versions of .NET do not honor CAS annotations and produce errors if CAS-related APIs are used. Developers should seek alternative means of accomplishing security tasks.


### PR DESCRIPTION
We can add a see also link to the include file once we have a landing page that explains alternative options. (The include file is the very last one in the PR.)

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/framework/data/adonet/code-access-security?branch=pr-en-us-29339).

Contributes to #29152 