### PR TITLE
Bitwise operators examples: improve example output with leading zeros

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
@@ -101,10 +101,10 @@
             Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2), 4}");
 
             uint y = x >> 2;
-            Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2), 4}");
+            Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2).PadLeft(4, '0'), 4}");
             // Output:
             // Before: 1001
-            // After:    10
+            // After:  0010
             // </SnippetRightShift>
 
             // <SnippetArithmeticRightShift>
@@ -123,10 +123,10 @@
             Console.WriteLine($"Before: {Convert.ToString(c, toBase: 2), 32}");
 
             uint d = c >> 3;
-            Console.WriteLine($"After:  {Convert.ToString(d, toBase: 2), 32}");
+            Console.WriteLine($"After:  {Convert.ToString(d, toBase: 2).PadLeft(32, '0'), 32}");
             // Output:
             // Before: 10000000000000000000000000000000
-            // After:     10000000000000000000000000000
+            // After:  00010000000000000000000000000000
             // </SnippetLogicalRightShift>
         }
 
@@ -140,11 +140,11 @@
             Console.WriteLine($"After  >>: {y,11}, hex: {y,8:x}, binary: {Convert.ToString(y, toBase: 2), 32}");
 
             int z = x >>> 2;
-            Console.WriteLine($"After >>>: {z,11}, hex: {z,8:x}, binary: {Convert.ToString(z, toBase: 2), 32}");
+            Console.WriteLine($"After >>>: {z,11}, hex: {z,8:x}, binary: {Convert.ToString(z, toBase: 2).PadLeft(32, '0'), 32}");
             // Output:
             // Before:             -8, hex: fffffff8, binary: 11111111111111111111111111111000
             // After  >>:          -2, hex: fffffffe, binary: 11111111111111111111111111111110
-            // After >>>:  1073741822, hex: 3ffffffe, binary:   111111111111111111111111111110
+            // After >>>:  1073741822, hex: 3ffffffe, binary: 00111111111111111111111111111110
             // </SnippetUnsignedRightShift>
         }
 
@@ -181,7 +181,7 @@
 
             a = INITIAL_VALUE;
             a ^= 0b_1000_0000;
-            Display(a);  // output: 1111000
+            Display(a);  // output: 01111000
 
             a = INITIAL_VALUE;
             a <<= 2;
@@ -189,13 +189,13 @@
 
             a = INITIAL_VALUE;
             a >>= 4;
-            Display(a);  // output: 1111
+            Display(a);  // output: 00001111
 
             a = INITIAL_VALUE;
             a >>>= 4;
-            Display(a);  // output: 1111
+            Display(a);  // output: 00001111
 
-            void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2), 8}");
+            void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2).PadLeft(8, '0'), 8}");
             // </SnippetCompoundAssignment>
         }
 


### PR DESCRIPTION
Fixes #30469 

Adding the call to [PadLeft](https://docs.microsoft.com/en-us/dotnet/api/system.string.padleft?view=net-6.0#system-string-padleft(system-int32-system-char)) where it makes the example output clearer.
