### PR TITLE
Update EF Core Packages 6.0.5 --> 6.0.6 in docs/core/extensions/snippets/configuration/custom-provider/custom-provider.csproj

### DIFF
--- a/docs/core/extensions/snippets/configuration/custom-provider/custom-provider.csproj
+++ b/docs/core/extensions/snippets/configuration/custom-provider/custom-provider.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Encapsulates the dependabot changes suggested in #29876, #29877, and #29878 -- which should compile correctly together but fail the build when applied separately because a package downgrade is detected.

Closes #29876 
Closes #29877 
Closes #29878