### PR TITLE
Fixes #27669

### DIFF
--- a/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
@@ -22,9 +22,11 @@ Programmers should throw exceptions when one or more of the following conditions
 
   :::code language="csharp" source="snippets/exceptions/ProgramLog.cs" ID="ProgramLog":::
 
-- When an argument to a method causes an exception. In this case, the original exception should be caught and an <xref:System.ArgumentException> instance should be created. The original exception should be passed to the constructor of the <xref:System.ArgumentException> as the <xref:System.Exception.InnerException%2A> parameter:
+- When an argument to a method causes an exception. In this case, the original exception should be caught and an <xref:System.ArgumentException> instance should be created. The original exception should be passed to the constructor of the <xref:System.ArgumentException> as the <xref:System.Exception.InnerException%2A> parameter.
 
   :::code language="csharp" source="snippets/exceptions/Program.cs" ID="InvalidArg":::
+  
+[!NOTE]The example above is for illustrative purpose, it's usually more desirable to check if an index is not out of range the normal way, without rellying on exceptions. Exceptions should be reserved for exceptional program conditions.
 
 Exceptions contain a property named <xref:System.Exception.StackTrace%2A>. This string contains the name of the methods on the current call stack, together with the file name and line number where the exception was thrown for each method. A <xref:System.Exception.StackTrace%2A> object is created automatically by the common language runtime (CLR) from the point of the `throw` statement, so that exceptions must be thrown from the point where the stack trace should begin.
 

--- a/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
@@ -22,11 +22,11 @@ Programmers should throw exceptions when one or more of the following conditions
 
   :::code language="csharp" source="snippets/exceptions/ProgramLog.cs" ID="ProgramLog":::
 
-- When an argument to a method causes an exception. In this case, the original exception should be caught and an <xref:System.ArgumentException> instance should be created. The original exception should be passed to the constructor of the <xref:System.ArgumentException> as the <xref:System.Exception.InnerException%2A> parameter.
+- When an argument to a method causes an exception. In this case, the original exception should be caught and an <xref:System.ArgumentException> instance should be created. The original exception should be passed to the constructor of the <xref:System.ArgumentException> as the <xref:System.Exception.InnerException%2A> parameter:
 
   :::code language="csharp" source="snippets/exceptions/Program.cs" ID="InvalidArg":::
   
-[!NOTE]The example above is for illustrative purpose, it's usually more desirable to check if an index is not out of range the normal way, without rellying on exceptions. Exceptions should be reserved for exceptional program conditions.
+[!NOTE]The example above is for illustrative purposes. Index validating via exceptions is in most cases bad practice. Exceptions should be reserved to guard against exceptional program conditions, not for argument checking as above.
 
 Exceptions contain a property named <xref:System.Exception.StackTrace%2A>. This string contains the name of the methods on the current call stack, together with the file name and line number where the exception was thrown for each method. A <xref:System.Exception.StackTrace%2A> object is created automatically by the common language runtime (CLR) from the point of the `throw` statement, so that exceptions must be thrown from the point where the stack trace should begin.
 

--- a/docs/csharp/fundamentals/exceptions/snippets/exceptions/Program.cs
+++ b/docs/csharp/fundamentals/exceptions/snippets/exceptions/Program.cs
@@ -183,9 +183,10 @@ namespace Exceptions
             {
                 return array[index];
             }
-            catch (IndexOutOfRangeException ex)
+            catch (IndexOutOfRangeException e)
             {
-                throw new ArgumentException("Index is out of range", nameof(index), ex);
+                throw new ArgumentOutOfRangeException(
+                    "Parameter index is out of range.", e);
             }
         }
         // </InvalidArg>


### PR DESCRIPTION
Changed exception to one more appropriate, an in line with other parts of the documentation. Added note to clarifiy that exceptions shouldn't be relied upon for index validating

Fixes #27669

-edit by @billwagner to add issue in the description for linking and automation.
