### PR TITLE
Include mention of init properties not working

### DIFF
--- a/docs/standard/serialization/xml-serializer-generator-tool-sgen-exe.md
+++ b/docs/standard/serialization/xml-serializer-generator-tool-sgen-exe.md
@@ -47,6 +47,12 @@ sgen [options]
  These generated assemblies cannot be used on the server side of a Web service. This tool is only for Web service clients and manual serialization scenarios.  
   
  If the assembly containing the type to serialize is named MyType.dll, then the associated serialization assembly will be named MyType.XmlSerializers.dll.  
+ 
+ sgen will fail if your assembly contains any public properties which have Init only setters:
+ ```csharp
+//Fails
+public int Age { get; int; }
+```
   
 ## Examples  
 

--- a/docs/standard/serialization/xml-serializer-generator-tool-sgen-exe.md
+++ b/docs/standard/serialization/xml-serializer-generator-tool-sgen-exe.md
@@ -47,7 +47,6 @@ sgen [options]
  These generated assemblies cannot be used on the server side of a Web service. This tool is only for Web service clients and manual serialization scenarios.  
   
  If the assembly containing the type to serialize is named MyType.dll, then the associated serialization assembly will be named MyType.XmlSerializers.dll.  
- 
 
 > [!NOTE]
 > The `sgen` tool is not compatible with [init](../../csharp/language-reference/keywords/init.md)-only setters. The tool will fail if the target assembly contains any public properties that use this feature.

--- a/docs/standard/serialization/xml-serializer-generator-tool-sgen-exe.md
+++ b/docs/standard/serialization/xml-serializer-generator-tool-sgen-exe.md
@@ -48,11 +48,9 @@ sgen [options]
   
  If the assembly containing the type to serialize is named MyType.dll, then the associated serialization assembly will be named MyType.XmlSerializers.dll.  
  
- sgen will fail if your assembly contains any public properties which have Init only setters:
- ```csharp
-//Fails
-public int Age { get; int; }
-```
+
+> [!NOTE]
+> The `sgen` tool is not compatible with [init](../../csharp/language-reference/keywords/init.md)-only setters. The tool will fail if the target assembly contains any public properties that use this feature.
   
 ## Examples  
 


### PR DESCRIPTION
## Summary

Sgen predates init only setters so having them in a serializable assembly will cause 
sgen to fail without an informative error message.

