### PR TITLE
Add options to top table - part 1

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0001.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0001.md
@@ -15,17 +15,19 @@ dev_langs:
 ---
 # Simplify name (IDE0001)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0001 |
-| **Title** | Simplify name |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                  |
+|--------------------------|------------------------|
+| **Rule ID**              | IDE0001                |
+| **Title**                | Simplify name          |
+| **Category**             | Style                  |
+| **Subcategory**          | Unnecessary code rules |
+| **Applicable languages** | C# and Visual Basic    |
 
 ## Overview
 
-This rule concerns the use of simplified type names in declarations and executable code, when possible. Unnecessary name qualification can be removed to simplify code and improve readability. This rule has no associated code style option.
+This rule concerns the use of simplified type names in declarations and executable code, when possible. You can remove unnecessary name qualification to simplify code and improve readability.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -54,7 +56,7 @@ End Class
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0001
@@ -69,7 +71,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0001.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0002.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0002.md
@@ -15,17 +15,19 @@ dev_langs:
 ---
 # Simplify member access (IDE0002)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0002 |
-| **Title** | Simplify member access |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                  |
+|--------------------------|------------------------|
+| **Rule ID**              | IDE0002                |
+| **Title**                | Simplify member access |
+| **Category**             | Style                  |
+| **Subcategory**          | Unnecessary code rules |
+| **Applicable languages** | C# and Visual Basic    |
 
 ## Overview
 
-This rule concerns use of simplified type member access in declarations and executable code, when possible. Unnecessary qualification can be removed to simplify code and improve readability. This rule has no associated code style option.
+This rule concerns use of simplified type member access in declarations and executable code, when possible. Unnecessary qualification can be removed to simplify code and improve readability.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -56,7 +58,7 @@ End Sub
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0002
@@ -71,7 +73,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0002.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0003-ide0009.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0003-ide0009.md
@@ -25,27 +25,57 @@ dev_langs:
 ---
 # this and Me preferences (IDE0003 and IDE0009)
 
-| Property                 | Value                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------|
-| **Rule ID**              | IDE0003 and IDE0009                                                                         |
-| **Title**                | IDE0003: Remove `this` or `Me` qualification<br/> IDE0009: Add `this` or `Me` qualification |
-| **Category**             | Style                                                                                       |
-| **Subcategory**          | Language rules                                                                              |
-| **Applicable languages** | C# and Visual Basic                                                                         |
+This article describes two related rules, `IDE0003` and `IDE0009`.
+
+| Property                 | Value                                     |
+| ------------------------ | ----------------------------------------- |
+| **Rule ID**              | IDE0003                                   |
+| **Title**                | **Remove** `this` or `Me` qualification   |
+| **Category**             | Style                                     |
+| **Subcategory**          | Language rules                            |
+| **Applicable languages** | C# and Visual Basic                       |
+| **Options**              | `dotnet_style_qualification_for_field`    |
+|                          | `dotnet_style_qualification_for_property` |
+|                          | `dotnet_style_qualification_for_method`   |
+|                          | `dotnet_style_qualification_for_event`    |
+
+| Property                 | Value                                     |
+| ------------------------ | ----------------------------------------- |
+| **Rule ID**              | IDE0009                                   |
+| **Title**                | **Add** `this` or `Me` qualification      |
+| **Category**             | Style                                     |
+| **Subcategory**          | Language rules                            |
+| **Applicable languages** | C# and Visual Basic                       |
+| **Options**              | `dotnet_style_qualification_for_field`    |
+|                          | `dotnet_style_qualification_for_property` |
+|                          | `dotnet_style_qualification_for_method`   |
+|                          | `dotnet_style_qualification_for_event`    |
 
 ## Overview
 
-These style rules can be applied to fields, properties, methods, or events. Option value of **true** means prefer the code symbol to be prefaced with `this.` in C# or `Me.` in Visual Basic. Option value of **false** means prefer the code element _not_ to be prefaced with `this.` or `Me.`.
+These two rules define whether or not you prefer the use of [this (C#)](../../../csharp/language-reference/keywords/this.md) and `Me.` (Visual Basic) qualifiers. To enforce that the qualifiers *aren't* present, set the severity of `IDE0003` to warning or error. To enforce that the qualifiers *are* present, set the severity of `IDE0009` to warning or error.
 
-## dotnet_style_qualification_for_field
+For example, if you prefer qualifiers for fields and properties but not for methods or events, then you can enable `IDE0009` and set the options `dotnet_style_qualification_for_field` and `dotnet_style_qualification_for_property` to `true`. However, this configuration would not flag methods and events that *do* have `this` and `Me` qualifiers. To also enforce that methods and events *don't* have qualifiers, enable `IDE0003`.
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_qualification_for_field |
-| **Option values** | `true` - Prefer fields to be prefaced with `this.` in C# or `Me.` in Visual Basic<br /><br />`false` - Prefer fields _not_ to be prefaced with `this.` or `Me.` |
-| **Default option value** | `false` |
+## Options
 
-### Example
+This rule's associated options define which of the following symbols this style preference should be applied to:
+
+- Fields ([dotnet_style_qualification_for_field](#dotnet_style_qualification_for_field))
+- Properties ([dotnet_style_qualification_for_property](#dotnet_style_qualification_for_property))
+- Methods ([dotnet_style_qualification_for_method](#dotnet_style_qualification_for_method))
+- Events ([dotnet_style_qualification_for_event](#dotnet_style_qualification_for_event))
+
+An option value of `true` means prefer the code symbol to be prefaced with `this.` in C# and `Me.` in Visual Basic. An option value of `false` means prefer the code element _not_ to be prefaced with `this.` or `Me.`.
+
+### dotnet_style_qualification_for_field
+
+| Property                 | Value                                | Description                                                              |
+| ------------------------ | ------------------------------------ | ------------------------------------------------------------------------ |
+| **Option name**          | dotnet_style_qualification_for_field |                                                                          |
+| **Option values**        | `true`                               | Prefer fields to be prefaced with `this.` in C# or `Me.` in Visual Basic |
+|                          | `false`                              | Prefer fields _not_ to be prefaced with `this.` or `Me.`                 |
+| **Default option value** | `false`                              |                                                                          |
 
 ```csharp
 // dotnet_style_qualification_for_field = true
@@ -63,15 +93,14 @@ Me.capacity = 0
 capacity = 0
 ```
 
-## dotnet_style_qualification_for_property
+### dotnet_style_qualification_for_property
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_qualification_for_property |
-| **Option values** | `true` - Prefer properties to be prefaced with `this.` in C# or `Me.` in Visual Basic<br /><br />`false` - Prefer properties _not_ to be prefaced with `this.` or `Me.` |
-| **Default option value** | `false` |
-
-### Example
+| Property                 | Value                                   | Description                                                                   |
+| ------------------------ | --------------------------------------- | ----------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_qualification_for_property |                                                                               |
+| **Option values**        | `true`                                  | Prefer properties to be prefaced with `this.` in C# or `Me.` in Visual Basic. |
+|                          | `false`                                 | Prefer properties _not_ to be prefaced with `this.` or `Me.`.                 |
+| **Default option value** | `false`                                 |                                                                               |
 
 ```csharp
 // dotnet_style_qualification_for_property = true
@@ -89,15 +118,14 @@ Me.ID = 0
 ID = 0
 ```
 
-## dotnet_style_qualification_for_method
+### dotnet_style_qualification_for_method
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_qualification_for_method |
-| **Option values** | `true` - Prefer methods to be prefaced with `this.` in C# or `Me.` in Visual Basic.<br /><br />`false` - Prefer methods _not_ to be prefaced with `this.` or `Me.`. |
-| **Default option value** | `false` |
-
-### Example
+| Property                 | Value                                 | Description                                                                |
+| ------------------------ | ------------------------------------- | -------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_qualification_for_method |                                                                            |
+| **Option values**        | `true`                                | Prefer methods to be prefaced with `this.` in C# or `Me.` in Visual Basic. |
+|                          | `false`                               | Prefer methods _not_ to be prefaced with `this.` or `Me.`.                 |
+| **Default option value** | `false`                               |                                                                            |
 
 ```csharp
 // dotnet_style_qualification_for_method = true
@@ -115,15 +143,14 @@ Me.Display()
 Display()
 ```
 
-## dotnet_style_qualification_for_event
+### dotnet_style_qualification_for_event
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_qualification_for_event |
-| **Option values** | `true` - Prefer events to be prefaced with `this.` in C# or `Me.` in Visual Basic.<br /><br />`false` - Prefer events _not_ to be prefaced with `this.` or `Me.`. |
-| **Default option value** | `false` |
-
-### Example
+| Property                 | Value                                | Description                                                               |
+| ------------------------ | ------------------------------------ | ------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_qualification_for_event |                                                                           |
+| **Option values**        | `true`                               | Prefer events to be prefaced with `this.` in C# or `Me.` in Visual Basic. |
+|                          | `false`                              | Prefer events _not_ to be prefaced with `this.` or `Me.`.                 |
+| **Default option value** | `false`                              |                                                                           |
 
 ```csharp
 // dotnet_style_qualification_for_event = true
@@ -143,7 +170,7 @@ AddHandler Elapsed, AddressOf Handler
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0003 // Or IDE0009
@@ -159,7 +186,7 @@ dotnet_diagnostic.IDE0003.severity = none
 dotnet_diagnostic.IDE0009.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -170,5 +197,6 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
+- [this (C# Reference)](../../../csharp/language-reference/keywords/this.md)
 - [Code style language rules](language-rules.md)
 - [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0004.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0004.md
@@ -25,7 +25,9 @@ dev_langs:
 
 ## Overview
 
-This rule flags unnecessary [type cast](../../../csharp/programming-guide/types/casting-and-type-conversions.md). A cast expression is unnecessary if the code semantics would be identical with or without it. This rule has no associated code style option.
+This rule flags unnecessary [type casts](../../../csharp/programming-guide/types/casting-and-type-conversions.md). A cast expression is unnecessary if the code semantics would be identical with or without it.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -47,7 +49,7 @@ Dim v As Integer = 0
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0004
@@ -62,7 +64,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0004.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0005.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0005.md
@@ -1,6 +1,6 @@
 ---
 title: "IDE0005: Remove unnecessary import"
-description: "Learn about code analysis rule IDE0005: Remove unnecessary import"
+description: "Learn about code analysis rule IDE0005: Remove unnecessary using directives"
 ms.date: 09/30/2020
 ms.topic: reference
 f1_keywords:
@@ -13,7 +13,7 @@ dev_langs:
 - CSharp
 - VB
 ---
-# Remove unnecessary import (IDE0005)
+# Remove unnecessary using directives (IDE0005)
 
 | Property                 | Value                     |
 |--------------------------|---------------------------|
@@ -25,13 +25,12 @@ dev_langs:
 
 ## Overview
 
-This rule flags the following unnecessary constructs:
+This rule flags the following unnecessary constructs. If unnecessary, these constructs can be removed without changing the semantics of the code:
 
-- C# unnecessary [using directive](../../../csharp/language-reference/keywords/using-directive.md).
-- C# unnecessary [using static directive](../../../csharp/language-reference/keywords/using-directive.md).
-- Visual Basic unnecessary [Import](../../../visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md) statement.
+- [using directives](../../../csharp/language-reference/keywords/using-directive.md) (C#).
+- [Import statements](../../../visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md) (Visual Basic).
 
-These unnecessary constructs can be removed without changing the semantics of the code. This rule has no associated code style option.
+This rule has no associated code-style options.
 
 > [!NOTE]
 > To enable this [rule on build](../overview.md#code-style-analysis), you need to enable [XML documentation comments](../../../csharp/language-reference/xmldoc/recommended-tags.md) for the project. For more information, see [dotnet/roslyn issue 41640](https://github.com/dotnet/roslyn/issues/41640).
@@ -80,7 +79,7 @@ End Class
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0005
@@ -95,7 +94,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0005.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -106,6 +105,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
+- ['using' directive placement (IDE0065)](ide0065.md)
 - [C# using directive](../../../csharp/language-reference/keywords/using-directive.md)
 - [C# using static directive](../../../csharp/language-reference/keywords/using-directive.md)
 - [Visual Basic Import statement](../../../visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0007-ide0008.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0007-ide0008.md
@@ -22,27 +22,50 @@ dev_langs:
 ---
 # 'var' preferences (IDE0007 and IDE0008)
 
-| Property                 | Value                                                                                        |
-|--------------------------|----------------------------------------------------------------------------------------------|
-| **Rule ID**              | IDE0007 and IDE0008                                                                          |
-| **Title**                | IDE0007: Use 'var' instead of explicit type<br/> IDE0008: Use explicit type instead of 'var' |
-| **Category**             | Style                                                                                        |
-| **Subcategory**          | Language rules                                                                               |
-| **Applicable languages** | C#                                                                                           |
+This article describes two related rules, `IDE0007` and `IDE0008`.
+
+| Property                 | Value                                    |
+| ------------------------ | ---------------------------------------- |
+| **Rule ID**              | IDE0007                                  |
+| **Title**                | Use `var` instead of explicit type       |
+| **Category**             | Style                                    |
+| **Subcategory**          | Language rules                           |
+| **Applicable languages** | C#                                       |
+| **Options**              | `csharp_style_var_for_built_in_types`    |
+|                          | `csharp_style_var_when_type_is_apparent` |
+|                          | `csharp_style_var_elsewhere`             |
+
+| Property                 | Value                                    |
+| ------------------------ | ---------------------------------------- |
+| **Rule ID**              | IDE0008                                  |
+| **Title**                | Use explicit type instead of `var`       |
+| **Category**             | Style                                    |
+| **Subcategory**          | Language rules                           |
+| **Applicable languages** | C#                                       |
+| **Options**              | `csharp_style_var_for_built_in_types`    |
+|                          | `csharp_style_var_when_type_is_apparent` |
+|                          | `csharp_style_var_elsewhere`             |
 
 ## Overview
 
-The style rules in this section concern the use of the [var](../../../csharp/language-reference/keywords/var.md) keyword versus an explicit type in a variable declaration. This rule can be applied separately to built-in types, places where the type is apparent, and elsewhere.
+These two style rules define whether the [var](../../../csharp/language-reference/keywords/var.md) keyword or an explicit type should be used in a variable declaration. To enforce that `var` is used, set the severity of `IDE0007` to warning or error. To enforce that the explicit type is used, set the severity of `IDE0008` to warning or error.
 
-## csharp_style_var_for_built_in_types
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_var_for_built_in_types |
-| **Option values** | `true` - Prefer `var` is used to declare variables with built-in system types such as `int`<br /><br />`false` - Prefer explicit type over `var` to declare variables with built-in system types such as `int` |
-| **Default option value** | `false` |
+This rule's associated options define where this style preference should be applied:
 
-### Example
+- Built-in types ([csharp_style_var_for_built_in_types](#csharp_style_var_for_built_in_types))
+- Places where the type is apparent ([csharp_style_var_when_type_is_apparent](#csharp_style_var_when_type_is_apparent))
+- Elsewhere ([csharp_style_var_elsewhere](#csharp_style_var_elsewhere))
+
+### csharp_style_var_for_built_in_types
+
+| Property                 | Value                               | Description                                                                                   |
+| ------------------------ | ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Option name**          | csharp_style_var_for_built_in_types |                                                                                               |
+| **Option values**        | `true`                              | Prefer `var` is used to declare variables with built-in system types such as `int`            |
+|                          | `false`                             | Prefer explicit type over `var` to declare variables with built-in system types such as `int` |
+| **Default option value** | `false`                             |                                                                                               |
 
 ```csharp
 // csharp_style_var_for_built_in_types = true
@@ -52,15 +75,14 @@ var x = 5;
 int x = 5;
 ```
 
-## csharp_style_var_when_type_is_apparent
+### csharp_style_var_when_type_is_apparent
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_var_when_type_is_apparent |
-| **Option values** | `true` - Prefer `var` when the type is already mentioned on the right-hand side of a declaration expression<br /><br />`false` - Prefer explicit type over `var` when the type is already mentioned on the right-hand side of a declaration expression |
-| **Default option value** | `false` |
-
-### Example
+| Property                 | Value                                  | Description                                                                                                |
+| ------------------------ | -------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Option name**          | csharp_style_var_when_type_is_apparent |                                                                                                            |
+| **Option values**        | `true`                                 | Prefer `var` when the type is already mentioned on the right-hand side of a declaration expression         |
+|                          | `false`                                | Prefer explicit type when the type is already mentioned on the right-hand side of a declaration expression |
+| **Default option value** | `false`                                |                                                                                                            |
 
 ```csharp
 // csharp_style_var_when_type_is_apparent = true
@@ -70,15 +92,14 @@ var obj = new Customer();
 Customer obj = new Customer();
 ```
 
-## csharp_style_var_elsewhere
+### csharp_style_var_elsewhere
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_var_elsewhere |
-| **Option values** | `true` - Prefer `var` over explicit type in all cases, unless overridden by another code style rule<br /><br />`false` - Prefer explicit type over `var` in all cases, unless overridden by another code style rule |
-| **Default option value** | `false` |
-
-### Example
+| Property                 | Value                      | Description                                                                                |
+| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------------ |
+| **Option name**          | csharp_style_var_elsewhere |                                                                                            |
+| **Option values**        | `true`                     | Prefer `var` over explicit type in all cases, unless overridden by another code style rule |
+|                          | `false`                    | Prefer explicit type over `var` in all cases, unless overridden by another code style rule |
+| **Default option value** | `false`                    |                                                                                            |
 
 ```csharp
 // csharp_style_var_elsewhere = true
@@ -90,7 +111,7 @@ bool f = this.Init();
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0007 // Or IDE0008
@@ -106,7 +127,7 @@ dotnet_diagnostic.IDE0007.severity = none
 dotnet_diagnostic.IDE0008.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0010.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0010.md
@@ -25,12 +25,12 @@ dev_langs:
 
 ## Overview
 
-This rule concerns specifying all the missing switch cases for a [`switch` statement](../../../csharp/language-reference/statements/selection-statements.md#the-switch-statement). A `switch` statement is considered incomplete with missing cases in the following scenarios:
+This rule concerns specifying all the missing switch cases for a [`switch` statement](../../../csharp/language-reference/statements/selection-statements.md#the-switch-statement). A `switch` statement is considered incomplete in the following scenarios:
 
-- An [enum](../../../csharp/language-reference/builtin-types/enum.md) `switch` statement which is missing cases for one or more enum members.
-- A `switch` statement with missing `default` case.
+- An [enum](../../../csharp/language-reference/builtin-types/enum.md) `switch` statement that's missing cases for one or more enum members.
+- A `switch` statement with a missing `default` case.
 
-This rule has no associated code style option.
+This rule has no associated code-style options.
 
 ## Example
 
@@ -74,7 +74,7 @@ class C
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0010
@@ -89,7 +89,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0010.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0011.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0011.md
@@ -17,25 +17,30 @@ dev_langs:
 # Add braces (IDE0011)
 
 | Property        | Value                                   |
-|-----------------|-----------------------------------------|
+| --------------- | --------------------------------------- |
 | **Rule ID**     | IDE0011                                 |
 | **Title**       | Add braces                              |
 | **Category**    | Style                                   |
 | **Subcategory** | Language rules (code block preferences) |
+| **Options**     | `csharp_prefer_braces`                  |
 
 ## Overview
 
 This style rule concerns the use of curly braces `{ }` to surround code blocks.
 
-## csharp_prefer_braces
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_prefer_braces
-| **Option values** | `true` - Prefer curly braces even for one line of code<br /><br />`false` - Prefer no curly braces if allowed<br /><br />`when_multiline` - Prefer curly braces on multiple lines |
-| **Default option value** | `true` |
+Use the following option to specify whether curly braces are preferred or not, and if preferred, whether only for multi-line code blocks.
 
-### Example
+### csharp_prefer_braces
+
+| Property                 | Value                | Description                                   |
+| ------------------------ | -------------------- | --------------------------------------------- |
+| **Option name**          | csharp_prefer_braces |                                               |
+| **Option values**        | `true`               | Prefer curly braces even for one line of code |
+|                          | `false`              | Prefer no curly braces if allowed             |
+|                          | `when_multiline`     | Prefer curly braces on multiple lines         |
+| **Default option value** | `true`               |                                               |
 
 ```csharp
 // csharp_prefer_braces = true
@@ -47,7 +52,7 @@ if (test) this.Display();
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0011
@@ -62,7 +67,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0011.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0016.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0016.md
@@ -17,26 +17,30 @@ dev_langs:
 # Use throw expression (IDE0016)
 
 | Property                 | Value                                      |
-|--------------------------|--------------------------------------------|
+| ------------------------ | ------------------------------------------ |
 | **Rule ID**              | IDE0016                                    |
 | **Title**                | Use throw expression                       |
 | **Category**             | Style                                      |
 | **Subcategory**          | Language rules (null-checking preferences) |
 | **Applicable languages** | C# 7.0+                                    |
+| **Options**              | `csharp_style_throw_expression`            |
 
 ## Overview
 
-This style rule concerns the use of [throw expressions](../../../csharp/language-reference/keywords/throw.md#the-throw-expression) instead of `throw` statements.
+This style rule concerns the use of [throw expressions](../../../csharp/language-reference/keywords/throw.md#the-throw-expression) instead of `throw` statements. Set the severity of rule `IDE0016` to define how the rule should be enforced, for example, as a warning or an error.
 
-## csharp_style_throw_expression
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_throw_expression
-| **Option values** | `true` - Prefer to use `throw` expressions instead of `throw` statements<br /><br />`false` - Prefer to use `throw` statements instead of `throw` expressions |
-| **Default option value** | `true` |
+The associated option for this rule specifies whether you prefer `throw` expressions or `throw` statements.
 
-### Example
+### csharp_style_throw_expression
+
+| Property                 | Value                         | Description                                                     |
+| ------------------------ | ----------------------------- | --------------------------------------------------------------- |
+| **Option name**          | csharp_style_throw_expression |                                                                 |
+| **Option values**        | `true`                        | Prefer to use `throw` expressions instead of `throw` statements |
+|                          | `false`                       | Prefer to use `throw` statements instead of `throw` expressions |
+| **Default option value** | `true`                        |                                                                 |
 
 ```csharp
 // csharp_style_throw_expression = true
@@ -49,7 +53,7 @@ this.s = s;
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0016
@@ -64,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0016.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0017.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0017.md
@@ -18,26 +18,30 @@ dev_langs:
 # Use object initializers (IDE0017)
 
 | Property                 | Value                                         |
-|--------------------------|-----------------------------------------------|
+| ------------------------ | --------------------------------------------- |
 | **Rule ID**              | IDE0017                                       |
 | **Title**                | Use object initializers                       |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# and Visual Basic                           |
+| **Options**              | `dotnet_style_object_initializer`             |
 
 ## Overview
 
-This style rule concerns with the use of object initializers for object initialization. The option value specifies whether or not initializers are desired.
+This style rule concerns the use of [object initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md#object-initializers) for object initialization.
 
-## dotnet_style_object_initializer
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_object_initializer
-| **Option values** | `true` - Prefer objects to be initialized using object initializers when possible<br /><br />`false` - Prefer objects to *not* be initialized using object initializers |
-| **Default option value** | `true` |
+The option value for this rule specifies whether or not initializers are desired.
 
-### Example
+### dotnet_style_object_initializer
+
+| Property                 | Value                           | Description                                                              |
+| ------------------------ | ------------------------------- | ------------------------------------------------------------------------ |
+| **Option name**          | dotnet_style_object_initializer |                                                                          |
+| **Option values**        | `true`                          | Prefer objects to be initialized using object initializers when possible |
+|                          | `false`                         | Prefer objects to *not* be initialized using object initializers         |
+| **Default option value** | `true`                          |                                                                          |
 
 ```csharp
 // dotnet_style_object_initializer = true
@@ -59,7 +63,7 @@ c.Age = 21
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0017
@@ -74,7 +78,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0017.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -85,7 +89,8 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use collection initializers](ide0028.md)
+- [Object and Collection Initializers (C# Programming Guide)](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md)
+- [IDE0028 - Use collection initializers](ide0028.md)
 - [Expression-level preferences](expression-level-preferences.md)
 - [Code style language rules](language-rules.md)
 - [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0018.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0018.md
@@ -17,26 +17,30 @@ dev_langs:
 # Inline variable declaration (IDE0018)
 
 | Property                 | Value                                         |
-|--------------------------|-----------------------------------------------|
+| ------------------------ | --------------------------------------------- |
 | **Rule ID**              | IDE0018                                       |
 | **Title**                | Inline variable declaration                   |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 7.0+                                       |
+| **Options**              | `csharp_style_inlined_variable_declaration`   |
 
 ## Overview
 
 This style rule concerns whether `out` variables are declared inline or not. Starting in C# 7, you can [declare an out variable in the argument list of a method call](../../../csharp/language-reference/keywords/out-parameter-modifier.md#calling-a-method-with-an-out-argument), rather than in a separate variable declaration.
 
-## csharp_style_inlined_variable_declaration
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_inlined_variable_declaration
-| **Option values** | `true` - Prefer `out` variables to be declared inline in the argument list of a method call when possible<br /><br />`false` - Prefer `out` variables to be declared before the method call |
-| **Default option value** | `true` |
+The associated option for this rule specifies whether you prefer `out` variables to be declared inline or separately.
 
-### Example
+### csharp_style_inlined_variable_declaration
+
+| Property                 | Value                                     | Description                                                                                      |
+| ------------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Option name**          | csharp_style_inlined_variable_declaration |                                                                                                  |
+| **Option values**        | `true`                                    | Prefer `out` variables to be declared inline in the argument list of a method call when possible |
+|                          | `false`                                   | Prefer `out` variables to be declared before the method call                                     |
+| **Default option value** | `true`                                    |                                                                                                  |
 
 ```csharp
 // csharp_style_inlined_variable_declaration = true
@@ -49,7 +53,7 @@ if (int.TryParse(value, out i) {...}
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0018
@@ -64,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0018.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0019.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0019.md
@@ -16,27 +16,31 @@ dev_langs:
 ---
 # Use pattern matching to avoid 'as' followed by a 'null' check (IDE0019)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0019 |
-| **Title** | Use pattern matching to avoid `as` followed by a `null` check |
-| **Category** | Style |
-| **Subcategory** | Language rules (pattern matching preferences) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                                         |
+| ------------------------ | ------------------------------------------------------------- |
+| **Rule ID**              | IDE0019                                                       |
+| **Title**                | Use pattern matching to avoid `as` followed by a `null` check |
+| **Category**             | Style                                                         |
+| **Subcategory**          | Language rules (pattern matching preferences)                 |
+| **Applicable languages** | C# 7.0+                                                       |
+| **Options**              | `csharp_style_pattern_matching_over_as_with_null_check`       |
 
 ## Overview
 
 This style rule concerns the use of C# [pattern matching](../../../csharp/fundamentals/functional/pattern-matching.md) over an `as` expression followed by a `null` check.
 
-## csharp_style_pattern_matching_over_as_with_null_check
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_pattern_matching_over_as_with_null_check
-| **Option values** | `true` - Prefer pattern matching instead of `as` expressions with null checks to determine if something is of a particular type<br /><br />`false` - Prefer `as` expressions with null checks instead of pattern matching to determine if something is of a particular type |
-| **Default option value** | `true` |
+The associated option for this rule specifies whether to prefer pattern match or an `as` expression with null checks to determine if something is of a particular type.
 
-### Example
+### csharp_style_pattern_matching_over_as_with_null_check
+
+| Property                 | Value                                                 | Description                                                                                |
+| ------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Option name**          | csharp_style_pattern_matching_over_as_with_null_check |                                                                                            |
+| **Option values**        | `true`                                                | Prefer pattern matching to determine if something is of a particular type                  |
+|                          | `false`                                               | Prefer `as` expressions with null checks to determine if something is of a particular type |
+| **Default option value** | `true`                                                |                                                                                            |
 
 ```csharp
 // csharp_style_pattern_matching_over_as_with_null_check = true
@@ -49,7 +53,7 @@ if (s != null) {...}
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0019
@@ -64,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0019.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
@@ -16,32 +16,47 @@ ms.author: gewarren
 dev_langs:
 - CSharp
 ---
-# Use pattern matching to avoid 'is' check followed by a cast (IDE0020)
+# Use pattern matching to avoid 'is' check followed by a cast (IDE0020 and IDE0038)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0020 and IDE0038 |
-| **Title** | IDE0020: Use pattern matching to avoid `is` check followed by a cast (with variable)<br/> IDE0038: Use pattern matching to avoid `is` check followed by a cast (without variable) |
-| **Category** | Style |
-| **Subcategory** | Language rules (pattern matching preferences) |
-| **Applicable languages** | C# 7.0+ |
+This article describes two related rules, `IDE0020` and `IDE0038`.
+
+| Property                 | Value                                                                       |
+| ------------------------ | --------------------------------------------------------------------------- |
+| **Rule ID**              | IDE0020                                                                     |
+| **Title**                | Use pattern matching to avoid `is` check followed by a cast (with variable) |
+| **Category**             | Style                                                                       |
+| **Subcategory**          | Language rules (pattern matching preferences)                               |
+| **Applicable languages** | C# 7.0+                                                                     |
+| **Options**              | `csharp_style_pattern_matching_over_is_with_cast_check`                     |
+
+| Property                 | Value                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| **Rule ID**              | IDE0038                                                                        |
+| **Title**                | Use pattern matching to avoid `is` check followed by a cast (without variable) |
+| **Category**             | Style                                                                          |
+| **Subcategory**          | Language rules (pattern matching preferences)                                  |
+| **Applicable languages** | C# 7.0+                                                                        |
+| **Options**              | `csharp_style_pattern_matching_over_is_with_cast_check`                        |
 
 ## Overview
 
-This style rule concerns the use of C# [pattern matching](../../../csharp/fundamentals/functional/pattern-matching.md) over an `is` check followed by a cast. For example, recommending use of `o is int i` instead of `if (o is int) { ... (int)o ...`. The option value determines if pattern matching is preferred or `is` check followed by a cast is preferred. Different rule IDs are used based on whether or not the cast expression is saved into a separate local variable in original code:
+This style rule concerns the use of C# [pattern matching](../../../csharp/fundamentals/functional/pattern-matching.md), for example, `o is int i`, over an `is` check followed by a cast, for example, `if (o is int) { ... (int)o ... }`. Enable either `IDE0020` or `IDE0038` based on whether or not the cast expression should be saved into a separate local variable:
 
-- IDE0020: Cast expression _is_ saved into a local variable. For example, original code is `if (o is int) { var i = (int)o; }`, which saves the result of `(int)o` in a local variable.
-- IDE0038: Cast expression _is not_ saved into a local variable. For example, original code is `if (o is int) { if ((int)o == 1) { ... } }`, which does not save the result of `(int)o` into a local variable.
+- `IDE0020`: Cast expression _is_ saved into a local variable. For example, `if (o is int) { var i = (int)o; }` saves the result of `(int)o` in a local variable.
+- `IDE0038`: Cast expression _is not_ saved into a local variable. For example, `if (o is int) { if ((int)o == 1) { ... } }` does not save the result of `(int)o` into a local variable.
 
-## csharp_style_pattern_matching_over_is_with_cast_check
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_pattern_matching_over_is_with_cast_check
-| **Option values** | `true` - Prefer pattern matching instead of `is` expressions with type casts<br /><br />`false` - Prefer `is` expressions with type casts instead of pattern matching |
-| **Default option value** | `true` |
+Set the value of the associated option for this rule to specify whether pattern matching or `is` check followed by a type cast is preferred.
 
-### Example
+### csharp_style_pattern_matching_over_is_with_cast_check
+
+| Property                 | Value                                                 | Description                                                         |
+| ------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| **Option name**          | csharp_style_pattern_matching_over_is_with_cast_check |                                                                     |
+| **Option values**        | `true`                                                | Prefer pattern matching instead of `is` expressions with type casts |
+|                          | `false`                                               | Prefer `is` expressions with type casts instead of pattern matching |
+| **Default option value** | `true`                                                |                                                                     |
 
 ```csharp
 // csharp_style_pattern_matching_over_is_with_cast_check = true
@@ -53,7 +68,7 @@ if (o is int) {var i = (int)o; ... }
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0020 // Or IDE0038
@@ -69,7 +84,7 @@ dotnet_diagnostic.IDE0020.severity = none
 dotnet_diagnostic.IDE0038.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0021.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0021.md
@@ -16,27 +16,32 @@ dev_langs:
 ---
 # Use expression body for constructors (IDE0021)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0021 |
-| **Title** | Use expression body for constructors |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0021                                       |
+| **Title**                | Use expression body for constructors          |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-bodied members)    |
+| **Applicable languages** | C# 7.0+                                       |
+| **Options**              | `csharp_style_expression_bodied_constructors` |
 
 ## Overview
 
 This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for constructors.
 
-## csharp_style_expression_bodied_constructors
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_constructors
-| **Option values** | `true` - Prefer expression bodies for constructors<br /><br />`when_on_single_line` - Prefer expression bodies for constructors when they will be a single line<br /><br />`false` - Prefer block bodies for constructors |
-| **Default option value** | `false` |
+Set the value of the associated option for this rule to specify whether expression bodies or block bodies for constructors are preferred, and if expression bodies are preferred, whether they're preferred only for single-line expressions.
 
-### Example
+### csharp_style_expression_bodied_constructors
+
+| Property                 | Value                                       | Description                                                               |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------------------------------- |
+| **Option name**          | csharp_style_expression_bodied_constructors |                                                                           |
+| **Option values**        | `true`                                      | Prefer expression bodies for constructors                                 |
+|                          | `when_on_single_line`                       | Prefer expression bodies for constructors when they will be a single line |
+|                          | `false`                                     | Prefer block bodies for constructors                                      |
+| **Default option value** | `false`                                     |                                                                           |
 
 ```csharp
 // csharp_style_expression_bodied_constructors = true
@@ -48,7 +53,7 @@ public Customer(int age) { Age = age; }
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0021
@@ -63,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0021.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0022.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0022.md
@@ -16,13 +16,14 @@ dev_langs:
 ---
 # Use expression body for methods (IDE0022)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0022 |
-| **Title** | Use expression body for methods |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 6.0+ |
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0022                                    |
+| **Title**                | Use expression body for methods            |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (expression-bodied members) |
+| **Applicable languages** | C# 6.0+                                    |
+| **Options**              | `csharp_style_expression_bodied_methods`   |
 
 ## Overview
 
@@ -30,15 +31,17 @@ This style rule concerns the use of [expression bodies](../../../csharp/programm
 
 ## Options
 
+Set the value of the associated option for this rule to specify whether expression bodies or block bodies for methods are preferred, and if expression bodies are preferred, whether they're preferred only for single-line expressions.
+
 ### csharp_style_expression_bodied_methods
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_methods
-| **Option values** | `true` - Prefer expression bodies for methods<br /><br />`when_on_single_line` - Prefer expression bodies for methods when they will be a single line<br /><br />`false` - Prefer block bodies for methods |
-| **Default option value** | `false` |
-
-#### Example
+| Property                 | Value                                  | Description                                                          |
+| ------------------------ | -------------------------------------- | -------------------------------------------------------------------- |
+| **Option name**          | csharp_style_expression_bodied_methods |                                                                      |
+| **Option values**        | `true`                                 | Prefer expression bodies for methods                                 |
+|                          | `when_on_single_line`                  | Prefer expression bodies for methods when they will be a single line |
+|                          | `false`                                | Prefer block bodies for methods                                      |
+| **Default option value** | `false`                                |                                                                      |
 
 ```csharp
 // csharp_style_expression_bodied_methods = true
@@ -50,7 +53,7 @@ public int GetAge() { return this.Age; }
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0022
@@ -65,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0022.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0023-ide0024.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0023-ide0024.md
@@ -18,27 +18,43 @@ dev_langs:
 ---
 # Use expression body for operators (IDE0023 and IDE0024)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0023 and IDE0024 |
-| **Title** | IDE0023: Use expression body for conversion operators<br/> IDE0024: Use expression body for operators |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 7.0+ |
+This article describes two related rules, `IDE0023` and `IDE0024`, which apply to *conversion operators* and *operators*, respectively.
+
+| Property                 | Value                                        |
+| ------------------------ | -------------------------------------------- |
+| **Rule ID**              | IDE0023                                      |
+| **Title**                | Use expression body for conversion operators |
+| **Category**             | Style                                        |
+| **Subcategory**          | Language rules (expression-bodied members)   |
+| **Applicable languages** | C# 7.0+                                      |
+| **Options**              | `csharp_style_expression_bodied_operators`   |
+
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0024                                    |
+| **Title**                | Use expression body for operators          |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (expression-bodied members) |
+| **Applicable languages** | C# 7.0+                                    |
+| **Options**              | `csharp_style_expression_bodied_operators` |
 
 ## Overview
 
 This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for operators.
 
-## csharp_style_expression_bodied_operators
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_operators
-| **Option values** | `true` - Prefer expression bodies for operators<br /><br />`when_on_single_line` - Prefer expression bodies for operators when they will be a single line<br /><br />`false` - Prefer block bodies for operators |
-| **Default option value** | `false` |
+Set the value of the associated option for these rules to specify whether expression bodies or block bodies for operators are preferred, and if expression bodies are preferred, whether they're preferred only for single-line expressions.
 
-#### Example
+### csharp_style_expression_bodied_operators
+
+| Property                 | Value                                    | Description                                                            |
+| ------------------------ | ---------------------------------------- | ---------------------------------------------------------------------- |
+| **Option name**          | csharp_style_expression_bodied_operators |                                                                        |
+| **Option values**        | `true`                                   | Prefer expression bodies for operators                                 |
+|                          | `when_on_single_line`                    | Prefer expression bodies for operators when they will be a single line |
+|                          | `false`                                  | Prefer block bodies for operators                                      |
+| **Default option value** | `false`                                  |                                                                        |
 
 ```csharp
 // csharp_style_expression_bodied_operators = true
@@ -52,7 +68,7 @@ public static ComplexNumber operator + (ComplexNumber c1, ComplexNumber c2)
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0023 // Or IDE0024
@@ -68,7 +84,7 @@ dotnet_diagnostic.IDE0023.severity = none
 dotnet_diagnostic.IDE0024.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0025.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0025.md
@@ -16,27 +16,32 @@ dev_langs:
 ---
 # Use expression body for properties (IDE0025)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0025 |
-| **Title** | Use expression body for properties |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                       |
+| ------------------------ | ------------------------------------------- |
+| **Rule ID**              | IDE0025                                     |
+| **Title**                | Use expression body for properties          |
+| **Category**             | Style                                       |
+| **Subcategory**          | Language rules (expression-bodied members)  |
+| **Applicable languages** | C# 7.0+                                     |
+| **Options**              | `csharp_style_expression_bodied_properties` |
 
 ## Overview
 
 This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for properties.
 
-## csharp_style_expression_bodied_properties
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_properties
-| **Option values** | `true` - Prefer expression bodies for properties<br /><br />`when_on_single_line` - Prefer expression bodies for properties when they will be a single line<br /><br />`false` - Prefer block bodies for properties |
-| **Default option value** | `true` |
+Set the value of the associated option for this rule to specify whether expression bodies or block bodies for properties are preferred, and if expression bodies are preferred, whether they're preferred only for single-line expressions.
 
-#### Example
+### csharp_style_expression_bodied_properties
+
+| Property                 | Value                                     | Description                                                             |
+| ------------------------ | ----------------------------------------- | ----------------------------------------------------------------------- |
+| **Option name**          | csharp_style_expression_bodied_properties |                                                                         |
+| **Option values**        | `true`                                    | Prefer expression bodies for properties                                 |
+|                          | `when_on_single_line`                     | Prefer expression bodies for properties when they will be a single line |
+|                          | `false`                                   | Prefer block bodies for properties                                      |
+| **Default option value** | `true`                                    |                                                                         |
 
 ```csharp
 // csharp_style_expression_bodied_properties = true
@@ -48,7 +53,7 @@ public int Age { get { return _age; }}
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0025
@@ -63,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0025.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0026.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0026.md
@@ -16,27 +16,32 @@ dev_langs:
 ---
 # Use expression body for indexers (IDE0026)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0026 |
-| **Title** | Use expression body for indexers |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0026                                    |
+| **Title**                | Use expression body for indexers           |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (expression-bodied members) |
+| **Applicable languages** | C# 7.0+                                    |
+| **Options**              | `csharp_style_expression_bodied_indexers`  |
 
 ## Overview
 
 This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for indexers.
 
-## csharp_style_expression_bodied_indexers
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_indexers
-| **Option values** | `true` - Prefer expression bodies for indexers<br /><br />`when_on_single_line` - Prefer expression bodies for indexers when they will be a single line<br /><br />`false` - Prefer block bodies for indexers |
-| **Default option value** | `true` |
+Set the value of the associated option for this rule to specify whether expression bodies or block bodies for indexers are preferred, and if expression bodies are preferred, whether they're preferred only for single-line expressions.
 
-#### Example
+### csharp_style_expression_bodied_indexers
+
+| Property                 | Value                                   | Description                                                           |
+| ------------------------ | --------------------------------------- | --------------------------------------------------------------------- |
+| **Option name**          | csharp_style_expression_bodied_indexers |                                                                       |
+| **Option values**        | `true`                                  | Prefer expression bodies for indexers                                 |
+|                          | `when_on_single_line`                   | Prefer expression bodies for indexers when they will be a single line |
+|                          | `false`                                 | Prefer block bodies for indexers                                      |
+| **Default option value** | `true`                                  |                                                                       |
 
 ```csharp
 // csharp_style_expression_bodied_indexers = true
@@ -48,7 +53,7 @@ public T this[int i] { get { return _values[i]; } }
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0026
@@ -63,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0026.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0027.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0027.md
@@ -16,27 +16,32 @@ dev_langs:
 ---
 # Use expression body for accessors (IDE0027)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0027 |
-| **Title** | Use expression body for accessors |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0027                                    |
+| **Title**                | Use expression body for accessors          |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (expression-bodied members) |
+| **Applicable languages** | C# 7.0+                                    |
+| **Options**              | `csharp_style_expression_bodied_accessors` |
 
 ## Overview
 
 This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for accessors.
 
-## csharp_style_expression_bodied_accessors
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_accessors
-| **Option values** | `true` - Prefer expression bodies for accessors<br /><br />`when_on_single_line` - Prefer expression bodies for accessors when they will be a single line<br /><br />`false` - Prefer block bodies for accessors |
-| **Default option value** | `true` |
+Set the value of the associated option for this rule to specify whether expression bodies or block bodies for accessors are preferred, and if expression bodies are preferred, whether they're preferred only for single-line expressions.
 
-#### Example
+### csharp_style_expression_bodied_accessors
+
+| Property                 | Value                                    | Description                                                            |
+| ------------------------ | ---------------------------------------- | ---------------------------------------------------------------------- |
+| **Option name**          | csharp_style_expression_bodied_accessors |                                                                        |
+| **Option values**        | `true`                                   | Prefer expression bodies for accessors                                 |
+|                          | `when_on_single_line`                    | Prefer expression bodies for accessors when they will be a single line |
+|                          | `false`                                  | Prefer block bodies for accessors                                      |
+| **Default option value** | `true`                                   |                                                                        |
 
 ```csharp
 // csharp_style_expression_bodied_accessors = true
@@ -48,7 +53,7 @@ public int Age { get { return _age; } set { _age = value; } }
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0027
@@ -63,7 +68,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0027.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -17,27 +17,31 @@ dev_langs:
 ---
 # Use collection initializers (IDE0028)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0028 |
-| **Title** | Use collection initializers |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0028                                       |
+| **Title**                | Use collection initializers                   |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
+| **Options**              | `dotnet_style_collection_initializer`         |
 
 ## Overview
 
-This style rule concerns with the use of collection initializers for collection initialization. The option value specifies whether or not initializers are desired.
+This style rule concerns the use of [collection initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) for collection initialization.
 
-## dotnet_style_collection_initializer
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_collection_initializer
-| **Option values** | `true` - Prefer collections to be initialized using collection initializers when possible<br /><br />`false` - Prefer collections to *not* be initialized using collection initializers |
-| **Default option value** | `true` |
+Set the value of the associated option for this rule to specify whether or not collection initializers are preferred when initializing collections.
 
-### Example
+### dotnet_style_collection_initializer
+
+| Property                 | Value                               | Description                                                                      |
+| ------------------------ | ----------------------------------- | -------------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_collection_initializer |                                                                                  |
+| **Option values**        | `true`                              | Prefer collections to be initialized using collection initializers when possible |
+|                          | `false`                             | Prefer collections to *not* be initialized using collection initializers         |
+| **Default option value** | `true`                              |                                                                                  |
 
 ```csharp
 // dotnet_style_collection_initializer = true
@@ -63,7 +67,7 @@ list.Add(3)
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0028
@@ -78,7 +82,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0028.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0029-ide0030.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0029-ide0030.md
@@ -19,30 +19,45 @@ dev_langs:
 ---
 # Use coalesce expression (IDE0029 and IDE0030)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0029 and IDE0030 |
-| **Title** | IDE0029: Use coalesce expression (non-nullable types)<br/> IDE0030: Use coalesce expression (nullable types) |
-| **Category** | Style |
-| **Subcategory** | Language rules (null-checking preferences) |
-| **Applicable languages** | C# and Visual Basic |
+This article describes two related rules, `IDE0029` and `IDE0030`.
+
+| Property                 | Value                                        |
+| ------------------------ | -------------------------------------------- |
+| **Rule ID**              | IDE0029                                      |
+| **Title**                | Use coalesce expression (non-nullable types) |
+| **Category**             | Style                                        |
+| **Subcategory**          | Language rules (null-checking preferences)   |
+| **Applicable languages** | C# and Visual Basic                          |
+| **Options**              | `dotnet_style_coalesce_expression`           |
+
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0030                                    |
+| **Title**                | Use coalesce expression (nullable types)   |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (null-checking preferences) |
+| **Applicable languages** | C# and Visual Basic                        |
+| **Options**              | `dotnet_style_coalesce_expression`         |
 
 ## Overview
 
-These style rules concern with the use of null coalescing expressions versus ternary conditional expression with null check. For example, recommending use of `x ?? y` instead of `x != null ? x : y`. Different rule IDs are used in context of nullable and non-nullable expressions:
+These style rules concern the use of [null-coalescing expressions](../../../csharp/language-reference/operators/null-coalescing-operator.md), for example, `x ?? y`, versus [ternary conditional expressions](../../../csharp/language-reference/operators/conditional-operator.md) with `null` checks, for example, `x != null ? x : y`. The two related rule IDs differ with respect to the nullability of the expressions:
 
-- IDE0029: Used when non-nullable expressions are involved. For example, recommending `x ?? y` instead of `x != null ? x : y` when `x` and `y` are non-nullable reference types.
-- IDE0030: Used when nullable expressions are involved. For example, recommending `x ?? y` instead of `x != null ? x : y` when `x` and `y` are [nullable value types](../../../csharp/language-reference/builtin-types/nullable-value-types.md) or [nullable reference types](../../../csharp/language-reference/builtin-types/nullable-reference-types.md)
+- `IDE0029`: Used when non-nullable expressions are involved. For example, this rule could recommend  `x ?? y` instead of `x != null ? x : y` when `x` and `y` are non-nullable reference types.
+- `IDE0030`: Used when nullable expressions are involved. For example, this rule could recommend `x ?? y` instead of `x != null ? x : y` when `x` and `y` are [nullable value types](../../../csharp/language-reference/builtin-types/nullable-value-types.md) or [nullable reference types](../../../csharp/language-reference/builtin-types/nullable-reference-types.md).
 
-## dotnet_style_coalesce_expression
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_coalesce_expression
-| **Option values** | `true` - Prefer null coalescing expressions to ternary operator checking<br /><br />`false` - Prefer ternary operator checking to null coalescing expressions |
-| **Default option value** | `true` |
+Set the value of the associated option to specify whether null-coalescing expressions or ternary operator checking is preferred. The rule enforces whichever option you choose.
 
-### Example
+### dotnet_style_coalesce_expression
+
+| Property                 | Value                            | Description                                                     |
+| ------------------------ | -------------------------------- | --------------------------------------------------------------- |
+| **Option name**          | dotnet_style_coalesce_expression |                                                                 |
+| **Option values**        | `true`                           | Prefer null coalescing expressions to ternary operator checking |
+|                          | `false`                          | Prefer ternary operator checking to null coalescing expressions |
+| **Default option value** | `true`                           |                                                                 |
 
 ```csharp
 // dotnet_style_coalesce_expression = true
@@ -64,7 +79,7 @@ Dim v = If(x IsNot Nothing, x, y)
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0029 // Or IDE0030
@@ -80,7 +95,7 @@ dotnet_diagnostic.IDE0029.severity = none
 dotnet_diagnostic.IDE0030.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]


### PR DESCRIPTION
Improves the options formatting for each rule and also lists all the options in the overview table.

Part 1 of 3.

[Internal preview](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009?branch=pr-en-us-29913).

Contributes to #24437.

Hide white space changes in diff.