### PR TITLE
Mention how to use the `RuntimeHostConfigurationOption` MSBuild item

### DIFF
--- a/docs/core/runtime-config/index.md
+++ b/docs/core/runtime-config/index.md
@@ -59,6 +59,8 @@ If you're placing the options in the output JSON file, nest them under the `runt
       "version": "3.1.0"
     },
     "configProperties": {
+      "System.Drawing.EnableUnixSupport": true,
+      "System.Net.DisableIPv6": true,
       "System.GC.Concurrent": false,
       "System.Threading.ThreadPool.MinThreads": 4,
       "System.Threading.ThreadPool.MaxThreads": 25
@@ -74,6 +76,8 @@ If you're placing the options in the template JSON file, omit the `runtimeOption
 ```json
 {
   "configProperties": {
+    "System.Drawing.EnableUnixSupport": true,
+    "System.Net.DisableIPv6": true,
     "System.GC.Concurrent": false,
     "System.Threading.ThreadPool.MinThreads": "4",
     "System.Threading.ThreadPool.MaxThreads": "25"
@@ -101,10 +105,17 @@ Here is an example SDK-style project file with MSBuild properties for configurin
     <ThreadPoolMaxThreads>25</ThreadPoolMaxThreads>
   </PropertyGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Net.DisableIPv6" Value="true" />
+  </ItemGroup>
+
 </Project>
 ```
 
 MSBuild properties for configuring run-time behavior are noted in the individual articles for each area, for example, [garbage collection](garbage-collector.md). They are also listed in the [Runtime configuration](../project-sdk/msbuild-props.md#runtime-configuration-properties) section of the MSBuild properties reference for SDK-style projects.
+
+For runtime configuration settings that don't have a specific MSBuild property, the `RuntimeHostConfigurationOption` MSBuild item may be used instead.
 
 ## Environment variables
 

--- a/docs/core/runtime-config/index.md
+++ b/docs/core/runtime-config/index.md
@@ -89,6 +89,8 @@ If you're placing the options in the template JSON file, omit the `runtimeOption
 
 Some runtime configuration options can be set using MSBuild properties in the *.csproj* or *.vbproj* file of SDK-style .NET Core projects. MSBuild properties take precedence over options set in the *runtimeconfig.template.json* file.
 
+For runtime configuration settings that don't have a specific MSBuild property, you can use the `RuntimeHostConfigurationOption` MSBuild item instead.
+
 Here is an example SDK-style project file with MSBuild properties for configuring run-time behavior:
 
 ```xml
@@ -114,8 +116,6 @@ Here is an example SDK-style project file with MSBuild properties for configurin
 ```
 
 MSBuild properties for configuring the behavior of the runtime are noted in the individual articles for each area, for example, [garbage collection](garbage-collector.md). They are also listed in the [Runtime configuration](../project-sdk/msbuild-props.md#runtime-configuration-properties) section of the MSBuild properties reference for SDK-style projects.
-
-For runtime configuration settings that don't have a specific MSBuild property, you can use the `RuntimeHostConfigurationOption` MSBuild item instead.
 
 ## Environment variables
 

--- a/docs/core/runtime-config/index.md
+++ b/docs/core/runtime-config/index.md
@@ -59,7 +59,7 @@ If you're placing the options in the output JSON file, nest them under the `runt
       "version": "3.1.0"
     },
     "configProperties": {
-      "System.Drawing.EnableUnixSupport": true,
+      "System.Globalization.UseNls": true,
       "System.Net.DisableIPv6": true,
       "System.GC.Concurrent": false,
       "System.Threading.ThreadPool.MinThreads": 4,
@@ -76,7 +76,7 @@ If you're placing the options in the template JSON file, omit the `runtimeOption
 ```json
 {
   "configProperties": {
-    "System.Drawing.EnableUnixSupport": true,
+    "System.Globalization.UseNls": true,
     "System.Net.DisableIPv6": true,
     "System.GC.Concurrent": false,
     "System.Threading.ThreadPool.MinThreads": "4",
@@ -108,7 +108,7 @@ Here is an example SDK-style project file with MSBuild properties for configurin
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
     <RuntimeHostConfigurationOption Include="System.Net.DisableIPv6" Value="true" />
   </ItemGroup>
 

--- a/docs/core/runtime-config/index.md
+++ b/docs/core/runtime-config/index.md
@@ -115,7 +115,7 @@ Here is an example SDK-style project file with MSBuild properties for configurin
 
 MSBuild properties for configuring the behavior of the runtime are noted in the individual articles for each area, for example, [garbage collection](garbage-collector.md). They are also listed in the [Runtime configuration](../project-sdk/msbuild-props.md#runtime-configuration-properties) section of the MSBuild properties reference for SDK-style projects.
 
-For runtime configuration settings that don't have a specific MSBuild property, the `RuntimeHostConfigurationOption` MSBuild item may be used instead.
+For runtime configuration settings that don't have a specific MSBuild property, you can use the `RuntimeHostConfigurationOption` MSBuild item instead.
 
 ## Environment variables
 

--- a/docs/core/runtime-config/index.md
+++ b/docs/core/runtime-config/index.md
@@ -113,7 +113,7 @@ Here is an example SDK-style project file with MSBuild properties for configurin
 </Project>
 ```
 
-MSBuild properties for configuring run-time behavior are noted in the individual articles for each area, for example, [garbage collection](garbage-collector.md). They are also listed in the [Runtime configuration](../project-sdk/msbuild-props.md#runtime-configuration-properties) section of the MSBuild properties reference for SDK-style projects.
+MSBuild properties for configuring the behavior of the runtime are noted in the individual articles for each area, for example, [garbage collection](garbage-collector.md). They are also listed in the [Runtime configuration](../project-sdk/msbuild-props.md#runtime-configuration-properties) section of the MSBuild properties reference for SDK-style projects.
 
 For runtime configuration settings that don't have a specific MSBuild property, the `RuntimeHostConfigurationOption` MSBuild item may be used instead.
 


### PR DESCRIPTION
Mention how to use the `RuntimeHostConfigurationOption` MSBuild item for runtime configuration settings that don't have a specific MSBuild property.