### PR TITLE
Add empty classes into the docs example

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/index.md
+++ b/docs/csharp/programming-guide/concepts/async/index.md
@@ -25,7 +25,7 @@ For a parallel algorithm, you'd need multiple cooks (or threads). One would make
 
 Now, consider those same instructions written as C# statements:
 
-:::code language="csharp" source="snippets/index/AsyncBreakfast-starter/Program.cs" highlight="8-27":::
+:::code language="csharp" source="snippets/index/AsyncBreakfast-starter/Program.cs" highlight="8-34":::
 
 :::image type="content" source="media/synchronous-breakfast.png" alt-text="synchronous breakfast":::
 

--- a/docs/csharp/programming-guide/concepts/async/index.md
+++ b/docs/csharp/programming-guide/concepts/async/index.md
@@ -31,9 +31,6 @@ Now, consider those same instructions written as C# statements:
 
 The synchronously prepared breakfast took roughly 30 minutes because the total is the sum of each task.
 
-> [!NOTE]
-> The `Coffee`, `Egg`, `Bacon`, `Toast`, and `Juice` classes are empty. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
-
 Computers don't interpret those instructions the same way people do. The computer will block on each statement until the work is complete before moving on to the next statement. That creates an unsatisfying breakfast. The later tasks wouldn't be started until the earlier tasks had been completed. It would take much longer to create the breakfast, and some items would have gotten cold before being served.
 
 If you want the computer to execute the above instructions asynchronously, you must write asynchronous code.

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Bacon.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Bacon.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Bacon
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Coffee.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Coffee.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Coffee
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Egg.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Egg.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Egg
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Juice.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Juice.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Juice
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Program.cs
@@ -6,6 +6,13 @@ namespace AsyncBreakfast
     class Program
     {
         // <SnippetMain>
+        // These classes are intentionally empty for the purpose of this example. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
+        internal class Bacon { }
+        internal class Coffee { }
+        internal class Egg { }
+        internal class Juice { }
+        internal class Toast { }
+
         static async Task Main(string[] args)
         {
             Coffee cup = PourCoffee();

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Toast.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Toast.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace AsyncBreakfast
-{
-    internal class Toast
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Bacon.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Bacon.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Bacon
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Coffee.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Coffee.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Coffee
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Egg.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Egg.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Egg
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Juice.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Juice.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Juice
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Program.cs
@@ -6,11 +6,18 @@ namespace AsyncBreakfast
     class Program
     {
         // <SnippetMain>
+        // These classes are intentionally empty for the purpose of this example. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
+        internal class Bacon { }
+        internal class Coffee { }
+        internal class Egg { }
+        internal class Juice { }
+        internal class Toast { }
+
         static async Task Main(string[] args)
         {
             Coffee cup = PourCoffee();
             Console.WriteLine("coffee is ready");
-            
+
             var eggsTask = FryEggsAsync(2);
             var baconTask = FryBaconAsync(3);
             var toastTask = MakeToastWithButterAndJamAsync(2);

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Toast.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Toast.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace AsyncBreakfast
-{
-    internal class Toast
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Bacon.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Bacon.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Bacon
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Coffee.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Coffee.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Coffee
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Egg.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Egg.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Egg
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Juice.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Juice.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Juice
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Program.cs
@@ -4,6 +4,13 @@ using System.Threading.Tasks;
 
 namespace AsyncBreakfast
 {
+    // These classes are intentionally empty for the purpose of this example. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
+    internal class Bacon { }
+    internal class Coffee { }
+    internal class Egg { }
+    internal class Juice { }
+    internal class Toast { }
+
     class Program
     {
         static async Task Main(string[] args)
@@ -97,7 +104,7 @@ namespace AsyncBreakfast
             Console.WriteLine("cooking the eggs ...");
             await Task.Delay(3000);
             Console.WriteLine("Put eggs on plate");
-            
+
             return new Egg();
         }
 

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Toast.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-final/Toast.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace AsyncBreakfast
-{
-    internal class Toast
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Bacon.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Bacon.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Bacon
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Coffee.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Coffee.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Coffee
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Egg.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Egg.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Egg
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Juice.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Juice.cs
@@ -1,6 +1,0 @@
-﻿namespace AsyncBreakfast
-{
-    internal class Juice
-    {
-    }
-}

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Program.cs
@@ -3,6 +3,13 @@ using System.Threading.Tasks;
 
 namespace AsyncBreakfast
 {
+    // These classes are intentionally empty for the purpose of this example. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
+    internal class Bacon { }
+    internal class Coffee { }
+    internal class Egg { }
+    internal class Juice { }
+    internal class Toast { }
+
     class Program
     {
         static void Main(string[] args)
@@ -32,10 +39,10 @@ namespace AsyncBreakfast
             return new Juice();
         }
 
-        private static void ApplyJam(Toast toast) => 
+        private static void ApplyJam(Toast toast) =>
             Console.WriteLine("Putting jam on the toast");
 
-        private static void ApplyButter(Toast toast) => 
+        private static void ApplyButter(Toast toast) =>
             Console.WriteLine("Putting butter on the toast");
 
         private static Toast ToastBread(int slices)

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Toast.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-starter/Toast.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace AsyncBreakfast
-{
-    internal class Toast
-    {
-    }
-}


### PR DESCRIPTION
In favor of a working example vs a note that requires follow-up.

## Summary

* [x] Removes note (in favor of working example)
* [x] Introduces the empty classes in the examples
* [x] Notes why the classes are empty

Fixes #27902