### PR TITLE
rename : Method name from `Handle` to `HandleAsync`

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
@@ -300,7 +300,7 @@ public class ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler
         // ...Parameter validations...
     }
 
-    public async Task Handle(OrderStartedDomainEvent orderStartedEvent)
+    public async Task HandleAsync(OrderStartedDomainEvent orderStartedEvent)
     {
         var cardTypeId = (orderStartedEvent.CardTypeId != 0) ? orderStartedEvent.CardTypeId : 1;
         var userGuid = _identityService.GetUserIdentity();


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/29427
