### PR TITLE
Added example of WinForms with .NET 6 consuming `IConfiguration`

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -93,7 +93,7 @@ An example *appsettings.xml* file with various configuration settings follows:
 :::code language="xml" source="snippets/configuration/console-xml/appsettings.xml":::
 
 > [!TIP]
-> To use the `IConfiguration` type in WinForms apps, add a reference to the [Microsoft.Extensions.Configuration.Xml](Microsoft.Extensions.Configuration.Xml) NuGet package. Instantiate the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> and chain calls to <xref:Microsoft.Extensions.Configuration.XmlConfigurationExtensions.AddXmlFile%2A> and <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder.Build>. For more information, see [.NET Docs Issue #29679](https://github.com/dotnet/docs/issues/29679#issuecomment-1169017078).
+> To use the `IConfiguration` type in WinForms apps, add a reference to the [Microsoft.Extensions.Configuration.Xml](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Xml) NuGet package. Instantiate the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> and chain calls to <xref:Microsoft.Extensions.Configuration.XmlConfigurationExtensions.AddXmlFile%2A> and <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder.Build>. For more information, see [.NET Docs Issue #29679](https://github.com/dotnet/docs/issues/29679#issuecomment-1169017078).
 
 In .NET 5 and earlier versions, add the `name` attribute to distinguish repeating elements that use the same element name. In .NET 6 and later versions, the XML configuration provider automatically indexes repeating elements. That means you don't have to specify the `name` attribute, except if you want the "0" index in the key and there's only one element.
 

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -3,7 +3,7 @@ title: Configuration providers in .NET
 description: Learn how the Configuration provider API is used to configure .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 01/24/2022
+ms.date: 06/29/2022
 ms.topic: reference
 ---
 
@@ -73,7 +73,7 @@ The application writes the following sample output:
 
 The <xref:Microsoft.Extensions.Configuration.Xml.XmlConfigurationProvider> class loads configuration from an XML file at run time. Install the [`Microsoft.Extensions.Configuration.Xml`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Xml) NuGet package.
 
-The following code demonstrates configuration of XML files using the XML configuration provider.
+The following code demonstrates the configuration of XML files using the XML configuration provider.
 
 :::code language="csharp" source="snippets/configuration/console-xml/Program.cs" range="1-18,36-41" highlight="7-18":::
 
@@ -84,13 +84,16 @@ The preceding code:
   - `optional: true`: The file is optional.
   - `reloadOnChange: true`: The file is reloaded when changes are saved.
 - Configures the environment variables configuration provider.
-- Configures the command-line configuration provider if the given `args` contains arguments.
+- Configures the command-line configuration provider if the given `args` contain arguments.
 
 The XML settings are overridden by settings in the [Environment variables configuration provider](#environment-variable-configuration-provider) and the [Command-line configuration provider](#command-line-configuration-provider).
 
 An example *appsettings.xml* file with various configuration settings follows:
 
 :::code language="xml" source="snippets/configuration/console-xml/appsettings.xml":::
+
+> [!TIP]
+> To use the `IConfiguration` type in WinForms apps, add a reference to the [Microsoft.Extensions.Configuration.Xml](Microsoft.Extensions.Configuration.Xml) NuGet package. Instantiate the <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder> and chain calls to <xref:Microsoft.Extensions.Configuration.XmlConfigurationExtensions.AddXmlFile%2A> and <xref:Microsoft.Extensions.Configuration.ConfigurationBuilder.Build>. For more information, see [.NET Docs Issue #29679](https://github.com/dotnet/docs/issues/29679#issuecomment-1169017078).
 
 In .NET 5 and earlier versions, add the `name` attribute to distinguish repeating elements that use the same element name. In .NET 6 and later versions, the XML configuration provider automatically indexes repeating elements. That means you don't have to specify the `name` attribute, except if you want the "0" index in the key and there's only one element.
 

--- a/docs/core/extensions/snippets/configuration/winforms-xml/App.config
+++ b/docs/core/extensions/snippets/configuration/winforms-xml/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <SecretKey>Secret key value</SecretKey>
+  <TransientFaultHandlingOptions>
+    <Enabled>true</Enabled>
+    <AutoRetryDelay>00:00:07</AutoRetryDelay>
+  </TransientFaultHandlingOptions>
+  <Logging>
+    <LogLevel>
+      <Default>Information</Default>
+      <Microsoft>Warning</Microsoft>
+    </LogLevel>
+  </Logging>
+</configuration>

--- a/docs/core/extensions/snippets/configuration/winforms-xml/MainForm.Designer.cs
+++ b/docs/core/extensions/snippets/configuration/winforms-xml/MainForm.Designer.cs
@@ -1,0 +1,119 @@
+﻿namespace WinForms.Xml
+{
+    partial class MainForm
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this._settingLabel = new System.Windows.Forms.Label();
+            this._settingsDataGridView = new System.Windows.Forms.DataGridView();
+            this._keyColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this._typeColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this._valueColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)(this._settingsDataGridView)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // _settingLabel
+            // 
+            this._settingLabel.AutoSize = true;
+            this._settingLabel.Location = new System.Drawing.Point(25, 25);
+            this._settingLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._settingLabel.Name = "_settingLabel";
+            this._settingLabel.Size = new System.Drawing.Size(527, 23);
+            this._settingLabel.TabIndex = 0;
+            this._settingLabel.Text = "Settings from winforms-xml.dll.config XML file:";
+            // 
+            // _settingsDataGridView
+            // 
+            this._settingsDataGridView.AllowUserToAddRows = false;
+            this._settingsDataGridView.AllowUserToDeleteRows = false;
+            this._settingsDataGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this._settingsDataGridView.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
+            this._settingsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this._settingsDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this._keyColumn,
+            this._typeColumn,
+            this._valueColumn});
+            this._settingsDataGridView.Location = new System.Drawing.Point(25, 69);
+            this._settingsDataGridView.Name = "_settingsDataGridView";
+            this._settingsDataGridView.ReadOnly = true;
+            this._settingsDataGridView.RowHeadersWidth = 51;
+            this._settingsDataGridView.RowTemplate.Height = 29;
+            this._settingsDataGridView.Size = new System.Drawing.Size(1088, 424);
+            this._settingsDataGridView.TabIndex = 2;
+            // 
+            // _keyColumn
+            // 
+            this._keyColumn.HeaderText = "Key";
+            this._keyColumn.MinimumWidth = 6;
+            this._keyColumn.Name = "_keyColumn";
+            this._keyColumn.ReadOnly = true;
+            this._keyColumn.Width = 125;
+            // 
+            // _typeColumn
+            // 
+            this._typeColumn.HeaderText = "Type";
+            this._typeColumn.MinimumWidth = 6;
+            this._typeColumn.Name = "_typeColumn";
+            this._typeColumn.ReadOnly = true;
+            this._typeColumn.Width = 125;
+            // 
+            // _valueColumn
+            // 
+            this._valueColumn.HeaderText = "Value";
+            this._valueColumn.MinimumWidth = 6;
+            this._valueColumn.Name = "_valueColumn";
+            this._valueColumn.ReadOnly = true;
+            this._valueColumn.Width = 125;
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 23F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1138, 518);
+            this.Controls.Add(this._settingsDataGridView);
+            this.Controls.Add(this._settingLabel);
+            this.Font = new System.Drawing.Font("Consolas", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.Name = "MainForm";
+            this.Text = "Config Example (XML)";
+            ((System.ComponentModel.ISupportInitialize)(this._settingsDataGridView)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private Label _settingLabel;
+        private DataGridView _settingsDataGridView;
+        private DataGridViewTextBoxColumn _keyColumn;
+        private DataGridViewTextBoxColumn _typeColumn;
+        private DataGridViewTextBoxColumn _valueColumn;
+    }
+}

--- a/docs/core/extensions/snippets/configuration/winforms-xml/MainForm.cs
+++ b/docs/core/extensions/snippets/configuration/winforms-xml/MainForm.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace WinForms.Xml;
+
+public sealed partial class MainForm : Form
+{
+    private readonly IConfiguration _config;
+
+    public MainForm()
+    {
+        _config = new ConfigurationBuilder()
+            .AddXmlFile("winforms-xml.dll.config", optional: true)
+            .AddXmlFile("winforms-xml.exe.config", optional: true)
+            .Build();
+
+        InitializeComponent();
+    }
+
+    protected override void OnLoad(EventArgs e)
+    {
+        base.OnLoad(e);
+
+        var secretKey = _config["SecretKey"];
+        AddItemToGrid("SecretKey", secretKey);
+
+        var transientFaultHandlingOptions =
+            _config.GetRequiredSection("TransientFaultHandlingOptions");
+        var isEnabled =
+            transientFaultHandlingOptions.GetValue<bool>("Enabled");
+        var autoRetryDelay =
+            transientFaultHandlingOptions.GetValue<TimeSpan>("AutoRetryDelay");
+
+        AddItemToGrid("TransientFaultHandlingOptions:Enabled", isEnabled);
+        AddItemToGrid("TransientFaultHandlingOptions:AutoRetryDelay", autoRetryDelay);
+
+        _settingsDataGridView.AutoResizeColumns(
+            DataGridViewAutoSizeColumnsMode.AllCells);
+    }
+
+    void AddItemToGrid<T>(string key, T value)
+    {
+        var row = new DataGridViewRow();
+        row.Cells.Add(new DataGridViewTextBoxCell { Value = key });
+        row.Cells.Add(new DataGridViewTextBoxCell { Value = typeof(T) });
+        row.Cells.Add(new DataGridViewTextBoxCell { Value = value });
+
+        _settingsDataGridView.Rows.Add(row);
+    }
+}

--- a/docs/core/extensions/snippets/configuration/winforms-xml/MainForm.resx
+++ b/docs/core/extensions/snippets/configuration/winforms-xml/MainForm.resx
@@ -1,0 +1,69 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="_keyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="_typeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="_valueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/docs/core/extensions/snippets/configuration/winforms-xml/Program.cs
+++ b/docs/core/extensions/snippets/configuration/winforms-xml/Program.cs
@@ -1,0 +1,16 @@
+﻿using WinForms.Xml;
+
+internal static class Program
+{
+    /// <summary>
+    ///  The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    static void Main()
+    {
+        // To customize application configuration such as set high DPI settings or default font,
+        // see https://aka.ms/applicationconfiguration.
+        ApplicationConfiguration.Initialize();
+        Application.Run(new MainForm());
+    } 
+}

--- a/docs/core/extensions/snippets/configuration/winforms-xml/winforms-xml.csproj
+++ b/docs/core/extensions/snippets/configuration/winforms-xml/winforms-xml.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>WinForms.Xml</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Added working example of WinForms with .NET 6, that consumes `IConfiguration` reading an _App.config_ XML file.

Fixes #29679
