### PR TITLE
Restore the `using` statement`

### DIFF
--- a/docs/csharp/fundamentals/types/snippets/classes/Program.cs
+++ b/docs/csharp/fundamentals/types/snippets/classes/Program.cs
@@ -1,4 +1,6 @@
-﻿public class Person
+using system;
+
+public class Person
 {
     // Constructor that takes no arguments:
     public Person()

--- a/docs/csharp/fundamentals/types/snippets/classes/Program.cs
+++ b/docs/csharp/fundamentals/types/snippets/classes/Program.cs
@@ -1,4 +1,4 @@
-using system;
+using System;
 
 public class Person
 {


### PR DESCRIPTION
Fixes #30117

This compiles without that using statement, but doesn't run in the interactive console where implicit usings aren't available.

