### PR TITLE
Fix example define symbols for .NET framework

### DIFF
--- a/includes/preprocessor-symbols.md
+++ b/includes/preprocessor-symbols.md
@@ -11,5 +11,5 @@ ms.custom: "updateeachrelease"
 >
 > * Versionless symbols are defined regardless of the version you're targeting.
 > * Version-specific symbols are only defined for the version you're targeting.
-> * The `<framework>_OR_GREATER` symbols are defined for the version you're targeting and all earlier versions. For example, if you're targeting .NET Framework 2.0, the following symbols are defined: `NET_2_0`, `NET_2_0_OR_GREATER`, `NET_1_1_OR_GREATER`, and `NET_1_0_OR_GREATER`.
+> * The `<framework>_OR_GREATER` symbols are defined for the version you're targeting and all earlier versions. For example, if you're targeting .NET Framework 2.0, the following symbols are defined: `NET20`, `NET20_OR_GREATER`, `NET11_OR_GREATER`, and `NET10_OR_GREATER`.
 > * These are different from the target framework monikers (TFMs) used by [the MSBuild `TargetFramework` property](../docs/standard/frameworks.md#supported-target-frameworks) and [NuGet](/nuget/reference/target-frameworks).


### PR DESCRIPTION
## Summary

These example symbols do not line up with the ones listed in the table directly above. This may confuse or mislead readers, who expect the .NET Framework symbols to follow the same underscored format as the .NET 5+ ones.

I tested with the .NET 6 SDK targeting .NET Framework 4.7.2, `NET20_OR_GREATER` was defined while `NET_2_0_OR_GREATER` was not.

The `NET11_OR_GREATER` and `NET10_OR_GREATER` symbols **were not defined**, however they aren't listed in the table either.