### PR TITLE
Add dotnet-monitor .NET tool documentation

### DIFF
--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -21,6 +21,8 @@ The [.NET Uninstall Tool](https://github.com/dotnet/cli-lab/releases) (`dotnet-c
 
 [dotnet-gcdump](../diagnostics/dotnet-gcdump.md) provides a way to collect GC (Garbage Collector) dumps of live .NET processes.
 
+[dotnet-monitor](../diagnostics/dotnet-monitor.md) provides a way to monitor .NET applications in production environments and to collect diagnostic artifacts (for example, dumps, traces, logs, and metrics) on-demand or using automated rules for collecting under specified conditions.
+
 [dotnet-trace](../diagnostics/dotnet-trace.md) collects profiling data from your app that can help in scenarios where you need to find out what causes an app to run slow.
 
 ## .NET Install tool for extension authors

--- a/docs/core/diagnostics/diagnostics-client-library.md
+++ b/docs/core/diagnostics/diagnostics-client-library.md
@@ -10,7 +10,7 @@ ms.author: tommcdon
 
 **This article applies to: ✔️** .NET Core 3.0 SDK and later versions for target apps, .NET Standard 2.0 to use the library.
 
-Microsoft.Diagnostics.NETCore.Client (also known as the Diagnostics client library) is a managed library that lets you interact with .NET Core runtime (CoreCLR) for various diagnostics related tasks, such as tracing via [EventPipe](eventpipe.md), requesting a dump, or attaching an ICorProfiler. This library is the backing library behind many diagnostics tools such as [`dotnet-counters`](dotnet-counters.md), [`dotnet-trace`](dotnet-trace.md), [`dotnet-gcdump`](dotnet-gcdump.md), and [`dotnet-dump`](dotnet-dump.md). Using this library, you can write your own diagnostics tools customized for your particular scenario.
+Microsoft.Diagnostics.NETCore.Client (also known as the Diagnostics client library) is a managed library that lets you interact with .NET Core runtime (CoreCLR) for various diagnostics related tasks, such as tracing via [EventPipe](eventpipe.md), requesting a dump, or attaching an ICorProfiler. This library is the backing library behind many diagnostics tools such as [`dotnet-counters`](dotnet-counters.md), [`dotnet-trace`](dotnet-trace.md), [`dotnet-gcdump`](dotnet-gcdump.md), [`dotnet-dump`](dotnet-dump.md), and [`dotnet-monitor`](dotnet-monitor.md). Using this library, you can write your own diagnostics tools customized for your particular scenario.
 
 You can acquire [Microsoft.Diagnostics.NETCore.Client](https://www.nuget.org/packages/Microsoft.Diagnostics.NETCore.Client/) by adding a `PackageReference` to your project. The package is hosted on `NuGet.org`.
 

--- a/docs/core/diagnostics/diagnostics-client-library.md
+++ b/docs/core/diagnostics/diagnostics-client-library.md
@@ -10,7 +10,7 @@ ms.author: tommcdon
 
 **This article applies to: ✔️** .NET Core 3.0 SDK and later versions for target apps, .NET Standard 2.0 to use the library.
 
-Microsoft.Diagnostics.NETCore.Client (also known as the Diagnostics client library) is a managed library that lets you interact with .NET Core runtime (CoreCLR) for various diagnostics related tasks, such as tracing via [EventPipe](eventpipe.md), requesting a dump, or attaching an ICorProfiler. This library is the backing library behind many diagnostics tools such as [`dotnet-counters`](dotnet-counters.md), [`dotnet-trace`](dotnet-trace.md), [`dotnet-gcdump`](dotnet-gcdump.md), [`dotnet-dump`](dotnet-dump.md), and [`dotnet-monitor`](dotnet-monitor.md). Using this library, you can write your own diagnostics tools customized for your particular scenario.
+`Microsoft.Diagnostics.NETCore.Client` (also known as the Diagnostics client library) is a managed library that lets you interact with .NET Core runtime (CoreCLR) for various diagnostics related tasks, such as tracing via [EventPipe](eventpipe.md), requesting a dump, or attaching an `ICorProfiler`. This library is the backing library behind many diagnostics tools such as [dotnet-counters](dotnet-counters.md), [dotnet-trace](dotnet-trace.md), [dotnet-gcdump](dotnet-gcdump.md), [dotnet-dump](dotnet-dump.md), and [dotnet-monitor](dotnet-monitor.md). Using this library, you can write your own diagnostics tools customized for your particular scenario.
 
 You can acquire [Microsoft.Diagnostics.NETCore.Client](https://www.nuget.org/packages/Microsoft.Diagnostics.NETCore.Client/) by adding a `PackageReference` to your project. The package is hosted on `NuGet.org`.
 

--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -12,7 +12,7 @@ The same diagnostics tools that are useful for diagnosing .NET Core issues in ot
 
 **These tools apply to: ✔️** .NET Core 3.1 SDK and later versions
 
-The .NET Core global CLI diagnostic tools ([`dotnet-counters`](dotnet-counters.md), [`dotnet-dump`](dotnet-dump.md), [`dotnet-gcdump`](dotnet-gcdump.md), [`dotnet-monitor`](dotnet-monitor.md), and [`dotnet-trace`](dotnet-trace.md)) are designed to work in a wide variety of environments and should all work directly in Docker containers. Because of this, these tools are the preferred method of collecting diagnostic information for .NET Core scenarios targeting .NET Core 3.1 or later in containers.
+The .NET Core global CLI diagnostic tools ([dotnet-counters](dotnet-counters.md), [dotnet-dump](dotnet-dump.md), [dotnet-gcdump](dotnet-gcdump.md), [dotnet-monitor](dotnet-monitor.md), and [dotnet-trace](dotnet-trace.md)) are designed to work in a wide variety of environments and should all work directly in Docker containers. Because of this, these tools are the preferred method of collecting diagnostic information for .NET Core scenarios targeting .NET Core 3.1 or later in containers.
 
 You can also install these tools without the .NET SDK by downloading the single-file variants from the links in the previous paragraph. These installs require a global install of the .NET runtime version 3.1 or later, which you can acquire following any of the prescribed methods in the [.NET installation documentation](../install/index.yml) or by consuming any of the official runtime containers.
 

--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -12,7 +12,7 @@ The same diagnostics tools that are useful for diagnosing .NET Core issues in ot
 
 **These tools apply to: ✔️** .NET Core 3.1 SDK and later versions
 
-The .NET Core global CLI diagnostic tools ([`dotnet-counters`](dotnet-counters.md), [`dotnet-dump`](dotnet-dump.md), [`dotnet-gcdump`](dotnet-gcdump.md), and [`dotnet-trace`](dotnet-trace.md)) are designed to work in a wide variety of environments and should all work directly in Docker containers. Because of this, these tools are the preferred method of collecting diagnostic information for .NET Core scenarios targeting .NET Core 3.1 or later in containers.
+The .NET Core global CLI diagnostic tools ([`dotnet-counters`](dotnet-counters.md), [`dotnet-dump`](dotnet-dump.md), [`dotnet-gcdump`](dotnet-gcdump.md), [`dotnet-monitor`](dotnet-monitor.md), and [`dotnet-trace`](dotnet-trace.md)) are designed to work in a wide variety of environments and should all work directly in Docker containers. Because of this, these tools are the preferred method of collecting diagnostic information for .NET Core scenarios targeting .NET Core 3.1 or later in containers.
 
 You can also install these tools without the .NET SDK by downloading the single-file variants from the links in the previous paragraph. These installs require a global install of the .NET runtime version 3.1 or later, which you can acquire following any of the prescribed methods in the [.NET installation documentation](../install/index.yml) or by consuming any of the official runtime containers.
 

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -53,7 +53,7 @@ The `dotnet-monitor` global tool is a way to monitor .NET applications in produc
 | Command                                                   |
 | --------------------------------------------------------- |
 | [dotnet monitor collect](#dotnet-monitor-collect)         |
-| [dotnet monitor config show](#dotnet-monitor-config-show)    |
+| [dotnet monitor config show](#dotnet-monitor-config-show) |
 | [dotnet monitor generatekey](#dotnet-monitor-generatekey) |
 
 ## dotnet-monitor collect
@@ -104,7 +104,7 @@ dotnet-monitor collect [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls] [--
 
 - **`--no-http-egress`**
 
-  Disables egress of diagnostic artifacts via the HTTP response. When specified, artifacts must be egress using an egress provider.
+  Disables egress of diagnostic artifacts via the HTTP response. When specified, artifacts must be egressed using an egress provider.
 
 ## dotnet-monitor config show
 
@@ -130,7 +130,7 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 
 - **`-m|--metrics [true|false]`**
 
-  Enable publishing of metrics to `/metrics` route. Default is `true`
+  Enable publishing of metrics to `/metrics` route. Default is `true`.
 
   This value is mapped into configuration as the `Metrics:Enabled` key.
 
@@ -166,7 +166,7 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 
 - **`--no-http-egress`**
 
-  Disables egress of diagnostic artifacts via the HTTP response. When specified, artifacts must be egress using an egress provider.
+  Disables egress of diagnostic artifacts via the HTTP response. When specified, artifacts must be egressed using an egress provider.
 
   This value is not mapped into configuration.
 
@@ -175,7 +175,7 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
   Configuration level. `Full` configuration can show sensitive information. There are two levels:
 
   - `Full` - The full configuration without any redaction of any values.
-  - `Redacted` - The full configuration but sensitive information, such as know secrets, is redacted.
+  - `Redacted` - The full configuration but sensitive information, such as known secrets, is redacted.
 
 - **`--show-sources`**
 

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -53,7 +53,7 @@ The `dotnet-monitor` global tool is a way to monitor .NET applications in produc
 | Command                                                   |
 | --------------------------------------------------------- |
 | [dotnet monitor collect](#dotnet-monitor-collect)         |
-| [dotnet monitor config show](#dotnet-dump-config-show)    |
+| [dotnet monitor config show](#dotnet-monitor-config-show)    |
 | [dotnet monitor generatekey](#dotnet-monitor-generatekey) |
 
 ## dotnet-monitor collect
@@ -63,7 +63,7 @@ Monitor .NET applications, allow collecting diagnostic artifacts, and send the r
 ### Synopsis
 
 ```console
-dotnet-dump collect [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls] [--diagnostic-port] [--no-auth] [--temp-apikey] [--no-http-egress]
+dotnet-monitor collect [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls] [--diagnostic-port] [--no-auth] [--temp-apikey] [--no-http-egress]
 ```
 
 ### Options
@@ -181,7 +181,7 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 
   Identifies from which configuration source each effective configuration value is provided.
 
-## dotnet-dump generatekey
+## dotnet-monitor generatekey
 
  Generate an API key and hash for HTTP authentication.
 

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -1,0 +1,214 @@
+---
+title: dotnet-monitor diagnostic tool - .NET
+description: Learn how to install and use the dotnet-monitor tool to collect dumps, traces, logs, and metrics from applications in production environments.
+ms.date: 06/16/2022
+ms.topic: reference
+---
+# Diagnostic monitoring and collection utility (dotnet-monitor)
+
+**This article applies to:** ✔️ `dotnet-monitor` version 6.0.0 and later versions
+
+## Install
+
+There are two ways to download `dotnet-monitor`:
+
+- **dotnet global tool:**
+
+  To install the latest release version of the `dotnet-monitor` [NuGet package](https://www.nuget.org/packages/dotnet-monitor), use the [dotnet tool install](../tools/dotnet-tool-install.md) command:
+
+  ```dotnetcli
+  dotnet tool install --global dotnet-monitor
+  ```
+
+- **Docker image:**
+
+  Download a Docker image for use in multi-container environments:
+
+  ```console
+  docker pull mcr.microsoft.com/dotnet/monitor
+  ```
+
+## Synopsis
+
+```console
+dotnet-monitor [-h|--help] [--version] <command>
+```
+
+## Description
+
+The `dotnet-monitor` global tool is a way to monitor .NET applications in production environments and to collect diagnostic artifacts (for example, dumps, traces, logs, and metrics) on-demand or using automated rules for collecting under specified conditions.
+
+## Options
+
+- **`--version`**
+
+  Displays the version of the dotnet-monitor utility.
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+## Commands
+
+| Command                                                   |
+| --------------------------------------------------------- |
+| [dotnet monitor collect](#dotnet-monitor-collect)         |
+| [dotnet monitor config show](#dotnet-dump-config-show)    |
+| [dotnet monitor generatekey](#dotnet-monitor-generatekey) |
+
+## dotnet-monitor collect
+
+Monitor .NET applications, allow collecting diagnostic artifacts, and send the results to a chosen destination.
+
+### Synopsis
+
+```console
+dotnet-dump collect [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls] [--diagnostic-port] [--no-auth] [--temp-apikey] [--no-http-egress]
+```
+
+### Options
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+- **`-u|--urls <urls>`**
+
+  Bindings for the HTTP api. Default is `https://localhost:52323`.
+
+- **`-m|--metrics [true|false]`**
+
+  Enable publishing of metrics to `/metrics` route. Default is `true`
+
+- **`--metricUrls <urls>`**
+
+  Bindings for the metrics HTTP api. Default is `http://localhost:52325`.
+
+- **`--diagnostic-port <path>`**
+
+  The fully qualified path and filename of the diagnostic port to which runtime instances can connect. Specifying this option places `dotnet-monitor` into
+  'listen' mode. When not specified, `dotnet-monitor` is in 'connect' mode.
+  
+  On Windows, this must be a valid named pipe name.
+  On Linux and macOS, this must be a valid Unix Domain Socket path.
+
+- **`--no-auth`**
+
+  Disables API key authentication. Default is `false`.
+
+  It is strongly recommended that this option is not used in production environments.
+  
+- **`--temp-apikey`**
+
+  Generates a temporary API key for the `dotnet-monitor` instance.
+
+- **`--no-http-egress`**
+
+  Disables egress of diagnostic artifacts via the HTTP response. When specified, artifacts must be egress using an egress provider.
+
+## dotnet-monitor config show
+
+Shows configuration, as if `dotnet-monitor collect` was executed with these parameters.
+
+### Synopsis
+
+```console
+dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls] [--diagnostic-port] [--no-auth] [--temp-apikey] [--no-http-egress] [--level] [--show-sources]
+```
+
+### Options
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+- **`-u|--urls <urls>`**
+
+  Bindings for the HTTP api. Default is `https://localhost:52323`.
+
+  This value is mapped into configuration as the `urls` key.
+
+- **`-m|--metrics [true|false]`**
+
+  Enable publishing of metrics to `/metrics` route. Default is `true`
+
+  This value is mapped into configuration as the `Metrics:Enabled` key.
+
+- **`--metricUrls <urls>`**
+
+  Bindings for the metrics HTTP api. Default is `http://localhost:52325`.
+
+  This value is mapped into configuration as the `Metrics:Endpoints` key.
+
+- **`--diagnostic-port <path>`**
+
+  The fully qualified path and filename of the diagnostic port to which runtime instances can connect. Specifying this option places `dotnet-monitor` into
+  'listen' mode. When not specified, `dotnet-monitor` is in 'connect' mode.
+  
+  On Windows, this must be a valid named pipe name.
+  On Linux and macOS, this must be a valid Unix Domain Socket path.
+
+  This value is mapped into configuraion as the `DiagnosticPort:EndpointName` key.
+
+- **`--no-auth`**
+
+  Disables API key authentication. Default is `false`.
+
+  It is strongly recommended that this option is not used in production environments.
+
+  This value is not mapped into configuration.
+  
+- **`--temp-apikey`**
+
+  Generates a temporary API key for the `dotnet-monitor` instance.
+
+  This value is mapped into configuration as the `Authentication:MonitorApiKey` key.
+
+- **`--no-http-egress`**
+
+  Disables egress of diagnostic artifacts via the HTTP response. When specified, artifacts must be egress using an egress provider.
+
+  This value is not mapped into configuration.
+
+- **`--level`**
+
+  Configuration level. `Full` configuration can show sensitive information. There are two levels:
+
+  - `Full` - The full configuration without any redaction of any values.
+  - `Redacted` - The full configuration but sensitive information, such as know secrets, is redacted.
+
+- **`--show-sources`**
+
+  Identifies from which configuration source each effective configuration value is provided.
+
+## dotnet-dump generatekey
+
+ Generate an API key and hash for HTTP authentication.
+
+### Synopsis
+
+```console
+dotnet-monitor generatekey [-h|--help] [-o|--output]
+```
+
+### Options
+
+- **`-h|--help`**
+
+  Shows command-line help.
+
+- **`-o|--output <Cmd|Json|MachineJson|PowerShell|Shell|Text>`**
+
+  The output format in which the API key information is written to standard output.
+
+  The allowable values are:
+  - `Cmd` - Outputs in a format usable in Windows Command Prompt or batch files.
+  - `Json` - Outputs in a format of a JSON object.
+  - `MachineJson` - Outputs in a format of a JSON object without comments and explanation. Useful for automation scenarios.
+  - `PowerShell` - Outputs in a format usable in PowerShell prompts and scripts.
+  - `Shell` - Outputs in a format usable in Linux shells such as Bash.
+  - `Text` - Outputs in a format that is plain text.
+
+## See Also
+
+- [dotnet/dotnet-monitor](https://github.com/dotnet/dotnet-monitor/tree/main/documentation)

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -61,6 +61,10 @@ The [dotnet-dump](dotnet-dump.md) tool is a way to collect and analyze Windows a
 
 The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Collector) dumps of live .NET processes.
 
+### dotnet-monitor
+
+The [dotnet-monitor](dotnet-monitor.md) tool is a way to monitor .NET applications in production environments and to collect diagnostic artifacts (for example, dumps, traces, logs, and metrics) on-demand or using automated rules for collecting under specified conditions.
+
 ### dotnet-trace
 
 .NET Core includes what is called the `EventPipe` through which diagnostics data is exposed. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root cause apps running slow.

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -731,6 +731,8 @@ items:
         href: ../core/diagnostics/dotnet-dump.md
       - name: dotnet-gcdump
         href: ../core/diagnostics/dotnet-gcdump.md
+      - name: dotnet-monitor
+        href: ../core/diagnostics/dotnet-monitor.md
       - name: dotnet-trace
         href: ../core/diagnostics/dotnet-trace.md
       - name: dotnet-stack


### PR DESCRIPTION
## Summary

Adds basic command line documentation for the dotnet-monitor diagnostic tool.
Updates TOC and other related diagnostic pages to link to this new documentation.

This basic documentation does reference to the fact that the tool has an HTTP API as well as some configuration elements, both of which I would like to propose to add documentation in subsequent pull requests. I would like to add sample usage and tutorials in subsequent pull requests as well.

cc @IEvangelist, @alexwolfmsft, @ldillonel, @poppastring 
cc @dotnet/dotnet-monitor, @dotnet/dotnet-diag