### PR TITLE
docs: fix info regarding is_global entry in .globalconfig

### DIFF
--- a/docs/fundamentals/code-analysis/configuration-files.md
+++ b/docs/fundamentals/code-analysis/configuration-files.md
@@ -97,7 +97,7 @@ Consider the following naming recommendations:
 - MSBuild tooling-generated global config files should be named *<%Target_Name%>_Generated.globalconfig* or similar.
 
 > [!NOTE]
-> The top-level entry `is_global = true` is required even when the file is named `.globalconfig`.
+> The top-level entry `is_global = true` is not required when the file is named `.globalconfig`, but it is recommended for clarity.
 
 ### Example
 


### PR DESCRIPTION
## Summary

The note regarding the necessity of `is_global = true` in files named `.globalconfig` is incorrect since https://github.com/dotnet/roslyn/pull/49834.
