### PR TITLE
Fixed csharp middleware example to use args

### DIFF
--- a/docs/standard/commandline/snippets/use-middleware/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/use-middleware/csharp/Program.cs
@@ -37,7 +37,7 @@ class Program
 
         commandLineBuilder.UseDefaults();
         var parser = commandLineBuilder.Build();
-        await parser.InvokeAsync("[just-say-hi] --delay 42 --message \"Hello world!\"");
+        await parser.InvokeAsync(args);
         // </middleware>
     }
 


### PR DESCRIPTION
The existing example ignores the args and _always_ assumes the command line is `[just-say-hi] --delay 42 --message "Hello world!"`, which doesn't show a realistic implementation of middleware.  This change makes the example use `args` so it will show middleware being used in the right circumstances.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
