### PR TITLE
Put p/invoke and marshalling pages into sub-groups instead of flat under native interoperability

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2864,21 +2864,27 @@ items:
       href: ../standard/native-interop/index.md
       displayName: Native interop
     - name: P/Invoke
-      href: ../standard/native-interop/pinvoke.md
+      items:
+      - name: Overview
+        href: ../standard/native-interop/pinvoke.md
+        displayName: P/Invoke
+      - name: Cross-platform P/Invoke
+        href: ../standard/native-interop/cross-platform.md
     - name: Type marshalling
-      href: ../standard/native-interop/type-marshalling.md
-    - name: Customize structure marshalling
-      href: ../standard/native-interop/customize-struct-marshalling.md
-    - name: Customize parameter marshalling
-      href: ../standard/native-interop/customize-parameter-marshalling.md
-    - name: Cross-platform P/Invoke
-      href: ../standard/native-interop/cross-platform.md
+      items:
+      - name: Overview
+        href: ../standard/native-interop/type-marshalling.md
+        displayName: Type marshalling
+      - name: Charsets and marshalling
+        href: ../standard/native-interop/charset.md
+      - name: Disabled marshalling
+        href: ../standard/native-interop/disabled-marshalling.md
+      - name: Customize structure marshalling
+        href: ../standard/native-interop/customize-struct-marshalling.md
+      - name: Customize parameter marshalling
+        href: ../standard/native-interop/customize-parameter-marshalling.md
     - name: Interop guidance
       href: ../standard/native-interop/best-practices.md
-    - name: Charsets and marshalling
-      href: ../standard/native-interop/charset.md
-    - name: Disabled marshalling
-      href: ../standard/native-interop/disabled-marshalling.md
     - name: Expose .NET components to COM
       href: ../core/native-interop/expose-components-to-com.md
     - name: Host .NET from native code
@@ -3034,8 +3040,8 @@ items:
         href: ../core/porting/upgrade-assistant-wpf-framework.md
       - name: Windows Forms
         href: ../core/porting/upgrade-assistant-winforms-framework.md
-      - name: Universal Windows Platform 
-        href:  ../core/porting/upgrade-assistant-uwp-framework.md       
+      - name: Universal Windows Platform
+        href:  ../core/porting/upgrade-assistant-uwp-framework.md
       - name: ASP.NET Core
         href: ../core/porting/upgrade-assistant-aspnetmvc.md
       - name: Telemetry


### PR DESCRIPTION
## Summary

Make 'P/Invoke' and 'Type marshalling' sub-groups under 'Native interoperability'. I'm hoping the hierarchy will make navigating from the table of contents easier, especially as we add docs for source-generated p/invokes via `LibraryImport` and custom marshalling via `NativeMarshalling`/`CustomMarshaller`.

cc @AaronRobinsonMSFT @jkoritzinsky 