### PR TITLE
Add PNSE breaking change for strong-name APIs

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -73,6 +73,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
 | [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
 | [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |
+| [Strong-name APIS throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ | |
 | [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -73,7 +73,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
 | [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
 | [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |
-| [Strong-name APIS throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ | |
+| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ | |
 | [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -73,7 +73,7 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 | [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
 | [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
 | [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |
-| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ | |
+| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |  Preview 4 |
 | [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |

--- a/docs/core/compatibility/aspnet-core/6.0/rc1-minimal-api-renames.md
+++ b/docs/core/compatibility/aspnet-core/6.0/rc1-minimal-api-renames.md
@@ -5,7 +5,7 @@ ms.date: 10/25/2021
 ---
 # Minimal API renames in RC 1
 
-Some APIS were renamed to improve the consistency of type names and to remove "minimal" and "action" from the API names.
+Some APIs were renamed to improve the consistency of type names and to remove "minimal" and "action" from the API names.
 
 ## Version introduced
 

--- a/docs/core/compatibility/core-libraries/5.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/5.0/obsolete-apis-with-custom-diagnostics.md
@@ -10,7 +10,7 @@ Some APIs have been marked as obsolete, starting in .NET 5. This breaking change
 
 ## Change description
 
-In previous .NET versions, these APIs can be used without any build warning. In .NET 5 and later versions, use of these APIS produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
+In previous .NET versions, these APIs can be used without any build warning. In .NET 5 and later versions, use of these APIs produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
 
 The following table lists the custom diagnostic IDs and their corresponding warning messages for obsoleted APIs.
 

--- a/docs/core/compatibility/core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md
+++ b/docs/core/compatibility/core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md
@@ -80,7 +80,7 @@ None.
 
 - Core .NET libraries
 
-### Affected APIS
+### Affected APIs
 
 Not detectible via API analysis.
 

--- a/docs/core/compatibility/core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md
@@ -10,7 +10,7 @@ Some APIs have been marked as obsolete, starting in .NET 6. This breaking change
 
 ## Change description
 
-In previous .NET versions, these APIs can be used without any build warning. In .NET 6 and later versions, use of these APIS produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
+In previous .NET versions, these APIs can be used without any build warning. In .NET 6 and later versions, use of these APIs produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
 
 The following table lists the custom diagnostic IDs and their corresponding warning messages for obsoleted APIs.
 

--- a/docs/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions.md
+++ b/docs/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions.md
@@ -1,0 +1,38 @@
+---
+title: "Breaking change: Strong-name APIS throw PlatformNotSupportedException"
+description: Learn about the .NET 6 breaking change in core .NET libraries where an exception is thrown in StrongNameKeyPair constructors and AssemblyName.KeyPair.
+ms.date: 05/31/2022
+---
+# Strong-name APIS throw PlatformNotSupportedException
+
+A few [APIs](#affected-apis) that aren't supported in .NET/.NET Core but didn't doing anything when accessed have been changed to now throw a <xref:System.PlatformNotSupportedException> at run time. Previously, using these APIs would eventually result in a run-time exception further along; the exception is now thrown earlier.
+
+## Previous behavior
+
+In previous versions, calling <xref:System.Reflection.AssemblyName.KeyPair?displayProperty=nameWithType> or <xref:System.Reflection.StrongNameKeyPair.%23ctor(System.Byte[])> was a no-op. Calling <xref:System.Reflection.StrongNameKeyPair.%23ctor(System.IO.FileStream)> read the stream but otherwise did nothing.
+
+## New behavior
+
+Starting in .NET 6, each of the three affected APIs throws a <xref:System.PlatformNotSupportedException> at run time.
+
+## Version introduced
+
+.NET 6
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+Previously, an application that called the API compiled and ran, but as soon as the instance was used in any code path, it threw a run-time exception. To make it more explicit that this scenario is unsupported, the exception-throwing logic was moved into the instance constructor. In case no instances are created, the exception is also thrown in public entry points that return this type, that is, <xref:System.Reflection.AssemblyName.KeyPair?displayProperty=nameWithType>.
+
+## Recommended action
+
+Strong-name signing is not supported in .NET/.NET Core, and there is no workaround.
+
+## Affected APIs
+
+- <xref:System.Reflection.StrongNameKeyPair.%23ctor(System.IO.FileStream)>
+- <xref:System.Reflection.StrongNameKeyPair.%23ctor(System.Byte[])>
+- <xref:System.Reflection.AssemblyName.KeyPair?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions.md
+++ b/docs/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions.md
@@ -5,7 +5,7 @@ ms.date: 05/31/2022
 ---
 # Strong-name APIS throw PlatformNotSupportedException
 
-A few [APIs](#affected-apis) that aren't supported in .NET/.NET Core but didn't doing anything when accessed have been changed to now throw a <xref:System.PlatformNotSupportedException> at run time. Previously, using these APIs would eventually result in a run-time exception further along; the exception is now thrown earlier.
+A few [APIs](#affected-apis) that aren't supported in .NET/.NET Core but didn't doing anything when accessed have been changed to now throw a <xref:System.PlatformNotSupportedException> at run time. Previously, using these APIs would eventually result in a run-time exception further along; the exception is now thrown when the type is instantiated or first accessed.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions.md
+++ b/docs/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions.md
@@ -1,11 +1,11 @@
 ---
-title: "Breaking change: Strong-name APIS throw PlatformNotSupportedException"
+title: "Breaking change: Strong-name APIs throw PlatformNotSupportedException"
 description: Learn about the .NET 6 breaking change in core .NET libraries where an exception is thrown in StrongNameKeyPair constructors and AssemblyName.KeyPair.
 ms.date: 05/31/2022
 ---
-# Strong-name APIS throw PlatformNotSupportedException
+# Strong-name APIs throw PlatformNotSupportedException
 
-A few [APIs](#affected-apis) that aren't supported in .NET/.NET Core but didn't doing anything when accessed have been changed to now throw a <xref:System.PlatformNotSupportedException> at run time. Previously, using these APIs would eventually result in a run-time exception further along; the exception is now thrown when the type is instantiated or first accessed.
+A few [APIs](#affected-apis) that aren't supported in .NET/.NET Core but didn't do anything when accessed have been changed to now throw a <xref:System.PlatformNotSupportedException> at run time. Previously, using these APIs would eventually result in a run-time exception further along; the exception is now thrown when the type is instantiated or first accessed.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
@@ -10,7 +10,7 @@ Some APIs have been marked as obsolete, starting in .NET 7. This breaking change
 
 ## Change description
 
-In previous .NET versions, these APIs can be used without any build warning. In .NET 7 and later versions, use of these APIS produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
+In previous .NET versions, these APIs can be used without any build warning. In .NET 7 and later versions, use of these APIs produces a compile-time warning or error with a custom diagnostic ID. The use of custom diagnostic IDs allows you to suppress the obsoletion warnings individually instead of blanket-suppressing all obsoletion warnings.
 
 The following table lists the custom diagnostic IDs and their corresponding warning messages for obsoleted APIs.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -187,7 +187,7 @@ items:
           href: core-libraries/6.0/static-abstract-interface-methods.md
         - name: StringBuilder.Append overloads and evaluation order
           href: core-libraries/6.0/stringbuilder-append-evaluation-order.md
-        - name: Strong-name APIS throw PlatformNotSupportedException
+        - name: Strong-name APIs throw PlatformNotSupportedException
           href: core-libraries/6.0/strong-name-signing-exceptions.md
         - name: System.Drawing.Common only supported on Windows
           href: core-libraries/6.0/system-drawing-common-windows-only.md
@@ -799,7 +799,7 @@ items:
           href: core-libraries/6.0/static-abstract-interface-methods.md
         - name: StringBuilder.Append overloads and evaluation order
           href: core-libraries/6.0/stringbuilder-append-evaluation-order.md
-        - name: Strong-name APIS throw PlatformNotSupportedException
+        - name: Strong-name APIs throw PlatformNotSupportedException
           href: core-libraries/6.0/strong-name-signing-exceptions.md
         - name: System.Drawing.Common only supported on Windows
           href: core-libraries/6.0/system-drawing-common-windows-only.md

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -187,6 +187,8 @@ items:
           href: core-libraries/6.0/static-abstract-interface-methods.md
         - name: StringBuilder.Append overloads and evaluation order
           href: core-libraries/6.0/stringbuilder-append-evaluation-order.md
+        - name: Strong-name APIS throw PlatformNotSupportedException
+          href: core-libraries/6.0/strong-name-signing-exceptions.md
         - name: System.Drawing.Common only supported on Windows
           href: core-libraries/6.0/system-drawing-common-windows-only.md
         - name: System.Security.SecurityContext is marked obsolete
@@ -797,6 +799,8 @@ items:
           href: core-libraries/6.0/static-abstract-interface-methods.md
         - name: StringBuilder.Append overloads and evaluation order
           href: core-libraries/6.0/stringbuilder-append-evaluation-order.md
+        - name: Strong-name APIS throw PlatformNotSupportedException
+          href: core-libraries/6.0/strong-name-signing-exceptions.md
         - name: System.Drawing.Common only supported on Windows
           href: core-libraries/6.0/system-drawing-common-windows-only.md
         - name: System.Security.SecurityContext is marked obsolete


### PR DESCRIPTION
Fixes #29681

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/strong-name-signing-exceptions?branch=pr-en-us-29686)