### PR TITLE
Add docs for SqlMoney.ToSqlInternalRepresentation

### DIFF
--- a/docs/framework/additional-apis/index.md
+++ b/docs/framework/additional-apis/index.md
@@ -43,6 +43,7 @@ These APIs support the product infrastructure and are not intended or supported 
 * [System.Data.SqlTypes.SqlChars.Stream property](system.data.sqltypes.sqlchars.stream.md)
 * [System.Data.SqlTypes.SqlGuid Constructor](system.data.sqltypes.sqlguid.-ctor.md)
 * [System.Data.SqlTypes.SqlMoney Constructor](system.data.sqltypes.sqlmoney.-ctor.md)
+* [System.Data.SqlTypes.SqlMoney.ToSqlInternalRepresentation Method](system.data.sqltypes.sqlmoney.tosqlinternalrepresentation.md)
 * [System.Data.SqlTypes.SqlStreamChars Constructor](system.data.sqltypes.sqlstreamchars.-ctor.md)
 * [System.Data.SqlTypes.SqlStreamChars.CanSeek property](system.data.sqltypes.sqlstreamchars.canseek.md)
 * [System.Data.SqlTypes.SqlStreamChars.IsNull property](system.data.sqltypes.sqlstreamchars.isnull.md)

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlmoney.tosqlinternalrepresentation.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlmoney.tosqlinternalrepresentation.md
@@ -1,0 +1,41 @@
+---
+description: "Learn more about: SqlMoney.ToSqlInternalRepresentation Method"
+title: SqlMoney.ToSqlInternalRepresentation Method (System.Data.SqlTypes)
+author: grabyourpitchforks
+ms.date: 06/16/2022
+ms.technology: "dotnet-data"
+topic_type:
+  - "apiref"
+api_name:
+  - "System.Data.SqlTypes.SqlMoney.ToSqlInternalRepresentation"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlMoney.ToSqlInternalRepresentation Method
+
+Returns the value of this `SqlMoney` instance scaled by a ten-thousandth of a currency unit.
+For example, if the current `SqlMoney` instance represents __2__ currency units, the
+`ToSqlInternalRepresentation` method will return __20000__.
+
+If this `SqlMoney` instance represents a null value (see <xref:System.Data.SqlTypes.SqlMoney.IsNull>), calling this method will throw a <xref:System.Data.SqlTypes.SqlNullValueException>.
+
+```csharp
+internal long ToSqlInternalRepresentation();
+```
+
+## Remarks
+
+> [!WARNING]
+> This method is internal and is not meant to be used directly in your code. This API may not be available in future versions of .NET.
+>
+> Microsoft does not support the use of this method in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/toc.yml
+++ b/docs/framework/toc.yml
@@ -479,6 +479,8 @@ items:
       items:
       - name: SqlMoney constructor
         href: additional-apis/system.data.sqltypes.sqlmoney.-ctor.md
+      - name: ToSqlInternalRepresentation method
+        href: additional-apis/system.data.sqltypes.sqlmoney.tosqlinternalrepresentation.md
     - name: SqlStreamChars class
       items:
       - name: SqlStreamChars constructor


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/docs/pull/28911. Adds docs for `SqlMoney.ToSqlInternalRepresentation` to serve as a complement for the internal ctors previously documented.

I tried to mimic the pattern in other API docs like https://docs.microsoft.com/en-us/dotnet/framework/additional-apis/system.data.sqltypes.sqlstreamchars.close, but feel free to mold this PR as needed. :)

/cc @David-Engel