### PR TITLE
Questionable word: "alignment"

### DIFF
--- a/docs/fsharp/language-reference/interpolated-strings.md
+++ b/docs/fsharp/language-reference/interpolated-strings.md
@@ -86,7 +86,7 @@ let pi = $"{System.Math.PI:N4}"  // "3.1416"
 let now = $"{System.DateTime.UtcNow:``yyyyMMdd``}" // e.g. "20220210"
 ```
 
-If a .NET alignment contains an unusual character, then it can be escaped using double-backticks:
+If a .NET-style specifier contains an unusual character, then it can be escaped using double-backticks:
 
 ```fsharp
 let nowDashes = $"{System.DateTime.UtcNow:``yyyy-MM-dd``}" // e.g. "2022-02-10"


### PR DESCRIPTION
## Summary

I found the word "alignment" questionable here. I think the author meant to say ".NET-style specifier" instead because we're talking about format specifiers in this section. The next section, _Aligning expressions in interpolated strings_, talks about alignment. Of course, I could be wrong. Thank you.
