### PR TITLE
Fix method name in CA2016 doc

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -103,7 +103,7 @@ Or explicitly pass `CancellationToken.None`:
 
 ### Example 2
 
-The rule will suggest forwarding the `c` parameter from `MyMethod` to the `MyMethodWithDefault` invocation, because the method has an overload that takes a `CancellationToken` parameter:
+The rule will suggest forwarding the `c` parameter from `MyMethod` to the `MyMethodWithOverload` invocation, because the method has an overload that takes a `CancellationToken` parameter:
 
 ```csharp
 using System.Threading;


### PR DESCRIPTION
Fix method name to make it consistent with the [example code below][2].

[2]: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2016#example-2