### PR TITLE
C# bitwise and shift operators: fix interactive snippets syntax

### DIFF
--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -52,7 +52,7 @@ Bitwise and shift operations never cause overflow and produce the same results i
 
 The `~` operator produces a bitwise complement of its operand by reversing each bit:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseComplement":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseComplement":::
 
 You can also use the `~` symbol to declare finalizers. For more information, see [Finalizers](../../programming-guide/classes-and-structs/finalizers.md).
 
@@ -62,11 +62,11 @@ The `<<` operator shifts its left-hand operand left by the number of bits define
 
 The left-shift operation discards the high-order bits that are outside the range of the result type and sets the low-order empty bit positions to zero, as the following example shows:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShift":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShift":::
 
 Because the shift operators are defined only for the `int`, `uint`, `long`, and `ulong` types, the result of an operation always contains at least 32 bits. If the left-hand operand is of another integral type (`sbyte`, `byte`, `short`, `ushort`, or `char`), its value is converted to the `int` type, as the following example shows:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShiftPromoted":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShiftPromoted":::
 
 ## Right-shift operator >>
 
@@ -74,17 +74,17 @@ The `>>` operator shifts its left-hand operand right by the number of bits defin
 
 The right-shift operation discards the low-order bits, as the following example shows:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="RightShift":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="RightShift":::
 
 The high-order empty bit positions are set based on the type of the left-hand operand as follows:
 
 - If the left-hand operand is of type `int` or `long`, the right-shift operator performs an *arithmetic* shift: the value of the most significant bit (the sign bit) of the left-hand operand is propagated to the high-order empty bit positions. That is, the high-order empty bit positions are set to zero if the left-hand operand is non-negative and set to one if it's negative.
 
-  :::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ArithmeticRightShift":::
+  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ArithmeticRightShift":::
 
 - If the left-hand operand is of type `uint` or `ulong`, the right-shift operator performs a *logical* shift: the high-order empty bit positions are always set to zero.
 
-  :::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LogicalRightShift":::
+  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LogicalRightShift":::
 
 > [!NOTE]
 > Use the [unsigned right-shift operator](#unsigned-right-shift-operator-) to perform a *logical* shift on signed integer types. This is preferred to casting the signed type to an unsigned type and casting back after the shift.
@@ -99,7 +99,7 @@ The `>>>` operator, available starting in C# 11, performs a *logical* shift on a
 
 The `&` operator computes the bitwise logical AND of its integral operands:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseAnd":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseAnd":::
 
 For `bool` operands, the `&` operator computes the [logical AND](boolean-logical-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
@@ -107,7 +107,7 @@ For `bool` operands, the `&` operator computes the [logical AND](boolean-logical
 
 The `^` operator computes the bitwise logical exclusive OR, also known as the bitwise logical XOR, of its integral operands:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseXor":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseXor":::
 
 For `bool` operands, the `^` operator computes the [logical exclusive OR](boolean-logical-operators.md#logical-exclusive-or-operator-) of its operands.
 
@@ -115,7 +115,7 @@ For `bool` operands, the `^` operator computes the [logical exclusive OR](boolea
 
 The `|` operator computes the bitwise logical OR of its integral operands:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseOr":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseOr":::
 
 For `bool` operands, the `|` operator computes the [logical OR](boolean-logical-operators.md#logical-or-operator-) of its operands.
 
@@ -137,11 +137,11 @@ except that `x` is only evaluated once.
 
 The following example demonstrates the usage of compound assignment with bitwise and shift operators:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="CompoundAssignment":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="CompoundAssignment":::
 
 Because of [numeric promotions](~/_csharpstandard/standard/expressions.md#1147-numeric-promotions), the result of the `op` operation might be not implicitly convertible to the type `T` of `x`. In such a case, if `op` is a predefined operator and the result of the operation is explicitly convertible to the type `T` of `x`, a compound assignment expression of the form `x op= y` is equivalent to `x = (T)(x op y)`, except that `x` is only evaluated once. The following example demonstrates that behavior:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="CompoundAssignmentWithCast":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="CompoundAssignmentWithCast":::
 
 ## Operator precedence
 
@@ -155,7 +155,7 @@ The following list orders bitwise and shift operators starting from the highest 
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="Precedence":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="Precedence":::
 
 For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
@@ -171,7 +171,7 @@ For the `x << count` and `x >> count` expressions, the actual shift count depend
 
 The following example demonstrates that behavior:
 
-:::code language="csharp-interactive" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ShiftCount":::
+:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ShiftCount":::
 
 > [!NOTE]
 > As the preceding example shows, the result of a shift operation can be non-zero even if the value of the right-hand operand is greater than the number of bits in the left-hand operand.


### PR DESCRIPTION
Interactive C# code UX is broken for the [bitwise and shift operators article](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators):
![image](https://user-images.githubusercontent.com/15279990/178718768-7c47430a-8126-45e6-a5fe-b9b5a2cb8e0d.png)

This PR should fix that. Please check that before merging.
