### PR TITLE
Added dotnet add package CPM support documentation

### DIFF
--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -51,37 +51,43 @@ The *ToDo.csproj* file now contains a [`<PackageReference>`](/nuget/consume-pack
 <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
 ```
 
-If the project is onboarded onto [Central Package Management (CPM)](https://devblogs.microsoft.com/nuget/introducing-central-package-management/) the `<PackageVersion>` element in the `Directory.Packages.props file` is added/updated and the `<PackageReference>` element is added to the project file. 
+If the project is onboarded onto [Central Package Management (CPM)](https://devblogs.microsoft.com/nuget/introducing-central-package-management/) the `<PackageVersion>` element in the `Directory.Packages.props file` is added/updated and the `<PackageReference>` element is added to the project file.
 
 The following scenarios are currently supported. These examples assume that the latest version of `Microsoft.EntityFrameworkCore` is 6.0.4. Additional scenarios related to CPM are documented in [this design spec](https://github.com/NuGet/Home/pull/11915).
 
-Scenario 1: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline. 
+Scenario 1: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline.
 
   CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore`
 
   The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+
   ```xml
   <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
   ```
+
   The `<PackageReference>` element is added to the project file.
+
   ```xml
   <PackageReference Include="Microsoft.EntityFrameworkCore" />
   ```
 
-Scenario 2: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is passed from the commandline. 
+Scenario 2: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is passed from the commandline.
 
   CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore --version 5.0.4`
 
   The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+
   ```xml
   <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
   ```
+
   The `<PackageReference>` element is added to the project file.
+
   ```xml
   <PackageReference Include="Microsoft.EntityFrameworkCore" />
   ```
 
-Scenario 3: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline. 
+Scenario 3: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline.
 
   CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore`
 

--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -92,27 +92,31 @@ Scenario 3: `<PackageReference>` does not exist in the project file, `<PackageVe
   CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore`
 
   The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+
   ```xml
   <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
   ```
-  The `<PackageReference>` element is added to the project file.
+
+The `<PackageReference>` element is added to the project file.
+
   ```xml
   <PackageReference Include="Microsoft.EntityFrameworkCore" />
   ```
 
-Scenario 4: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does exist in the `Directory.Packages.props file`, and the version argument is passed from the commandline. 
+Scenario 4: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does exist in the `Directory.Packages.props file`, and the version argument is passed from the commandline.
 
   CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore --version 5.0.4`
 
   The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+
   ```xml
   <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
   ```
   The `<PackageReference>` element is added to the project file.
+
   ```xml
   <PackageReference Include="Microsoft.EntityFrameworkCore" />
   ```
-
 
 ### Implicit restore
 

--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -53,7 +53,7 @@ The *ToDo.csproj* file now contains a [`<PackageReference>`](/nuget/consume-pack
 
 If the project is onboarded onto [Central Package Management (CPM)](https://devblogs.microsoft.com/nuget/introducing-central-package-management/) the `<PackageVersion>` element in the `Directory.Packages.props file` is added/updated and the `<PackageReference>` element is added to the project file. 
 
-The currently implemented scenarios are outlined below. Additional scenarios related to CPM are documented in this [design spec](https://github.com/NuGet/Home/pull/11915).
+The following scenarios are currently supported. These examples assume that the latest version of `Microsoft.EntityFrameworkCore` is 6.0.4. Additional scenarios related to CPM are documented in [this design spec](https://github.com/NuGet/Home/pull/11915).
 
 Scenario 1: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline. 
 
@@ -107,7 +107,6 @@ Scenario 4: `<PackageReference>` does not exist in the project file, `<PackageVe
   <PackageReference Include="Microsoft.EntityFrameworkCore" />
   ```
 
-*Note: These scenarios assume that the latest version of `Microsoft.EntityFrameworkCore` is 6.0.4.*
 
 ### Implicit restore
 

--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -112,6 +112,7 @@ Scenario 4: `<PackageReference>` does not exist in the project file, `<PackageVe
   ```xml
   <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
   ```
+
   The `<PackageReference>` element is added to the project file.
 
   ```xml

--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -51,6 +51,64 @@ The *ToDo.csproj* file now contains a [`<PackageReference>`](/nuget/consume-pack
 <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
 ```
 
+If the project is onboarded onto [Central Package Management (CPM)](https://devblogs.microsoft.com/nuget/introducing-central-package-management/) the `<PackageVersion>` element in the `Directory.Packages.props file` is added/updated and the `<PackageReference>` element is added to the project file. 
+
+The currently implemented scenarios are outlined below. Additional scenarios related to CPM are documented in this [design spec](https://github.com/NuGet/Home/pull/11915).
+
+Scenario 1: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline. 
+
+  CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore`
+
+  The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+  ```xml
+  <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
+  ```
+  The `<PackageReference>` element is added to the project file.
+  ```xml
+  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  ```
+
+Scenario 2: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does not exist in the `Directory.Packages.props file`, and the version argument is passed from the commandline. 
+
+  CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore --version 5.0.4`
+
+  The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+  ```xml
+  <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
+  ```
+  The `<PackageReference>` element is added to the project file.
+  ```xml
+  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  ```
+
+Scenario 3: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does exist in the `Directory.Packages.props file`, and the version argument is not passed from the commandline. 
+
+  CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore`
+
+  The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+  ```xml
+  <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
+  ```
+  The `<PackageReference>` element is added to the project file.
+  ```xml
+  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  ```
+
+Scenario 4: `<PackageReference>` does not exist in the project file, `<PackageVersion>` element does exist in the `Directory.Packages.props file`, and the version argument is passed from the commandline. 
+
+  CLI command that is executed: `dotnet add ToDo.csproj package Microsoft.EntityFrameworkCore --version 5.0.4`
+
+  The `<PackageVersion>` element is added to the `Directory.Packages.props file`.
+  ```xml
+  <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
+  ```
+  The `<PackageReference>` element is added to the project file.
+  ```xml
+  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  ```
+
+*Note: These scenarios assume that the latest version of `Microsoft.EntityFrameworkCore` is 6.0.4.*
+
 ### Implicit restore
 
 [!INCLUDE[DotNet Restore Note](../../../includes/dotnet-restore-note.md)]


### PR DESCRIPTION
## Summary

CPM support has been added to the dotnet add package command. This work is currently still in progress and can be found here: https://github.com/NuGet/NuGet.Client/pull/4700. 

The scenarios that have been currently implemented is documented here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-add-package.md](https://github.com/dotnet/docs/blob/d767ac021825bcc8592701354336b270fe60f7f0/docs/core/tools/dotnet-add-package.md) | [docs/core/tools/dotnet-add-package](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package?branch=pr-en-us-30496) |


<!-- PREVIEW-TABLE-END -->