### PR TITLE
Missing name Console.

### DIFF
--- a/docs/csharp/fundamentals/types/snippets/classes/Program.cs
+++ b/docs/csharp/fundamentals/types/snippets/classes/Program.cs
@@ -1,4 +1,6 @@
-﻿public class Person
+using System;
+
+public class Person
 {
     // Constructor that takes no arguments:
     public Person()


### PR DESCRIPTION
Fixes: Program.cs(36,9): error CS0103: The name 'Console' does not exist in the current context.
