### PR TITLE
Update to correct typo with ReferenceEquals usage

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/implement-value-objects.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/implement-value-objects.md
@@ -45,7 +45,7 @@ public abstract class ValueObject
         {
             return false;
         }
-        return ReferenceEquals(left, null) || left.Equals(right);
+        return ReferenceEquals(left, right) || left.Equals(right);
     }
 
     protected static bool NotEqualOperator(ValueObject left, ValueObject right)


### PR DESCRIPTION
- Edited usage of ReferenceEquals() in the EqualOperator() function to use the reference of the right value object rather than null. I believe this was a typo since checking against a null reference with the left value object a second time makes little sense as the function would have already returned. It makes more sense to check if the left and right value object reference the same object at that point in the function.

## Summary

Changed call to `ReferenceEquals(left, null)` to `ReferenceEquals(left, right)`.

Fixes #Issue_Number (if available)
