### PR TITLE
doc(orleans): use ConfigureBlobServiceClient instead of ConnectionString for azure blob storage

### DIFF
--- a/docs/orleans/grains/grain-persistence/azure-storage.md
+++ b/docs/orleans/grains/grain-persistence/azure-storage.md
@@ -37,7 +37,7 @@ siloBuilder.AddAzureBlobGrainStorage(
     configureOptions: options =>
     {
         options.UseJson = true;
-        options.ConnectionString =
-             "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1";
+        options.ConfigureBlobServiceClient(
+             "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1");
     });
 ```


### PR DESCRIPTION
## Summary

`AzureBlobStorageOptions.ConnectionString` is obsolete. 
Use `ConfigureBlobServiceClient` instead.

![image](https://user-images.githubusercontent.com/7039457/178422387-b1a62077-1e58-4d8a-8950-a094dc4c9828.png)

