### PR TITLE
Update components.md

### DIFF
--- a/docs/architecture/blazor-for-web-forms-developers/components.md
+++ b/docs/architecture/blazor-for-web-forms-developers/components.md
@@ -557,7 +557,7 @@ To capture a component reference in Blazor, use the `@ref` directive attribute. 
 <MyLoginDialog @ref="loginDialog" ... />
 
 @code {
-    MyLoginDialog loginDialog;
+    MyLoginDialog loginDialog = default!;
 
     void OnSomething()
     {


### PR DESCRIPTION
The original sample code will generate *warning CS8625: Cannot convert null literal to non-nullable reference type* when *net6.0* is targeted with *Nullable enabled* which are the defaults when creating a Blazor application in VS2022.  This change resolves the warning.

### References

https://docs.microsoft.com/en-us/dotnet/csharp/nullable-warnings
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-forgiving

## Summary

Initializes referenced component with a null forgiving default.
