### PR TITLE
Bug fix in code example

### DIFF
--- a/docs/fsharp/language-reference/functions/inline-functions.md
+++ b/docs/fsharp/language-reference/functions/inline-functions.md
@@ -41,10 +41,10 @@ For example, consider the following `iterateTwice` function to traverse an array
 
 ```fsharp
 let inline iterateTwice ([<InlineIfLambda>] action) (array: 'T[]) =
-    for j = 0 to array.Length-1 do
-        action array[j]
-    for j = 0 to array.Length-1 do
-        action array[j]
+    for i = 0 to array.Length-1 do
+        action array[i]
+    for i = 0 to array.Length-1 do
+        action array[i]
 ```
 
 If the call site is:
@@ -61,10 +61,10 @@ Then after inlining and other optimizations, the code becomes:
 ```fsharp
 let arr = [| 1..100 |]
 let mutable sum = 0
-for j = 0 to arr.Length - 1 do
-    sum <- sum + arr[j] 
-for j = 0 to arr.Length - 1 do
-    sum <- sum + arr[j] 
+for i = 0 to arr.Length - 1 do
+    sum <- sum + arr[i] 
+for i = 0 to arr.Length - 1 do
+    sum <- sum + arr[i] 
 ```
 
 This optimization is applied regardless of the size of the lambda expression involved. This feature can also be used to implement loop unrolling and similar transformations more reliably.

--- a/docs/fsharp/language-reference/functions/inline-functions.md
+++ b/docs/fsharp/language-reference/functions/inline-functions.md
@@ -59,12 +59,12 @@ arr  |> iterateTwice (fun x ->
 Then after inlining and other optimizations, the code becomes:
 
 ```fsharp
-let arr = [| 1.. 100 |]
+let arr = [| 1..100 |]
 let mutable sum = 0
-for j = 0 to array.Length-1 do
-    sum <- array[i] + x
-for j = 0 to array.Length-1 do
-    sum <- array[i] + x
+for j = 0 to arr.Length - 1 do
+    sum <- sum + arr[j] 
+for j = 0 to arr.Length - 1 do
+    sum <- sum + arr[j] 
 ```
 
 This optimization is applied regardless of the size of the lambda expression involved. This feature can also be used to implement loop unrolling and similar transformations more reliably.


### PR DESCRIPTION
## Summary

This code example seems to have multiple issues:

- It's referring to a variable called `array` instead of `arr`.
- It's referring to an undeclared variable called `x`.
- It's referring to a counter `i` when the actual counter is `j`.
- It's not incrementing `sum`.

The fixed code example actually runs and produces the same `sum` result as the example above it. 

I also changed the loop counters from `j` to `i` because `i` is standard.

Thank you.
