### PR TITLE
Fix System.CommandLine model-binding ComplexType.cs example

### DIFF
--- a/docs/standard/commandline/snippets/model-binding/csharp/ComplexType.cs
+++ b/docs/standard/commandline/snippets/model-binding/csharp/ComplexType.cs
@@ -19,7 +19,7 @@ public class Program
 
         var lastNameOption = new Option<string>(
               name: "--last-name",
-              description: "Person.FirstName");
+              description: "Person.LastName");
 
         var rootCommand = new RootCommand();
         rootCommand.Add(fileOption);


### PR DESCRIPTION
## Summary

Description for the `lastNameOption` referred to the first name. I assume this is incorrect.

Fixes #Issue_Number (if available)
