### PR TITLE
Extended nameof parameter scope

### DIFF
--- a/docs/csharp/language-reference/attributes/caller-information.md
+++ b/docs/csharp/language-reference/attributes/caller-information.md
@@ -62,7 +62,7 @@ This attribute enables you to write diagnostic utilities that provide more detai
 
 :::code language="csharp" source="./snippets/CallerInformation.cs" id="ExtensionMethod":::
 
-You could call this method as follows:
+The previous example uses the [`nameof`](../operators/nameof.md) operator for the parameter `sequence`. That feature is available in C# 11. Before C# 11, you'll need to type the name of the parameter as a string. You could call this method as follows:
 
 :::code language="csharp" source="./snippets/Program.cs" id="ShortSequence":::
 

--- a/docs/csharp/language-reference/attributes/nullable-analysis.md
+++ b/docs/csharp/language-reference/attributes/nullable-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: "Attributes interpreted by the C# compiler: Nullable static analysis"
-ms.date: 12/16/2021
+ms.date: 05/20/2022
 description: Learn about attributes that are interpreted by the compiler to provide better static analysis for nullable and non-nullable reference types.
 ---
 # Attributes for null-state static analysis interpreted by the C# compiler
@@ -167,7 +167,7 @@ That also works, but will often force callers to implement extra `null` checks. 
 
 :::code language="csharp" source="snippets/NullableAttributes.cs" ID="ExtractComponentIfNotNull" :::
 
-The return value and the argument have both been annotated with the `?` indicating that either could be `null`. The attribute further clarifies that the return value won't be null when the `url` argument isn't `null`.
+The previous example uses the [`nameof`](../operators/nameof.md) operator for the parameter `url`. That feature is available in C# 11. Before C# 11, you'll need to type the name of the parameter as a string. The return value and the argument have both been annotated with the `?` indicating that either could be `null`. The attribute further clarifies that the return value won't be null when the `url` argument isn't `null`.
 
 You specify conditional postconditions using these attributes:
 

--- a/docs/csharp/language-reference/attributes/snippets/CallerInformation.cs
+++ b/docs/csharp/language-reference/attributes/snippets/CallerInformation.cs
@@ -1,79 +1,73 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 
-namespace attributes
+namespace attributes;
+
+internal class CallerInformation
 {
-    internal class CallerInformation
+    // <CallerFileMemberLine>
+    public void DoProcessing()
     {
-        // <CallerFileMemberLine>
-        public void DoProcessing()
-        {
-            TraceMessage("Something happened.");
-        }
-
-        public void TraceMessage(string message,
-                [CallerMemberName] string memberName = "",
-                [CallerFilePath] string sourceFilePath = "",
-                [CallerLineNumber] int sourceLineNumber = 0)
-        {
-            Trace.WriteLine("message: " + message);
-            Trace.WriteLine("member name: " + memberName);
-            Trace.WriteLine("source file path: " + sourceFilePath);
-            Trace.WriteLine("source line number: " + sourceLineNumber);
-        }
-
-        // Sample Output:
-        //  message: Something happened.
-        //  member name: DoProcessing
-        //  source file path: c:\Visual Studio Projects\CallerInfoCS\CallerInfoCS\Form1.cs
-        //  source line number: 31
-        // </CallerFileMemberLine>
-
-        // <InvokeTestCondition>
-        public void Operation(Action func)
-        {
-            Utilities.ValidateArgument(nameof(func), func is not null);
-            func();
-        }
-        // </InvokeTestCondition>
-
-
-        public static class Utilities
-        {
-            // <TestCondition>
-            public static void ValidateArgument(string parameterName, bool condition, [CallerArgumentExpression("condition")] string? message=null)
-            {
-                if (!condition)
-                {
-                    throw new ArgumentException($"Argument failed validation: <{message}>", parameterName);
-                }
-            }
-            // </TestCondition>
-        }
+        TraceMessage("Something happened.");
     }
 
-    public static class Extensions
+    public void TraceMessage(string message,
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string sourceFilePath = "",
+            [CallerLineNumber] int sourceLineNumber = 0)
     {
-        // <ExtensionMethod>
-        public static IEnumerable<T> Sample<T>(this IEnumerable<T> sequence, int frequency, 
-            [CallerArgumentExpression("sequence")] string? message = null)
+        Trace.WriteLine("message: " + message);
+        Trace.WriteLine("member name: " + memberName);
+        Trace.WriteLine("source file path: " + sourceFilePath);
+        Trace.WriteLine("source line number: " + sourceLineNumber);
+    }
+
+    // Sample Output:
+    //  message: Something happened.
+    //  member name: DoProcessing
+    //  source file path: c:\Visual Studio Projects\CallerInfoCS\CallerInfoCS\Form1.cs
+    //  source line number: 31
+    // </CallerFileMemberLine>
+
+    // <InvokeTestCondition>
+    public void Operation(Action func)
+    {
+        Utilities.ValidateArgument(nameof(func), func is not null);
+        func();
+    }
+    // </InvokeTestCondition>
+
+
+    public static class Utilities
+    {
+        // <TestCondition>
+        public static void ValidateArgument(string parameterName, bool condition, [CallerArgumentExpression("condition")] string? message=null)
         {
-            if (sequence.Count() < frequency)
-                throw new ArgumentException($"Expression doesn't have enough elements: {message}", nameof(sequence));
-            int i = 0;
-            foreach (T item in sequence)
+            if (!condition)
             {
-                if (i++ % frequency == 0)
-                    yield return item;
+                throw new ArgumentException($"Argument failed validation: <{message}>", parameterName);
             }
         }
-        // </ExtensionMethod>
-
+        // </TestCondition>
     }
+}
+
+public static class Extensions
+{
+    // <ExtensionMethod>
+    public static IEnumerable<T> Sample<T>(this IEnumerable<T> sequence, int frequency, 
+        [CallerArgumentExpression(nameof(sequence))] string? message = null)
+    {
+        if (sequence.Count() < frequency)
+            throw new ArgumentException($"Expression doesn't have enough elements: {message}", nameof(sequence));
+        int i = 0;
+        foreach (T item in sequence)
+        {
+            if (i++ % frequency == 0)
+                yield return item;
+        }
+    }
+    // </ExtensionMethod>
+
 }

--- a/docs/csharp/language-reference/attributes/snippets/ConditionalExamples.cs
+++ b/docs/csharp/language-reference/attributes/snippets/ConditionalExamples.cs
@@ -1,46 +1,44 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
-namespace AttributeExamples
+namespace AttributeExamples;
+
+public class Conditionals
 {
-    public class Conditionals
-    {
-        // <SnippetConditional>
-        [Conditional("DEBUG")]
-        static void DebugMethod()
-        {
-        }
-        // </SnippetConditional>
-
-        // <SnippetMultipleConditions>
-        [Conditional("A"), Conditional("B")]
-        static void DoIfAorB()
-        {
-            // ...
-        }
-        // </SnippetMultipleConditions>
-    }
-
-    // <SnippetConditionalConditionalAttribute>
+    // <SnippetConditional>
     [Conditional("DEBUG")]
-    public class DocumentationAttribute : System.Attribute
+    static void DebugMethod()
     {
-        string text;
-
-        public DocumentationAttribute(string text)
-        {
-            this.text = text;
-        }
     }
+    // </SnippetConditional>
 
-    class SampleClass
+    // <SnippetMultipleConditions>
+    [Conditional("A"), Conditional("B")]
+    static void DoIfAorB()
     {
-        // This attribute will only be included if DEBUG is defined.
-        [Documentation("This method displays an integer.")]
-        static void DoWork(int i)
-        {
-            System.Console.WriteLine(i.ToString());
-        }
+        // ...
     }
-    // </SnippetConditionalConditionalAttribute>
+    // </SnippetMultipleConditions>
 }
+
+// <SnippetConditionalConditionalAttribute>
+[Conditional("DEBUG")]
+public class DocumentationAttribute : System.Attribute
+{
+    string text;
+
+    public DocumentationAttribute(string text)
+    {
+        this.text = text;
+    }
+}
+
+class SampleClass
+{
+    // This attribute will only be included if DEBUG is defined.
+    [Documentation("This method displays an integer.")]
+    static void DoWork(int i)
+    {
+        System.Console.WriteLine(i.ToString());
+    }
+}
+// </SnippetConditionalConditionalAttribute>

--- a/docs/csharp/language-reference/attributes/snippets/InitializeMembers.cs
+++ b/docs/csharp/language-reference/attributes/snippets/InitializeMembers.cs
@@ -1,36 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
+﻿using System.Diagnostics.CodeAnalysis;
 
-namespace attributes
+namespace attributes;
+
+class InitializeMembers
 {
-    class InitializeMembers
-    {
-    }
-
-    // <MemberNotNullExample>
-    public class Container
-    {
-        private string _uniqueIdentifier; // must be initialized.
-        private string? _optionalMessage;
-
-        public Container()
-        {
-            Helper();
-        }
-
-        public Container(string message)
-        {
-            Helper();
-            _optionalMessage = message;
-        }
-
-        [MemberNotNull(nameof(_uniqueIdentifier))]
-        private void Helper()
-        {
-            _uniqueIdentifier = DateTime.Now.Ticks.ToString();
-        }
-    }
-    // </MemberNotNullExample>
 }
+
+// <MemberNotNullExample>
+public class Container
+{
+    private string _uniqueIdentifier; // must be initialized.
+    private string? _optionalMessage;
+
+    public Container()
+    {
+        Helper();
+    }
+
+    public Container(string message)
+    {
+        Helper();
+        _optionalMessage = message;
+    }
+
+    [MemberNotNull(nameof(_uniqueIdentifier))]
+    private void Helper()
+    {
+        _uniqueIdentifier = DateTime.Now.Ticks.ToString();
+    }
+}
+// </MemberNotNullExample>

--- a/docs/csharp/language-reference/attributes/snippets/MultiUseAttribute.cs
+++ b/docs/csharp/language-reference/attributes/snippets/MultiUseAttribute.cs
@@ -1,16 +1,13 @@
-﻿using System;
+﻿namespace AttributeExamples;
 
-namespace AttributeExamples
-{
-    // <SnippetMultiUse>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    class MultiUse : Attribute { }
+// <SnippetMultiUse>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+class MultiUse : Attribute { }
 
-    [MultiUse]
-    [MultiUse]
-    class Class1 { }
+[MultiUse]
+[MultiUse]
+class Class1 { }
 
-    [MultiUse, MultiUse]
-    class Class2 { }
-    // </SnippetMultiUse>
-}
+[MultiUse, MultiUse]
+class Class2 { }
+// </SnippetMultiUse>

--- a/docs/csharp/language-reference/attributes/snippets/NewAttribute.cs
+++ b/docs/csharp/language-reference/attributes/snippets/NewAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace AttributeExamples
+﻿namespace AttributeExamples
 {
     namespace VersionOne
     {

--- a/docs/csharp/language-reference/attributes/snippets/NewPropertyOrFieldAttribute.cs
+++ b/docs/csharp/language-reference/attributes/snippets/NewPropertyOrFieldAttribute.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 
-namespace AttributeExamples
+namespace AttributeExamples;
+
+// <SnippetDefinePropertyAttribute>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+class NewPropertyOrFieldAttribute : Attribute { }
+// </SnippetDefinePropertyAttribute>
+
+// <SnippetUsePropertyAttribute>
+class MyClass
 {
-    // <SnippetDefinePropertyAttribute>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-    class NewPropertyOrFieldAttribute : Attribute { }
-    // </SnippetDefinePropertyAttribute>
+    // Attribute attached to property:
+    [NewPropertyOrField]
+    public string Name { get; set; } = string.Empty;
 
-    // <SnippetUsePropertyAttribute>
-    class MyClass
-    {
-        // Attribute attached to property:
-        [NewPropertyOrField]
-        public string Name { get; set; } = string.Empty;
-
-        // Attribute attached to backing field:
-        [field: NewPropertyOrField]
-        public string Description { get; set; } = string.Empty;
-    }
-    // </SnippetUsePropertyAttribute>
+    // Attribute attached to backing field:
+    [field: NewPropertyOrField]
+    public string Description { get; set; } = string.Empty;
 }
+// </SnippetUsePropertyAttribute>

--- a/docs/csharp/language-reference/attributes/snippets/NonInheritedAttribute.cs
+++ b/docs/csharp/language-reference/attributes/snippets/NonInheritedAttribute.cs
@@ -1,14 +1,11 @@
-﻿using System;
+﻿namespace attributes;
 
-namespace attributes
-{
-    // <SnippetNonInherited>
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    class NonInheritedAttribute : Attribute { }
+// <SnippetNonInherited>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+class NonInheritedAttribute : Attribute { }
 
-    [NonInherited]
-    class BClass { }
+[NonInherited]
+class BClass { }
 
-    class DClass : BClass { }
-    // </SnippetNonInherited>
-}
+class DClass : BClass { }
+// </SnippetNonInherited>

--- a/docs/csharp/language-reference/attributes/snippets/NullableAttributes.cs
+++ b/docs/csharp/language-reference/attributes/snippets/NullableAttributes.cs
@@ -1,206 +1,200 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 
-namespace attributes
-{
+namespace attributes;
+
 #nullable disable
-    public class NullableOblivious
+public class NullableOblivious
+{
+    private Dictionary<string, string> _messageMap = new();
+    // <TryGetExample>
+    bool TryGetMessage(string key, out string message)
     {
-        private Dictionary<string, string> _messageMap = new();
-        // <TryGetExample>
-        bool TryGetMessage(string key, out string message)
-        {
-            if (_messageMap.ContainsKey(key))
-                message = _messageMap[key];
-            else
-                message = null;
-            return message != null;
-        }
-        // </TryGetExample>
+        if (_messageMap.ContainsKey(key))
+            message = _messageMap[key];
+        else
+            message = null;
+        return message != null;
+    }
+    // </TryGetExample>
 
-        // <PropertyExample>
-        public string ScreenName
-        {
-            get => _screenName;
-            set => _screenName = value ?? GenerateRandomScreenName();
-        }
-        private string _screenName;
-        // </PropertyExample>
-        private static string GenerateRandomScreenName() => throw new NotImplementedException();
+    // <PropertyExample>
+    public string ScreenName
+    {
+        get => _screenName;
+        set => _screenName = value ?? GenerateRandomScreenName();
+    }
+    private string _screenName;
+    // </PropertyExample>
+    private static string GenerateRandomScreenName() => throw new NotImplementedException();
 
-        // <MessagingExample>
-        public string ReviewComment
-        {
-            get => _comment;
-            set => _comment = value ?? throw new ArgumentNullException(nameof(value), "Cannot set to null");
-        }
-        string _comment;
-        // </MessagingExample>
+    // <MessagingExample>
+    public string ReviewComment
+    {
+        get => _comment;
+        set => _comment = value ?? throw new ArgumentNullException(nameof(value), "Cannot set to null");
+    }
+    string _comment;
+    // </MessagingExample>
 
-        // <FindMethod>
-        public T Find<T>(IEnumerable<T> sequence, Func<T, bool> predicate)
-        // </FindMethod>
+    // <FindMethod>
+    public T Find<T>(IEnumerable<T> sequence, Func<T, bool> predicate)
+    // </FindMethod>
+    {
+        foreach (T item in sequence)
         {
-            foreach (T item in sequence)
-            {
-                if (predicate(item)) return item;
-            }
-            return default;
+            if (predicate(item)) return item;
         }
+        return default;
+    }
 
-        // <ThrowWhenNull>
-        public static void ThrowWhenNull(object value, string valueExpression = "")
-        {
-            if (value is null) throw new ArgumentNullException(nameof(value), valueExpression);
-        }
-        // </ThrowWhenNull>
+    // <ThrowWhenNull>
+    public static void ThrowWhenNull(object value, string valueExpression = "")
+    {
+        if (value is null) throw new ArgumentNullException(nameof(value), valueExpression);
+    }
+    // </ThrowWhenNull>
 
-        // <ExtractComponent>
-        string GetTopLevelDomainFromFullUrl(string url)
-        // </ExtractComponent>
+    // <ExtractComponent>
+    string GetTopLevelDomainFromFullUrl(string url)
+    // </ExtractComponent>
+    {
+        return default;
+    }
+
+}
+
+#nullable restore
+public class NullableAttributes
+{
+    private Dictionary<string, string> _messageMap = new();
+
+    // <NotNullWhenTryGet>
+    bool TryGetMessage(string key, [NotNullWhen(true)] out string? message)
+    {
+        if (_messageMap.ContainsKey(key))
+            message = _messageMap[key];
+        else
+            message = null;
+        return message is not null;
+    }
+    // </NotNullWhenTryGet>
+
+    // <AllowNullableProperty>
+    [AllowNull]
+    public string ScreenName
+    {
+        get => _screenName;
+        set => _screenName = value ?? GenerateRandomScreenName();
+    }
+    private string _screenName = GenerateRandomScreenName();
+    // </AllowNullableProperty>
+    private static string GenerateRandomScreenName() => throw new NotImplementedException();
+
+    // <DisallowNullProperty>
+    [DisallowNull]
+    public string? ReviewComment
+    {
+        get => _comment;
+        set => _comment = value ?? throw new ArgumentNullException(nameof(value), "Cannot set to null");
+    }
+    string? _comment;
+    // </DisallowNullProperty>
+
+    // <FindMethodMaybeNull>
+    [return: MaybeNull]
+    public T Find<T>(IEnumerable<T> sequence, Func<T, bool> predicate)
+    // </FindMethodMaybeNull>
+    {
+        foreach (T item in sequence)
         {
-            return default;
+            if (predicate(item)) return item;
         }
+        return default;
+    }
+
+    // <NotNullThrowHelper>
+    public static void ThrowWhenNull([NotNull] object? value, string valueExpression = "")
+    {
+        _ = value ?? throw new ArgumentNullException(nameof(value), valueExpression);
+        // other logic elided
+    // </NotNullThrowHelper>
+    }
+
+    // <TestThrowHelper>
+    public static void LogMessage(string? message)
+    {
+        ThrowWhenNull(message, $"{nameof(message)} must not be null");
+
+        Console.WriteLine(message.Length);
+    }
+    // </TestThrowHelper>
+
+    public static void ExampleNullCheck()
+    {
+        // <NullCheckExample>
+        string? userInput = GetUserInput();
+        if (!string.IsNullOrEmpty(userInput))
+        {
+            int messageLength = userInput.Length; // no null check needed.
+        }
+        // null check needed on userInput here.
+        // </NullCheckExample>
 
     }
 
-#nullable restore
-    public class NullableAttributes
+    private static string? GetUserInput() => throw new NotImplementedException();
+
+    // <DoesNotReturn>
+    [DoesNotReturn]
+    private void FailFast()
     {
-        private Dictionary<string, string> _messageMap = new();
+        throw new InvalidOperationException();
+    }
 
-        // <NotNullWhenTryGet>
-        bool TryGetMessage(string key, [NotNullWhen(true)] out string? message)
+    public void SetState(object containedField)
+    {
+        if (containedField is null)
         {
-            if (_messageMap.ContainsKey(key))
-                message = _messageMap[key];
-            else
-                message = null;
-            return message is not null;
-        }
-        // </NotNullWhenTryGet>
-
-        // <AllowNullableProperty>
-        [AllowNull]
-        public string ScreenName
-        {
-            get => _screenName;
-            set => _screenName = value ?? GenerateRandomScreenName();
-        }
-        private string _screenName = GenerateRandomScreenName();
-        // </AllowNullableProperty>
-        private static string GenerateRandomScreenName() => throw new NotImplementedException();
-
-        // <DisallowNullProperty>
-        [DisallowNull]
-        public string? ReviewComment
-        {
-            get => _comment;
-            set => _comment = value ?? throw new ArgumentNullException(nameof(value), "Cannot set to null");
-        }
-        string? _comment;
-        // </DisallowNullProperty>
-
-        // <FindMethodMaybeNull>
-        [return: MaybeNull]
-        public T Find<T>(IEnumerable<T> sequence, Func<T, bool> predicate)
-        // </FindMethodMaybeNull>
-        {
-            foreach (T item in sequence)
-            {
-                if (predicate(item)) return item;
-            }
-            return default;
+            FailFast();
         }
 
-        // <NotNullThrowHelper>
-        public static void ThrowWhenNull([NotNull] object? value, string valueExpression = "")
-        {
-            _ = value ?? throw new ArgumentNullException(nameof(value), valueExpression);
-            // other logic elided
-        // </NotNullThrowHelper>
-        }
+        // containedField can't be null:
+        _field = containedField;
+    }
+    // </DoesNotReturn>
 
-        // <TestThrowHelper>
-        public static void LogMessage(string? message)
-        {
-            ThrowWhenNull(message, $"{nameof(message)} must not be null");
+    object _field = new object();
 
-            Console.WriteLine(message.Length);
-        }
-        // </TestThrowHelper>
-
-        public static void ExampleNullCheck()
-        {
-            // <NullCheckExample>
-            string? userInput = GetUserInput();
-            if (!string.IsNullOrEmpty(userInput))
-            {
-                int messageLength = userInput.Length; // no null check needed.
-            }
-            // null check needed on userInput here.
-            // </NullCheckExample>
-
-        }
-
-        private static string? GetUserInput() => throw new NotImplementedException();
-
-        // <DoesNotReturn>
-        [DoesNotReturn]
-        private void FailFast()
+    // <DoesNotReturnIf>
+    private void FailFastIf([DoesNotReturnIf(true)] bool isNull)
+    {
+        if (isNull)
         {
             throw new InvalidOperationException();
         }
+    }
 
-        public void SetState(object containedField)
+    public void SetFieldState(object? containedField)
+    {
+        FailFastIf(containedField == null);
+        // No warning: containedField can't be null here:
+        _field = containedField;
+    }
+    // </DoesNotReturnIf>
+
+
+    // <ExtractComponentIfNotNull>
+    [return: NotNullIfNotNull(nameof(url))]
+    string? GetTopLevelDomainFromFullUrl(string? url)
+    // </ExtractComponentIfNotNull>
+    {
+        if (url is null)
         {
-            if (containedField is null)
-            {
-                FailFast();
-            }
-
-            // containedField can't be null:
-            _field = containedField;
+            return null;
         }
-        // </DoesNotReturn>
-
-        object _field = new object();
-
-        // <DoesNotReturnIf>
-        private void FailFastIf([DoesNotReturnIf(true)] bool isNull)
+        else
         {
-            if (isNull)
-            {
-                throw new InvalidOperationException();
-            }
-        }
-
-        public void SetFieldState(object? containedField)
-        {
-            FailFastIf(containedField == null);
-            // No warning: containedField can't be null here:
-            _field = containedField;
-        }
-        // </DoesNotReturnIf>
-
-
-        // <ExtractComponentIfNotNull>
-        [return: NotNullIfNotNull("url")]
-        string? GetTopLevelDomainFromFullUrl(string? url)
-        // </ExtractComponentIfNotNull>
-        {
-            if (url is null)
-            {
-                return null;
-            }
-            else
-            {
-                return ".com";
-            }
+            return ".com";
         }
     }
 }

--- a/docs/csharp/language-reference/attributes/snippets/ObsoleteExample.cs
+++ b/docs/csharp/language-reference/attributes/snippets/ObsoleteExample.cs
@@ -1,5 +1,4 @@
 ﻿// <Snippet1>
-using System;
 
 namespace AttributeExamples
 {

--- a/docs/csharp/language-reference/attributes/snippets/Program.cs
+++ b/docs/csharp/language-reference/attributes/snippets/Program.cs
@@ -1,45 +1,36 @@
-﻿using System;
-using attributes;
+﻿using attributes;
+using AttributeExamples;
 
-namespace AttributeExamples
+TraceExample.Main();
+ObsoleteProgram.Main();
+ModuleInitializerExampleMain.Main();
+SkipLocalsInitExample.Main();
+
+var info = new CallerInformation();
+Console.WriteLine("To see these messages, run in the debugger");
+info.DoProcessing();
+
+try
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            TraceExample.Main();
-            ObsoleteProgram.Main();
-            ModuleInitializerExampleMain.Main();
-            SkipLocalsInitExample.Main();
 
-            var info = new CallerInformation();
-            Console.WriteLine("To see these messages, run in the debugger");
-            info.DoProcessing();
+    info.Operation(null!);
+} catch (ArgumentException e)
+{
+    Console.WriteLine(e.Message);
+}
 
-            try
-            {
+try
+{
+    var sample = Enumerable.Range(0, 100).Sample(10);
+    foreach(var item in sample)
+        Console.WriteLine(item);
 
-                info.Operation(null!);
-            } catch (ArgumentException e)
-            {
-                Console.WriteLine(e.Message);
-            }
-
-            try
-            {
-                var sample = Enumerable.Range(0, 100).Sample(10);
-                foreach(var item in sample)
-                    Console.WriteLine(item);
-
-                // <ShortSequence>
-                sample = Enumerable.Range(0, 10).Sample(100);
-                // </ShortSequence>
-                foreach (var item in sample)
-                    Console.WriteLine(item);
-            } catch (ArgumentException e)
-            {
-                Console.WriteLine(e.Message);
-            }
-        }
-    }
+    // <ShortSequence>
+    sample = Enumerable.Range(0, 10).Sample(100);
+    // </ShortSequence>
+    foreach (var item in sample)
+        Console.WriteLine(item);
+} catch (ArgumentException e)
+{
+    Console.WriteLine(e.Message);
 }

--- a/docs/csharp/language-reference/attributes/snippets/SkipLocalsInitExample.cs
+++ b/docs/csharp/language-reference/attributes/snippets/SkipLocalsInitExample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 internal class SkipLocalsInitExample
 {

--- a/docs/csharp/language-reference/attributes/snippets/attributes.csproj
+++ b/docs/csharp/language-reference/attributes/snippets/attributes.csproj
@@ -4,9 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <StartupObject>AttributeExamples.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <NoWarn>7022</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/docs/csharp/language-reference/attributes/snippets/trace.cs
+++ b/docs/csharp/language-reference/attributes/snippets/trace.cs
@@ -1,24 +1,22 @@
 ﻿#define TRACE_ON
-using System;
 using System.Diagnostics;
 
-namespace AttributeExamples
-{
-    public class Trace
-    {
-        [Conditional("TRACE_ON")]
-        public static void Msg(string msg)
-        {
-            Console.WriteLine(msg);
-        }
-    }
+namespace AttributeExamples;
 
-    public class TraceExample
+public class Trace
+{
+    [Conditional("TRACE_ON")]
+    public static void Msg(string msg)
     {
-        public static void Main()
-        {
-            Trace.Msg("Now in Main...");
-            Console.WriteLine("Done.");
-        }
+        Console.WriteLine(msg);
+    }
+}
+
+public class TraceExample
+{
+    public static void Main()
+    {
+        Trace.Msg("Now in Main...");
+        Console.WriteLine("Done.");
     }
 }

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -1,13 +1,12 @@
 ---
 title: "nameof expression - C# reference"
 description: "Learn about the C# nameof expression that produces the name of its operand."
-ms.date: 04/23/2020
+ms.date: 05/20/2022
 f1_keywords:
   - "nameof_CSharpKeyword"
   - "nameof"
 helpviewer_keywords:
   - "nameof expression [C#]"
-ms.assetid: 33601bf3-cc2c-4496-846d-f9679bccf2a7
 ---
 # nameof expression (C# reference)
 
@@ -27,7 +26,11 @@ You can use a `nameof` expression to make the argument-checking code more mainta
 
 [!code-csharp[nameof and argument check](snippets/shared/NameOfOperator.cs#ExceptionMessage)]
 
-A `nameof` expression is available in C# 6 and later.
+The argument to the `nameof` operator must be in scope. Beginning with C# 11, parameters and type parameters are in scope inside an attribute for the purpose of the `nameof` operator. The following examples show `nameof` used on parameters for a method, a local function, and a lambda expression:
+
+:::code language="csharp" source="snippets/shared/NameOfOperator.cs" id="SnippetNameOfParameter":::
+
+Using `nameof` on parameters is most useful when using the [Nullable analysis attributes](../attributes/nullable-analysis.md).
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/snippets/shared/AdditionOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/AdditionOperator.cs
@@ -1,77 +1,74 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class AdditionOperator
 {
-    public static class AdditionOperator
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            NumericAddition();
-            StringConcatenation();
-            AddDelegates();
-            AddAndAssign();
-        }
+        NumericAddition();
+        StringConcatenation();
+        AddDelegates();
+        AddAndAssign();
+    }
 
-        private static void NumericAddition()
-        {
-            // <SnippetAddNumerics>
-            Console.WriteLine(5 + 4);       // output: 9
-            Console.WriteLine(5 + 4.3);     // output: 9.3
-            Console.WriteLine(5.1m + 4.2m); // output: 9.3
-            // </SnippetAddNumerics>
-        }
+    private static void NumericAddition()
+    {
+        // <SnippetAddNumerics>
+        Console.WriteLine(5 + 4);       // output: 9
+        Console.WriteLine(5 + 4.3);     // output: 9.3
+        Console.WriteLine(5.1m + 4.2m); // output: 9.3
+        // </SnippetAddNumerics>
+    }
 
-        private static void StringConcatenation()
-        {
-            // <SnippetAddStrings>
-            Console.WriteLine("Forgot" + "white space");
-            Console.WriteLine("Probably the oldest constant: " + Math.PI);
-            Console.WriteLine(null + "Nothing to add.");
-            // Output:
-            // Forgotwhite space
-            // Probably the oldest constant: 3.14159265358979
-            // Nothing to add.
-            // </SnippetAddStrings>
+    private static void StringConcatenation()
+    {
+        // <SnippetAddStrings>
+        Console.WriteLine("Forgot" + "white space");
+        Console.WriteLine("Probably the oldest constant: " + Math.PI);
+        Console.WriteLine(null + "Nothing to add.");
+        // Output:
+        // Forgotwhite space
+        // Probably the oldest constant: 3.14159265358979
+        // Nothing to add.
+        // </SnippetAddStrings>
 
-            // <SnippetUseStringInterpolation>
-            Console.WriteLine($"Probably the oldest constant: {Math.PI:F2}");
-            // Output:
-            // Probably the oldest constant: 3.14
-            // </SnippetUseStringInterpolation>
-        }
+        // <SnippetUseStringInterpolation>
+        Console.WriteLine($"Probably the oldest constant: {Math.PI:F2}");
+        // Output:
+        // Probably the oldest constant: 3.14
+        // </SnippetUseStringInterpolation>
+    }
 
-        private static void AddDelegates()
-        {
-            // <SnippetAddDelegates>
-            Action a = () => Console.Write("a");
-            Action b = () => Console.Write("b");
-            Action ab = a + b;
-            ab();  // output: ab
-            // </SnippetAddDelegates>
-            Console.WriteLine();
-        }
+    private static void AddDelegates()
+    {
+        // <SnippetAddDelegates>
+        Action a = () => Console.Write("a");
+        Action b = () => Console.Write("b");
+        Action ab = a + b;
+        ab();  // output: ab
+        // </SnippetAddDelegates>
+        Console.WriteLine();
+    }
 
-        private static void AddAndAssign()
-        {
-            // <SnippetAddAndAssign>
-            int i = 5;
-            i += 9;
-            Console.WriteLine(i);
-            // Output: 14
+    private static void AddAndAssign()
+    {
+        // <SnippetAddAndAssign>
+        int i = 5;
+        i += 9;
+        Console.WriteLine(i);
+        // Output: 14
 
-            string story = "Start. ";
-            story += "End.";
-            Console.WriteLine(story);
-            // Output: Start. End.
+        string story = "Start. ";
+        story += "End.";
+        Console.WriteLine(story);
+        // Output: Start. End.
 
-            Action printer = () => Console.Write("a");
-            printer();  // output: a
+        Action printer = () => Console.Write("a");
+        printer();  // output: a
 
-            Console.WriteLine();
-            printer += () => Console.Write("b");
-            printer();  // output: ab
-            // </SnippetAddAndAssign>
-            Console.WriteLine();
-        }
+        Console.WriteLine();
+        printer += () => Console.Write("b");
+        printer();  // output: ab
+        // </SnippetAddAndAssign>
+        Console.WriteLine();
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/ArithmeticOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/ArithmeticOperators.cs
@@ -1,263 +1,260 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class ArithmeticOperators
 {
-    public static class ArithmeticOperators
+    public static void Examples()
     {
-        public static void Examples()
+        Console.WriteLine("==== ++ and -- operators");
+        Increment();
+        Decrement();
+
+        Console.WriteLine("==== Unary + and - operators");
+        UnaryPlusAndMinus();
+
+        Console.WriteLine("==== *, /, %, +, and - operators");
+        Multiplication();
+        IntegerDivision();
+        IntegerAsFloatingPointDivision();
+        FloatingPointDivision();
+        IntegerRemainder();
+        FloatingPointRemainder();
+        Addition();
+        Subtraction();
+
+        Console.WriteLine("==== Precedence and associativity examples");
+        PrecedenceAndAssociativity();
+
+        Console.WriteLine("==== Compound assignment");
+        CompoundAssignment();
+        CompoundAssignmentWithCast();
+
+        Console.WriteLine("==== Special cases");
+        CheckedUnchecked();
+        FloatingPointOverflow();
+        RoundOffErrors();
+    }
+
+    private static void Increment()
+    {
+        // <SnippetPrefixIncrement>
+        double a = 1.5;
+        Console.WriteLine(a);   // output: 1.5
+        Console.WriteLine(++a); // output: 2.5
+        Console.WriteLine(a);   // output: 2.5
+        // </SnippetPrefixIncrement>
+
+        // <SnippetPostfixIncrement>
+        int i = 3;
+        Console.WriteLine(i);   // output: 3
+        Console.WriteLine(i++); // output: 3
+        Console.WriteLine(i);   // output: 4
+        // </SnippetPostfixIncrement>
+    }
+
+    private static void Decrement()
+    {
+        // <SnippetPrefixDecrement>
+        double a = 1.5;
+        Console.WriteLine(a);   // output: 1.5
+        Console.WriteLine(--a); // output: 0.5
+        Console.WriteLine(a);   // output: 0.5
+        // </SnippetPrefixDecrement>
+
+        // <SnippetPostfixDecrement>
+        int i = 3;
+        Console.WriteLine(i);   // output: 3
+        Console.WriteLine(i--); // output: 3
+        Console.WriteLine(i);   // output: 2
+        // </SnippetPostfixDecrement>
+    }
+
+    private static void UnaryPlusAndMinus()
+    {
+        // <SnippetUnaryPlusAndMinus>
+        Console.WriteLine(+4);     // output: 4
+
+        Console.WriteLine(-4);     // output: -4
+        Console.WriteLine(-(-4));  // output: 4
+
+        uint a = 5;
+        var b = -a;
+        Console.WriteLine(b);            // output: -5
+        Console.WriteLine(b.GetType());  // output: System.Int64
+
+        Console.WriteLine(-double.NaN);  // output: NaN
+        // </SnippetUnaryPlusAndMinus>
+    }
+
+    private static void Multiplication()
+    {
+        // <SnippetMultiplication>
+        Console.WriteLine(5 * 2);         // output: 10
+        Console.WriteLine(0.5 * 2.5);     // output: 1.25
+        Console.WriteLine(0.1m * 23.4m);  // output: 2.34
+        // </SnippetMultiplication>
+    }
+
+    private static void IntegerDivision()
+    {
+        // <SnippetIntegerDivision>
+        Console.WriteLine(13 / 5);    // output: 2
+        Console.WriteLine(-13 / 5);   // output: -2
+        Console.WriteLine(13 / -5);   // output: -2
+        Console.WriteLine(-13 / -5);  // output: 2
+        // </SnippetIntegerDivision>
+    }
+
+    private static void IntegerAsFloatingPointDivision()
+    {
+        // <SnippetIntegerAsFloatingPointDivision>
+        Console.WriteLine(13 / 5.0);       // output: 2.6
+
+        int a = 13;
+        int b = 5;
+        Console.WriteLine((double)a / b);  // output: 2.6
+        // </SnippetIntegerAsFloatingPointDivision>
+    }
+
+    private static void FloatingPointDivision()
+    {
+        // <SnippetFloatingPointDivision>
+        Console.WriteLine(16.8f / 4.1f);   // output: 4.097561
+        Console.WriteLine(16.8d / 4.1d);   // output: 4.09756097560976
+        Console.WriteLine(16.8m / 4.1m);   // output: 4.0975609756097560975609756098
+        // </SnippetFloatingPointDivision>
+    }
+
+    private static void IntegerRemainder()
+    {
+        // <SnippetIntegerRemainder>
+        Console.WriteLine(5 % 4);   // output: 1
+        Console.WriteLine(5 % -4);  // output: 1
+        Console.WriteLine(-5 % 4);  // output: -1
+        Console.WriteLine(-5 % -4); // output: -1
+        // </SnippetIntegerRemainder>
+    }
+
+    private static void FloatingPointRemainder()
+    {
+        // <SnippetFloatingPointRemainder>
+        Console.WriteLine(-5.2f % 2.0f); // output: -1.2
+        Console.WriteLine(5.9 % 3.1);    // output: 2.8
+        Console.WriteLine(5.9m % 3.1m);  // output: 2.8
+        // </SnippetFloatingPointRemainder>
+    }
+
+    private static void Addition()
+    {
+        // <SnippetAddition>
+        Console.WriteLine(5 + 4);       // output: 9
+        Console.WriteLine(5 + 4.3);     // output: 9.3
+        Console.WriteLine(5.1m + 4.2m); // output: 9.3
+        // </SnippetAddition>
+    }
+
+    private static void Subtraction()
+    {
+        // <SnippetSubtraction>
+        Console.WriteLine(47 - 3);      // output: 44
+        Console.WriteLine(5 - 4.3);     // output: 0.7
+        Console.WriteLine(7.5m - 2.3m); // output: 5.2
+        // </SnippetSubtraction>
+    }
+
+    private static void PrecedenceAndAssociativity()
+    {
+        // <SnippetPrecedenceAndAssociativity>
+        Console.WriteLine(2 + 2 * 2);   // output: 6
+        Console.WriteLine((2 + 2) * 2); // output: 8
+
+        Console.WriteLine(9 / 5 / 2);   // output: 0
+        Console.WriteLine(9 / (5 / 2)); // output: 4
+        // </SnippetPrecedenceAndAssociativity>
+    }
+
+    private static void CompoundAssignment()
+    {
+        // <SnippetCompoundAssignment>
+        int a = 5;
+        a += 9;
+        Console.WriteLine(a);  // output: 14
+
+        a -= 4;
+        Console.WriteLine(a);  // output: 10
+
+        a *= 2;
+        Console.WriteLine(a);  // output: 20
+
+        a /= 4;
+        Console.WriteLine(a);  // output: 5
+
+        a %= 3;
+        Console.WriteLine(a);  // output: 2
+        // </SnippetCompoundAssignment>
+    }
+
+    private static void CompoundAssignmentWithCast()
+    {
+        // <SnippetCompoundAssignmentWithCast>
+        byte a = 200;
+        byte b = 100;
+
+        var c = a + b;
+        Console.WriteLine(c.GetType());  // output: System.Int32
+        Console.WriteLine(c);  // output: 300
+
+        a += b;
+        Console.WriteLine(a);  // output: 44
+        // </SnippetCompoundAssignmentWithCast>
+    }
+
+    private static void CheckedUnchecked()
+    {
+        // <SnippetCheckedUnchecked>
+        int a = int.MaxValue;
+        int b = 3;
+
+        Console.WriteLine(unchecked(a + b));  // output: -2147483646
+        try
         {
-            Console.WriteLine("==== ++ and -- operators");
-            Increment();
-            Decrement();
-
-            Console.WriteLine("==== Unary + and - operators");
-            UnaryPlusAndMinus();
-
-            Console.WriteLine("==== *, /, %, +, and - operators");
-            Multiplication();
-            IntegerDivision();
-            IntegerAsFloatingPointDivision();
-            FloatingPointDivision();
-            IntegerRemainder();
-            FloatingPointRemainder();
-            Addition();
-            Subtraction();
-
-            Console.WriteLine("==== Precedence and associativity examples");
-            PrecedenceAndAssociativity();
-
-            Console.WriteLine("==== Compound assignment");
-            CompoundAssignment();
-            CompoundAssignmentWithCast();
-
-            Console.WriteLine("==== Special cases");
-            CheckedUnchecked();
-            FloatingPointOverflow();
-            RoundOffErrors();
+            int d = checked(a + b);
         }
-
-        private static void Increment()
+        catch(OverflowException)
         {
-            // <SnippetPrefixIncrement>
-            double a = 1.5;
-            Console.WriteLine(a);   // output: 1.5
-            Console.WriteLine(++a); // output: 2.5
-            Console.WriteLine(a);   // output: 2.5
-            // </SnippetPrefixIncrement>
-
-            // <SnippetPostfixIncrement>
-            int i = 3;
-            Console.WriteLine(i);   // output: 3
-            Console.WriteLine(i++); // output: 3
-            Console.WriteLine(i);   // output: 4
-            // </SnippetPostfixIncrement>
+            Console.WriteLine($"Overflow occurred when adding {a} to {b}.");
         }
+        // </SnippetCheckedUnchecked>
+    }
 
-        private static void Decrement()
-        {
-            // <SnippetPrefixDecrement>
-            double a = 1.5;
-            Console.WriteLine(a);   // output: 1.5
-            Console.WriteLine(--a); // output: 0.5
-            Console.WriteLine(a);   // output: 0.5
-            // </SnippetPrefixDecrement>
+    private static void FloatingPointOverflow()
+    {
+        // <SnippetFloatingPointOverflow>
+        double a = 1.0 / 0.0;
+        Console.WriteLine(a);                    // output: Infinity
+        Console.WriteLine(double.IsInfinity(a)); // output: True
 
-            // <SnippetPostfixDecrement>
-            int i = 3;
-            Console.WriteLine(i);   // output: 3
-            Console.WriteLine(i--); // output: 3
-            Console.WriteLine(i);   // output: 2
-            // </SnippetPostfixDecrement>
-        }
+        Console.WriteLine(double.MaxValue + double.MaxValue); // output: Infinity
 
-        private static void UnaryPlusAndMinus()
-        {
-            // <SnippetUnaryPlusAndMinus>
-            Console.WriteLine(+4);     // output: 4
+        double b = 0.0 / 0.0;
+        Console.WriteLine(b);                // output: NaN
+        Console.WriteLine(double.IsNaN(b));  // output: True
+        // </SnippetFloatingPointOverflow>
+    }
 
-            Console.WriteLine(-4);     // output: -4
-            Console.WriteLine(-(-4));  // output: 4
+    private static void RoundOffErrors()
+    {
+        // <SnippetRoundOffErrors>
+        Console.WriteLine(.41f % .2f); // output: 0.00999999
 
-            uint a = 5;
-            var b = -a;
-            Console.WriteLine(b);            // output: -5
-            Console.WriteLine(b.GetType());  // output: System.Int64
+        double a = 0.1;
+        double b = 3 * a;
+        Console.WriteLine(b == 0.3);   // output: False
+        Console.WriteLine(b - 0.3);    // output: 5.55111512312578E-17
 
-            Console.WriteLine(-double.NaN);  // output: NaN
-            // </SnippetUnaryPlusAndMinus>
-        }
-
-        private static void Multiplication()
-        {
-            // <SnippetMultiplication>
-            Console.WriteLine(5 * 2);         // output: 10
-            Console.WriteLine(0.5 * 2.5);     // output: 1.25
-            Console.WriteLine(0.1m * 23.4m);  // output: 2.34
-            // </SnippetMultiplication>
-        }
-
-        private static void IntegerDivision()
-        {
-            // <SnippetIntegerDivision>
-            Console.WriteLine(13 / 5);    // output: 2
-            Console.WriteLine(-13 / 5);   // output: -2
-            Console.WriteLine(13 / -5);   // output: -2
-            Console.WriteLine(-13 / -5);  // output: 2
-            // </SnippetIntegerDivision>
-        }
-
-        private static void IntegerAsFloatingPointDivision()
-        {
-            // <SnippetIntegerAsFloatingPointDivision>
-            Console.WriteLine(13 / 5.0);       // output: 2.6
-
-            int a = 13;
-            int b = 5;
-            Console.WriteLine((double)a / b);  // output: 2.6
-            // </SnippetIntegerAsFloatingPointDivision>
-        }
-
-        private static void FloatingPointDivision()
-        {
-            // <SnippetFloatingPointDivision>
-            Console.WriteLine(16.8f / 4.1f);   // output: 4.097561
-            Console.WriteLine(16.8d / 4.1d);   // output: 4.09756097560976
-            Console.WriteLine(16.8m / 4.1m);   // output: 4.0975609756097560975609756098
-            // </SnippetFloatingPointDivision>
-        }
-
-        private static void IntegerRemainder()
-        {
-            // <SnippetIntegerRemainder>
-            Console.WriteLine(5 % 4);   // output: 1
-            Console.WriteLine(5 % -4);  // output: 1
-            Console.WriteLine(-5 % 4);  // output: -1
-            Console.WriteLine(-5 % -4); // output: -1
-            // </SnippetIntegerRemainder>
-        }
-
-        private static void FloatingPointRemainder()
-        {
-            // <SnippetFloatingPointRemainder>
-            Console.WriteLine(-5.2f % 2.0f); // output: -1.2
-            Console.WriteLine(5.9 % 3.1);    // output: 2.8
-            Console.WriteLine(5.9m % 3.1m);  // output: 2.8
-            // </SnippetFloatingPointRemainder>
-        }
-
-        private static void Addition()
-        {
-            // <SnippetAddition>
-            Console.WriteLine(5 + 4);       // output: 9
-            Console.WriteLine(5 + 4.3);     // output: 9.3
-            Console.WriteLine(5.1m + 4.2m); // output: 9.3
-            // </SnippetAddition>
-        }
-
-        private static void Subtraction()
-        {
-            // <SnippetSubtraction>
-            Console.WriteLine(47 - 3);      // output: 44
-            Console.WriteLine(5 - 4.3);     // output: 0.7
-            Console.WriteLine(7.5m - 2.3m); // output: 5.2
-            // </SnippetSubtraction>
-        }
-
-        private static void PrecedenceAndAssociativity()
-        {
-            // <SnippetPrecedenceAndAssociativity>
-            Console.WriteLine(2 + 2 * 2);   // output: 6
-            Console.WriteLine((2 + 2) * 2); // output: 8
-
-            Console.WriteLine(9 / 5 / 2);   // output: 0
-            Console.WriteLine(9 / (5 / 2)); // output: 4
-            // </SnippetPrecedenceAndAssociativity>
-        }
-
-        private static void CompoundAssignment()
-        {
-            // <SnippetCompoundAssignment>
-            int a = 5;
-            a += 9;
-            Console.WriteLine(a);  // output: 14
-
-            a -= 4;
-            Console.WriteLine(a);  // output: 10
-
-            a *= 2;
-            Console.WriteLine(a);  // output: 20
-
-            a /= 4;
-            Console.WriteLine(a);  // output: 5
-
-            a %= 3;
-            Console.WriteLine(a);  // output: 2
-            // </SnippetCompoundAssignment>
-        }
-
-        private static void CompoundAssignmentWithCast()
-        {
-            // <SnippetCompoundAssignmentWithCast>
-            byte a = 200;
-            byte b = 100;
-
-            var c = a + b;
-            Console.WriteLine(c.GetType());  // output: System.Int32
-            Console.WriteLine(c);  // output: 300
-
-            a += b;
-            Console.WriteLine(a);  // output: 44
-            // </SnippetCompoundAssignmentWithCast>
-        }
-
-        private static void CheckedUnchecked()
-        {
-            // <SnippetCheckedUnchecked>
-            int a = int.MaxValue;
-            int b = 3;
-
-            Console.WriteLine(unchecked(a + b));  // output: -2147483646
-            try
-            {
-                int d = checked(a + b);
-            }
-            catch(OverflowException)
-            {
-                Console.WriteLine($"Overflow occurred when adding {a} to {b}.");
-            }
-            // </SnippetCheckedUnchecked>
-        }
-
-        private static void FloatingPointOverflow()
-        {
-            // <SnippetFloatingPointOverflow>
-            double a = 1.0 / 0.0;
-            Console.WriteLine(a);                    // output: Infinity
-            Console.WriteLine(double.IsInfinity(a)); // output: True
-
-            Console.WriteLine(double.MaxValue + double.MaxValue); // output: Infinity
-
-            double b = 0.0 / 0.0;
-            Console.WriteLine(b);                // output: NaN
-            Console.WriteLine(double.IsNaN(b));  // output: True
-            // </SnippetFloatingPointOverflow>
-        }
-
-        private static void RoundOffErrors()
-        {
-            // <SnippetRoundOffErrors>
-            Console.WriteLine(.41f % .2f); // output: 0.00999999
-
-            double a = 0.1;
-            double b = 3 * a;
-            Console.WriteLine(b == 0.3);   // output: False
-            Console.WriteLine(b - 0.3);    // output: 5.55111512312578E-17
-
-            decimal c = 1 / 3.0m;
-            decimal d = 3 * c;
-            Console.WriteLine(d == 1.0m);  // output: False
-            Console.WriteLine(d);          // output: 0.9999999999999999999999999999
-            // </SnippetRoundOffErrors>
-        }
+        decimal c = 1 / 3.0m;
+        decimal d = 3 * c;
+        Console.WriteLine(d == 1.0m);  // output: False
+        Console.WriteLine(d);          // output: 0.9999999999999999999999999999
+        // </SnippetRoundOffErrors>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/AssignmentOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/AssignmentOperator.cs
@@ -1,60 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace operators;
 
-namespace operators
+public static class AssignmentOperator
 {
-    public static class AssignmentOperator
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            Simple();
-            RefAssignment();
-        }
+        Simple();
+        RefAssignment();
+    }
 
-        private static void Simple()
-        {
-            // <SnippetSimple>
-            var numbers = new List<double>() { 1.0, 2.0, 3.0 };
+    private static void Simple()
+    {
+        // <SnippetSimple>
+        var numbers = new List<double>() { 1.0, 2.0, 3.0 };
 
-            Console.WriteLine(numbers.Capacity);
-            numbers.Capacity = 100;
-            Console.WriteLine(numbers.Capacity);
-            // Output:
-            // 4
-            // 100
+        Console.WriteLine(numbers.Capacity);
+        numbers.Capacity = 100;
+        Console.WriteLine(numbers.Capacity);
+        // Output:
+        // 4
+        // 100
 
-            int newFirstElement;
-            double originalFirstElement = numbers[0];
-            newFirstElement = 5;
-            numbers[0] = newFirstElement;
-            Console.WriteLine(originalFirstElement);
-            Console.WriteLine(numbers[0]);
-            // Output:
-            // 1
-            // 5
-            // </SnippetSimple>
-        }
+        int newFirstElement;
+        double originalFirstElement = numbers[0];
+        newFirstElement = 5;
+        numbers[0] = newFirstElement;
+        Console.WriteLine(originalFirstElement);
+        Console.WriteLine(numbers[0]);
+        // Output:
+        // 1
+        // 5
+        // </SnippetSimple>
+    }
 
-        private static void RefAssignment()
-        {
-            // <SnippetRefAssignment>
-            void Display(double[] s) => Console.WriteLine(string.Join(" ", s));
+    private static void RefAssignment()
+    {
+        // <SnippetRefAssignment>
+        void Display(double[] s) => Console.WriteLine(string.Join(" ", s));
 
-            double[] arr = { 0.0, 0.0, 0.0 };
-            Display(arr);
+        double[] arr = { 0.0, 0.0, 0.0 };
+        Display(arr);
 
-            ref double arrayElement = ref arr[0];
-            arrayElement = 3.0;
-            Display(arr);
+        ref double arrayElement = ref arr[0];
+        arrayElement = 3.0;
+        Display(arr);
 
-            arrayElement = ref arr[arr.Length - 1];
-            arrayElement = 5.0;
-            Display(arr);
-            // Output:
-            // 0 0 0
-            // 3 0 0
-            // 3 0 5
-            // </SnippetRefAssignment>
-        }
+        arrayElement = ref arr[arr.Length - 1];
+        arrayElement = 5.0;
+        Display(arr);
+        // Output:
+        // 0 0 0
+        // 3 0 0
+        // 3 0 5
+        // </SnippetRefAssignment>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace operators
+﻿namespace operators
 {
     public static class BitwiseAndShiftOperators
     {

--- a/docs/csharp/language-reference/operators/snippets/shared/BooleanLogicalOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BooleanLogicalOperators.cs
@@ -1,189 +1,186 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class BooleanLogicalOperators
 {
-    public static class BooleanLogicalOperators
+    public static void Examples()
     {
-        public static void Examples()
+        Console.WriteLine("==== !, &, |, ^ operators");
+        Negation();
+        And();
+        Or();
+        Xor();
+        WithNullableBoolean();
+
+        Console.WriteLine("==== && and || operators");
+        ConditionalAnd();
+        ConditionalOr();
+
+        Console.WriteLine("==== Compound assignment and precedence");
+        CompoundAssignment();
+        Precedence();
+    }
+
+    private static void Negation()
+    {
+        // <SnippetNegation>
+        bool passed = false;
+        Console.WriteLine(!passed);  // output: True
+        Console.WriteLine(!true);    // output: False
+        // </SnippetNegation>
+    }
+
+    private static void And()
+    {
+        // <SnippetAnd>
+        bool SecondOperand()
         {
-            Console.WriteLine("==== !, &, |, ^ operators");
-            Negation();
-            And();
-            Or();
-            Xor();
-            WithNullableBoolean();
-
-            Console.WriteLine("==== && and || operators");
-            ConditionalAnd();
-            ConditionalOr();
-
-            Console.WriteLine("==== Compound assignment and precedence");
-            CompoundAssignment();
-            Precedence();
+            Console.WriteLine("Second operand is evaluated.");
+            return true;
         }
 
-        private static void Negation()
+        bool a = false & SecondOperand();
+        Console.WriteLine(a);
+        // Output:
+        // Second operand is evaluated.
+        // False
+
+        bool b = true & SecondOperand();
+        Console.WriteLine(b);
+        // Output:
+        // Second operand is evaluated.
+        // True
+        // </SnippetAnd>
+    }
+
+    private static void Or()
+    {
+        // <SnippetOr>
+        bool SecondOperand()
         {
-            // <SnippetNegation>
-            bool passed = false;
-            Console.WriteLine(!passed);  // output: True
-            Console.WriteLine(!true);    // output: False
-            // </SnippetNegation>
+            Console.WriteLine("Second operand is evaluated.");
+            return true;
         }
 
-        private static void And()
+        bool a = true | SecondOperand();
+        Console.WriteLine(a);
+        // Output:
+        // Second operand is evaluated.
+        // True
+
+        bool b = false | SecondOperand();
+        Console.WriteLine(b);
+        // Output:
+        // Second operand is evaluated.
+        // True
+        // </SnippetOr>
+    }
+
+    private static void Xor()
+    {
+        // <SnippetXor>
+        Console.WriteLine(true ^ true);    // output: False
+        Console.WriteLine(true ^ false);   // output: True
+        Console.WriteLine(false ^ true);   // output: True
+        Console.WriteLine(false ^ false);  // output: False
+        // </SnippetXor>
+    }
+
+    private static void ConditionalAnd()
+    {
+        // <SnippetConditionalAnd>
+        bool SecondOperand()
         {
-            // <SnippetAnd>
-            bool SecondOperand()
-            {
-                Console.WriteLine("Second operand is evaluated.");
-                return true;
-            }
-
-            bool a = false & SecondOperand();
-            Console.WriteLine(a);
-            // Output:
-            // Second operand is evaluated.
-            // False
-
-            bool b = true & SecondOperand();
-            Console.WriteLine(b);
-            // Output:
-            // Second operand is evaluated.
-            // True
-            // </SnippetAnd>
+            Console.WriteLine("Second operand is evaluated.");
+            return true;
         }
 
-        private static void Or()
+        bool a = false && SecondOperand();
+        Console.WriteLine(a);
+        // Output:
+        // False
+
+        bool b = true && SecondOperand();
+        Console.WriteLine(b);
+        // Output:
+        // Second operand is evaluated.
+        // True
+        // </SnippetConditionalAnd>
+    }
+
+    private static void ConditionalOr()
+    {
+        // <SnippetConditionalOr>
+        bool SecondOperand()
         {
-            // <SnippetOr>
-            bool SecondOperand()
-            {
-                Console.WriteLine("Second operand is evaluated.");
-                return true;
-            }
-
-            bool a = true | SecondOperand();
-            Console.WriteLine(a);
-            // Output:
-            // Second operand is evaluated.
-            // True
-
-            bool b = false | SecondOperand();
-            Console.WriteLine(b);
-            // Output:
-            // Second operand is evaluated.
-            // True
-            // </SnippetOr>
+            Console.WriteLine("Second operand is evaluated.");
+            return true;
         }
 
-        private static void Xor()
+        bool a = true || SecondOperand();
+        Console.WriteLine(a);
+        // Output:
+        // True
+
+        bool b = false || SecondOperand();
+        Console.WriteLine(b);
+        // Output:
+        // Second operand is evaluated.
+        // True
+        // </SnippetConditionalOr>
+    }
+
+    private static void WithNullableBoolean()
+    {
+        // <SnippetWithNullableBoolean>
+        bool? test = null;
+        Display(!test);         // output: null
+        Display(test ^ false);  // output: null
+        Display(test ^ null);   // output: null
+        Display(true ^ null);   // output: null
+
+        void Display(bool? b) => Console.WriteLine(b is null ? "null" : b.Value.ToString());
+        // </SnippetWithNullableBoolean>
+    }
+
+    private static void CompoundAssignment()
+    {
+        // <SnippetCompoundAssignment>
+        bool test = true;
+        test &= false;
+        Console.WriteLine(test);  // output: False
+
+        test |= true;
+        Console.WriteLine(test);  // output: True
+
+        test ^= false;
+        Console.WriteLine(test);  // output: True
+        // </SnippetCompoundAssignment>
+    }
+
+    private static void Precedence()
+    {
+        // <SnippetPrecedence>
+        Console.WriteLine(true | true & false);   // output: True
+        Console.WriteLine((true | true) & false); // output: False
+
+        bool Operand(string name, bool value)
         {
-            // <SnippetXor>
-            Console.WriteLine(true ^ true);    // output: False
-            Console.WriteLine(true ^ false);   // output: True
-            Console.WriteLine(false ^ true);   // output: True
-            Console.WriteLine(false ^ false);  // output: False
-            // </SnippetXor>
+            Console.WriteLine($"Operand {name} is evaluated.");
+            return value;
         }
 
-        private static void ConditionalAnd()
-        {
-            // <SnippetConditionalAnd>
-            bool SecondOperand()
-            {
-                Console.WriteLine("Second operand is evaluated.");
-                return true;
-            }
+        var byDefaultPrecedence = Operand("A", true) || Operand("B", true) && Operand("C", false);
+        Console.WriteLine(byDefaultPrecedence);
+        // Output:
+        // Operand A is evaluated.
+        // True
 
-            bool a = false && SecondOperand();
-            Console.WriteLine(a);
-            // Output:
-            // False
-
-            bool b = true && SecondOperand();
-            Console.WriteLine(b);
-            // Output:
-            // Second operand is evaluated.
-            // True
-            // </SnippetConditionalAnd>
-        }
-
-        private static void ConditionalOr()
-        {
-            // <SnippetConditionalOr>
-            bool SecondOperand()
-            {
-                Console.WriteLine("Second operand is evaluated.");
-                return true;
-            }
-
-            bool a = true || SecondOperand();
-            Console.WriteLine(a);
-            // Output:
-            // True
-
-            bool b = false || SecondOperand();
-            Console.WriteLine(b);
-            // Output:
-            // Second operand is evaluated.
-            // True
-            // </SnippetConditionalOr>
-        }
-
-        private static void WithNullableBoolean()
-        {
-            // <SnippetWithNullableBoolean>
-            bool? test = null;
-            Display(!test);         // output: null
-            Display(test ^ false);  // output: null
-            Display(test ^ null);   // output: null
-            Display(true ^ null);   // output: null
-
-            void Display(bool? b) => Console.WriteLine(b is null ? "null" : b.Value.ToString());
-            // </SnippetWithNullableBoolean>
-        }
-
-        private static void CompoundAssignment()
-        {
-            // <SnippetCompoundAssignment>
-            bool test = true;
-            test &= false;
-            Console.WriteLine(test);  // output: False
-
-            test |= true;
-            Console.WriteLine(test);  // output: True
-
-            test ^= false;
-            Console.WriteLine(test);  // output: True
-            // </SnippetCompoundAssignment>
-        }
-
-        private static void Precedence()
-        {
-            // <SnippetPrecedence>
-            Console.WriteLine(true | true & false);   // output: True
-            Console.WriteLine((true | true) & false); // output: False
-
-            bool Operand(string name, bool value)
-            {
-                Console.WriteLine($"Operand {name} is evaluated.");
-                return value;
-            }
-
-            var byDefaultPrecedence = Operand("A", true) || Operand("B", true) && Operand("C", false);
-            Console.WriteLine(byDefaultPrecedence);
-            // Output:
-            // Operand A is evaluated.
-            // True
-
-            var changedOrder = (Operand("A", true) || Operand("B", true)) && Operand("C", false);
-            Console.WriteLine(changedOrder);
-            // Output:
-            // Operand A is evaluated.
-            // Operand C is evaluated.
-            // False
-            // </SnippetPrecedence>
-        }
+        var changedOrder = (Operand("A", true) || Operand("B", true)) && Operand("C", false);
+        Console.WriteLine(changedOrder);
+        // Output:
+        // Operand A is evaluated.
+        // Operand C is evaluated.
+        // False
+        // </SnippetPrecedence>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/ComparisonOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/ComparisonOperators.cs
@@ -1,67 +1,64 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class ComparisonOperators
 {
-    public static class ComparisonOperators
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            Console.WriteLine("--- >");
-            Greater();
-            Console.WriteLine("--- <");
-            Less();
-            Console.WriteLine("--- >=");
-            GreaterOrEqual();
-            Console.WriteLine("--- <=");
-            LessOrEqual();
-        }
+        Console.WriteLine("--- >");
+        Greater();
+        Console.WriteLine("--- <");
+        Less();
+        Console.WriteLine("--- >=");
+        GreaterOrEqual();
+        Console.WriteLine("--- <=");
+        LessOrEqual();
+    }
 
-        private static void Greater()
-        {
-            // <SnippetGreater>
-            Console.WriteLine(7.0 > 5.1);   // output: True
-            Console.WriteLine(5.1 > 5.1);   // output: False
-            Console.WriteLine(0.0 > 5.1);   // output: False
+    private static void Greater()
+    {
+        // <SnippetGreater>
+        Console.WriteLine(7.0 > 5.1);   // output: True
+        Console.WriteLine(5.1 > 5.1);   // output: False
+        Console.WriteLine(0.0 > 5.1);   // output: False
 
-            Console.WriteLine(double.NaN > 5.1);   // output: False
-            Console.WriteLine(double.NaN <= 5.1);  // output: False
-            // </SnippetGreater>
-        }
+        Console.WriteLine(double.NaN > 5.1);   // output: False
+        Console.WriteLine(double.NaN <= 5.1);  // output: False
+        // </SnippetGreater>
+    }
 
-        private static void Less()
-        {
-            // <SnippetLess>
-            Console.WriteLine(7.0 < 5.1);   // output: False
-            Console.WriteLine(5.1 < 5.1);   // output: False
-            Console.WriteLine(0.0 < 5.1);   // output: True
+    private static void Less()
+    {
+        // <SnippetLess>
+        Console.WriteLine(7.0 < 5.1);   // output: False
+        Console.WriteLine(5.1 < 5.1);   // output: False
+        Console.WriteLine(0.0 < 5.1);   // output: True
 
-            Console.WriteLine(double.NaN < 5.1);   // output: False
-            Console.WriteLine(double.NaN >= 5.1);  // output: False
-            // </SnippetLess>
-        }
+        Console.WriteLine(double.NaN < 5.1);   // output: False
+        Console.WriteLine(double.NaN >= 5.1);  // output: False
+        // </SnippetLess>
+    }
 
-        private static void GreaterOrEqual()
-        {
-            // <SnippetGreaterOrEqual>
-            Console.WriteLine(7.0 >= 5.1);   // output: True
-            Console.WriteLine(5.1 >= 5.1);   // output: True
-            Console.WriteLine(0.0 >= 5.1);   // output: False
+    private static void GreaterOrEqual()
+    {
+        // <SnippetGreaterOrEqual>
+        Console.WriteLine(7.0 >= 5.1);   // output: True
+        Console.WriteLine(5.1 >= 5.1);   // output: True
+        Console.WriteLine(0.0 >= 5.1);   // output: False
 
-            Console.WriteLine(double.NaN < 5.1);   // output: False
-            Console.WriteLine(double.NaN >= 5.1);  // output: False
-            // </SnippetGreaterOrEqual>
-        }
+        Console.WriteLine(double.NaN < 5.1);   // output: False
+        Console.WriteLine(double.NaN >= 5.1);  // output: False
+        // </SnippetGreaterOrEqual>
+    }
 
-        private static void LessOrEqual()
-        {
-            // <SnippetLessOrEqual>
-            Console.WriteLine(7.0 <= 5.1);   // output: False
-            Console.WriteLine(5.1 <= 5.1);   // output: True
-            Console.WriteLine(0.0 <= 5.1);   // output: True
+    private static void LessOrEqual()
+    {
+        // <SnippetLessOrEqual>
+        Console.WriteLine(7.0 <= 5.1);   // output: False
+        Console.WriteLine(5.1 <= 5.1);   // output: True
+        Console.WriteLine(0.0 <= 5.1);   // output: True
 
-            Console.WriteLine(double.NaN > 5.1);   // output: False
-            Console.WriteLine(double.NaN <= 5.1);  // output: False
-            // </SnippetLessOrEqual>
-        }
+        Console.WriteLine(double.NaN > 5.1);   // output: False
+        Console.WriteLine(double.NaN <= 5.1);  // output: False
+        // </SnippetLessOrEqual>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/ConditionalOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/ConditionalOperator.cs
@@ -1,89 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace operators;
 
-namespace operators
+public class ConditionalOperator
 {
-    public class ConditionalOperator
+    public static void Examples()
     {
-        public static void Examples()
+        BasicExample();
+        ConditionalRefExpressions();
+        ComparisonWithIf();
+        TargetTyped();
+        NotTargetTyped();
+    }
+
+    private static void BasicExample()
+    {
+        // <BasicExample>
+        string GetWeatherDisplay(double tempInCelsius) => tempInCelsius < 20.0 ? "Cold." : "Perfect!";
+        
+        Console.WriteLine(GetWeatherDisplay(15));  // output: Cold.
+        Console.WriteLine(GetWeatherDisplay(27));  // output: Perfect!
+        // </BasicExample>
+    }
+
+    private static void ConditionalRefExpressions()
+    {
+        // <SnippetConditionalRef>
+        var smallArray = new int[] { 1, 2, 3, 4, 5 };
+        var largeArray = new int[] { 10, 20, 30, 40, 50 };
+
+        int index = 7;
+        ref int refValue = ref ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]);
+        refValue = 0;
+
+        index = 2;
+        ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]) = 100;
+
+        Console.WriteLine(string.Join(" ", smallArray));
+        Console.WriteLine(string.Join(" ", largeArray));
+        // Output:
+        // 1 2 100 4 5
+        // 10 20 0 40 50
+        // </SnippetConditionalRef>
+    }
+
+    private static void TargetTyped()
+    {
+        // <SnippetTargetTyped>
+        var rand = new Random();
+        var condition = rand.NextDouble() > 0.5;
+
+        int? x = condition ? 12 : null;
+
+        IEnumerable<int> xs = x is null ? new List<int>() { 0, 1 } : new int[] { 2, 3 };
+        // </SnippetTargetTyped>
+    }
+
+    private static void NotTargetTyped()
+    {
+        // <SnippetNotTargetTyped>
+        var rand = new Random();
+        var condition = rand.NextDouble() > 0.5;
+
+        var x = condition ? 12 : (int?)null;
+        // </SnippetNotTargetTyped>
+    }
+
+    private static void ComparisonWithIf()
+    {
+        // <SnippetCompareWithIf>
+        int input = new Random().Next(-5, 5);
+
+        string classify;
+        if (input >= 0)
         {
-            BasicExample();
-            ConditionalRefExpressions();
-            ComparisonWithIf();
-            TargetTyped();
-            NotTargetTyped();
+            classify = "nonnegative";
+        }
+        else
+        {
+            classify = "negative";
         }
 
-        private static void BasicExample()
-        {
-            // <BasicExample>
-            string GetWeatherDisplay(double tempInCelsius) => tempInCelsius < 20.0 ? "Cold." : "Perfect!";
-            
-            Console.WriteLine(GetWeatherDisplay(15));  // output: Cold.
-            Console.WriteLine(GetWeatherDisplay(27));  // output: Perfect!
-            // </BasicExample>
-        }
-
-        private static void ConditionalRefExpressions()
-        {
-            // <SnippetConditionalRef>
-            var smallArray = new int[] { 1, 2, 3, 4, 5 };
-            var largeArray = new int[] { 10, 20, 30, 40, 50 };
-
-            int index = 7;
-            ref int refValue = ref ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]);
-            refValue = 0;
-
-            index = 2;
-            ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]) = 100;
-
-            Console.WriteLine(string.Join(" ", smallArray));
-            Console.WriteLine(string.Join(" ", largeArray));
-            // Output:
-            // 1 2 100 4 5
-            // 10 20 0 40 50
-            // </SnippetConditionalRef>
-        }
-
-        private static void TargetTyped()
-        {
-            // <SnippetTargetTyped>
-            var rand = new Random();
-            var condition = rand.NextDouble() > 0.5;
-
-            int? x = condition ? 12 : null;
-
-            IEnumerable<int> xs = x is null ? new List<int>() { 0, 1 } : new int[] { 2, 3 };
-            // </SnippetTargetTyped>
-        }
-
-        private static void NotTargetTyped()
-        {
-            // <SnippetNotTargetTyped>
-            var rand = new Random();
-            var condition = rand.NextDouble() > 0.5;
-
-            var x = condition ? 12 : (int?)null;
-            // </SnippetNotTargetTyped>
-        }
-
-        private static void ComparisonWithIf()
-        {
-            // <SnippetCompareWithIf>
-            int input = new Random().Next(-5, 5);
-
-            string classify;
-            if (input >= 0)
-            {
-                classify = "nonnegative";
-            }
-            else
-            {
-                classify = "negative";
-            }
-
-            classify = (input >= 0) ? "nonnegative" : "negative";
-            // </SnippetCompareWithIf>
-        }
+        classify = (input >= 0) ? "nonnegative" : "negative";
+        // </SnippetCompareWithIf>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/DefaultOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/DefaultOperator.cs
@@ -1,63 +1,60 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class DefaultOperator
 {
-    public static class DefaultOperator
+    public static void Examples()
     {
-        public static void Examples()
+        WithOperand();
+        DefaultLiteral();
+    }
+
+    private static void WithOperand()
+    {
+        // <SnippetWithOperand>
+        Console.WriteLine(default(int));  // output: 0
+        Console.WriteLine(default(object) is null);  // output: True
+
+        void DisplayDefaultOf<T>()
         {
-            WithOperand();
-            DefaultLiteral();
+            var val = default(T);
+            Console.WriteLine($"Default value of {typeof(T)} is {(val == null ? "null" : val.ToString())}.");
         }
 
-        private static void WithOperand()
-        {
-            // <SnippetWithOperand>
-            Console.WriteLine(default(int));  // output: 0
-            Console.WriteLine(default(object) is null);  // output: True
+        DisplayDefaultOf<int?>();
+        DisplayDefaultOf<System.Numerics.Complex>();
+        DisplayDefaultOf<System.Collections.Generic.List<int>>();
+        // Output:
+        // Default value of System.Nullable`1[System.Int32] is null.
+        // Default value of System.Numerics.Complex is (0, 0).
+        // Default value of System.Collections.Generic.List`1[System.Int32] is null.
+        // </SnippetWithOperand>
+    }
 
-            void DisplayDefaultOf<T>()
+    private static void DefaultLiteral()
+    {
+        // <SnippetDefaultLiteral>
+        T[] InitializeArray<T>(int length, T initialValue = default)
+        {
+            if (length < 0)
             {
-                var val = default(T);
-                Console.WriteLine($"Default value of {typeof(T)} is {(val == null ? "null" : val.ToString())}.");
+                throw new ArgumentOutOfRangeException(nameof(length), "Array length must be nonnegative.");
             }
 
-            DisplayDefaultOf<int?>();
-            DisplayDefaultOf<System.Numerics.Complex>();
-            DisplayDefaultOf<System.Collections.Generic.List<int>>();
-            // Output:
-            // Default value of System.Nullable`1[System.Int32] is null.
-            // Default value of System.Numerics.Complex is (0, 0).
-            // Default value of System.Collections.Generic.List`1[System.Int32] is null.
-            // </SnippetWithOperand>
-        }
-
-        private static void DefaultLiteral()
-        {
-            // <SnippetDefaultLiteral>
-            T[] InitializeArray<T>(int length, T initialValue = default)
+            var array = new T[length];
+            for (var i = 0; i < length; i++)
             {
-                if (length < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(length), "Array length must be nonnegative.");
-                }
-
-                var array = new T[length];
-                for (var i = 0; i < length; i++)
-                {
-                    array[i] = initialValue;
-                }
-                return array;
+                array[i] = initialValue;
             }
-
-            void Display<T>(T[] values) => Console.WriteLine($"[ {string.Join(", ", values)} ]");
-
-            Display(InitializeArray<int>(3));  // output: [ 0, 0, 0 ]
-            Display(InitializeArray<bool>(4, default));  // output: [ False, False, False, False ]
-
-            System.Numerics.Complex fillValue = default;
-            Display(InitializeArray(3, fillValue));  // output: [ (0, 0), (0, 0), (0, 0) ]
-            // </SnippetDefaultLiteral>
+            return array;
         }
+
+        void Display<T>(T[] values) => Console.WriteLine($"[ {string.Join(", ", values)} ]");
+
+        Display(InitializeArray<int>(3));  // output: [ 0, 0, 0 ]
+        Display(InitializeArray<bool>(4, default));  // output: [ False, False, False, False ]
+
+        System.Numerics.Complex fillValue = default;
+        Display(InitializeArray(3, fillValue));  // output: [ (0, 0), (0, 0), (0, 0) ]
+        // </SnippetDefaultLiteral>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/DelegateOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/DelegateOperator.cs
@@ -1,64 +1,60 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace operators;
 
-namespace operators
+public static class DelegateOperator
 {
-    public static class DelegateOperator
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            AnonymousMethod();
-            Lambda();
-            WithoutParameterList();
-            Discards();
-            Static();
-        }
+        AnonymousMethod();
+        Lambda();
+        WithoutParameterList();
+        Discards();
+        Static();
+    }
 
-        private static void AnonymousMethod()
-        {
-            // <SnippetAnonymousMethod>
-            Func<int, int, int> sum = delegate (int a, int b) { return a + b; };
-            Console.WriteLine(sum(3, 4));  // output: 7
-            // </SnippetAnonymousMethod>
-        }
+    private static void AnonymousMethod()
+    {
+        // <SnippetAnonymousMethod>
+        Func<int, int, int> sum = delegate (int a, int b) { return a + b; };
+        Console.WriteLine(sum(3, 4));  // output: 7
+        // </SnippetAnonymousMethod>
+    }
 
-        private static void Lambda()
-        {
-            // <SnippetLambda>
-            Func<int, int, int> sum = (a, b) => a + b;
-            Console.WriteLine(sum(3, 4));  // output: 7
-            // </SnippetLambda>
-        }
+    private static void Lambda()
+    {
+        // <SnippetLambda>
+        Func<int, int, int> sum = (a, b) => a + b;
+        Console.WriteLine(sum(3, 4));  // output: 7
+        // </SnippetLambda>
+    }
 
-        private static void WithoutParameterList()
-        {
-            // <SnippetWithoutParameterList>
-            Action greet = delegate { Console.WriteLine("Hello!"); };
-            greet();
+    private static void WithoutParameterList()
+    {
+        // <SnippetWithoutParameterList>
+        Action greet = delegate { Console.WriteLine("Hello!"); };
+        greet();
 
-            Action<int, double> introduce = delegate { Console.WriteLine("This is world!"); };
-            introduce(42, 2.7);
+        Action<int, double> introduce = delegate { Console.WriteLine("This is world!"); };
+        introduce(42, 2.7);
 
-            // Output:
-            // Hello!
-            // This is world!
-            // </SnippetWithoutParameterList>
-        }
+        // Output:
+        // Hello!
+        // This is world!
+        // </SnippetWithoutParameterList>
+    }
 
-        private static void Discards()
-        {
-            // <SnippetDiscards>
-            Func<int, int, int> constant = delegate (int _, int _) { return 42; };
-            Console.WriteLine(constant(3, 4));  // output: 42
-            // </SnippetDiscards>
-        }
+    private static void Discards()
+    {
+        // <SnippetDiscards>
+        Func<int, int, int> constant = delegate (int _, int _) { return 42; };
+        Console.WriteLine(constant(3, 4));  // output: 42
+        // </SnippetDiscards>
+    }
 
-        private static void Static()
-        {
-            // <SnippetStatic>
-            Func<int, int, int> sum = static delegate (int a, int b) { return a + b; };
-            Console.WriteLine(sum(10, 4));  // output: 14
-            // </SnippetStatic>
-        }
+    private static void Static()
+    {
+        // <SnippetStatic>
+        Func<int, int, int> sum = static delegate (int a, int b) { return a + b; };
+        Console.WriteLine(sum(10, 4));  // output: 14
+        // </SnippetStatic>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/EqualityOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/EqualityOperators.cs
@@ -1,145 +1,141 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace operators;
 
-namespace operators
+public static class EqualityOperators
 {
-    public static class EqualityOperators
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            Console.WriteLine("Value types:");
-            ValueTypesEquality();
+        Console.WriteLine("Value types:");
+        ValueTypesEquality();
 
-            Console.WriteLine("Strings:");
-            StringEquality();
+        Console.WriteLine("Strings:");
+        StringEquality();
 
-            Console.WriteLine("Reference types:");
-            ReferenceTypesEquality.Main();
+        Console.WriteLine("Reference types:");
+        ReferenceTypesEquality.Main();
 
-            Console.WriteLine("Record types:");
-            RecordTypesEquality.Main();
+        Console.WriteLine("Record types:");
+        RecordTypesEquality.Main();
 
-            Console.WriteLine("Delegate types:");
-            DelegateEquality();
-            IdenticalLambdasNotEqual();
+        Console.WriteLine("Delegate types:");
+        DelegateEquality();
+        IdenticalLambdasNotEqual();
 
-            Console.WriteLine("Non equality:");
-            NonEquality();
-        }
-
-        private static void ValueTypesEquality()
-        {
-            // <SnippetValueTypesEquality>
-            int a = 1 + 2 + 3;
-            int b = 6;
-            Console.WriteLine(a == b);  // output: True
-
-            char c1 = 'a';
-            char c2 = 'A';
-            Console.WriteLine(c1 == c2);  // output: False
-            Console.WriteLine(c1 == char.ToLower(c2));  // output: True
-            // </SnippetValueTypesEquality>
-        }
-
-        private static void StringEquality()
-        {
-            // <SnippetStringEquality>
-            string s1 = "hello!";
-            string s2 = "HeLLo!";
-            Console.WriteLine(s1 == s2.ToLower());  // output: True
-
-            string s3 = "Hello!";
-            Console.WriteLine(s1 == s3);  // output: False
-            // </SnippetStringEquality>
-        }
-
-        // Rationale for the structure of the next snippet.
-        // A method cannot contain a class definition. Thus, a standard way to include snippet doesn't work.
-        // We want snippets to be interactive. Thus, the whole snippet has a structure of the console program.
-        // (Running the code without the ReferenceTypesEquality class doesn't produce any output in the interactive Output control.)
-
-        // <SnippetReferenceTypesEquality>
-        public class ReferenceTypesEquality
-        {
-            public class MyClass
-            {
-                private int id;
-
-                public MyClass(int id) => this.id = id;
-            }
-
-            public static void Main()
-            {
-                var a = new MyClass(1);
-                var b = new MyClass(1);
-                var c = a;
-                Console.WriteLine(a == b);  // output: False
-                Console.WriteLine(a == c);  // output: True
-            }
-        }
-        // </SnippetReferenceTypesEquality>
-
-        private static void NonEquality()
-        {
-            // <SnippetNonEquality>
-            int a = 1 + 1 + 2 + 3;
-            int b = 6;
-            Console.WriteLine(a != b);  // output: True
-
-            string s1 = "Hello";
-            string s2 = "Hello";
-            Console.WriteLine(s1 != s2);  // output: False
-
-            object o1 = 1;
-            object o2 = 1;
-            Console.WriteLine(o1 != o2);  // output: True
-            // </SnippetNonEquality>
-        }
-
-        private static void DelegateEquality()
-        {
-            // <SnippetDelegateEquality>
-            Action a = () => Console.WriteLine("a");
-
-            Action b = a + a;
-            Action c = a + a;
-            Console.WriteLine(object.ReferenceEquals(b, c));  // output: False
-            Console.WriteLine(b == c);  // output: True
-            // </SnippetDelegateEquality>
-        }
-
-        private static void IdenticalLambdasNotEqual()
-        {
-            // <SnippetIdenticalLambdas>
-            Action a = () => Console.WriteLine("a");
-            Action b = () => Console.WriteLine("a");
-
-            Console.WriteLine(a == b);  // output: False
-            Console.WriteLine(a + b == a + b);  // output: True
-            Console.WriteLine(b + a == a + b);  // output: False
-            // </SnippetIdenticalLambdas>
-        }
-
-        // <RecordTypesEquality>
-        public class RecordTypesEquality
-        {
-            public record Point(int X, int Y, string Name);
-            public record TaggedNumber(int Number, List<string> Tags);
-
-            public static void Main()
-            {
-                var p1 = new Point(2, 3, "A");
-                var p2 = new Point(1, 3, "B");
-                var p3 = new Point(2, 3, "A");
-
-                Console.WriteLine(p1 == p2);  // output: False
-                Console.WriteLine(p1 == p3);  // output: True
-
-                var n1 = new TaggedNumber(2, new List<string>() { "A" });
-                var n2 = new TaggedNumber(2, new List<string>() { "A" });
-                Console.WriteLine(n1 == n2);  // output: False
-            }
-        }
-        // </RecordTypesEquality>
+        Console.WriteLine("Non equality:");
+        NonEquality();
     }
+
+    private static void ValueTypesEquality()
+    {
+        // <SnippetValueTypesEquality>
+        int a = 1 + 2 + 3;
+        int b = 6;
+        Console.WriteLine(a == b);  // output: True
+
+        char c1 = 'a';
+        char c2 = 'A';
+        Console.WriteLine(c1 == c2);  // output: False
+        Console.WriteLine(c1 == char.ToLower(c2));  // output: True
+        // </SnippetValueTypesEquality>
+    }
+
+    private static void StringEquality()
+    {
+        // <SnippetStringEquality>
+        string s1 = "hello!";
+        string s2 = "HeLLo!";
+        Console.WriteLine(s1 == s2.ToLower());  // output: True
+
+        string s3 = "Hello!";
+        Console.WriteLine(s1 == s3);  // output: False
+        // </SnippetStringEquality>
+    }
+
+    // Rationale for the structure of the next snippet.
+    // A method cannot contain a class definition. Thus, a standard way to include snippet doesn't work.
+    // We want snippets to be interactive. Thus, the whole snippet has a structure of the console program.
+    // (Running the code without the ReferenceTypesEquality class doesn't produce any output in the interactive Output control.)
+
+    // <SnippetReferenceTypesEquality>
+    public class ReferenceTypesEquality
+    {
+        public class MyClass
+        {
+            private int id;
+
+            public MyClass(int id) => this.id = id;
+        }
+
+        public static void Main()
+        {
+            var a = new MyClass(1);
+            var b = new MyClass(1);
+            var c = a;
+            Console.WriteLine(a == b);  // output: False
+            Console.WriteLine(a == c);  // output: True
+        }
+    }
+    // </SnippetReferenceTypesEquality>
+
+    private static void NonEquality()
+    {
+        // <SnippetNonEquality>
+        int a = 1 + 1 + 2 + 3;
+        int b = 6;
+        Console.WriteLine(a != b);  // output: True
+
+        string s1 = "Hello";
+        string s2 = "Hello";
+        Console.WriteLine(s1 != s2);  // output: False
+
+        object o1 = 1;
+        object o2 = 1;
+        Console.WriteLine(o1 != o2);  // output: True
+        // </SnippetNonEquality>
+    }
+
+    private static void DelegateEquality()
+    {
+        // <SnippetDelegateEquality>
+        Action a = () => Console.WriteLine("a");
+
+        Action b = a + a;
+        Action c = a + a;
+        Console.WriteLine(object.ReferenceEquals(b, c));  // output: False
+        Console.WriteLine(b == c);  // output: True
+        // </SnippetDelegateEquality>
+    }
+
+    private static void IdenticalLambdasNotEqual()
+    {
+        // <SnippetIdenticalLambdas>
+        Action a = () => Console.WriteLine("a");
+        Action b = () => Console.WriteLine("a");
+
+        Console.WriteLine(a == b);  // output: False
+        Console.WriteLine(a + b == a + b);  // output: True
+        Console.WriteLine(b + a == a + b);  // output: False
+        // </SnippetIdenticalLambdas>
+    }
+
+    // <RecordTypesEquality>
+    public class RecordTypesEquality
+    {
+        public record Point(int X, int Y, string Name);
+        public record TaggedNumber(int Number, List<string> Tags);
+
+        public static void Main()
+        {
+            var p1 = new Point(2, 3, "A");
+            var p2 = new Point(1, 3, "B");
+            var p3 = new Point(2, 3, "A");
+
+            Console.WriteLine(p1 == p2);  // output: False
+            Console.WriteLine(p1 == p3);  // output: True
+
+            var n1 = new TaggedNumber(2, new List<string>() { "A" });
+            var n2 = new TaggedNumber(2, new List<string>() { "A" });
+            Console.WriteLine(n1 == n2);  // output: False
+        }
+    }
+    // </RecordTypesEquality>
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
@@ -1,76 +1,73 @@
-using System;
+﻿namespace operators;
 
-namespace operators
+public static class IsOperator
 {
-    public static class IsOperator
+    public static void Examples()
     {
-        public static void Examples()
+        DeclarationPattern();
+        IsFirstFridayOfOctober(DateTime.Now);
+        NullCheck(default(object));
+        NonNullCheck(new object());
+        ListPattern();
+    }
+
+    // <IntroExample>
+    static bool IsFirstFridayOfOctober(DateTime date) =>
+        date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
+    // </IntroExample>
+
+    private static void DeclarationPattern()
+    {
+        // <DeclarationPattern>
+        int i = 34;
+        object iBoxed = i;
+        int? jNullable = 42;
+        if (iBoxed is int a && jNullable is int b)
         {
-            DeclarationPattern();
-            IsFirstFridayOfOctober(DateTime.Now);
-            NullCheck(default(object));
-            NonNullCheck(new object());
-            ListPattern();
+            Console.WriteLine(a + b);  // output 76
         }
+        // </DeclarationPattern>
+    }
 
-        // <IntroExample>
-        static bool IsFirstFridayOfOctober(DateTime date) =>
-            date is { Month: 10, Day: <=7, DayOfWeek: DayOfWeek.Friday };
-        // </IntroExample>
-
-        private static void DeclarationPattern()
+    private static void NullCheck(object input)
+    {
+        // <NullCheck>
+        if (input is null)
         {
-            // <DeclarationPattern>
-            int i = 34;
-            object iBoxed = i;
-            int? jNullable = 42;
-            if (iBoxed is int a && jNullable is int b)
-            {
-                Console.WriteLine(a + b);  // output 76
-            }
-            // </DeclarationPattern>
+            return;
         }
+        // </NullCheck>
+    }
 
-        private static void NullCheck(object input)
+    private static void NonNullCheck(object result)
+    {
+        // <NonNullCheck>
+        if (result is not null)
         {
-            // <NullCheck>
-            if (input is null)
-            {
-                return;
-            }
-            // </NullCheck>
+            Console.WriteLine(result.ToString());
         }
+        // </NonNullCheck>
+    }
 
-        private static void NonNullCheck(object result)
-        {
-            // <NonNullCheck>
-            if (result is not null)
-            {
-                Console.WriteLine(result.ToString());
-            }
-            // </NonNullCheck>
-        }
+    private static void ListPattern()
+    {
+        // <ListPatterns>
+        int[] empty = { };
+        int[] one = { 1 };
+        int[] odd = { 1, 3, 5 };
+        int[] even = { 2, 4, 6 };
+        int[] fib = { 1, 1, 2, 3, 5 };
 
-        private static void ListPattern()
-        {
-            // <ListPatterns>
-            int[] empty = { };
-            int[] one = { 1 };
-            int[] odd = { 1, 3, 5 };
-            int[] even = { 2, 4, 6 };
-            int[] fib = { 1, 1, 2, 3, 5 };
+        Console.WriteLine(odd is [1, _, 2, ..]);   // false
+        Console.WriteLine(fib is [1, _, 2, ..]);   // true
+        Console.WriteLine(fib is [_, 1, 2, 3, ..]);     // true
+        Console.WriteLine(fib is [.., 1, 2, 3, _ ]);     // true
+        Console.WriteLine(even is [2, _, 6]);     // true
+        Console.WriteLine(even is [2, .., 6]);    // true
+        Console.WriteLine(odd is [.., 3, 5]); // true
+        Console.WriteLine(even is [.., 3, 5]); // false
+        Console.WriteLine(fib is [.., 3, 5]); // true
+        // </ListPatterns>
 
-            Console.WriteLine(odd is [1, _, 2, ..]);   // false
-            Console.WriteLine(fib is [1, _, 2, ..]);   // true
-            Console.WriteLine(fib is [_, 1, 2, 3, ..]);     // true
-            Console.WriteLine(fib is [.., 1, 2, 3, _ ]);     // true
-            Console.WriteLine(even is [2, _, 6]);     // true
-            Console.WriteLine(even is [2, .., 6]);    // true
-            Console.WriteLine(odd is [.., 3, 5]); // true
-            Console.WriteLine(even is [.., 3, 5]); // false
-            Console.WriteLine(fib is [.., 3, 5]); // true
-            // </ListPatterns>
-
-        }
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
@@ -1,47 +1,43 @@
-﻿using System;
-using System.Linq;
+﻿namespace operators;
 
-namespace operators
+public static class LambdaOperator
 {
-    public static class LambdaOperator
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            WithInferredTypes();
-            WithExplicitTypes();
-            WithoutInput();
-        }
+        WithInferredTypes();
+        WithExplicitTypes();
+        WithoutInput();
+    }
 
-        private static void WithInferredTypes()
-        {
-            // <SnippetInferredTypes>
-            string[] words = { "bot", "apple", "apricot" };
-            int minimalLength = words
-              .Where(w => w.StartsWith("a"))
-              .Min(w => w.Length);
-            Console.WriteLine(minimalLength);   // output: 5
+    private static void WithInferredTypes()
+    {
+        // <SnippetInferredTypes>
+        string[] words = { "bot", "apple", "apricot" };
+        int minimalLength = words
+          .Where(w => w.StartsWith("a"))
+          .Min(w => w.Length);
+        Console.WriteLine(minimalLength);   // output: 5
 
-            int[] numbers = { 4, 7, 10 };
-            int product = numbers.Aggregate(1, (interim, next) => interim * next);
-            Console.WriteLine(product);   // output: 280
-            // </SnippetInferredTypes>
-        }
+        int[] numbers = { 4, 7, 10 };
+        int product = numbers.Aggregate(1, (interim, next) => interim * next);
+        Console.WriteLine(product);   // output: 280
+        // </SnippetInferredTypes>
+    }
 
-        private static void WithExplicitTypes()
-        {
-            // <SnippetExplicitTypes>
-            int[] numbers = { 4, 7, 10 };
-            int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
-            Console.WriteLine(product);   // output: 280
-            // </SnippetExplicitTypes>
-        }
+    private static void WithExplicitTypes()
+    {
+        // <SnippetExplicitTypes>
+        int[] numbers = { 4, 7, 10 };
+        int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
+        Console.WriteLine(product);   // output: 280
+        // </SnippetExplicitTypes>
+    }
 
-        private static void WithoutInput()
-        {
-            // <SnippetWithoutInput>
-            Func<string> greet = () => "Hello, World!";
-            Console.WriteLine(greet());
-            // </SnippetWithoutInput>
-        }
+    private static void WithoutInput()
+    {
+        // <SnippetWithoutInput>
+        Func<string> greet = () => "Hello, World!";
+        Console.WriteLine(greet());
+        // </SnippetWithoutInput>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -1,193 +1,190 @@
-﻿using System;
-// <SnippetNestedNamespace>
+﻿// <SnippetNestedNamespace>
 using System.Collections.Generic;
 // </SnippetNestedNamespace>
-using System.Linq;
 
-namespace operators
+namespace operators;
+
+public static class MemberAccessOperators
 {
-    public static class MemberAccessOperators
+    public static void Examples()
     {
-        public static void Examples()
+        TypeMemberAccess();
+        Arrays();
+        Indexers();
+        NullConditional();
+        NullConditionalWithNullCoalescing();
+        Invocation();
+        IndexFromEnd();
+        Ranges();
+        RangesOptional();
+    }
+
+    private static void QualifiedName()
+    {
+        // <SnippetQualifiedName>
+        System.Collections.Generic.IEnumerable<int> numbers = new int[] { 1, 2, 3 };
+        // </SnippetQualifiedName>
+    }
+
+    private static void TypeMemberAccess()
+    {
+        // <SnippetTypeMemberAccess>
+        var constants = new List<double>();
+        constants.Add(Math.PI);
+        constants.Add(Math.E);
+        Console.WriteLine($"{constants.Count} values to show:");
+        Console.WriteLine(string.Join(", ", constants));
+        // Output:
+        // 2 values to show:
+        // 3.14159265358979, 2.71828182845905
+        // </SnippetTypeMemberAccess>
+    }
+
+    private static void Arrays()
+    {
+        // <SnippetArrays>
+        int[] fib = new int[10];
+        fib[0] = fib[1] = 1;
+        for (int i = 2; i < fib.Length; i++)
         {
-            TypeMemberAccess();
-            Arrays();
-            Indexers();
-            NullConditional();
-            NullConditionalWithNullCoalescing();
-            Invocation();
-            IndexFromEnd();
-            Ranges();
-            RangesOptional();
+            fib[i] = fib[i - 1] + fib[i - 2];
+        }
+        Console.WriteLine(fib[fib.Length - 1]);  // output: 55
+
+        double[,] matrix = new double[2,2];
+        matrix[0,0] = 1.0;
+        matrix[0,1] = 2.0;
+        matrix[1,0] = matrix[1,1] = 3.0;
+        var determinant = matrix[0,0] * matrix[1,1] - matrix[1,0] * matrix[0,1];
+        Console.WriteLine(determinant);  // output: -3
+        // </SnippetArrays>
+    }
+
+    private static void Indexers()
+    {
+        // <SnippetIndexers>
+        var dict = new Dictionary<string, double>();
+        dict["one"] = 1;
+        dict["pi"] = Math.PI;
+        Console.WriteLine(dict["one"] + dict["pi"]);  // output: 4.14159265358979
+        // </SnippetIndexers>
+    }
+
+    private static void NullConditional()
+    {
+        // <SnippetNullConditional>
+        double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
+        {
+            return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
         }
 
-        private static void QualifiedName()
-        {
-            // <SnippetQualifiedName>
-            System.Collections.Generic.IEnumerable<int> numbers = new int[] { 1, 2, 3 };
-            // </SnippetQualifiedName>
-        }
+        var sum1 = SumNumbers(null, 0);
+        Console.WriteLine(sum1);  // output: NaN
 
-        private static void TypeMemberAccess()
+        var numberSets = new List<double[]>
         {
-            // <SnippetTypeMemberAccess>
-            var constants = new List<double>();
-            constants.Add(Math.PI);
-            constants.Add(Math.E);
-            Console.WriteLine($"{constants.Count} values to show:");
-            Console.WriteLine(string.Join(", ", constants));
-            // Output:
-            // 2 values to show:
-            // 3.14159265358979, 2.71828182845905
-            // </SnippetTypeMemberAccess>
-        }
+            new[] { 1.0, 2.0, 3.0 },
+            null
+        };
 
-        private static void Arrays()
+        var sum2 = SumNumbers(numberSets, 0);
+        Console.WriteLine(sum2);  // output: 6
+
+        var sum3 = SumNumbers(numberSets, 1);
+        Console.WriteLine(sum3);  // output: NaN
+        // </SnippetNullConditional>
+    }
+
+    private static void NullConditionalWithNullCoalescing()
+    {
+        // <SnippetNullConditionalWithNullCoalescing>
+        int GetSumOfFirstTwoOrDefault(int[] numbers)
         {
-            // <SnippetArrays>
-            int[] fib = new int[10];
-            fib[0] = fib[1] = 1;
-            for (int i = 2; i < fib.Length; i++)
+            if ((numbers?.Length ?? 0) < 2)
             {
-                fib[i] = fib[i - 1] + fib[i - 2];
+                return 0;
             }
-            Console.WriteLine(fib[fib.Length - 1]);  // output: 55
-
-            double[,] matrix = new double[2,2];
-            matrix[0,0] = 1.0;
-            matrix[0,1] = 2.0;
-            matrix[1,0] = matrix[1,1] = 3.0;
-            var determinant = matrix[0,0] * matrix[1,1] - matrix[1,0] * matrix[0,1];
-            Console.WriteLine(determinant);  // output: -3
-            // </SnippetArrays>
+            return numbers[0] + numbers[1];
         }
 
-        private static void Indexers()
-        {
-            // <SnippetIndexers>
-            var dict = new Dictionary<string, double>();
-            dict["one"] = 1;
-            dict["pi"] = Math.PI;
-            Console.WriteLine(dict["one"] + dict["pi"]);  // output: 4.14159265358979
-            // </SnippetIndexers>
-        }
+        Console.WriteLine(GetSumOfFirstTwoOrDefault(null));  // output: 0
+        Console.WriteLine(GetSumOfFirstTwoOrDefault(new int[0]));  // output: 0
+        Console.WriteLine(GetSumOfFirstTwoOrDefault(new[] { 3, 4, 5 }));  // output: 7
+        // </SnippetNullConditionalWithNullCoalescing>
+    }
 
-        private static void NullConditional()
-        {
-            // <SnippetNullConditional>
-            double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
-            {
-                return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
-            }
+    private static void Invocation()
+    {
+        // <SnippetInvocation>
+        Action<int> display = s => Console.WriteLine(s);
 
-            var sum1 = SumNumbers(null, 0);
-            Console.WriteLine(sum1);  // output: NaN
+        var numbers = new List<int>();
+        numbers.Add(10);
+        numbers.Add(17);
+        display(numbers.Count);   // output: 2
 
-            var numberSets = new List<double[]>
-            {
-                new[] { 1.0, 2.0, 3.0 },
-                null
-            };
+        numbers.Clear();
+        display(numbers.Count);   // output: 0
+        // </SnippetInvocation>
+    }
 
-            var sum2 = SumNumbers(numberSets, 0);
-            Console.WriteLine(sum2);  // output: 6
+    private static void IndexFromEnd()
+    {
+        // <SnippetIndexFromEnd>
+        int[] xs = new[] { 0, 10, 20, 30, 40 };
+        int last = xs[^1];
+        Console.WriteLine(last);  // output: 40
 
-            var sum3 = SumNumbers(numberSets, 1);
-            Console.WriteLine(sum3);  // output: NaN
-            // </SnippetNullConditional>
-        }
+        var lines = new List<string> { "one", "two", "three", "four" };
+        string prelast = lines[^2];
+        Console.WriteLine(prelast);  // output: three
 
-        private static void NullConditionalWithNullCoalescing()
-        {
-            // <SnippetNullConditionalWithNullCoalescing>
-            int GetSumOfFirstTwoOrDefault(int[] numbers)
-            {
-                if ((numbers?.Length ?? 0) < 2)
-                {
-                    return 0;
-                }
-                return numbers[0] + numbers[1];
-            }
+        string word = "Twenty";
+        Index toFirst = ^word.Length;
+        char first = word[toFirst];
+        Console.WriteLine(first);  // output: T
+        // </SnippetIndexFromEnd>
+    }
 
-            Console.WriteLine(GetSumOfFirstTwoOrDefault(null));  // output: 0
-            Console.WriteLine(GetSumOfFirstTwoOrDefault(new int[0]));  // output: 0
-            Console.WriteLine(GetSumOfFirstTwoOrDefault(new[] { 3, 4, 5 }));  // output: 7
-            // </SnippetNullConditionalWithNullCoalescing>
-        }
+    private static void Ranges()
+    {
+        // <SnippetRanges>
+        int[] numbers = new[] { 0, 10, 20, 30, 40, 50 };
+        int start = 1;
+        int amountToTake = 3;
+        int[] subset = numbers[start..(start + amountToTake)];
+        Display(subset);  // output: 10 20 30
 
-        private static void Invocation()
-        {
-            // <SnippetInvocation>
-            Action<int> display = s => Console.WriteLine(s);
+        int margin = 1;
+        int[] inner = numbers[margin..^margin];
+        Display(inner);  // output: 10 20 30 40
 
-            var numbers = new List<int>();
-            numbers.Add(10);
-            numbers.Add(17);
-            display(numbers.Count);   // output: 2
+        string line = "one two three";
+        int amountToTakeFromEnd = 5;
+        Range endIndices = ^amountToTakeFromEnd..^0;
+        string end = line[endIndices];
+        Console.WriteLine(end);  // output: three
 
-            numbers.Clear();
-            display(numbers.Count);   // output: 0
-            // </SnippetInvocation>
-        }
+        void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
+        // </SnippetRanges>
+    }
 
-        private static void IndexFromEnd()
-        {
-            // <SnippetIndexFromEnd>
-            int[] xs = new[] { 0, 10, 20, 30, 40 };
-            int last = xs[^1];
-            Console.WriteLine(last);  // output: 40
+    private static void RangesOptional()
+    {
+        // <SnippetRangesOptional>
+        int[] numbers = new[] { 0, 10, 20, 30, 40, 50 };
+        int amountToDrop = numbers.Length / 2;
 
-            var lines = new List<string> { "one", "two", "three", "four" };
-            string prelast = lines[^2];
-            Console.WriteLine(prelast);  // output: three
+        int[] rightHalf = numbers[amountToDrop..];
+        Display(rightHalf);  // output: 30 40 50
 
-            string word = "Twenty";
-            Index toFirst = ^word.Length;
-            char first = word[toFirst];
-            Console.WriteLine(first);  // output: T
-            // </SnippetIndexFromEnd>
-        }
+        int[] leftHalf = numbers[..^amountToDrop];
+        Display(leftHalf);  // output: 0 10 20
 
-        private static void Ranges()
-        {
-            // <SnippetRanges>
-            int[] numbers = new[] { 0, 10, 20, 30, 40, 50 };
-            int start = 1;
-            int amountToTake = 3;
-            int[] subset = numbers[start..(start + amountToTake)];
-            Display(subset);  // output: 10 20 30
+        int[] all = numbers[..];
+        Display(all);  // output: 0 10 20 30 40 50
 
-            int margin = 1;
-            int[] inner = numbers[margin..^margin];
-            Display(inner);  // output: 10 20 30 40
-
-            string line = "one two three";
-            int amountToTakeFromEnd = 5;
-            Range endIndices = ^amountToTakeFromEnd..^0;
-            string end = line[endIndices];
-            Console.WriteLine(end);  // output: three
-
-            void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
-            // </SnippetRanges>
-        }
-
-        private static void RangesOptional()
-        {
-            // <SnippetRangesOptional>
-            int[] numbers = new[] { 0, 10, 20, 30, 40, 50 };
-            int amountToDrop = numbers.Length / 2;
-
-            int[] rightHalf = numbers[amountToDrop..];
-            Display(rightHalf);  // output: 30 40 50
-
-            int[] leftHalf = numbers[..^amountToDrop];
-            Display(leftHalf);  // output: 0 10 20
-
-            int[] all = numbers[..];
-            Display(all);  // output: 0 10 20 30 40 50
-
-            void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
-            // </SnippetRangesOptional>
-        }
+        void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
+        // </SnippetRangesOptional>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators2.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators2.cs
@@ -1,38 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace MemberAccessOperators2;
 
-namespace MemberAccessOperators2
+public static class NullConditionalShortCircuiting
 {
-    public static class NullConditionalShortCircuiting
+    public static void Main()
     {
-        public static void Main()
+        Person person = null;
+        person?.Name.Write(); // no output: Write() is not called due to short-circuit.
+        try
         {
-            Person person = null;
-            person?.Name.Write(); // no output: Write() is not called due to short-circuit.
-            try
-            {
-                (person?.Name).Write();
-            }
-            catch (NullReferenceException)
-            {
-                Console.WriteLine("NullReferenceException");
-            }; // output: NullReferenceException
+            (person?.Name).Write();
         }
-    }
-
-    public class Person
-    {
-        public FullName Name { get; set; }
-    }
-
-    public class FullName
-    {
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public void Write()
+        catch (NullReferenceException)
         {
-            Console.WriteLine($"{FirstName} {LastName}");
-        }
+            Console.WriteLine("NullReferenceException");
+        }; // output: NullReferenceException
+    }
+}
+
+public class Person
+{
+    public FullName Name { get; set; }
+}
+
+public class FullName
+{
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public void Write()
+    {
+        Console.WriteLine($"{FirstName} {LastName}");
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/NameOfOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NameOfOperator.cs
@@ -1,41 +1,55 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace operators;
 
-namespace operators
+public static class NameOfOperator
 {
-    public static class NameOfOperator
+    public static void Examples()
     {
-        public static void Examples()
+        // <SnippetExamples>
+        Console.WriteLine(nameof(System.Collections.Generic));  // output: Generic
+        Console.WriteLine(nameof(List<int>));  // output: List
+        Console.WriteLine(nameof(List<int>.Count));  // output: Count
+        Console.WriteLine(nameof(List<int>.Add));  // output: Add
+
+        var numbers = new List<int> { 1, 2, 3 };
+        Console.WriteLine(nameof(numbers));  // output: numbers
+        Console.WriteLine(nameof(numbers.Count));  // output: Count
+        Console.WriteLine(nameof(numbers.Add));  // output: Add
+        // </SnippetExamples>
+
+        // <SnippetVerbatim>
+        var @new = 5;
+        Console.WriteLine(nameof(@new));  // output: new
+        // </SnippetVerbatim>
+    }
+
+    // <SnippetNameOfParameter>
+    [ParameterString(nameof(msg))]
+    public static void Method( string msg)
+    {
+        [ParameterString(nameof(param))]
+        void LocalFunction(string param) { }
+
+        var lambdaExpression = [ParameterString(nameof(aNumber))] (int aNumber) => aNumber.ToString();
+
+    }
+    // </SnippetNameOfParameter>
+
+    public class ParameterStringAttribute : Attribute
+    {
+        public ParameterStringAttribute(string parameterName) { }
+
+    }
+
+    private class Person
+    {
+        string name;
+
+        // <SnippetExceptionMessage>
+        public string Name
         {
-            // <SnippetExamples>
-            Console.WriteLine(nameof(System.Collections.Generic));  // output: Generic
-            Console.WriteLine(nameof(List<int>));  // output: List
-            Console.WriteLine(nameof(List<int>.Count));  // output: Count
-            Console.WriteLine(nameof(List<int>.Add));  // output: Add
-
-            var numbers = new List<int> { 1, 2, 3 };
-            Console.WriteLine(nameof(numbers));  // output: numbers
-            Console.WriteLine(nameof(numbers.Count));  // output: Count
-            Console.WriteLine(nameof(numbers.Add));  // output: Add
-            // </SnippetExamples>
-
-            // <SnippetVerbatim>
-            var @new = 5;
-            Console.WriteLine(nameof(@new));  // output: new
-            // </SnippetVerbatim>
+            get => name;
+            set => name = value ?? throw new ArgumentNullException(nameof(value), $"{nameof(Name)} cannot be null");
         }
-
-        private class Person
-        {
-            string name;
-
-            // <SnippetExceptionMessage>
-            public string Name
-            {
-                get => name;
-                set => name = value ?? throw new ArgumentNullException(nameof(value), $"{nameof(Name)} cannot be null");
-            }
-            // </SnippetExceptionMessage>
-        }
+        // </SnippetExceptionMessage>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/NewOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NewOperator.cs
@@ -1,98 +1,93 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace operators;
 
-namespace operators
+public static class NewOperator
 {
-    public static class NewOperator
+    public static void Examples()
     {
-        public static void Examples()
+        Constructor();
+        ConstructorWithInitializer();
+        Array();
+        ArrayInitialization();
+        AnonymousType();
+    }
+
+    private static void Constructor()
+    {
+        // <SnippetConstructor>
+        var dict = new Dictionary<string, int>();
+        dict["first"] = 10;
+        dict["second"] = 20;
+        dict["third"] = 30;
+
+        Console.WriteLine(string.Join("; ", dict.Select(entry => $"{entry.Key}: {entry.Value}")));
+        // Output:
+        // first: 10; second: 20; third: 30
+        // </SnippetConstructor>
+    }
+
+    private static void ConstructorWithInitializer()
+    {
+        // <SnippetConstructorWithInitializer>
+        var dict = new Dictionary<string, int>
         {
-            Constructor();
-            ConstructorWithInitializer();
-            Array();
-            ArrayInitialization();
-            AnonymousType();
-        }
+            ["first"] = 10,
+            ["second"] = 20,
+            ["third"] = 30
+        };
 
-        private static void Constructor()
+        Console.WriteLine(string.Join("; ", dict.Select(entry => $"{entry.Key}: {entry.Value}")));
+        // Output:
+        // first: 10; second: 20; third: 30
+        // </SnippetConstructorWithInitializer>
+    }
+
+    private static void TargetTyped()
+    {
+        // <SnippetTargetTyped>
+        List<int> xs = new();
+        List<int> ys = new(capacity: 10_000);
+        List<int> zs = new() { Capacity = 20_000 };
+
+        Dictionary<int, List<int>> lookup = new()
         {
-            // <SnippetConstructor>
-            var dict = new Dictionary<string, int>();
-            dict["first"] = 10;
-            dict["second"] = 20;
-            dict["third"] = 30;
+            [1] = new() { 1, 2, 3 },
+            [2] = new() { 5, 8, 3 },
+            [5] = new() { 1, 0, 4 }
+        };
+        // </SnippetTargetTyped>
+    }
 
-            Console.WriteLine(string.Join("; ", dict.Select(entry => $"{entry.Key}: {entry.Value}")));
-            // Output:
-            // first: 10; second: 20; third: 30
-            // </SnippetConstructor>
-        }
+    private static void Array()
+    {
+        // <SnippetArray>
+        var numbers = new int[3];
+        numbers[0] = 10;
+        numbers[1] = 20;
+        numbers[2] = 30;
 
-        private static void ConstructorWithInitializer()
-        {
-            // <SnippetConstructorWithInitializer>
-            var dict = new Dictionary<string, int>
-            {
-                ["first"] = 10,
-                ["second"] = 20,
-                ["third"] = 30
-            };
+        Console.WriteLine(string.Join(", ", numbers));
+        // Output:
+        // 10, 20, 30
+        // </SnippetArray>
+    }
 
-            Console.WriteLine(string.Join("; ", dict.Select(entry => $"{entry.Key}: {entry.Value}")));
-            // Output:
-            // first: 10; second: 20; third: 30
-            // </SnippetConstructorWithInitializer>
-        }
+    private static void ArrayInitialization()
+    {
+        // <SnippetArrayInitialization>
+        var a = new int[3] { 10, 20, 30 };
+        var b = new int[] { 10, 20, 30 };
+        var c = new[] { 10, 20, 30 };
+        Console.WriteLine(c.GetType());  // output: System.Int32[]
+        // </SnippetArrayInitialization>
+    }
 
-        private static void TargetTyped()
-        {
-            // <SnippetTargetTyped>
-            List<int> xs = new();
-            List<int> ys = new(capacity: 10_000);
-            List<int> zs = new() { Capacity = 20_000 };
-
-            Dictionary<int, List<int>> lookup = new()
-            {
-                [1] = new() { 1, 2, 3 },
-                [2] = new() { 5, 8, 3 },
-                [5] = new() { 1, 0, 4 }
-            };
-            // </SnippetTargetTyped>
-        }
-
-        private static void Array()
-        {
-            // <SnippetArray>
-            var numbers = new int[3];
-            numbers[0] = 10;
-            numbers[1] = 20;
-            numbers[2] = 30;
-
-            Console.WriteLine(string.Join(", ", numbers));
-            // Output:
-            // 10, 20, 30
-            // </SnippetArray>
-        }
-
-        private static void ArrayInitialization()
-        {
-            // <SnippetArrayInitialization>
-            var a = new int[3] { 10, 20, 30 };
-            var b = new int[] { 10, 20, 30 };
-            var c = new[] { 10, 20, 30 };
-            Console.WriteLine(c.GetType());  // output: System.Int32[]
-            // </SnippetArrayInitialization>
-        }
-
-        private static void AnonymousType()
-        {
-            // <SnippetAnonymousType>
-            var example = new { Greeting = "Hello", Name = "World" };
-            Console.WriteLine($"{example.Greeting}, {example.Name}!");
-            // Output:
-            // Hello, World!
-            // </SnippetAnonymousType>
-        }
+    private static void AnonymousType()
+    {
+        // <SnippetAnonymousType>
+        var example = new { Greeting = "Hello", Name = "World" };
+        Console.WriteLine($"{example.Greeting}, {example.Name}!");
+        // Output:
+        // Hello, World!
+        // </SnippetAnonymousType>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
@@ -1,73 +1,68 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace operators;
 
-namespace operators
+public static class NullCoalescingOperator
 {
-    public static class NullCoalescingOperator
+    public static void Examples()
     {
-        public static void Examples()
+        WithNullConditional();
+        WithNullableTypes();
+        NullCoalescingAssignment();
+    }
+
+    private static void WithNullConditional()
+    {
+        // <SnippetWithNullConditional>
+        double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
         {
-            WithNullConditional();
-            WithNullableTypes();
-            NullCoalescingAssignment();
+            return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
         }
 
-        private static void WithNullConditional()
+        var sum = SumNumbers(null, 0);
+        Console.WriteLine(sum);  // output: NaN
+        // </SnippetWithNullConditional>
+    }
+
+    private static void WithNullableTypes()
+    {
+        // <SnippetWithNullableTypes>
+        int? a = null;
+        int b = a ?? -1;
+        Console.WriteLine(b);  // output: -1
+        // </SnippetWithNullableTypes>
+    }
+
+    private class Person
+    {
+        string name;
+
+        // <SnippetWithThrowExpression>
+        public string Name
         {
-            // <SnippetWithNullConditional>
-            double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
-            {
-                return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
-            }
-
-            var sum = SumNumbers(null, 0);
-            Console.WriteLine(sum);  // output: NaN
-            // </SnippetWithNullConditional>
+            get => name;
+            set => name = value ?? throw new ArgumentNullException(nameof(value), "Name cannot be null");
         }
+        // </SnippetWithThrowExpression>
+    }
 
-        private static void WithNullableTypes()
-        {
-            // <SnippetWithNullableTypes>
-            int? a = null;
-            int b = a ?? -1;
-            Console.WriteLine(b);  // output: -1
-            // </SnippetWithNullableTypes>
-        }
+    // <SnippetUnconstrainedType>
+    private static void Display<T>(T a, T backup)
+    {
+        Console.WriteLine(a ?? backup);
+    }
+    // </SnippetUnconstrainedType>
 
-        private class Person
-        {
-            string name;
+    private static void NullCoalescingAssignment()
+    {
+        // <SnippetAssignment>
+        List<int> numbers = null;
+        int? a = null;
 
-            // <SnippetWithThrowExpression>
-            public string Name
-            {
-                get => name;
-                set => name = value ?? throw new ArgumentNullException(nameof(value), "Name cannot be null");
-            }
-            // </SnippetWithThrowExpression>
-        }
+        (numbers ??= new List<int>()).Add(5);
+        Console.WriteLine(string.Join(" ", numbers));  // output: 5
 
-        // <SnippetUnconstrainedType>
-        private static void Display<T>(T a, T backup)
-        {
-            Console.WriteLine(a ?? backup);
-        }
-        // </SnippetUnconstrainedType>
-
-        private static void NullCoalescingAssignment()
-        {
-            // <SnippetAssignment>
-            List<int> numbers = null;
-            int? a = null;
-
-            (numbers ??= new List<int>()).Add(5);
-            Console.WriteLine(string.Join(" ", numbers));  // output: 5
-
-            numbers.Add(a ??= 0);
-            Console.WriteLine(string.Join(" ", numbers));  // output: 5 0
-            Console.WriteLine(a);  // output: 0
-            // </SnippetAssignment>
-        }
+        numbers.Add(a ??= 0);
+        Console.WriteLine(string.Join(" ", numbers));  // output: 5 0
+        Console.WriteLine(a);  // output: 0
+        // </SnippetAssignment>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/NullForgivingOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullForgivingOperator.cs
@@ -1,66 +1,64 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace operators
+namespace operators;
+
+// <SnippetPersonClass>
+#nullable enable
+public class Person
 {
-    // <SnippetPersonClass>
-    #nullable enable
-    public class Person
-    {
-        public Person(string name) => Name = name ?? throw new ArgumentNullException(nameof(name));
+    public Person(string name) => Name = name ?? throw new ArgumentNullException(nameof(name));
 
-        public string Name { get; }
+    public string Name { get; }
+}
+// </SnippetPersonClass>
+
+[TestClass]
+public class PersonTests
+{
+    // <SnippetTestPerson>
+    [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+    public void NullNameShouldThrowTest()
+    {
+        var person = new Person(null!);
     }
-    // </SnippetPersonClass>
+    // </SnippetTestPerson>
+}
 
-    [TestClass]
-    public class PersonTests
+public static class UseNullForgivingExample
+{
+    // <SnippetUseNullForgiving>
+    public static void Main()
     {
-        // <SnippetTestPerson>
-        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
-        public void NullNameShouldThrowTest()
+        Person? p = Find("John");
+        if (IsValid(p))
         {
-            var person = new Person(null!);
+            Console.WriteLine($"Found {p!.Name}");
         }
-        // </SnippetTestPerson>
     }
 
-    public static class UseNullForgivingExample
+    public static bool IsValid(Person? person)
+        => person is not null && person.Name is not null;
+    // </SnippetUseNullForgiving>
+
+    public static Person? Find(string name) => null;
+}
+
+public static class UseAttributeExample
+{
+    // <SnippetUseAttribute>
+    public static void Main()
     {
-        // <SnippetUseNullForgiving>
-        public static void Main()
+        Person? p = Find("John");
+        if (IsValid(p))
         {
-            Person? p = Find("John");
-            if (IsValid(p))
-            {
-                Console.WriteLine($"Found {p!.Name}");
-            }
+            Console.WriteLine($"Found {p.Name}");
         }
-
-        public static bool IsValid(Person? person)
-            => person is not null && person.Name is not null;
-        // </SnippetUseNullForgiving>
-
-        public static Person? Find(string name) => null;
     }
 
-    public static class UseAttributeExample
-    {
-        // <SnippetUseAttribute>
-        public static void Main()
-        {
-            Person? p = Find("John");
-            if (IsValid(p))
-            {
-                Console.WriteLine($"Found {p.Name}");
-            }
-        }
+    public static bool IsValid([NotNullWhen(true)] Person? person)
+        => person is not null && person.Name is not null;
+    // </SnippetUseAttribute>
 
-        public static bool IsValid([NotNullWhen(true)] Person? person)
-            => person is not null && person.Name is not null;
-        // </SnippetUseAttribute>
-
-        public static Person? Find(string name) => null;
-    }
+    public static Person? Find(string name) => null;
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/OperatorOverloading.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/OperatorOverloading.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-public readonly struct Fraction
+﻿public readonly struct Fraction
 {
     private readonly int num;
     private readonly int den;

--- a/docs/csharp/language-reference/operators/snippets/shared/Overview.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/Overview.cs
@@ -1,73 +1,68 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace operators;
 
-namespace operators
+public static class Overview
 {
-    public static class Overview
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            GeneralExamples();
-            InterpolatedString();
-            Lambda();
-            Query();
-        }
+        GeneralExamples();
+        InterpolatedString();
+        Lambda();
+        Query();
+    }
 
-        private static void GeneralExamples()
-        {
-            // <SnippetExpressions>
-            int a, b, c;
-            a = 7;
-            b = a;
-            c = b++;
-            b = a + b * c;
-            c = a >= 100 ? b : c / 10;
-            a = (int)Math.Sqrt(b * b + c * c);
-            
-            string s = "String literal";
-            char l = s[s.Length - 1];
-            
-            var numbers = new List<int>(new[] { 1, 2, 3 });
-            b = numbers.FindLast(n => n > 1);
-            // </SnippetExpressions>
-        }
+    private static void GeneralExamples()
+    {
+        // <SnippetExpressions>
+        int a, b, c;
+        a = 7;
+        b = a;
+        c = b++;
+        b = a + b * c;
+        c = a >= 100 ? b : c / 10;
+        a = (int)Math.Sqrt(b * b + c * c);
+        
+        string s = "String literal";
+        char l = s[s.Length - 1];
+        
+        var numbers = new List<int>(new[] { 1, 2, 3 });
+        b = numbers.FindLast(n => n > 1);
+        // </SnippetExpressions>
+    }
 
-        private static void InterpolatedString()
-        {
-            // <SnippetInterpolatedString>
-            var r = 2.3;
-            var message = $"The area of a circle with radius {r} is {Math.PI * r * r:F3}.";
-            Console.WriteLine(message);
-            // Output:
-            // The area of a circle with radius 2.3 is 16.619.
-            // </SnippetInterpolatedString>
-        }
+    private static void InterpolatedString()
+    {
+        // <SnippetInterpolatedString>
+        var r = 2.3;
+        var message = $"The area of a circle with radius {r} is {Math.PI * r * r:F3}.";
+        Console.WriteLine(message);
+        // Output:
+        // The area of a circle with radius 2.3 is 16.619.
+        // </SnippetInterpolatedString>
+    }
 
-        private static void Lambda()
-        {
-            // <SnippetLambda>
-            int[] numbers = { 2, 3, 4, 5 };
-            var maximumSquare = numbers.Max(x => x * x);
-            Console.WriteLine(maximumSquare);
-            // Output:
-            // 25
-            // </SnippetLambda>
-        }
+    private static void Lambda()
+    {
+        // <SnippetLambda>
+        int[] numbers = { 2, 3, 4, 5 };
+        var maximumSquare = numbers.Max(x => x * x);
+        Console.WriteLine(maximumSquare);
+        // Output:
+        // 25
+        // </SnippetLambda>
+    }
 
-        private static void Query()
-        {
-            // <SnippetQuery>
-            var scores = new[] { 90, 97, 78, 68, 85 };
-            IEnumerable<int> highScoresQuery =
-                from score in scores
-                where score > 80
-                orderby score descending
-                select score;
-            Console.WriteLine(string.Join(" ", highScoresQuery));
-            // Output:
-            // 97 90 85
-            // </SnippetQuery>
-        }
+    private static void Query()
+    {
+        // <SnippetQuery>
+        var scores = new[] { 90, 97, 78, 68, 85 };
+        IEnumerable<int> highScoresQuery =
+            from score in scores
+            where score > 80
+            orderby score descending
+            select score;
+        Console.WriteLine(string.Join(" ", highScoresQuery));
+        // Output:
+        // 97 90 85
+        // </SnippetQuery>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/PointerOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/PointerOperators.cs
@@ -1,170 +1,167 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class PointerOperators
 {
-    public static class PointerOperators
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            AddressOf();
-            PointerIndirection();
-            PointerMemberAccessExample.Main();
-            PointerElementAccess();
-            PointerAddition();
-            PointerSubtraction();
-            Increment();
-        }
+        AddressOf();
+        PointerIndirection();
+        PointerMemberAccessExample.Main();
+        PointerElementAccess();
+        PointerAddition();
+        PointerSubtraction();
+        Increment();
+    }
 
-        private static void AddressOf()
+    private static void AddressOf()
+    {
+        // <SnippetAddressOf>
+        unsafe
         {
-            // <SnippetAddressOf>
-            unsafe
+            int number = 27;
+            int* pointerToNumber = &number;
+
+            Console.WriteLine($"Value of the variable: {number}");
+            Console.WriteLine($"Address of the variable: {(long)pointerToNumber:X}");
+        }
+        // Output is similar to:
+        // Value of the variable: 27
+        // Address of the variable: 6C1457DBD4
+        // </SnippetAddressOf>
+    }
+
+    private static void AddressOfFixed()
+    {
+        // <SnippetAddressOfFixed>
+        unsafe
+        {
+            byte[] bytes = { 1, 2, 3 };
+            fixed (byte* pointerToFirst = &bytes[0])
             {
-                int number = 27;
-                int* pointerToNumber = &number;
-
-                Console.WriteLine($"Value of the variable: {number}");
-                Console.WriteLine($"Address of the variable: {(long)pointerToNumber:X}");
-            }
-            // Output is similar to:
-            // Value of the variable: 27
-            // Address of the variable: 6C1457DBD4
-            // </SnippetAddressOf>
-        }
-
-        private static void AddressOfFixed()
-        {
-            // <SnippetAddressOfFixed>
-            unsafe
-            {
-                byte[] bytes = { 1, 2, 3 };
-                fixed (byte* pointerToFirst = &bytes[0])
-                {
-                    // The address stored in pointerToFirst
-                    // is valid only inside this fixed statement block.
-                }
-            }
-            // </SnippetAddressOfFixed>
-        }
-
-        private static void PointerIndirection()
-        {
-            // <SnippetPointerIndirection>
-            unsafe
-            {
-                char letter = 'A';
-                char* pointerToLetter = &letter;
-                Console.WriteLine($"Value of the `letter` variable: {letter}");
-                Console.WriteLine($"Address of the `letter` variable: {(long)pointerToLetter:X}");
-
-                *pointerToLetter = 'Z';
-                Console.WriteLine($"Value of the `letter` variable after update: {letter}");
-            }
-            // Output is similar to:
-            // Value of the `letter` variable: A
-            // Address of the `letter` variable: DCB977DDF4
-            // Value of the `letter` variable after update: Z
-            // </SnippetPointerIndirection>
-        }
-
-        // <SnippetMemberAccess>
-        public struct Coords
-        {
-            public int X;
-            public int Y;
-            public override string ToString() => $"({X}, {Y})";
-        }
-
-        public class PointerMemberAccessExample
-        {
-            public static unsafe void Main()
-            {
-                Coords coords;
-                Coords* p = &coords;
-                p->X = 3;
-                p->Y = 4;
-                Console.WriteLine(p->ToString());  // output: (3, 4)
+                // The address stored in pointerToFirst
+                // is valid only inside this fixed statement block.
             }
         }
-        // </SnippetMemberAccess>
+        // </SnippetAddressOfFixed>
+    }
 
-        private static void PointerElementAccess()
+    private static void PointerIndirection()
+    {
+        // <SnippetPointerIndirection>
+        unsafe
         {
-            // <SnippetElementAccess>
-            unsafe
-            {
-                char* pointerToChars = stackalloc char[123];
+            char letter = 'A';
+            char* pointerToLetter = &letter;
+            Console.WriteLine($"Value of the `letter` variable: {letter}");
+            Console.WriteLine($"Address of the `letter` variable: {(long)pointerToLetter:X}");
 
-                for (int i = 65; i < 123; i++)
-                {
-                    pointerToChars[i] = (char)i;
-                }
-
-                Console.Write("Uppercase letters: ");
-                for (int i = 65; i < 91; i++)
-                {
-                    Console.Write(pointerToChars[i]);
-                }
-            }
-            // Output:
-            // Uppercase letters: ABCDEFGHIJKLMNOPQRSTUVWXYZ
-            // </SnippetElementAccess>
-            Console.WriteLine();
+            *pointerToLetter = 'Z';
+            Console.WriteLine($"Value of the `letter` variable after update: {letter}");
         }
+        // Output is similar to:
+        // Value of the `letter` variable: A
+        // Address of the `letter` variable: DCB977DDF4
+        // Value of the `letter` variable after update: Z
+        // </SnippetPointerIndirection>
+    }
 
-        private static void PointerAddition()
+    // <SnippetMemberAccess>
+    public struct Coords
+    {
+        public int X;
+        public int Y;
+        public override string ToString() => $"({X}, {Y})";
+    }
+
+    public class PointerMemberAccessExample
+    {
+        public static unsafe void Main()
         {
-            // <SnippetAddNumber>
-            unsafe
-            {
-                const int Count = 3;
-                int[] numbers = new int[Count] { 10, 20, 30 };
-                fixed (int* pointerToFirst = &numbers[0])
-                {
-                    int* pointerToLast = pointerToFirst + (Count - 1);
-
-                    Console.WriteLine($"Value {*pointerToFirst} at address {(long)pointerToFirst}");
-                    Console.WriteLine($"Value {*pointerToLast} at address {(long)pointerToLast}");
-                }
-            }
-            // Output is similar to:
-            // Value 10 at address 1818345918136
-            // Value 30 at address 1818345918144
-            // </SnippetAddNumber>
+            Coords coords;
+            Coords* p = &coords;
+            p->X = 3;
+            p->Y = 4;
+            Console.WriteLine(p->ToString());  // output: (3, 4)
         }
+    }
+    // </SnippetMemberAccess>
 
-        private static void PointerSubtraction()
+    private static void PointerElementAccess()
+    {
+        // <SnippetElementAccess>
+        unsafe
         {
-            // <SnippetSubtractPointers>
-            unsafe
-            {
-                int* numbers = stackalloc int[] { 0, 1, 2, 3, 4, 5 };
-                int* p1 = &numbers[1];
-                int* p2 = &numbers[5];
-                Console.WriteLine(p2 - p1);  // output: 4
-            }
-            // </SnippetSubtractPointers>
-        }
+            char* pointerToChars = stackalloc char[123];
 
-        private static void Increment()
-        {
-            // <SnippetIncrement>
-            unsafe
+            for (int i = 65; i < 123; i++)
             {
-                int* numbers = stackalloc int[] { 0, 1, 2 };
-                int* p1 = &numbers[0];
-                int* p2 = p1;
-                Console.WriteLine($"Before operation: p1 - {(long)p1}, p2 - {(long)p2}");
-                Console.WriteLine($"Postfix increment of p1: {(long)(p1++)}");
-                Console.WriteLine($"Prefix increment of p2: {(long)(++p2)}");
-                Console.WriteLine($"After operation: p1 - {(long)p1}, p2 - {(long)p2}");
+                pointerToChars[i] = (char)i;
             }
-            // Output is similar to
-            // Before operation: p1 - 816489946512, p2 - 816489946512
-            // Postfix increment of p1: 816489946512
-            // Prefix increment of p2: 816489946516
-            // After operation: p1 - 816489946516, p2 - 816489946516
-            // </SnippetIncrement>
+
+            Console.Write("Uppercase letters: ");
+            for (int i = 65; i < 91; i++)
+            {
+                Console.Write(pointerToChars[i]);
+            }
         }
+        // Output:
+        // Uppercase letters: ABCDEFGHIJKLMNOPQRSTUVWXYZ
+        // </SnippetElementAccess>
+        Console.WriteLine();
+    }
+
+    private static void PointerAddition()
+    {
+        // <SnippetAddNumber>
+        unsafe
+        {
+            const int Count = 3;
+            int[] numbers = new int[Count] { 10, 20, 30 };
+            fixed (int* pointerToFirst = &numbers[0])
+            {
+                int* pointerToLast = pointerToFirst + (Count - 1);
+
+                Console.WriteLine($"Value {*pointerToFirst} at address {(long)pointerToFirst}");
+                Console.WriteLine($"Value {*pointerToLast} at address {(long)pointerToLast}");
+            }
+        }
+        // Output is similar to:
+        // Value 10 at address 1818345918136
+        // Value 30 at address 1818345918144
+        // </SnippetAddNumber>
+    }
+
+    private static void PointerSubtraction()
+    {
+        // <SnippetSubtractPointers>
+        unsafe
+        {
+            int* numbers = stackalloc int[] { 0, 1, 2, 3, 4, 5 };
+            int* p1 = &numbers[1];
+            int* p2 = &numbers[5];
+            Console.WriteLine(p2 - p1);  // output: 4
+        }
+        // </SnippetSubtractPointers>
+    }
+
+    private static void Increment()
+    {
+        // <SnippetIncrement>
+        unsafe
+        {
+            int* numbers = stackalloc int[] { 0, 1, 2 };
+            int* p1 = &numbers[0];
+            int* p2 = p1;
+            Console.WriteLine($"Before operation: p1 - {(long)p1}, p2 - {(long)p2}");
+            Console.WriteLine($"Postfix increment of p1: {(long)(p1++)}");
+            Console.WriteLine($"Prefix increment of p2: {(long)(++p2)}");
+            Console.WriteLine($"After operation: p1 - {(long)p1}, p2 - {(long)p2}");
+        }
+        // Output is similar to
+        // Before operation: p1 - 816489946512, p2 - 816489946512
+        // Postfix increment of p1: 816489946512
+        // Prefix increment of p2: 816489946516
+        // After operation: p1 - 816489946516, p2 - 816489946516
+        // </SnippetIncrement>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/Program.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/Program.cs
@@ -1,120 +1,110 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using operators;
 
-namespace operators
-{
-    class Program
-    {
-        static async Task Main(string[] args)
-        {
-            Console.WriteLine("============== Overview ========================");
-            Overview.Examples();
-            Console.WriteLine();
+Console.WriteLine("============== Overview ========================");
+Overview.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("======== Arithmetic operators examples =========");
-            ArithmeticOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("======== Arithmetic operators examples =========");
+ArithmeticOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============= == and != operators examples =====");
-            EqualityOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("============= == and != operators examples =====");
+EqualityOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("======== Logical operators examples ============");
-            BooleanLogicalOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("======== Logical operators examples ============");
+BooleanLogicalOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("==== Bitwise and shift operators examples ======");
-            BitwiseAndShiftOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("==== Bitwise and shift operators examples ======");
+BitwiseAndShiftOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("====== >, <, >=, and <= operators examples =====");
-            ComparisonOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("====== >, <, >=, and <= operators examples =====");
+ComparisonOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("========= Member access operators examples =====");
-            MemberAccessOperators.Examples();
-            MemberAccessOperators2.NullConditionalShortCircuiting.Main();
-            Console.WriteLine();
+Console.WriteLine("========= Member access operators examples =====");
+MemberAccessOperators.Examples();
+MemberAccessOperators2.NullConditionalShortCircuiting.Main();
+Console.WriteLine();
 
-            Console.WriteLine("======= Pointer related operators examples =====");
-            PointerOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("======= Pointer related operators examples =====");
+PointerOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("= Type-testing and conversion operators examples");
-            TypeTestingAndConversionOperators.Examples();
-            Console.WriteLine();
+Console.WriteLine("= Type-testing and conversion operators examples");
+TypeTestingAndConversionOperators.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============== = operator examples =============");
-            AssignmentOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============== = operator examples =============");
+AssignmentOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============== + operator examples =============");
-            AdditionOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============== + operator examples =============");
+AdditionOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============== - operator examples =============");
-            SubtractionOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============== - operator examples =============");
+SubtractionOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============== ?: operator examples ============");
-            ConditionalOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============== ?: operator examples ============");
+ConditionalOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("========== ?? and ??= operators examples =======");
-            NullCoalescingOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("========== ?? and ??= operators examples =======");
+NullCoalescingOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============== => operator examples ============");
-            LambdaOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============== => operator examples ============");
+LambdaOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("=============== await operator examples ========");
-            await AwaitOperator.Main();
-            Console.WriteLine();
+Console.WriteLine("=============== await operator examples ========");
+await AwaitOperator.Main();
+Console.WriteLine();
 
-            Console.WriteLine("=========== default operator examples ==========");
-            DefaultOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("=========== default operator examples ==========");
+DefaultOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("========== delegate operator examples ==========");
-            DelegateOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("========== delegate operator examples ==========");
+DelegateOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("=========== nameof operator examples ===========");
-            NameOfOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("=========== nameof operator examples ===========");
+NameOfOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============= new operator examples ============");
-            NewOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============= new operator examples ============");
+NewOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("=============== sizeof operator examples =======");
-            SizeOfOperator.Main();
-            Console.WriteLine();
+Console.WriteLine("=============== sizeof operator examples =======");
+SizeOfOperator.Main();
+Console.WriteLine();
 
-            Console.WriteLine("============ stackalloc operator examples ======");
-            StackallocOperator.Examples();
-            Console.WriteLine();
+Console.WriteLine("============ stackalloc operator examples ======");
+StackallocOperator.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("========= true and false operators examples ====");
-            LaunchStatusTest.Main();
-            Console.WriteLine();
+Console.WriteLine("========= true and false operators examples ====");
+LaunchStatusTest.Main();
+Console.WriteLine();
 
-            Console.WriteLine("========= operator overloading example =========");
-            OperatorOverloading.Main();
-            Console.WriteLine();
+Console.WriteLine("========= operator overloading example =========");
+OperatorOverloading.Main();
+Console.WriteLine();
 
-            Console.WriteLine("========= conversion operators example =========");
-            UserDefinedConversions.Main();
-            Console.WriteLine();
+Console.WriteLine("========= conversion operators example =========");
+UserDefinedConversions.Main();
+Console.WriteLine();
 
-            Console.WriteLine("========= switch expression example ============");
-            SwitchExpressions.Examples();
-            Console.WriteLine();
+Console.WriteLine("========= switch expression example ============");
+SwitchExpressions.Examples();
+Console.WriteLine();
 
-            Console.WriteLine("============= is operator example ==============");
-            IsOperator.Examples();
-            Console.WriteLine();
-        }
-    }
-}
+Console.WriteLine("============= is operator example ==============");
+IsOperator.Examples();
+Console.WriteLine();

--- a/docs/csharp/language-reference/operators/snippets/shared/SizeOfOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/SizeOfOperator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-public struct Point
+﻿public struct Point
 {
     public Point(byte tag, double x, double y) => (Tag, X, Y) = (tag, x, y);
 

--- a/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
@@ -1,73 +1,70 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class StackallocOperator
 {
-    public static class StackallocOperator
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            StackallocInNestedExpressions();
-        }
+        StackallocInNestedExpressions();
+    }
 
-        private static void AssignToPointer()
+    private static void AssignToPointer()
+    {
+        // <SnippetAssignToPointer>
+        unsafe
         {
-            // <SnippetAssignToPointer>
-            unsafe
-            {
-                int length = 3;
-                int* numbers = stackalloc int[length];
-                for (var i = 0; i < length; i++)
-                {
-                    numbers[i] = i;
-                }
-            }
-            // </SnippetAssignToPointer>
-        }
-
-        private static void AssignToSpan()
-        {
-            // <SnippetAssignToSpan>
             int length = 3;
-            Span<int> numbers = stackalloc int[length];
+            int* numbers = stackalloc int[length];
             for (var i = 0; i < length; i++)
             {
                 numbers[i] = i;
             }
-            // </SnippetAssignToSpan>
         }
+        // </SnippetAssignToPointer>
+    }
 
-        private static void AsExpression()
+    private static void AssignToSpan()
+    {
+        // <SnippetAssignToSpan>
+        int length = 3;
+        Span<int> numbers = stackalloc int[length];
+        for (var i = 0; i < length; i++)
         {
-            // <SnippetAsExpression>
-            int length = 1000;
-            Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
-            // </SnippetAsExpression>
+            numbers[i] = i;
         }
+        // </SnippetAssignToSpan>
+    }
 
-        private static void StackallocInit()
-        {
-            // <SnippetStackallocInit>
-            Span<int> first = stackalloc int[3] { 1, 2, 3 };
-            Span<int> second = stackalloc int[] { 1, 2, 3 };
-            ReadOnlySpan<int> third = stackalloc[] { 1, 2, 3 };
-            // </SnippetStackallocInit>
-        }
+    private static void AsExpression()
+    {
+        // <SnippetAsExpression>
+        int length = 1000;
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        // </SnippetAsExpression>
+    }
 
-        private static void StackallocInNestedExpressions()
-        {
-            // <SnippetNested>
-            Span<int> numbers = stackalloc[] { 1, 2, 3, 4, 5, 6 };
-            var ind = numbers.IndexOfAny(stackalloc[] { 2, 4, 6, 8 });
-            Console.WriteLine(ind);  // output: 1
-            // </SnippetNested>
-        }
+    private static void StackallocInit()
+    {
+        // <SnippetStackallocInit>
+        Span<int> first = stackalloc int[3] { 1, 2, 3 };
+        Span<int> second = stackalloc int[] { 1, 2, 3 };
+        ReadOnlySpan<int> third = stackalloc[] { 1, 2, 3 };
+        // </SnippetStackallocInit>
+    }
 
-        private static void LimitStackAllocatedMemory(int inputLength)
-        {
-            // <SnippetLimitStackalloc>
-            const int MaxStackLimit = 1024;
-            Span<byte> buffer = inputLength <= MaxStackLimit ? stackalloc byte[MaxStackLimit] : new byte[inputLength];
-            // </SnippetLimitStackalloc>
-        }
+    private static void StackallocInNestedExpressions()
+    {
+        // <SnippetNested>
+        Span<int> numbers = stackalloc[] { 1, 2, 3, 4, 5, 6 };
+        var ind = numbers.IndexOfAny(stackalloc[] { 2, 4, 6, 8 });
+        Console.WriteLine(ind);  // output: 1
+        // </SnippetNested>
+    }
+
+    private static void LimitStackAllocatedMemory(int inputLength)
+    {
+        // <SnippetLimitStackalloc>
+        const int MaxStackLimit = 1024;
+        Span<byte> buffer = inputLength <= MaxStackLimit ? stackalloc byte[MaxStackLimit] : new byte[inputLength];
+        // </SnippetLimitStackalloc>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/SubtractionOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/SubtractionOperator.cs
@@ -1,95 +1,92 @@
-﻿using System;
+﻿namespace operators;
 
-namespace operators
+public static class SubtractionOperator
 {
-    public static class SubtractionOperator
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            DelegateRemoval();
-            DelegateRemovalNoChange();
-            DelegateRemovalAndNull();
-            SubtractAndAssign();
-        }
+        DelegateRemoval();
+        DelegateRemovalNoChange();
+        DelegateRemovalAndNull();
+        SubtractAndAssign();
+    }
 
-        private static void DelegateRemoval()
-        {
-            // <SnippetDelegateRemoval>
-            Action a = () => Console.Write("a");
-            Action b = () => Console.Write("b");
+    private static void DelegateRemoval()
+    {
+        // <SnippetDelegateRemoval>
+        Action a = () => Console.Write("a");
+        Action b = () => Console.Write("b");
 
-            var abbaab = a + b + b + a + a + b;
-            abbaab();  // output: abbaab
-            Console.WriteLine();
+        var abbaab = a + b + b + a + a + b;
+        abbaab();  // output: abbaab
+        Console.WriteLine();
 
-            var ab = a + b;
-            var abba = abbaab - ab;
-            abba();  // output: abba
-            Console.WriteLine();
+        var ab = a + b;
+        var abba = abbaab - ab;
+        abba();  // output: abba
+        Console.WriteLine();
 
-            var nihil = abbaab - abbaab;
-            Console.WriteLine(nihil is null);  // output: True
-            // </SnippetDelegateRemoval>
-        }
+        var nihil = abbaab - abbaab;
+        Console.WriteLine(nihil is null);  // output: True
+        // </SnippetDelegateRemoval>
+    }
 
-        private static void DelegateRemovalNoChange()
-        {
-            // <SnippetDelegateRemovalNoChange>
-            Action a = () => Console.Write("a");
-            Action b = () => Console.Write("b");
+    private static void DelegateRemovalNoChange()
+    {
+        // <SnippetDelegateRemovalNoChange>
+        Action a = () => Console.Write("a");
+        Action b = () => Console.Write("b");
 
-            var abbaab = a + b + b + a + a + b;
-            var aba = a + b + a;
+        var abbaab = a + b + b + a + a + b;
+        var aba = a + b + a;
 
-            var first = abbaab - aba;
-            first();  // output: abbaab
-            Console.WriteLine();
-            Console.WriteLine(object.ReferenceEquals(abbaab, first));  // output: True
+        var first = abbaab - aba;
+        first();  // output: abbaab
+        Console.WriteLine();
+        Console.WriteLine(object.ReferenceEquals(abbaab, first));  // output: True
 
-            Action a2 = () => Console.Write("a");
-            var changed = aba - a;
-            changed();  // output: ab
-            Console.WriteLine();
-            var unchanged = aba - a2;
-            unchanged();  // output: aba
-            Console.WriteLine();
-            Console.WriteLine(object.ReferenceEquals(aba, unchanged));  // output: True
-            // </SnippetDelegateRemovalNoChange>
-        }
+        Action a2 = () => Console.Write("a");
+        var changed = aba - a;
+        changed();  // output: ab
+        Console.WriteLine();
+        var unchanged = aba - a2;
+        unchanged();  // output: aba
+        Console.WriteLine();
+        Console.WriteLine(object.ReferenceEquals(aba, unchanged));  // output: True
+        // </SnippetDelegateRemovalNoChange>
+    }
 
-        private static void DelegateRemovalAndNull()
-        {
-            // <SnippetDelegateRemovalAndNull>
-            Action a = () => Console.Write("a");
+    private static void DelegateRemovalAndNull()
+    {
+        // <SnippetDelegateRemovalAndNull>
+        Action a = () => Console.Write("a");
 
-            var nothing = null - a;
-            Console.WriteLine(nothing is null);  // output: True
+        var nothing = null - a;
+        Console.WriteLine(nothing is null);  // output: True
 
-            var first = a - null;
-            a();  // output: a
-            Console.WriteLine();
-            Console.WriteLine(object.ReferenceEquals(first, a));  // output: True
-            // </SnippetDelegateRemovalAndNull>
-        }
+        var first = a - null;
+        a();  // output: a
+        Console.WriteLine();
+        Console.WriteLine(object.ReferenceEquals(first, a));  // output: True
+        // </SnippetDelegateRemovalAndNull>
+    }
 
-        private static void SubtractAndAssign()
-        {
-            // <SnippetSubtractAndAssign>
-            int i = 5;
-            i -= 9;
-            Console.WriteLine(i);
-            // Output: -4
+    private static void SubtractAndAssign()
+    {
+        // <SnippetSubtractAndAssign>
+        int i = 5;
+        i -= 9;
+        Console.WriteLine(i);
+        // Output: -4
 
-            Action a = () => Console.Write("a");
-            Action b = () => Console.Write("b");
-            var printer = a + b + a;
-            printer();  // output: aba
+        Action a = () => Console.Write("a");
+        Action b = () => Console.Write("b");
+        var printer = a + b + a;
+        printer();  // output: aba
 
-            Console.WriteLine();
-            printer -= a;
-            printer();  // output: ab
-            // </SnippetSubtractAndAssign>
-            Console.WriteLine();
-        }
+        Console.WriteLine();
+        printer -= a;
+        printer();  // output: ab
+        // </SnippetSubtractAndAssign>
+        Console.WriteLine();
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/SwitchExpressions.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/SwitchExpressions.cs
@@ -1,73 +1,68 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace operators;
 
-namespace operators
+// <SnippetBasicStructure>
+public static class SwitchExample
 {
-    // <SnippetBasicStructure>
-    public static class SwitchExample
+    public enum Direction
     {
-        public enum Direction
-        {
-            Up,
-            Down,
-            Right,
-            Left
-        }
-
-        public enum Orientation
-        {
-            North,
-            South,
-            East,
-            West
-        }
-
-        public static Orientation ToOrientation(Direction direction) => direction switch
-        {
-            Direction.Up    => Orientation.North,
-            Direction.Right => Orientation.East,
-            Direction.Down  => Orientation.South,
-            Direction.Left  => Orientation.West,
-            _ => throw new ArgumentOutOfRangeException(nameof(direction), $"Not expected direction value: {direction}"),
-        };
-
-        public static void Main()
-        {
-            var direction = Direction.Right;
-            Console.WriteLine($"Map view direction is {direction}");
-            Console.WriteLine($"Cardinal orientation is {ToOrientation(direction)}");
-            // Output:
-            // Map view direction is Right
-            // Cardinal orientation is East
-        }
+        Up,
+        Down,
+        Right,
+        Left
     }
-    // </SnippetBasicStructure>
 
-    public static class SwitchExpressions
+    public enum Orientation
     {
-        public static void Examples()
-        {
-            SwitchExample.Main();
-        }
-
-        // <CaseGuardExample>
-        public readonly struct Point
-        {
-            public Point(int x, int y) => (X, Y) = (x, y);
-            
-            public int X { get; }
-            public int Y { get; }
-        }
-
-        static Point Transform(Point point) => point switch
-        {
-            { X: 0, Y: 0 }                    => new Point(0, 0),
-            { X: var x, Y: var y } when x < y => new Point(x + y, y),
-            { X: var x, Y: var y } when x > y => new Point(x - y, y),
-            { X: var x, Y: var y }            => new Point(2 * x, 2 * y),
-        };
-        // </CaseGuardExample>
+        North,
+        South,
+        East,
+        West
     }
+
+    public static Orientation ToOrientation(Direction direction) => direction switch
+    {
+        Direction.Up    => Orientation.North,
+        Direction.Right => Orientation.East,
+        Direction.Down  => Orientation.South,
+        Direction.Left  => Orientation.West,
+        _ => throw new ArgumentOutOfRangeException(nameof(direction), $"Not expected direction value: {direction}"),
+    };
+
+    public static void Main()
+    {
+        var direction = Direction.Right;
+        Console.WriteLine($"Map view direction is {direction}");
+        Console.WriteLine($"Cardinal orientation is {ToOrientation(direction)}");
+        // Output:
+        // Map view direction is Right
+        // Cardinal orientation is East
+    }
+}
+// </SnippetBasicStructure>
+
+public static class SwitchExpressions
+{
+    public static void Examples()
+    {
+        SwitchExample.Main();
+    }
+
+    // <CaseGuardExample>
+    public readonly struct Point
+    {
+        public Point(int x, int y) => (X, Y) = (x, y);
+        
+        public int X { get; }
+        public int Y { get; }
+    }
+
+    static Point Transform(Point point) => point switch
+    {
+        { X: 0, Y: 0 }                    => new Point(0, 0),
+        { X: var x, Y: var y } when x < y => new Point(x + y, y),
+        { X: var x, Y: var y } when x > y => new Point(x - y, y),
+        { X: var x, Y: var y }            => new Point(2 * x, 2 * y),
+    };
+    // </CaseGuardExample>
 }
 

--- a/docs/csharp/language-reference/operators/snippets/shared/TrueFalseOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/TrueFalseOperators.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-public struct LaunchStatus
+﻿public struct LaunchStatus
 {
     public static readonly LaunchStatus Green = new LaunchStatus(0);
     public static readonly LaunchStatus Yellow = new LaunchStatus(1);

--- a/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
@@ -1,136 +1,132 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace operators;
 
-namespace operators
+public static class TypeTestingAndConversionOperators
 {
-    public static class TypeTestingAndConversionOperators
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            Cast();
-            IsOperatorExample.Main();
-            IsOperatorWithInt();
-            IsOperatorDeclarationPattern();
-            AsOperator();
-            TypeOf();
-            TypeOfUnboundGeneric();
-            TypeOfExample.Main();
-        }
-
-        private static void Cast()
-        {
-            // <SnippetCast>
-            double x = 1234.7;
-            int a = (int)x;
-            Console.WriteLine(a);   // output: 1234
-
-            IEnumerable<int> numbers = new int[] { 10, 20, 30 };
-            IList<int> list = (IList<int>)numbers;
-            Console.WriteLine(list.Count);  // output: 3
-            Console.WriteLine(list[1]);  // output: 20
-            // </SnippetCast>
-        }
-
-        // <SnippetIsWithReferenceConversion>
-        public class Base { }
-
-        public class Derived : Base { }
-
-        public static class IsOperatorExample
-        {
-            public static void Main()
-            {
-                object b = new Base();
-                Console.WriteLine(b is Base);  // output: True
-                Console.WriteLine(b is Derived);  // output: False
-
-                object d = new Derived();
-                Console.WriteLine(d is Base);  // output: True
-                Console.WriteLine(d is Derived); // output: True
-            }
-        }
-        // </SnippetIsWithReferenceConversion>
-
-        private static void IsOperatorWithInt()
-        {
-            // <SnippetIsWithInt>
-            int i = 27;
-            Console.WriteLine(i is System.IFormattable);  // output: True
-
-            object iBoxed = i;
-            Console.WriteLine(iBoxed is int);  // output: True
-            Console.WriteLine(iBoxed is long);  // output: False
-            // </SnippetIsWithInt>
-        }
-
-        private static void IsOperatorDeclarationPattern()
-        {
-            // <SnippetIsDeclarationPattern>
-            int i = 23;
-            object iBoxed = i;
-            int? jNullable = 7;
-            if (iBoxed is int a && jNullable is int b)
-            {
-                Console.WriteLine(a + b);  // output 30
-            }
-            // </SnippetIsDeclarationPattern>
-        }
-
-        private static void AsOperator()
-        {
-            // <SnippetAsOperator>
-            IEnumerable<int> numbers = new[] { 10, 20, 30 };
-            IList<int> indexable = numbers as IList<int>;
-            if (indexable != null)
-            {
-                Console.WriteLine(indexable[0] + indexable[indexable.Count - 1]);  // output: 40
-            }
-            // </SnippetAsOperator>
-        }
-
-        private static void TypeOf()
-        {
-            // <SnippetTypeOf>
-            void PrintType<T>() => Console.WriteLine(typeof(T));
-
-            Console.WriteLine(typeof(List<string>));
-            PrintType<int>();
-            PrintType<System.Int32>();
-            PrintType<Dictionary<int, char>>();
-            // Output:
-            // System.Collections.Generic.List`1[System.String]
-            // System.Int32
-            // System.Int32
-            // System.Collections.Generic.Dictionary`2[System.Int32,System.Char]
-            // </SnippetTypeOf>
-        }
-
-        private static void TypeOfUnboundGeneric()
-        {
-            // <SnippetTypeOfUnboundGeneric>
-            Console.WriteLine(typeof(Dictionary<,>));
-            // Output:
-            // System.Collections.Generic.Dictionary`2[TKey,TValue]
-            // </SnippetTypeOfUnboundGeneric>
-        }
-
-        // <SnippetTypeCheckWithTypeOf>
-        public class Animal { }
-
-        public class Giraffe : Animal { }
-
-        public static class TypeOfExample
-        {
-            public static void Main()
-            {
-                object b = new Giraffe();
-                Console.WriteLine(b is Animal);  // output: True
-                Console.WriteLine(b.GetType() == typeof(Animal));  // output: False
-
-                Console.WriteLine(b is Giraffe);  // output: True
-                Console.WriteLine(b.GetType() == typeof(Giraffe));  // output: True
-            }
-        }
-        // </SnippetTypeCheckWithTypeOf>
+        Cast();
+        IsOperatorExample.Main();
+        IsOperatorWithInt();
+        IsOperatorDeclarationPattern();
+        AsOperator();
+        TypeOf();
+        TypeOfUnboundGeneric();
+        TypeOfExample.Main();
     }
+
+    private static void Cast()
+    {
+        // <SnippetCast>
+        double x = 1234.7;
+        int a = (int)x;
+        Console.WriteLine(a);   // output: 1234
+
+        IEnumerable<int> numbers = new int[] { 10, 20, 30 };
+        IList<int> list = (IList<int>)numbers;
+        Console.WriteLine(list.Count);  // output: 3
+        Console.WriteLine(list[1]);  // output: 20
+        // </SnippetCast>
+    }
+
+    // <SnippetIsWithReferenceConversion>
+    public class Base { }
+
+    public class Derived : Base { }
+
+    public static class IsOperatorExample
+    {
+        public static void Main()
+        {
+            object b = new Base();
+            Console.WriteLine(b is Base);  // output: True
+            Console.WriteLine(b is Derived);  // output: False
+
+            object d = new Derived();
+            Console.WriteLine(d is Base);  // output: True
+            Console.WriteLine(d is Derived); // output: True
+        }
+    }
+    // </SnippetIsWithReferenceConversion>
+
+    private static void IsOperatorWithInt()
+    {
+        // <SnippetIsWithInt>
+        int i = 27;
+        Console.WriteLine(i is System.IFormattable);  // output: True
+
+        object iBoxed = i;
+        Console.WriteLine(iBoxed is int);  // output: True
+        Console.WriteLine(iBoxed is long);  // output: False
+        // </SnippetIsWithInt>
+    }
+
+    private static void IsOperatorDeclarationPattern()
+    {
+        // <SnippetIsDeclarationPattern>
+        int i = 23;
+        object iBoxed = i;
+        int? jNullable = 7;
+        if (iBoxed is int a && jNullable is int b)
+        {
+            Console.WriteLine(a + b);  // output 30
+        }
+        // </SnippetIsDeclarationPattern>
+    }
+
+    private static void AsOperator()
+    {
+        // <SnippetAsOperator>
+        IEnumerable<int> numbers = new[] { 10, 20, 30 };
+        IList<int> indexable = numbers as IList<int>;
+        if (indexable != null)
+        {
+            Console.WriteLine(indexable[0] + indexable[indexable.Count - 1]);  // output: 40
+        }
+        // </SnippetAsOperator>
+    }
+
+    private static void TypeOf()
+    {
+        // <SnippetTypeOf>
+        void PrintType<T>() => Console.WriteLine(typeof(T));
+
+        Console.WriteLine(typeof(List<string>));
+        PrintType<int>();
+        PrintType<System.Int32>();
+        PrintType<Dictionary<int, char>>();
+        // Output:
+        // System.Collections.Generic.List`1[System.String]
+        // System.Int32
+        // System.Int32
+        // System.Collections.Generic.Dictionary`2[System.Int32,System.Char]
+        // </SnippetTypeOf>
+    }
+
+    private static void TypeOfUnboundGeneric()
+    {
+        // <SnippetTypeOfUnboundGeneric>
+        Console.WriteLine(typeof(Dictionary<,>));
+        // Output:
+        // System.Collections.Generic.Dictionary`2[TKey,TValue]
+        // </SnippetTypeOfUnboundGeneric>
+    }
+
+    // <SnippetTypeCheckWithTypeOf>
+    public class Animal { }
+
+    public class Giraffe : Animal { }
+
+    public static class TypeOfExample
+    {
+        public static void Main()
+        {
+            object b = new Giraffe();
+            Console.WriteLine(b is Animal);  // output: True
+            Console.WriteLine(b.GetType() == typeof(Animal));  // output: False
+
+            Console.WriteLine(b is Giraffe);  // output: True
+            Console.WriteLine(b.GetType() == typeof(Giraffe));  // output: True
+        }
+    }
+    // </SnippetTypeCheckWithTypeOf>
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/operators.csproj
+++ b/docs/csharp/language-reference/operators/snippets/shared/operators.csproj
@@ -4,9 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <StartupObject>operators.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
+    <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>7022</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -12,6 +12,7 @@ The following features are available in Visual Studio 2022 version 17.3:
 
 - [auto-default structs](#auto-default-struct)
 - [pattern match `Span<char>` on a constant `string`](#pattern-match-spanchar-or-readonlyspanchar-on-a-constant-string)
+- [Extended `nameof` scope](#extended-nameof-scope)
 
 The following features are available in Visual Studio 2022 version 17.2:
 
@@ -150,3 +151,7 @@ The C# 11 compiler ensures that all fields of a `struct` type are initialized to
 ## Pattern match `Span<char>` or `ReadOnlySpan<char>` on a constant `string`
 
 You've been able to test if a `string` had a specific constant value using pattern matching for several releases. Now, you can use the same pattern matching logic with variables that are `Span<char>` or `ReadOnlySpan<char>`.
+
+## Extended nameof scope
+
+Type parameter names and parameter names are now in scope when used in a `nameof` expression in an [attribute declaration](../programming-guide/concepts/attributes/index.md#using-attributes) on that method. This feature means you can use the `nameof` operator to specify the name of a method parameter in an attribute on the method or parameter declaration. This feature is most often useful to add attributes for [nullable analysis](../language-reference/attributes/nullable-analysis.md).


### PR DESCRIPTION
Fixes #29271

Updates for the new scope rules for `nameof` and parameters.

- Update the what's new article for C# 11.
- Update the Nullable analysis and caller information attribute pages with examples.
- Update the nameof reference page with new rules and new examples.

