### PR TITLE
Use the docfx.json to define '.NET' `titleSuffix`

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -827,6 +827,7 @@
                 "docs/core/compatibility/**.md": ".NET",
                 "docs/core/deploying/**.md": ".NET",
                 "docs/core/docker/**.md": ".NET",
+                "docs/core/extensions/**.md": ".NET",
                 "docs/core/migration/**.md": ".NET Core",
                 "docs/core/porting/**.md": ".NET Core",
                 "docs/core/runtime-config/**.md": ".NET",

--- a/docs/core/extensions/channels.md
+++ b/docs/core/extensions/channels.md
@@ -1,5 +1,5 @@
 ---
-title: Channels in .NET
+title: Channels
 description: Learn how to use System.Threading.Channels in .NET.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration providers in .NET
+title: Configuration providers
 description: Learn how the Configuration provider API is used to configure .NET applications.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration in .NET
+title: Configuration
 description: Learn how to use the Configuration API to configure .NET applications.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/create-resource-files.md
+++ b/docs/core/extensions/create-resource-files.md
@@ -1,5 +1,5 @@
 ---
-title: Create resource files for .NET apps
+title: Create resource files
 description: Make resource files for .NET apps. Build text files with string resources, XML or binary files programmatically, or XML files with string, image, or object data.
 ms.date: 03/23/2022
 dev_langs:

--- a/docs/core/extensions/create-satellite-assemblies.md
+++ b/docs/core/extensions/create-satellite-assemblies.md
@@ -1,5 +1,5 @@
 ---
-title: Create satellite assemblies for .NET apps
+title: Create satellite assemblies
 description: Get started with creating satellite assemblies for .NET apps. A satellite assembly can be easily updated or replaced to provide localized resources.
 ms.date: 05/19/2022
 dev_langs:

--- a/docs/core/extensions/custom-configuration-provider.md
+++ b/docs/core/extensions/custom-configuration-provider.md
@@ -1,5 +1,5 @@
 ---
-title: Implement a custom configuration provider in .NET
+title: Implement a custom configuration provider
 description: Learn how to implement a custom configuration provider in .NET applications.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -1,5 +1,5 @@
 ---
-title: Implement a custom logging provider in .NET
+title: Implement a custom logging provider
 description: Learn how to implement a custom logging provider in your .NET applications.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -1,5 +1,5 @@
 ---
-title: Use dependency injection in .NET
+title: Use dependency injection
 description: Learn how to use dependency injection in your .NET applications.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -1,5 +1,5 @@
 ---
-title: Dependency injection in .NET
+title: Dependency injection
 description: Learn how .NET implements dependency injection and how to use it.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -1,5 +1,5 @@
 ---
-title: File globbing in .NET
+title: File globbing
 author: IEvangelist
 description: Learn how to use file globbing in .NET to match various files with the same partial names, extensions, or segments.
 ms.author: dapine

--- a/docs/core/extensions/high-performance-logging.md
+++ b/docs/core/extensions/high-performance-logging.md
@@ -1,5 +1,5 @@
 ---
-title: High-performance logging in .NET
+title: High-performance logging
 author: IEvangelist
 description: Learn how to use LoggerMessage to create cacheable delegates that require fewer object allocations for high-performance logging scenarios.
 ms.author: dapine

--- a/docs/core/extensions/http-client.md
+++ b/docs/core/extensions/http-client.md
@@ -1,5 +1,5 @@
 ---
-title: IHttpClientFactory with .NET
+title: Use the IHttpClientFactory
 description: Learn how to use the HttpClient and IHttpClientFactory implementations with dependency injection in your .NET workloads.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/localization.md
+++ b/docs/core/extensions/localization.md
@@ -1,5 +1,5 @@
 ---
-title: Localization in .NET
+title: Localization
 description: Learn the concepts of localization while learning how to use the IStringLocalizer and IStringLocalizerFactory implementations in your .NET workloads.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Logging providers in .NET
+title: Logging providers
 description: Learn how the logging provider API is used in .NET applications.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -1,5 +1,5 @@
 ---
-title: Logging in .NET
+title: Logging
 author: IEvangelist
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
 ms.author: dapine

--- a/docs/core/extensions/options.md
+++ b/docs/core/extensions/options.md
@@ -1,5 +1,5 @@
 ---
-title: Options pattern in .NET
+title: Options pattern
 author: IEvangelist
 description: Learn how to use the options pattern to represent groups of related settings in .NET apps.
 ms.author: dapine

--- a/docs/core/extensions/primitives.md
+++ b/docs/core/extensions/primitives.md
@@ -1,5 +1,5 @@
 ---
-title: "Primitives: the extensions library for .NET"
+title: "Use the Microsoft.Extensions.Primitives library"
 description: Learn about the various primitive types from the Microsoft.Extensions.Primitives library.
 author: IEvangelist
 ms.author: dapine

--- a/docs/core/extensions/workers.md
+++ b/docs/core/extensions/workers.md
@@ -1,5 +1,5 @@
 ---
-title: Worker Services in .NET
+title: Worker Services
 description: Learn how to implement a custom IHostedService and use existing implementations with .NET.
 author: IEvangelist
 ms.author: dapine


### PR DESCRIPTION
## Summary

- Use the _docfx.json_ to define '.NET' `titleSuffix`
- Update `title` metadata accordingly

Fixes #30489 
