### PR TITLE
Document how to enable logging of HTTP request and response bodies

### DIFF
--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -216,7 +216,7 @@ By default, logging of the aforementioned content is disabled. To enable logging
     };
     ```
 
-1. Set an [event level](/dotnet/api/system.diagnostics.tracing.eventlevel?view=net-6.0) of either `Verbose` or `LogAlways`. For example:
+1. Set an [event level](/dotnet/api/system.diagnostics.tracing.eventlevel) of either `Verbose` or `LogAlways`. For example:
 
     ```csharp
     using AzureEventSourceListener listener = 

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -216,12 +216,13 @@ By default, logging of the aforementioned content is disabled. To enable logging
     };
     ```
 
-1. Set an [event level](/dotnet/api/system.diagnostics.tracing.eventlevel) of either `Verbose` or `LogAlways`. For example:
+1. Use your preferred logging approach with an event/log level of verbose/debug or higher. Find your approach in the following table for specific instructions.
 
-    ```csharp
-    using AzureEventSourceListener listener = 
-        AzureEventSourceListener.CreateConsoleLogger(EventLevel.Verbose);
-    ```
+    |Approach |Instructions |
+    |---------|-------------|
+    |[Enable logging with built-in methods](#enable-logging-with-built-in-methods) |Pass `EventLevel.Verbose` or `EventLevel.LogAlways` to `AzureEventSourceListener.CreateConsoleLogger` or `AzureEventSourceListener.CreateTraceLogger` |
+    |[Configure custom logging](#configure-custom-logging) |Set the `AzureEventSourceListener` class' `level` constructor parameter to `EventLevel.Verbose` or `EventLevel.LogAlways` |
+    |[Map to ASP.NET Core logging](#map-to-aspnet-core-logging) |Add `"Azure.Core": "Debug"` to *appsettings.json* |
 
 ## Next steps
 

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -1,7 +1,7 @@
 ---
 title: Logging with the Azure SDK for .NET
 description: Learn how to enable logging with the Azure SDK for .NET client libraries
-ms.date: 06/14/2022
+ms.date: 07/21/2022
 ms.custom: devx-track-dotnet
 ms.author: casoper
 author: camsoper
@@ -38,21 +38,12 @@ HTTP response log entry:
 - Response headers
 - Error information, when applicable
 
-For request and response content:
+For HTTP request and response content:
 
 - Content stream as text or bytes depending on the `Content-Type` header.
-    > [!NOTE]
-    > Content logging is disabled by default. To enable it, set the client options object's <xref:Azure.Core.DiagnosticsOptions.IsLoggingContentEnabled%2A> property to `true`. For example:
-    >
-    > ```csharp
-    > var options = new SecretClientOptions
-    > {
-    >     Diagnostics = 
-    >     {
-    >         IsLoggingContentEnabled = true,
-    >     }
-    > };
-    > ```
+
+  > [!NOTE]
+  > Content logging is disabled by default. To enable it, see [Log HTTP request and response bodies](#log-http-request-and-response-bodies).
 
 Event logs are output usually at one of these three levels:
 
@@ -62,16 +53,17 @@ Event logs are output usually at one of these three levels:
 
 ## Enable logging with built-in methods
 
-The Azure SDK for .NET's client libraries log events to Event Tracing for Windows (ETW) via the <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> class, which is typical for .NET. Event sources allow you to use structured logging in your app with a minimal performance overhead. To gain access to the event logs, you need to register event listeners.
+The Azure SDK for .NET's client libraries log events to Event Tracing for Windows (ETW) via the <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> class, which is typical for .NET. Event sources allow you to use structured logging in your app with minimal performance overhead. To gain access to the event logs, you need to register event listeners.
 
-The SDK includes the <xref:Azure.Core.Diagnostics.AzureEventSourceListener?displayProperty=nameWithType> class, which contains two static methods that simplify comprehensive logging for your .NET app: `CreateConsoleLogger` and `CreateTraceLogger`. These methods take an optional parameter that specifies a log level.
+The SDK includes the <xref:Azure.Core.Diagnostics.AzureEventSourceListener?displayProperty=nameWithType> class, which contains two static methods that simplify comprehensive logging for your .NET app: `CreateConsoleLogger` and `CreateTraceLogger`. Each of these methods accepts an optional parameter that specifies a log level. If the parameter isn't provided, the default log level of `Informational` is used.
 
 ### Log to the console window
 
 A core tenet of the Azure SDK for .NET client libraries is to simplify the ability to view comprehensive logs in real time. The `CreateConsoleLogger` method allows you to send logs to the console window with a single line of code:
 
 ```csharp
-using AzureEventSourceListener listener = AzureEventSourceListener.CreateConsoleLogger();
+using AzureEventSourceListener listener = 
+    AzureEventSourceListener.CreateConsoleLogger();
 ```
 
 ### Log to diagnostic traces
@@ -81,12 +73,13 @@ If you implement trace listeners, you can use the `CreateTraceLogger` method to 
 This example specifies a log level of verbose:
 
 ```csharp
-using AzureEventSourceListener listener = AzureEventSourceListener.CreateTraceLogger(EventLevel.Verbose);
+using AzureEventSourceListener listener = 
+    AzureEventSourceListener.CreateTraceLogger(EventLevel.Verbose);
 ```
 
 ## Configure custom logging
 
-As mentioned above, you need to register event listeners to receive log messages from the Azure SDK for .NET. If you don't want to implement comprehensive logging using one the simplified methods above, you can construct an instance of the `AzureEventSourceListener` class and pass it a callback method that you write. This method will receive log messages that you can process however you need to. In addition, when you construct the instance, you can specify the log levels to include.
+As mentioned above, you need to register event listeners to receive log messages from the Azure SDK for .NET. If you don't want to implement comprehensive logging using one of the simplified methods above, you can construct an instance of the `AzureEventSourceListener` class. Pass that instance a callback method that you write. This method will receive log messages that you can process however you need to. In addition, when you construct the instance, you can specify the log levels to include.
 
 The following example creates an event listener that logs to the console with a custom message. The logs are filtered to those events emitted from the Azure Core client library with a level of verbose. The Azure Core library uses an event source name of `Azure-Core`.
 
@@ -163,9 +156,9 @@ Since the `Logging:LogLevel:Azure.Messaging.ServiceBus` key is set to `Debug`, S
 
 While this approach is far less common, your app may not need to explicitly register clients for Azure SDK libraries. In that scenario, a call to `AddAzureClientsCore` will suffice. Take this approach when your app uses ASP.NET extension libraries that depend on other Azure SDK libraries. Common examples of such ASP.NET extension libraries include:
 
-* [Azure Key Vault key encryptor for DataProtection](/dotnet/api/overview/azure/Extensions.AspNetCore.DataProtection.Keys-readme)
-* [Azure Key Vault secrets configuration provider](/dotnet/api/overview/azure/Extensions.AspNetCore.Configuration.Secrets-readme)
-* [Azure Blob Storage key store for DataProtection](/dotnet/api/overview/azure/Extensions.AspNetCore.DataProtection.Blobs-readme)
+- [Azure Key Vault key encryptor for DataProtection](/dotnet/api/overview/azure/Extensions.AspNetCore.DataProtection.Keys-readme)
+- [Azure Key Vault secrets configuration provider](/dotnet/api/overview/azure/Extensions.AspNetCore.Configuration.Secrets-readme)
+- [Azure Blob Storage key store for DataProtection](/dotnet/api/overview/azure/Extensions.AspNetCore.DataProtection.Blobs-readme)
 
 Consider the following *Program.cs* example, which uses the two aforementioned [ASP.NET Core Data Protection](/aspnet/core/security/data-protection/introduction) extension libraries:
 
@@ -201,6 +194,34 @@ In the ASP.NET Core project's *appsettings.json* file, the default log level for
 Since the `Logging:LogLevel:Azure.Core` key is set to `Debug`, Azure Core library events up to `EventLevel.Verbose` will be logged.
 
 For more information, see [Logging in .NET Core and ASP.NET Core](/aspnet/core/fundamentals/logging/).
+
+## Log HTTP request and response bodies
+
+When troubleshooting unexpected behavior with a client library, it's helpful to inspect the following items:
+
+- The HTTP request body sent to the underlying Azure service's REST API.
+- The HTTP response body received from the Azure service's REST API.
+
+By default, logging of the aforementioned content is disabled. To enable logging of the HTTP request and response bodies, complete the following steps:
+
+1. Set the client options object's <xref:Azure.Core.DiagnosticsOptions.IsLoggingContentEnabled%2A> property to `true`. For example:
+
+    ```csharp
+    var options = new SecretClientOptions
+    {
+        Diagnostics = 
+        {
+            IsLoggingContentEnabled = true,
+        }
+    };
+    ```
+
+1. Set an [event level](/dotnet/api/system.diagnostics.tracing.eventlevel?view=net-6.0) of either `Verbose` or `LogAlways`. For example:
+
+    ```csharp
+    using AzureEventSourceListener listener = 
+        AzureEventSourceListener.CreateConsoleLogger(EventLevel.Verbose);
+    ```
 
 ## Next steps
 


### PR DESCRIPTION
When customers open issues in the Azure SDK for .NET repo, we often ask them to enable logging. It's the HTTP request and response bodies that we're interested in seeing. While helping a customer in https://github.com/Azure/azure-sdk-for-net/issues/29707, I realized the instructions to enable this behavior were missing from the logging doc.

[Internal review page](https://review.docs.microsoft.com/dotnet/azure/sdk/logging?branch=pr-en-us-30312#log-http-request-and-response-bodies)