### PR TITLE
Clarification about binary expressions in units of measure to F# style guide

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -515,6 +515,20 @@ let function1 arg1 arg2 arg3 arg4 =
     arg3 + arg4
 ```
 
+This rule also applies to units of measures in types and constant annotations:
+
+```fsharp
+// ✔️ OK
+type Test =
+    { WorkHoursPerWeek: uint<hr / (staff weeks)> }
+    static member create = { WorkHoursPerWeek = 40u<hr / (staff weeks)> }
+
+// ❌ Not OK
+type Test =
+    { WorkHoursPerWeek: uint<hr/(staff weeks)> }
+    static member create = { WorkHoursPerWeek = 40u<hr/(staff weeks)> }
+```
+
 The following operators are defined in the F# standard library and should be used instead of defining equivalents. Using these operators is recommended as it tends to make code more readable and idiomatic. The following list summarizes the recommended F# operators.
 
 ```fsharp


### PR DESCRIPTION
## Summary

Adds a clarification about binary expressions in units of measure to the F# style guide.

Fixes [660](https://github.com/fsharp/fslang-design/issues/660)
