### PR TITLE
Update linux-ubuntu.md

### DIFF
--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -20,7 +20,7 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Ubuntu                 | .NET       |
 |------------------------|------------|
-| [22.04 (LTS)](#2110)   | 6+         |
+| [22.04 (LTS)](#2204)   | 6+         |
 | [21.10](#2004)         | 3.1, 6     |
 | [20.04 (LTS)](#2004)   | 3.1, 6     |
 | [18.04 (LTS)](#1804)   | 3.1, 6     |


### PR DESCRIPTION
Changed Link reference on Line 23 to proper Ubuntu version in documentation. Was pointing to 21.10,, therefore causing errors in install.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
