### PR TITLE
fix: Go is not an acronym

### DIFF
--- a/docs/orleans/deployment/consul-deployment.md
+++ b/docs/orleans/deployment/consul-deployment.md
@@ -10,7 +10,7 @@ ms.date: 03/09/2022
 
 There is a very detailed overview of Consul including comparisons with similar solutions [here](https://www.consul.io/intro/index.html).
 
-Consul is written in GO and is [open source](https://github.com/hashicorp/consul); compiled downloads are available for [Mac OS X, FreeBSD, Linux, Solaris and Windows](https://www.consul.io/downloads.html)
+Consul is written in Go and is [open source](https://github.com/hashicorp/consul); compiled downloads are available for [Mac OS X, FreeBSD, Linux, Solaris and Windows](https://www.consul.io/downloads.html)
 
 ## Why choose Consul?
 


### PR DESCRIPTION
## Summary

The "Go" programming language is not an acronym. See how it refers to itself on https://go.dev/
