### PR TITLE
Add example for range indices from arrays

### DIFF
--- a/docs/csharp/whats-new/tutorials/ranges-indexes.md
+++ b/docs/csharp/whats-new/tutorials/ranges-indexes.md
@@ -101,7 +101,7 @@ You'll often use ranges and indices when you want to analyze a portion of a larg
 
 ## A Note on Range Indices and Arrays
 
-When taking a range from an array, the result is an array that is copied from the initial array, rather than referenced. Modifying values in the resulting array will not change values in the initial array. 
+When taking a range from an array, the result is an array that is copied from the initial array, rather than referenced. Modifying values in the resulting array will not change values in the initial array.
 
 For example:
 

--- a/docs/csharp/whats-new/tutorials/ranges-indexes.md
+++ b/docs/csharp/whats-new/tutorials/ranges-indexes.md
@@ -98,3 +98,23 @@ In all cases, the range operator for <xref:System.Array> allocates an array to s
 You'll often use ranges and indices when you want to analyze a portion of a larger sequence. The new syntax is clearer in reading exactly what portion of the sequence is involved. The local function `MovingAverage` takes a <xref:System.Range> as its argument. The method then enumerates just that range when calculating the min, max, and average. Try the following code in your project:
 
 [!code-csharp[MovingAverages](~/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs#IndicesAndRanges_MovingAverage)]
+
+## A Note on Range Indices and Arrays
+
+When taking a range from an array, the result is an array that is copied from the initial array, rather than referenced. Modifying values in the resulting array will not change values in the initial array. 
+
+For example:
+
+```csharp
+var arrayOfFiveItems = new[] { 1, 2, 3, 4, 5 };
+
+var firstThreeItems = arrayOfFiveItems[..3]; // contains 1,2,3
+firstThreeItems[0] =  11; // now contains 11,2,3
+
+Console.WriteLine(string.Join(",", firstThreeItems));
+Console.WriteLine(string.Join(",", arrayOfFiveItems));
+
+// output:
+// 11,2,3
+// 1,2,3,4,5
+```


### PR DESCRIPTION
## Summary

Adds an explanation and example of range indices from arrays, and notes that taking a range from an array creates a new array with a copy of the array's data.

Fixes #28329
