### PR TITLE
Update .NET 5 to NET 5+ to avoid confusion

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -67,7 +67,7 @@ For more information, see the [list of project repositories on GitHub.com](https
 
 [Tizen supports .NET](https://developer.tizen.org/development/training/.net-application) on Tizen platforms.
 
-For more information, see [Releases and support for .NET Core and .NET 5](releases-and-support.md).
+For more information, see [Releases and support for .NET Core and .NET 5+](releases-and-support.md).
 
 ## .NET Core, .NET Framework, Mono, UWP
 


### PR DESCRIPTION
## Summary

While reviewing #29644, I did find one instance where `.NET 5` could better be described as `.NET 5+`. This PR updates that text.
