### PR TITLE
Document new PublishRelease and PackRelease properties

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -139,6 +139,15 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 </PropertyGroup>
 ```
 
+### PackRelease 
+
+The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`.
+```xml
+<PropertyGroup>
+	<PackRelease>true</PackRelease>
+</PropertyGroup>
+```
+
 ## Publish-related properties
 
 The following MSBuild properties are documented in this section:
@@ -155,6 +164,7 @@ The following MSBuild properties are documented in this section:
 - [PreserveCompilationContext](#preservecompilationcontext)
 - [PreserveCompilationReferences](#preservecompilationreferences)
 - [ProduceReferenceAssemblyInOutDir](#producereferenceassemblyinoutdir)
+- [PublishRelease](#publishrelease)
 - [RollForward](#rollforward)
 - [RuntimeFrameworkVersion](#runtimeframeworkversion)
 - [RuntimeIdentifier](#runtimeidentifier)
@@ -303,6 +313,17 @@ In .NET 5 and earlier versions, reference assemblies are always written to the `
 ```
 
 For more information, see [Write reference assemblies to intermediate output](../compatibility/sdk/6.0/write-reference-assemblies-to-obj.md).
+
+### PublishRelease
+
+The `PublishRelease` property informs `dotnet publish` to leverage `Release` configuration instead of `Debug` by default. Add it to a `Directory.Build.props` file.
+```xml
+<PropertyGroup>
+	<PublishRelease>true</PublishRelease>
+</PropertyGroup>
+```
+> [!NOTE]
+> This property does not affect the behavior of `dotnet build /t:Publish`.
 
 ### RollForward
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -139,12 +139,13 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 </PropertyGroup>
 ```
 
-### PackRelease 
+### PackRelease
 
 The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`.
+
 ```xml
 <PropertyGroup>
-	<PackRelease>true</PackRelease>
+  <PackRelease>true</PackRelease>
 </PropertyGroup>
 ```
 
@@ -317,11 +318,13 @@ For more information, see [Write reference assemblies to intermediate output](..
 ### PublishRelease
 
 The `PublishRelease` property informs `dotnet publish` to leverage `Release` configuration instead of `Debug` by default. Add it to a `Directory.Build.props` file.
+
 ```xml
 <PropertyGroup>
-	<PublishRelease>true</PublishRelease>
+  <PublishRelease>true</PublishRelease>
 </PropertyGroup>
 ```
+
 > [!NOTE]
 > This property does not affect the behavior of `dotnet build /t:Publish`.
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -317,7 +317,7 @@ For more information, see [Write reference assemblies to intermediate output](..
 
 ### PublishRelease
 
-The `PublishRelease` property informs `dotnet publish` to leverage `Release` configuration instead of `Debug` by default. Add it to a `Directory.Build.props` file.
+The `PublishRelease` property informs `dotnet publish` to leverage the `Release` configuration instead of the `Debug` configuration. We recommend adding this property to a `Directory.Build.props` file instead of a project file so that it's evaluated early enough for the configuration change to propagate.
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
## Summary

Add documentation for the new properties we are adding to the SDK. 
* The pack property was included here because it is specific to the SDK and not part of MSBuild. 
Reflects the changes we're adding here https://github.com/dotnet/sdk/pull/25991


