### PR TITLE
Add FS0703 to compiler messages documentation

### DIFF
--- a/docs/fsharp/language-reference/compiler-messages/fs0703.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0703.md
@@ -1,0 +1,12 @@
+﻿---
+title: "Compiler error FS0703"
+ms.date: 06/30/2022
+f1_keywords:
+  - "FS0703"
+helpviewer_keywords:
+  - "FS0703"
+---
+
+# FS0703: Expected type parameter, not unit-of-measure parameter
+
+[!code-fsharp[FS0703-comment](~/samples/snippets/fsharp/compiler-messages/fs0703.fsx#L2-L3)]

--- a/docs/fsharp/language-reference/compiler-messages/toc.yml
+++ b/docs/fsharp/language-reference/compiler-messages/toc.yml
@@ -19,3 +19,5 @@
     href: ./fs0037.md
   - name: FS0052 - Defensive copy
     href: ./fs0052.md
+  - name: FS0703 - Expected type parameter, not unit-of-measure parameter
+    href: ./fs0703.md

--- a/samples/snippets/fsharp/compiler-messages/fs0703.fsx
+++ b/samples/snippets/fsharp/compiler-messages/fs0703.fsx
@@ -1,3 +1,5 @@
-(* comment *)
-let someCode = 5
-printfn "%i" someCode
+(*
+Trying to use the result of typeof
+on a unit of measure
+*)
+let theBadFunction<[<Measure>] 'u> = typeof<'u>

--- a/samples/snippets/fsharp/compiler-messages/fs0703.fsx
+++ b/samples/snippets/fsharp/compiler-messages/fs0703.fsx
@@ -1,0 +1,3 @@
+(* comment *)
+let someCode = 5
+printfn "%i" someCode


### PR DESCRIPTION
## Summary

Compiler message `0703` was not in the documentation [here](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs0703) which I found when following the link through Ionide for VSCode today.

I followed the instructions [here](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/) so please let me know if there is anything else to add.