### PR TITLE
Update portability-analyzer.md

### DIFF
--- a/docs/standard/analyzers/portability-analyzer.md
+++ b/docs/standard/analyzers/portability-analyzer.md
@@ -5,6 +5,8 @@ ms.date: 04/22/2022
 ms.assetid: 0375250f-5704-4993-a6d5-e21c499cea1e
 ---
 
+> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](docs/Console/README.md#run-the-tool-in-an-offline-mode).*
+
 # The .NET Portability Analyzer
 
 Want to make your libraries support multi-platform? Want to see how much work is required to make your .NET Framework application run on .NET Core? The [.NET Portability Analyzer](https://github.com/microsoft/dotnet-apiport) is a tool that analyzes assemblies and provides a detailed report on .NET APIs that are missing for the applications or libraries to be portable on your specified targeted .NET platforms. The Portability Analyzer is offered as a [Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer), which analyzes one assembly per project, and as an [ApiPort console app](https://aka.ms/apiportdownload), which analyzes assemblies by specified files or directory.

--- a/docs/standard/analyzers/portability-analyzer.md
+++ b/docs/standard/analyzers/portability-analyzer.md
@@ -7,7 +7,8 @@ ms.assetid: 0375250f-5704-4993-a6d5-e21c499cea1e
 
 # The .NET Portability Analyzer
 
-> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](https://github.com/microsoft/dotnet-apiport/blob/dev/docs/Console/README.md#run-the-tool-in-an-offline-mode).*
+> [!NOTE]
+> We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shut down the backend service of API Port, which will require using the tool offline. For more information, see [GitHub: .NET API Port repository](https://github.com/microsoft/dotnet-apiport/blob/dev/docs/Console/README.md#run-the-tool-in-an-offline-mode).*
 
 Want to make your libraries support multi-platform? Want to see how much work is required to make your .NET Framework application run on .NET Core? The [.NET Portability Analyzer](https://github.com/microsoft/dotnet-apiport) is a tool that analyzes assemblies and provides a detailed report on .NET APIs that are missing for the applications or libraries to be portable on your specified targeted .NET platforms. The Portability Analyzer is offered as a [Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer), which analyzes one assembly per project, and as an [ApiPort console app](https://aka.ms/apiportdownload), which analyzes assemblies by specified files or directory.
 

--- a/docs/standard/analyzers/portability-analyzer.md
+++ b/docs/standard/analyzers/portability-analyzer.md
@@ -5,9 +5,9 @@ ms.date: 04/22/2022
 ms.assetid: 0375250f-5704-4993-a6d5-e21c499cea1e
 ---
 
-> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](docs/Console/README.md#run-the-tool-in-an-offline-mode).*
-
 # The .NET Portability Analyzer
+
+> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](https://github.com/microsoft/dotnet-apiport/blob/dev/docs/Console/README.md#run-the-tool-in-an-offline-mode).*
 
 Want to make your libraries support multi-platform? Want to see how much work is required to make your .NET Framework application run on .NET Core? The [.NET Portability Analyzer](https://github.com/microsoft/dotnet-apiport) is a tool that analyzes assemblies and provides a detailed report on .NET APIs that are missing for the applications or libraries to be portable on your specified targeted .NET platforms. The Portability Analyzer is offered as a [Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer), which analyzes one assembly per project, and as an [ApiPort console app](https://aka.ms/apiportdownload), which analyzes assemblies by specified files or directory.
 


### PR DESCRIPTION
## Summary

Propagating [the notice from the repo's README regarding deprecation](https://github.com/microsoft/dotnet-apiport#net-api-portability) into this landing page for its aka.ms link