### PR TITLE
Use C# 7.3 for .NET Framework example code

### DIFF
--- a/docs/framework/network-programming/how-to-upload-files-with-ftp.md
+++ b/docs/framework/network-programming/how-to-upload-files-with-ftp.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Upload files with FTP"
 description: "This article shows a sample of how to upload a file to an FTP server."
-ms.date: "06/26/2018"
+ms.date: 05/13/2022
 dev_langs: 
   - "csharp"
   - "vb"
@@ -37,16 +37,16 @@ namespace Examples.System.Net
 
             // Copy the contents of the file to the request stream.
             using (FileStream fileStream = File.Open("testfile.txt", FileMode.Open, FileAccess.Read))
-			{
-            	using (Stream requestStream = request.GetRequestStream())
-				{
-					await fileStream.CopyToAsync(requestStream);
-					using (FtpWebResponse response = (FtpWebResponse)request.GetResponse())
-					{
-						Console.WriteLine($"Upload File Complete, status {response.StatusDescription}");
-					}
-				}
-			}
+            {
+                using (Stream requestStream = request.GetRequestStream())
+                {
+                    await fileStream.CopyToAsync(requestStream);
+                    using (FtpWebResponse response = (FtpWebResponse)request.GetResponse())
+                    {
+                        Console.WriteLine($"Upload File Complete, status {response.StatusDescription}");
+                    }
+                }
+           }
         }
     }
 }

--- a/docs/framework/network-programming/how-to-upload-files-with-ftp.md
+++ b/docs/framework/network-programming/how-to-upload-files-with-ftp.md
@@ -20,6 +20,7 @@ This sample shows how to upload a file to an FTP server.
 using System;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace Examples.System.Net
 {
@@ -35,12 +36,17 @@ namespace Examples.System.Net
             request.Credentials = new NetworkCredential("anonymous", "janeDoe@contoso.com");
 
             // Copy the contents of the file to the request stream.
-            await using FileStream fileStream = File.Open("testfile.txt", FileMode.Open, FileAccess.Read);
-            await using Stream requestStream = request.GetRequestStream();
-            await fileStream.CopyToAsync(requestStream);
-
-            using FtpWebResponse response = (FtpWebResponse)request.GetResponse();
-            Console.WriteLine($"Upload File Complete, status {response.StatusDescription}");
+            using (FileStream fileStream = File.Open("testfile.txt", FileMode.Open, FileAccess.Read))
+			{
+            	using (Stream requestStream = request.GetRequestStream())
+				{
+					await fileStream.CopyToAsync(requestStream);
+					using (FtpWebResponse response = (FtpWebResponse)request.GetResponse())
+					{
+						Console.WriteLine($"Upload File Complete, status {response.StatusDescription}");
+					}
+				}
+			}
         }
     }
 }


### PR DESCRIPTION
## Summary

Use C# 7.3 for .NET Framework example code.

Fixes #29363
