### PR TITLE
Update Null-Conditional Operator for Member Access

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -139,6 +139,9 @@ If `a.x` or `a[x]` is of a non-nullable value type `T`, `a?.x` or `a?[x]` is of 
 
 In the preceding example, if you don't use the `??` operator, `numbers?.Length < 2` evaluates to `false` when `numbers` is `null`.
 
+> [!NOTE]
+> The `?.` operator evaluates its left-hand operand no more than once, guaranteeing that it cannot be changed to `null` after being verified as non-null.
+
 The null-conditional member access operator `?.` is also known as the Elvis operator.
 
 ### Thread-safe delegate invocation
@@ -159,7 +162,7 @@ if (handler != null)
 }
 ```
 
-That is a thread-safe way to ensure that only a non-null `handler` is invoked. Because delegate instances are immutable, no thread can change the object referenced by the `handler` local variable. In particular, if the code executed by another thread unsubscribes from the `PropertyChanged` event and `PropertyChanged` becomes `null` before `handler` is invoked, the object referenced by `handler` remains unaffected. The `?.` operator evaluates its left-hand operand no more than once, guaranteeing that it cannot be changed to `null` after being verified as non-null.
+That is a thread-safe way to ensure that only a non-null `handler` is invoked. Because delegate instances are immutable, no thread can change the object referenced by the `handler` local variable. In particular, if the code executed by another thread unsubscribes from the `PropertyChanged` event and `PropertyChanged` becomes `null` before `handler` is invoked, the object referenced by `handler` remains unaffected.
 
 ## Invocation expression ()
 


### PR DESCRIPTION
Clarification that the null-conditional operator used in member access evaluates the left-hand operand just once regardless of whether it is a delegate type or not.

Related to issue https://github.com/dotnet/docs/issues/29953

## Summary

Reorganizes the documentation to make it clear that the left-hand operand is evaluated once regardless of the type of the operand.

Fixes #29953