### PR TITLE
String interpolation $ signs

### DIFF
--- a/docs/fsharp/what-is-fsharp.md
+++ b/docs/fsharp/what-is-fsharp.md
@@ -77,9 +77,9 @@ let handleWithdrawal amount =
 
     // The F# compiler enforces accounting for each case!
     match w with
-    | Success s -> printfn "Successfully withdrew %f{s.Amount}"
-    | InsufficientFunds f -> printfn "Failed: balance is %f{f.Balance}"
-    | CardExpired d -> printfn "Failed: card expired on {d}"
+    | Success s -> printfn $"Successfully withdrew %f{s.Amount}"
+    | InsufficientFunds f -> printfn $"Failed: balance is %f{f.Balance}"
+    | CardExpired d -> printfn $"Failed: card expired on {d}"
     | UndisclosedFailure -> printfn "Failed: unknown :("
 ```
 


### PR DESCRIPTION
## Summary

I believe the dollar signs are required for string interpolation in this example. Thank you.
