### PR TITLE
Fix the snippet for a property pattern

### DIFF
--- a/docs/csharp/fundamentals/functional/snippets/patterns/OrderProcessor.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/OrderProcessor.cs
@@ -10,9 +10,9 @@ class OrderProcessor
     public decimal CalculateDiscount(Order order) =>
         order switch
         {
-            (Items: > 10, Cost: > 1000.00m) => 0.10m,
-            (Items: > 5, Cost: > 500.00m) => 0.05m,
-            Order { Cost: > 250.00m } => 0.02m,
+            { Items: > 10, Cost: > 1000.00m } => 0.10m,
+            { Items: > 5, Cost: > 500.00m } => 0.05m,
+            { Cost: > 250.00m } => 0.02m,
             null => throw new ArgumentNullException(nameof(order), "Can't calculate discount on null order"),
             var someObject => 0m,
         };
@@ -27,7 +27,7 @@ class OrderProcessing
         {
             ( > 10,  > 1000.00m) => 0.10m,
             ( > 5, > 50.00m) => 0.05m,
-            Order { Cost: > 250.00m } => 0.02m,
+            { Cost: > 250.00m } => 0.02m,
             null => throw new ArgumentNullException(nameof(order), "Can't calculate discount on null order"),
             var someObject => 0m,
         };


### PR DESCRIPTION
Fixes #30248

Also removes unnecessary type-check as the parameter is already of the `Order` type.