### PR TITLE
Add .NET MAUI to hub page.

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -233,7 +233,7 @@ additionalContent:
           - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Forms (.NET Framework)
           - url: /dotnet/maui
-            text: .NET Multi-platform App UI (.NET MAUI)            
+            text: .NET Multi-platform App UI (.NET MAUI)
           - url: /xamarin/mac
             text: Xamarin for macOS
       # Card

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -209,6 +209,8 @@ additionalContent:
       # Card
       - title: Mobile
         links:
+          - url: /dotnet/maui
+            text: .NET Multi-platform App UI (.NET MAUI)
           - url: /xamarin/xamarin-forms
             text: Xamarin.Forms
           - url: /xamarin/ios
@@ -230,8 +232,10 @@ additionalContent:
             text: Windows Forms (.NET 5+)
           - url: /dotnet/desktop/winforms/?view=netframeworkdesktop-4.8&preserve-view=true
             text: Windows Forms (.NET Framework)
+          - url: /dotnet/maui
+            text: .NET Multi-platform App UI (.NET MAUI)            
           - url: /xamarin/mac
-            text: Xamarin for macOS         
+            text: Xamarin for macOS
       # Card
       - title: Microservices
         links:


### PR DESCRIPTION
## Summary

Add .NET MAUI to the hub page, in both the mobile and desktop cards.

Fixes https://github.com/dotnet/docs-maui/issues/406