### PR TITLE
Write content for UTF-8 string literals for C# 11.

### DIFF
--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -11,6 +11,7 @@ f1_keywords:
   - "string"
   - "string_CSharpKeyword"
   - "RawStringLiteral_CSharpKeyword"
+  - "Utf8StringLiteral_CSharpKeyword"
 helpviewer_keywords: 
   - "object keyword [C#]"
   - "delegate keyword [C#]"
@@ -181,6 +182,21 @@ To include a double quotation mark in an @-quoted string, double it:
 ```csharp
 @"""Ahoy!"" cried the captain." // "Ahoy!" cried the captain.
 ```
+
+Strings in .NET have always been stored using UTF-16 encoding. UTF-8 is the standard for Web protocols and other important libraries. Beginning in C# 11, you can add the `u8` suffix to a string literal to specify UTF-8 encoding. UTF-8 literals are stored as `ReadOnlySpan<byte>` objects. Using a UTF-8 string literal creates a more clear declaration than declaring the equivalent <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as shown in the following code:
+
+```csharp
+ReadOnlySpan<byte> AuthWithTrailingSpace = new byte[] { 0x41, 0x55, 0x54, 0x48, 0x20 };
+ReadOnlySpan<byte> AuthStringLiteral = "AUTH "u8;
+```
+
+To store a UTF-8 string literal as an array requires the use of <xref:System.ReadOnlySpan%601.ToArray?displayProperty=nameWithType>:
+
+```csharp
+byte[] AuthStringLiteral = "AUTH "u8.ToArray();
+```
+
+UTF-8 string literals aren't compile time constants. Therefore, they cannot be used as the default value for an optional parameter.
 
 ## The delegate type
 

--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -1,7 +1,7 @@
 ---
 title: "Built-in reference types - C# reference"
 description: "Learn about reference types that have C# keywords you can use to declare them."
-ms.date: 04/15/2022
+ms.date: 08/16/2022
 f1_keywords: 
   - "object_CSharpKeyword"
   - "object"
@@ -46,7 +46,7 @@ Console.WriteLine(a == b);
 Console.WriteLine(object.ReferenceEquals(a, b));
 ```
 
-The previous example displays "True" and then "False" because the content of the strings are equivalent, but `a` and `b` don't refer to the same string instance.
+The previous example displays "True" and then "False" because the content of the strings is equivalent, but `a` and `b` don't refer to the same string instance.
 
 The [+ operator](../operators/addition-operator.md#string-concatenation) concatenates strings:
 
@@ -56,7 +56,7 @@ string a = "good " + "morning";
 
 The preceding code creates a string object that contains "good morning".
 
-Strings are *immutable*--the contents of a string object can't be changed after the object is created, although the syntax makes it appear as if you can. For example, when you write this code, the compiler actually creates a new string object to hold the new sequence of characters, and that new object is assigned to `b`. The memory that had been allocated for `b` (when it contained the string "h") is then eligible for garbage collection.
+Strings are *immutable*--the contents of a string object can't be changed after the object is created. For example, when you write this code, the compiler actually creates a new string object to hold the new sequence of characters, and that new object is assigned to `b`. The memory that had been allocated for `b` (when it contained the string "h") is then eligible for garbage collection.
 
 ```csharp
 string b = "h";
@@ -117,7 +117,7 @@ Console.WriteLine(message);
 // output: "This is a very important message."
 ```
 
-When the starting and ending quotes are on separate lines, the newlines following the opening quote and preceding the ending quote are not included in the final content. The closing quote sequence dictates the leftmost column for the string literal. You can indent a raw string literal to match the overall code format:
+When the starting and ending quotes are on separate lines, the newlines following the opening quote and preceding the ending quote aren't included in the final content. The closing quote sequence dictates the leftmost column for the string literal. You can indent a raw string literal to match the overall code format:
 
 ```csharp
 var message = """
@@ -128,7 +128,7 @@ Console.WriteLine(message);
 // The leftmost whitespace is not part of the raw string literal
 ```
 
-Columns to the right of the ending quote sequence are preserved. This enables raw strings for data formats such as JSON, YAML, or XML, as shown in the following example:
+Columns to the right of the ending quote sequence are preserved. This behavior enables raw strings for data formats such as JSON, YAML, or XML, as shown in the following example:
 
 ```csharp
 var json= """
@@ -183,20 +183,22 @@ To include a double quotation mark in an @-quoted string, double it:
 @"""Ahoy!"" cried the captain." // "Ahoy!" cried the captain.
 ```
 
-Strings in .NET have always been stored using UTF-16 encoding. UTF-8 is the standard for Web protocols and other important libraries. Beginning in C# 11, you can add the `u8` suffix to a string literal to specify UTF-8 encoding. UTF-8 literals are stored as `ReadOnlySpan<byte>` objects. Using a UTF-8 string literal creates a more clear declaration than declaring the equivalent <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as shown in the following code:
+### UTF-8 string literals
+
+Strings in .NET are stored using UTF-16 encoding. UTF-8 is the standard for Web protocols and other important libraries. Beginning in C# 11, you can add the `u8` suffix to a string literal to specify UTF-8 encoding. UTF-8 literals are stored as `ReadOnlySpan<byte>` objects. The natural type of a UTF-8 string literal is `ReadOnlySpan<byte>`. Using a UTF-8 string literal creates a more clear declaration than declaring the equivalent <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as shown in the following code:
 
 ```csharp
 ReadOnlySpan<byte> AuthWithTrailingSpace = new byte[] { 0x41, 0x55, 0x54, 0x48, 0x20 };
 ReadOnlySpan<byte> AuthStringLiteral = "AUTH "u8;
 ```
 
-To store a UTF-8 string literal as an array requires the use of <xref:System.ReadOnlySpan%601.ToArray?displayProperty=nameWithType>:
+To store a UTF-8 string literal as an array requires the use of <xref:System.ReadOnlySpan%601.ToArray?displayProperty=nameWithType> to copy the bytes containing the literal to the mutable array:
 
 ```csharp
 byte[] AuthStringLiteral = "AUTH "u8.ToArray();
 ```
 
-UTF-8 string literals aren't compile time constants. Therefore, they cannot be used as the default value for an optional parameter.
+UTF-8 string literals aren't compile time constants; they're runtime constants. Therefore, they can't be used as the default value for an optional parameter.
 
 ## The delegate type
 
@@ -213,7 +215,7 @@ A `delegate` is a reference type that can be used to encapsulate a named or an a
 
 The delegate must be instantiated with a method or lambda expression that has a compatible return type and input parameters. For more information on the degree of variance that is allowed in the method signature, see [Variance in Delegates](../../programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md). For use with anonymous methods, the delegate and the code to be associated with it are declared together.
 
-Delegate combination and removal fails with a runtime exception when the delegate types involved at run time are different due to variant conversion. The following example demonstrates a situation that fails:
+Delegate combination or removal fails with a runtime exception when the delegate types involved at run time are different due to variant conversion. The following example demonstrates a situation that fails:
 
 ```csharp
 Action<string> stringAction = str => {};

--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -198,7 +198,7 @@ To store a UTF-8 string literal as an array requires the use of <xref:System.Rea
 byte[] AuthStringLiteral = "AUTH "u8.ToArray();
 ```
 
-UTF-8 string literals aren't compile time constants; they're runtime constants. Therefore, they can't be used as the default value for an optional parameter.
+UTF-8 string literals aren't compile time constants; they're runtime constants. Therefore, they can't be used as the default value for an optional parameter. UTF-8 string literals can't be combined with string interpolation. You can't use the `$` token and the `u8` suffix on the same string expression.
 
 ## The delegate type
 

--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -33,6 +33,8 @@ Beginning with C# 6, [string interpolation](../tokens/interpolated.md) provides 
 
 Beginning with C# 10, you can use string interpolation to initialize a constant string when all the expressions used for placeholders are also constant strings.
 
+Beginning with C# 11, the `+` operator performs string concatenation for UTF-8 literal strings. This operator concatenates two `ReadOnlySpan<byte>` objects.
+
 ## Delegate combination
 
 For operands of the same [delegate](../builtin-types/reference-types.md#the-delegate-type) type, the `+` operator returns a new delegate instance that, when invoked, invokes the left-hand operand and then invokes the right-hand operand. If any of the operands is `null`, the `+` operator returns the value of another operand (which also might be `null`). The following example shows how delegates can be combined with the `+` operator:
@@ -67,7 +69,7 @@ You also use the `+=` operator to specify an event handler method when you subsc
 
 ## Operator overloadability
 
-A user-defined type can [overload](operator-overloading.md) the `+` operator. When a binary `+` operator is overloaded, the `+=` operator is also implicitly overloaded. A user-defined type cannot explicitly overload the `+=` operator.
+A user-defined type can [overload](operator-overloading.md) the `+` operator. When a binary `+` operator is overloaded, the `+=` operator is also implicitly overloaded. A user-defined type can't explicitly overload the `+=` operator.
 
 ## C# language specification
 

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in C# 11 - C# Guide
 description: Get an overview of the new features coming in C# 11.
-ms.date: 06/02/2022
+ms.date: 08/16/2022
 ---
 # What's new in C# 11
 
@@ -173,10 +173,12 @@ Type parameter names and parameter names are now in scope when used in a `nameof
 
 ## UTF-8 string literals
 
-You can specify the `u8` suffix on a string literal to specify UTF-8 character encoding. The natural type for a UTF-8 string literal is `ReadOnlySpan<byte>`. You can learn more about UTF-8 string literals in the string literal section of the article on [builtin reference types](../language-reference/builtin-types/reference-types.md#string-literals).
+You can specify the `u8` suffix on a string literal to specify UTF-8 character encoding. 
+
+You can learn more about UTF-8 string literals in the string literal section of the article on [builtin reference types](../language-reference/builtin-types/reference-types.md#utf-8-string-literals).
 
 ## Required members
 
 You can add the [`required` modifier](../language-reference/keywords/required.md) to properties and fields to enforce constructors and callers to initialize those values. The <xref:System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute?displayProperty=nameWithType> can be added to constructors to inform the compiler that a constructor initializes *all* required members.
 
-See [init-only](../properties.md#init-only) for more information.
+For more information on required members, See the [init-only](../properties.md#init-only) section of the properties article.

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -15,6 +15,7 @@ The following features are available in Visual Studio 2022 version 17.3:
 - [pattern match `Span<char>` on a constant `string`](#pattern-match-spanchar-or-readonlyspanchar-on-a-constant-string)
 - [Extended `nameof` scope](#extended-nameof-scope)
 - [Numeric IntPtr](#numeric-intptr-and-uintptr)
+- [UTF-8 string literals](#utf-8-string-literals)
 - [Required members](#required-members)
 
 The following features are available in Visual Studio 2022 version 17.2:
@@ -169,6 +170,10 @@ You've been able to test if a `string` had a specific constant value using patte
 ## Extended nameof scope
 
 Type parameter names and parameter names are now in scope when used in a `nameof` expression in an [attribute declaration](../programming-guide/concepts/attributes/index.md#using-attributes) on that method. This feature means you can use the `nameof` operator to specify the name of a method parameter in an attribute on the method or parameter declaration. This feature is most often useful to add attributes for [nullable analysis](../language-reference/attributes/nullable-analysis.md).
+
+## UTF-8 string literals
+
+You can specify the `u8` suffix on a string literal to specify UTF-8 character encoding. The natural type for a UTF-8 string literal is `ReadOnlySpan<byte>`. You can learn more about UTF-8 string literals in the string literal section of the article on [builtin reference types](../language-reference/builtin-types/reference-types.md#string-literals).
 
 ## Required members
 

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -173,7 +173,7 @@ Type parameter names and parameter names are now in scope when used in a `nameof
 
 ## UTF-8 string literals
 
-You can specify the `u8` suffix on a string literal to specify UTF-8 character encoding. 
+You can specify the `u8` suffix on a string literal to specify UTF-8 character encoding. If your application needs UTF-8 strings, for HTTP string constants or similar text protocols, you can use this feature to simplify the creation of UTF-8 strings.
 
 You can learn more about UTF-8 string literals in the string literal section of the article on [builtin reference types](../language-reference/builtin-types/reference-types.md#utf-8-string-literals).
 

--- a/docs/standard/base-types/character-encoding-introduction.md
+++ b/docs/standard/base-types/character-encoding-introduction.md
@@ -316,7 +316,7 @@ UTF-32: [ 000104CC ]     (1x 32-bit code unit  = 32 bits total)
 As noted earlier, a single UTF-16 code unit from a [surrogate pair](#surrogate-pairs) is meaningless by itself. In the same way, a single UTF-8 code unit is meaningless by itself if it's in a sequence of two, three, or four used to calculate a scalar value.
 
 > [!NOTE]
-> Beginning with C# 11, you can represent UTF-8 string literals using the "u8" suffix on a literal string. For more information on UTF-8 string literals, see the "string literals" section of the article on [built in reference types](../../csharp/language-reference/builtin-types/reference-types.md#string-literals) in the C# Guide.
+> Beginning with C# 11, you can represent UTF-8 string literals using the "u8" suffix on a literal string. For more information on UTF-8 string literals, see the "string literals" section of the article on [built in reference types](../../csharp/language-reference/builtin-types/reference-types.md#utf-8-string-literals) in the C# Guide.
 
 ### Endianness
 

--- a/docs/standard/base-types/character-encoding-introduction.md
+++ b/docs/standard/base-types/character-encoding-introduction.md
@@ -315,6 +315,9 @@ UTF-32: [ 000104CC ]     (1x 32-bit code unit  = 32 bits total)
 
 As noted earlier, a single UTF-16 code unit from a [surrogate pair](#surrogate-pairs) is meaningless by itself. In the same way, a single UTF-8 code unit is meaningless by itself if it's in a sequence of two, three, or four used to calculate a scalar value.
 
+> [!NOTE]
+> Beginning with C# 11, you can represent UTF-8 string literals using the "u8" suffix on a literal string. For more information on UTF-8 string literals, see the "string literals" section of the article on [built in reference types](../../csharp/language-reference/builtin-types/reference-types.md#string-literals) in the C# Guide.
+
 ### Endianness
 
 In .NET, the UTF-16 code units of a string are stored in contiguous memory as a sequence of 16-bit integers (`char` instances). The bits of individual code units are laid out according to the [endianness](https://en.wikipedia.org/wiki/Endianness) of the current architecture.


### PR DESCRIPTION
Fixes #29269

- Update the article on builtin reference types to cover UTF-8 literals.
- Add note in character encoding article to reference UTF-8 literals.
- Add note in addition operator that addition is now supported for UTF-8 literals, as concatenating `ReadOnlySpan<byte>`.

