### PR TITLE
Add bool keyword to System.Boolean in type table

### DIFF
--- a/docs/standard/native-interop/type-marshalling.md
+++ b/docs/standard/native-interop/type-marshalling.md
@@ -40,7 +40,7 @@ This first table describes the mappings for various types for whom the marshalli
 |             | .NET Pointer types (ex. `void*`)  | `void*` |
 |             | Type derived from `System.Runtime.InteropServices.SafeHandle` | `void*` |
 |             | Type derived from `System.Runtime.InteropServices.CriticalHandle` | `void*`          |
-|             | `System.Boolean` | Win32 `BOOL` type       |
+| `bool`      | `System.Boolean` | Win32 `BOOL` type       |
 | `decimal`   | `System.Decimal` | COM `DECIMAL` struct |
 |             | .NET Delegate | Native function pointer |
 |             | `System.DateTime` | Win32 `DATE` type |


### PR DESCRIPTION
The `bool` keyword was missing in the type table, so I added it.
