### PR TITLE
Update right-to-left regex search section

### DIFF
--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 
 # Regular expression options
 
-By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. Most of these options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
+By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. Some of these options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
 
 |RegexOptions member|Inline character|Effect|
 |-------------------------|----------------------|------------|
@@ -291,7 +291,7 @@ By default, the regular expression engine searches from left to right. You can r
 
 ### Example
 
-The regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first and second words begin with "b" and the third word end with "b". As the output from the right-to-left search example shows, only the first and second words match the regular expression pattern, with the second word being matched first.
+The regular expression `\bb\w+\s` matches words with two or more characters that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first and second words begin with "b" and the third word ends with "b". As the output from the right-to-left search example shows, only the first and second words match the regular expression pattern, with the second word being matched first.
 
 [!code-csharp[Conceptual.Regex.Language.Options#17](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs#17)]
 [!code-vb[Conceptual.Regex.Language.Options#17](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb#17)]

--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -1,7 +1,7 @@
 ---
-title: "Regular Expression Options"
+title: Options for regular expression
 description: Learn how to use regular expression options in .NET, such as case-insensitive matching, multiline mode, and right-to-left mode.
-ms.date: "03/30/2017"
+ms.date: 06/02/2022
 dev_langs:
   - "csharp"
   - "vb"
@@ -11,12 +11,11 @@ helpviewer_keywords:
   - ".NET regular expressions, options"
   - "inline option constructs"
   - "options parameter"
-ms.assetid: c82dc689-7e82-4767-a18d-cd24ce5f05e9
 ---
 
-# Regular Expression Options
+# Regular expression options
 
-By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. These options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
+By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. Most of these options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
 
 |RegexOptions member|Inline character|Effect|
 |-------------------------|----------------------|------------|
@@ -31,7 +30,7 @@ By default, the comparison of an input string with any literal characters in a r
 |<xref:System.Text.RegularExpressions.RegexOptions.ECMAScript>|Not available|Enable ECMAScript-compliant behavior for the expression. For more information, see [ECMAScript Matching Behavior](#ecmascript-matching-behavior).|
 |<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#comparison-using-the-invariant-culture).|
 
-## Specifying the Options
+## Specify options
 
 You can specify options for regular expressions in one of three ways:
 
@@ -87,7 +86,7 @@ The following five regular expression options can be set using the `options` par
 
 - <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType>
 
-## Determining the Options
+## Determine options
 
 You can determine which options were provided to a <xref:System.Text.RegularExpressions.Regex> object when it was instantiated by retrieving the value of the read-only <xref:System.Text.RegularExpressions.Regex.Options%2A?displayProperty=nameWithType> property. This property is particularly useful for determining the options that are defined for a compiled regular expression created by the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A?displayProperty=nameWithType> method.
 
@@ -103,7 +102,7 @@ To test for <xref:System.Text.RegularExpressions.RegexOptions.None?displayProper
 
 The following sections list the options supported by regular expression in .NET.
 
-## Default Options
+## Default options
 
 The <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameWithType> option indicates that no options have been specified, and the regular expression engine uses its default behavior. This includes the following:
 
@@ -128,7 +127,7 @@ The <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameW
 
 Because the <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameWithType> option represents the default behavior of the regular expression engine, it is rarely explicitly specified in a method call. A constructor or static pattern-matching method without an `options` parameter is called instead.
 
-## Case-Insensitive Matching
+## Case-insensitive matching
 
 The <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase> option, or the `i` inline option, provides case-insensitive matching. By default, the casing conventions of the current culture are used.
 
@@ -142,7 +141,7 @@ The following example modifies the regular expression pattern from the previous 
 [!code-csharp[Conceptual.Regex.Language.Options#2](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/case2.cs#2)]
 [!code-vb[Conceptual.Regex.Language.Options#2](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/case2.vb#2)]
 
-## Multiline Mode
+## Multiline mode
 
 The <xref:System.Text.RegularExpressions.RegexOptions.Multiline?displayProperty=nameWithType> option, or the `m` inline option, enables the regular expression engine to handle an input string that consists of multiple lines. It changes the interpretation of the `^` and `$` language elements so that they match the beginning and end of a line, instead of the beginning and end of the input string.
 
@@ -169,7 +168,7 @@ The following example is equivalent to the previous one, except that it uses the
 [!code-csharp[Conceptual.Regex.Language.Options#4](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline2.cs#4)]
 [!code-vb[Conceptual.Regex.Language.Options#4](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline2.vb#4)]
 
-## Single-line Mode
+## Single-line mode
 
 The <xref:System.Text.RegularExpressions.RegexOptions.Singleline?displayProperty=nameWithType> option, or the `s` inline option, causes the regular expression engine to treat the input string as if it consists of a single line. It does this by changing the behavior of the period (`.`) language element so that it matches every character, instead of matching every character except for the newline character `\n` or `\u000A`.
 
@@ -185,7 +184,7 @@ The following example is equivalent to the previous one, except that it uses the
 [!code-csharp[Conceptual.Regex.Language.Options#5](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/singleline1.cs#5)]
 [!code-vb[Conceptual.Regex.Language.Options#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/singleline1.vb#5)]
 
-## Explicit Captures Only
+## Explicit captures only
 
 By default, capturing groups are defined by the use of parentheses in the regular expression pattern. Named groups are assigned a name or number by the `(?<`*name*`>`*subexpression*`)` language option, whereas unnamed groups are accessible by index. In the <xref:System.Text.RegularExpressions.GroupCollection> object, unnamed groups precede named groups.
 
@@ -223,7 +222,7 @@ Finally, you can use the inline group element `(?n:)` to suppress automatic capt
 [!code-csharp[Conceptual.Regex.Language.Options#11](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit3.cs#11)]
 [!code-vb[Conceptual.Regex.Language.Options#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit3.vb#11)]
 
-## Compiled Regular Expressions
+## Compiled regular expressions
 
 By default, regular expressions in .NET are interpreted. When a <xref:System.Text.RegularExpressions.Regex> object is instantiated or a static <xref:System.Text.RegularExpressions.Regex> method is called, the regular expression pattern is parsed into a set of custom opcodes, and an interpreter uses these opcodes to run the regular expression. This involves a tradeoff: The cost of initializing the regular expression engine is minimized at the expense of run-time performance.
 
@@ -245,7 +244,7 @@ However, this improvement in performance occurs only under the following conditi
 > [!NOTE]
 > The <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType> option is unrelated to the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A?displayProperty=nameWithType> method, which creates a special-purpose assembly that contains predefined compiled regular expressions.
 
-## Ignore White Space
+## Ignore white space
 
 By default, white space in a regular expression pattern is significant; it forces the regular expression engine to match a white-space character in the input string. Because of this, the regular expression "`\b\w+\s`" and "`\b\w+` " are roughly equivalent regular expressions. In addition, when the number sign (#) is encountered in a regular expression pattern, it is interpreted as a literal character to be matched.
 
@@ -283,19 +282,27 @@ The following example uses the inline option `(?x)` to ignore pattern white spac
 [!code-csharp[Conceptual.Regex.Language.Options#13](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace2.cs#13)]
 [!code-vb[Conceptual.Regex.Language.Options#13](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace2.vb#13)]
 
-## Right-to-Left Mode
+## Right-to-left mode
 
-By default, the regular expression engine searches from left to right. You can reverse the search direction by using the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option. The search automatically begins at the last character position of the string. For pattern-matching methods that include a starting position parameter, such as <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.Int32%29?displayProperty=nameWithType>, the starting position is the index of the rightmost character position at which the search is to begin.
+By default, the regular expression engine searches from left to right. You can reverse the search direction by using the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option. The right-to-left search automatically begins at the last character position of the string. For pattern-matching methods that include a starting position parameter, such as <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.Int32%29?displayProperty=nameWithType>, the specified starting position is the index of the rightmost character position at which the search is to begin.
 
 > [!NOTE]
 > Right-to-left pattern mode is available only by supplying the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> value to the `options` parameter of a <xref:System.Text.RegularExpressions.Regex> class constructor or static pattern-matching method. It is not available as an inline option.
 
-The <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option changes the search direction only; it does not interpret the regular expression pattern from right to left. For example, the regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first word begins with "b", the second ends with "b", and the third includes two "b" characters in the middle of the word. As the output from the example shows, only the first word matches the regular expression pattern.
+### Example
+
+The regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first and second words begin with "b" and the third word end with "b". As the output from the right-to-left search example shows, only the first and second words match the regular expression pattern, with the second word being matched first.
 
 [!code-csharp[Conceptual.Regex.Language.Options#17](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs#17)]
 [!code-vb[Conceptual.Regex.Language.Options#17](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb#17)]
 
-Also note that the lookahead assertion (the `(?=`*subexpression*`)` language element) and the lookbehind assertion (the `(?<=`*subexpression*`)` language element) do not change direction. The lookahead assertions look to the right; the lookbehind assertions look to the left. For example, the regular expression `(?<=\d{1,2}\s)\w+,?\s\d{4}` uses the lookbehind assertion to test for a date that precedes a month name. The regular expression then matches the month and the year. For information on lookahead and lookbehind assertions, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).
+### Evaluation order
+
+The <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option changes the search direction and also reverses the order in which the regular expression pattern is evaluated. In a right-to-left search, the search pattern is read from right to left. This distinction is important because it can affect things like capture groups and [backreferences](backreference-constructs-in-regular-expressions.md). For example, the expression `Regex.Match("abcabc", @"\1(abc)", RegexOptions.RightToLeft)` finds a match `abcabc`, but in a left-to-right search (`Regex.Match("abcabc", @"\1(abc)", RegexOptions.None)`), no match is found. That's because the `(abc)` element must be evaluated before the numbered capturing group element (`\1`) for a match to be found.
+
+### Lookaheads
+
+The lookahead assertion (the `(?=`*subexpression*`)` language element) and the lookbehind assertion (the `(?<=`*subexpression*`)` language element) do not change direction. The lookahead assertions look to the right; the lookbehind assertions look to the left. For example, the regular expression `(?<=\d{1,2}\s)\w+,?\s\d{4}` uses the lookbehind assertion to test for a date that precedes a month name. The regular expression then matches the month and the year. For information on lookahead and lookbehind assertions, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).
 
 [!code-csharp[Conceptual.Regex.Language.Options#18](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs#18)]
 [!code-vb[Conceptual.Regex.Language.Options#18](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb#18)]
@@ -310,7 +317,7 @@ The regular expression pattern is defined as shown in the following table.
 |`\s`|Match a white-space character.|
 |`\d{4}`|Match four decimal digits.|
 
-## ECMAScript Matching Behavior
+## ECMAScript matching behavior
 
 By default, the regular expression engine uses canonical behavior when matching a regular expression pattern to input text. However, you can instruct the regular expression engine to use ECMAScript matching behavior by specifying the <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType> option.
 
@@ -350,7 +357,7 @@ The behavior of ECMAScript and canonical regular expressions differs in three ar
   |`\` followed by a digit from 1 to 9, followed by no additional decimal digits,|Interpret as a backreference. For example, `\9` always means backreference 9, even if a ninth capturing group does not exist. If the capturing group does not exist, the regular expression parser throws an <xref:System.ArgumentException>.|If a single decimal digit capturing group exists, backreference to that digit. Otherwise, interpret the value as a literal.|
   |`\` followed by a digit from 1 to 9, followed by additional decimal digits|Interpret the digits as a decimal value. If that capturing group exists, interpret the expression as a backreference.<br /><br /> Otherwise, interpret the leading octal digits up to octal 377; that is, consider only the low 8 bits of the value. Interpret the remaining digits as literals. For example, in the expression `\3000`, if capturing group 300 exists, interpret as backreference 300; if capturing group 300 does not exist, interpret as octal 300 followed by 0.|Interpret as a backreference by converting as many digits as possible to a decimal value that can refer to a capture. If no digits can be converted, interpret as an octal by using the leading octal digits up to octal 377; interpret the remaining digits as literals.|
 
-## Comparison Using the Invariant Culture
+## Compare using the invariant culture
 
 By default, when the regular expression engine performs case-insensitive comparisons, it uses the casing conventions of the current culture to determine equivalent uppercase and lowercase characters.
 

--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -28,7 +28,7 @@ By default, the comparison of an input string with any literal characters in a r
 |<xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace>|`x`|Exclude unescaped white space from the pattern, and enable comments after a number sign (`#`). For more information, see [Ignore White Space](#ignore-white-space).|
 |<xref:System.Text.RegularExpressions.RegexOptions.RightToLeft>|Not available|Change the search direction. Search moves from right to left instead of from left to right. For more information, see [Right-to-Left Mode](#right-to-left-mode).|
 |<xref:System.Text.RegularExpressions.RegexOptions.ECMAScript>|Not available|Enable ECMAScript-compliant behavior for the expression. For more information, see [ECMAScript Matching Behavior](#ecmascript-matching-behavior).|
-|<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#comparison-using-the-invariant-culture).|
+|<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#compare-using-the-invariant-culture).|
 
 ## Specify options
 

--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -1,7 +1,7 @@
 ---
-title: Options for regular expression
+title: "Regular Expression Options"
 description: Learn how to use regular expression options in .NET, such as case-insensitive matching, multiline mode, and right-to-left mode.
-ms.date: 06/02/2022
+ms.date: "03/30/2017"
 dev_langs:
   - "csharp"
   - "vb"
@@ -11,11 +11,12 @@ helpviewer_keywords:
   - ".NET regular expressions, options"
   - "inline option constructs"
   - "options parameter"
+ms.assetid: c82dc689-7e82-4767-a18d-cd24ce5f05e9
 ---
 
-# Regular expression options
+# Regular Expression Options
 
-By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. Most of these options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
+By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. These options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
 
 |RegexOptions member|Inline character|Effect|
 |-------------------------|----------------------|------------|
@@ -28,9 +29,9 @@ By default, the comparison of an input string with any literal characters in a r
 |<xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace>|`x`|Exclude unescaped white space from the pattern, and enable comments after a number sign (`#`). For more information, see [Ignore White Space](#ignore-white-space).|
 |<xref:System.Text.RegularExpressions.RegexOptions.RightToLeft>|Not available|Change the search direction. Search moves from right to left instead of from left to right. For more information, see [Right-to-Left Mode](#right-to-left-mode).|
 |<xref:System.Text.RegularExpressions.RegexOptions.ECMAScript>|Not available|Enable ECMAScript-compliant behavior for the expression. For more information, see [ECMAScript Matching Behavior](#ecmascript-matching-behavior).|
-|<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#compare-using-the-invariant-culture).|
+|<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#comparison-using-the-invariant-culture).|
 
-## Specify options
+## Specifying the Options
 
 You can specify options for regular expressions in one of three ways:
 
@@ -86,7 +87,7 @@ The following five regular expression options can be set using the `options` par
 
 - <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType>
 
-## Determine options
+## Determining the Options
 
 You can determine which options were provided to a <xref:System.Text.RegularExpressions.Regex> object when it was instantiated by retrieving the value of the read-only <xref:System.Text.RegularExpressions.Regex.Options%2A?displayProperty=nameWithType> property. This property is particularly useful for determining the options that are defined for a compiled regular expression created by the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A?displayProperty=nameWithType> method.
 
@@ -102,7 +103,7 @@ To test for <xref:System.Text.RegularExpressions.RegexOptions.None?displayProper
 
 The following sections list the options supported by regular expression in .NET.
 
-## Default options
+## Default Options
 
 The <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameWithType> option indicates that no options have been specified, and the regular expression engine uses its default behavior. This includes the following:
 
@@ -127,7 +128,7 @@ The <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameW
 
 Because the <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameWithType> option represents the default behavior of the regular expression engine, it is rarely explicitly specified in a method call. A constructor or static pattern-matching method without an `options` parameter is called instead.
 
-## Case-insensitive matching
+## Case-Insensitive Matching
 
 The <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase> option, or the `i` inline option, provides case-insensitive matching. By default, the casing conventions of the current culture are used.
 
@@ -141,7 +142,7 @@ The following example modifies the regular expression pattern from the previous 
 [!code-csharp[Conceptual.Regex.Language.Options#2](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/case2.cs#2)]
 [!code-vb[Conceptual.Regex.Language.Options#2](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/case2.vb#2)]
 
-## Multiline mode
+## Multiline Mode
 
 The <xref:System.Text.RegularExpressions.RegexOptions.Multiline?displayProperty=nameWithType> option, or the `m` inline option, enables the regular expression engine to handle an input string that consists of multiple lines. It changes the interpretation of the `^` and `$` language elements so that they match the beginning and end of a line, instead of the beginning and end of the input string.
 
@@ -168,7 +169,7 @@ The following example is equivalent to the previous one, except that it uses the
 [!code-csharp[Conceptual.Regex.Language.Options#4](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline2.cs#4)]
 [!code-vb[Conceptual.Regex.Language.Options#4](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline2.vb#4)]
 
-## Single-line mode
+## Single-line Mode
 
 The <xref:System.Text.RegularExpressions.RegexOptions.Singleline?displayProperty=nameWithType> option, or the `s` inline option, causes the regular expression engine to treat the input string as if it consists of a single line. It does this by changing the behavior of the period (`.`) language element so that it matches every character, instead of matching every character except for the newline character `\n` or `\u000A`.
 
@@ -184,7 +185,7 @@ The following example is equivalent to the previous one, except that it uses the
 [!code-csharp[Conceptual.Regex.Language.Options#5](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/singleline1.cs#5)]
 [!code-vb[Conceptual.Regex.Language.Options#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/singleline1.vb#5)]
 
-## Explicit captures only
+## Explicit Captures Only
 
 By default, capturing groups are defined by the use of parentheses in the regular expression pattern. Named groups are assigned a name or number by the `(?<`*name*`>`*subexpression*`)` language option, whereas unnamed groups are accessible by index. In the <xref:System.Text.RegularExpressions.GroupCollection> object, unnamed groups precede named groups.
 
@@ -222,7 +223,7 @@ Finally, you can use the inline group element `(?n:)` to suppress automatic capt
 [!code-csharp[Conceptual.Regex.Language.Options#11](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit3.cs#11)]
 [!code-vb[Conceptual.Regex.Language.Options#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit3.vb#11)]
 
-## Compiled regular expressions
+## Compiled Regular Expressions
 
 By default, regular expressions in .NET are interpreted. When a <xref:System.Text.RegularExpressions.Regex> object is instantiated or a static <xref:System.Text.RegularExpressions.Regex> method is called, the regular expression pattern is parsed into a set of custom opcodes, and an interpreter uses these opcodes to run the regular expression. This involves a tradeoff: The cost of initializing the regular expression engine is minimized at the expense of run-time performance.
 
@@ -244,7 +245,7 @@ However, this improvement in performance occurs only under the following conditi
 > [!NOTE]
 > The <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType> option is unrelated to the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A?displayProperty=nameWithType> method, which creates a special-purpose assembly that contains predefined compiled regular expressions.
 
-## Ignore white space
+## Ignore White Space
 
 By default, white space in a regular expression pattern is significant; it forces the regular expression engine to match a white-space character in the input string. Because of this, the regular expression "`\b\w+\s`" and "`\b\w+` " are roughly equivalent regular expressions. In addition, when the number sign (#) is encountered in a regular expression pattern, it is interpreted as a literal character to be matched.
 
@@ -282,27 +283,19 @@ The following example uses the inline option `(?x)` to ignore pattern white spac
 [!code-csharp[Conceptual.Regex.Language.Options#13](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace2.cs#13)]
 [!code-vb[Conceptual.Regex.Language.Options#13](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace2.vb#13)]
 
-## Right-to-left mode
+## Right-to-Left Mode
 
-By default, the regular expression engine searches from left to right. You can reverse the search direction by using the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option. The right-to-left search automatically begins at the last character position of the string. For pattern-matching methods that include a starting position parameter, such as <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.Int32%29?displayProperty=nameWithType>, the specified starting position is the index of the rightmost character position at which the search is to begin.
+By default, the regular expression engine searches from left to right. You can reverse the search direction by using the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option. The search automatically begins at the last character position of the string. For pattern-matching methods that include a starting position parameter, such as <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.Int32%29?displayProperty=nameWithType>, the starting position is the index of the rightmost character position at which the search is to begin.
 
 > [!NOTE]
 > Right-to-left pattern mode is available only by supplying the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> value to the `options` parameter of a <xref:System.Text.RegularExpressions.Regex> class constructor or static pattern-matching method. It is not available as an inline option.
 
-### Example
-
-The regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first and second words begin with "b" and the third word end with "b". As the output from the right-to-left search example shows, only the first and second words match the regular expression pattern, with the second word being matched first.
+The <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option changes the search direction only; it does not interpret the regular expression pattern from right to left. For example, the regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first word begins with "b", the second ends with "b", and the third includes two "b" characters in the middle of the word. As the output from the example shows, only the first word matches the regular expression pattern.
 
 [!code-csharp[Conceptual.Regex.Language.Options#17](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs#17)]
 [!code-vb[Conceptual.Regex.Language.Options#17](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb#17)]
 
-### Evaluation order
-
-The <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option changes the search direction and also reverses the order in which the regular expression pattern is evaluated. In a right-to-left search, the search pattern is read from right to left. This distinction is important because it can affect things like capture groups and [backreferences](backreference-constructs-in-regular-expressions.md). For example, the expression `Regex.Match("abcabc", @"\1(abc)", RegexOptions.RightToLeft)` finds a match `abcabc`, but in a left-to-right search (`Regex.Match("abcabc", @"\1(abc)", RegexOptions.None)`), no match is found. That's because the `(abc)` element must be evaluated before the numbered capturing group element (`\1`) for a match to be found.
-
-### Lookaheads
-
-The lookahead assertion (the `(?=`*subexpression*`)` language element) and the lookbehind assertion (the `(?<=`*subexpression*`)` language element) do not change direction. The lookahead assertions look to the right; the lookbehind assertions look to the left. For example, the regular expression `(?<=\d{1,2}\s)\w+,?\s\d{4}` uses the lookbehind assertion to test for a date that precedes a month name. The regular expression then matches the month and the year. For information on lookahead and lookbehind assertions, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).
+Also note that the lookahead assertion (the `(?=`*subexpression*`)` language element) and the lookbehind assertion (the `(?<=`*subexpression*`)` language element) do not change direction. The lookahead assertions look to the right; the lookbehind assertions look to the left. For example, the regular expression `(?<=\d{1,2}\s)\w+,?\s\d{4}` uses the lookbehind assertion to test for a date that precedes a month name. The regular expression then matches the month and the year. For information on lookahead and lookbehind assertions, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).
 
 [!code-csharp[Conceptual.Regex.Language.Options#18](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs#18)]
 [!code-vb[Conceptual.Regex.Language.Options#18](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb#18)]
@@ -317,7 +310,7 @@ The regular expression pattern is defined as shown in the following table.
 |`\s`|Match a white-space character.|
 |`\d{4}`|Match four decimal digits.|
 
-## ECMAScript matching behavior
+## ECMAScript Matching Behavior
 
 By default, the regular expression engine uses canonical behavior when matching a regular expression pattern to input text. However, you can instruct the regular expression engine to use ECMAScript matching behavior by specifying the <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType> option.
 
@@ -357,7 +350,7 @@ The behavior of ECMAScript and canonical regular expressions differs in three ar
   |`\` followed by a digit from 1 to 9, followed by no additional decimal digits,|Interpret as a backreference. For example, `\9` always means backreference 9, even if a ninth capturing group does not exist. If the capturing group does not exist, the regular expression parser throws an <xref:System.ArgumentException>.|If a single decimal digit capturing group exists, backreference to that digit. Otherwise, interpret the value as a literal.|
   |`\` followed by a digit from 1 to 9, followed by additional decimal digits|Interpret the digits as a decimal value. If that capturing group exists, interpret the expression as a backreference.<br /><br /> Otherwise, interpret the leading octal digits up to octal 377; that is, consider only the low 8 bits of the value. Interpret the remaining digits as literals. For example, in the expression `\3000`, if capturing group 300 exists, interpret as backreference 300; if capturing group 300 does not exist, interpret as octal 300 followed by 0.|Interpret as a backreference by converting as many digits as possible to a decimal value that can refer to a capture. If no digits can be converted, interpret as an octal by using the leading octal digits up to octal 377; interpret the remaining digits as literals.|
 
-## Compare using the invariant culture
+## Comparison Using the Invariant Culture
 
 By default, when the regular expression engine performs case-insensitive comparisons, it uses the casing conventions of the current culture to determine equivalent uppercase and lowercase characters.
 

--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -1,7 +1,7 @@
 ---
-title: "Regular Expression Options"
+title: Options for regular expression
 description: Learn how to use regular expression options in .NET, such as case-insensitive matching, multiline mode, and right-to-left mode.
-ms.date: "03/30/2017"
+ms.date: 06/02/2022
 dev_langs:
   - "csharp"
   - "vb"
@@ -11,12 +11,11 @@ helpviewer_keywords:
   - ".NET regular expressions, options"
   - "inline option constructs"
   - "options parameter"
-ms.assetid: c82dc689-7e82-4767-a18d-cd24ce5f05e9
 ---
 
-# Regular Expression Options
+# Regular expression options
 
-By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. These options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
+By default, the comparison of an input string with any literal characters in a regular expression pattern is case sensitive, white space in a regular expression pattern is interpreted as literal white-space characters, and capturing groups in a regular expression are named implicitly as well as explicitly. You can modify these and several other aspects of default regular expression behavior by specifying regular expression options. Most of these options, which are listed in the following table, can be included inline as part of the regular expression pattern, or they can be supplied to a <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class constructor or static pattern matching method as a <xref:System.Text.RegularExpressions.RegexOptions?displayProperty=nameWithType> enumeration value.
 
 |RegexOptions member|Inline character|Effect|
 |-------------------------|----------------------|------------|
@@ -29,9 +28,10 @@ By default, the comparison of an input string with any literal characters in a r
 |<xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace>|`x`|Exclude unescaped white space from the pattern, and enable comments after a number sign (`#`). For more information, see [Ignore White Space](#ignore-white-space).|
 |<xref:System.Text.RegularExpressions.RegexOptions.RightToLeft>|Not available|Change the search direction. Search moves from right to left instead of from left to right. For more information, see [Right-to-Left Mode](#right-to-left-mode).|
 |<xref:System.Text.RegularExpressions.RegexOptions.ECMAScript>|Not available|Enable ECMAScript-compliant behavior for the expression. For more information, see [ECMAScript Matching Behavior](#ecmascript-matching-behavior).|
-|<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#comparison-using-the-invariant-culture).|
+|<xref:System.Text.RegularExpressions.RegexOptions.CultureInvariant>|Not available|Ignore cultural differences in language. For more information, see [Comparison Using the Invariant Culture](#compare-using-the-invariant-culture).|
+|<xref:System.Text.RegularExpressions.RegexOptions.NonBacktracking>|Not available|Match using an approach that avoids backtracking and guarantees linear-time processing in the length of the input. (Available in .NET 7 and later versions.)|
 
-## Specifying the Options
+## Specify options
 
 You can specify options for regular expressions in one of three ways:
 
@@ -87,7 +87,7 @@ The following five regular expression options can be set using the `options` par
 
 - <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType>
 
-## Determining the Options
+## Determine options
 
 You can determine which options were provided to a <xref:System.Text.RegularExpressions.Regex> object when it was instantiated by retrieving the value of the read-only <xref:System.Text.RegularExpressions.Regex.Options%2A?displayProperty=nameWithType> property. This property is particularly useful for determining the options that are defined for a compiled regular expression created by the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A?displayProperty=nameWithType> method.
 
@@ -103,7 +103,7 @@ To test for <xref:System.Text.RegularExpressions.RegexOptions.None?displayProper
 
 The following sections list the options supported by regular expression in .NET.
 
-## Default Options
+## Default options
 
 The <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameWithType> option indicates that no options have been specified, and the regular expression engine uses its default behavior. This includes the following:
 
@@ -128,7 +128,7 @@ The <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameW
 
 Because the <xref:System.Text.RegularExpressions.RegexOptions.None?displayProperty=nameWithType> option represents the default behavior of the regular expression engine, it is rarely explicitly specified in a method call. A constructor or static pattern-matching method without an `options` parameter is called instead.
 
-## Case-Insensitive Matching
+## Case-insensitive matching
 
 The <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase> option, or the `i` inline option, provides case-insensitive matching. By default, the casing conventions of the current culture are used.
 
@@ -142,7 +142,7 @@ The following example modifies the regular expression pattern from the previous 
 [!code-csharp[Conceptual.Regex.Language.Options#2](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/case2.cs#2)]
 [!code-vb[Conceptual.Regex.Language.Options#2](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/case2.vb#2)]
 
-## Multiline Mode
+## Multiline mode
 
 The <xref:System.Text.RegularExpressions.RegexOptions.Multiline?displayProperty=nameWithType> option, or the `m` inline option, enables the regular expression engine to handle an input string that consists of multiple lines. It changes the interpretation of the `^` and `$` language elements so that they match the beginning and end of a line, instead of the beginning and end of the input string.
 
@@ -169,7 +169,7 @@ The following example is equivalent to the previous one, except that it uses the
 [!code-csharp[Conceptual.Regex.Language.Options#4](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline2.cs#4)]
 [!code-vb[Conceptual.Regex.Language.Options#4](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline2.vb#4)]
 
-## Single-line Mode
+## Single-line mode
 
 The <xref:System.Text.RegularExpressions.RegexOptions.Singleline?displayProperty=nameWithType> option, or the `s` inline option, causes the regular expression engine to treat the input string as if it consists of a single line. It does this by changing the behavior of the period (`.`) language element so that it matches every character, instead of matching every character except for the newline character `\n` or `\u000A`.
 
@@ -185,7 +185,7 @@ The following example is equivalent to the previous one, except that it uses the
 [!code-csharp[Conceptual.Regex.Language.Options#5](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/singleline1.cs#5)]
 [!code-vb[Conceptual.Regex.Language.Options#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/singleline1.vb#5)]
 
-## Explicit Captures Only
+## Explicit captures only
 
 By default, capturing groups are defined by the use of parentheses in the regular expression pattern. Named groups are assigned a name or number by the `(?<`*name*`>`*subexpression*`)` language option, whereas unnamed groups are accessible by index. In the <xref:System.Text.RegularExpressions.GroupCollection> object, unnamed groups precede named groups.
 
@@ -223,7 +223,7 @@ Finally, you can use the inline group element `(?n:)` to suppress automatic capt
 [!code-csharp[Conceptual.Regex.Language.Options#11](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit3.cs#11)]
 [!code-vb[Conceptual.Regex.Language.Options#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit3.vb#11)]
 
-## Compiled Regular Expressions
+## Compiled regular expressions
 
 By default, regular expressions in .NET are interpreted. When a <xref:System.Text.RegularExpressions.Regex> object is instantiated or a static <xref:System.Text.RegularExpressions.Regex> method is called, the regular expression pattern is parsed into a set of custom opcodes, and an interpreter uses these opcodes to run the regular expression. This involves a tradeoff: The cost of initializing the regular expression engine is minimized at the expense of run-time performance.
 
@@ -245,7 +245,7 @@ However, this improvement in performance occurs only under the following conditi
 > [!NOTE]
 > The <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType> option is unrelated to the <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A?displayProperty=nameWithType> method, which creates a special-purpose assembly that contains predefined compiled regular expressions.
 
-## Ignore White Space
+## Ignore white space
 
 By default, white space in a regular expression pattern is significant; it forces the regular expression engine to match a white-space character in the input string. Because of this, the regular expression "`\b\w+\s`" and "`\b\w+` " are roughly equivalent regular expressions. In addition, when the number sign (#) is encountered in a regular expression pattern, it is interpreted as a literal character to be matched.
 
@@ -283,34 +283,47 @@ The following example uses the inline option `(?x)` to ignore pattern white spac
 [!code-csharp[Conceptual.Regex.Language.Options#13](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace2.cs#13)]
 [!code-vb[Conceptual.Regex.Language.Options#13](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace2.vb#13)]
 
-## Right-to-Left Mode
+## Right-to-left mode
 
-By default, the regular expression engine searches from left to right. You can reverse the search direction by using the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option. The search automatically begins at the last character position of the string. For pattern-matching methods that include a starting position parameter, such as <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.Int32%29?displayProperty=nameWithType>, the starting position is the index of the rightmost character position at which the search is to begin.
+By default, the regular expression engine searches from left to right. You can reverse the search direction by using the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option. The right-to-left search automatically begins at the last character position of the string. For pattern-matching methods that include a starting position parameter, such as <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.Int32%29?displayProperty=nameWithType>, the specified starting position is the index of the rightmost character position at which the search is to begin.
 
 > [!NOTE]
 > Right-to-left pattern mode is available only by supplying the <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> value to the `options` parameter of a <xref:System.Text.RegularExpressions.Regex> class constructor or static pattern-matching method. It is not available as an inline option.
 
-The <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option changes the search direction only; it does not interpret the regular expression pattern from right to left. For example, the regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first word begins with "b", the second ends with "b", and the third includes two "b" characters in the middle of the word. As the output from the example shows, only the first word matches the regular expression pattern.
+### Example
+
+The regular expression `\bb\w+\s` matches words that begin with the letter "b" and are followed by a white-space character. In the following example, the input string consists of three words that include one or more "b" characters. The first and second words begin with "b" and the third word end with "b". As the output from the right-to-left search example shows, only the first and second words match the regular expression pattern, with the second word being matched first.
 
 [!code-csharp[Conceptual.Regex.Language.Options#17](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs#17)]
 [!code-vb[Conceptual.Regex.Language.Options#17](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb#17)]
 
-Also note that the lookahead assertion (the `(?=`*subexpression*`)` language element) and the lookbehind assertion (the `(?<=`*subexpression*`)` language element) do not change direction. The lookahead assertions look to the right; the lookbehind assertions look to the left. For example, the regular expression `(?<=\d{1,2}\s)\w+,?\s\d{4}` uses the lookbehind assertion to test for a date that precedes a month name. The regular expression then matches the month and the year. For information on lookahead and lookbehind assertions, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).
+### Evaluation order
+
+The <xref:System.Text.RegularExpressions.RegexOptions.RightToLeft?displayProperty=nameWithType> option changes the search direction and also reverses the order in which the regular expression pattern is evaluated. In a right-to-left search, the search pattern is read from right to left. This distinction is important because it can affect things like capture groups and [backreferences](backreference-constructs-in-regular-expressions.md). For example, the expression `Regex.Match("abcabc", @"\1(abc)", RegexOptions.RightToLeft)` finds a match `abcabc`, but in a left-to-right search (`Regex.Match("abcabc", @"\1(abc)", RegexOptions.None)`), no match is found. That's because the `(abc)` element must be evaluated before the numbered capturing group element (`\1`) for a match to be found.
+
+### Lookahead and lookbehind assertions
+
+The location of a match for a lookahead (`(?=subexpression)`) or lookbehind (`(?<=subexpression)`) assertion doesn't change in a right-to-left search. The lookahead assertions look to the right of the current match location; the lookbehind assertions look to the left of the current match location.
+
+> [!TIP]
+> Whether a search is right-to-left or not, lookbehinds are implemented using a right-to-left search starting at the current match location.
+
+For example, the regular expression `(?<=\d{1,2}\s)\w+,\s\d{4}` uses the lookbehind assertion to test for a date that precedes a month name. The regular expression then matches the month and the year. For information on lookahead and lookbehind assertions, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).
 
 [!code-csharp[Conceptual.Regex.Language.Options#18](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs#18)]
 [!code-vb[Conceptual.Regex.Language.Options#18](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb#18)]
 
 The regular expression pattern is defined as shown in the following table.
 
-|Pattern|Description|
-|-------------|-----------------|
-|`(?<=\d{1,2}\s)`|The beginning of the match must be preceded by one or two decimal digits followed by a space.|
-|`\w+`|Match one or more word characters.|
-|`,?`|Match zero or one comma characters.|
-|`\s`|Match a white-space character.|
-|`\d{4}`|Match four decimal digits.|
+| Pattern          | Description                                                                                   |
+|------------------|-----------------------------------------------------------------------------------------------|
+| `(?<=\d{1,2}\s)` | The beginning of the match must be preceded by one or two decimal digits followed by a space. |
+| `\w+`            | Match one or more word characters.                                                            |
+| `,`              | Match one comma character.                                                                    |
+| `\s`             | Match a white-space character.                                                                |
+| `\d{4}`          | Match four decimal digits.                                                                    |
 
-## ECMAScript Matching Behavior
+## ECMAScript matching behavior
 
 By default, the regular expression engine uses canonical behavior when matching a regular expression pattern to input text. However, you can instruct the regular expression engine to use ECMAScript matching behavior by specifying the <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType> option.
 
@@ -350,7 +363,7 @@ The behavior of ECMAScript and canonical regular expressions differs in three ar
   |`\` followed by a digit from 1 to 9, followed by no additional decimal digits,|Interpret as a backreference. For example, `\9` always means backreference 9, even if a ninth capturing group does not exist. If the capturing group does not exist, the regular expression parser throws an <xref:System.ArgumentException>.|If a single decimal digit capturing group exists, backreference to that digit. Otherwise, interpret the value as a literal.|
   |`\` followed by a digit from 1 to 9, followed by additional decimal digits|Interpret the digits as a decimal value. If that capturing group exists, interpret the expression as a backreference.<br /><br /> Otherwise, interpret the leading octal digits up to octal 377; that is, consider only the low 8 bits of the value. Interpret the remaining digits as literals. For example, in the expression `\3000`, if capturing group 300 exists, interpret as backreference 300; if capturing group 300 does not exist, interpret as octal 300 followed by 0.|Interpret as a backreference by converting as many digits as possible to a decimal value that can refer to a capture. If no digits can be converted, interpret as an octal by using the leading octal digits up to octal 377; interpret the remaining digits as literals.|
 
-## Comparison Using the Invariant Culture
+## Compare using the invariant culture
 
 By default, when the regular expression engine performs case-insensitive comparisons, it uses the casing conventions of the current culture to determine equivalent uppercase and lowercase characters.
 

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/Project.csproj
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/Project.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>   
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/case2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/case2.cs
@@ -2,21 +2,21 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class CaseExample
 {
-   public static void Main()
-   {
-      string pattern = @"\b(?i:t)he\w*\b";
-      string input = "The man then told them about that event.";
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine("Found {0} at index {1}.", match.Value, match.Index);
+    public static void Main()
+    {
+        string pattern = @"\b(?i:t)he\w*\b";
+        string input = "The man then told them about that event.";
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine("Found {0} at index {1}.", match.Value, match.Index);
 
-      Console.WriteLine();
-      pattern = @"(?i)\bthe\w*\b";
-      foreach (Match match in Regex.Matches(input, pattern,
-                                            RegexOptions.IgnoreCase))
-         Console.WriteLine("Found {0} at index {1}.", match.Value, match.Index);
-   }
+        Console.WriteLine();
+        pattern = @"(?i)\bthe\w*\b";
+        foreach (Match match in Regex.Matches(input, pattern,
+                                              RegexOptions.IgnoreCase))
+            Console.WriteLine("Found {0} at index {1}.", match.Value, match.Index);
+    }
 }
 // The example displays the following output:
 //       Found The at index 0.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/culture1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/culture1.cs
@@ -3,58 +3,58 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-public class Example
+public class CultureExample
 {
-   public static void Main()
-   {
-      ShowIllegalAccess();
-      Console.WriteLine("-----");
-      ShowNoAccess();
-   }
+    public static void Main()
+    {
+        ShowIllegalAccess();
+        Console.WriteLine("-----");
+        ShowNoAccess();
+    }
 
-   private static void ShowIllegalAccess()
-   {
-      // <Snippet14>
-      CultureInfo defaultCulture = Thread.CurrentThread.CurrentCulture;
-      Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+    private static void ShowIllegalAccess()
+    {
+        // <Snippet14>
+        CultureInfo defaultCulture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
 
-      string input = "file://c:/Documents.MyReport.doc";
-      string pattern = "FILE://";
+        string input = "file://c:/Documents.MyReport.doc";
+        string pattern = "FILE://";
 
-      Console.WriteLine("Culture-sensitive matching ({0} culture)...",
-                        Thread.CurrentThread.CurrentCulture.Name);
-      if (Regex.IsMatch(input, pattern, RegexOptions.IgnoreCase))
-         Console.WriteLine("URLs that access files are not allowed.");
-      else
-         Console.WriteLine("Access to {0} is allowed.", input);
+        Console.WriteLine("Culture-sensitive matching ({0} culture)...",
+                          Thread.CurrentThread.CurrentCulture.Name);
+        if (Regex.IsMatch(input, pattern, RegexOptions.IgnoreCase))
+            Console.WriteLine("URLs that access files are not allowed.");
+        else
+            Console.WriteLine("Access to {0} is allowed.", input);
 
-      Thread.CurrentThread.CurrentCulture = defaultCulture;
-      // The example displays the following output:
-      //       Culture-sensitive matching (tr-TR culture)...
-      //       Access to file://c:/Documents.MyReport.doc is allowed.
-      // </Snippet14>
-   }
+        Thread.CurrentThread.CurrentCulture = defaultCulture;
+        // The example displays the following output:
+        //       Culture-sensitive matching (tr-TR culture)...
+        //       Access to file://c:/Documents.MyReport.doc is allowed.
+        // </Snippet14>
+    }
 
-   private static void ShowNoAccess()
-   {
-      // <Snippet15>
-      CultureInfo defaultCulture = Thread.CurrentThread.CurrentCulture;
-      Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+    private static void ShowNoAccess()
+    {
+        // <Snippet15>
+        CultureInfo defaultCulture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
 
-      string input = "file://c:/Documents.MyReport.doc";
-      string pattern = "FILE://";
+        string input = "file://c:/Documents.MyReport.doc";
+        string pattern = "FILE://";
 
-      Console.WriteLine("Culture-insensitive matching...");
-      if (Regex.IsMatch(input, pattern,
-                        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
-         Console.WriteLine("URLs that access files are not allowed.");
-      else
-         Console.WriteLine("Access to {0} is allowed.", input);
+        Console.WriteLine("Culture-insensitive matching...");
+        if (Regex.IsMatch(input, pattern,
+                          RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+            Console.WriteLine("URLs that access files are not allowed.");
+        else
+            Console.WriteLine("Access to {0} is allowed.", input);
 
-      Thread.CurrentThread.CurrentCulture = defaultCulture;
-      // The example displays the following output:
-      //       Culture-insensitive matching...
-      //       URLs that access files are not allowed.
-      // </Snippet15>
-   }
+        Thread.CurrentThread.CurrentCulture = defaultCulture;
+        // The example displays the following output:
+        //       Culture-insensitive matching...
+        //       URLs that access files are not allowed.
+        // </Snippet15>
+    }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/determine1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/determine1.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class DetermineOptionsExample
 {
-   public static void Main()
-   {
-      Regex rgx = new Regex(@"\w*\s", RegexOptions.IgnoreCase);
-      // <Snippet19>
-      if ((rgx.Options & RegexOptions.IgnoreCase) == RegexOptions.IgnoreCase)
-         Console.WriteLine("Case-insensitive pattern comparison.");
-      else
-         Console.WriteLine("Case-sensitive pattern comparison.");
-      // </Snippet19>
-      // <Snippet20>
-      if (rgx.Options == RegexOptions.None)
-         Console.WriteLine("No options have been set.");
-      // </Snippet20>
-   }
+    public static void Main()
+    {
+        Regex rgx = new Regex(@"\w*\s", RegexOptions.IgnoreCase);
+        // <Snippet19>
+        if ((rgx.Options & RegexOptions.IgnoreCase) == RegexOptions.IgnoreCase)
+            Console.WriteLine("Case-insensitive pattern comparison.");
+        else
+            Console.WriteLine("Case-sensitive pattern comparison.");
+        // </Snippet19>
+        // <Snippet20>
+        if (rgx.Options == RegexOptions.None)
+            Console.WriteLine("No options have been set.");
+        // </Snippet20>
+    }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/ecmascript1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/ecmascript1.cs
@@ -2,28 +2,28 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class EcmaScriptExample
 {
-   public static void Main()
-   {
-      string[] values = { "целый мир", "the whole world" };
-      string pattern = @"\b(\w+\s*)+";
-      foreach (var value in values)
-      {
-         Console.Write("Canonical matching: ");
-         if (Regex.IsMatch(value, pattern))
-            Console.WriteLine("'{0}' matches the pattern.", value);
-         else
-            Console.WriteLine("{0} does not match the pattern.", value);
+    public static void Main()
+    {
+        string[] values = { "целый мир", "the whole world" };
+        string pattern = @"\b(\w+\s*)+";
+        foreach (var value in values)
+        {
+            Console.Write("Canonical matching: ");
+            if (Regex.IsMatch(value, pattern))
+                Console.WriteLine("'{0}' matches the pattern.", value);
+            else
+                Console.WriteLine("{0} does not match the pattern.", value);
 
-         Console.Write("ECMAScript matching: ");
-         if (Regex.IsMatch(value, pattern, RegexOptions.ECMAScript))
-            Console.WriteLine("'{0}' matches the pattern.", value);
-         else
-            Console.WriteLine("{0} does not match the pattern.", value);
-         Console.WriteLine();
-      }
-   }
+            Console.Write("ECMAScript matching: ");
+            if (Regex.IsMatch(value, pattern, RegexOptions.ECMAScript))
+                Console.WriteLine("'{0}' matches the pattern.", value);
+            else
+                Console.WriteLine("{0} does not match the pattern.", value);
+            Console.WriteLine();
+        }
+    }
 }
 // The example displays the following output:
 //       Canonical matching: 'целый мир' matches the pattern.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/ecmascript2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/ecmascript2.cs
@@ -2,47 +2,47 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class EcmaScript2Example
 {
-   static string pattern;
+    static string pattern;
 
-   public static void Main()
-   {
-      string input = "aa aaaa aaaaaa ";
-      pattern = @"((a+)(\1) ?)+";
+    public static void Main()
+    {
+        string input = "aa aaaa aaaaaa ";
+        pattern = @"((a+)(\1) ?)+";
 
-      // Match input using canonical matching.
-      AnalyzeMatch(Regex.Match(input, pattern));
+        // Match input using canonical matching.
+        AnalyzeMatch(Regex.Match(input, pattern));
 
-      // Match input using ECMAScript.
-      AnalyzeMatch(Regex.Match(input, pattern, RegexOptions.ECMAScript));
-   }
+        // Match input using ECMAScript.
+        AnalyzeMatch(Regex.Match(input, pattern, RegexOptions.ECMAScript));
+    }
 
-   private static void AnalyzeMatch(Match m)
-   {
-      if (m.Success)
-      {
-         Console.WriteLine("'{0}' matches {1} at position {2}.",
-                           pattern, m.Value, m.Index);
-         int grpCtr = 0;
-         foreach (Group grp in m.Groups)
-         {
-            Console.WriteLine("   {0}: '{1}'", grpCtr, grp.Value);
-            grpCtr++;
-            int capCtr = 0;
-            foreach (Capture cap in grp.Captures)
+    private static void AnalyzeMatch(Match m)
+    {
+        if (m.Success)
+        {
+            Console.WriteLine("'{0}' matches {1} at position {2}.",
+                              pattern, m.Value, m.Index);
+            int grpCtr = 0;
+            foreach (Group grp in m.Groups)
             {
-               Console.WriteLine("      {0}: '{1}'", capCtr, cap.Value);
-               capCtr++;
+                Console.WriteLine("   {0}: '{1}'", grpCtr, grp.Value);
+                grpCtr++;
+                int capCtr = 0;
+                foreach (Capture cap in grp.Captures)
+                {
+                    Console.WriteLine("      {0}: '{1}'", capCtr, cap.Value);
+                    capCtr++;
+                }
             }
-         }
-      }
-      else
-      {
-         Console.WriteLine("No match found.");
-      }
-      Console.WriteLine();
-   }
+        }
+        else
+        {
+            Console.WriteLine("No match found.");
+        }
+        Console.WriteLine();
+    }
 }
 // The example displays the following output:
 //    No match found.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/example1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/example1.cs
@@ -1,57 +1,57 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class ShowOptionsExamples
 {
-   public static void Main()
-   {
-      ShowOptionsArgument();
-      Console.WriteLine("-----");
-      ShowInlineOptions();
-      Console.WriteLine("-----");
-      ShowGroupOptions();
-   }
+    public static void Main()
+    {
+        ShowOptionsArgument();
+        Console.WriteLine("-----");
+        ShowInlineOptions();
+        Console.WriteLine("-----");
+        ShowGroupOptions();
+    }
 
-   private static void ShowOptionsArgument()
-   {
-      // <Snippet6>
-      string pattern = @"d \w+ \s";
-      string input = "Dogs are decidedly good pets.";
-      RegexOptions options = RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace;
+    private static void ShowOptionsArgument()
+    {
+        // <Snippet6>
+        string pattern = @"d \w+ \s";
+        string input = "Dogs are decidedly good pets.";
+        RegexOptions options = RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace;
 
-      foreach (Match match in Regex.Matches(input, pattern, options))
-         Console.WriteLine("'{0}// found at index {1}.", match.Value, match.Index);
-      // The example displays the following output:
-      //    'Dogs // found at index 0.
-      //    'decidedly // found at index 9.
-      // </Snippet6>
-   }
+        foreach (Match match in Regex.Matches(input, pattern, options))
+            Console.WriteLine("'{0}// found at index {1}.", match.Value, match.Index);
+        // The example displays the following output:
+        //    'Dogs // found at index 0.
+        //    'decidedly // found at index 9.
+        // </Snippet6>
+    }
 
-   private static void ShowInlineOptions()
-   {
-      // <Snippet7>
-      string pattern = @"(?ix) d \w+ \s";
-      string input = "Dogs are decidedly good pets.";
+    private static void ShowInlineOptions()
+    {
+        // <Snippet7>
+        string pattern = @"(?ix) d \w+ \s";
+        string input = "Dogs are decidedly good pets.";
 
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine("'{0}// found at index {1}.", match.Value, match.Index);
-      // The example displays the following output:
-      //    'Dogs // found at index 0.
-      //    'decidedly // found at index 9.
-      // </Snippet7>
-   }
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine("'{0}// found at index {1}.", match.Value, match.Index);
+        // The example displays the following output:
+        //    'Dogs // found at index 0.
+        //    'decidedly // found at index 9.
+        // </Snippet7>
+    }
 
-   private static void ShowGroupOptions()
-   {
-      // <Snippet8>
-      string pattern = @"\b(?ix: d \w+)\s";
-      string input = "Dogs are decidedly good pets.";
+    private static void ShowGroupOptions()
+    {
+        // <Snippet8>
+        string pattern = @"\b(?ix: d \w+)\s";
+        string input = "Dogs are decidedly good pets.";
 
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine("'{0}// found at index {1}.", match.Value, match.Index);
-      // The example displays the following output:
-      //    'Dogs // found at index 0.
-      //    'decidedly // found at index 9.
-      // </Snippet8>
-   }
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine("'{0}// found at index {1}.", match.Value, match.Index);
+        // The example displays the following output:
+        //    'Dogs // found at index 0.
+        //    'decidedly // found at index 9.
+        // </Snippet8>
+    }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit1.cs
@@ -2,50 +2,50 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Explicit1Example
 {
-   public static void Main()
-   {
-      string input = "This is the first sentence. Is it the beginning " +
-                     "of a literary masterpiece? I think not. Instead, " +
-                     "it is a nonsensical paragraph.";
-      string pattern = @"\b\(?((?>\w+),?\s?)+[\.!?]\)?";
-      Console.WriteLine("With implicit captures:");
-      foreach (Match match in Regex.Matches(input, pattern))
-      {
-         Console.WriteLine("The match: {0}", match.Value);
-         int groupCtr = 0;
-         foreach (Group group in match.Groups)
-         {
-            Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
-            groupCtr++;
-            int captureCtr = 0;
-            foreach (Capture capture in group.Captures)
+    public static void Main()
+    {
+        string input = "This is the first sentence. Is it the beginning " +
+                       "of a literary masterpiece? I think not. Instead, " +
+                       "it is a nonsensical paragraph.";
+        string pattern = @"\b\(?((?>\w+),?\s?)+[\.!?]\)?";
+        Console.WriteLine("With implicit captures:");
+        foreach (Match match in Regex.Matches(input, pattern))
+        {
+            Console.WriteLine("The match: {0}", match.Value);
+            int groupCtr = 0;
+            foreach (Group group in match.Groups)
             {
-               Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
-               captureCtr++;
+                Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
+                groupCtr++;
+                int captureCtr = 0;
+                foreach (Capture capture in group.Captures)
+                {
+                    Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
+                    captureCtr++;
+                }
             }
-         }
-      }
-      Console.WriteLine();
-      Console.WriteLine("With explicit captures only:");
-      foreach (Match match in Regex.Matches(input, pattern, RegexOptions.ExplicitCapture))
-      {
-         Console.WriteLine("The match: {0}", match.Value);
-         int groupCtr = 0;
-         foreach (Group group in match.Groups)
-         {
-            Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
-            groupCtr++;
-            int captureCtr = 0;
-            foreach (Capture capture in group.Captures)
+        }
+        Console.WriteLine();
+        Console.WriteLine("With explicit captures only:");
+        foreach (Match match in Regex.Matches(input, pattern, RegexOptions.ExplicitCapture))
+        {
+            Console.WriteLine("The match: {0}", match.Value);
+            int groupCtr = 0;
+            foreach (Group group in match.Groups)
             {
-               Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
-               captureCtr++;
+                Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
+                groupCtr++;
+                int captureCtr = 0;
+                foreach (Capture capture in group.Captures)
+                {
+                    Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
+                    captureCtr++;
+                }
             }
-         }
-      }
-   }
+        }
+    }
 }
 // The example displays the following output:
 //    With implicit captures:

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit2.cs
@@ -2,32 +2,32 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Explicit2Example
 {
-   public static void Main()
-   {
-      string input = "This is the first sentence. Is it the beginning " +
-                     "of a literary masterpiece? I think not. Instead, " +
-                     "it is a nonsensical paragraph.";
-      string pattern = @"(?n)\b\(?((?>\w+),?\s?)+[\.!?]\)?";
+    public static void Main()
+    {
+        string input = "This is the first sentence. Is it the beginning " +
+                       "of a literary masterpiece? I think not. Instead, " +
+                       "it is a nonsensical paragraph.";
+        string pattern = @"(?n)\b\(?((?>\w+),?\s?)+[\.!?]\)?";
 
-      foreach (Match match in Regex.Matches(input, pattern))
-      {
-         Console.WriteLine("The match: {0}", match.Value);
-         int groupCtr = 0;
-         foreach (Group group in match.Groups)
-         {
-            Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
-            groupCtr++;
-            int captureCtr = 0;
-            foreach (Capture capture in group.Captures)
+        foreach (Match match in Regex.Matches(input, pattern))
+        {
+            Console.WriteLine("The match: {0}", match.Value);
+            int groupCtr = 0;
+            foreach (Group group in match.Groups)
             {
-               Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
-               captureCtr++;
+                Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
+                groupCtr++;
+                int captureCtr = 0;
+                foreach (Capture capture in group.Captures)
+                {
+                    Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
+                    captureCtr++;
+                }
             }
-         }
-      }
-   }
+        }
+    }
 }
 // The example displays the following output:
 //       The match: This is the first sentence.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/explicit3.cs
@@ -2,32 +2,32 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Explicit3Example
 {
-   public static void Main()
-   {
-      string input = "This is the first sentence. Is it the beginning " +
-                     "of a literary masterpiece? I think not. Instead, " +
-                     "it is a nonsensical paragraph.";
-      string pattern = @"\b\(?(?n:(?>\w+),?\s?)+[\.!?]\)?";
+    public static void Main()
+    {
+        string input = "This is the first sentence. Is it the beginning " +
+                       "of a literary masterpiece? I think not. Instead, " +
+                       "it is a nonsensical paragraph.";
+        string pattern = @"\b\(?(?n:(?>\w+),?\s?)+[\.!?]\)?";
 
-      foreach (Match match in Regex.Matches(input, pattern))
-      {
-         Console.WriteLine("The match: {0}", match.Value);
-         int groupCtr = 0;
-         foreach (Group group in match.Groups)
-         {
-            Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
-            groupCtr++;
-            int captureCtr = 0;
-            foreach (Capture capture in group.Captures)
+        foreach (Match match in Regex.Matches(input, pattern))
+        {
+            Console.WriteLine("The match: {0}", match.Value);
+            int groupCtr = 0;
+            foreach (Group group in match.Groups)
             {
-               Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
-               captureCtr++;
+                Console.WriteLine("   Group {0}: {1}", groupCtr, group.Value);
+                groupCtr++;
+                int captureCtr = 0;
+                foreach (Capture capture in group.Captures)
+                {
+                    Console.WriteLine("      Capture {0}: {1}", captureCtr, capture.Value);
+                    captureCtr++;
+                }
             }
-         }
-      }
-   }
+        }
+    }
 }
 // The example displays the following output:
 //       The match: This is the first sentence.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline1.cs
@@ -3,47 +3,47 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Multiline1Example
 {
-   public static void Main()
-   {
-      SortedList<int, string> scores = new SortedList<int, string>(new DescendingComparer<int>());
+    public static void Main()
+    {
+        SortedList<int, string> scores = new SortedList<int, string>(new DescendingComparer1<int>());
 
-      string input = "Joe 164\n" +
-                     "Sam 208\n" +
-                     "Allison 211\n" +
-                     "Gwen 171\n";
-      string pattern = @"^(\w+)\s(\d+)$";
-      bool matched = false;
+        string input = "Joe 164\n" +
+                       "Sam 208\n" +
+                       "Allison 211\n" +
+                       "Gwen 171\n";
+        string pattern = @"^(\w+)\s(\d+)$";
+        bool matched = false;
 
-      Console.WriteLine("Without Multiline option:");
-      foreach (Match match in Regex.Matches(input, pattern))
-      {
-         scores.Add(Int32.Parse(match.Groups[2].Value), (string) match.Groups[1].Value);
-         matched = true;
-      }
-      if (! matched)
-         Console.WriteLine("   No matches.");
-      Console.WriteLine();
+        Console.WriteLine("Without Multiline option:");
+        foreach (Match match in Regex.Matches(input, pattern))
+        {
+            scores.Add(Int32.Parse(match.Groups[2].Value), (string)match.Groups[1].Value);
+            matched = true;
+        }
+        if (!matched)
+            Console.WriteLine("   No matches.");
+        Console.WriteLine();
 
-      // Redefine pattern to handle multiple lines.
-      pattern = @"^(\w+)\s(\d+)\r*$";
-      Console.WriteLine("With multiline option:");
-      foreach (Match match in Regex.Matches(input, pattern, RegexOptions.Multiline))
-         scores.Add(Int32.Parse(match.Groups[2].Value), (string) match.Groups[1].Value);
+        // Redefine pattern to handle multiple lines.
+        pattern = @"^(\w+)\s(\d+)\r*$";
+        Console.WriteLine("With multiline option:");
+        foreach (Match match in Regex.Matches(input, pattern, RegexOptions.Multiline))
+            scores.Add(Int32.Parse(match.Groups[2].Value), (string)match.Groups[1].Value);
 
-      // List scores in descending order.
-      foreach (KeyValuePair<int, string> score in scores)
-         Console.WriteLine("{0}: {1}", score.Value, score.Key);
-   }
+        // List scores in descending order.
+        foreach (KeyValuePair<int, string> score in scores)
+            Console.WriteLine("{0}: {1}", score.Value, score.Key);
+    }
 }
 
-public class DescendingComparer<T> : IComparer<T>
+public class DescendingComparer1<T> : IComparer<T>
 {
-   public int Compare(T x, T y)
-   {
-      return Comparer<T>.Default.Compare(x, y) * -1;
-   }
+    public int Compare(T x, T y)
+    {
+        return Comparer<T>.Default.Compare(x, y) * -1;
+    }
 }
 // The example displays the following output:
 //   Without Multiline option:

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/multiline2.cs
@@ -3,33 +3,33 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Multiline2Example
 {
-   public static void Main()
-   {
-      SortedList<int, string> scores = new SortedList<int, string>(new DescendingComparer<int>());
+    public static void Main()
+    {
+        SortedList<int, string> scores = new SortedList<int, string>(new DescendingComparer<int>());
 
-      string input = "Joe 164\n" +
-                     "Sam 208\n" +
-                     "Allison 211\n" +
-                     "Gwen 171\n";
-      string pattern = @"(?m)^(\w+)\s(\d+)\r*$";
+        string input = "Joe 164\n" +
+                       "Sam 208\n" +
+                       "Allison 211\n" +
+                       "Gwen 171\n";
+        string pattern = @"(?m)^(\w+)\s(\d+)\r*$";
 
-      foreach (Match match in Regex.Matches(input, pattern, RegexOptions.Multiline))
-         scores.Add(Convert.ToInt32(match.Groups[2].Value), match.Groups[1].Value);
+        foreach (Match match in Regex.Matches(input, pattern, RegexOptions.Multiline))
+            scores.Add(Convert.ToInt32(match.Groups[2].Value), match.Groups[1].Value);
 
-      // List scores in descending order.
-      foreach (KeyValuePair<int, string> score in scores)
-         Console.WriteLine("{0}: {1}", score.Value, score.Key);
-   }
+        // List scores in descending order.
+        foreach (KeyValuePair<int, string> score in scores)
+            Console.WriteLine("{0}: {1}", score.Value, score.Key);
+    }
 }
 
 public class DescendingComparer<T> : IComparer<T>
 {
-   public int Compare(T x, T y)
-   {
-      return Comparer<T>.Default.Compare(x, y) * -1;
-   }
+    public int Compare(T x, T y)
+    {
+        return Comparer<T>.Default.Compare(x, y) * -1;
+    }
 }
 // The example displays the following output:
 //    Allison: 211

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs
@@ -7,11 +7,12 @@ public class Example
    public static void Main()
    {
       string pattern = @"\bb\w+\s";
-      string input = "builder rob rabble";
+      string input = "build band tab";
       foreach (Match match in Regex.Matches(input, pattern, RegexOptions.RightToLeft))
          Console.WriteLine("'{0}' found at position {1}.", match.Value, match.Index);
    }
 }
 // The example displays the following output:
-//       'builder ' found at position 0.
+//       'band ' found at position 6.
+//       'build ' found at position 0.
 // </Snippet17>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft1.cs
@@ -2,15 +2,15 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class RTL1Example
 {
-   public static void Main()
-   {
-      string pattern = @"\bb\w+\s";
-      string input = "build band tab";
-      foreach (Match match in Regex.Matches(input, pattern, RegexOptions.RightToLeft))
-         Console.WriteLine("'{0}' found at position {1}.", match.Value, match.Index);
-   }
+    public static void Main()
+    {
+        string pattern = @"\bb\w+\s";
+        string input = "build band tab";
+        foreach (Match match in Regex.Matches(input, pattern, RegexOptions.RightToLeft))
+            Console.WriteLine("'{0}' found at position {1}.", match.Value, match.Index);
+    }
 }
 // The example displays the following output:
 //       'band ' found at position 6.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs
@@ -6,8 +6,8 @@ public class RTL2Example
 {
     public static void Main()
     {
-        string[] inputs = { "1 May 1917", "June 16, 2003" };
-        string pattern = @"(?<=\d{1,2}\s)\w+,?\s\d{4}";
+        string[] inputs = { "1 May, 1917", "June 16, 2003" };
+        string pattern = @"(?<=\d{1,2}\s)\w+,\s\d{4}";
 
         foreach (string input in inputs)
         {
@@ -19,7 +19,8 @@ public class RTL2Example
         }
     }
 }
+
 // The example displays the following output:
-//       The date occurs in May 1917.
+//       The date occurs in May, 1917.
 //       June 16, 2003 does not match.
 // </Snippet18>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/righttoleft2.cs
@@ -2,22 +2,22 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class RTL2Example
 {
-   public static void Main()
-   {
-      string[] inputs = { "1 May 1917", "June 16, 2003" };
-      string pattern = @"(?<=\d{1,2}\s)\w+,?\s\d{4}";
+    public static void Main()
+    {
+        string[] inputs = { "1 May 1917", "June 16, 2003" };
+        string pattern = @"(?<=\d{1,2}\s)\w+,?\s\d{4}";
 
-      foreach (string input in inputs)
-      {
-         Match match = Regex.Match(input, pattern, RegexOptions.RightToLeft);
-         if (match.Success)
-            Console.WriteLine("The date occurs in {0}.", match.Value);
-         else
-            Console.WriteLine("{0} does not match.", input);
-      }
-   }
+        foreach (string input in inputs)
+        {
+            Match match = Regex.Match(input, pattern, RegexOptions.RightToLeft);
+            if (match.Success)
+                Console.WriteLine("The date occurs in {0}.", match.Value);
+            else
+                Console.WriteLine("{0} does not match.", input);
+        }
+    }
 }
 // The example displays the following output:
 //       The date occurs in May 1917.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/singleline1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/singleline1.cs
@@ -2,16 +2,16 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class SingleLineExample
 {
-   public static void Main()
-   {
-      string pattern = "(?s)^.+";
-      string input = "This is one line and" + Environment.NewLine + "this is the second.";
+    public static void Main()
+    {
+        string pattern = "(?s)^.+";
+        string input = "This is one line and" + Environment.NewLine + "this is the second.";
 
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine(Regex.Escape(match.Value));
-   }
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine(Regex.Escape(match.Value));
+    }
 }
 // The example displays the following output:
 //       This\ is\ one\ line\ and\r\nthis\ is\ the\ second\.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace1.cs
@@ -2,18 +2,18 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Whitespace1Example
 {
-   public static void Main()
-   {
-      string input = "This is the first sentence. Is it the beginning " +
-                     "of a literary masterpiece? I think not. Instead, " +
-                     "it is a nonsensical paragraph.";
-      string pattern = @"\b \(? ( (?>\w+) ,?\s? )+ [\.!?] \)? # Matches an entire sentence.";
+    public static void Main()
+    {
+        string input = "This is the first sentence. Is it the beginning " +
+                       "of a literary masterpiece? I think not. Instead, " +
+                       "it is a nonsensical paragraph.";
+        string pattern = @"\b \(? ( (?>\w+) ,?\s? )+ [\.!?] \)? # Matches an entire sentence.";
 
-      foreach (Match match in Regex.Matches(input, pattern, RegexOptions.IgnorePatternWhitespace))
-         Console.WriteLine(match.Value);
-   }
+        foreach (Match match in Regex.Matches(input, pattern, RegexOptions.IgnorePatternWhitespace))
+            Console.WriteLine(match.Value);
+    }
 }
 // The example displays the following output:
 //       This is the first sentence.

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.options/cs/whitespace2.cs
@@ -2,18 +2,18 @@
 using System;
 using System.Text.RegularExpressions;
 
-public class Example
+public class Whitespace2Example
 {
-   public static void Main()
-   {
-      string input = "This is the first sentence. Is it the beginning " +
-                     "of a literary masterpiece? I think not. Instead, " +
-                     "it is a nonsensical paragraph.";
-      string pattern = @"(?x)\b \(? ( (?>\w+) ,?\s? )+  [\.!?] \)? # Matches an entire sentence.";
+    public static void Main()
+    {
+        string input = "This is the first sentence. Is it the beginning " +
+                       "of a literary masterpiece? I think not. Instead, " +
+                       "it is a nonsensical paragraph.";
+        string pattern = @"(?x)\b \(? ( (?>\w+) ,?\s? )+  [\.!?] \)? # Matches an entire sentence.";
 
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine(match.Value);
-   }
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine(match.Value);
+    }
 }
 // The example displays the following output:
 //       This is the first sentence.

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/Project.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/Project.vbproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>   
+</Project>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/case2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/case2.vb
@@ -4,7 +4,7 @@ Option Strict On
 ' <Snippet2>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module CaseExample
     Public Sub Main()
         Dim pattern As String = "\b(?i:t)he\w*\b"
         Dim input As String = "The man then told them about that event."
@@ -18,6 +18,7 @@ Module Example
         Next
     End Sub
 End Module
+
 ' The example displays the following output:
 '       Found The at index 0.
 '       Found then at index 8.

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/culture1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/culture1.vb
@@ -5,7 +5,7 @@ Imports System.Globalization
 Imports System.Text.RegularExpressions
 Imports System.Threading
 
-Module Example
+Module CultureExample
     Public Sub Main()
         ShowIllegalAccess()
         Console.WriteLine("-----")
@@ -20,7 +20,7 @@ Module Example
         Dim input As String = "file://c:/Documents.MyReport.doc"
         Dim pattern As String = "$FILE://"
 
-        Console.WriteLine("Culture-sensitive matching ({0} culture)...", _
+        Console.WriteLine("Culture-sensitive matching ({0} culture)...",
                           Thread.CurrentThread.CurrentCulture.Name)
         If Regex.IsMatch(input, pattern, RegexOptions.IgnoreCase) Then
             Console.WriteLine("URLs that access files are not allowed.")
@@ -44,7 +44,7 @@ Module Example
         Dim pattern As String = "$FILE://"
 
         Console.WriteLine("Culture-insensitive matching...")
-        If Regex.IsMatch(input, pattern, _
+        If Regex.IsMatch(input, pattern,
                        RegexOptions.IgnoreCase Or RegexOptions.CultureInvariant) Then
             Console.WriteLine("URLs that access files are not allowed.")
         Else

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/determine1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/determine1.vb
@@ -3,7 +3,7 @@ Option Strict On
 
 Imports System.Text.RegularExpressions
 
-Module Example
+Module DetermineExample
     Public Sub Main()
         Dim rgx As New Regex("\w*\s", RegexOptions.IgnoreCase)
         ' <Snippet19>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/ecmascript1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/ecmascript1.vb
@@ -6,20 +6,20 @@ Imports System.IO
 ' <Snippet16>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Ecma1Example
     Public Sub Main()
         Dim values() As String = {"целый мир", "the whole world"}
         Dim pattern As String = "\b(\w+\s*)+"
         For Each value In values
             Console.Write("Canonical matching: ")
-            If Regex.IsMatch(value, pattern)
+            If Regex.IsMatch(value, pattern) Then
                 Console.WriteLine("'{0}' matches the pattern.", value)
             Else
                 Console.WriteLine("{0} does not match the pattern.", value)
             End If
 
             Console.Write("ECMAScript matching: ")
-            If Regex.IsMatch(value, pattern, RegexOptions.ECMAScript)
+            If Regex.IsMatch(value, pattern, RegexOptions.ECMAScript) Then
                 Console.WriteLine("'{0}' matches the pattern.", value)
             Else
                 Console.WriteLine("{0} does not match the pattern.", value)

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/ecmascript2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/ecmascript2.vb
@@ -5,7 +5,7 @@ Option Infer On
 ' <Snippet21>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Ecma2Example
     Dim pattern As String
 
     Public Sub Main()
@@ -20,8 +20,8 @@ Module Example
     End Sub
 
     Private Sub AnalyzeMatch(m As Match)
-        If m.Success
-            Console.WriteLine("'{0}' matches {1} at position {2}.", _
+        If m.Success Then
+            Console.WriteLine("'{0}' matches {1} at position {2}.",
                               pattern, m.Value, m.Index)
             Dim grpCtr As Integer = 0
             For Each grp As Group In m.Groups

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/example1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/example1.vb
@@ -3,7 +3,7 @@ Option Strict On
 
 Imports System.Text.RegularExpressions
 
-Module Example
+Module ShowOptionsExamples
     Public Sub Main()
         ShowOptionsArgument()
         Console.WriteLine("-----")

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit1.vb
@@ -4,10 +4,10 @@ Option Strict On
 ' <Snippet9>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Explicit1Example
     Public Sub Main()
-        Dim input As String = "This is the first sentence. Is it the beginning " + _
-                              "of a literary masterpiece? I think not. Instead, " + _
+        Dim input As String = "This is the first sentence. Is it the beginning " +
+                              "of a literary masterpiece? I think not. Instead, " +
                               "it is a nonsensical paragraph."
         Dim pattern As String = "\b\(?((?>\w+),?\s?)+[\.!?]\)?"
         Console.WriteLine("With implicit captures:")

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit2.vb
@@ -4,10 +4,10 @@ Option Strict On
 ' <Snippet10>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Explicit2Example
     Public Sub Main()
-        Dim input As String = "This is the first sentence. Is it the beginning " + _
-                              "of a literary masterpiece? I think not. Instead, " + _
+        Dim input As String = "This is the first sentence. Is it the beginning " +
+                              "of a literary masterpiece? I think not. Instead, " +
                               "it is a nonsensical paragraph."
         Dim pattern As String = "(?n)\b\(?((?>\w+),?\s?)+[\.!?]\)?"
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit3.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/explicit3.vb
@@ -4,10 +4,10 @@ Option Strict On
 ' <Snippet11>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Explicit3Example
     Public Sub Main()
-        Dim input As String = "This is the first sentence. Is it the beginning " + _
-                              "of a literary masterpiece? I think not. Instead, " + _
+        Dim input As String = "This is the first sentence. Is it the beginning " +
+                              "of a literary masterpiece? I think not. Instead, " +
                               "it is a nonsensical paragraph."
         Dim pattern As String = "\b\(?(?n:(?>\w+),?\s?)+[\.!?]\)?"
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline1.vb
@@ -5,13 +5,13 @@ Option Strict On
 Imports System.Collections.Generic
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Multiline1Example
     Public Sub Main()
-        Dim scores As New SortedList(Of Integer, String)(New DescendingComparer(Of Integer)())
+        Dim scores As New SortedList(Of Integer, String)(New DescendingComparer1(Of Integer)())
 
-        Dim input As String = "Joe 164" + vbCrLf + _
-                              "Sam 208" + vbCrLf + _
-                              "Allison 211" + vbCrLf + _
+        Dim input As String = "Joe 164" + vbCrLf +
+                              "Sam 208" + vbCrLf +
+                              "Allison 211" + vbCrLf +
                               "Gwen 171" + vbCrLf
         Dim pattern As String = "^(\w+)\s(\d+)$"
         Dim matched As Boolean = False
@@ -37,7 +37,7 @@ Module Example
     End Sub
 End Module
 
-Public Class DescendingComparer(Of T) : Implements IComparer(Of T)
+Public Class DescendingComparer1(Of T) : Implements IComparer(Of T)
     Public Function Compare(x As T, y As T) As Integer _
            Implements IComparer(Of T).Compare
         Return Comparer(Of T).Default.Compare(x, y) * -1

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/multiline2.vb
@@ -5,13 +5,13 @@ Option Strict On
 Imports System.Collections.Generic
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Multiline2Example
     Public Sub Main()
         Dim scores As New SortedList(Of Integer, String)(New DescendingComparer(Of Integer)())
 
-        Dim input As String = "Joe 164" + vbCrLf + _
-                              "Sam 208" + vbCrLf + _
-                              "Allison 211" + vbCrLf + _
+        Dim input As String = "Joe 164" + vbCrLf +
+                              "Sam 208" + vbCrLf +
+                              "Allison 211" + vbCrLf +
                               "Gwen 171" + vbCrLf
         Dim pattern As String = "(?m)^(\w+)\s(\d+)\r*$"
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb
@@ -7,12 +7,13 @@ Imports System.Text.RegularExpressions
 Module Example
     Public Sub Main()
         Dim pattern As String = "\bb\w+\s"
-        Dim input As String = "builder rob rabble"
+        Dim input As String = "build band tab"
         For Each match As Match In Regex.Matches(input, pattern, RegexOptions.RightToLeft)
             Console.WriteLine("'{0}' found at position {1}.", match.Value, match.Index)
         Next
     End Sub
 End Module
 ' The example displays the following output:
-'       'builder ' found at position 0.
+'       'band ' found at position 6.
+'       'build ' found at position 0.
 ' </Snippet17>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft1.vb
@@ -4,7 +4,7 @@ Option Strict On
 ' <Snippet17>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module RTL1Example
     Public Sub Main()
         Dim pattern As String = "\bb\w+\s"
         Dim input As String = "build band tab"

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb
@@ -6,8 +6,8 @@ Imports System.Text.RegularExpressions
 
 Module RTL2Example
     Public Sub Main()
-        Dim inputs() As String = {"1 May 1917", "June 16, 2003"}
-        Dim pattern As String = "(?<=\d{1,2}\s)\w+,?\s\d{4}"
+        Dim inputs() As String = {"1 May, 1917", "June 16, 2003"}
+        Dim pattern As String = "(?<=\d{1,2}\s)\w+,\s\d{4}"
 
         For Each input As String In inputs
             Dim match As Match = Regex.Match(input, pattern, RegexOptions.RightToLeft)
@@ -19,7 +19,8 @@ Module RTL2Example
         Next
     End Sub
 End Module
+
 ' The example displays the following output:
-'       The date occurs in May 1917.
+'       The date occurs in May, 1917.
 '       June 16, 2003 does not match.
 ' </Snippet18>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/righttoleft2.vb
@@ -4,7 +4,7 @@ Option Strict On
 ' <Snippet18>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module RTL2Example
     Public Sub Main()
         Dim inputs() As String = {"1 May 1917", "June 16, 2003"}
         Dim pattern As String = "(?<=\d{1,2}\s)\w+,?\s\d{4}"

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/singleline1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/singleline1.vb
@@ -4,7 +4,7 @@ Option Strict On
 ' <Snippet5>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module SingleLineExample
     Public Sub Main()
         Dim pattern As String = "(?s)^.+"
         Dim input As String = "This is one line and" + vbCrLf + "this is the second."

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace1.vb
@@ -4,10 +4,10 @@ Option Strict On
 ' <Snippet12>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Whitespace1Example
     Public Sub Main()
-        Dim input As String = "This is the first sentence. Is it the beginning " + _
-                              "of a literary masterpiece? I think not. Instead, " + _
+        Dim input As String = "This is the first sentence. Is it the beginning " +
+                              "of a literary masterpiece? I think not. Instead, " +
                               "it is a nonsensical paragraph."
         Dim pattern As String = "\b \(? ( (?>\w+) ,?\s? )+  [\.!?] \)? # Matches an entire sentence."
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.options/vb/whitespace2.vb
@@ -4,10 +4,10 @@ Option Strict On
 ' <Snippet13>
 Imports System.Text.RegularExpressions
 
-Module Example
+Module Whitespace2Example
     Public Sub Main()
-        Dim input As String = "This is the first sentence. Is it the beginning " + _
-                              "of a literary masterpiece? I think not. Instead, " + _
+        Dim input As String = "This is the first sentence. Is it the beginning " +
+                              "of a literary masterpiece? I think not. Instead, " +
                               "it is a nonsensical paragraph."
         Dim pattern As String = "(?x)\b \(? ( (?>\w+) ,?\s? )+  [\.!?] \)? # Matches an entire sentence."
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/dotnet-api-docs/pull/8116.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options?branch=pr-en-us-29708#right-to-left-mode).