### PR TITLE
Update ide0054-ide0074.md

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
@@ -43,18 +43,18 @@ This style rule concerns with the use of compound assignments. The option value 
 
 ```csharp
 // dotnet_style_prefer_compound_assignment = true
-x += 1;
+x += 5;
 
 // dotnet_style_prefer_compound_assignment = false
-x = x + 1;
+x = x + 5;
 ```
 
 ```vb
 ' dotnet_style_prefer_compound_assignment = true
-x += 1
+x += 5
 
 ' dotnet_style_prefer_compound_assignment = false
-x = x + 1
+x = x + 5
 ```
 
 ## Suppress a warning


### PR DESCRIPTION
## Summary

Value in the example changed from `1` to `5` as in C# it looks unesthetic to write `x += 1` - one would write `++x` or `x++` instead.

Fixes n/a