### PR TITLE
Update 'scl read' example to use quotes command

### DIFF
--- a/docs/standard/commandline/get-started-tutorial.md
+++ b/docs/standard/commandline/get-started-tutorial.md
@@ -390,7 +390,7 @@ Build the project, and then try the following commands.
 Submit a nonexistent file to `--file` with the `read` command, and you get an error message instead of an exception and stack trace:
 
 ```console
-scl read --file nofile
+scl quotes read --file nofile
 ```
 
 ```output


### PR DESCRIPTION
## Summary

After the last code changes in the tutorial, the reader is instructed to run `scl read --file nofile` to see the new custom error message `File does not exist`. However, running this as is also shows the errors `Required command was not provided.` and `Unrecognized command or argument 'read'.` By changing the command to `scl quotes read --file nofile` the extra errors are eliminated.