### PR TITLE
Add documentation for `MergeSources`

### DIFF
--- a/docs/fsharp/language-reference/computation-expressions.md
+++ b/docs/fsharp/language-reference/computation-expressions.md
@@ -99,6 +99,7 @@ let doThingsAsync url otherUrl =
         ...
     }
 ```
+
 If you use `and!` then each computation expression may be bound in parallel, therefore the bindings may not depend on other bindings. All of the values will be retrieved and then collated at the end of the computation expression.
 
 ### `do!`


### PR DESCRIPTION
- I haven't filled in the Expression -> Translation table starting at line 286 as I don't know the exact translation.
- Not 100% sure that the added documentation is good, but wanted to have them in as a starting point for adding the Applicative CE feature to this page.

## Summary

Started to add documentation for `MergeSources` to the CE page in the language reference
