### PR TITLE
Update how-to-use-expression-trees-to-build-dynamic-queries.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -7,6 +7,9 @@ ms.assetid: 52cd44dd-a3ec-441e-b93a-4eca388119c7
 ---
 # Querying based on runtime state (C#)
 
+> [!NOTE]
+> Make sure you add `using System.Linq.Expressions;` and `using static System.Linq.Expressions.Expression;` at the top of your *.cs* file.
+> 
 Consider code that defines an <xref:System.Linq.IQueryable> or an [IQueryable\<T>](<xref:System.Linq.IQueryable%601>) against a data source:
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Initialize":::

--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -9,7 +9,6 @@ ms.assetid: 52cd44dd-a3ec-441e-b93a-4eca388119c7
 
 > [!NOTE]
 > Make sure you add `using System.Linq.Expressions;` and `using static System.Linq.Expressions.Expression;` at the top of your *.cs* file.
-> 
 Consider code that defines an <xref:System.Linq.IQueryable> or an [IQueryable\<T>](<xref:System.Linq.IQueryable%601>) against a data source:
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Initialize":::


### PR DESCRIPTION
Fixes #29136

## Summary

Added a note similar to the one used in other parts of the documentation, alerting the user for the usings required.
