### PR TITLE
Mention consequences of specify PublishTrimmed

### DIFF
--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -18,6 +18,8 @@ Trimming with `PublishTrimmed` was introduced in .NET Core 3.0. The other option
 
   Enable trimming during publish. This also turns off trim-incompatible features and enables [trim analysis](#roslyn-analyzer) during build.
 
+
+**Note:** If you specify that property from command line, your debugging experience would differ and you may encounter additional bugs in final product. 
 Place this setting in the project file to ensure that the setting applies during `dotnet build`, not just `dotnet publish`.
 
 This setting trims any assemblies that have been configured for trimming. With `Microsoft.NET.Sdk` in .NET 6, this includes any assemblies with `[AssemblyMetadata("IsTrimmable", "True")]`, which is the case for framework assemblies. In .NET 5, framework assemblies from the netcoreapp runtime pack are configured for trimming via `<IsTrimmable>` MSBuild metadata. Other SDKs may define different defaults.

--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -18,7 +18,6 @@ Trimming with `PublishTrimmed` was introduced in .NET Core 3.0. The other option
 
   Enable trimming during publish. This also turns off trim-incompatible features and enables [trim analysis](#roslyn-analyzer) during build.
 
-
 **Note:** If you specify that property from command line, your debugging experience would differ and you may encounter additional bugs in final product. 
 Place this setting in the project file to ensure that the setting applies during `dotnet build`, not just `dotnet publish`.
 

--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -18,7 +18,9 @@ Trimming with `PublishTrimmed` was introduced in .NET Core 3.0. The other option
 
   Enable trimming during publish. This also turns off trim-incompatible features and enables [trim analysis](#roslyn-analyzer) during build.
 
-**Note:** If you specify that property from command line, your debugging experience would differ and you may encounter additional bugs in final product.
+> [!NOTE]
+> If you specify trimming as enabled from the command line, your debugging experience will differ and you may encounter additional bugs in the final product.
+
 Place this setting in the project file to ensure that the setting applies during `dotnet build`, not just `dotnet publish`.
 
 This setting trims any assemblies that have been configured for trimming. With `Microsoft.NET.Sdk` in .NET 6, this includes any assemblies with `[AssemblyMetadata("IsTrimmable", "True")]`, which is the case for framework assemblies. In .NET 5, framework assemblies from the netcoreapp runtime pack are configured for trimming via `<IsTrimmable>` MSBuild metadata. Other SDKs may define different defaults.

--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -18,7 +18,7 @@ Trimming with `PublishTrimmed` was introduced in .NET Core 3.0. The other option
 
   Enable trimming during publish. This also turns off trim-incompatible features and enables [trim analysis](#roslyn-analyzer) during build.
 
-**Note:** If you specify that property from command line, your debugging experience would differ and you may encounter additional bugs in final product. 
+**Note:** If you specify that property from command line, your debugging experience would differ and you may encounter additional bugs in final product.
 Place this setting in the project file to ensure that the setting applies during `dotnet build`, not just `dotnet publish`.
 
 This setting trims any assemblies that have been configured for trimming. With `Microsoft.NET.Sdk` in .NET 6, this includes any assemblies with `[AssemblyMetadata("IsTrimmable", "True")]`, which is the case for framework assemblies. In .NET 5, framework assemblies from the netcoreapp runtime pack are configured for trimming via `<IsTrimmable>` MSBuild metadata. Other SDKs may define different defaults.


### PR DESCRIPTION
When specifying `PublishTrimmed` from command line and not in project file, developer would have different debugging experience and may miss things until publish.
