### PR TITLE
Fix Category on CA1806

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -20,7 +20,7 @@ dev_langs:
 | | Value |
 |-|-|
 | **Rule ID** |CA1806|
-| **Category** |[Usage](usage-warnings.md)|
+| **Category** |[Performance](performance-warnings.md)|
 | **Fix is breaking or non-breaking** |Non-breaking|
 
 ## Cause


### PR DESCRIPTION
## Summary

`CA1806` is in the `Performance` category, but its page incorrectly indicates that it is in the `Usage` category. Correcting the category in the page.

See 

https://github.com/dotnet/docs/blob/5e675dc04ff4caa7bf130cb2abb87d46d0322410/docs/fundamentals/code-analysis/quality-rules/performance-warnings.md?plain=1#L26

and

https://github.com/dotnet/roslyn-analyzers/blob/d2ef898a6283858c1224c0114cd87fa27b6cb091/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/DoNotIgnoreMethodResults.cs#L68-L76