### PR TITLE
Made the order of the See also list consistent

### DIFF
--- a/docs/csharp/language-reference/statements/selection-statements.md
+++ b/docs/csharp/language-reference/statements/selection-statements.md
@@ -101,9 +101,9 @@ For more information about features introduced in C# 7.0 and later, see the foll
 
 ## See also
 
-- [Add missing cases to switch statement (style rule IDE0010)](../../../fundamentals/code-analysis/style-rules/ide0010.md)
 - [C# reference](../index.md)
 - [Conditional operator `?:`](../operators/conditional-operator.md)
 - [Logical operators](../operators/boolean-logical-operators.md)
 - [Patterns](../operators/patterns.md)
 - [`switch` expression](../operators/switch-expression.md)
+- [Add missing cases to switch statement (style rule IDE0010)](../../../fundamentals/code-analysis/style-rules/ide0010.md)


### PR DESCRIPTION
Typically, the link to the "C# reference" goes first in the C# reference articles
