### PR TITLE
.NET Standard 2 does not support net461

### DIFF
--- a/includes/net-standard-2.0.md
+++ b/includes/net-standard-2.0.md
@@ -3,7 +3,7 @@
 | .NET implementation         | Version support                                   |
 |-----------------------------|---------------------------------------------------|
 | .NET and .NET Core          | 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0                 |
-| .NET Framework <sup>1</sup> | 4.6.1 <sup>2</sup>, 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 |
+| .NET Framework <sup>1</sup> | <sup>2</sup> 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 |
 | Mono                        | 5.4, 6.4                                          |
 | Xamarin.iOS                 | 10.14, 12.16                                      |
 | Xamarin.Mac                 | 3.8, 5.16                                         |
@@ -13,7 +13,7 @@
 
 <sup>1</sup> The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/main/release-notes/download-archives) if you cannot upgrade to Visual Studio 2017 or a later version.
 
-<sup>2</sup> The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. While NuGet considers .NET Framework 4.6.1 as supporting .NET Standard 1.5 through 2.0, there are several issues with consuming .NET Standard libraries that were built for those versions from .NET Framework 4.6.1 projects. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.
+<sup>2</sup> The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.
 
 For more information, see [.NET Standard 2.0][2.0]. For an interactive table, see [.NET Standard versions](https://dotnet.microsoft.com/platform/dotnet-standard#versions).
 

--- a/includes/net-standard-2.0.md
+++ b/includes/net-standard-2.0.md
@@ -3,7 +3,7 @@
 | .NET implementation         | Version support                                   |
 |-----------------------------|---------------------------------------------------|
 | .NET and .NET Core          | 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0                 |
-| .NET Framework <sup>1</sup> | <sup>2</sup> 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 |
+| .NET Framework <sup>1</sup> | <sup>2</sup> 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8        |
 | Mono                        | 5.4, 6.4                                          |
 | Xamarin.iOS                 | 10.14, 12.16                                      |
 | Xamarin.Mac                 | 3.8, 5.16                                         |

--- a/includes/net-standard-2.0.md
+++ b/includes/net-standard-2.0.md
@@ -13,7 +13,7 @@
 
 <sup>1</sup> The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/main/release-notes/download-archives) if you cannot upgrade to Visual Studio 2017 or a later version.
 
-<sup>2</sup> The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.
+<sup>2</sup> The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. For .NET Framework projects that need to use .NET Standard 2.0, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.
 
 For more information, see [.NET Standard 2.0][2.0]. For an interactive table, see [.NET Standard versions](https://dotnet.microsoft.com/platform/dotnet-standard#versions).
 

--- a/includes/net-standard-2.0.md
+++ b/includes/net-standard-2.0.md
@@ -3,7 +3,7 @@
 | .NET implementation         | Version support                                   |
 |-----------------------------|---------------------------------------------------|
 | .NET and .NET Core          | 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0                 |
-| .NET Framework <sup>1</sup> | <sup>2</sup> 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8        |
+| .NET Framework <sup>1</sup> | 4.6.1 <sup>2</sup>, 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 |
 | Mono                        | 5.4, 6.4                                          |
 | Xamarin.iOS                 | 10.14, 12.16                                      |
 | Xamarin.Mac                 | 3.8, 5.16                                         |


### PR DESCRIPTION
it is misleading to imply that is does when there are so many incompatibilities between the two
https://www.google.com/search?q=netStandard2+net461+error

Having it as subtext is pretty poor way to communicate

> While NuGet considers .NET Framework 4.6.1 as supporting .NET Standard 1.5 through 2.0, there are several issues with consuming .NET Standard libraries that were built for those versions from .NET Framework 4.6.1 projects. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.
