### PR TITLE
Mention adding dockerignore file as resolution to NETSDK1047

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1005.md
+++ b/docs/core/tools/sdk-errors/netsdk1005.md
@@ -24,4 +24,4 @@ Here are some actions you can take that may resolve the error:
 
 * Make sure that the missing target value is included in the `TargetFrameworks` property of your project.
 
-* If you're building a Docker image, make sure the *.dockerignore* file ignores the *bin* and *obj* directories.
+* If you're building a Docker image, make sure the *.dockerignore* file ignores the *bin* and *obj* directories. For more information, see https://github.com/dotnet/docs/pull/29530.

--- a/docs/core/tools/sdk-errors/netsdk1005.md
+++ b/docs/core/tools/sdk-errors/netsdk1005.md
@@ -23,3 +23,5 @@ Here are some actions you can take that may resolve the error:
 * Delete the *obj* folder before building the project.
 
 * Make sure that the missing target value is included in the `TargetFrameworks` property of your project.
+
+* If you're building a Docker image, make sure the *.dockerignore* file ignores the *bin* and *obj* directories.

--- a/docs/core/tools/sdk-errors/netsdk1005.md
+++ b/docs/core/tools/sdk-errors/netsdk1005.md
@@ -24,4 +24,4 @@ Here are some actions you can take that may resolve the error:
 
 * Make sure that the missing target value is included in the `TargetFrameworks` property of your project.
 
-* If you're building a Docker image, make sure the *.dockerignore* file ignores the *bin* and *obj* directories. For more information, see https://github.com/dotnet/docs/pull/29530.
+* If you're building a Docker image, make sure the *.dockerignore* file ignores the *bin* and *obj* directories. For more information, see GitHub pull request [dotnet/docs #29530](https://github.com/dotnet/docs/pull/29530).


### PR DESCRIPTION
## Summary

Note added resolution is similar to [netsdk1064](https://github.com/dotnet/docs/blob/7c9532fa3c8180c465e410e8ab70ee36d29e6be1/docs/core/tools/sdk-errors/netsdk1064.md?plain=1#L22).

Here are repeatable steps to repro the issue:

```
$ dotnet new worker --name dotnetapp
$ cd dotnetapp
$ curl https://raw.githubusercontent.com/dotnet/dotnet-docker/main/samples/dotnetapp/Dockerfile.alpine-x64-slim > Dockerfile
$ docker build .
```

Observe the error NETSDK1047 after the above command.

Adding `dockerignore` file to ignore `bin` and `obj` solves the error:

```
$ echo "**/bin/" >> .dockerignore
$ echo "**/obj/" >> .dockerignore
$ docker build .
```

### Full console output

```
$ dotnet --version
6.0.202
$ dotnet new worker --name dotnetapp
The template "Worker Service" was created successfully.

Processing post-creation actions...
Running 'dotnet restore' on /home/will/code/dotnetapp/dotnetapp.csproj...
  Determining projects to restore...
  Restored /home/will/code/dotnetapp/dotnetapp.csproj (in 230 ms).
Restore succeeded.

$ cd dotnetapp
$ curl https://raw.githubusercontent.com/dotnet/dotnet-docker/main/samples/dotnetapp/Dockerfile.alpine-x64-slim > Dockerfile
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   854  100   854    0     0  27326      0 --:--:-- --:--:-- --:--:-- 27548

$ docker build .
Sending build context to Docker daemon  80.38kB
Step 1/10 : FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 ---> 0124e89c43c7
Step 2/10 : WORKDIR /source
 ---> Using cache
 ---> 1554014dffe5
Step 3/10 : COPY *.csproj .
 ---> 01caeda5ca14
Step 4/10 : RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 ---> Running in 926d1062053f
  Determining projects to restore...
  Restored /source/dotnetapp.csproj (in 16.04 sec).
Removing intermediate container 926d1062053f
 ---> 5531fcf3a003
Step 5/10 : COPY . .
 ---> b25de1cd476a
Step 6/10 : RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 ---> Running in 8c271c93794d
Microsoft (R) Build Engine version 17.2.0+41abc5629 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

/usr/share/dotnet/sdk/6.0.300/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(267,5): error NETSDK1047: Assets file '/source/obj/project.assets.json' doesn't have a target for 'net6.0/linux-musl-x64'. Ensure that restore has run and that you have included 'net6.0' in the TargetFrameworks for your project. You may also need to include 'linux-musl-x64' in your project's RuntimeIdentifiers. [/source/dotnetapp.csproj]
The command '/bin/sh -c dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true' returned a non-zero code: 1

$ echo "**/bin/" >> .dockerignore

$ echo "**/obj/" >> .dockerignore

$ docker build .
Sending build context to Docker daemon  10.75kB
Step 1/10 : FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 ---> 0124e89c43c7
Step 2/10 : WORKDIR /source
 ---> Using cache
 ---> 1554014dffe5
Step 3/10 : COPY *.csproj .
 ---> Using cache
 ---> 01caeda5ca14
Step 4/10 : RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 ---> Using cache
 ---> 5531fcf3a003
Step 5/10 : COPY . .
 ---> 60d2efbfb4d0
Step 6/10 : RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 ---> Running in c1cb541971e2
Microsoft (R) Build Engine version 17.2.0+41abc5629 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  dotnetapp -> /source/bin/release/net6.0/linux-musl-x64/dotnetapp.dll
  Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  dotnetapp -> /app/
Removing intermediate container c1cb541971e2
 ---> 728b78522360
Step 7/10 : FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine-amd64
 ---> 00348c290af7
Step 8/10 : WORKDIR /app
 ---> Using cache
 ---> e96486253dab
Step 9/10 : COPY --from=build /app .
 ---> 59bb12244572
Step 10/10 : ENTRYPOINT ["./dotnetapp"]
 ---> Running in 6aee9eeb84d5
Removing intermediate container 6aee9eeb84d5
 ---> 0a54d15e22ce
Successfully built 0a54d15e22ce
```
