### PR TITLE
Use{Service} extension methods are NOT commonplace

### DIFF
--- a/docs/core/extensions/options-library-authors.md
+++ b/docs/core/extensions/options-library-authors.md
@@ -14,7 +14,7 @@ As a .NET library author, you'll learn general guidance on how to correctly expo
 
 ## Naming conventions
 
-By convention, extension methods responsible for registering services are named `Add{Service}`, where `{Service}` is a meaningful and descriptive name. Depending on the package, the registration of services may be accompanied by `Use{Service}` extension methods. The `Use{Service}` extension methods are commonplace in [ASP.NET Core](/aspnet).
+By convention, extension methods responsible for registering services are named `Add{Service}`, where `{Service}` is a meaningful and descriptive name. `Add{Service}` extension methods are commonplace in [ASP.NET Core](/aspnet).
 
 ✔️ CONSIDER names that disambiguate your service from other offerings.
 


### PR DESCRIPTION
I'm not aware of any `Use{Service}` extension methods. To the extent they exist, they are definitely not following a common pattern, and suggesting they do can create confusion making people think that the same type of options configuration is used by `Use{Middleware}` extension methods which is not the case.

See the conversation at https://github.com/dotnet/aspnetcore/issues/41655#issuecomment-1124969507 for context.