### PR TITLE
Fix word order typo

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/syslib1001.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1001.md
@@ -6,7 +6,7 @@ ms.date: 05/07/2021
 
 # SYSLIB1001: Logging method names can't start with an underscore
 
-The name a of method annotated with the `LoggerMessageAttribute` starts with an underscore character. This is not allowed, as it may result in conflicting symbol names with respect to the automatically generated code.
+The name of a method annotated with the `LoggerMessageAttribute` starts with an underscore character. This is not allowed, as it may result in conflicting symbol names with respect to the automatically generated code.
 
 ## Workarounds
 

--- a/docs/fundamentals/syslib-diagnostics/syslib1003.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1003.md
@@ -6,7 +6,7 @@ ms.date: 05/07/2021
 
 # SYSLIB1003: Logging method parameter names can't start with an underscore
 
-The name a of parameter of a method annotated with the `LoggerMessageAttribute` starts with an underscore character. This is not allowed as it may result in conflicting symbol names with respect to the automatically generated code.
+The name of a parameter of a method annotated with the `LoggerMessageAttribute` starts with an underscore character. This is not allowed as it may result in conflicting symbol names with respect to the automatically generated code.
 
 ## Workarounds
 


### PR DESCRIPTION
Fix word order typo in `docs/fundamentals/syslib-diagnostics/syslib100?.md`.