### PR TITLE
Clarify MetadataLoadContext limitations

### DIFF
--- a/docs/standard/assembly/inspect-contents-using-metadataloadcontext.md
+++ b/docs/standard/assembly/inspect-contents-using-metadataloadcontext.md
@@ -33,6 +33,10 @@ The following code sample creates <xref:System.Reflection.MetadataLoadContext>, 
 
 [!code-csharp[](snippets/inspect-contents-using-metadataloadcontext/MetadataLoadContextSnippets.cs#CreateContext)]
 
+If you need to test types in <xref:System.Reflection.MetadataLoadContext> for equality or assignability, only use type objects loaded into that context. Mixing <xref:System.Reflection.MetadataLoadContext> types with runtime types is not supported. For example, suppose we have a type `testedType` in <xref:System.Reflection.MetadataLoadContext>. If you need to test whether another type is assignable from it, do not use code like `typeof(MyType).IsAssignableFrom(testedType)`. Use code like this instead:
+
+[!code-csharp[](snippets/inspect-contents-using-metadataloadcontext/MetadataLoadContextSnippets.cs#Assignability)]
+
 ## Example
 
 For a complete code example, see the [Inspect assembly contents using MetadataLoadContext sample](/samples/dotnet/samples/inspect-assembly-contents-using-metadataloadcontext/).

--- a/docs/standard/assembly/inspect-contents-using-metadataloadcontext.md
+++ b/docs/standard/assembly/inspect-contents-using-metadataloadcontext.md
@@ -33,7 +33,7 @@ The following code sample creates <xref:System.Reflection.MetadataLoadContext>, 
 
 [!code-csharp[](snippets/inspect-contents-using-metadataloadcontext/MetadataLoadContextSnippets.cs#CreateContext)]
 
-If you need to test types in <xref:System.Reflection.MetadataLoadContext> for equality or assignability, only use type objects loaded into that context. Mixing <xref:System.Reflection.MetadataLoadContext> types with runtime types is not supported. For example, suppose we have a type `testedType` in <xref:System.Reflection.MetadataLoadContext>. If you need to test whether another type is assignable from it, do not use code like `typeof(MyType).IsAssignableFrom(testedType)`. Use code like this instead:
+If you need to test types in <xref:System.Reflection.MetadataLoadContext> for equality or assignability, only use type objects loaded into that context. Mixing <xref:System.Reflection.MetadataLoadContext> types with runtime types is not supported. For example, consider a type `testedType` in <xref:System.Reflection.MetadataLoadContext>. If you need to test whether another type is assignable from it, don't use code like `typeof(MyType).IsAssignableFrom(testedType)`. Use code like this instead:
 
 [!code-csharp[](snippets/inspect-contents-using-metadataloadcontext/MetadataLoadContextSnippets.cs#Assignability)]
 

--- a/docs/standard/assembly/snippets/inspect-contents-using-metadataloadcontext/MetadataLoadContextSnippets.cs
+++ b/docs/standard/assembly/snippets/inspect-contents-using-metadataloadcontext/MetadataLoadContextSnippets.cs
@@ -56,5 +56,29 @@ namespace AssemblySnippets
             }
             //</SnippetCreateContext>
         }
+        
+        public static void SnippetsAssignability()
+        {
+            var resolver = new PathAssemblyResolver(new string[] { "ExampleAssembly.dll", typeof(object).Assembly.Location});
+            var mlc = new MetadataLoadContext(resolver);
+            
+            using (mlc)
+            {
+                Assembly assembly = mlc.LoadFromAssemblyPath("ExampleAssembly.dll");
+                Type testedType = assembly.GetType("ExampleType")!;
+                
+                //<SnippetAssignability>
+                Assembly matchAssembly = mlc.LoadFromAssemblyPath(typeof(MyType).Assembly.Location);
+                Type matchType = assembly.GetType(typeof(MyType).FullName!)!;
+                
+                if (matchType.IsAssignableFrom(testedType))
+                {
+                    Console.WriteLine($"{nameof(matchType)} is assignable from {nameof(testedType)}");
+                }
+                //</SnippetAssignability>
+            }
+        }
+        
+        class MyType{}
     }
 }

--- a/docs/standard/assembly/snippets/inspect-contents-using-metadataloadcontext/Program.cs
+++ b/docs/standard/assembly/snippets/inspect-contents-using-metadataloadcontext/Program.cs
@@ -8,6 +8,7 @@ namespace AssemblySnippets
         {
             MetadataLoadContextSnippets.SnippetsResolver();
             MetadataLoadContextSnippets.SnippetsMetadataLoadContext();
+            MetadataLoadContextSnippets.SnippetsAssignability();
         }
     }
 }


### PR DESCRIPTION
Clarify MetadataLoadContext limitations when testing types for equality or assignability with other types

Related to: https://github.com/dotnet/docs/issues/29336
