### PR TITLE
Added missing arrow

### DIFF
--- a/docs/core/extensions/snippets/configuration/console-raw/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-raw/Program.cs
@@ -7,7 +7,7 @@ IConfiguration config = new ConfigurationBuilder()
     .Build();
 
 // Get values from the config given their key and their target type.
-Settings settings = config.GetRequiredSection("Settings").Get<Settings>();
+Settings settings => config.GetRequiredSection("Settings").Get<Settings>();
 
 // Write the values to the console.
 Console.WriteLine($"KeyOne = {settings.KeyOne}");


### PR DESCRIPTION
## Summary
The provided example yield a "A field initializer cannot reference the non-static field, method, or property" error. 
Changing it to a get-only property solves the issue.
Describe your changes here.

Fixes #Issue_Number (if available)