### PR TITLE
Corrections in example codes in /docs/csharp/programming-guide/concepts/async

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/index.md
+++ b/docs/csharp/programming-guide/concepts/async/index.md
@@ -25,7 +25,7 @@ For a parallel algorithm, you'd need multiple cooks (or threads). One would make
 
 Now, consider those same instructions written as C# statements:
 
-:::code language="csharp" source="snippets/index/AsyncBreakfast-starter/Program.cs" highlight="8-34":::
+:::code language="csharp" source="snippets/index/AsyncBreakfast-starter/Program.cs" highlight="15-34":::
 
 :::image type="content" source="media/synchronous-breakfast.png" alt-text="synchronous breakfast":::
 
@@ -247,7 +247,7 @@ while (breakfastTasks.Count > 0)
 
 After all those changes, the final version of the code looks like this:
 <a id="final-version"></a>
-:::code language="csharp" source="snippets/index/AsyncBreakfast-final/Program.cs" highlight="9-40":::
+:::code language="csharp" source="snippets/index/AsyncBreakfast-final/Program.cs" highlight="16-47":::
 
 :::image type="content" source="media/whenany-async-breakfast.png" alt-text="when any async breakfast":::
 

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V2/Program.cs
@@ -5,7 +5,6 @@ namespace AsyncBreakfast
 {
     class Program
     {
-        // <SnippetMain>
         // These classes are intentionally empty for the purpose of this example. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
         internal class Bacon { }
         internal class Coffee { }
@@ -13,6 +12,7 @@ namespace AsyncBreakfast
         internal class Juice { }
         internal class Toast { }
 
+        // <SnippetMain>
         static async Task Main(string[] args)
         {
             Coffee cup = PourCoffee();

--- a/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Program.cs
+++ b/docs/csharp/programming-guide/concepts/async/snippets/index/AsyncBreakfast-V3/Program.cs
@@ -5,7 +5,6 @@ namespace AsyncBreakfast
 {
     class Program
     {
-        // <SnippetMain>
         // These classes are intentionally empty for the purpose of this example. They are simply marker classes for the purpose of demonstration, contain no properties, and serve no other purpose.
         internal class Bacon { }
         internal class Coffee { }
@@ -13,6 +12,7 @@ namespace AsyncBreakfast
         internal class Juice { }
         internal class Toast { }
 
+        // <SnippetMain>
         static async Task Main(string[] args)
         {
             Coffee cup = PourCoffee();


### PR DESCRIPTION
## Summary

I made a few changes on the [Asynchronous programming with async and await](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/) page. These changes are corrections to the changes made in #29790.

- [x] Fix highlighted line numbers in example codes.
- [x] Exclude class declarations from SnippetMain.