### PR TITLE
BinaryFormatter APIs obsolete as error

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -34,6 +34,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
+| [BinaryFormatter serialization APIs produce compiler errors](core-libraries/7.0/binaryformatter-apis-produce-errors.md) | ✔️ | ❌ | RC 1 |
 | [C++/CLI projects in Visual Studio](core-libraries/7.0/cpluspluscli-compiler-version.md) | ✔️ | ❌ | Preview 3 |
 | [Changes to reflection invoke API exceptions](core-libraries/7.0/reflection-invoke-exceptions.md) | ❌ | ✔️ | Preview 4 |
 | [Collectible Assembly in non-collectible AssemblyLoadContext](core-libraries/7.0/collectible-assemblies.md) | ❌ | ✔️ | Preview 5 |

--- a/docs/core/compatibility/core-libraries/5.0/binaryformatter-serialization-obsolete.md
+++ b/docs/core/compatibility/core-libraries/5.0/binaryformatter-serialization-obsolete.md
@@ -7,6 +7,9 @@ ms.date: 11/01/2020
 
 `Serialize` and `Deserialize` methods on <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter>, <xref:System.Runtime.Serialization.Formatter>, and <xref:System.Runtime.Serialization.IFormatter> are now obsolete as warning. Additionally, <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> serialization is prohibited by default for ASP.NET apps.
 
+> [!NOTE]
+> In .NET 7, the [affected APIs](#affected-apis) are obsolete as *error*. For more information, see [BinaryFormatter serialization APIs produce compiler errors](../7.0/binaryformatter-apis-produce-errors.md).
+
 ## Change description
 
 Due to [security vulnerabilities](../../../../standard/serialization/binaryformatter-security-guide.md#binaryformatter-security-vulnerabilities) in <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter>, the following methods are now obsolete and produce a compile-time warning with ID `SYSLIB0011`. Additionally, in ASP.NET Core 5.0 and later apps, they will throw a <xref:System.NotSupportedException>, unless the web app has re-enabled <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> functionality.
@@ -82,4 +85,5 @@ For more information about recommended actions, see [Resolving BinaryFormatter o
 
 ## See also
 
-- [SerializationFormat.Binary is obsolete](../7.0/serializationformat-binary.md)
+- [SerializationFormat.Binary is obsolete (.NET 7)](../7.0/serializationformat-binary.md)
+- [BinaryFormatter serialization APIs produce compiler errors (.NET 7)](../7.0/binaryformatter-apis-produce-errors.md)

--- a/docs/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors.md
+++ b/docs/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors.md
@@ -17,7 +17,9 @@ As part of the BinaryFormatter [long-term deprecation plan](https://github.com/d
 
 ## Previous behavior
 
-Since .NET 5, using the affected `Serialize` and `Deserialize` methods produced a compiler *warning* with ID `SYSLIB0011`. However, using the <xref:System.Exception.SerializeObjectState?displayProperty=nameWithType> event did not produce an error.
+Since .NET 5, using the affected `Serialize` and `Deserialize` methods produced a compiler *warning* with ID `SYSLIB0011`. For more information, see [BinaryFormatter serialization methods are obsolete and prohibited in ASP.NET apps (.NET 5)](../5.0/binaryformatter-serialization-obsolete.md).
+
+Using the <xref:System.Exception.SerializeObjectState?displayProperty=nameWithType> event did not produce an error.
 
 ## New behavior
 

--- a/docs/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors.md
+++ b/docs/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors.md
@@ -5,7 +5,7 @@ ms.date: 08/08/2022
 ---
 # BinaryFormatter serialization APIs produce compiler errors
 
-As part of the BinaryFormatter [long-term deprecation plan](nameWithType), we continue to cull `BinaryFormatter` functionality from our libraries and to wean developers off of the type. Starting in .NET 7, calls to the following APIs produce compile-time errors across all C# and Visual Basic project types:
+As part of the BinaryFormatter [long-term deprecation plan](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md), we continue to cull `BinaryFormatter` functionality from our libraries and to wean developers off of the type. Starting in .NET 7, calls to the following APIs produce compile-time errors across all C# and Visual Basic project types:
 
 - <xref:System.Exception.SerializeObjectState?displayProperty=fullName> event
 - <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize%2A?displayProperty=nameWithType> method
@@ -38,7 +38,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 ## Reason for change
 
-As part of the BinaryFormatter [long-term deprecation plan](nameWithType), we continue to cull `BinaryFormatter` functionality from our libraries and to wean developers off of the type.
+As part of the BinaryFormatter [long-term deprecation plan](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md), we continue to cull `BinaryFormatter` functionality from our libraries and to wean developers off of the type.
 
 ## Recommended action
 
@@ -71,6 +71,7 @@ The `<EnableUnsafeBinaryFormatterSerialization` property was introduced in .NET 
 | Desktop apps and all other app types | The affected APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you've suppressed the `SYSLIB0011` warning code. The runtime will *allow* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. | The affected APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed. The runtime will *forbid* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. | The affected APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed. The runtime will *allow* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. |
 
 <sup>1</sup>Runtime policy is controlled by the app host. Calls into `BinaryFormatter` might still fail at run time even if `<EnableUnsafeBinaryFormatterSerialization>` is set to `true` within your library's project file. Libraries can't override the app host's runtime policy.
+
 <sup>2</sup>The Blazor and MAUI runtimes forbid calls to `BinaryFormatter`. Regardless of any value you set for `<EnableUnsafeBinaryFormatterSerialization>`, the calls will fail at run time. Don't call these APIs from Blazor or MAUI applications or from libraries intended to be consumed by Blazor or MAUI apps.
 
 ## Affected APIs

--- a/docs/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors.md
+++ b/docs/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors.md
@@ -1,0 +1,90 @@
+---
+title: "Breaking change: BinaryFormatter serialization APIs produce compiler errors"
+description: Learn about the .NET 7 breaking change in core .NET libraries where serialize and deserialize methods on BinaryFormatter, Formatter, and IFormatter are obsolete as errors.
+ms.date: 08/08/2022
+---
+# BinaryFormatter serialization APIs produce compiler errors
+
+As part of the BinaryFormatter [long-term deprecation plan](nameWithType), we continue to cull `BinaryFormatter` functionality from our libraries and to wean developers off of the type. Starting in .NET 7, calls to the following APIs produce compile-time errors across all C# and Visual Basic project types:
+
+- <xref:System.Exception.SerializeObjectState?displayProperty=fullName> event
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize%2A?displayProperty=nameWithType> method
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize%2A?displayProperty=nameWithType> method
+- <xref:System.Runtime.Serialization.Formatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType> method
+- <xref:System.Runtime.Serialization.Formatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType> method
+- <xref:System.Runtime.Serialization.IFormatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType> method
+- <xref:System.Runtime.Serialization.IFormatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType> method
+
+## Previous behavior
+
+Since .NET 5, using the affected `Serialize` and `Deserialize` methods produced a compiler *warning* with ID `SYSLIB0011`. However, using the <xref:System.Exception.SerializeObjectState?displayProperty=nameWithType> event did not produce an error.
+
+## New behavior
+
+Starting in .NET 7, using any of the [affected APIs](#affected-apis) in code produces a compiler *error* with the same ID, `SYSLIB0011`. Your project will be affected if it meets all of the following criteria:
+
+- It's a C# or Visual Basic project.
+- It targets `net7.0` or higher.
+- It directly calls one of the [affected APIs](#affected-apis).
+- It's not already suppressing the `SYSLIB0011` warning code.
+
+## Version introduced
+
+.NET 7 RC 1
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+As part of the BinaryFormatter [long-term deprecation plan](nameWithType), we continue to cull `BinaryFormatter` functionality from our libraries and to wean developers off of the type.
+
+## Recommended action
+
+The best course of action is to migrate away from `BinaryFormatter` due to its security and reliability flaws. `BinaryFormatter` may be removed from .NET in a future release. The .NET libraries team has already taken a stance that recent types such as <xref:System.Half?displayProperty=fullName> and <xref:System.DateOnly?displayProperty=fullName> won't be compatible with `BinaryFormatter`.
+
+If you must suppress the errors, you can do so by following the guidelines in the [original obsoletion article](../5.0/binaryformatter-serialization-obsolete.md#recommended-action). You can also disable the error project-wide by setting a project property that converts the error back to a warning (to match the .NET 5/6 behavior).
+
+> [!WARNING]
+> Setting this property might change host behavior. See [\<EnableUnsafeBinaryFormatterSerialization> property](#enableunsafebinaryformatterserialization-property).
+
+```csharp
+<PropertyGroup>
+    ...
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+</PropertyGroup>
+```
+
+> [!NOTE]
+> If your project compiles with "warnings as errors" enabled, compilation will still fail. (This matches the behavior that shipped in the .NET 5 and .NET 6 SDKs.) If that's the case, you'll still need to suppress the `SYSLIB0011` warning in source or in your project file's `<NoWarn>` element.
+
+### \<EnableUnsafeBinaryFormatterSerialization> property
+
+The `<EnableUnsafeBinaryFormatterSerialization` property was introduced in .NET 5. With .NET 7, the behavior of this switch has changed to control *both compilation and host* run-time behavior. The meaning of this switch differs based on the project type, as described in the following table.
+
+| Type of project | Property set to `true` | Property set to `false` | Property omitted |
+| - | - | - | - |
+| Library/shared component<sup>1</sup> | The affected APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you've suppressed the `SYSLIB0011` warning code. | The affected APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed. | (Same as for `false`.) |
+| Blazor and MAUI apps<sup>2</sup> | Calls to `BinaryFormatter` will fail at run time. | Calls to `BinaryFormatter` will fail at run time. | Calls to `BinaryFormatter` will fail at run time. |
+| ASP.NET app | The affected APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you've suppressed the `SYSLIB0011` warning code. The runtime will *allow* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. | The affected APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed. The runtime will *forbid* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. | (Same as for `false`.) |
+| Desktop apps and all other app types | The affected APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you've suppressed the `SYSLIB0011` warning code. The runtime will *allow* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. | The affected APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed. The runtime will *forbid* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. | The affected APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed. The runtime will *allow* calls to `BinaryFormatter`, regardless of whether the call originates from your code or from a dependency that you consume. |
+
+<sup>1</sup>Runtime policy is controlled by the app host. Calls into `BinaryFormatter` might still fail at run time even if `<EnableUnsafeBinaryFormatterSerialization>` is set to `true` within your library's project file. Libraries can't override the app host's runtime policy.
+<sup>2</sup>The Blazor and MAUI runtimes forbid calls to `BinaryFormatter`. Regardless of any value you set for `<EnableUnsafeBinaryFormatterSerialization>`, the calls will fail at run time. Don't call these APIs from Blazor or MAUI applications or from libraries intended to be consumed by Blazor or MAUI apps.
+
+## Affected APIs
+
+- <xref:System.Exception.SerializeObjectState?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize%2A?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize%2A?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.Formatter.Serialize(System.IO.Stream,System.Object)?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.Formatter.Deserialize(System.IO.Stream)?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.IFormatter.Serialize(System.IO.Stream,System.Object)?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.IFormatter.Deserialize(System.IO.Stream)?displayProperty=fullName>
+
+## See also
+
+- [dotnet/runtime issue 72132](https://github.com/dotnet/runtime/issues/72132)
+- [BinaryFormatter serialization methods are obsolete (.NET 5)](../5.0/binaryformatter-serialization-obsolete.md)
+- [SerializationFormat.Binary is obsolete](../7.0/serializationformat-binary.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -49,6 +49,8 @@ items:
         items:
         - name: API obsoletions with non-default diagnostic IDs
           href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+        - name: BinaryFormatter serialization APIs produce compiler errors
+          href: core-libraries/7.0/binaryformatter-apis-produce-errors.md
         - name: C++/CLI projects in Visual Studio
           href: core-libraries/7.0/cpluspluscli-compiler-version.md
         - name: Collectible Assembly in non-collectible AssemblyLoadContext
@@ -775,6 +777,8 @@ items:
         items:
         - name: API obsoletions with non-default diagnostic IDs
           href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+        - name: BinaryFormatter serialization APIs produce compiler errors
+          href: core-libraries/7.0/binaryformatter-apis-produce-errors.md
         - name: C++/CLI projects in Visual Studio
           href: core-libraries/7.0/cpluspluscli-compiler-version.md
         - name: Collectible Assembly in non-collectible AssemblyLoadContext


### PR DESCRIPTION
[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors?branch=pr-en-us-30532).