### PR TITLE
Fix note callout in work-with-resx-files-programmatically.md

### DIFF
--- a/docs/core/extensions/work-with-resx-files-programmatically.md
+++ b/docs/core/extensions/work-with-resx-files-programmatically.md
@@ -13,7 +13,7 @@ ms.assetid: 168f941a-2b84-43f8-933f-cf4a8548d824
 
 # Work with .resx files programmatically
 
-> ![NOTE]
+> [!NOTE]
 > This article applies to .NET Framework. For information that applies to .NET 5+ (including .NET Core), see [Resources in .resx files](create-resource-files.md#resources-in-resx-files).
 
 Because XML resource (.resx) files must consist of well-defined XML, including a header that must follow a specific schema followed by data in name/value pairs, you may find that creating these files manually is error-prone. As an alternative, you can create .resx files programmatically by using types and members in the .NET Class Library. You can also use the .NET Class Library to retrieve resources that are stored in .resx files. This article explains how you can use the types and members in the <xref:System.Resources> namespace to work with .resx files.


### PR DESCRIPTION
## Summary
This PR corrects a `[!NOTE]` callout block in work-with-resx-files-programmatically.md, which was previously rendering incorrectly due to the callout block header being mistyped:

![image](https://user-images.githubusercontent.com/2093321/169493681-fc6c6f67-a45b-4da5-a90d-674f680b0df5.png)

