### PR TITLE
Direct addresation of the subject instead of infer

### DIFF
--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -48,7 +48,7 @@ The `foreach` statement can be used to enumerate the elements of any collection.
 
 :::code language="csharp" source="./snippets/shared/Features.cs" ID="EnumerateArray":::
 
-The `foreach` statement uses the <xref:System.Collections.Generic.IEnumerable%601> interface, so can work with any collection.
+The `foreach` statement uses the <xref:System.Collections.Generic.IEnumerable%601> interface, so it can work with any collection.
 
 ## String interpolation
 


### PR DESCRIPTION
## Summary

I was reading through the chapter "Arrays, collections and LINQ" and I've came across this statement:

"The <code>foreach</code> statement uses the IEnumerable<T> interface, so can work with any collection."

In my opinion, we should use direct addresation of the subject - the "foreach" statement, instead of letting the reader infer the subject.
The first time that I've read the statement it took me around 2 seconds to infer the subject, since until now, every other chapter in "Getting Started" doesn't let me, the reader, infer the subject.

You can also directly reach out to me on Teams (aolariu) or leave a message here if you have any questions about  this PR.
Thank you!

