### PR TITLE
Rewrite opening sentences

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/quantifier-operations.md
+++ b/docs/csharp/programming-guide/concepts/linq/quantifier-operations.md
@@ -8,7 +8,7 @@ ms.date: 03/30/2022
 
 Quantifier operations return a <xref:System.Boolean> value that indicates whether some or all of the elements in a sequence satisfy a condition.  
   
- The following illustration depicts two different quantifier operations on two different source sequences. The first operation asks if one or more of the elements are the character 'A', and the result is `true`. The second operation asks if all the elements are the character 'A', and the result is `true`.  
+ The following illustration depicts two different quantifier operations on two different source sequences. The first operation asks if any of the elements are the character 'A'. The second operation asks if all the elements are the character 'A'. Both methods return `true` in this example.  
   
  ![LINQ Quantifier Operations](./media/quantifier-operations/linq-quantifier-operations.png)  
   


### PR DESCRIPTION
Fixes #29730 

The opening sentences were harder to parse.
