### PR TITLE
Change "finally" to "catch"

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -52,7 +52,7 @@ To fix a violation of this rule, call <xref:System.IDisposable.Dispose%2A> on th
 
 You can use the [`using` statement](../../../csharp/language-reference/keywords/using-statement.md) ([`Using`](../../../visual-basic/language-reference/statements/using-statement.md) in Visual Basic) to wrap objects that implement <xref:System.IDisposable>. Objects that are wrapped in this manner are automatically disposed at the end of the `using` block. However, the following situations should not or cannot be handled with a `using` statement:
 
-- To return a disposable object, the object must be constructed in a `try/finally` block outside of a `using` block.
+- To return a disposable object, the object must be constructed in a `try/catch` block outside of a `using` block.
 
 - Do not initialize members of a disposable object in the constructor of a `using` statement.
 


### PR DESCRIPTION
## Summary

A disposable is returned from the method and as such shouldn't be disposed yet. A `Dispose` call within a `finally` block would always be executed, which is not what one would want in this situation. A `catch` block makes more sense.

Fixes #29584