### PR TITLE
constant string pattern and Spans

### DIFF
--- a/docs/csharp/fundamentals/functional/pattern-matching.md
+++ b/docs/csharp/fundamentals/functional/pattern-matching.md
@@ -1,7 +1,7 @@
 ---
 title: Pattern matching overview - C# guide
 description: Learn about pattern matching expressions in C#
-ms.date: 05/14/2021
+ms.date: 06/02/2022
 ---
 
 # Pattern matching overview
@@ -40,7 +40,11 @@ The previous example demonstrates a method dispatch based on the value of an enu
 
 :::code language="csharp" source="snippets/patterns/Simulation.cs" ID="PerformStringOperation":::
 
-The preceding example shows the same algorithm, but uses string values instead of an enum. You would use this scenario if your application responds to text commands instead of a regular data format. In all these examples, the *discard pattern* ensures that you handle every input. The compiler helps you by making sure every possible input value is handled.
+The preceding example shows the same algorithm, but uses string values instead of an enum. You would use this scenario if your application responds to text commands instead of a regular data format. Starting with C# 11, you can also use a `Span<char>` or a `ReadOnlySpan<char>`to test for constant string values, as shown in the following sample:
+
+:::code language="csharp" source="snippets/patterns/Simulation.cs" ID="PerformSpanOperation":::
+
+In all these examples, the *discard pattern* ensures that you handle every input. The compiler helps you by making sure every possible input value is handled.
 
 ## Relational patterns
 

--- a/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Simulation.cs
@@ -41,6 +41,18 @@ class Simulation
        };
     // </PerformStringOperation>
 
+    // <PerformSpanOperation>
+    public State PerformOperation(ReadOnlySpan<char> command) =>
+       command switch
+       {
+           "SystemTest" => RunDiagnostics(),
+           "Start" => StartSystem(),
+           "Stop" => StopSystem(),
+           "Reset" => ResetToReady(),
+           _ => throw new ArgumentException("Invalid string value for command", nameof(command)),
+       };
+    // </PerformSpanOperation>
+
     // <RelationalPattern>
     string WaterState(int tempInFahrenheit) =>
         tempInFahrenheit switch

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -1,7 +1,7 @@
 ---
 title: "Patterns - C# reference"
 description: "Learn about the patterns supported by C# pattern matching expressions and statements."
-ms.date: 08/23/2021
+ms.date: 06/02/2022
 f1_keywords: 
   - "and_CSharpKeyword"
   - "or_CSharpKeyword"
@@ -85,11 +85,14 @@ Beginning with C# 7.0, you use a *constant pattern* to test if an expression res
 In a constant pattern, you can use any constant expression, such as:
 
 - an [integer](../builtin-types/integral-numeric-types.md) or [floating-point](../builtin-types/floating-point-numeric-types.md) numerical literal
-- a [char](../builtin-types/char.md) or a [string](../builtin-types/reference-types.md#the-string-type) literal
+- a [char](../builtin-types/char.md)
+- a [string](../builtin-types/reference-types.md#the-string-type) literal.
 - a Boolean value `true` or `false`
 - an [enum](../builtin-types/enum.md) value
 - the name of a declared [const](../keywords/const.md) field or local
 - `null`
+
+The expression must be a type that is convertible to the constant type, with one exception: An expression whose type is `Span<char>` or `ReadOnlySpan<char>` can be matched against constant strings in C# 11 and later versions.
 
 Use a constant pattern to check for `null`, as the following example shows:
 

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -1,11 +1,9 @@
 ---
 title: What's new in C# 11 - C# Guide
 description: Get an overview of the new features coming in C# 11.
-ms.date: 05/11/2022
+ms.date: 06/02/2022
 ---
 # What's new in C# 11
-
-Beginning with the .NET 6.0.200 SDK or Visual Studio 2022 version 17.1, preview features in C# are available for you to try.
 
 > [!IMPORTANT]
 > These are currently preview features. You must [set `<LangVersion>` to `preview`](../language-reference/compiler-options/language.md#langversion) to enable these features. Any feature may change before its final release. These features may not all be released in C# 11. Some may remain in a preview phase for longer based on feedback on the feature.
@@ -13,6 +11,7 @@ Beginning with the .NET 6.0.200 SDK or Visual Studio 2022 version 17.1, preview 
 The following features are available in Visual Studio 2022 version 17.3:
 
 - [auto-default structs](#auto-default-struct)
+- [pattern match `Span<char>` on a constant `string`](#pattern-match-span)
 
 The following features are available in Visual Studio 2022 version 17.2:
 
@@ -147,3 +146,7 @@ You can learn more about raw string literals in the article on [strings in the p
 ## Auto-default struct
 
 The C# 11 compiler ensures that all fields of a `struct` type are initialized to their default value as part of executing a constructor. This change means any field or auto property not initialized by a constructor is automatically initialized by the compiler. Structs where the constructor doesn't definitely assign all fields now compile, and any fields not explicitly initialized are set to their default value. You can read more about how this change affects struct initialization in the article on [structs](../language-reference/builtin-types/struct.md#struct-initialization-and-default-values).
+
+## Pattern match `Span<char>` or `ReadOnlySpan<char>` on a constant `string`
+
+You've been able to test if a `string` had a specific constant value using pattern matching for several releases. Now, you can use the same pattern matching logic with variables that are `Span<char>` or `ReadOnlySpan<char>`.

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -11,7 +11,7 @@ ms.date: 06/02/2022
 The following features are available in Visual Studio 2022 version 17.3:
 
 - [auto-default structs](#auto-default-struct)
-- [pattern match `Span<char>` on a constant `string`](#pattern-match-span)
+- [pattern match `Span<char>` on a constant `string`](#pattern-match-spanchar-or-readonlyspanchar-on-a-constant-string)
 
 The following features are available in Visual Studio 2022 version 17.2:
 


### PR DESCRIPTION
Fixes #29270

This feature affects only a few docs. You can match a Span<char> (or ReadOnlySpan<char>) against a literal string constant.

Update the language reference for pattern matching. Mention this feature in one tutorial.
