### PR TITLE
Update journaledgrain-basics.md

### DIFF
--- a/docs/orleans/grains/event-sourcing/journaledgrain-basics.md
+++ b/docs/orleans/grains/event-sourcing/journaledgrain-basics.md
@@ -8,8 +8,8 @@ ms.date: 01/31/2022
 
 Journaled grains derive from <xref:Orleans.EventSourcing.JournaledGrain%602>, with the following type parameters:
 
-* The `StateType` represents the state of the grain. It must be a class with a public default constructor.
-* `EventType` is a common supertype for all the events that can be raised for this grain, and can be any class or interface.
+* The `TGrainState` represents the state of the grain. It must be a class with a public default constructor.
+* `TEventBase` is a common supertype for all the events that can be raised for this grain, and can be any class or interface.
 
 All state and event objects should be serializable (because the log-consistency providers may need to persist them, and/or send them in notification messages).
 


### PR DESCRIPTION
Align the generic type parameter names with the actual API

## Summary

Make the two descriptions of generic type parameters the same with actual name in API:
https://docs.microsoft.com/en-us/dotnet/api/orleans.eventsourcing.journaledgrain-2 