### PR TITLE
Fix note mistake: ObservableGauge can be substituted with ObservableCounter

### DIFF
--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -173,7 +173,7 @@ Types of instruments currently available:
 
 > [!NOTE]
 > OpenTelemetry also defines an UpDownCounter not currently present in the .NET API. UpDownCounter can usually be substituted by defining a variable to store the running
-> total and reporting the value of that variable in the ObservableCounter callback.
+> total and reporting the value of that variable in the ObservableGauge callback.
 
 ### Example of different instrument types
 

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -173,7 +173,7 @@ Types of instruments currently available:
 
 > [!NOTE]
 > OpenTelemetry also defines an UpDownCounter not currently present in the .NET API. ObservableGauge can usually be substituted by defining a variable to store the running
-> total and reporting the value of that variable in the ObservableGauge callback.
+> total and reporting the value of that variable in the ObservableCounter callback.
 
 ### Example of different instrument types
 

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -172,7 +172,7 @@ Types of instruments currently available:
 - Other common cases, such as business metrics, physical sensors, cache hit rates, or sizes of caches, queues, and files are usually well suited for `ObservableGauge`.
 
 > [!NOTE]
-> OpenTelemetry also defines an UpDownCounter not currently present in the .NET API. ObservableGauge can usually be substituted by defining a variable to store the running
+> OpenTelemetry also defines an UpDownCounter not currently present in the .NET API. UpDownCounter can usually be substituted by defining a variable to store the running
 > total and reporting the value of that variable in the ObservableCounter callback.
 
 ### Example of different instrument types


### PR DESCRIPTION
## Summary

With the previous wording it was weird: ObservableGauge can be substituted with ObservableGauge. If I am not mistaken `ObservableCounter` was meant there.
