### PR TITLE
Improve dotnet nuget push to Azure DevOps Artifacts documentation

### DIFF
--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -55,7 +55,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - **`-k|--api-key <API_KEY>`**
 
   The API key for the server.
-  - Azure Artifacts feeds do not accept a personal access token (PAT) specified by this command-line argument. When using a local development environment, you must have the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) installed which provides authentication when pushing or downloading packages (see examples section). For hosted builds that interfact with Azure Artifacts feeds, you must use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate) task.
+  - Azure Artifacts feeds do not accept a personal access token (PAT) specified by this command-line argument. When using a local development environment, you must have the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) installed which provides authentication when pushing or downloading packages (see examples section). For Azure hosted builds that interfact with Azure Artifacts feeds, you must use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate) task.
 
 - **`-n|--no-symbols`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -55,7 +55,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - **`-k|--api-key <API_KEY>`**
 
   The API key for the server.
-  - Azure DevOps Artifacts feeds doesn't accept PAT(personal access tokens) passed directly in cli as `API_KEY`. For dev box, you need have the [cred provider](https://github.com/microsoft/artifacts-credprovider) installed and that would work for both push and download (see examples section). For CI, you need use the [NuGet Authenticate](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for pushing to Azure DevOps Artifacts.
+  - Azure DevOps Artifacts feeds doesn't accept PAT(personal access tokens) passed directly in cli as `API_KEY`. For dev box, you need have the [cred provider](https://github.com/microsoft/artifacts-credprovider) installed and that would work for both push and download (see examples section). For CI, you need use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for pushing to Azure DevOps Artifacts.
 
 - **`-n|--no-symbols`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -55,7 +55,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - **`-k|--api-key <API_KEY>`**
 
   The API key for the server.
-  - Azure DevOps Artifacts feeds doesn't accept PAT(personal access tokens) passed directly in cli as `API_KEY`. For dev box, you need have the [cred provider](https://github.com/microsoft/artifacts-credprovider) installed and that would work for both push and download (see examples section). For CI, you need use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for pushing to Azure DevOps Artifacts.
+  - Azure Artifacts feeds do not accept a personal access token (PAT) specified by this command-line argument. When using a local development environment, you must have the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) installed which provides authentication when pushing or downloading packages (see examples section). For hosted builds that interfact with Azure Artifacts feeds, you must use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate) task.
 
 - **`-n|--no-symbols`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -156,7 +156,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push MyPackage.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
   ```
   
-- In the example below "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
+- In the example below, pushing "MyPackage" version "1.1.5" to an Azure Artifacts feed from a hosted build, the API key "AZ" is only used as a placeholder. An Azure Artifacts feed still requires your pipeline to use the [NuGet Authenticate task](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops).
 
   ```bashcli
     - task: NuGetAuthenticate@1

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -153,7 +153,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - In the example below, pushing "MyPackage" version "5.0.2" to an Azure Artifacts feed from a local development environment, the API key "AZ" is only used as a placeholder. An Azure Artifacts feed still requires the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) to be installed to properly authenticate.
 
   ```dotnetcli
-  dotnet nuget push Foo.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+  dotnet nuget push MyPackage.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
   ```
   
 - In the example below "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -157,7 +157,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   
 - In the example below pushing nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
-  ```bash
+  ```bashcli
     - task: NuGetAuthenticate@1
       inputs:
         nuGetServiceConnections: MyServiceConnection_ExternalServer

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -164,7 +164,7 @@ The command pushes an existing package. It doesn't create a package. To create a
         nuGetServiceConnections: MyServiceConnection_ExternalServer
         
     - bash: |
-        dotnet build foo/foo.csproj -c Release
+        dotnet build mypackage/mypackage.csproj -c Release
         dotnet pack foo/foo.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
         dotnet nuget push nupkgs/foo.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
       displayName: "Pack and push"          

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -55,6 +55,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - **`-k|--api-key <API_KEY>`**
 
   The API key for the server.
+  - Azure DevOps Artifacts feeds doesn't accept PAT(personal access tokens) passed directly in cli as `API_KEY`. For dev box, you need have the [cred provider](https://github.com/microsoft/artifacts-credprovider) installed and that would work for both push and download (see examples section). For CI, you need use the [NuGet Authenticate](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for pushing to Azure DevOps Artifacts.
 
 - **`-n|--no-symbols`**
 
@@ -148,5 +149,22 @@ The command pushes an existing package. It doesn't create a package. To create a
   ```dotnetcli
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
+- In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
+```dotnetcli
+nuget push Foo.5.0.2.nupkg -src https://dev.azure.com/yourAzureDevOpsFeed/nuget/v3/index.json AZ
+```
+
+- In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
+
+```dotnetcli
+  - task: NuGetAuthenticate@1
+    inputs:
+      nuGetServiceConnections: MyServiceConnection_ExternalServer
+
+  - powershell: |
+      nuget push *.nupkg -source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json AZ
+    displayName: "Push"
+```
+                
   This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -165,7 +165,7 @@ The command pushes an existing package. It doesn't create a package. To create a
         
     - bash: |
         dotnet build mypackage/mypackage.csproj -c Release
-        dotnet pack foo/foo.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
+        dotnet pack mypackage/mypackage.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
         dotnet nuget push nupkgs/foo.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
       displayName: "Pack and push"          
   ```

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,6 +149,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   ```dotnetcli
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
+  
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
   ```dotnetcli

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -151,20 +151,20 @@ The command pushes an existing package. It doesn't create a package. To create a
   ```
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
-```dotnetcli
-dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
-```
-
+  ```dotnetcli
+  dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+  ```
+  
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
-```dotnetcli
-  - task: NuGetAuthenticate@1
-    inputs:
-      nuGetServiceConnections: MyServiceConnection_ExternalServer
+  ```dotnetcli
+    - task: NuGetAuthenticate@1
+      inputs:
+        nuGetServiceConnections: MyServiceConnection_ExternalServer
 
-  - powershell: |
-     dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
-    displayName: "Push package"
-```
-                
+    - powershell: |
+        dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+      displayName: "Push package"
+  ```
+
   This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -54,7 +54,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`-k|--api-key <API_KEY>`**
 
-The API key for the server.
+- The API key for the server.
 
 - **`-n|--no-symbols`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,13 +149,13 @@ The command pushes an existing package. It doesn't create a package. To create a
   ```dotnetcli
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
-- In the example below pushing nupkgs to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
+- In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
   ```dotnetcli
-  dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+  dotnet nuget push Foo.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
   ```
   
-- In the example below pushing nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
+- In the example belowg "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
   ```bashcli
     - task: NuGetAuthenticate@1
@@ -163,9 +163,9 @@ The command pushes an existing package. It doesn't create a package. To create a
         nuGetServiceConnections: MyServiceConnection_ExternalServer
         
     - bash: |
-        dotnet build src/src.csproj -c Release
-        dotnet pack src/src.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
-        dotnet nuget push nupkgs/src.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+        dotnet build foo/foo.csproj -c Release
+        dotnet pack foo/foo.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
+        dotnet nuget push nupkgs/foo.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
       displayName: "Pack and push"          
   ```
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,4 +149,4 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- For Azure Artifacts push examples, see [Azure Artifacts' examples](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).
+- For pushing to Azure Artifacts, [see Azure Artifacts' push documentation](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,4 +149,4 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- For Azure DevOps Artifacts related push examples, see [Azure Devops examples](https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).
+- For Azure DevOps Artifacts push examples, see [Azure Devops examples](https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,22 +149,24 @@ The command pushes an existing package. It doesn't create a package. To create a
   ```dotnetcli
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
-- In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
+- In the example below pushing nupkgs to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
   ```dotnetcli
   dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
   ```
   
-- In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
+- In the example below pushing nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
   ```dotnetcli
     - task: NuGetAuthenticate@1
       inputs:
         nuGetServiceConnections: MyServiceConnection_ExternalServer
-
-    - powershell: |
-        dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
-      displayName: "Push package"
+        
+    - bash: |
+        dotnet build src/src.csproj -c Release
+        dotnet pack src/src.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
+        dotnet nuget push nupkgs/src.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+      displayName: "Pack and push"          
   ```
 
   This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,6 +149,6 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- For pushing to Azure Artifacts, [see Azure Artifacts' push documentation](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).
+- For pushing to Azure Artifacts, [see Azure Artifacts' push documentation](/azure/devops/artifacts/nuget/dotnet-exe#examples).
 
   This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -155,7 +155,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push Foo.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
   ```
   
-- In the example belowg "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
+- In the example below "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
   ```bashcli
     - task: NuGetAuthenticate@1

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,4 +149,4 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- For Azure Artifacts push examples, see [Azure Devops examples](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).
+- For Azure Artifacts push examples, see [Azure Artifacts' examples](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -55,7 +55,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - **`-k|--api-key <API_KEY>`**
 
   The API key for the server.
-  - Azure DevOps Artifacts feeds doesn't accept PAT(personal access tokens) passed directly in cli as `API_KEY`. For dev box, you need have the [cred provider](https://github.com/microsoft/artifacts-credprovider) installed and that would work for both push and download (see examples section). For CI, you need use the [NuGet Authenticate](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for pushing to Azure DevOps Artifacts.
+  - Azure DevOps Artifacts feeds doesn't accept PAT(personal access tokens) passed directly in cli as `API_KEY`. For dev box, you need have the [cred provider](https://github.com/microsoft/artifacts-credprovider) installed and that would work for both push and download (see examples section). For CI, you need use the [NuGet Authenticate](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for pushing to Azure DevOps Artifacts.
 
 - **`-n|--no-symbols`**
 
@@ -155,7 +155,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push Foo.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
   ```
   
-- In the example below "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
+- In the example below "Foo" version "1.1.5" nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
   ```bashcli
     - task: NuGetAuthenticate@1

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -163,8 +163,8 @@ nuget push Foo.5.0.2.nupkg -src https://dev.azure.com/yourAzureDevOpsFeed/nuget/
       nuGetServiceConnections: MyServiceConnection_ExternalServer
 
   - powershell: |
-      nuget push *.nupkg -source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json AZ
-    displayName: "Push"
+     dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k Az
+    displayName: "Push package"
 ```
                 
   This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -152,7 +152,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
 ```dotnetcli
-nuget push Foo.5.0.2.nupkg -src https://dev.azure.com/yourAzureDevOpsFeed/nuget/v3/index.json AZ
+dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k Az
 ```
 
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -157,7 +157,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   
 - In the example below pushing nupkg to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
 
-  ```dotnetcli
+  ```bash
     - task: NuGetAuthenticate@1
       inputs:
         nuGetServiceConnections: MyServiceConnection_ExternalServer

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -56,6 +56,8 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`-n|--no-symbols`**
 
+The API key for the server.
+
   Doesn't push symbols (even if present).
 
 - **`--no-service-endpoint`**

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -152,7 +152,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
 
 ```dotnetcli
-dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k Az
+dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
 ```
 
 - In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from CI, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely. You need to setup [NuGet Authenticate task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) with [NuGet service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#nuget-service-connection) for authenticate with external Azure DevOps Artifacts server.
@@ -163,7 +163,7 @@ dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{pr
       nuGetServiceConnections: MyServiceConnection_ExternalServer
 
   - powershell: |
-     dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k Az
+     dotnet nuget push *.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
     displayName: "Push package"
 ```
                 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -150,7 +150,7 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- In the example below pushing "Foo" version "5.0.2" to Azure DevOps Artifacts from dev box, here AZ is just a placeholder for ApiKey, this prevents authentication fail prematurely, in order to authentication to work you need to install [cred provider](https://github.com/microsoft/artifacts-credprovider). Below command trigger open Cred Provider window if authentication is necessary, it's suitable for pushing from dev box, but not for CI.
+- In the example below, pushing "MyPackage" version "5.0.2" to an Azure Artifacts feed from a local development environment, the API key "AZ" is only used as a placeholder. An Azure Artifacts feed still requires the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) to be installed to properly authenticate.
 
   ```dotnetcli
   dotnet nuget push Foo.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -149,4 +149,4 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- For Azure DevOps Artifacts push examples, see [Azure Devops examples](https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).
+- For Azure Artifacts push examples, see [Azure Devops examples](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -166,7 +166,7 @@ The command pushes an existing package. It doesn't create a package. To create a
     - bash: |
         dotnet build mypackage/mypackage.csproj -c Release
         dotnet pack mypackage/mypackage.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
-        dotnet nuget push nupkgs/foo.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
+        dotnet nuget push nupkgs/mypackage.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
       displayName: "Pack and push"          
   ```
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -54,9 +54,9 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`-k|--api-key <API_KEY>`**
 
-- **`-n|--no-symbols`**
-
 The API key for the server.
+
+- **`-n|--no-symbols`**
 
   Doesn't push symbols (even if present).
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -54,9 +54,6 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`-k|--api-key <API_KEY>`**
 
-  The API key for the server.
-  - Azure Artifacts feeds do not accept a personal access token (PAT) specified by this command-line argument. When using a local development environment, you must have the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) installed which provides authentication when pushing or downloading packages (see examples section). For Azure hosted builds that interfact with Azure Artifacts feeds, you must use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate) task.
-
 - **`-n|--no-symbols`**
 
   Doesn't push symbols (even if present).
@@ -150,24 +147,4 @@ The command pushes an existing package. It doesn't create a package. To create a
   dotnet nuget push "*.nupkg" -s c:\mydir
   ```
   
-- In the example below, pushing "MyPackage" version "5.0.2" to an Azure Artifacts feed from a local development environment, the API key "AZ" is only used as a placeholder. An Azure Artifacts feed still requires the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) to be installed to properly authenticate.
-
-  ```dotnetcli
-  dotnet nuget push MyPackage.5.0.2.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
-  ```
-  
-- In the example below, pushing "MyPackage" version "1.1.5" to an Azure Artifacts feed from a hosted build, the API key "AZ" is only used as a placeholder. An Azure Artifacts feed still requires your pipeline to use the [NuGet Authenticate task](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops).
-
-  ```bashcli
-    - task: NuGetAuthenticate@1
-      inputs:
-        nuGetServiceConnections: MyServiceConnection_ExternalServer
-        
-    - bash: |
-        dotnet build mypackage/mypackage.csproj -c Release
-        dotnet pack mypackage/mypackage.csproj /property:PackageVersion=1.1.5 -o nupkgs -c Release
-        dotnet nuget push nupkgs/mypackage.1.1.5.nupkg --source https://pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/nuget/v3/index.json -k AZ
-      displayName: "Pack and push"          
-  ```
-
-  This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  
+- For Azure DevOps Artifacts related push examples, see [Azure Devops examples](https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -54,7 +54,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`-k|--api-key <API_KEY>`**
 
-- The API key for the server.
+  The API key for the server.
 
 - **`-n|--no-symbols`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -150,3 +150,5 @@ The command pushes an existing package. It doesn't create a package. To create a
   ```
   
 - For pushing to Azure Artifacts, [see Azure Artifacts' push documentation](https://docs.microsoft.com/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#examples).
+
+  This command doesn't store packages in a hierarchical folder structure, which is recommended to optimize performance. For more information, see [Local feeds](/nuget/hosting-packages/local-feeds).  


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2787

Description: Improve dotnet nuget push to Azure DevOps Artifacts documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push
Add example for pushing nupkg to Azdo Artifacts.