### PR TITLE
Fix typo

### DIFF
--- a/docs/azure/sdk/dependency-injection.md
+++ b/docs/azure/sdk/dependency-injection.md
@@ -178,7 +178,7 @@ At some point, you might want to change the default settings for a service clien
 {
   "AzureDefaults": {
     "Retry": {
-      "maxTries": 3
+      "maxRetries": 3
     }
   },
   "KeyVault": {


### PR DESCRIPTION
`maxTries` should be rather be `maxRetries` as the former one is not a valid property on the [retry options](https://docs.microsoft.com/en-us/dotnet/api/azure.core.retryoptions?view=azure-dotnet) object.