### PR TITLE
Remove obsolete install instructions for obsolete package apt-transport-https

### DIFF
--- a/docs/core/install/includes/linux-install-21-apt.md
+++ b/docs/core/install/includes/linux-install-21-apt.md
@@ -4,9 +4,7 @@
 The .NET Core SDK allows you to develop apps with .NET Core. If you install the .NET Core SDK, you don't need to install the corresponding runtime. To install the .NET Core SDK, run the following commands:
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y dotnet-sdk-2.1
 ```
 
@@ -18,9 +16,7 @@ sudo apt-get update; \
 The .NET Core Runtime allows you to run apps that were made with .NET Core that didn't include the runtime. The following commands install the ASP.NET Core Runtime, which is the most compatible runtime for .NET Core. In your terminal, run the following commands.
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y aspnetcore-runtime-2.1
 ```
 

--- a/docs/core/install/includes/linux-install-31-apt.md
+++ b/docs/core/install/includes/linux-install-31-apt.md
@@ -4,9 +4,7 @@
 The .NET Core SDK allows you to develop apps with .NET Core. If you install the .NET Core SDK, you don't need to install the corresponding runtime. To install the .NET Core SDK, run the following commands:
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y dotnet-sdk-3.1
 ```
 
@@ -18,9 +16,7 @@ sudo apt-get update; \
 The .NET Core Runtime allows you to run apps that were made with .NET Core that didn't include the runtime. The following commands install the ASP.NET Core Runtime, which is the most compatible runtime for .NET Core. In your terminal, run the following commands.
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y aspnetcore-runtime-3.1
 ```
 

--- a/docs/core/install/includes/linux-install-50-apt.md
+++ b/docs/core/install/includes/linux-install-50-apt.md
@@ -4,9 +4,7 @@
 The .NET SDK allows you to develop apps with .NET. If you install the .NET SDK, you don't need to install the corresponding runtime. To install the .NET SDK, run the following commands:
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y dotnet-sdk-5.0
 ```
 
@@ -18,9 +16,7 @@ sudo apt-get update; \
 The ASP.NET Core Runtime allows you to run apps that were made with .NET that didn't provide the runtime. The following commands install the ASP.NET Core Runtime, which is the most compatible runtime for .NET. In your terminal, run the following commands:
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y aspnetcore-runtime-5.0
 ```
 

--- a/docs/core/install/includes/linux-install-60-apt.md
+++ b/docs/core/install/includes/linux-install-60-apt.md
@@ -10,9 +10,7 @@ ms.topic: include
 The .NET SDK allows you to develop apps with .NET. If you install the .NET SDK, you don't need to install the corresponding runtime. To install the .NET SDK, run the following commands:
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y dotnet-sdk-6.0
 ```
 
@@ -24,9 +22,7 @@ sudo apt-get update; \
 The ASP.NET Core Runtime allows you to run apps that were made with .NET that didn't provide the runtime. The following commands install the ASP.NET Core Runtime, which is the most compatible runtime for .NET. In your terminal, run the following commands:
 
 ```bash
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y aspnetcore-runtime-6.0
 ```
 

--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -130,9 +130,7 @@ wget https://packages.microsoft.com/config/debian/{os-version}/prod.list
 sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y {dotnet-package}
 ```
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -133,9 +133,7 @@ wget https://packages.microsoft.com/config/ubuntu/{os-version}/prod.list
 sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
+sudo apt-get update && \
   sudo apt-get install -y {dotnet-package}
 ```
 


### PR DESCRIPTION
Apt 1.5 released 2017 supports https out-the-box. The package apt-transport-https is empty and not required. https://packages.debian.org/buster/apt-transport-https

> This is a dummy transitional package - https support has been moved into the apt package in 1.5. It can be safely removed.

