### PR TITLE
Removed ISiloHost reference in Orleans Tutorial

### DIFF
--- a/docs/orleans/tutorials-and-samples/tutorial-1.md
+++ b/docs/orleans/tutorials-and-samples/tutorial-1.md
@@ -52,6 +52,7 @@ You will replace the default code with the code given for each project, below. Y
 |------------------|---------------------------------------------|
 | Silo             | `Microsoft.Orleans.Server`                  |
 | Silo             | `Microsoft.Extensions.Logging.Console`      |
+| Silo             | `Microsoft.Extensions.Hosting`              |
 | Client           | `Microsoft.Extensions.Logging.Console`      |
 | Client           | `Microsoft.Orleans.Client`                  |
 | Grain Interfaces | `Microsoft.Orleans.Core.Abstractions`       |
@@ -119,6 +120,7 @@ Add the following code to _Program.cs_ of the Silo project:
 ```csharp
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
@@ -141,7 +143,7 @@ catch (Exception ex)
     return 1;
 }
 
-static async Task<ISiloHost> StartSiloAsync()
+static async Task<IHost> StartSiloAsync()
 {
     var builder = new HostBuilder()
         .UseOrleans(c =>


### PR DESCRIPTION
Orleans recently switched from a specialist SiloHostBuilder, which would construct a SiloHost, to use the generic host builder (Microsoft.Extensions.Hosting.HostBuilder), which constructs an IHost. The code sample does not compile as-is, which may dissuade newcomers to Orleans. this change advises to add the Microsoft.Extensions.Hosting nuget package and updates the code sample to include the using statement and changes the ISiloHost return type to IHost. Built and tested locally successfully.

## Summary

Describe your changes here.

Fixes #29909
