### PR TITLE
Records (C# reference): more correct value equality information

### DIFF
--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -1,7 +1,7 @@
 ---
 title: "Records - C# reference"
 description: Learn about the record type in C#
-ms.date: 02/25/2022
+ms.date: 07/23/2022
 f1_keywords: 
   - "record_CSharpKeyword"
 helpviewer_keywords: 
@@ -93,7 +93,7 @@ The features unique to record types are implemented by compiler-synthesized meth
 
 ## Value equality
 
-For any type you define, you can override <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType>, and overload [`operator ==`](../operators/equality-operators.md#equality-operator-). If you don't override `Equals` or overload `operator ==`, the type you declare governs how equality is defined:
+If you don't override or replace equality methods, the type you declare governs how equality is defined:
 
 - For `class` types, two objects are equal if they refer to the same object in memory.
 - For `struct` types, two objects are equal if they are of the same type and store the same values.
@@ -107,21 +107,23 @@ The following example illustrates value equality of record types:
 
 :::code language="csharp" source="snippets/shared/RecordType.cs" id="Equality":::
 
-To implement value equality, the compiler synthesizes the following methods:
+To implement value equality, the compiler synthesizes several methods, including:
 
-* An override of <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType>.
+* An override of <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType>. It is an error if the override is declared explicitly.
 
   This method is used as the basis for the <xref:System.Object.Equals(System.Object,System.Object)?displayProperty=nameWithType> static method when both parameters are non-null.
 
-* A virtual `Equals` method whose parameter is the record type. This method implements <xref:System.IEquatable%601>.
+* A `virtual`, or `sealed`, `Equals(R? other)` where `R` is the record type. This method implements <xref:System.IEquatable%601>. This method can be declared explicitly.
 
-* An override of <xref:System.Object.GetHashCode?displayProperty=nameWithType>.
+* If the record type is derived from a base record type Base, `Equals(Base? other)`. It is an error if the override is declared explicitly. If you provide your own implementation of `Equals(R? other)`, provide an implementation of `GetHashCode` also.
 
-* Overrides of operators `==` and `!=`.
+* An override of <xref:System.Object.GetHashCode?displayProperty=nameWithType>. This method can be declared explicitly.
 
-You can write your own implementations to replace any of these synthesized methods. If a record type has a method that matches the signature of any synthesized method, the compiler doesn't synthesize that method.
+* Overrides of operators `==` and `!=`. It is an error if the operators are declared explicitly.
 
-If you provide your own implementation of `Equals` in a record type, provide an implementation of `GetHashCode` also.
+* If the record type is derived from a base record type, `protected override Type EqualityContract { get; };`. This property can be declared explicitly. For more information, see [Equality in inheritance hierarchies](#equality-in-inheritance-hierarchies).
+
+If a record type has a method that matches the signature of a synthesized method allowed to be declared explicitly, the compiler doesn't synthesize that method.
 
 ## Nondestructive mutation
 

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -115,7 +115,7 @@ To implement value equality, the compiler synthesizes several methods, including
 
 * A `virtual`, or `sealed`, `Equals(R? other)` where `R` is the record type. This method implements <xref:System.IEquatable%601>. This method can be declared explicitly.
 
-* If the record type is derived from a base record type Base, `Equals(Base? other)`. It is an error if the override is declared explicitly. If you provide your own implementation of `Equals(R? other)`, provide an implementation of `GetHashCode` also.
+* If the record type is derived from a base record type `Base`, `Equals(Base? other)`. It is an error if the override is declared explicitly. If you provide your own implementation of `Equals(R? other)`, provide an implementation of `GetHashCode` also.
 
 * An override of <xref:System.Object.GetHashCode?displayProperty=nameWithType>. This method can be declared explicitly.
 


### PR DESCRIPTION
## Summary

More correct value equality information for *Records (C# reference)*. 

Fixes #30325 
