### PR TITLE
Separate note from sentence below

### DIFF
--- a/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries.md
@@ -9,6 +9,7 @@ ms.assetid: 52cd44dd-a3ec-441e-b93a-4eca388119c7
 
 > [!NOTE]
 > Make sure you add `using System.Linq.Expressions;` and `using static System.Linq.Expressions.Expression;` at the top of your *.cs* file.
+
 Consider code that defines an <xref:System.Linq.IQueryable> or an [IQueryable\<T>](<xref:System.Linq.IQueryable%601>) against a data source:
 
 :::code language="csharp" source="../../../../../samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/Program.cs" id="Initialize":::


### PR DESCRIPTION
The sentence below shouldn't be part of the Note, so I separated the two.

See:
* https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries
* https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/concepts/expression-trees/how-to-use-expression-trees-to-build-dynamic-queries