### PR TITLE
Add no response action

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,7 +6,7 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
+    # Schedule every day at 00:05
     - cron: '5 0 * * *'
 
 jobs:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
   schedule:
     # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    - cron: '5 0 * * *'
 
 jobs:
   noResponse:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,23 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
+        with:
+          token: ${{ github.token }}
+          responseRequiredLabel: needs-more-info
+          daysUntilClose: 14
+          closeComment: >
+            This issue has been automatically closed due to no response from the original author.
+            Please feel free to reopen it if you have more information that can help us investigate the issue further.


### PR DESCRIPTION
## Summary

I looked into the no response bot and it seems it's been deprecated for a year. They suggested using this action.

@gewarren 

Do we need to add auth for this action in the github settings?

How do we remove the no-response bot app? 
