### PR TITLE
x500DistinguishedName parsing

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -38,6 +38,12 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [SerializationFormat.Binary is obsolete](core-libraries/7.0/serializationformat-binary.md) | ❌ | ❌ | Preview 2 |
 | [Validate CompressionLevel for BrotliStream](core-libraries/7.0/compressionlevel-validation.md) | ❌ | ✔️ | Preview 1 |
 
+## Cryptography
+
+| Title | Binary compatible | Source compatible | Introduced |
+| - | :-: | :-: | - |
+| [X500DistinguishedName parsing of friendly names](cryptography/7.0/x500-distinguished-names.md) | ❌ | ✔️  | Preview 5 |
+
 ## Deployment
 
 | Title | Binary compatible | Source compatible | Introduced |

--- a/docs/core/compatibility/cryptography/7.0/x500-distinguished-names.md
+++ b/docs/core/compatibility/cryptography/7.0/x500-distinguished-names.md
@@ -1,0 +1,37 @@
+---
+title: "Breaking change: X500DistinguishedName parsing of friendly names"
+description: Learn about the .NET 7 breaking change in cryptography where X500DistinguishedName parsing doesn't permit friendly names where OIDs are expected on MacOS and Linux.
+ms.date: 05/19/2022
+---
+# X500DistinguishedName parsing of friendly names
+
+On Linux and macOS, a distinguished name with a relative distinguished name component that is prefixed with "OID." followed by a friendly name will no longer parse. For example, `OID.STREET=MainStreet` no longer parses.
+
+## Previous behavior
+
+On Linux and macOS only, a distinguished name would successfully parse even if the object identifier (OID) was a friendly name.
+
+## New behavior
+
+Attempting to parse a distinguished name with a component prefixed with "OID." but not followed by a well-formed, dotted-decimal OID throws a <xref:System.Security.Cryptography.CryptographicException>.
+
+## Version introduced
+
+.NET 7 Preview 5
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+Windows does not permit distinguished names with friendly name OIDs, and that it worked in Linux and macOS was coincidence and not intentional. To bring consistency throughout platforms, the parsing logic was improved to not accept this form.
+
+## Recommended action
+
+Change "OID."-prefixed relative distinguished name components to use an OID, such as `OID.1.2.3.4=MyValue`.
+
+## Affected APIs
+
+- <xref:System.Security.Cryptography.X509Certificates.X500DistinguishedName.%23ctor(System.String)>
+- <xref:System.Security.Cryptography.X509Certificates.X500DistinguishedName.%23ctor(System.String,System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags)>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -55,6 +55,10 @@ items:
           href: core-libraries/7.0/serializationformat-binary.md
         - name: Validate CompressionLevel for BrotliStream
           href: core-libraries/7.0/compressionlevel-validation.md
+      - name: Cryptography
+        items:
+        - name: X500DistinguishedName parsing of friendly names
+          href: cryptography/7.0/x500-distinguished-names.md
       - name: Deployment
         items:
         - name: Multi-level lookup is disabled
@@ -861,6 +865,10 @@ items:
         href: corefx.md
     - name: Cryptography
       items:
+      - name: .NET 7
+        items:
+        - name: X500DistinguishedName parsing of friendly names
+          href: cryptography/7.0/x500-distinguished-names.md
       - name: .NET 6
         items:
         - name: CreateEncryptor methods throw exception for incorrect feedback size


### PR DESCRIPTION
Fixes #29538

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/cryptography/7.0/x500-distinguished-names?branch=pr-en-us-29545).