### PR TITLE
Fix accidental ")" typo in the "Extension methods" sub-paragraph.

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/index.md
+++ b/docs/csharp/fundamentals/object-oriented/index.md
@@ -90,7 +90,7 @@ In situations where it isn't convenient or necessary to create a named class you
   
 ## Extension Methods  
 
-You can "extend" a class without creating a derived class by creating a separate type. That type contains methods that can be called as if they belonged to the original type. For more information, see [Extension methods)](../../programming-guide/classes-and-structs/extension-methods.md).
+You can "extend" a class without creating a derived class by creating a separate type. That type contains methods that can be called as if they belonged to the original type. For more information, see [Extension methods](../../programming-guide/classes-and-structs/extension-methods.md).
   
 ## Implicitly Typed Local Variables  
 


### PR DESCRIPTION
## Summary

Hi,

It's me again - I was browsing through our docs and found the following paragraph in the "Object Oriented Programming" -> "Classes, structs, and records" chapter.

old value: For more information, see Extension methods<code>)</code>.
new value: For more information, see Extension methods.


You can also reach out to me directly on Teams (aolariu) or leave a message here, if there any problem with this PR.
Thank you!