### PR TITLE
Enable fabricbot with 4 rules

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -23,13 +23,6 @@
           "title": "Merge main into live",
           "frequency": [
             {
-              "weekDay": 0,
-              "hours": [
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
               "weekDay": 1,
               "hours": [
                 22
@@ -59,13 +52,6 @@
             },
             {
               "weekDay": 5,
-              "hours": [
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 6,
               "hours": [
                 22
               ],

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -152,6 +152,40 @@
             ]
           }
         }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "PullRequestResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "prMatchesPattern",
+                "parameters": {
+                  "matchRegex": "docs/**/*.md"
+                }
+              }
+            ]
+          },
+          "eventType": "pull_request",
+          "eventNames": [
+            "pull_request",
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Insert preview link",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "[Internal preview link](https://review.docs.microsoft.com/dotnet/fundamentals/?branch=pr-en-us-${number})"
+              }
+            }
+          ]
+        }
       }
     ],
     "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,172 @@
+{
+    "version": "1.0",
+    "tasks": [
+      {
+        "taskType": "trigger",
+        "capabilityId": "InPrLabel",
+        "subCapability": "InPrLabel",
+        "version": "1.0",
+        "config": {
+          "label_inPr": "in-pr",
+          "taskName": "Add in-pr label to issues"
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledPR",
+        "subCapability": "ScheduledPR",
+        "version": "1.0",
+        "config": {
+          "head": "main",
+          "base": "live",
+          "body": "Please don't squash-merge this PR.",
+          "title": "Merge main into live",
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                22
+              ],
+              "timezoneOffset": -7
+            }
+          ],
+          "taskName": "Push to live branch (publish)"
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "PullRequestResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Label community PRs",
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "community-contribution"
+              }
+            }
+          ],
+          "eventType": "pull_request",
+          "eventNames": [
+            "pull_request"
+          ],
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "opened"
+                }
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "activitySenderHasPermissions",
+                        "parameters": {
+                          "permissions": "admin"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "activitySenderHasPermissions",
+                        "parameters": {
+                          "permissions": "maintain"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "activitySenderHasPermissions",
+                        "parameters": {
+                          "permissions": "write"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "isActivitySender",
+                        "parameters": {
+                          "user": "github-actions[bot]"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "isActivitySender",
+                        "parameters": {
+                          "user": "github-actions"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "userGroups": []
+  }


### PR DESCRIPTION
- Configuration portal is here: https://portal.fabricbot.ms/bot/?repo=dotnet/docs
- General info is here: https://portal.fabricbot.ms/

This PR adds 4 rules for FabricBot:

1. Automatically create a PR from main to live each weekday at 10 PM PDT.
2. Add `community-contribution` label to PRs where the author doesn't have admin/maintain/write permissions.
3. Add `in-pr` label to issues that will be closed by an active PR.
4. Add an internal preview link as a new comment in a PR that's been opened and that modifies a Markdown file under docs/.