### PR TITLE
Add examples and improve description of CA2254.

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -44,7 +44,7 @@ var firstName = "Lorenz";
 var lastName = "Otto";
 
 // Here, the log template itself is changing, and the association between named placeholders and their values is lost.
-logger.Warning("Person " + firstName + " " + {lastName} + " encountered an issue");
+logger.Warning("Person " + firstName + " " + lastName + " encountered an issue");
 
 // String interpolation also loses the association between placeholder names and their values.
 logger.Warning($"Person {firstName} {lastName} encountered an issue");

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -31,7 +31,7 @@ Preferred:
 
 ```csharp
 var firstName = "Lorenz";
-var lastName = "Smith";
+var lastName = "Otto";
 
 // This will tell the logger that there are FirstName and LastName properties on the log message, and will correlate them with the values that are passed in
 logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -37,7 +37,7 @@ var lastName = "Otto";
 logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
 ```
 
-over:
+Not preferred:
 
 ```csharp
 var firstName = "Bob";

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -25,11 +25,40 @@ A message template passed to a logger API is not constant.
 
 ## Rule description
 
+When performing logging, we want to preserve the structure of the log (including parameter names) along with the parameter values themselves. This allows for better observability and search in log aggregation and monitoring software. We want to maintain the full fidelity of the log message.
+
+Therefore, we prefer:
+
+```csharp
+var firstName = "Bob";
+var lastName = "Smith";
+
+// This will tell the logger that there are FirstName and LastName properties on the log message, and will correlate them with the values that are passed in
+logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
+```
+
+over:
+
+```csharp
+var firstName = "Bob";
+var lastName = "Smith";
+
+// Here, the log template itself is changing, and we will lose the association between named log properties and their values
+logger.Warning("Person " + firstName + " " + {lastName} + " encountered an issue");
+
+// Still an issue when using string interpolation
+logger.Warning($"Person {firstName} {lastName} encountered an issue");
+```
+
 The logging message template should not vary between calls.
 
 ## How to fix violations
 
-Update the message template to be a constant expression.
+Update the message template to be a constant expression. If you are using values directly in the template, refacor them instead to be along the lines of:
+
+```csharp
+logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
+```
 
 ## When to suppress errors
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -33,13 +33,16 @@ Preferred:
 var firstName = "Lorenz";
 var lastName = "Otto";
 
-// This tells the logger that there are FirstName and LastName properties on the log message, and correlates them with the values that are passed in.
+// This tells the logger that there are FirstName and LastName properties
+// on the log message, and correlates them with to the argument values.
 logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
 ```
 
 Not preferred:
 
 ```csharp
+// DO NOT DO THIS
+
 var firstName = "Lorenz";
 var lastName = "Otto";
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -40,7 +40,7 @@ logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, 
 Not preferred:
 
 ```csharp
-var firstName = "Bob";
+var firstName = "Lorenz";
 var lastName = "Smith";
 
 // Here, the log template itself is changing, and the association between named placeholders and their values is lost.

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -27,7 +27,7 @@ A message template passed to a logger API is not constant.
 
 When performing logging, it's desirable to preserve the structure of the log (including placeholder names) along with the placeholder values. Preserving this information allows for better observability and search in log aggregation and monitoring software.
 
-Therefore, we prefer:
+Preferred:
 
 ```csharp
 var firstName = "Bob";

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -30,7 +30,7 @@ When performing logging, it's desirable to preserve the structure of the log (in
 Preferred:
 
 ```csharp
-var firstName = "Bob";
+var firstName = "Lorenz";
 var lastName = "Smith";
 
 // This will tell the logger that there are FirstName and LastName properties on the log message, and will correlate them with the values that are passed in

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -46,7 +46,7 @@ var lastName = "Smith";
 // Here, the log template itself is changing, and the association between named placeholders and their values is lost.
 logger.Warning("Person " + firstName + " " + {lastName} + " encountered an issue");
 
-// Still an issue when using string interpolation
+// String interpolation also loses the association between placeholder names and their values.
 logger.Warning($"Person {firstName} {lastName} encountered an issue");
 ```
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -41,7 +41,7 @@ Not preferred:
 
 ```csharp
 var firstName = "Lorenz";
-var lastName = "Smith";
+var lastName = "Otto";
 
 // Here, the log template itself is changing, and the association between named placeholders and their values is lost.
 logger.Warning("Person " + firstName + " " + {lastName} + " encountered an issue");

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -43,7 +43,7 @@ Not preferred:
 var firstName = "Bob";
 var lastName = "Smith";
 
-// Here, the log template itself is changing, and we will lose the association between named log properties and their values
+// Here, the log template itself is changing, and the association between named placeholders and their values is lost.
 logger.Warning("Person " + firstName + " " + {lastName} + " encountered an issue");
 
 // Still an issue when using string interpolation

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -54,7 +54,7 @@ The logging message template should not vary between calls.
 
 ## How to fix violations
 
-Update the message template to be a constant expression. If you are using values directly in the template, refacor them instead to be along the lines of:
+Update the message template to be a constant expression. If you're using values directly in the template, refactor them to use named placeholders instead.
 
 ```csharp
 logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -33,7 +33,7 @@ Preferred:
 var firstName = "Lorenz";
 var lastName = "Otto";
 
-// This will tell the logger that there are FirstName and LastName properties on the log message, and will correlate them with the values that are passed in
+// This tells the logger that there are FirstName and LastName properties on the log message, and correlates them with the values that are passed in.
 logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
 ```
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -25,7 +25,7 @@ A message template passed to a logger API is not constant.
 
 ## Rule description
 
-When performing logging, we want to preserve the structure of the log (including parameter names) along with the parameter values themselves. This allows for better observability and search in log aggregation and monitoring software. We want to maintain the full fidelity of the log message.
+When performing logging, it's desirable to preserve the structure of the log (including placeholder names) along with the placeholder values. Preserving this information allows for better observability and search in log aggregation and monitoring software.
 
 Therefore, we prefer:
 


### PR DESCRIPTION
## Summary

Adds examples and a more thorough description to CA2254. I think I've captured the reasoning, though I intentionally left out that logging software often caches the templates for performance considerations (happy to add that in if desired).

Fixes #28400

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254?branch=pr-en-us-29787).