### PR TITLE
Add options to top table - part 2

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0031.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0031.md
@@ -17,27 +17,31 @@ dev_langs:
 ---
 # Use null propagation (IDE0031)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0031 |
-| **Title** | Use null propagation |
-| **Category** | Style |
-| **Subcategory** | Language rules (null-checking preferences) |
-| **Applicable languages** | C# 6.0+ and Visual Basic 14+ |
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0031                                    |
+| **Title**                | Use null propagation                       |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (null-checking preferences) |
+| **Applicable languages** | C# 6.0+ and Visual Basic 14+               |
+| **Options**              | `dotnet_style_null_propagation`            |
 
 ## Overview
 
-This style rule concerns with the use of null-conditional operator versus ternary conditional expression with null check.
+This style rule concerns the use of the [null-conditional operator](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-) versus a [ternary conditional expression](../../../csharp/language-reference/operators/conditional-operator.md) with null check.
 
-## dotnet_style_null_propagation
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_null_propagation
-| **Option values** | `true` - Prefer to use null-conditional operator when possible<br /><br />`false` - Prefer to use ternary null checking where possible |
-| **Default option value** | `true` |
+Set the value of the associated option to specify whether null-conditional operators or ternary conditional expressions with null checks.
 
-### Example
+### dotnet_style_null_propagation
+
+| Property                 | Value                         | Description                                           |
+| ------------------------ | ----------------------------- | ----------------------------------------------------- |
+| **Option name**          | dotnet_style_null_propagation |                                                       |
+| **Option values**        | `true`                        | Prefer to use null-conditional operator when possible |
+|                          | `false`                       | Prefer to use ternary null checking where possible    |
+| **Default option value** | `true`                        |                                                       |
 
 ```csharp
 // dotnet_style_null_propagation = true
@@ -59,7 +63,7 @@ Dim v = If(o IsNot Nothing, o.ToString(), Nothing)
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0031
@@ -74,7 +78,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0031.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0032.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0032.md
@@ -15,30 +15,32 @@ dev_langs:
 - CSharp
 - VB
 ---
-# Use auto property (IDE0032)
+# Use auto-implemented property (IDE0032)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0032 |
-| **Title** | Use auto property |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.7 |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0032                                       |
+| **Title**                | Use auto-implemented property                 |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
+| **Introduced version**   | Visual Studio 2017 version 15.7               |
+| **Options**              | `dotnet_style_prefer_auto_properties`         |
 
 ## Overview
 
-This style rule concerns with the use of auto properties versus properties with private backing fields.
+This style rule concerns the use of [auto-implemented properties](../../../csharp/programming-guide/classes-and-structs/auto-implemented-properties.md) versus properties with private backing fields.
 
-## dotnet_style_prefer_auto_properties
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_auto_properties
-| **Option values** | `true` - Prefer auto properties over properties with private backing fields<br /><br />`false` - Prefer properties with private backing fields over auto properties |
-| **Default option value** | `true` |
+### dotnet_style_prefer_auto_properties
 
-### Example
+| Property                 | Value                               | Description                                   |
+| ------------------------ | ----------------------------------- | --------------------------------------------- |
+| **Option name**          | dotnet_style_prefer_auto_properties |                                               |
+| **Option values**        | `true`                              | Prefer auto-implemented properties            |
+|                          | `false`                             | Prefer properties with private backing fields |
+| **Default option value** | `true`                              |                                               |
 
 ```csharp
 // dotnet_style_prefer_auto_properties = true
@@ -72,7 +74,7 @@ End Property
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0032
@@ -87,7 +89,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0032.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0033.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0033.md
@@ -17,27 +17,29 @@ dev_langs:
 ---
 # Use explicitly provided tuple name (IDE0033)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0033 |
-| **Title** | Use explicitly provided tuple name |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 7.0+ and Visual Basic 15+ |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0033                                       |
+| **Title**                | Use explicitly provided tuple name            |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# 7.0+ and Visual Basic 15+                  |
+| **Options**              | `dotnet_style_explicit_tuple_names`           |
 
 ## Overview
 
-This style rule concerns with the use of explicit tuple names versus use of implicit 'ItemX' properties.
+This style rule concerns the use of explicit [tuple](../../../csharp/language-reference/builtin-types/value-tuples.md) names versus implicit 'ItemX' properties when accessing tuple fields.
 
-## dotnet_style_explicit_tuple_names
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_explicit_tuple_names
-| **Option values** | `true` - Prefer tuple names to ItemX properties<br /><br />`false` - Prefer ItemX properties to tuple names |
-| **Default option value** | `true` |
+### dotnet_style_explicit_tuple_names
 
-### Example
+| Property                 | Value                             | Description                            |
+| ------------------------ | --------------------------------- | -------------------------------------- |
+| **Option name**          | dotnet_style_explicit_tuple_names |                                        |
+| **Option values**        | `true`                            | Prefer tuple names to ItemX properties |
+|                          | `false`                           | Prefer ItemX properties to tuple names |
+| **Default option value** | `true`                            |                                        |
 
 ```csharp
 // dotnet_style_explicit_tuple_names = true
@@ -61,7 +63,7 @@ Dim name = customer.Item1
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0033
@@ -76,7 +78,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0033.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -87,6 +89,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
+- [Use inferred member names (IDE0037)](ide0037.md)
 - [Use object initializers](ide0017.md)
 - [Expression-level preferences](expression-level-preferences.md)
 - [Code style language rules](language-rules.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0034.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0034.md
@@ -16,27 +16,29 @@ dev_langs:
 ---
 # Simplify 'default' expression (IDE0034)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0034 |
-| **Title** | Simplify `default` expression |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 7.1+ |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0034                                       |
+| **Title**                | Simplify `default` expression                 |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# 7.1+                                       |
+| **Options**              | `csharp_prefer_simple_default_expression`     |
 
 ## Overview
 
 This style rule concerns using the [default literal for default value expressions](../../../csharp/language-reference/operators/default.md#default-literal) when the compiler can infer the type of the expression.
 
-## csharp_prefer_simple_default_expression
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_prefer_simple_default_expression
-| **Option values** | `true` - Prefer `default` over `default(T)`<br /><br />`false` - Prefer `default(T)` over `default` |
-| **Default option value** | `true` |
+### csharp_prefer_simple_default_expression
 
-#### Example
+| Property                 | Value                                   | Description                        |
+| ------------------------ | --------------------------------------- | ---------------------------------- |
+| **Option name**          | csharp_prefer_simple_default_expression |                                    |
+| **Option values**        | `true`                                  | Prefer `default` over `default(T)` |
+|                          | `false`                                 | Prefer `default(T)` over `default` |
+| **Default option value** | `true`                                  |                                    |
 
 ```csharp
 // csharp_prefer_simple_default_expression = true
@@ -48,7 +50,7 @@ void DoWork(CancellationToken cancellationToken = default(CancellationToken)) { 
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0034
@@ -63,7 +65,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0034.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0035.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0035.md
@@ -15,17 +15,19 @@ dev_langs:
 ---
 # Remove unreachable code (IDE0035)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0035 |
-| **Title** | Remove unreachable code |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                   |
+| ------------------------ | ----------------------- |
+| **Rule ID**              | IDE0035                 |
+| **Title**                | Remove unreachable code |
+| **Category**             | Style                   |
+| **Subcategory**          | Unnecessary code rules  |
+| **Applicable languages** | C# and Visual Basic     |
 
 ## Overview
 
-This rule flags unreachable executable code within methods and properties that can never be reached, and hence can be removed. This rule has no associated code style option.
+This rule flags executable code within methods and properties that can never be reached, and hence can be removed.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -48,7 +50,7 @@ void M()
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0035
@@ -63,7 +65,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0035.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0036.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0036.md
@@ -19,32 +19,39 @@ dev_langs:
 ---
 # Order modifiers (IDE0036)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0036 |
-| **Title** | Order modifiers |
-| **Category** | Style |
-| **Subcategory** | Language rules (modifier preferences) |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.5 |
+| Property                 | Value                                   |
+| ------------------------ | --------------------------------------- |
+| **Rule ID**              | IDE0036                                 |
+| **Title**                | Order modifiers                         |
+| **Category**             | Style                                   |
+| **Subcategory**          | Language rules (modifier preferences)   |
+| **Applicable languages** | C# and Visual Basic                     |
+| **Introduced version**   | Visual Studio 2017 version 15.5         |
+| **Options**              | `csharp_preferred_modifier_order`       |
+|                          | `visual_basic_preferred_modifier_order` |
 
 ## Overview
 
-The style rules in this section concern specifying the desired modifier sort order.
+This rule lets you enforce a desired [modifier](../../../csharp/programming-guide/classes-and-structs/access-modifiers.md) sort order.
 
-- When this rule is set to a list of modifiers, prefer the specified ordering.
-- When this rule is omitted from the file, do not prefer a modifier order.
+- When this rule is enabled and the associated options are set to a list of modifiers, prefer the specified ordering.
+- When this rule is not enabled, no specific modifier order is preferred.
 
-## csharp_preferred_modifier_order
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_preferred_modifier_order |
-| **Applicable languages** | C# |
-| **Option values** | One or more C# modifiers, such as `public`, `private`, and `protected` |
-| **Default option value** | `public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:silent` |
+The associated options for this rule let you specify the desired modifier order for C# and Visual Basic, respectively.
 
-### Example
+- [csharp_preferred_modifier_order](#csharp_preferred_modifier_order)
+- [visual_basic_preferred_modifier_order](#visual_basic_preferred_modifier_order)
+
+### csharp_preferred_modifier_order
+
+| Property                 | Value                                                                                                                               | Description |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Option name**          | csharp_preferred_modifier_order                                                                                                     |             |
+| **Applicable languages** | C#                                                                                                                                  |             |
+| **Option values**        | One or more C# modifiers, such as `public`, `private`, and `protected`                                                              |             |
+| **Default option value** | `public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async` |             |
 
 ```csharp
 // csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
@@ -54,16 +61,14 @@ class MyClass
 }
 ```
 
-## visual_basic_preferred_modifier_order
+### visual_basic_preferred_modifier_order
 
-|Property|Value|
-|-|-|
-| **Option name** | visual_basic_preferred_modifier_order |
-| **Applicable languages** | Visual Basic |
-| **Option values** | One or more Visual Basic modifiers, such as `Partial`, `Private`, and `Public` |
-| **Default option value** | `Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async:silent` |
-
-### Example
+| Property                 | Value                                                                                                                                                                                                                                                          | Description |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Option name**          | visual_basic_preferred_modifier_order                                                                                                                                                                                                                          |             |
+| **Applicable languages** | Visual Basic                                                                                                                                                                                                                                                   |             |
+| **Option values**        | One or more Visual Basic modifiers, such as `Partial`, `Private`, and `Public`                                                                                                                                                                                 |             |
+| **Default option value** | `Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async` |             |
 
 ```vb
 ' visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async
@@ -74,7 +79,7 @@ End Class
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0036
@@ -89,7 +94,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0036.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0037.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0037.md
@@ -15,33 +15,38 @@ dev_langs:
 - CSharp
 - VB
 ---
-# Use inferred member name (IDE0037)
+# Use inferred member names (IDE0037)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0037 |
-| **Title** | Use inferred member name |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 7.1+ and Visual Basic 15+ |
-| **Introduced version** | Visual Studio 2017 version 15.6 |
+| Property                 | Value                                                      |
+| ------------------------ | ---------------------------------------------------------- |
+| **Rule ID**              | IDE0037                                                    |
+| **Title**                | Use inferred member name                                   |
+| **Category**             | Style                                                      |
+| **Subcategory**          | Language rules (expression-level preferences)              |
+| **Applicable languages** | C# 7.1+ and Visual Basic 15+                               |
+| **Introduced version**   | Visual Studio 2017 version 15.6                            |
+| **Options**              | `dotnet_style_prefer_inferred_tuple_names`                 |
+|                          | `dotnet_style_prefer_inferred_anonymous_type_member_names` |
 
 ## Overview
 
-This style rule concerns the following code styles for use of inferred names:
+This rule enforces whether inferred [tuple](../../../csharp/language-reference/builtin-types/value-tuples.md) element names and inferred [anonymous type](../../../csharp/fundamentals/types/anonymous-types.md) member names are preferred when the tuple or anonymous type is declared.
 
-- [Use of inferred tuple element names](#dotnet_style_prefer_inferred_tuple_names) (`dotnet_style_prefer_inferred_tuple_names`) and
-- [Use of inferred anonymous type member names](#dotnet_style_prefer_inferred_anonymous_type_member_names) (`dotnet_style_prefer_inferred_anonymous_type_member_names`)
+## Options
 
-## dotnet_style_prefer_inferred_tuple_names
+Set the values of the rule's associated options to specify whether inferred or explicit names are preferred for tuple elements and anonymous type members.
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_inferred_tuple_names
-| **Option values** | `true` - Prefer inferred tuple element names<br /><br />`false` - Prefer explicit tuple element names |
-| **Default option value** | `true` |
+- [dotnet_style_prefer_inferred_tuple_names](#dotnet_style_prefer_inferred_tuple_names)
+- [dotnet_style_prefer_inferred_anonymous_type_member_names](#dotnet_style_prefer_inferred_anonymous_type_member_names)
 
-### Example
+### dotnet_style_prefer_inferred_tuple_names
+
+| Property                 | Value                                    | Description                         |
+| ------------------------ | ---------------------------------------- | ----------------------------------- |
+| **Option name**          | dotnet_style_prefer_inferred_tuple_names |                                     |
+| **Option values**        | `true`                                   | Prefer inferred tuple element names |
+|                          | `false`                                  | Prefer explicit tuple element names |
+| **Default option value** | `true`                                   |                                     |
 
 ```csharp
 // dotnet_style_prefer_inferred_tuple_names = true
@@ -59,15 +64,14 @@ Dim tuple = (name, age)
 Dim tuple = (name:=name, age:=age)
 ```
 
-## dotnet_style_prefer_inferred_anonymous_type_member_names
+### dotnet_style_prefer_inferred_anonymous_type_member_names
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_inferred_anonymous_type_member_names
-| **Option values** | `true` - Prefer inferred anonymous type member names<br /><br />`false` - Prefer explicit anonymous type member names |
-| **Default option value** | `true` |
-
-### Example
+| Property                 | Value                                                    | Description                                 |
+| ------------------------ | -------------------------------------------------------- | ------------------------------------------- |
+| **Option name**          | dotnet_style_prefer_inferred_anonymous_type_member_names |                                             |
+| **Option values**        | `true`                                                   | Prefer inferred anonymous type member names |
+|                          | `false`                                                  | Prefer explicit anonymous type member names |
+| **Default option value** | `true`                                                   |                                             |
 
 ```csharp
 // dotnet_style_prefer_inferred_anonymous_type_member_names = true
@@ -87,7 +91,7 @@ Dim anon = New With {.name = name, .age = age}
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0037
@@ -102,7 +106,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0037.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -113,6 +117,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
+- [Use explicitly provided tuple name (IDE0033)](ide0033.md)
 - [Expression-level preferences](expression-level-preferences.md)
 - [Code style language rules](language-rules.md)
 - [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0039.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0039.md
@@ -16,27 +16,29 @@ dev_langs:
 ---
 # Use local function instead of lambda (IDE0039)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0039 |
-| **Title** | Use local function instead of lambda |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                                |
+| ------------------------ | ---------------------------------------------------- |
+| **Rule ID**              | IDE0039                                              |
+| **Title**                | Use local function instead of lambda                 |
+| **Category**             | Style                                                |
+| **Subcategory**          | Language rules (expression-level preferences)        |
+| **Applicable languages** | C# 7.0+                                              |
+| **Options**              | `csharp_style_pattern_local_over_anonymous_function` |
 
 ## Overview
 
-This style rule concerns the use of [local functions](../../../csharp/programming-guide/classes-and-structs/local-functions.md) versus lambdas (anonymous functions).
+This style rule concerns the use of [local functions](../../../csharp/programming-guide/classes-and-structs/local-functions.md) versus [lambda expressions](../../../csharp/language-reference/operators/lambda-expressions.md) (anonymous functions).
 
-## csharp_style_pattern_local_over_anonymous_function
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_pattern_local_over_anonymous_function
-| **Option values** | `true` - Prefer local functions over anonymous functions<br /><br />`false` - Prefer anonymous functions over local functions |
-| **Default option value** | `true` |
+### csharp_style_pattern_local_over_anonymous_function
 
-#### Example
+| Property                 | Value                                              | Description                                     |
+| ------------------------ | -------------------------------------------------- | ----------------------------------------------- |
+| **Option name**          | csharp_style_pattern_local_over_anonymous_function |                                                 |
+| **Option values**        | `true`                                             | Prefer local functions over anonymous functions |
+|                          | `false`                                            | Prefer anonymous functions over local functions |
+| **Default option value** | `true`                                             |                                                 |
 
 ```csharp
 // csharp_style_pattern_local_over_anonymous_function = true
@@ -55,7 +57,7 @@ fibonacci = (int n) =>
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0039
@@ -70,7 +72,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0039.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0040.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0040.md
@@ -19,28 +19,34 @@ dev_langs:
 ---
 # Add accessibility modifiers (IDE0040)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0040 |
-| **Title** | Add accessibility modifiers |
-| **Category** | Style |
-| **Subcategory** | Language rules (modifier preferences) |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.5 |
+| Property                 | Value                                          |
+| ------------------------ | ---------------------------------------------- |
+| **Rule ID**              | IDE0040                                        |
+| **Title**                | Add accessibility modifiers                    |
+| **Category**             | Style                                          |
+| **Subcategory**          | Language rules (modifier preferences)          |
+| **Applicable languages** | C# and Visual Basic                            |
+| **Introduced version**   | Visual Studio 2017 version 15.5                |
+| **Options**              | `dotnet_style_require_accessibility_modifiers` |
 
 ## Overview
 
-This style rule concerns requiring accessibility modifiers in declarations. The option value specifies the preferences for required accessibility modifiers.
+This style rule concerns requiring [accessibility modifiers](../../../csharp/language-reference/keywords/access-modifiers.md) in declarations.
 
-## dotnet_style_require_accessibility_modifiers
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_require_accessibility_modifiers
-| **Option values** | `always` - Prefer accessibility modifiers to be specified.<br /><br />`for_non_interface_members` - Prefer accessibility modifiers to be declared except for public interface members.<br /><br />`never` - Do not prefer accessibility modifiers to be specified.<br /><br />`omit_if_default` - Prefer accessibility modifiers to be specified except if they are the default modifier. |
-| **Default option value** | `for_non_interface_members` |
+The option value specifies the preferences for required accessibility modifiers.
 
-### Example
+### dotnet_style_require_accessibility_modifiers
+
+| Property                 | Value                                        | Description                                                             |
+| ------------------------ | -------------------------------------------- | ----------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_require_accessibility_modifiers |                                                                         |
+| **Option values**        | `always`                                     | Prefer accessibility modifiers to be specified.                         |
+|                          | `for_non_interface_members`                  | Prefer accessibility modifiers except for public interface members.     |
+|                          | `never`                                      | Do not prefer accessibility modifiers to be specified.                  |
+|                          | `omit_if_default`                            | Prefer accessibility modifiers except if they are the default modifier. |
+| **Default option value** | `for_non_interface_members`                  |                                                                         |
 
 ```csharp
 // dotnet_style_require_accessibility_modifiers = always
@@ -59,7 +65,7 @@ class MyClass
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0040
@@ -74,7 +80,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0040.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0041.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0041.md
@@ -1,5 +1,5 @@
 ---
-title: "IDE0041: Use is null check"
+title: "IDE0041: Use 'is null' check"
 description: "Learn about code analysis rule IDE0041: Use is null check"
 ms.date: 09/30/2020
 ms.topic: reference
@@ -15,30 +15,32 @@ dev_langs:
 - CSharp
 - VB
 ---
-# Use is null check (IDE0041)
+# Use 'is null' check (IDE0041)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0041 |
-| **Title** | Use is null check |
-| **Category** | Style |
-| **Subcategory** | Language rules (null-checking preferences) |
-| **Applicable languages** | C# 6.0+ and Visual Basic 14+ |
-| **Introduced version** | Visual Studio 2017 version 15.7 |
+| Property                 | Value                                                              |
+| ------------------------ | ------------------------------------------------------------------ |
+| **Rule ID**              | IDE0041                                                            |
+| **Title**                | Use 'is null' check                                                |
+| **Category**             | Style                                                              |
+| **Subcategory**          | Language rules (null-checking preferences)                         |
+| **Applicable languages** | C# 6.0+ and Visual Basic 14+                                       |
+| **Introduced version**   | Visual Studio 2017 version 15.7                                    |
+| **Options**              | `dotnet_style_prefer_is_null_check_over_reference_equality_method` |
 
 ## Overview
 
-This style rule concerns with the use of null check with pattern-matching versus use of reference equality method `object.ReferenceEquals`.
+This style rule concerns the use of a null check with pattern-matching versus calling the reference-equality method <xref:System.Object.ReferenceEquals(System.Object,System.Object)?displayProperty=nameWithType>.
 
-## dotnet_style_prefer_is_null_check_over_reference_equality_method
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_is_null_check_over_reference_equality_method
-| **Option values** | `true` - Prefer is null check over reference equality method<br /><br />`false` - Prefer reference equality method over is null check |
-| **Default option value** | `true` |
+### dotnet_style_prefer_is_null_check_over_reference_equality_method
 
-### Example
+| Property                 | Value                                                            | Description                      |
+| ------------------------ | ---------------------------------------------------------------- | -------------------------------- |
+| **Option name**          | dotnet_style_prefer_is_null_check_over_reference_equality_method |                                  |
+| **Option values**        | `true`                                                           | Prefer `is null` check           |
+|                          | `false`                                                          | Prefer reference equality method |
+| **Default option value** | `true`                                                           |                                  |
 
 ```csharp
 // dotnet_style_prefer_is_null_check_over_reference_equality_method = true
@@ -64,7 +66,7 @@ End If
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0041
@@ -79,7 +81,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0041.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0042.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0042.md
@@ -16,27 +16,29 @@ dev_langs:
 ---
 # Deconstruct variable declaration (IDE0042)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0042 |
-| **Title** | Deconstruct variable declaration |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                             |
+| ------------------------ | ------------------------------------------------- |
+| **Rule ID**              | IDE0042                                           |
+| **Title**                | Deconstruct variable declaration                  |
+| **Category**             | Style                                             |
+| **Subcategory**          | Language rules (expression-level preferences)     |
+| **Applicable languages** | C# 7.0+                                           |
+| **Options**              | `csharp_style_deconstructed_variable_declaration` |
 
 ## Overview
 
-This style rule concerns the use of deconstruction in variable declarations, when possible.
+This style rule concerns the use of [deconstruction](../../../csharp/fundamentals/functional/deconstruct.md) in variable declarations, when possible.
 
-## csharp_style_deconstructed_variable_declaration
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_deconstructed_variable_declaration
-| **Option values** | `true` - Prefer deconstructed variable declaration<br /><br />`false` - Do not prefer deconstruction in variable declarations |
-| **Default option value** | `true` |
+### csharp_style_deconstructed_variable_declaration
 
-#### Example
+| Property                 | Value                                           | Description                                           |
+| ------------------------ | ----------------------------------------------- | ----------------------------------------------------- |
+| **Option name**          | csharp_style_deconstructed_variable_declaration |                                                       |
+| **Option values**        | `true`                                          | Prefer deconstructed variable declaration             |
+|                          | `false`                                         | Do not prefer deconstruction in variable declarations |
+| **Default option value** | `true`                                          |                                                       |
 
 ```csharp
 // csharp_style_deconstructed_variable_declaration = true
@@ -56,7 +58,7 @@ Console.WriteLine($"{point.x} {point.y}");
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0042
@@ -71,7 +73,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0042.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0044.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0044.md
@@ -17,28 +17,30 @@ dev_langs:
 ---
 # Add readonly modifier (IDE0044)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0044 |
-| **Title** | Add readonly modifier |
-| **Category** | Style |
-| **Subcategory** | Language rules (modifier preferences) |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.7 |
+| Property                 | Value                                 |
+| ------------------------ | ------------------------------------- |
+| **Rule ID**              | IDE0044                               |
+| **Title**                | Add readonly modifier                 |
+| **Category**             | Style                                 |
+| **Subcategory**          | Language rules (modifier preferences) |
+| **Applicable languages** | C# and Visual Basic                   |
+| **Introduced version**   | Visual Studio 2017 version 15.7       |
+| **Options**              | `dotnet_style_readonly_field`         |
 
 ## Overview
 
-This style rule concerns specifying the readonly modifier for private fields that are initialized (either inline or inside of a constructor) but never reassigned.
+This style rule concerns specifying the [`readonly` (C#)](../../../csharp/language-reference/keywords/readonly.md) or [`ReadOnly` (Visual Basic)](../../../visual-basic/language-reference/modifiers/readonly.md) modifier for private fields that are initialized (either inline or inside of a constructor) but never reassigned.
 
-## dotnet_style_readonly_field
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_readonly_field |
-| **Option values** | `true` - Prefer that private fields should be marked with `readonly` (C#) or `ReadOnly` (Visual Basic) if they are only ever assigned inline, or inside of a constructor<br /><br />`false` - Specify no preference over whether private fields should be marked with `readonly` (C#) or `ReadOnly` (Visual Basic) |
-| **Default option value** | `true` |
+### dotnet_style_readonly_field
 
-### Example
+| Property                 | Value                       | Description                                                                                              |
+| ------------------------ | --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_readonly_field |                                                                                                          |
+| **Option values**        | `true`                      | Prefer that private fields be marked `readonly` if they're only ever assigned inline or in a constructor |
+|                          | `false`                     | Specify no preference over whether private fields are marked `readonly`                                  |
+| **Default option value** | `true`                      |                                                                                                          |
 
 ```csharp
 // dotnet_style_readonly_field = true
@@ -57,7 +59,7 @@ End Class
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0044
@@ -72,7 +74,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0044.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0045.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0045.md
@@ -17,28 +17,30 @@ dev_langs:
 ---
 # Use conditional expression for assignment (IDE0045)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0045 |
-| **Title** | Use conditional expression for assignment |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.8 |
+| Property                 | Value                                                        |
+| ------------------------ | ------------------------------------------------------------ |
+| **Rule ID**              | IDE0045                                                      |
+| **Title**                | Use conditional expression for assignment                    |
+| **Category**             | Style                                                        |
+| **Subcategory**          | Language rules (expression-level preferences)                |
+| **Applicable languages** | C# and Visual Basic                                          |
+| **Introduced version**   | Visual Studio 2017 version 15.8                              |
+| **Options**              | `dotnet_style_prefer_conditional_expression_over_assignment` |
 
 ## Overview
 
-This style rule concerns with the use of ternary conditional expressions versus an if-else statement for assignments that require conditional logic.
+This style rule concerns the use of a [ternary conditional expression](../../../csharp/language-reference/operators/conditional-operator.md) versus an [if-else statement](../../../csharp/language-reference/statements/selection-statements.md) for assignments that require conditional logic.
 
-## dotnet_style_prefer_conditional_expression_over_assignment
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_conditional_expression_over_assignment
-| **Option values** | `true` - Prefer assignments with a ternary conditional over an if-else statement<br /><br />`false` - Prefer assignments with an if-else statement over a ternary conditional |
-| **Default option value** | `true` |
+### dotnet_style_prefer_conditional_expression_over_assignment
 
-### Example
+| Property                 | Value                                                      | Description                                   |
+| ------------------------ | ---------------------------------------------------------- | --------------------------------------------- |
+| **Option name**          | dotnet_style_prefer_conditional_expression_over_assignment |                                               |
+| **Option values**        | `true`                                                     | Prefer assignments with a ternary conditional |
+|                          | `false`                                                    | Prefer assignments with an if-else statement  |
+| **Default option value** | `true`                                                     |                                               |
 
 ```csharp
 // dotnet_style_prefer_conditional_expression_over_assignment = true
@@ -71,7 +73,7 @@ End If
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0045
@@ -86,7 +88,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0045.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
@@ -97,7 +99,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use conditional expression for return](ide0046.md)
+- [Use conditional expression for return (IDE0046)](ide0046.md)
 - [Expression-level preferences](expression-level-preferences.md)
 - [Code style language rules](language-rules.md)
 - [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0046.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0046.md
@@ -17,28 +17,30 @@ dev_langs:
 ---
 # Use conditional expression for return (IDE0046)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0046 |
-| **Title** | Use conditional expression for return |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.8 |
+| Property                 | Value                                                    |
+| ------------------------ | -------------------------------------------------------- |
+| **Rule ID**              | IDE0046                                                  |
+| **Title**                | Use conditional expression for return                    |
+| **Category**             | Style                                                    |
+| **Subcategory**          | Language rules (expression-level preferences)            |
+| **Applicable languages** | C# and Visual Basic                                      |
+| **Introduced version**   | Visual Studio 2017 version 15.8                          |
+| **Options**              | `dotnet_style_prefer_conditional_expression_over_return` |
 
 ## Overview
 
-This style rule concerns with the use of ternary conditional expressions versus an if-else statement for return statements that require conditional logic.
+This style rule concerns the use of a [ternary conditional expression](../../../csharp/language-reference/operators/conditional-operator.md) versus an [if-else statement](../../../csharp/language-reference/statements/selection-statements.md) for return statements that require conditional logic.
 
-## dotnet_style_prefer_conditional_expression_over_return
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_conditional_expression_over_return
-| **Option values** | `true` - Prefer return statements to use a ternary conditional over an if-else statement<br /><br />`false` - Prefer return statements to use an if-else statement over a ternary conditional |
-| **Default option value** | `true` |
+### dotnet_style_prefer_conditional_expression_over_return
 
-### Example
+| Property                 | Value                                                  | Description                                           |
+| ------------------------ | ------------------------------------------------------ | ----------------------------------------------------- |
+| **Option name**          | dotnet_style_prefer_conditional_expression_over_return |                                                       |
+| **Option values**        | `true`                                                 | Prefer return statements to use a ternary conditional |
+|                          | `false`                                                | Prefer return statements to use an if-else statement  |
+| **Default option value** | `true`                                                 |                                                       |
 
 ```csharp
 // dotnet_style_prefer_conditional_expression_over_return = true
@@ -69,7 +71,7 @@ End If
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0046
@@ -84,7 +86,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0046.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0047-ide0048.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0047-ide0048.md
@@ -25,28 +25,57 @@ dev_langs:
 ---
 # Parentheses preferences (IDE0047 and IDE0048)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0047 and IDE0048 |
-| **Title** | IDE0047: Remove unnecessary parentheses<br/> IDE0048: Add parentheses for clarity |
-| **Category** | Style |
-| **Subcategory** | Language rules |
-| **Applicable languages** | C# and Visual Basic |
-| **Introduced version** | Visual Studio 2017 version 15.8 |
+This article describes two related rules, `IDE0047` and `IDE0048`.
+
+| Property                 | Value                                                     |
+| ------------------------ | --------------------------------------------------------- |
+| **Rule ID**              | IDE0047                                                   |
+| **Title**                | Remove unnecessary parentheses                            |
+| **Category**             | Style                                                     |
+| **Subcategory**          | Language rules                                            |
+| **Applicable languages** | C# and Visual Basic                                       |
+| **Introduced version**   | Visual Studio 2017 version 15.8                           |
+| **Options**              | `dotnet_style_parentheses_in_arithmetic_binary_operators` |
+|                          | `dotnet_style_parentheses_in_relational_binary_operators` |
+|                          | `dotnet_style_parentheses_in_other_binary_operators`      |
+|                          | `dotnet_style_parentheses_in_other_operators`             |F
+
+| Property                 | Value                                                     |
+| ------------------------ | --------------------------------------------------------- |
+| **Rule ID**              | IDE0048                                                   |
+| **Title**                | Add parentheses for clarity                               |
+| **Category**             | Style                                                     |
+| **Subcategory**          | Language rules                                            |
+| **Applicable languages** | C# and Visual Basic                                       |
+| **Introduced version**   | Visual Studio 2017 version 15.8                           |
+| **Options**              | `dotnet_style_parentheses_in_arithmetic_binary_operators` |
+|                          | `dotnet_style_parentheses_in_relational_binary_operators` |
+|                          | `dotnet_style_parentheses_in_other_binary_operators`      |
+|                          | `dotnet_style_parentheses_in_other_operators`             |
 
 ## Overview
 
-The style rules in this section concern parentheses preferences, including the use of parentheses for arithmetic, relational, and other binary operators.
+The style rules in this section concern parentheses preferences, including the use of parentheses to clarify precedence for arithmetic, relational, and other binary [operators](../../../csharp/language-reference/operators/index.md).
 
-## dotnet_style_parentheses_in_arithmetic_binary_operators
+## Option
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_parentheses_in_arithmetic_binary_operators |
-| **Option values** | `always_for_clarity` - Prefer parentheses to clarify arithmetic operator (`*`, `/`, `%`, `+`, `-`, `<<`, `>>`, `&`, `^`, `|`) precedence<br /><br />`never_if_unnecessary` - Prefer to not have parentheses when arithmetic operator (`*`, `/`, `%`, `+`, `-`, `<<`, `>>`, `&`, `^`, `|`) precedence is obvious |
-| **Default option value** | `always_for_clarity` |
+This rule has associated options to specify preferences based on the type of operator:
 
-### Example
+- Arithmetic binary operators - [dotnet_style_parentheses_in_arithmetic_binary_operators](#dotnet_style_parentheses_in_arithmetic_binary_operators)
+- Relational binary operators - [dotnet_style_parentheses_in_relational_binary_operators](#dotnet_style_parentheses_in_relational_binary_operators)
+- Other binary operators - [dotnet_style_parentheses_in_other_binary_operators](#dotnet_style_parentheses_in_other_binary_operators)
+- Other operators - [dotnet_style_parentheses_in_other_operators](#dotnet_style_parentheses_in_other_operators)
+
+### dotnet_style_parentheses_in_arithmetic_binary_operators
+
+| Property                 | Value                                                   | Description                                                          |
+| ------------------------ | ------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_parentheses_in_arithmetic_binary_operators |                                                                      |
+| **Option values**        | `always_for_clarity`                                    | Prefer parentheses to clarify arithmetic operator precedence         |
+|                          | `never_if_unnecessary`                                  | Prefer no parentheses when arithmetic operator precedence is obvious |
+| **Default option value** | `always_for_clarity`                                    |                                                                      |
+
+The arithmetic binary operators are: `*`, `/`, `%`, `+`, `-`, `<<`, `>>`, `&`, `^`, and `|`.
 
 ```csharp
 // dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
@@ -64,15 +93,16 @@ Dim v = a + (b * c)
 Dim v = a + b * c
 ```
 
-## dotnet_style_parentheses_in_relational_binary_operators
+### dotnet_style_parentheses_in_relational_binary_operators
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_parentheses_in_relational_binary_operators |
-| **Option values** | `always_for_clarity` - Prefer parentheses to clarify relational operator (`>`, `<`, `<=`, `>=`, `is`, `as`, `==`, `!=`) precedence<br /><br />`never_if_unnecessary` - Prefer to not have parentheses when relational operator (`>`, `<`, `<=`, `>=`, `is`, `as`, `==`, `!=`) precedence is obvious |
-| **Default option value** | `always_for_clarity` |
+| Property                 | Value                                                   | Description                                                                   |
+| ------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_parentheses_in_relational_binary_operators |                                                                               |
+| **Option values**        | `always_for_clarity`                                    | Prefer parentheses to clarify relational operator precedence                  |
+|                          | `never_if_unnecessary`                                  | Prefer to not have parentheses when relational operator precedence is obvious |
+| **Default option value** | `always_for_clarity`                                    |                                                                               |
 
-### Example
+The relational binary operators are: `>`, `<`, `<=`, `>=`, `is`, `as`, `==`, and `!=`.
 
 ```csharp
 // dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
@@ -90,15 +120,16 @@ Dim v = (a < b) = (c > d)
 Dim v = a < b = c > d
 ```
 
-## dotnet_style_parentheses_in_other_binary_operators
+### dotnet_style_parentheses_in_other_binary_operators
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_parentheses_in_other_binary_operators |
-| **Option values** | `always_for_clarity` - Prefer parentheses to clarify other binary operator (`&&`, `||`, `??`) precedence<br /><br />`never_if_unnecessary` - Prefer to not have parentheses when other binary operator (`&&`, `||`, `??`) precedence is obvious |
-| **Default option value** | `always_for_clarity` |
+| Property                 | Value                                              | Description                                                                     |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_parentheses_in_other_binary_operators |                                                                                 |
+| **Option values**        | `always_for_clarity`                               | Prefer parentheses to clarify other binary operator precedence                  |
+|                          | `never_if_unnecessary`                             | Prefer to not have parentheses when other binary operator precedence is obvious |
+| **Default option value** | `always_for_clarity`                               |                                                                                 |
 
-### Example
+The other binary operators are: `&&`, `||`, and `??`.
 
 ```csharp
 // dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
@@ -116,15 +147,20 @@ Dim v = a OrElse (b AndAlso c)
 Dim v = a OrElse b AndAlso c
 ```
 
-## dotnet_style_parentheses_in_other_operators
+### dotnet_style_parentheses_in_other_operators
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_parentheses_in_other_operators |
-| **Option values** | `always_for_clarity` - Prefer parentheses to clarify operator precedence<br /><br />`never_if_unnecessary` - Prefer to not have parentheses when operator precedence is obvious |
-| **Default option value** | `never_if_unnecessary` |
+| Property                 | Value                                       | Description                                                              |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------------------------------ |
+| **Option name**          | dotnet_style_parentheses_in_other_operators |                                                                          |
+| **Option values**        | `always_for_clarity`                        | Prefer parentheses to clarify other operator precedence                  |
+|                          | `never_if_unnecessary`                      | Prefer to not have parentheses when other operator precedence is obvious |
+| **Default option value** | `never_if_unnecessary`                      |                                                                          |
 
-### Example
+This option applies to operators *other than* the following:
+
+`*`, `/`, `%`, `+`, `-`, `<<`, `>>`, `&`, `^`, `|`
+`>`, `<`, `<=`, `>=`, `is`, `as`, `==`, `!=`
+`&&`, `||`, `??`
 
 ```csharp
 // dotnet_style_parentheses_in_other_operators = always_for_clarity
@@ -144,7 +180,7 @@ Dim v = a.b.Length
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0047 // Or IDE0048
@@ -160,7 +196,7 @@ dotnet_diagnostic.IDE0047.severity = none
 dotnet_diagnostic.IDE0048.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0049.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0049.md
@@ -19,27 +19,36 @@ dev_langs:
 ---
 # Use language keywords instead of framework type names for type references (IDE0049)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0049 |
-| **Title** | Use language keywords instead of framework type names for type references |
-| **Category** | Style |
-| **Subcategory** | Language rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                                                     |
+| ------------------------ | ------------------------------------------------------------------------- |
+| **Rule ID**              | IDE0049                                                                   |
+| **Title**                | Use language keywords instead of framework type names for type references |
+| **Category**             | Style                                                                     |
+| **Subcategory**          | Language rules                                                            |
+| **Applicable languages** | C# and Visual Basic                                                       |
+| **Options**              | `dotnet_style_predefined_type_for_locals_parameters_members`              |
 
 ## Overview
 
-This style rule can be applied to local variables, method parameters, and class members, or as a separate rule to type-member access expressions. A value of **true** means prefer the language keyword (for example, `int` or `Integer`) instead of the type name (for example, `Int32`) for types that have a keyword to represent them. A value of **false** means prefer the type name instead of the language keyword.
+This rule concerns the use of language keywords, [where they exist](../../../csharp/language-reference/builtin-types/built-in-types.md), instead of framework type names.
 
-## dotnet_style_predefined_type_for_locals_parameters_members
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_predefined_type_for_locals_parameters_members |
-| **Option values** | `true` - Prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them<br /><br />`false` - Prefer the type name for local variables, method parameters, and class members, instead of the language keyword |
-| **Default option value** | `true` |
+Use the associated options for this rule to apply it to:
 
-### Example
+- Local variables, method parameters, and class members - [dotnet_style_predefined_type_for_locals_parameters_members](#dotnet_style_predefined_type_for_locals_parameters_members)
+- Type-member access expressions - [dotnet_style_predefined_type_for_member_access](#dotnet_style_predefined_type_for_member_access)
+
+An option value of `true` means prefer the language keyword (for example, `int` or `Integer`) instead of the type name (for example, `Int32`) for types that have a keyword to represent them. A value of `false` means prefer the type name instead of the language keyword.
+
+### dotnet_style_predefined_type_for_locals_parameters_members
+
+| Property                 | Value                                                      | Description                                                                           |
+| ------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_predefined_type_for_locals_parameters_members |                                                                                       |
+| **Option values**        | `true`                                                     | Prefer the language keyword for local variables, method parameters, and class members |
+|                          | `false`                                                    | Prefer the type name for local variables, method parameters, and class members        |
+| **Default option value** | `true`                                                     |                                                                                       |
 
 ```csharp
 // dotnet_style_predefined_type_for_locals_parameters_members = true
@@ -59,13 +68,12 @@ Private _member As Int32
 
 ## dotnet_style_predefined_type_for_member_access
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_predefined_type_for_member_access |
-| **Option values** | `true` - Prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them<br /><br />`false` - Prefer the type name for member access expressions, instead of the language keyword |
-| **Default option value** | `true` |
-
-### Example
+| Property                 | Value                                          | Description                                               |
+| ------------------------ | ---------------------------------------------- | --------------------------------------------------------- |
+| **Option name**          | dotnet_style_predefined_type_for_member_access |                                                           |
+| **Option values**        | `true`                                         | Prefer the language keyword for member access expressions |
+|                          | `false`                                        | Prefer the type name for member access expressions        |
+| **Default option value** | `true`                                         |                                                           |
 
 ```csharp
 // dotnet_style_predefined_type_for_member_access = true
@@ -85,7 +93,7 @@ Dim local = Int32.MaxValue
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0049
@@ -100,7 +108,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0049.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0050.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0050.md
@@ -18,17 +18,19 @@ dev_langs:
 > [!IMPORTANT]
 > This style rule was removed and converted to a Visual Studio refactoring in Visual Studio 2022. For information about the refactoring, see [Convert anonymous type to tuple](/visualstudio/ide/reference/convert-anonymous-type-to-tuple).
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0050 |
-| **Title** | Convert anonymous type to tuple |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                         |
+|--------------------------|-----------------------------------------------|
+| **Rule ID**              | IDE0050                                       |
+| **Title**                | Convert anonymous type to tuple               |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
 
 ## Overview
 
-This rule recommends use of [tuples](../../../csharp/language-reference/builtin-types/value-tuples.md) over [anonymous types](../../../csharp/fundamentals/types/anonymous-types.md), when the anonymous type has two or more fields. This rule has no associated code style option.
+This rule recommends use of [tuples](../../../csharp/language-reference/builtin-types/value-tuples.md) over [anonymous types](../../../csharp/fundamentals/types/anonymous-types.md), when the anonymous type has two or more fields.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -50,7 +52,7 @@ Dim t1 = (a:=1, b:=2)
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0050
@@ -65,7 +67,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0050.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0051.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0051.md
@@ -15,17 +15,19 @@ dev_langs:
 ---
 # Remove unused private member (IDE0051)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0051 |
-| **Title** | Remove unused private member |
-| **Category** | CodeQuality |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                        |
+|--------------------------|------------------------------|
+| **Rule ID**              | IDE0051                      |
+| **Title**                | Remove unused private member |
+| **Category**             | CodeQuality                  |
+| **Subcategory**          | Unnecessary code rules       |
+| **Applicable languages** | C# and Visual Basic          |
 
 ## Overview
 
-This rule flags unused private methods, fields, properties and events which have no read or write references. This rule has no associated code style option.
+This rule flags unused private methods, fields, properties, and events that have no read or write references.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -62,7 +64,7 @@ class C
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0051

--- a/docs/fundamentals/code-analysis/style-rules/ide0052.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0052.md
@@ -15,17 +15,19 @@ dev_langs:
 ---
 # Remove unread private member (IDE0052)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0052 |
-| **Title** | Remove unread private member |
-| **Category** | CodeQuality |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                        |
+|--------------------------|------------------------------|
+| **Rule ID**              | IDE0052                      |
+| **Title**                | Remove unread private member |
+| **Category**             | CodeQuality                  |
+| **Subcategory**          | Unnecessary code rules       |
+| **Applicable languages** | C# and Visual Basic          |
 
 ## Overview
 
-This rule flags private fields and properties which have one or more write references, but no read references. This indicates that some parts of code can be refactored or removed to fix maintainability, performance or functional issues. This rule has no associated code style option.
+This rule flags private fields and properties that have one or more write references but no read references. In this scenario, some parts of the code can be refactored or removed to fix maintainability, performance, or functional issues.
+
+This rule has no associated code-style options.
 
 ## Example
 
@@ -65,7 +67,7 @@ class C
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0052

--- a/docs/fundamentals/code-analysis/style-rules/ide0053.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0053.md
@@ -16,27 +16,30 @@ dev_langs:
 ---
 # Use expression body for lambdas (IDE0053)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0053 |
-| **Title** | Use expression body for lambdas |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-bodied members) |
-| **Applicable languages** | C# 7.0+ |
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE0053                                    |
+| **Title**                | Use expression body for lambdas            |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (expression-bodied members) |
+| **Applicable languages** | C# 7.0+                                    |
+| **Options**              | `csharp_style_expression_bodied_lambdas`   |
 
 ## Overview
 
-This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for lambdas.
+This style rule concerns the use of [expression bodies](../../../csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) versus block bodies for [lambda expressions](../../../csharp/language-reference/operators/lambda-expressions.md).
 
-## csharp_style_expression_bodied_lambdas
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_expression_bodied_lambdas
-| **Option values** | `true` - Prefer expression bodies for lambdas<br /><br />`when_on_single_line` - Prefer expression bodies for lambdas when they will be a single line<br /><br />`false` - Prefer block bodies for lambdas |
-| **Default option value** | `true` |
+### csharp_style_expression_bodied_lambdas
 
-#### Example
+| Property                 | Value                                  | Description                                                        |
+| ------------------------ | -------------------------------------- | ------------------------------------------------------------------ |
+| **Option name**          | csharp_style_expression_bodied_lambdas |                                                                    |
+| **Option values**        | `true`                                 | Prefer expression bodies for lambdas                               |
+|                          | `when_on_single_line`                  | Prefer expression bodies for lambdas when they'll be a single line |
+|                          | `false`                                | Prefer block bodies for lambdas                                    |
+| **Default option value** | `true`                                 |                                                                    |
 
 ```csharp
 // csharp_style_expression_bodied_lambdas = true
@@ -48,7 +51,7 @@ Func<int, int> square = x => { return x * x; };
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0053
@@ -63,7 +66,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0053.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0054-ide0074.md
@@ -19,27 +19,42 @@ dev_langs:
 ---
 # Use compound assignment (IDE0054 and IDE0074)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0054 and IDE0074 |
-| **Title** | IDE0054: Use compound assignment<br/> IDE0074: Use coalesce compound assignment |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# and Visual Basic |
+This article describes two related rules, `IDE0054` and `IDE0074`.
+
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0054                                       |
+| **Title**                | Use compound assignment                       |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
+| **Options**              | `dotnet_style_prefer_compound_assignment`     |
+
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0074                                       |
+| **Title**                | Use coalesce compound assignment              |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# and Visual Basic                           |
+| **Options**              | `dotnet_style_prefer_compound_assignment`     |
 
 ## Overview
 
-This style rule concerns with the use of compound assignments. The option value specifies whether or not they are desired. `IDE0074` is reported for coalesce compound assignments and `IDE0054` for other compound assignments.
+These rules concern the use of [compound assignment](../../../csharp/language-reference/operators/assignment-operator.md#compound-assignment). `IDE0074` is reported for coalesce compound assignments and `IDE0054` is reported for other compound assignments.
 
-## dotnet_style_prefer_compound_assignment
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | dotnet_style_prefer_compound_assignment
-| **Option values** | `true` - Prefer [compound assignment](../../../csharp/language-reference/operators/assignment-operator.md#compound-assignment) expressions<br /><br />`false` - Don't prefer compound assignment expressions |
-| **Default option value** | `true` |
+The option value specifies whether or not compound assignments are desired.
 
-### Example
+### dotnet_style_prefer_compound_assignment
+
+| Property                 | Value                                   | Description                                  |
+| ------------------------ | --------------------------------------- | -------------------------------------------- |
+| **Option name**          | dotnet_style_prefer_compound_assignment |                                              |
+| **Option values**        | `true`                                  | Prefer compound assignment expressions       |
+|                          | `false`                                 | Don't prefer compound assignment expressions |
+| **Default option value** | `true`                                  |                                              |
 
 ```csharp
 // dotnet_style_prefer_compound_assignment = true
@@ -59,7 +74,7 @@ x = x + 5
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0054 // Or IDE0074
@@ -75,7 +90,7 @@ dotnet_diagnostic.IDE0054.severity = none
 dotnet_diagnostic.IDE0074.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0056.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0056.md
@@ -16,27 +16,29 @@ dev_langs:
 ---
 # Use index operator (IDE0056)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0056 |
-| **Title** | Use index operator |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 8.0+ |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0056                                       |
+| **Title**                | Use index operator                            |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# 8.0+                                       |
+| **Options**              | `csharp_style_prefer_index_operator`          |
 
 ## Overview
 
-This style rule concern the use of the [index-from-end operator](../../../csharp/language-reference/operators/member-access-operators.md#index-from-end-operator-), which is available in C# 8.0 and later.
+This style rule concerns the use of the [index-from-end operator (`^`)](../../../csharp/language-reference/operators/member-access-operators.md#index-from-end-operator-), which is available in C# 8.0 and later.
 
-## csharp_style_prefer_index_operator
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_prefer_index_operator
-| **Option values** | `true` - Prefer to use the `^` operator when calculating an index from the end of a collection<br /><br />`false` - Don't prefer to use the `^` operator when calculating an index from the end of a collection |
-| **Default option value** | `true` |
+### csharp_style_prefer_index_operator
 
-#### Example
+| Property                 | Value                              | Description                                                                               |
+| ------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Option name**          | csharp_style_prefer_index_operator |                                                                                           |
+| **Option values**        | `true`                             | Prefer to use the `^` operator when calculating an index from the end of a collection     |
+|                          | `false`                            | Prefer not to use the `^` operator when calculating an index from the end of a collection |
+| **Default option value** | `true`                             |                                                                                           |
 
 ```csharp
 // csharp_style_prefer_index_operator = true
@@ -50,7 +52,7 @@ var index = names[names.Length - 1];
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0056
@@ -65,7 +67,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0056.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0057.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0057.md
@@ -16,27 +16,29 @@ dev_langs:
 ---
 # Use range operator (IDE0057)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0057 |
-| **Title** | Use range operator |
-| **Category** | Style |
-| **Subcategory** | Language rules (expression-level preferences) |
-| **Applicable languages** | C# 8.0+ |
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0057                                       |
+| **Title**                | Use range operator                            |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C# 8.0+                                       |
+| **Options**              | `csharp_style_prefer_range_operator`          |
 
 ## Overview
 
-This style rule concern the use of the [range operator](../../../csharp/language-reference/operators/member-access-operators.md#range-operator-), which is available in C# 8.0 and later.
+This style rule concerns the use of the [range operator (`..`)](../../../csharp/language-reference/operators/member-access-operators.md#range-operator-), which is available in C# 8.0 and later.
 
-## csharp_style_prefer_range_operator
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_prefer_range_operator
-| **Option values** | `true` - Prefer to use the range operator `..` when extracting a "slice" of a collection<br /><br />`false` - Don't prefer to use the range operator `..` when extracting a "slice" of a collection |
-| **Default option value** | `true` |
+### csharp_style_prefer_range_operator
 
-#### Example
+| Property                 | Value                              | Description                                                                           |
+| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| **Option name**          | csharp_style_prefer_range_operator |                                                                                       |
+| **Option values**        | `true`                             | Prefer to use the range operator `..` when extracting a "slice" of a collection       |
+|                          | `false`                            | Prefer *not* to use the range operator `..` when extracting a "slice" of a collection |
+| **Default option value** | `true`                             |                                                                                       |
 
 ```csharp
 // csharp_style_prefer_range_operator = true
@@ -50,7 +52,7 @@ var sub = sentence.Substring(0, sentence.Length - 4);
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0057
@@ -65,7 +67,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0057.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0058.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0058.md
@@ -19,13 +19,15 @@ dev_langs:
 ---
 # Remove unnecessary expression value (IDE0058)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0058 |
-| **Title** | Remove unnecessary expression value |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                                             |
+| ------------------------ | ----------------------------------------------------------------- |
+| **Rule ID**              | IDE0058                                                           |
+| **Title**                | Remove unnecessary expression value                               |
+| **Category**             | Style                                                             |
+| **Subcategory**          | Unnecessary code rules                                            |
+| **Applicable languages** | C# and Visual Basic                                               |
+| **Options**              | `csharp_style_unused_value_expression_statement_preference`       |
+|                          | `visual_basic_style_unused_value_expression_statement_preference` |
 
 ## Overview
 
@@ -40,26 +42,32 @@ void M()
 int Compute();
 ```
 
-Users can take one of the following actions to fix this violation:
+You can take one of the following actions to fix this violation:
 
 - If the expression has no side effects, remove the entire statement. This improves performance by avoiding unnecessary computation.
 
-- If the expression has side effects, replace the left side of the assignment with a [discard](../../../csharp/fundamentals/functional/discards.md) or a local variable that's never used. This improves code clarity and explicit intent of discarding an unused value. The option for this rule concerns the use of a discard versus unused local variable.
+- If the expression has side effects, replace the left side of the assignment with a [discard](../../../csharp/fundamentals/functional/discards.md) (C# only) or a local variable that's never used. This improves code clarity by explicitly showing the intent to discard an unused value.
 
   ```csharp
   _ = Compute();
   ```
 
-## csharp_style_unused_value_expression_statement_preference
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_unused_value_expression_statement_preference
-| **Applicable languages** | C# |
-| **Option values** | `discard_variable` - Prefer to assign an unused expression to a [discard](../../../csharp/fundamentals/functional/discards.md) <br /><br />`unused_local_variable` - Prefer to assign an unused expression to a local variable that is never used |
-| **Default option value** | `discard_variable` |
+The options for this specify whether to prefer the use of a discard or an unused local variable:
 
-### Example
+- C# - [csharp_style_unused_value_expression_statement_preference](#csharp_style_unused_value_expression_statement_preference)
+- Visual Basic - [visual_basic_style_unused_value_expression_statement_preference](#visual_basic_style_unused_value_expression_statement_preference)
+
+### csharp_style_unused_value_expression_statement_preference
+
+| Property                 | Value                                                     | Description                                                                 |
+| ------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Option name**          | csharp_style_unused_value_expression_statement_preference |                                                                             |
+| **Applicable languages** | C#                                                        |                                                                             |
+| **Option values**        | `discard_variable`                                        | Prefer to assign an unused expression to a discard                          |
+|                          | `unused_local_variable`                                   | Prefer to assign an unused expression to a local variable that's never used |
+| **Default option value** | `discard_variable`                                        |                                                                             |
 
 ```csharp
 // Original code:
@@ -74,16 +82,14 @@ _ = System.Convert.ToInt32("35");
 var unused = Convert.ToInt32("35");
 ```
 
-## visual_basic_style_unused_value_expression_statement_preference
+### visual_basic_style_unused_value_expression_statement_preference
 
-|Property|Value|
-|-|-|
-| **Option name** | visual_basic_style_unused_value_expression_statement_preference
-| **Applicable languages** | Visual Basic |
-| **Option values** | `unused_local_variable` - Prefer to assign an unused expression to a local variable that is never used |
-| **Default option value** | `unused_local_variable` |
-
-### Example
+| Property                 | Value                                                           | Description                                                                 |
+| ------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Option name**          | visual_basic_style_unused_value_expression_statement_preference |                                                                             |
+| **Applicable languages** | Visual Basic                                                    |                                                                             |
+| **Option values**        | `unused_local_variable`                                         | Prefer to assign an unused expression to a local variable that's never used |
+| **Default option value** | `unused_local_variable`                                         |                                                                             |
 
 ```vb
 ' visual_basic_style_unused_value_expression_statement_preference = unused_local_variable
@@ -92,7 +98,7 @@ Dim unused = Computation()
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0058
@@ -107,7 +113,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0058.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide0059.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0059.md
@@ -19,13 +19,15 @@ dev_langs:
 ---
 # Remove unnecessary value assignment (IDE0059)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE0059 |
-| **Title** | Remove unnecessary value assignment |
-| **Category** | Style |
-| **Subcategory** | Unnecessary code rules |
-| **Applicable languages** | C# and Visual Basic |
+| Property                 | Value                                                   |
+| ------------------------ | ------------------------------------------------------- |
+| **Rule ID**              | IDE0059                                                 |
+| **Title**                | Remove unnecessary value assignment                     |
+| **Category**             | Style                                                   |
+| **Subcategory**          | Unnecessary code rules                                  |
+| **Applicable languages** | C# and Visual Basic                                     |
+| **Options**              | `csharp_style_unused_value_assignment_preference`       |
+|                          | `visual_basic_style_unused_value_assignment_preference` |
 
 ## Overview
 
@@ -44,23 +46,29 @@ Users can take one of the following actions to fix this violation:
   int v = Compute2();
   ```
 
-- If the expression on the right side of the assignment has side effects, replace the left side of the assignment with a [discard](../../../csharp/fundamentals/functional/discards.md) or a local variable that's never used. This improves code clarity and explicit intent of discarding an unused value. The option for this rule concerns the use of a discard versus unused local variable.
+- If the expression on the right side of the assignment has side effects, replace the left side of the assignment with a [discard](../../../csharp/fundamentals/functional/discards.md) (C# only) or a local variable that's never used. This improves code clarity by explicitly showing the intent to discard an unused value.
 
   ```csharp
   _ = Compute();
   int v = Compute2();
   ```
 
-## csharp_style_unused_value_assignment_preference
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_unused_value_assignment_preference
-| **Applicable languages** | C# |
-| **Option values** | `discard_variable` - Prefer to use a [discard](../../../csharp/fundamentals/functional/discards.md) when assigning a value that's not used<br /><br />`unused_local_variable` - Prefer to use a local variable when assigning a value that's not used |
-| **Default option value** | `discard_variable` |
+The options for this specify whether to prefer the use of a discard or an unused local variable:
 
-### Example
+- C# - [csharp_style_unused_value_assignment_preference](#csharp_style_unused_value_assignment_preference)
+- Visual Basic - [visual_basic_style_unused_value_assignment_preference](#visual_basic_style_unused_value_assignment_preference)
+
+### csharp_style_unused_value_assignment_preference
+
+| Property                 | Value                                           | Description                                                           |
+| ------------------------ | ----------------------------------------------- | --------------------------------------------------------------------- |
+| **Option name**          | csharp_style_unused_value_assignment_preference |                                                                       |
+| **Applicable languages** | C#                                              |                                                                       |
+| **Option values**        | `discard_variable`                              | Prefer to use a discard when assigning a value that's not used        |
+|                          | `unused_local_variable`                         | Prefer to use a local variable when assigning a value that's not used |
+| **Default option value** | `discard_variable`                              |                                                                       |
 
 ```csharp
 // csharp_style_unused_value_assignment_preference = discard_variable
@@ -78,16 +86,14 @@ int GetCount(Dictionary<string, int> wordCount, string searchWord)
 }
 ```
 
-## visual_basic_style_unused_value_assignment_preference
+### visual_basic_style_unused_value_assignment_preference
 
-|Property|Value|
-|-|-|
-| **Option name** | visual_basic_style_unused_value_assignment_preference
-| **Applicable languages** | Visual Basic |
-| **Option values** | `unused_local_variable` - Prefer to use a local variable when assigning a value that's not used |
-| **Default option value** | `unused_local_variable` |
-
-### Example
+| Property                 | Value                                                 | Description                                                           |
+| ------------------------ | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| **Option name**          | visual_basic_style_unused_value_assignment_preference |                                                                       |
+| **Applicable languages** | Visual Basic                                          |                                                                       |
+| **Option values**        | `unused_local_variable`                               | Prefer to use a local variable when assigning a value that's not used |
+| **Default option value** | `unused_local_variable`                               |                                                                       |
 
 ```vb
 ' visual_basic_style_unused_value_assignment_preference = unused_local_variable
@@ -96,7 +102,7 @@ Dim unused = Computation()
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE0059
@@ -111,7 +117,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE0059.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]

--- a/docs/fundamentals/code-analysis/style-rules/ide1005.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide1005.md
@@ -16,27 +16,29 @@ dev_langs:
 ---
 # Use conditional delegate call (IDE1005)
 
-|Property|Value|
-|-|-|
-| **Rule ID** | IDE1005 |
-| **Title** | Use conditional delegate call |
-| **Category** | Style |
-| **Subcategory** | Language rules (null-checking preferences) |
-| **Applicable languages** | C# 6.0+ |
+| Property                 | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| **Rule ID**              | IDE1005                                    |
+| **Title**                | Use conditional delegate call              |
+| **Category**             | Style                                      |
+| **Subcategory**          | Language rules (null-checking preferences) |
+| **Applicable languages** | C# 6.0+                                    |
+| **Options**              | `csharp_style_conditional_delegate_call`   |
 
 ## Overview
 
-This style rule concerns the use of the [null-conditional operator](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-) (`?.`) when invoking a lambda expression, instead of performing a null check.
+This style rule concerns the use of the [null-conditional operator](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-) (`?.`) when invoking a lambda expression, as opposed to performing a null check.
 
-## csharp_style_conditional_delegate_call
+## Options
 
-|Property|Value|
-|-|-|
-| **Option name** | csharp_style_conditional_delegate_call
-| **Option values** | `true` - Prefer to use the conditional coalescing operator (`?.`) when invoking a lambda expression, instead of performing a null check<br /><br />`false` - Prefer to perform a null check before invoking a lambda expression, instead of using the conditional coalescing operator (`?.`) |
-| **Default option value** | `true` |
+### csharp_style_conditional_delegate_call
 
-### Example
+| Property                 | Value                                  | Description                                                                                |
+| ------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Option name**          | csharp_style_conditional_delegate_call |                                                                                            |
+| **Option values**        | `true`                                 | Prefer to use the conditional coalescing operator (`?.`) when invoking a lambda expression |
+|                          | `false`                                | Prefer to perform a null check before invoking a lambda expression                         |
+| **Default option value** | `true`                                 |                                                                                            |
 
 ```csharp
 // csharp_style_conditional_delegate_call = true
@@ -48,7 +50,7 @@ if (func != null) { func(args); }
 
 ## Suppress a warning
 
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
 #pragma warning disable IDE1005
@@ -63,7 +65,7 @@ To disable the rule for a file, folder, or project, set its severity to `none` i
 dotnet_diagnostic.IDE1005.severity = none
 ```
 
-To disable this entire category of rules, set the severity for the category to `none` in the [configuration file](../configuration-files.md).
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]


### PR DESCRIPTION
Improves the options formatting for each rule and also lists all the options in the overview table.
Adds links to related topics.

Part 2 of 3 (see #29913).

Contributes to #24437.

Hide white space changes in diff.