### PR TITLE
Expand suppression info for quality rules

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1000.md
@@ -80,7 +80,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1000.md
@@ -61,14 +61,29 @@ Do not suppress a warning from this rule. Providing generics in a syntax that is
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1000
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1000
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1000.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -45,14 +45,29 @@ In general, do not suppress a warning from this rule. It's okay to suppress the 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1001
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1001
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1001.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -50,14 +50,29 @@ Do not suppress a warning from this rule unless the assembly that raises this wa
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1002
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1002
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1002.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -69,7 +69,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1005.md
@@ -40,14 +40,29 @@ Do not suppress a warning from this rule unless the design absolutely requires m
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1005
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1005
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1005.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1005.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -45,14 +45,29 @@ Do not suppress a warning from this rule except for flags-attributed enumeration
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1008
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1008
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1008.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1010.md
@@ -69,7 +69,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1010.md
@@ -50,14 +50,29 @@ It is safe to suppress a warning from this rule; however, the use of the collect
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1010
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1010
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1010.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -42,14 +42,29 @@ Do not suppress a warning from this rule. The abstract type has a public constru
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1012
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1012
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1012.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1014.md
@@ -43,14 +43,29 @@ Do not suppress a warning from this rule. If you do not want the assembly to be 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1014
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1014
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1014.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1014.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1016.md
@@ -51,14 +51,29 @@ Do not suppress a warning from this rule for assemblies that are used by third p
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1016
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1016
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1016.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1016.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1019.md
@@ -45,14 +45,29 @@ Suppress a warning from this rule if you do not want the value of the mandatory 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1019
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1019
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1019.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1019.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1021.md
@@ -69,7 +69,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1021.md
@@ -50,14 +50,29 @@ It is safe to suppress a warning from this rule. However, this design could caus
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1021
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1021
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1021.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -55,14 +55,29 @@ Suppress a warning from this rule if the method meets one of the following crite
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1024
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1024
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1024.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -74,7 +74,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -42,14 +42,29 @@ Suppress a warning from this rule if you do not want the enumeration values to b
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1027
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1027
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1027.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -43,14 +43,29 @@ Suppress a warning from this rule only if backward compatibility issues require 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1028
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1028
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1028.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -47,14 +47,29 @@ Suppress a warning from this rule if the method does not work with the .NET even
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1030
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1030
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1030.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1032.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1032.md
@@ -67,7 +67,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1032.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1032.md
@@ -48,14 +48,29 @@ It's safe to suppress a warning from this rule when the violation is caused by u
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1032
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1032
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1032.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1033.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1033.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1033.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1033.md
@@ -40,14 +40,29 @@ It is safe to suppress a warning from this rule if an externally visible method 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1033
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1033
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1033.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -73,7 +73,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -54,14 +54,29 @@ It is safe to suppress a warning from rule CA1036 when the violation is caused b
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1036
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1036
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1036.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1040.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1040.md
@@ -45,14 +45,29 @@ It is safe to suppress a warning from this rule when the interface is used to id
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1040
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1040
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1040.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1040.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1040.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -43,14 +43,29 @@ Suppress a warning from this rule only after carefully considering the need for 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1043
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1043
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1043.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1045.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1045.md
@@ -49,14 +49,29 @@ It is safe to suppress a warning from this rule; however, this design could caus
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1045
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1045
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1045.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1045.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1045.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1046.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1046.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1046.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1046.md
@@ -38,14 +38,29 @@ It is safe to suppress a warning from this rule when the reference type behaves 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1046
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1046
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1046.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1050.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1050.md
@@ -41,14 +41,29 @@ Although you never have to suppress a warning from this rule, it is safe to do t
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1050
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1050
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1050.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example 1
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1050.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1050.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1051.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1051.md
@@ -49,14 +49,29 @@ Consumers may need field access in the following situations:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1051
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1051
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1051.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Include or exclude APIs
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1051.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1051.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1052.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1052.md
@@ -51,14 +51,29 @@ You can suppress violations in the following cases:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1052
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1052
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1052.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1052.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1052.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1054.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1054.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1054.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1054.md
@@ -43,14 +43,29 @@ It's safe to suppress a warning from this rule if the parameter does not represe
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1054
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1054
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1054.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -43,14 +43,29 @@ It's safe to suppress a warning from this rule if the return value does not repr
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1055
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1055
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1055.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1056.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1056.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1056.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1056.md
@@ -43,14 +43,29 @@ It is safe to suppress a warning from this rule if the property does not represe
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1056
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1056
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1056.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1058.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1058.md
@@ -98,7 +98,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1058.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1058.md
@@ -79,14 +79,29 @@ Do not suppress a warning from this rule for violations about <xref:System.Appli
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1058
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1058
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1058.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1062.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1062.md
@@ -65,7 +65,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1062.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1062.md
@@ -46,14 +46,29 @@ You can suppress a warning from this rule if you are sure that the dereferenced 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1062
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1062
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1062.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1064.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1064.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1064.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1064.md
@@ -40,14 +40,29 @@ Suppress a message from this rule if you are sure in all cases that the private 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1064
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1064
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1064.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1065.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1065.md
@@ -136,14 +136,29 @@ If the violation was caused by an exception declaration instead of a thrown exce
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1065
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1065
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1065.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1065.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1065.md
@@ -155,7 +155,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1066.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1066.md
@@ -96,7 +96,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1066.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1066.md
@@ -77,14 +77,29 @@ It is safe to suppress violations from this rule if the design and performance b
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1066
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1066
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1066.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -82,7 +82,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -63,14 +63,29 @@ If the method is an externally visible public API that is already part of a ship
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1068
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1068
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1068.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1070.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1070.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Design.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1070.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1070.md
@@ -47,14 +47,29 @@ If the event is an externally visible public API that is already part of a shipp
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1070
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1070
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1070.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1200.md
@@ -81,7 +81,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Documentation.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1200.md
@@ -62,14 +62,29 @@ It's safe to suppress this warning if the code reference must use a prefix becau
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1200
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1200
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1200.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1303.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1303.md
@@ -60,14 +60,29 @@ It's safe to suppress a warning from this rule if either of the following statem
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1303
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1303
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1303.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1303.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1303.md
@@ -79,7 +79,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1304.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1304.md
@@ -55,14 +55,29 @@ It is safe to suppress a warning from this rule when it is certain that the defa
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1304
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1304
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1304.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1304.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1304.md
@@ -74,7 +74,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -57,14 +57,29 @@ It is safe to suppress a warning from this rule when it is certain that the defa
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1305
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1305
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1305.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -76,7 +76,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1307.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1307.md
@@ -46,14 +46,29 @@ It is safe to suppress a warning from this rule when clarity of intent is not re
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1307
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1307
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1307.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1307.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1307.md
@@ -65,7 +65,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1308.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1308.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1308.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1308.md
@@ -38,14 +38,29 @@ It's safe to suppress a warning when you're not making security decisions based 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1308
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1308
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1308.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1309.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1309.md
@@ -40,14 +40,29 @@ It is safe to suppress a warning from this rule when the library or application 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1309
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1309
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1309.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1309.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1309.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1310.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1310.md
@@ -45,14 +45,29 @@ It is safe to suppress a warning from this rule when the library or application 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1310
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1310
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1310.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1310.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1310.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -43,14 +43,29 @@ It is safe to suppress a warning from this rule. However, the code might be more
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1501
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1501
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1501.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Maintainability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1502.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1502.md
@@ -49,14 +49,29 @@ It is safe to suppress a warning from this rule if the complexity cannot easily 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1502
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1502
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1502.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## How cyclomatic complexity is calculated
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1502.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1502.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Maintainability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1505.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1505.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Maintainability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1505.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1505.md
@@ -40,14 +40,29 @@ You can suppress this warning when the type or method cannot be split or is cons
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1505
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1505
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1505.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1506.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1506.md
@@ -37,14 +37,29 @@ You can suppress this warning when the type or method is considered maintainable
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1506
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1506
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1506.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1506.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1506.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Maintainability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1507.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1507.md
@@ -70,14 +70,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1507
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1507
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1507.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1507.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1507.md
@@ -89,7 +89,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Maintainability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1508.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1508.md
@@ -64,14 +64,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1508
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1508
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1508.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1508.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1508.md
@@ -83,7 +83,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Maintainability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1700.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1700.md
@@ -48,14 +48,29 @@ It is safe to suppress a warning from this rule for a member that is currently u
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1700
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1700
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1700.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1700.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1700.md
@@ -67,7 +67,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -40,14 +40,29 @@ Do not suppress warnings for production code. However, it's safe to suppress thi
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1707
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1707
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1707.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 For well-known methods in Microsoft code that currently use an underscore and cannot be modified, the rule should be suppressed.
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -105,7 +105,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -86,14 +86,29 @@ For other suffixes, do not suppress a warning from this rule. The suffix allows 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1710
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1710
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1710.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -84,7 +84,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -65,14 +65,29 @@ Do not suppress a warning from this rule unless the suffix has an unambiguous me
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1711
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1711
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1711.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1714.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1714.md
@@ -42,14 +42,29 @@ It is safe to suppress a violation if the name is a plural word but does not end
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1714
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1714
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1714.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1714.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1714.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -48,14 +48,29 @@ You can suppress a warning from this rule if you're sure that the identifier won
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1716
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1716
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1716.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -67,7 +67,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1717.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1717.md
@@ -63,7 +63,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1717.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1717.md
@@ -44,14 +44,29 @@ It is safe to suppress a warning from the rule if the name ends in a singular wo
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1717
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1717
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1717.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1720.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1720.md
@@ -96,14 +96,29 @@ Occasional use of type-based parameter and member names might be appropriate. Ho
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1720
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1720
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1720.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1720.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1720.md
@@ -115,7 +115,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1721.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1721.md
@@ -65,7 +65,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1721.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1721.md
@@ -46,14 +46,29 @@ Do not suppress a warning from this rule. One exception to that rule is if the "
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1721
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1721
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1721.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1724.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1724.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1724.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1724.md
@@ -38,14 +38,29 @@ For new development, no known scenarios occur where you must suppress a warning 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1724
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1724
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1724.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -40,14 +40,29 @@ Do not suppress a warning from this rule except for COM visible methods in libra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1725
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1725
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1725.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1727.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1727.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Naming.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1727.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1727.md
@@ -37,11 +37,26 @@ It is safe to suppress a warning from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1727
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1727
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1727.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -68,14 +68,29 @@ It is safe to suppress a warning from this rule:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1801
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1801
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1801.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -87,7 +87,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -50,14 +50,29 @@ It is safe to suppress a warning from this rule, or disable the rule, if perform
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1802
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1802
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1802.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -69,7 +69,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1805.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1805.md
@@ -81,7 +81,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1805.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1805.md
@@ -62,14 +62,29 @@ It is always safe to suppress the warning, as the warning simply highlights pote
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1805
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1805
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1805.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -67,14 +67,29 @@ Do not suppress a warning from this rule unless the act of creating the object s
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1806
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1806
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1806.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -86,7 +86,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1810.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1810.md
@@ -52,14 +52,29 @@ It is safe to suppress a warning from this rule if one of the following applies:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1810
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1810
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1810.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1810.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1810.md
@@ -71,7 +71,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1812.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1812.md
@@ -81,14 +81,29 @@ It is safe to suppress a warning from this rule. We recommend that you suppress 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1812
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1812
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1812.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1812.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1812.md
@@ -100,7 +100,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1813.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1813.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1813.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1813.md
@@ -41,14 +41,29 @@ It is safe to suppress a warning from this rule. Suppress only if you are defini
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1813
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1813
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1813.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1814.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1814.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1814.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1814.md
@@ -41,14 +41,29 @@ It's okay to suppress a warning from this rule if the multidimensional array doe
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1814
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1814
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1814.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1815.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1815.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1815.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1815.md
@@ -40,14 +40,29 @@ It's safe to suppress a warning from this rule if instances of the value type wi
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1815
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1815
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1815.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1816.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1816.md
@@ -76,7 +76,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1816.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1816.md
@@ -57,14 +57,29 @@ Only suppress a warning from this rule if you're deliberately using <xref:System
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1816
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1816
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1816.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example that violates CA1816
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1819.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1819.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1819.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1819.md
@@ -47,14 +47,29 @@ Otherwise, do not suppress a warning from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1819
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1819
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1819.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1820.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1820.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1820.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1820.md
@@ -40,14 +40,29 @@ It's safe to suppress a warning from this rule if performance is not an issue.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1820
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1820
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1820.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -38,14 +38,29 @@ It is safe to suppress a warning from this rule for previously shipped code for 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1822
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1822
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1822.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1823.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1823.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1823.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1823.md
@@ -38,14 +38,29 @@ It is safe to suppress a warning from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1823
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1823
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1823.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1824.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1824.md
@@ -54,14 +54,29 @@ It's permissible to suppress a warning from this rule. However, startup performa
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1824
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1824
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1824.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1824.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1824.md
@@ -73,7 +73,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1825.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1825.md
@@ -67,14 +67,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1825
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1825
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1825.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1825.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1825.md
@@ -86,7 +86,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1826.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1826.md
@@ -88,14 +88,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1826
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1826
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1826.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1826.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1826.md
@@ -107,7 +107,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -71,14 +71,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1827
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1827
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1827.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -90,7 +90,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1828.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1828.md
@@ -92,7 +92,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1828.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1828.md
@@ -73,14 +73,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1828
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1828
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1828.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1829.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1829.md
@@ -102,7 +102,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1829.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1829.md
@@ -83,14 +83,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1829
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1829
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1829.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1830.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1830.md
@@ -59,14 +59,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1830
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1830
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1830.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1830.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1830.md
@@ -78,7 +78,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1831.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1831.md
@@ -112,7 +112,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1831.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1831.md
@@ -93,14 +93,29 @@ It's safe to suppress a violation of this rule if creating a copy is intended.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1831
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1831
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1831.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1832.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1832.md
@@ -111,14 +111,29 @@ It's safe to suppress a violation of this rule if creating a copy is intended.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1832
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1832
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1832.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1832.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1832.md
@@ -130,7 +130,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1833.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1833.md
@@ -130,7 +130,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1833.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1833.md
@@ -111,14 +111,29 @@ It's safe to suppress a violation of this rule if creating a copy is intended.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1833
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1833
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1833.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1834.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1834.md
@@ -128,14 +128,29 @@ It's safe to suppress a violation of this rule if you're not concerned about imp
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1834
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1834
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1834.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1834.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1834.md
@@ -147,7 +147,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -284,7 +284,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -265,14 +265,29 @@ It's safe to suppress a violation of this rule if you're not concerned about imp
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1835
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1835
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1835.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1836.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1836.md
@@ -84,7 +84,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1836.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1836.md
@@ -65,14 +65,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1836
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1836
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1836.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1837.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1837.md
@@ -122,7 +122,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1837.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1837.md
@@ -103,14 +103,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1837
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1837
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1837.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1838.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1838.md
@@ -147,14 +147,29 @@ Suppress a violation of this rule if you're not concerned about the performance 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1838
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1838
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1838.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1838.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1838.md
@@ -166,7 +166,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1839.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1839.md
@@ -120,7 +120,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1839.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1839.md
@@ -101,14 +101,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1839
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1839
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1839.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1840.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1840.md
@@ -90,14 +90,29 @@ It's safe to suppress a violation of this rule if you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1840
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1840
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1840.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1840.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1840.md
@@ -109,7 +109,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1841.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1841.md
@@ -96,14 +96,29 @@ It is safe to suppress warnings from this rule if the code in question is not pe
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1841
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1841
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1841.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1841.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1841.md
@@ -115,7 +115,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1844.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1844.md
@@ -49,14 +49,29 @@ It's safe to suppress a warning from this rule if any of the following situation
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1844
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1844
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1844.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1844.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1844.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1847.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1847.md
@@ -71,14 +71,29 @@ Suppress a violation of this rule if you're not concerned about the performance 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1847
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1847
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1847.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1847.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1847.md
@@ -90,7 +90,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1849.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1849.md
@@ -55,14 +55,29 @@ It's safe to suppress a warning from this rule in the case where there are two s
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1849
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1849
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1849.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1849.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1849.md
@@ -74,7 +74,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1850.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1850.md
@@ -86,14 +86,29 @@ It is safe to suppress a warning from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1850
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1850
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1850.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1850.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1850.md
@@ -105,7 +105,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1851.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1851.md
@@ -152,14 +152,29 @@ It is safe to suppress this warning if the underlying type of the `IEnumerable` 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1851
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1851
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1851.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1851.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1851.md
@@ -171,7 +171,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1854.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1854.md
@@ -109,7 +109,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Performance.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1854.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1854.md
@@ -90,11 +90,26 @@ It's safe to suppress this warning if you're using a custom implementation of `I
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1854
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1854
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA1854.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -75,14 +75,29 @@ Do not suppress a warning from this rule unless:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2000
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2000
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2000.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -94,7 +94,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2002.md
@@ -65,14 +65,29 @@ Otherwise, do not suppress a warning from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2002
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2002
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2002.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2002.md
@@ -84,7 +84,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2007.md
@@ -67,14 +67,29 @@ You can suppress this warning in any situation where either the continuation sho
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2007
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2007
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2007.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2007.md
@@ -86,7 +86,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2008.md
@@ -47,14 +47,29 @@ This warning is intended primarily for libraries, where the code may be executed
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2008
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2008
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2008.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2008.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2009.md
@@ -109,14 +109,29 @@ Do not suppress violations from this rule, unless you're not concerned about the
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2009
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2009
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2009.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2009.md
@@ -128,7 +128,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2011.md
@@ -86,14 +86,29 @@ It is fine to suppress violations from this rule if you are sure that the recurs
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2011
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2011
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2011.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2011.md
@@ -105,7 +105,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2012.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2012.md
@@ -38,14 +38,29 @@ For `ValueTask` objects returned from arbitrary member calls, the caller needs t
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2012
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2012
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2012.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2014.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2014.md
@@ -38,14 +38,29 @@ It may be safe to suppress the warning when the containing loop or loops are inv
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2014
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2014
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2014.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2015.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2015.md
@@ -78,7 +78,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2015.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2015.md
@@ -59,14 +59,29 @@ It is safe to suppress a violation of this rule if the intent is to create a fin
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2015
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2015
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2015.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -296,11 +296,26 @@ namespace ConsoleApp
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2016
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2016
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2016.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -315,7 +315,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Reliability.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2100.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2100.md
@@ -74,14 +74,29 @@ It is safe to suppress a warning from this rule if the command text does not con
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2100
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2100
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2100.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2100.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2100.md
@@ -93,7 +93,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -52,14 +52,29 @@ Suppress a warning from this rule only after a careful security review to make s
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2109
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2109
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2109.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -71,7 +71,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2119.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2119.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2119.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2119.md
@@ -51,14 +51,29 @@ It is safe to suppress a warning from this rule if, after careful review, no sec
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2119
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2119
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2119.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example 1
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -67,14 +67,29 @@ It's safe to suppress a warning from this rule only if a parameterized construct
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2208
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2208
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2208.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -86,7 +86,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2211.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2211.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2211.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2211.md
@@ -41,14 +41,29 @@ It is safe to suppress a warning from this rule if you are developing an applica
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2211
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2211
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2211.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2213.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2213.md
@@ -56,14 +56,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2213
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2213
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2213.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2213.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2213.md
@@ -75,7 +75,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2215.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2215.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2215.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2215.md
@@ -42,14 +42,29 @@ It is safe to suppress a warning from this rule if the call to `base`.<xref:Syst
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2215
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2215
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2215.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2216.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2216.md
@@ -44,14 +44,29 @@ It is safe to suppress a warning from this rule if the type does not implement <
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2216
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2216
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2216.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2216.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2216.md
@@ -63,7 +63,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -40,14 +40,29 @@ It is safe to suppress a warning from this rule if the equality operator returns
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2224
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2224
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2224.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2225.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2225.md
@@ -111,7 +111,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2225.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2225.md
@@ -92,14 +92,29 @@ Do not suppress a warning from this rule if you're implementing a shared library
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2225
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2225
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2225.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2227.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2227.md
@@ -45,14 +45,29 @@ Otherwise, do not suppress warnings from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2227
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2227
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2227.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2227.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2227.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2231.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2231.md
@@ -60,14 +60,29 @@ It is safe to suppress a warning from this rule; however, we recommend that you 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2231
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2231
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2231.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2231.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2231.md
@@ -79,7 +79,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2234.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2234.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2234.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2234.md
@@ -43,14 +43,29 @@ It is safe to suppress a warning from this rule if the string parameter does not
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2234
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2234
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2234.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2235.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2235.md
@@ -44,14 +44,29 @@ Only suppress a warning from this rule if a <xref:System.Runtime.Serialization.I
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2235
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2235
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2235.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2235.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2235.md
@@ -63,7 +63,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2237.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2237.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2237.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2237.md
@@ -41,14 +41,29 @@ Do not suppress a warning from this rule for exception classes, because they mus
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2237
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2237
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2237.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2243.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2243.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2243.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2243.md
@@ -42,14 +42,29 @@ It is safe to suppress a warning from this rule if the parameter does not repres
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2243
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2243
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2243.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2245.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2245.md
@@ -93,7 +93,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2245.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2245.md
@@ -74,14 +74,29 @@ It is safe to suppress violations from this rule if fetching a property value ca
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2245
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2245
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2245.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -47,14 +47,29 @@ A violation of this rule almost always highlights a bug in the calling code, suc
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2247
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2247
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2247.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md)..
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md)..
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md)..

--- a/docs/fundamentals/code-analysis/quality-rules/ca2249.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2249.md
@@ -146,14 +146,29 @@ It's safe to suppress a violation of this rule if improving code readability is 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2249
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2249
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2249.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2249.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2249.md
@@ -165,7 +165,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2250.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2250.md
@@ -92,14 +92,29 @@ It is safe to suppress warnings from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2250
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2250
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2250.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2250.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2250.md
@@ -111,7 +111,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2251.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2251.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2251.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2251.md
@@ -37,14 +37,29 @@ It is safe to suppress warnings from this rule.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2251
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2251
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2251.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2252.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2252.md
@@ -83,7 +83,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2252.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2252.md
@@ -18,7 +18,7 @@ dev_langs:
 |                                     | Value                                |
 | ----------------------------------- | ------------------------------------ |
 | **Rule ID**                         | CA2252                               |
-| **Category**                        | [Microsoft.Usage](usage-warnings.md) |
+| **Category**                        | [Usage](usage-warnings.md)           |
 | **Fix is breaking or non-breaking** | Non-breaking                         |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2252.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2252.md
@@ -64,14 +64,29 @@ The following images show how to disable the CA2252 analyzer locally.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2252
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2252
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2252.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2255.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2255.md
@@ -37,14 +37,29 @@ It is safe to suppress warnings from this rule if a solution uses a Class Librar
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2255
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2255
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2255.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2255.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2255.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Usage.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2321.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2321.md
@@ -63,7 +63,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2321.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2321.md
@@ -44,14 +44,29 @@ This rule finds <xref:System.Web.Script.Serialization.JavaScriptSerializer?displ
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2321
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2321
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2321.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2322.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2322.md
@@ -63,7 +63,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2322.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2322.md
@@ -44,14 +44,29 @@ This rule finds <xref:System.Web.Script.Serialization.JavaScriptSerializer?displ
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2322
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2322
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2322.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2326.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2326.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2326.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2326.md
@@ -45,14 +45,29 @@ This rule finds [Newtonsoft.Json.TypeNameHandling](https://www.newtonsoft.com/js
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2326
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2326
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2326.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2327.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2327.md
@@ -72,7 +72,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2327.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2327.md
@@ -53,14 +53,29 @@ This rule finds [Newtonsoft.Json.JsonSerializerSettings](https://www.newtonsoft.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2327
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2327
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2327.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2328.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2328.md
@@ -78,7 +78,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2328.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2328.md
@@ -59,14 +59,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2328
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2328
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2328.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2329.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2329.md
@@ -65,7 +65,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2329.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2329.md
@@ -46,14 +46,29 @@ This rule finds [Newtonsoft.Json.JsonSerializer](https://www.newtonsoft.com/json
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2329
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2329
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2329.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2330.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2330.md
@@ -52,14 +52,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2330
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2330
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2330.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2330.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2330.md
@@ -71,7 +71,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2350.md
@@ -39,14 +39,29 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2350
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2350
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2350.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2350.md
@@ -58,7 +58,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2351.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2351.md
@@ -47,14 +47,29 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2351
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2351
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2351.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2352.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2352.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2352.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2352.md
@@ -47,14 +47,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2352
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2352
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2352.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2353.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2353.md
@@ -67,14 +67,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2353
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2353
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2353.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2353.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2353.md
@@ -86,7 +86,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2354.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2354.md
@@ -41,14 +41,29 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2354
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2354
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2354.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2354.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2354.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2355.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2355.md
@@ -52,14 +52,29 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2355
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2355
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2355.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2355.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2355.md
@@ -71,7 +71,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2356.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2356.md
@@ -41,14 +41,29 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2356
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2356
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2356.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2356.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2356.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2361.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca2361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2361.md
@@ -49,14 +49,29 @@ For more information, see [DataSet and DataTable security guidance](../../../fra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2361
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2361
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2361.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2362.md
@@ -49,14 +49,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA2362
+// The code that's violating the rule is on this line.
+#pragma warning restore CA2362
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA2362.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2362.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3001.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3001.md
@@ -45,14 +45,29 @@ It's safe to suppress a warning from this rule if you know that the input is alw
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3001
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3001
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3001.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3002.md
@@ -71,7 +71,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3002.md
@@ -52,14 +52,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3002
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3002
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3002.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3004.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3004.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3004.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3004.md
@@ -45,14 +45,29 @@ If you know your web output is within your application's trust boundary and neve
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3004
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3004
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3004.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3005.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3005.md
@@ -51,14 +51,29 @@ If you know the input has been validated or escaped to be safe, it's okay to sup
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3005
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3005
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3005.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3006.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3006.md
@@ -46,14 +46,29 @@ If you know the input has been validated or escaped to be safe, it's safe to sup
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3006
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3006
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3006.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3006.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3006.md
@@ -65,7 +65,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3007.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3007.md
@@ -51,14 +51,29 @@ If you know you've validated the input to be restricted to intended URLs, it's o
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3007
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3007
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3007.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3008.md
@@ -49,14 +49,29 @@ If you know you've validated the input to be safe, it's okay to suppress this wa
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3008
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3008
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3008.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3008.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3012.md
@@ -69,7 +69,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3012.md
@@ -50,14 +50,29 @@ If you know you're using a [match timeout](../../../standard/base-types/best-pra
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3012
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3012
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3012.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3061.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3061.md
@@ -36,14 +36,29 @@ Suppress this rule if you are sure your XML does not resolve dangerous external 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3061
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3061
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3061.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3061.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3061.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3075.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3075.md
@@ -67,14 +67,29 @@ Unless you're sure that the input is known to be from a trusted source, do not s
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3075
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3075
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3075.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3075.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3075.md
@@ -86,7 +86,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3076.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3076.md
@@ -36,14 +36,29 @@ Unless you're sure that the input is known to be from a trusted source, do not s
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3076
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3076
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3076.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3076.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3076.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3077.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3077.md
@@ -38,14 +38,29 @@ Unless you're sure that the input is known to be from a trusted source, do not s
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3077
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3077
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3077.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3077.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3077.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca3147.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3147.md
@@ -47,14 +47,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA3147
+// The code that's violating the rule is on this line.
+#pragma warning restore CA3147
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA3147.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## ValidateAntiForgeryToken attribute example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3147.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3147.md
@@ -66,7 +66,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5350.md
@@ -11,7 +11,7 @@ ms.author: gewarren
 |                                     | Value                                |
 |-------------------------------------|--------------------------------------|
 | **Rule ID**                         | CA5350                               |
-| **Category**                        | [Cryptography](security-warnings.md) |
+| **Category**                        | [Security](security-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                         |
 
 > [!NOTE]
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-Cryptography.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5350.md
@@ -43,14 +43,29 @@ Suppress a warning from this rule when the level of protection needed for the da
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5350
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5350
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5350.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5350.md
@@ -8,11 +8,11 @@ ms.author: gewarren
 ---
 # CA5350: Do Not Use Weak Cryptographic Algorithms
 
-| | Value |
-|-|-|
-| **Rule ID** |CA5350|
-| **Category** |[Microsoft.Cryptography](security-warnings.md)|
-| **Fix is breaking or non-breaking** |Non-breaking|
+|                                     | Value                               |
+|-------------------------------------|-------------------------------------|
+| **Rule ID**                         | CA5350                              |
+| **Category**                        | Cryptography](security-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking                        |
 
 > [!NOTE]
 > This warning was last updated on November 2015.

--- a/docs/fundamentals/code-analysis/quality-rules/ca5350.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5350.md
@@ -8,11 +8,11 @@ ms.author: gewarren
 ---
 # CA5350: Do Not Use Weak Cryptographic Algorithms
 
-|                                     | Value                               |
-|-------------------------------------|-------------------------------------|
-| **Rule ID**                         | CA5350                              |
-| **Category**                        | Cryptography](security-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                        |
+|                                     | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA5350                               |
+| **Category**                        | [Cryptography](security-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking                         |
 
 > [!NOTE]
 > This warning was last updated on November 2015.
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Cryptography.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5351.md
@@ -68,7 +68,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5351.md
@@ -49,14 +49,29 @@ Do not suppress a warning from this rule, unless it's been reviewed by a cryptog
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5351
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5351
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5351.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5358.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5358.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5358.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5358.md
@@ -43,14 +43,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5358
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5358
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5358.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5359.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5359.md
@@ -54,7 +54,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5359.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5359.md
@@ -35,14 +35,29 @@ If multiple delegates are attached to <xref:System.Net.ServicePointManager.Serve
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5359
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5359
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5359.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5360.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5360.md
@@ -69,14 +69,29 @@ It's safe to suppress this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5360
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5360
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5360.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5360.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5360.md
@@ -88,7 +88,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5361.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5361.md
@@ -42,14 +42,29 @@ You can suppress this warning if you need to connect to a legacy service that ca
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5361
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5361
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5361.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5362.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5362.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5362.md
@@ -40,14 +40,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5362
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5362
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5362.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5363.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5363.md
@@ -36,14 +36,29 @@ You can suppress this violation if all the payload in the incoming HTTP request 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5363
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5363
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5363.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5363.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5363.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5364.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5364.md
@@ -69,7 +69,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5364.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5364.md
@@ -50,14 +50,29 @@ You can suppress this warning if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5364
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5364
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5364.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5365.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5365.md
@@ -34,14 +34,29 @@ HTTP header continuations rely on headers spanning multiple lines and require ne
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5365
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5365
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5365.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5365.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5365.md
@@ -53,7 +53,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5366.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5366.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5366.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5366.md
@@ -38,14 +38,29 @@ Suppress a warning from this rule when dealing with a trusted data source.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5366
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5366
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5366.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5368.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5368.md
@@ -40,14 +40,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5368
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5368
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5368.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5368.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5368.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5369.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5369.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5369.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5369.md
@@ -36,14 +36,29 @@ You can potentially suppress this warning if the parsed XML comes from a trusted
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5369
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5369
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5369.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5370.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5370.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5370.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5370.md
@@ -37,14 +37,29 @@ You can potentially suppress this warning if the `XmlValidatingReader` is always
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5370
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5370
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5370.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5371.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5371.md
@@ -36,14 +36,29 @@ You can potentially suppress this warning if the <xref:System.Xml.Schema.XmlSche
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5371
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5371
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5371.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5371.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5371.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5372.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5372.md
@@ -36,14 +36,29 @@ You can potentially suppress this warning if the `XPathDocument` object is used 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5372
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5372
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5372.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5372.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5372.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5373.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5373.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5373.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5373.md
@@ -37,14 +37,29 @@ Suppress the warning if the risk associated with using PBKDF1 is carefully revie
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5373
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5373
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5373.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5374.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5374.md
@@ -37,14 +37,29 @@ The <xref:System.Xml.Xsl.XslTransform> object, XSLT style sheets, and XML source
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5374
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5374
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5374.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5374.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5374.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5375.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5375.md
@@ -35,14 +35,29 @@ It is safe to suppress this rule if you're sure that the permissions of all reso
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5375
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5375
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5375.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5375.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5375.md
@@ -54,7 +54,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5377.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5377.md
@@ -37,14 +37,29 @@ It is safe to suppress this rule if you're sure that the permissions of all reso
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5377
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5377
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5377.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5377.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5377.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5378.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5378.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5378.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5378.md
@@ -42,14 +42,29 @@ You can suppress this warning if you need to connect to a legacy service that ca
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5378
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5378
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5378.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5379.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5379.md
@@ -41,14 +41,29 @@ It is not recommended to suppress this rule except for application compatibility
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5379
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5379
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5379.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5379.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5379.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5382.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5382.md
@@ -55,14 +55,29 @@ Set <xref:Microsoft.AspNetCore.Http.CookieOptions.Secure> property as `true`.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5382
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5382
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5382.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5382.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5382.md
@@ -74,7 +74,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5383.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5383.md
@@ -74,7 +74,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5383.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5383.md
@@ -55,14 +55,29 @@ Set <xref:Microsoft.AspNetCore.Http.CookieOptions.Secure> property as `true` und
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5383
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5383
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5383.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5384.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5384.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5384.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5384.md
@@ -40,14 +40,29 @@ It is not recommended to suppress this rule unless for compatibility with legacy
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5384
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5384
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5384.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5385.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5385.md
@@ -42,14 +42,29 @@ It is not recommended to suppress this rule unless for compatibility with legacy
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5385
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5385
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5385.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5385.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5385.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5386.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5386.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5386.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5386.md
@@ -45,14 +45,29 @@ You can suppress this warning if your application targets .NET Framework v4.6.2 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5386
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5386
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5386.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5387.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5387.md
@@ -38,14 +38,29 @@ It's safe to suppress a warning if you need to use a smaller iteration count for
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5387
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5387
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5387.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5387.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5387.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5388.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5388.md
@@ -41,14 +41,29 @@ It's safe to suppress warnings from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5388
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5388
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5388.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5388.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5388.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5389.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5389.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5389.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5389.md
@@ -45,14 +45,29 @@ You can suppress this warning if the source path always comes from a trusted sou
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5389
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5389
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5389.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5391.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5391.md
@@ -38,14 +38,29 @@ It's safe to suppress this rule if solutions other than using antiforgery token 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5391
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5391
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5391.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5391.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5391.md
@@ -57,7 +57,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5392.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5392.md
@@ -41,14 +41,29 @@ It's safe to suppress this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5392
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5392
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5392.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5392.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5392.md
@@ -60,7 +60,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -48,14 +48,29 @@ It's safe to suppress this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5393
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5393
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5393.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -67,7 +67,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5394.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5394.md
@@ -34,14 +34,29 @@ It's safe to suppress warnings from this rule if you're sure that the weak pseud
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5394
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5394
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5394.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5394.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5394.md
@@ -53,7 +53,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5395.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5395.md
@@ -37,14 +37,29 @@ It's safe to suppress warnings from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5395
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5395
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5395.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5395.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5395.md
@@ -56,7 +56,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5396.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5396.md
@@ -62,7 +62,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5396.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5396.md
@@ -43,14 +43,29 @@ Set <xref:System.Web.HttpCookie.HttpOnly?displayProperty=fullName> to `true`.
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5396
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5396
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5396.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5397.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5397.md
@@ -51,14 +51,29 @@ You can suppress this warning if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5397
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5397
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5397.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5397.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5397.md
@@ -70,7 +70,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5398.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5398.md
@@ -64,7 +64,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5398.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5398.md
@@ -45,14 +45,29 @@ It's safe to suppress a warning if you need to connect to a legacy service that 
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5398
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5398
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5398.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -36,14 +36,29 @@ It's safe to suppress this rule if you're sure that the `CheckCertificateRevocat
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5400
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5400
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5400.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Configure code to analyze
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5401.md
@@ -39,14 +39,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5401
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5401
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5401.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5401.md
@@ -58,7 +58,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5402.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5402.md
@@ -59,7 +59,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5402.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5402.md
@@ -40,14 +40,29 @@ It's safe to suppress a warning from this rule if:
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5402
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5402
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5402.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5403.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5403.md
@@ -61,7 +61,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5403.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5403.md
@@ -42,14 +42,29 @@ It's safe to suppress a warning from this rule if the hard-coded data doesn't co
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5403
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5403
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5403.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5404.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5404.md
@@ -35,14 +35,29 @@ In the vast majority of cases, this validation is essential to ensure the securi
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5404
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5404
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5404.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5404.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5404.md
@@ -54,7 +54,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -55,7 +55,7 @@ To disable this entire category of rules, set the severity for the category to `
 
 ```ini
 [*.{cs,vb}]
-dotnet_analyzer_diagnostic.category-<cat>.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -36,14 +36,29 @@ In some specific cases where you're utilizing the delegate for additional loggin
 
 ## Suppress a warning
 
-One way to suppress a warning is to disable the rule for a file, folder, or project by setting its severity to `none` in the [configuration file](../configuration-files.md).
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA5405
+// The code that's violating the rule is on this line.
+#pragma warning restore CA5405
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
 dotnet_diagnostic.CA5405.severity = none
 ```
 
-For more information and to find other ways to suppress a rule, such as with a preprocessor directive, see [How to suppress code analysis warnings](../suppress-warnings.md).
+To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-<cat>.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Pseudo-code examples
 


### PR DESCRIPTION
Adds preprocessor directive and category-specific suppression examples specific to each code quality rule.

Contributes to https://github.com/dotnet/docs/issues/24437.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1002?branch=pr-en-us-29826#suppress-a-warning).

cc @Youssef1313 