### PR TITLE
Update `HighEntropyVA` option's default value

### DIFF
--- a/docs/csharp/language-reference/compiler-options/security.md
+++ b/docs/csharp/language-reference/compiler-options/security.md
@@ -71,6 +71,6 @@ The **HighEntropyVA** compiler option tells the Windows kernel whether a particu
 <HighEntropyVA>true</HighEntropyVA>
 ```
 
-This option specifies that a 64-bit executable or an executable that is marked by the [**PlatformTarget**](output.md#platformtarget) compiler option supports a high entropy virtual address space. The option is disabled by default. Use **HighEntropyVA** to enable it.
+This option specifies that a 64-bit executable or an executable that is marked by the [**PlatformTarget**](output.md#platformtarget) compiler option supports a high entropy virtual address space. The option is enabled by default for all .NET Standard and .NET Core versions, and .NET Framework versions starting with .NET Framework 4.5.
 
 The **HighEntropyVA** option enables compatible versions of the Windows kernel to use higher degrees of entropy when randomizing the address space layout of a process as part of ASLR. Using higher degrees of entropy means a larger number of addresses can be allocated to memory regions such as stacks and heaps. As a result, it's more difficult to guess the location of a particular memory region. The **HighEntropyVA** compiler option requires the target executable and any modules that it depends on can handle pointer values larger than 4 gigabytes (GB) when they're running as a 64-bit process.


### PR DESCRIPTION
The default value for `HighEntropyVA` was changed to true for all .NET Core and .NET Standard since 2018: https://github.com/dotnet/msbuild/pull/3207

For .NET Framework, it was also enabled by default if it's not neither CLR 2.0 nor .NET Framework 4.0, which is all the versions starting with .NET Framework 4.5, according to [this list of .NET Framework versions](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies) (if we ignore .NET Framework 1.0 and 1.1).

I didn't leave out the "starting with .NET Framework 4.5" part because `.NET Framework 3.5` is still an officially supported version of [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework).

## Summary

Update doc to match with the actual default value of the `HighEntropyVA` option.
