### PR TITLE
Fix placement of summary paragraph

### DIFF
--- a/docs/csharp/fundamentals/functional/pattern-matching.md
+++ b/docs/csharp/fundamentals/functional/pattern-matching.md
@@ -78,13 +78,13 @@ The first two arms examine two properties of the `Order`. The third examines onl
 
 The preceding code demonstrates the [*positional pattern*](../../language-reference/operators/patterns.md#positional-pattern) where the properties are deconstructed for the expression.
 
-This article provided a tour of the kinds of code you can write with pattern matching in C#. The following articles show more examples of using patterns in scenarios, and the full vocabulary of patterns available to use.
-
 ## List patterns
 
 You can check elements in a list or an array using a *list pattern*. A list pattern provides a means to apply a pattern to any element of a sequence. In addition, you can apply the *discard pattern* (`_`) to match any element, or apply a *slice pattern* to match zero or more elements. The following example determines if an array matches the binary digits, or the start of a Fibonacci sequence:
 
 :::code language="csharp" source="snippets/patterns/OrderProcessor.cs" id="ListPattern":::
+
+This article provided a tour of the kinds of code you can write with pattern matching in C#. The following articles show more examples of using patterns in scenarios, and the full vocabulary of patterns available to use.
 
 ## See also
 


### PR DESCRIPTION
When the section "List patterns" was added in https://github.com/dotnet/docs/commit/b181812600f3a1efe8a57fefd7dee80a469d9f93, it was placed after the paragraph that was intended to be at the end of the article. This commit puts the summary paragraph back at the end where it was intended to be.
