### PR TITLE
Add dash between name and description for dotnet new update

### DIFF
--- a/docs/core/tools/dotnet-new-update.md
+++ b/docs/core/tools/dotnet-new-update.md
@@ -9,9 +9,9 @@ ms.date: 04/29/2021
 
 ## Name
 
-`dotnet new --update-check` checks for available updates for installed template packages.
+`dotnet new --update-check` - Checks for available updates for installed template packages.
 
-`dotnet new --update-apply` applies updates to installed template packages.
+`dotnet new --update-apply` - Applies updates to installed template packages.
 
 ## Synopsis
 


### PR DESCRIPTION
All the other tool doc pages have a dash between the command/name and the
description. This follows the general convention for man pages as
documented in `man 7 man-pages`:
https://man7.org/linux/man-pages/man7/man-pages.7.html

This was missing in the `dotnet-new-update` page. Fix that.
