### PR TITLE
Fix "Related rules" link in ca1836.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1836.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1836.md
@@ -93,7 +93,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 - [CA1827: Do not use Count/LongCount when Any can be used](ca1827.md)
 - [CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used](ca1828.md)
-- [CA1829: Do not use CountAsync/LongCountAsync when AnyAsync can be used](ca1828.md)
+- [CA1829: Use Length/Count property instead of Enumerable.Count method](ca1829.md)
 
 ## See also
 


### PR DESCRIPTION
## Summary

The last 2 links in the [Related rules section of the CA1836 page](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1836#related-rules) were mistakenly pointing to the same page. I fixed the wrong one.