### PR TITLE
Improve code style rule suppression reference

### DIFF
--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -94,7 +94,7 @@ The following table shows the different rule severities that you can configure f
 
 - **Category of rules**
 
-  To set the default rule severity for a category of rules, use the following syntax. (Notice that the prefix is slightly different when disabling via category. It's `dotnet_analyzer_diagnostic` instead of `dotnet_diagnostic`.)
+  To set the default rule severity for a category of rules, use the following syntax. However, this severity setting only affects rules in that category that are enabled by default.
 
   ```ini
   dotnet_analyzer_diagnostic.category-<rule category>.severity = <severity value>
@@ -104,7 +104,7 @@ The following table shows the different rule severities that you can configure f
 
 - **All rules**
 
-  To set the default rule severity for all analyzer rules, use the following syntax.
+  To set the default rule severity for all analyzer rules, use the following syntax. However, this severity setting only affects rules that are enabled by default.
 
   ```ini
   dotnet_analyzer_diagnostic.severity = <severity value>
@@ -116,6 +116,9 @@ The following table shows the different rule severities that you can configure f
 > - Add an explicit `dotnet_diagnostic.<rule ID>.severity = <severity>` configuration entry for each rule.
 > - In .NET 6+, enable a category of rules by setting [\<AnalysisMode\<Category>>](../../core/project-sdk/msbuild-props.md#analysismodecategory) to `All`.
 > - Enable *all* rules by setting [\<AnalysisMode>](../../core/project-sdk/msbuild-props.md#analysismode) to `All` or by setting [\<AnalysisLevel>](../../core/project-sdk/msbuild-props.md#analysislevel) to `latest-All`.
+
+> [!NOTE]
+> The prefix for setting severity for a single rule, `dotnet_diagnostic`, is slightly different than the prefix for configuring severity via category or for all rules, `dotnet_analyzer_diagnostic`.
 
 #### Precedence
 

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -94,7 +94,7 @@ The following table shows the different rule severities that you can configure f
 
 - **Category of rules**
 
-  To set the default rule severity for a category of rules, use the following syntax.
+  To set the default rule severity for a category of rules, use the following syntax. (Notice that the prefix is slightly different when disabling via category. It's `dotnet_analyzer_diagnostic` instead of `dotnet_diagnostic`.)
 
   ```ini
   dotnet_analyzer_diagnostic.category-<rule category>.severity = <severity value>

--- a/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
@@ -34,6 +34,17 @@ dotnet_diagnostic.IDE0055.severity = <severity value>
 
 The severity value must be `warning` or `error` to be [enforced on build](../overview.md#code-style-analysis). For all possible severity values, see [severity level](../configuration-options.md#severity-level).
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0065.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## Option format
 
 Options for formatting rules can be specified in an EditorConfig file with the following format:

--- a/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
@@ -39,16 +39,16 @@ The severity value must be `warning` or `error` to be [enforced on build](../ove
 If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
-#pragma warning disable IDE0065
+#pragma warning disable IDE0055
 // The code that's violating the rule is on this line.
-#pragma warning restore IDE0065
+#pragma warning restore IDE0055
 ```
 
 To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
-dotnet_diagnostic.IDE0065.severity = none
+dotnet_diagnostic.IDE0055.severity = none
 ```
 
 To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).

--- a/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/formatting-rules.md
@@ -36,14 +36,29 @@ The severity value must be `warning` or `error` to be [enforced on build](../ove
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0065
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0065
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0065.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Option format
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0001.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0001.md
@@ -52,6 +52,17 @@ Class C
 End Class
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0001.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Simplify member access (IDE0002)](ide0002.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0001.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0001.md
@@ -54,14 +54,29 @@ End Class
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0001
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0001
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0001.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0002.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0002.md
@@ -54,6 +54,17 @@ Shared Sub M2()
 End Sub
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0002.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Simplify name (IDE0001)](ide0001.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0002.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0002.md
@@ -56,14 +56,29 @@ End Sub
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0002
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0002
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0002.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0003-ide0009.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0003-ide0009.md
@@ -25,13 +25,13 @@ dev_langs:
 ---
 # this and Me preferences (IDE0003 and IDE0009)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0003 and IDE0009 |
-| **Title** | IDE0003: Remove `this` or `Me` qualification<br/> IDE0009: Add `this` or `Me` qualification |
-| **Category** | Style |
-| **Subcategory** | Language rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------|
+| **Rule ID**              | IDE0003 and IDE0009                                                                         |
+| **Title**                | IDE0003: Remove `this` or `Me` qualification<br/> IDE0009: Add `this` or `Me` qualification |
+| **Category**             | Style                                                                                       |
+| **Subcategory**          | Language rules                                                                              |
+| **Applicable languages** | C# and Visual Basic                                                                         |
 
 ## Overview
 
@@ -140,6 +140,18 @@ AddHandler Me.Elapsed, AddressOf Handler
 ' dotnet_style_qualification_for_event = false
 AddHandler Elapsed, AddressOf Handler
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0003.severity = none
+dotnet_diagnostic.IDE0009.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0003-ide0009.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0003-ide0009.md
@@ -143,7 +143,15 @@ AddHandler Elapsed, AddressOf Handler
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0003 // Or IDE0009
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0003 // Or IDE0009
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -151,7 +159,14 @@ dotnet_diagnostic.IDE0003.severity = none
 dotnet_diagnostic.IDE0009.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0004.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0004.md
@@ -47,14 +47,29 @@ Dim v As Integer = 0
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0004
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0004
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0004.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0004.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0004.md
@@ -15,13 +15,13 @@ dev_langs:
 ---
 # Remove unnecessary cast (IDE0004)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0004 |
-| **Title** | Remove unnecessary cast |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                   |
+|--------------------------|-------------------------|
+| **Rule ID**              | IDE0004                 |
+| **Title**                | Remove unnecessary cast |
+| **Category**             | Style                   |
+| **Subcategory**          | Unnecessary code rules  |
+| **Applicable languages** | C# and Visual Basic     |
 
 ## Overview
 
@@ -44,6 +44,17 @@ Dim v As Integer = CType(0, Integer)
 ' Fixed code
 Dim v As Integer = 0
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0004.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0005.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0005.md
@@ -15,13 +15,13 @@ dev_langs:
 ---
 # Remove unnecessary import (IDE0005)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0005 |
-| **Title** | Remove unnecessary import |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                     |
+|--------------------------|---------------------------|
+| **Rule ID**              | IDE0005                   |
+| **Title**                | Remove unnecessary import |
+| **Category**             | Style                     |
+| **Subcategory**          | Unnecessary code rules    |
+| **Applicable languages** | C# and Visual Basic       |
 
 ## Overview
 
@@ -31,10 +31,10 @@ This rule flags the following unnecessary constructs:
 - C# unnecessary [using static directive](../../../csharp/language-reference/keywords/using-directive.md).
 - Visual Basic unnecessary [Import](../../../visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md) statement.
 
- These unnecessary constructs can be removed without changing the semantics of the code. This rule has no associated code style option.
+These unnecessary constructs can be removed without changing the semantics of the code. This rule has no associated code style option.
 
 > [!NOTE]
-> To enable this [rule on build](../overview.md#code-style-analysis), you need to enable [XML documentation comments](../../../csharp/language-reference/xmldoc/recommended-tags.md) for the project. See [this issue](https://github.com/dotnet/roslyn/issues/41640) for more details.
+> To enable this [rule on build](../overview.md#code-style-analysis), you need to enable [XML documentation comments](../../../csharp/language-reference/xmldoc/recommended-tags.md) for the project. For more information, see [dotnet/roslyn issue 41640](https://github.com/dotnet/roslyn/issues/41640).
 
 ## Example
 
@@ -77,6 +77,17 @@ Class C
     End Sub
 End Class
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0005.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0005.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0005.md
@@ -80,14 +80,29 @@ End Class
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0005
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0005
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0005.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0007-ide0008.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0007-ide0008.md
@@ -90,7 +90,15 @@ bool f = this.Init();
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0007 // Or IDE0008
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0007 // Or IDE0008
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -98,7 +106,14 @@ dotnet_diagnostic.IDE0007.severity = none
 dotnet_diagnostic.IDE0008.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0007-ide0008.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0007-ide0008.md
@@ -22,13 +22,13 @@ dev_langs:
 ---
 # 'var' preferences (IDE0007 and IDE0008)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0007 and IDE0008 |
-| **Title** | IDE0007: Use 'var' instead of explicit type<br/> IDE0008: Use explicit type instead of 'var' |
-| **Category** | Style |
-| **Subcategory** | Language rules |
-| **Applicable languages** | C# |
+| Property                 | Value                                                                                        |
+|--------------------------|----------------------------------------------------------------------------------------------|
+| **Rule ID**              | IDE0007 and IDE0008                                                                          |
+| **Title**                | IDE0007: Use 'var' instead of explicit type<br/> IDE0008: Use explicit type instead of 'var' |
+| **Category**             | Style                                                                                        |
+| **Subcategory**          | Language rules                                                                               |
+| **Applicable languages** | C#                                                                                           |
 
 ## Overview
 
@@ -42,7 +42,7 @@ The style rules in this section concern the use of the [var](../../../csharp/lan
 | **Option values** | `true` - Prefer `var` is used to declare variables with built-in system types such as `int`<br /><br />`false` - Prefer explicit type over `var` to declare variables with built-in system types such as `int` |
 | **Default option value** | `false` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_var_for_built_in_types = true
@@ -60,7 +60,7 @@ int x = 5;
 | **Option values** | `true` - Prefer `var` when the type is already mentioned on the right-hand side of a declaration expression<br /><br />`false` - Prefer explicit type over `var` when the type is already mentioned on the right-hand side of a declaration expression |
 | **Default option value** | `false` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_var_when_type_is_apparent = true
@@ -78,7 +78,7 @@ Customer obj = new Customer();
 | **Option values** | `true` - Prefer `var` over explicit type in all cases, unless overridden by another code style rule<br /><br />`false` - Prefer explicit type over `var` in all cases, unless overridden by another code style rule |
 | **Default option value** | `false` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_var_elsewhere = true
@@ -87,6 +87,18 @@ var f = this.Init();
 // csharp_style_var_elsewhere = false
 bool f = this.Init();
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0007.severity = none
+dotnet_diagnostic.IDE0008.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0010.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0010.md
@@ -74,14 +74,29 @@ class C
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0010
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0010
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0010.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0010.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0010.md
@@ -15,13 +15,13 @@ dev_langs:
 ---
 # Add missing cases to switch statement (IDE0010)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0010 |
-| **Title** | Add missing cases to switch statement |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                         |
+|--------------------------|-----------------------------------------------|
+| **Rule ID**              | IDE0010                                       |
+| **Title**                | Add missing cases to switch statement         |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
 
 ## Overview
 
@@ -71,6 +71,17 @@ class C
     }
 }
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0010.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0011.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0011.md
@@ -47,14 +47,29 @@ if (test) this.Display();
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0011
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0011
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0011.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0011.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0011.md
@@ -16,11 +16,11 @@ dev_langs:
 ---
 # Add braces (IDE0011)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0011 |
-| **Title** | Add braces |
-| **Category** | Style |
+| Property        | Value                                   |
+|-----------------|-----------------------------------------|
+| **Rule ID**     | IDE0011                                 |
+| **Title**       | Add braces                              |
+| **Category**    | Style                                   |
 | **Subcategory** | Language rules (code block preferences) |
 
 ## Overview
@@ -44,6 +44,17 @@ if (test) { this.Display(); }
 // csharp_prefer_braces = false
 if (test) this.Display();
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0011.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0016.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0016.md
@@ -49,14 +49,29 @@ this.s = s;
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0016
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0016
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0016.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0016.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0016.md
@@ -16,13 +16,13 @@ dev_langs:
 ---
 # Use throw expression (IDE0016)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0016 |
-| **Title** | Use throw expression |
-| **Category** | Style |
-| **Subcategory** | Language rules (null-checking preferences) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                      |
+|--------------------------|--------------------------------------------|
+| **Rule ID**              | IDE0016                                    |
+| **Title**                | Use throw expression                       |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (null-checking preferences) |
+| **Applicable languages** | C# 7.0+                                    |
 
 ## Overview
 
@@ -46,6 +46,17 @@ this.s = s ?? throw new ArgumentNullException(nameof(s));
 if (s == null) { throw new ArgumentNullException(nameof(s)); }
 this.s = s;
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0016.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0017.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0017.md
@@ -17,13 +17,13 @@ dev_langs:
 ---
 # Use object initializers (IDE0017)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0017 |
-| **Title** | Use object initializers |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                         |
+|--------------------------|-----------------------------------------------|
+| **Rule ID**              | IDE0017                                       |
+| **Title**                | Use object initializers                       |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
 
 ## Overview
 
@@ -56,6 +56,17 @@ Dim c = New Customer() With {.Age = 21}
 Dim c = New Customer()
 c.Age = 21
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0017.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0017.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0017.md
@@ -59,14 +59,29 @@ c.Age = 21
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0017
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0017
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0017.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0018.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0018.md
@@ -49,14 +49,29 @@ if (int.TryParse(value, out i) {...}
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0018
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0018
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0018.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0018.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0018.md
@@ -16,13 +16,13 @@ dev_langs:
 ---
 # Inline variable declaration (IDE0018)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0018 |
-| **Title** | Inline variable declaration |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                         |
+|--------------------------|-----------------------------------------------|
+| **Rule ID**              | IDE0018                                       |
+| **Title**                | Inline variable declaration                   |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# 7.0+                                       |
 
 ## Overview
 
@@ -36,7 +36,7 @@ This style rule concerns whether `out` variables are declared inline or not. Sta
 | **Option values** | `true` - Prefer `out` variables to be declared inline in the argument list of a method call when possible<br /><br />`false` - Prefer `out` variables to be declared before the method call |
 | **Default option value** | `true` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_inlined_variable_declaration = true
@@ -46,6 +46,17 @@ if (int.TryParse(value, out int i) {...}
 int i;
 if (int.TryParse(value, out i) {...}
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0018.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0019.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0019.md
@@ -49,14 +49,29 @@ if (s != null) {...}
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0019
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0019
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0019.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0019.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0019.md
@@ -36,7 +36,7 @@ This style rule concerns the use of C# [pattern matching](../../../csharp/fundam
 | **Option values** | `true` - Prefer pattern matching instead of `as` expressions with null checks to determine if something is of a particular type<br /><br />`false` - Prefer `as` expressions with null checks instead of pattern matching to determine if something is of a particular type |
 | **Default option value** | `true` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_pattern_matching_over_as_with_null_check = true
@@ -46,6 +46,17 @@ if (o is string s) {...}
 var s = o as string;
 if (s != null) {...}
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0019.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
@@ -41,7 +41,7 @@ This style rule concerns the use of C# [pattern matching](../../../csharp/fundam
 | **Option values** | `true` - Prefer pattern matching instead of `is` expressions with type casts<br /><br />`false` - Prefer `is` expressions with type casts instead of pattern matching |
 | **Default option value** | `true` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_pattern_matching_over_is_with_cast_check = true
@@ -50,6 +50,18 @@ if (o is int i) {...}
 // csharp_style_pattern_matching_over_is_with_cast_check = false
 if (o is int) {var i = (int)o; ... }
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0020.severity = none
+dotnet_diagnostic.IDE0038.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
@@ -53,7 +53,15 @@ if (o is int) {var i = (int)o; ... }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0020 // Or IDE0038
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0020 // Or IDE0038
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -61,7 +69,14 @@ dotnet_diagnostic.IDE0020.severity = none
 dotnet_diagnostic.IDE0038.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0021.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0021.md
@@ -36,7 +36,7 @@ This style rule concerns the use of [expression bodies](../../../csharp/programm
 | **Option values** | `true` - Prefer expression bodies for constructors<br /><br />`when_on_single_line` - Prefer expression bodies for constructors when they will be a single line<br /><br />`false` - Prefer block bodies for constructors |
 | **Default option value** | `false` |
 
-#### Example
+### Example
 
 ```csharp
 // csharp_style_expression_bodied_constructors = true
@@ -45,6 +45,17 @@ public Customer(int age) => Age = age;
 // csharp_style_expression_bodied_constructors = false
 public Customer(int age) { Age = age; }
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0021.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0021.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0021.md
@@ -48,14 +48,29 @@ public Customer(int age) { Age = age; }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0021
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0021
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0021.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0022.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0022.md
@@ -28,7 +28,9 @@ dev_langs:
 
 This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for methods.
 
-## csharp_style_expression_bodied_methods
+## Options
+
+### csharp_style_expression_bodied_methods
 
 |Property|Value|
 |-|-|
@@ -45,6 +47,17 @@ public int GetAge() => this.Age;
 // csharp_style_expression_bodied_methods = false
 public int GetAge() { return this.Age; }
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0022.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0022.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0022.md
@@ -50,14 +50,29 @@ public int GetAge() { return this.Age; }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0022
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0022
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0022.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0023-ide0024.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0023-ide0024.md
@@ -50,6 +50,18 @@ public static ComplexNumber operator + (ComplexNumber c1, ComplexNumber c2)
 { return new ComplexNumber(c1.Real + c2.Real, c1.Imaginary + c2.Imaginary); }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0023.severity = none
+dotnet_diagnostic.IDE0024.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-bodied members](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0023-ide0024.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0023-ide0024.md
@@ -52,7 +52,15 @@ public static ComplexNumber operator + (ComplexNumber c1, ComplexNumber c2)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0023 // Or IDE0024
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0023 // Or IDE0024
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -60,7 +68,14 @@ dotnet_diagnostic.IDE0023.severity = none
 dotnet_diagnostic.IDE0024.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0025.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0025.md
@@ -46,6 +46,17 @@ public int Age => _age;
 public int Age { get { return _age; }}
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0025.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-bodied members](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0025.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0025.md
@@ -48,14 +48,29 @@ public int Age { get { return _age; }}
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0025
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0025
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0025.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0026.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0026.md
@@ -46,6 +46,17 @@ public T this[int i] => _values[i];
 public T this[int i] { get { return _values[i]; } }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0026.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-bodied members](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0026.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0026.md
@@ -48,14 +48,29 @@ public T this[int i] { get { return _values[i]; } }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0026
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0026
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0026.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0027.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0027.md
@@ -48,14 +48,29 @@ public int Age { get { return _age; } set { _age = value; } }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0027
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0027
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0027.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0027.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0027.md
@@ -46,6 +46,17 @@ public int Age { get => _age; set => _age = value; }
 public int Age { get { return _age; } set { _age = value; } }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0027.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-bodied members](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -63,14 +63,29 @@ list.Add(3)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0028
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0028
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0028.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -61,6 +61,17 @@ list.Add(2)
 list.Add(3)
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0028.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Use object initializers](ide0017.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0029-ide0030.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0029-ide0030.md
@@ -64,7 +64,15 @@ Dim v = If(x IsNot Nothing, x, y)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0029 // Or IDE0030
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0029 // Or IDE0030
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -72,7 +80,14 @@ dotnet_diagnostic.IDE0029.severity = none
 dotnet_diagnostic.IDE0030.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0029-ide0030.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0029-ide0030.md
@@ -62,6 +62,18 @@ Dim v = If(x Is Nothing, y, x) ' or
 Dim v = If(x IsNot Nothing, x, y)
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0029.severity = none
+dotnet_diagnostic.IDE0030.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Null-checking preferences](null-checking-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0031.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0031.md
@@ -59,14 +59,29 @@ Dim v = If(o IsNot Nothing, o.ToString(), Nothing)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0031
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0031
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0031.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0031.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0031.md
@@ -57,6 +57,17 @@ Dim v = If(o Is Nothing, Nothing, o.ToString()) ' or
 Dim v = If(o IsNot Nothing, o.ToString(), Nothing)
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0031.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Null-checking preferences](null-checking-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0032.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0032.md
@@ -72,14 +72,29 @@ End Property
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0032
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0032
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0032.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0032.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0032.md
@@ -70,6 +70,17 @@ Public ReadOnly Property Age As Integer
 End Property
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0032.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0033.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0033.md
@@ -61,14 +61,29 @@ Dim name = customer.Item1
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0033
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0033
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0033.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0033.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0033.md
@@ -59,6 +59,17 @@ Dim customer As (name As String, age As Integer) = GetCustomer()
 Dim name = customer.Item1
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0033.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Use object initializers](ide0017.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0034.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0034.md
@@ -48,14 +48,29 @@ void DoWork(CancellationToken cancellationToken = default(CancellationToken)) { 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0034
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0034
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0034.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0034.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0034.md
@@ -46,6 +46,17 @@ void DoWork(CancellationToken cancellationToken = default) { ... }
 void DoWork(CancellationToken cancellationToken = default(CancellationToken)) { ... }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0034.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [default literal](../../../csharp/language-reference/operators/default.md#default-literal)

--- a/docs/fundamentals/code-analysis/style-rules/ide0035.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0035.md
@@ -46,6 +46,17 @@ void M()
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0035.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Remove unused private member (IDE0051)](ide0051.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0035.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0035.md
@@ -48,14 +48,29 @@ void M()
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0035
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0035
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0035.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0036.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0036.md
@@ -74,14 +74,29 @@ End Class
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0036
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0036
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0036.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0036.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0036.md
@@ -72,6 +72,17 @@ Public Class MyClass
 End Class
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0036.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Modifier preferences](modifier-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0037.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0037.md
@@ -87,14 +87,29 @@ Dim anon = New With {.name = name, .age = age}
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0037
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0037
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0037.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0037.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0037.md
@@ -85,6 +85,17 @@ Dim anon = New With {name, age}
 Dim anon = New With {.name = name, .age = age}
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0037.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0039.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0039.md
@@ -55,14 +55,29 @@ fibonacci = (int n) =>
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0039
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0039
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0039.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0039.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0039.md
@@ -53,6 +53,17 @@ fibonacci = (int n) =>
 };
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0039.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0040.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0040.md
@@ -57,6 +57,17 @@ class MyClass
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0040.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Modifier preferences](modifier-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0040.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0040.md
@@ -59,14 +59,29 @@ class MyClass
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0040
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0040
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0040.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0041.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0041.md
@@ -64,14 +64,29 @@ End If
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0041
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0041
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0041.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0041.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0041.md
@@ -62,6 +62,17 @@ If Object.ReferenceEquals(value, Nothing)
 End If
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0041.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Null-checking preferences](null-checking-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0042.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0042.md
@@ -54,6 +54,17 @@ Console.WriteLine($"{person.name} {person.age}");
 Console.WriteLine($"{point.x} {point.y}");
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0042.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0042.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0042.md
@@ -56,14 +56,29 @@ Console.WriteLine($"{point.x} {point.y}");
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0042
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0042
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0042.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0044.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0044.md
@@ -57,14 +57,29 @@ End Class
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0044
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0044
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0044.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0044.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0044.md
@@ -55,6 +55,17 @@ Public Class MyClass
 End Class
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0044.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Modifier preferences](modifier-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0045.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0045.md
@@ -69,6 +69,17 @@ Else
 End If
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0045.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Use conditional expression for return](ide0046.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0045.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0045.md
@@ -71,14 +71,29 @@ End If
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0045
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0045
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0045.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0046.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0046.md
@@ -67,6 +67,17 @@ Else
 End If
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0046.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Use conditional expression for assignment](ide0045.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0046.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0046.md
@@ -69,14 +69,29 @@ End If
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0046
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0046
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0046.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0047-ide0048.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0047-ide0048.md
@@ -142,6 +142,18 @@ Dim v = (a.b).Length
 Dim v = a.b.Length
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0047.severity = none
+dotnet_diagnostic.IDE0048.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Code style language rules](language-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0047-ide0048.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0047-ide0048.md
@@ -144,7 +144,15 @@ Dim v = a.b.Length
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0047 // Or IDE0048
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0047 // Or IDE0048
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -152,7 +160,14 @@ dotnet_diagnostic.IDE0047.severity = none
 dotnet_diagnostic.IDE0048.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0049.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0049.md
@@ -85,14 +85,29 @@ Dim local = Int32.MaxValue
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0049
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0049
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0049.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0049.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0049.md
@@ -83,6 +83,17 @@ Dim local = Integer.MaxValue
 Dim local = Int32.MaxValue
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0049.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Code style language rules](language-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0050.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0050.md
@@ -50,14 +50,29 @@ Dim t1 = (a:=1, b:=2)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0050
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0050
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0050.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0050.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0050.md
@@ -48,6 +48,17 @@ Dim t1 = New With { .a = 1, .b = 2 }
 Dim t1 = (a:=1, b:=2)
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0050.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Tuples](../../../csharp/language-reference/builtin-types/value-tuples.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0051.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0051.md
@@ -81,7 +81,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Style.severity = none
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/style-rules/ide0051.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0051.md
@@ -60,6 +60,17 @@ class C
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0051.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Remove unread private member (IDE0052)](ide0052.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0051.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0051.md
@@ -62,14 +62,29 @@ class C
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0051
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0051
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0051.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0052.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0052.md
@@ -84,7 +84,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Style.severity = none
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/style-rules/ide0052.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0052.md
@@ -65,14 +65,29 @@ class C
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0052
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0052
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0052.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0052.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0052.md
@@ -63,6 +63,17 @@ class C
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0052.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Remove unused private member (IDE0051)](ide0051.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0053.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0053.md
@@ -48,14 +48,29 @@ Func<int, int> square = x => { return x * x; };
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0053
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0053
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0053.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0053.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0053.md
@@ -46,6 +46,17 @@ Func<int, int> square = x => x * x;
 Func<int, int> square = x => { return x * x; };
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0053.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-bodied members](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
@@ -57,6 +57,18 @@ x += 1
 x = x + 1
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0054.severity = none
+dotnet_diagnostic.IDE0074.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
@@ -59,7 +59,15 @@ x = x + 1
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0054 // Or IDE0074
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0054 // Or IDE0074
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -67,7 +75,14 @@ dotnet_diagnostic.IDE0054.severity = none
 dotnet_diagnostic.IDE0074.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0056.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0056.md
@@ -48,6 +48,17 @@ string[] names = { "Archimedes", "Pythagoras", "Euclid" };
 var index = names[names.Length - 1];
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0056.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [index-from-end operator](../../../csharp/language-reference/operators/member-access-operators.md#index-from-end-operator-)

--- a/docs/fundamentals/code-analysis/style-rules/ide0056.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0056.md
@@ -50,14 +50,29 @@ var index = names[names.Length - 1];
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0056
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0056
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0056.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0057.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0057.md
@@ -48,6 +48,17 @@ string sentence = "the quick brown fox";
 var sub = sentence.Substring(0, sentence.Length - 4);
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0057.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0057.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0057.md
@@ -50,14 +50,29 @@ var sub = sentence.Substring(0, sentence.Length - 4);
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0057
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0057
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0057.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0058.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0058.md
@@ -90,6 +90,17 @@ var unused = Convert.ToInt32("35");
 Dim unused = Computation()
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0058.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Remove unnecessary value assignment (IDE0059)](ide0059.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0058.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0058.md
@@ -92,14 +92,29 @@ Dim unused = Computation()
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0058
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0058
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0058.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0059.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0059.md
@@ -94,6 +94,17 @@ int GetCount(Dictionary<string, int> wordCount, string searchWord)
 Dim unused = Computation()
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0059.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Remove unused expression value (IDE0058)](ide0058.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0059.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0059.md
@@ -96,14 +96,29 @@ Dim unused = Computation()
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0059
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0059
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0059.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0060.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0060.md
@@ -76,6 +76,17 @@ Private Function GetNum5(arg1 As Integer)
 End Function
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0060.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Unnecessary code rules](unnecessary-code-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0060.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0060.md
@@ -78,14 +78,29 @@ End Function
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0060
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0060
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0060.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0061.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0061.md
@@ -59,14 +59,29 @@ void M()
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0061
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0061
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0061.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0061.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0061.md
@@ -57,6 +57,17 @@ void M()
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0061.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-bodied members](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0062.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0062.md
@@ -62,14 +62,29 @@ void M()
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0062
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0062
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0062.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0062.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0062.md
@@ -60,6 +60,17 @@ void M()
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0062.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Modifier preferences](modifier-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0063.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0063.md
@@ -48,14 +48,29 @@ using (var a = b) { }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0063
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0063
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0063.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0063.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0063.md
@@ -46,6 +46,17 @@ using var a = b;
 using (var a = b) { }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0063.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [using statement](../../../csharp/language-reference/keywords/using-statement.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0064.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0064.md
@@ -64,6 +64,17 @@ struct MyStruct
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0064.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Modifier preferences](modifier-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0064.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0064.md
@@ -85,7 +85,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Style.severity = none
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/style-rules/ide0064.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0064.md
@@ -66,14 +66,29 @@ struct MyStruct
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0064
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0064
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0064.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0065.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0065.md
@@ -57,14 +57,29 @@ namespace Conventions
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0065
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0065
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0065.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0065.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0065.md
@@ -16,13 +16,13 @@ dev_langs:
 ---
 # 'using' directive placement (IDE0065)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0065 |
-| **Title** | `using` directive placement |
-| **Category** | Style |
-| **Subcategory** | Language rules (`using` directive preferences) |
-| **Applicable languages** | C# |
+| Property                 | Value                                          |
+|--------------------------|------------------------------------------------|
+| **Rule ID**              | IDE0065                                        |
+| **Title**                | `using` directive placement                    |
+| **Category**             | Style                                          |
+| **Subcategory**          | Language rules (`using` directive preferences) |
+| **Applicable languages** | C#                                             |
 
 ## Overview
 
@@ -36,7 +36,7 @@ This style rule concerns the preference of placing `using` directives outside or
 | **Option values** | `outside_namespace` - Prefer `using` directives to be placed outside the namespace<br /><br />`inside_namespace` - Prefer `using` directives to be placed inside the namespace |
 | **Default option value** | `outside_namespace` |
 
-#### Example
+## Example
 
 ```csharp
 // csharp_using_directive_placement = outside_namespace
@@ -54,6 +54,17 @@ namespace Conventions
     ...
 }
 ```
+
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0065.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0066.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0066.md
@@ -62,14 +62,29 @@ switch (x)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0066
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0066
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0066.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0066.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0066.md
@@ -60,6 +60,17 @@ switch (x)
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0066.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [switch expression](../../../csharp/language-reference/operators/switch-expression.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0070.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0070.md
@@ -57,6 +57,17 @@ class C : B
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0070.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Expression-level preferences](expression-level-preferences.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0070.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0070.md
@@ -59,14 +59,29 @@ class C : B
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0070
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0070
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0070.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0071.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0071.md
@@ -57,14 +57,29 @@ Dim str = $"prefix {someValue.ToString()} suffix"
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0071
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0071
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0071.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0071.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0071.md
@@ -55,6 +55,17 @@ Dim str = $"prefix {someValue} suffix"
 Dim str = $"prefix {someValue.ToString()} suffix"
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0071.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [interpolated strings](../../../csharp/language-reference/tokens/interpolated.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0072.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0072.md
@@ -66,6 +66,17 @@ class C
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0072.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Switch expression](../../../csharp/language-reference/operators/switch-expression.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0072.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0072.md
@@ -68,14 +68,29 @@ class C
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0072
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0072
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0072.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0073.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0073.md
@@ -82,14 +82,29 @@ End Namespace
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0073
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0073
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0073.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0073.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0073.md
@@ -80,6 +80,17 @@ Namespace N2
 End Namespace
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0073.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Code style language rules](language-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0075.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0075.md
@@ -59,6 +59,17 @@ Dim result1 = If (M1() AndAlso M2(), True, False)
 Dim result2 = If (M1(), True, M2())
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0075.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Conditional operator](../../../csharp/language-reference/operators/conditional-operator.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0075.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0075.md
@@ -61,14 +61,29 @@ Dim result2 = If (M1(), True, M2())
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0075
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0075
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0075.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0076.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0076.md
@@ -49,6 +49,17 @@ namespace N
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0076.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Global SuppressMessageAttribute](/visualstudio/code-quality/in-source-suppression-overview#global-level-suppressions)

--- a/docs/fundamentals/code-analysis/style-rules/ide0076.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0076.md
@@ -51,14 +51,29 @@ namespace N
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0076
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0076
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0076.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0076.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0076.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Style.severity = none
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/style-rules/ide0077.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0077.md
@@ -72,7 +72,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Style.severity = none
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/style-rules/ide0077.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0077.md
@@ -53,14 +53,29 @@ namespace N
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0077
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0077
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0077.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0077.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0077.md
@@ -51,6 +51,17 @@ namespace N
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0077.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Global SuppressMessageAttribute](/visualstudio/code-quality/in-source-suppression-overview#global-level-suppressions)

--- a/docs/fundamentals/code-analysis/style-rules/ide0078.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0078.md
@@ -50,14 +50,29 @@ var y = !(o is C c);
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0078
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0078
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0078.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0078.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0078.md
@@ -48,6 +48,17 @@ var x = i == default || i > default(int);
 var y = !(o is C c);
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0078.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [C# 9.0 pattern matching](../../../csharp/whats-new/csharp-9.md#pattern-matching-enhancements)

--- a/docs/fundamentals/code-analysis/style-rules/ide0079.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0079.md
@@ -89,6 +89,17 @@ class C1
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0079.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [pragma](../../../csharp/language-reference/preprocessor-directives.md#pragmas)

--- a/docs/fundamentals/code-analysis/style-rules/ide0079.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0079.md
@@ -91,14 +91,29 @@ class C1
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0079
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0079
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0079.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0079.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0079.md
@@ -110,7 +110,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Style.severity = none
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/style-rules/ide0080.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0080.md
@@ -47,14 +47,29 @@ if (o is string) { }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0080
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0080
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0080.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0080.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0080.md
@@ -45,6 +45,17 @@ if (!(o is string)) { }
 if (o is string) { }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0080.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Suppression or null-forgiving operator](../../../csharp/language-reference/operators/null-forgiving.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0081.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0081.md
@@ -38,6 +38,17 @@ Sub M(p1 As Integer, ByRef p2 As Integer)
 End Sub
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0081.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [ByVal](../../../visual-basic/language-reference/modifiers/byval.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0081.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0081.md
@@ -40,14 +40,29 @@ End Sub
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0081
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0081
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0081.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0082.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0082.md
@@ -51,14 +51,29 @@ Dim n2 = NameOf(Int32)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0082
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0082
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0082.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0082.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0082.md
@@ -49,6 +49,17 @@ Dim n1 = NameOf(T)
 Dim n2 = NameOf(Int32)
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0082.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [nameof operator](../../../csharp/language-reference/operators/nameof.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0083.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0083.md
@@ -51,6 +51,17 @@ var y = o is not C c;
 var y = !(o is C c);
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0083.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [IDE0078: Use pattern matching](ide0078.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0083.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0083.md
@@ -53,14 +53,29 @@ var y = !(o is C c);
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0083
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0083
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0083.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0084.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0084.md
@@ -46,6 +46,17 @@ Dim y = o IsNot C
 Dim y = Not o Is C
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0084.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [IDE0078: Use pattern matching](ide0078.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0084.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0084.md
@@ -48,14 +48,29 @@ Dim y = Not o Is C
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0084
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0084
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0084.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0090.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0090.md
@@ -50,14 +50,29 @@ C c2 = new C() { Field = 0 };
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0090
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0090
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0090.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0090.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0090.md
@@ -48,6 +48,17 @@ C c = new C();
 C c2 = new C() { Field = 0 };
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0090.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Target-typed new expressions](/dotnet/csharp/language-reference/proposals/csharp-9.0/target-typed-new)

--- a/docs/fundamentals/code-analysis/style-rules/ide0100.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0100.md
@@ -25,7 +25,7 @@ dev_langs:
 
 ## Overview
 
-This style rule flags unnecessary equality operator when comparing a non-constant boolean expression with a constant `true` or `false`. This rule has no associated code style option.
+This style rule flags unnecessary equality operator when comparing a non-constant Boolean expression with a constant `true` or `false`. This rule has no associated code style option.
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0100.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0100.md
@@ -55,6 +55,17 @@ If M() Then
 End If
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0100.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Unnecessary code rules](unnecessary-code-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0100.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0100.md
@@ -57,14 +57,29 @@ End If
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0100
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0100
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0100.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0110.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0110.md
@@ -56,14 +56,29 @@ switch (o)
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0110
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0110
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0110.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0110.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0110.md
@@ -54,6 +54,17 @@ switch (o)
 }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0110.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Unnecessary code rules](unnecessary-code-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0140.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0140.md
@@ -44,14 +44,29 @@ Dim x As New Student()
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0140
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0140
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE0140.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0140.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0140.md
@@ -42,6 +42,17 @@ Dim x As Student = New Student()
 Dim x As New Student()
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0140.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [Unnecessary code rules](unnecessary-code-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide1005.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide1005.md
@@ -48,14 +48,29 @@ if (func != null) { func(args); }
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE1005
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE1005
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.IDE1005.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/style-rules/ide1005.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide1005.md
@@ -46,6 +46,17 @@ func?.Invoke(args);
 if (func != null) { func(args); }
 ```
 
+## Suppress a warning
+
+One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE1005.severity = none
+```
+
+For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
 ## See also
 
 - [null-conditional operator](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-)

--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -37,9 +37,9 @@ or
 
 - **Severity** (optional in Visual Studio 2019 version 16.9 Preview 2 and later versions)
 
-  The second part of the rule specifies the [severity level](../configuration-options.md#severity-level) for the rule. When specified in this way, the severity setting is only respected inside development IDEs, such as Visual Studio. It is *not* respected during build.
+  The second part of the rule specifies the [severity level](../configuration-options.md#severity-level) for the rule. When specified in this way, *the severity setting is only respected inside development IDEs, such as Visual Studio*. It is *not* respected during build.
 
-  To enforce code style rules at build time, set the severity by using the rule ID-based severity configuration syntax for analyzers instead. The syntax takes the form `dotnet_diagnostic.<rule ID>.severity = <severity>`, for example, `dotnet_diagnostic.IDE0040.severity = silent`. For more information, see [severity level](../configuration-options.md#severity-level).
+  To enforce code style rules at build time, set the severity by using the rule ID-based severity configuration syntax for analyzers instead. The syntax takes the form `dotnet_diagnostic.<rule ID>.severity = <severity>`, for example, `dotnet_diagnostic.IDE0040.severity = none`. For more information, see [severity level](../configuration-options.md#severity-level).
 
 > [!TIP]
 >

--- a/docs/fundamentals/code-analysis/suppress-warnings.md
+++ b/docs/fundamentals/code-analysis/suppress-warnings.md
@@ -26,7 +26,7 @@ By disabling the code analysis rule that's causing the warning, you disable the 
 dotnet_diagnostic.<rule-ID>.severity = none
 ```
 
-For more information about rule severities, see [Configure rule severity](~/docs/fundamentals/code-analysis/configuration-options.md#severity-level).
+For more information about rule severities, see [Configure rule severity](configuration-options.md#severity-level).
 
 ## Use a preprocessor directive
 


### PR DESCRIPTION
Adds preprocessor directive, rule-specific, and category-specific suppression examples specific to each code style rule.

Contributes to #24437.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0022?branch=pr-en-us-29823#suppress-a-warning).