### PR TITLE
Fix formatting.

### DIFF
--- a/docs/core/compatibility/aspnet-core/7.0/default-authentication-scheme.md
+++ b/docs/core/compatibility/aspnet-core/7.0/default-authentication-scheme.md
@@ -17,6 +17,7 @@ Moving forward, when a *single* authentication scheme is registered, that scheme
 
 ```csharp
 builder.Services.AddAuthentication().AddOAuth("MyDefaultScheme");
+```
 
 This change might expose unintended behavior changes in applications, such as authentication options being validated earlier than expected.
 


### PR DESCRIPTION
## Summary

A .NET 7 braking change document misses a closing ` ``` `.