### PR TITLE
Add a Note, GenerateSatelliteAssembliesForCore is related to deterministic option.

### DIFF
--- a/docs/core/extensions/create-satellite-assemblies.md
+++ b/docs/core/extensions/create-satellite-assemblies.md
@@ -93,7 +93,7 @@ For a complete list of options available with *al.exe*, see [Assembly Linker (*a
 > </Project>
 > ```
 >
-> The .NET Core MSBuild task uses *csc.exe* instead of *al.exe* to generate satellite assemblies, by default. For more information, see [Make it easier to opt into "Core" satellite assembly generation](https://github.com/dotnet/msbuild/pull/2726).
+> The .NET Core MSBuild task uses *csc.exe* instead of *al.exe* to generate satellite assemblies, by default. When some options, like deterministic option, is used, GenerateSatelliteAssembliesForCore may be needed for effecting satellite assemblies as well. For more information, see [Make it easier to opt into "Core" satellite assembly generation](https://github.com/dotnet/msbuild/pull/2726).
 
 ## Satellite assemblies example
 


### PR DESCRIPTION
## Summary

GenerateSatelliteAssembliesForCore is needed when satellite assemblies are built with deterministic option for creating same outputs from same source code by every builds.
Deterministic option belong to a compiler and msbuild task, but many customers would face this issue, so this doc should be mentioned this scenario as a note.