### PR TITLE
Removed Serialization constructor from Creating/Throwing Exceptions page

### DIFF
--- a/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
@@ -45,7 +45,7 @@ The following list identifies practices to avoid when throwing exceptions:
 
 ## Defining Exception Classes
 
-Programs can throw a predefined exception class in the <xref:System> namespace (except where previously noted), or create their own exception classes by deriving from <xref:System.Exception>. The derived classes should define at least four constructors: one parameterless constructor, one that sets the message property, and one that sets both the <xref:System.Exception.Message%2A> and <xref:System.Exception.InnerException%2A> properties. The fourth constructor is used to serialize the exception. New exception classes should be serializable. For example:
+Programs can throw a predefined exception class in the <xref:System> namespace (except where previously noted), or create their own exception classes by deriving from <xref:System.Exception>. The derived classes should define at least three constructors: one parameterless constructor, one that sets the message property, and one that sets both the <xref:System.Exception.Message%2A> and <xref:System.Exception.InnerException%2A> properties. For example:
 
 :::code language="csharp" source="snippets/exceptions/InvalidDepartmentException.cs" ID="DefineExceptionClass":::
 

--- a/docs/csharp/fundamentals/exceptions/snippets/exceptions/InvalidDepartmentException.cs
+++ b/docs/csharp/fundamentals/exceptions/snippets/exceptions/InvalidDepartmentException.cs
@@ -9,11 +9,6 @@ namespace Exceptions
         public InvalidDepartmentException() : base() { }
         public InvalidDepartmentException(string message) : base(message) { }
         public InvalidDepartmentException(string message, Exception inner) : base(message, inner) { }
-
-        // A constructor is needed for serialization when an
-        // exception propagates from a remoting server to the client.
-        protected InvalidDepartmentException(System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     // </DefineExceptionClass>
 }


### PR DESCRIPTION
## Summary

Removed references to the Serialization constructor for custom exceptions to be consistent with [this page](https://docs.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#include-three-constructors-in-custom-exception-classes), since this is no longer recommended.

Fixes #30644 
