### PR TITLE
Update Jammy instructions

### DIFF
--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -21,7 +21,6 @@ The following table is a list of currently supported .NET releases and the versi
 | Ubuntu                 | .NET       |
 |------------------------|------------|
 | [22.04 (LTS)](#2204)   | 6+         |
-| [21.10](#2110)         | 3.1, 6     |
 | [20.04 (LTS)](#2004)   | 3.1, 6     |
 | [18.04 (LTS)](#1804)   | 3.1, 6     |
 | [16.04 (LTS)](#1604)   | 3.1, 6     |
@@ -38,6 +37,32 @@ The following table is a list of currently supported .NET releases and the versi
 
 ## 22.04
 
+> Warning: If you've previously installed .NET 6 from `packages.microsoft.com`, see the [Advisory on installing .NET 6 on Ubuntu 22.04].
+
+.NET 6 is included in Ubuntu 22.04. You can install it with the following commands:
+
+For the .NET SDK:
+
+```bash
+sudo apt install -y dotnet6
+```
+
+For ASP.NET Core
+
+```bash
+sudo apt install -y apt install -y aspnetcore-runtime-6.0
+```
+
+For .NET Runtime
+
+```bash
+sudo apt install -y apt install -y dotnet-runtime-6.0
+```
+
+## 22.04 -- packages.microsoft.com
+
+> Warning: .NET 6 is included in Ubuntu 22.04. See the [Advisory on installing .NET 6 on Ubuntu 22.04] if you want to use .NET packages from `packages.microsoft.com`.
+
 [!INCLUDE [linux-prep-intro-apt](includes/linux-prep-intro-apt.md)]
 
 ```bash
@@ -49,18 +74,6 @@ rm packages-microsoft-prod.deb
 [!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
 
 Note: [Ubuntu 22.04 includes OpenSSL 3](https://discourse.ubuntu.com/t/openssl-3-0-transition-plans/24453) as the baseline version. [.NET 6 supports OpenSSL 3](https://devblogs.microsoft.com/dotnet/announcing-net-6/#security) while earlier .NET versions do not. Microsoft does not test or support using OpenSSL 1.x on Ubuntu 22.04.
-
-## 21.10
-
-[!INCLUDE [linux-prep-intro-apt](includes/linux-prep-intro-apt.md)]
-
-```bash
-wget https://packages.microsoft.com/config/ubuntu/21.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-rm packages-microsoft-prod.deb
-```
-
-[!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
 
 ## 20.04
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -59,7 +59,7 @@ For .NET Runtime
 sudo apt install -y apt install -y dotnet-runtime-6.0
 ```
 
-## 22.04 -- packages.microsoft.com
+## 22.04 (Microsoft package feed)
 
 > Warning: .NET 6 is included in Ubuntu 22.04. See the [Advisory on installing .NET 6 on Ubuntu 22.04] if you want to use .NET packages from `packages.microsoft.com`.
 
@@ -73,7 +73,8 @@ rm packages-microsoft-prod.deb
 
 [!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
 
-Note: [Ubuntu 22.04 includes OpenSSL 3](https://discourse.ubuntu.com/t/openssl-3-0-transition-plans/24453) as the baseline version. [.NET 6 supports OpenSSL 3](https://devblogs.microsoft.com/dotnet/announcing-net-6/#security) while earlier .NET versions do not. Microsoft does not test or support using OpenSSL 1.x on Ubuntu 22.04.
+> [!NOTE]
+> [Ubuntu 22.04 includes OpenSSL 3](https://discourse.ubuntu.com/t/openssl-3-0-transition-plans/24453) as the baseline version. .NET 6 supports OpenSSL 3 while earlier .NET versions don't. Microsoft doesn't test or support using OpenSSL 1.x on Ubuntu 22.04. For more information, see [.NET 6 Security Improvements](https://devblogs.microsoft.com/dotnet/announcing-net-6/#security).
 
 ## 20.04
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -52,9 +52,6 @@ sudo apt-get update && \
   sudo apt-get install -y dotnet6
 ```
 
-> [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package dotnet-sdk-6.0**, see the [APT troubleshooting](#apt-troubleshooting) section.
-
 ### Install the runtime
 
 The ASP.NET Core Runtime allows you to run apps that were made with .NET that didn't provide the runtime. The following commands install the ASP.NET Core Runtime, which is the most compatible runtime for .NET. In your terminal, run the following commands:
@@ -63,9 +60,6 @@ The ASP.NET Core Runtime allows you to run apps that were made with .NET that di
 sudo apt-get update && \
   sudo apt-get install -y aspnetcore-runtime-6.0
 ```
-
-> [!IMPORTANT]
-> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-6.0**, see the [APT troubleshooting](#apt-troubleshooting) section.
 
 As an alternative to the ASP.NET Core Runtime, you can install the .NET Runtime, which doesn't include ASP.NET Core support: replace `aspnetcore-runtime-6.0` in the previous command with `dotnet-runtime-6.0`:
 
@@ -151,6 +145,9 @@ This section provides information on common errors you may get while using APT t
 [!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
 
 ### Unable to locate \\ Some packages could not be installed
+
+> [!NOTE]
+> This information only applies when .NET is installed from the Microsoft package feed.
 
 [!INCLUDE [package-manager-failed-to-find-deb](includes/package-manager-failed-to-find-deb.md)]
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -37,8 +37,8 @@ The following table is a list of currently supported .NET releases and the versi
 
 ## 22.04
 
-> [!NOTE]
-> Warning: If you've previously installed .NET 6 from `packages.microsoft.com`, see the [Advisory on installing .NET 6 on Ubuntu 22.04](https://github.com/dotnet/core/issues/7699).
+> [!WARNING]
+> If you've previously installed .NET 6 from `packages.microsoft.com`, see the [Advisory on installing .NET 6 on Ubuntu 22.04](https://github.com/dotnet/core/issues/7699).
 
 .NET 6 is included in Ubuntu 22.04.
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -40,25 +40,9 @@ The following table is a list of currently supported .NET releases and the versi
 > [!NOTE]
 > Warning: If you've previously installed .NET 6 from `packages.microsoft.com`, see the [Advisory on installing .NET 6 on Ubuntu 22.04](https://github.com/dotnet/core/issues/7699).
 
-.NET 6 is included in Ubuntu 22.04. You can install it with the following commands:
+.NET 6 is included in Ubuntu 22.04.
 
-For the .NET SDK:
-
-```bash
-sudo apt install -y dotnet6
-```
-
-For ASP.NET Core
-
-```bash
-sudo apt install -y apt install -y aspnetcore-runtime-6.0
-```
-
-For .NET Runtime
-
-```bash
-sudo apt install -y apt install -y dotnet-runtime-6.0
-```
+[!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
 
 ## 22.04 (Microsoft package feed)
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -37,7 +37,8 @@ The following table is a list of currently supported .NET releases and the versi
 
 ## 22.04
 
-> Warning: If you've previously installed .NET 6 from `packages.microsoft.com`, see the [Advisory on installing .NET 6 on Ubuntu 22.04].
+> [!NOTE]
+> Warning: If you've previously installed .NET 6 from `packages.microsoft.com`, see the [Advisory on installing .NET 6 on Ubuntu 22.04](https://github.com/dotnet/core/issues/7699).
 
 .NET 6 is included in Ubuntu 22.04. You can install it with the following commands:
 
@@ -61,7 +62,8 @@ sudo apt install -y apt install -y dotnet-runtime-6.0
 
 ## 22.04 (Microsoft package feed)
 
-> Warning: .NET 6 is included in Ubuntu 22.04. See the [Advisory on installing .NET 6 on Ubuntu 22.04] if you want to use .NET packages from `packages.microsoft.com`.
+> [!NOTE]
+> Warning: .NET 6 is included in Ubuntu 22.04. See the [Advisory on installing .NET 6 on Ubuntu 22.04](https://github.com/dotnet/core/issues/7699) if you want to use .NET packages from `packages.microsoft.com`.
 
 [!INCLUDE [linux-prep-intro-apt](includes/linux-prep-intro-apt.md)]
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -42,7 +42,6 @@ The following table is a list of currently supported .NET releases and the versi
 
 .NET 6 is included in Ubuntu 22.04.
 
-
 ### Install the SDK
 
 The .NET SDK allows you to develop apps with .NET. If you install the .NET SDK, you don't need to install the corresponding runtime. To install the .NET SDK, run the following commands:

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -42,7 +42,36 @@ The following table is a list of currently supported .NET releases and the versi
 
 .NET 6 is included in Ubuntu 22.04.
 
-[!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
+
+### Install the SDK
+
+The .NET SDK allows you to develop apps with .NET. If you install the .NET SDK, you don't need to install the corresponding runtime. To install the .NET SDK, run the following commands:
+
+```bash
+sudo apt-get update && \
+  sudo apt-get install -y dotnet6
+```
+
+> [!IMPORTANT]
+> If you receive an error message similar to **Unable to locate package dotnet-sdk-6.0**, see the [APT troubleshooting](#apt-troubleshooting) section.
+
+### Install the runtime
+
+The ASP.NET Core Runtime allows you to run apps that were made with .NET that didn't provide the runtime. The following commands install the ASP.NET Core Runtime, which is the most compatible runtime for .NET. In your terminal, run the following commands:
+
+```bash
+sudo apt-get update && \
+  sudo apt-get install -y aspnetcore-runtime-6.0
+```
+
+> [!IMPORTANT]
+> If you receive an error message similar to **Unable to locate package aspnetcore-runtime-6.0**, see the [APT troubleshooting](#apt-troubleshooting) section.
+
+As an alternative to the ASP.NET Core Runtime, you can install the .NET Runtime, which doesn't include ASP.NET Core support: replace `aspnetcore-runtime-6.0` in the previous command with `dotnet-runtime-6.0`:
+
+```bash
+sudo apt-get install -y dotnet-runtime-6.0
+```
 
 ## 22.04 (Microsoft package feed)
 

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -30,6 +30,7 @@ You may need to install [.NET dependencies](https://github.com/dotnet/core/blob/
 
 .NET is available in the [official package archives](https://pkgs.org/search/?q=dotnet) for various Linux distributions, including the following ones.
 
+- [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=dotnet*)
 - [Arch Linux](https://archlinux.org/packages/?q=dotnet)
 - [Arch Linux User Repository](https://aur.archlinux.org/packages?K=dotnet)
 - [Fedora](https://packages.fedoraproject.org/search?query=dotnet)

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -34,10 +34,9 @@ You may need to install [.NET dependencies](https://github.com/dotnet/core/blob/
 - [Arch Linux User Repository](https://aur.archlinux.org/packages?K=dotnet)
 - [Fedora](https://packages.fedoraproject.org/search?query=dotnet)
 - [Red Hat Enterprise Linux](https://access.redhat.com/documentation/en-us/net/6.0)
+- [Ubuntu](https://packages.ubuntu.com/search?keywords=dotnet6)
 
-.NET may or may not be [supported by Microsoft](https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md) as published in the official package archives. You can still [open issues at dotnet/core](https://github.com/dotnet/core/issues) if you run into problems.
-
-[Red Hat supports .NET](https://developers.redhat.com/topics/dotnet/) on Red Hat Enterprise Linux (RHEL). Red Hat and Microsoft collaborate to ensure that .NET works well on RHEL.
+Microsoft collaborates with partners to ensure .NET works well on their Linux distributions. Support is provided by those distributions. You can still [open issues at dotnet/core](https://github.com/dotnet/core/issues) if you run into problems.
 
 ## Microsoft packages
 


### PR DESCRIPTION
Instructions have changed for Ubuntu 22.04.

It appears like this doc may need to be re-structured. We need to update the instructions as a higher priority than considering broader changes.

Fixes #30686