### PR TITLE
clarify tutorial description

### DIFF
--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -30,7 +30,7 @@ This file will contain the definition of a ***bank account***. Object Oriented p
 1. It accepts deposits.
 1. It accepts withdrawals.
 1. The initial balance must be positive.
-1. Withdrawals cannot result in a negative balance.
+1. Withdrawals can't result in a negative balance.
 
 ## Define the bank account type
 
@@ -57,13 +57,13 @@ public class BankAccount
 
 Before going on, let's take a look at what you've built.  The `namespace` declaration provides a way to logically organize your code. This tutorial is relatively small, so you'll put all the code in one namespace.
 
-`public class BankAccount` defines the class, or type, you are creating. Everything inside the `{` and `}` that follows the class declaration defines the state and behavior of the class. There are five ***members*** of the `BankAccount` class. The first three are ***properties***. Properties are data elements and can have code that enforces validation or other rules. The last two are ***methods***. Methods are blocks of code that perform a single function. Reading the names of each of the members should provide enough information for you or another developer to understand what the class does.
+`public class BankAccount` defines the class, or type, you're creating. Everything inside the `{` and `}` that follows the class declaration defines the state and behavior of the class. There are five ***members*** of the `BankAccount` class. The first three are ***properties***. Properties are data elements and can have code that enforces validation or other rules. The last two are ***methods***. Methods are blocks of code that perform a single function. Reading the names of each of the members should provide enough information for you or another developer to understand what the class does.
 
 ## Open a new account
 
 The first feature to implement is to open a bank account. When a customer opens an account, they must supply an initial balance, and information about the owner or owners of that account.
 
-Creating a new object of the `BankAccount` type means defining a ***constructor*** that assigns those values. A ***constructor*** is a member that has the same name as the class. It is used to initialize objects of that class type. Add the following constructor to the `BankAccount` type. Place the following code above the declaration of `MakeDeposit`:
+Creating a new object of the `BankAccount` type means defining a ***constructor*** that assigns those values. A ***constructor*** is a member that has the same name as the class. It's used to initialize objects of that class type. Add the following constructor to the `BankAccount` type. Place the following code above the declaration of `MakeDeposit`:
 
 ```csharp
 public BankAccount(string name, decimal initialBalance)
@@ -72,6 +72,18 @@ public BankAccount(string name, decimal initialBalance)
     this.Balance = initialBalance;
 }
 ```
+
+The preceding code identifies the properties of the object being constructed by including the `this` qualifier. That qualifier is usually optional and omitted. You could also have written:
+
+```csharp
+public BankAccount(string name, decimal initialBalance)
+{
+    Owner = name;
+    Balance = initialBalance;
+}
+```
+
+The `this` qualifier is only required when a local variable or parameter has the same name is that field or property. The `this` qualifier is omitted throughout the remainder of this article unless it's necessary.
 
 Constructors are called when you create an object using [`new`](../../language-reference/operators/new-operator.md). Replace the line `Console.WriteLine("Hello World!");` in *Program.cs* with the following code (replace `<name>` with your name):
 
@@ -84,7 +96,7 @@ Console.WriteLine($"Account {account.Number} was created for {account.Owner} wit
 
 Let's run what you've built so far. If you're using Visual Studio, Select **Start without debugging** from the **Debug** menu. If you're using a command line, type `dotnet run` in the directory where you've created your project.
 
-Did you notice that the account number is blank? It's time to fix that. The account number should be assigned when the object is constructed. But it shouldn't be the responsibility of the caller to create it. The `BankAccount` class code should know how to assign new account numbers.  A simple way to do this is to start with a 10-digit number. Increment it when each new account is created. Finally, store the current account number when an object is constructed.
+Did you notice that the account number is blank? It's time to fix that. The account number should be assigned when the object is constructed. But it shouldn't be the responsibility of the caller to create it. The `BankAccount` class code should know how to assign new account numbers.  A simple way is to start with a 10-digit number. Increment it when each new account is created. Finally, store the current account number when an object is constructed.
 
 Add a member declaration to the `BankAccount` class. Place the following line of code after the opening brace `{` at the beginning of the `BankAccount` class:
 
@@ -92,7 +104,7 @@ Add a member declaration to the `BankAccount` class. Place the following line of
 private static int accountNumberSeed = 1234567890;
 ```
 
-This is a data member. It's `private`, which means it can only be accessed by code inside the `BankAccount` class. It's a way of separating the public responsibilities (like having an account number) from the private implementation (how account numbers are generated). It is also `static`, which means it is shared by all of the `BankAccount` objects. The value of a non-static variable is unique to each instance of the `BankAccount` object. Add the following two lines to the constructor to assign the account number. Place them after the line that says `this.Balance = initialBalance`:
+The `accountNumberSeed` is a data member. It's `private`, which means it can only be accessed by code inside the `BankAccount` class. It's a way of separating the public responsibilities (like having an account number) from the private implementation (how account numbers are generated). It's also `static`, which means it's shared by all of the `BankAccount` objects. The value of a non-static variable is unique to each instance of the `BankAccount` object. Add the following two lines to the constructor to assign the account number. Place them after the line that says `this.Balance = initialBalance`:
 
 ```csharp
 this.Number = accountNumberSeed.ToString();
@@ -103,9 +115,9 @@ Type `dotnet run` to see the results.
 
 ## Create deposits and withdrawals
 
-Your bank account class needs to accept deposits and withdrawals to work correctly. Let's implement deposits and withdrawals by creating a journal of every transaction for the account. That has a few advantages over simply updating the balance on each transaction. The history can be used to audit all transactions and manage daily balances. By computing the balance from the history of all transactions when needed, any errors in a single transaction that are fixed will be correctly reflected in the balance on the next computation.
+Your bank account class needs to accept deposits and withdrawals to work correctly. Let's implement deposits and withdrawals by creating a journal of every transaction for the account. Tracking every transaction has a few advantages over simply updating the balance on each transaction. The history can be used to audit all transactions and manage daily balances. Computing the balance from the history of all transactions when needed ensures any errors in a single transaction that are fixed will be correctly reflected in the balance on the next computation.
 
-Let's start by creating a new type to represent a transaction. This is a simple type that doesn't have any responsibilities. It needs a few properties. Create a new file named *Transaction.cs*. Add the following code to it:
+Let's start by creating a new type to represent a transaction. The transaction is a simple type that doesn't have any responsibilities. It needs a few properties. Create a new file named *Transaction.cs*. Add the following code to it:
 
 :::code language="csharp" source="./snippets/introduction-to-classes/Transaction.cs":::
 
@@ -119,9 +131,9 @@ Now, let's correctly compute the `Balance`. The current balance can be found by 
 
 This example shows an important aspect of ***properties***. You're now computing the balance when another programmer asks for the value. Your computation enumerates all transactions, and provides the sum as the current balance.
 
-Next, implement the `MakeDeposit` and `MakeWithdrawal` methods. These methods will enforce the final two rules: that the initial balance must be positive, and that any withdrawal must not create a negative balance.
+Next, implement the `MakeDeposit` and `MakeWithdrawal` methods. These methods will enforce the final two rules: the initial balance must be positive, and any withdrawal must not create a negative balance.
 
-This introduces the concept of ***exceptions***. The standard way of indicating that a method cannot complete its work successfully is to throw an exception. The type of exception and the message associated with it describe the error. Here, the `MakeDeposit` method throws an exception if the amount of the deposit is not greater than 0. The `MakeWithdrawal` method throws an exception if the withdrawal amount is not greater than 0, or if applying the withdrawal results in a negative balance. Add the following code after the declaration of the `allTransactions` list:
+These rules introduce the concept of ***exceptions***. The standard way of indicating that a method can't complete its work successfully is to throw an exception. The type of exception and the message associated with it describe the error. Here, the `MakeDeposit` method throws an exception if the amount of the deposit isn't greater than 0. The `MakeWithdrawal` method throws an exception if the withdrawal amount isn't greater than 0, or if applying the withdrawal results in a negative balance. Add the following code after the declaration of the `allTransactions` list:
 
 :::code language="csharp" source="./snippets/introduction-to-classes/BankAccount.cs" id="DepositAndWithdrawal":::
 
@@ -131,7 +143,7 @@ The constructor should get one change so that it adds an initial transaction, ra
 
 :::code language="csharp" source="./snippets/introduction-to-classes/BankAccount.cs" id="Constructor":::
 
-<xref:System.DateTime.Now?displayProperty=nameWithType> is a property that returns the current date and time. Test this by adding a few deposits and withdrawals in your `Main` method, following the code that creates a new `BankAccount`:
+<xref:System.DateTime.Now?displayProperty=nameWithType> is a property that returns the current date and time. Test this code by adding a few deposits and withdrawals in your `Main` method, following the code that creates a new `BankAccount`:
 
 ```csharp
 account.MakeWithdrawal(500, DateTime.Now, "Rent payment");
@@ -140,7 +152,7 @@ account.MakeDeposit(100, DateTime.Now, "Friend paid me back");
 Console.WriteLine(account.Balance);
 ```
 
-Next, test that you are catching error conditions by trying to create an account with a negative balance. Add the following code after the preceding code you just added:
+Next, test that you're catching error conditions by trying to create an account with a negative balance. Add the following code after the preceding code you just added:
 
 ```csharp
 // Test that the initial balances must be positive.
@@ -157,7 +169,7 @@ catch (ArgumentOutOfRangeException e)
 }
 ```
 
-You use the [`try` and `catch` statements](../../language-reference/keywords/try-catch.md) to mark a block of code that may throw exceptions and to catch those errors that you expect. You can use the same technique to test the code that throws an exception for a negative balance. Add the following code at the end of your `Main` method:
+You use the [`try` and `catch` statements](../../language-reference/keywords/try-catch.md) to mark a block of code that may throw exceptions and to catch those errors that you expect. You can use the same technique to test the code that throws an exception for a negative balance. Add the following code before the declaration of `invalidAccount` in your `Main` method:
 
 ```csharp
 // Test for a negative balance.
@@ -180,7 +192,7 @@ To finish this tutorial, you can write the `GetAccountHistory` method that creat
 
 :::code language="csharp" source="./snippets/introduction-to-classes/BankAccount.cs" id="History":::
 
-This uses the <xref:System.Text.StringBuilder> class to format a string that contains one line for each transaction. You've seen the string formatting code earlier in these tutorials. One new character is `\t`. That inserts a tab to format the output.
+The history uses the <xref:System.Text.StringBuilder> class to format a string that contains one line for each transaction. You've seen the string formatting code earlier in these tutorials. One new character is `\t`. That inserts a tab to format the output.
 
 Add this line to test it in *Program.cs*:
 

--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -83,7 +83,7 @@ public BankAccount(string name, decimal initialBalance)
 }
 ```
 
-The `this` qualifier is only required when a local variable or parameter has the same name is that field or property. The `this` qualifier is omitted throughout the remainder of this article unless it's necessary.
+The `this` qualifier is only required when a local variable or parameter has the same name as that field or property. The `this` qualifier is omitted throughout the remainder of this article unless it's necessary.
 
 Constructors are called when you create an object using [`new`](../../language-reference/operators/new-operator.md). Replace the line `Console.WriteLine("Hello World!");` in *Program.cs* with the following code (replace `<name>` with your name):
 


### PR DESCRIPTION
Fixes #29175

- Add text that `this` is often optional.
- Clarify where to add one set of sample code.
- General grammar check.
