### PR TITLE
Update preprocessor-directives.md

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -69,7 +69,7 @@ You use four preprocessor directives to control conditional compilation:
 - `#else`: Closes the preceding conditional compilation and opens a new conditional compilation if the previous specified symbol isn't defined.
 - `#endif`: Closes the preceding conditional compilation.
 
-The C# compiler compiles the code between the `#if` directive and  `#endif` directive only if the specified symbol is defined, or not defined when the `!` not operator is used. Unlike C and C++, a numeric value to a symbol can't be assigned. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example, the following code is compiled whe `DEBUG` is defined:
+The C# compiler compiles the code between the `#if` directive and  `#endif` directive only if the specified symbol is defined, or not defined when the `!` not operator is used. Unlike C and C++, a numeric value to a symbol can't be assigned. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example, the following code is compiled when `DEBUG` is defined:
 
 ```csharp
 #if DEBUG
@@ -77,7 +77,7 @@ The C# compiler compiles the code between the `#if` directive and  `#endif` dire
 #endif
 ```
 
-The following code is compiled whe `MYTEST` is **not** defined:
+The following code is compiled when `MYTEST` is **not** defined:
 
 ```csharp
 #if !MYTEST

--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -69,7 +69,7 @@ You use four preprocessor directives to control conditional compilation:
 - `#else`: Closes the preceding conditional compilation and opens a new conditional compilation if the previous specified symbol isn't defined.
 - `#endif`: Closes the preceding conditional compilation.
 
-The C# compiler compiles the code between the `#if` directive and  `#endif` directive only if the specified symbol is defined, or not defined when the `!` not operator is used. Unlike C and C++,  a numeric value to a symbol can't be assigned. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example, the following code is compiled whe `DEBUG` is defined:
+The C# compiler compiles the code between the `#if` directive and  `#endif` directive only if the specified symbol is defined, or not defined when the `!` not operator is used. Unlike C and C++, a numeric value to a symbol can't be assigned. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example, the following code is compiled whe `DEBUG` is defined:
 
 ```csharp
 #if DEBUG

--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -77,11 +77,11 @@ The C# compiler compiles the code between the `#if` directive and  `#endif` dire
 #endif
 ```
 
-The following code is compiled whe `DEBUG` is **not** defined:
+The following code is compiled whe `MYTEST` is **not** defined:
 
 ```csharp
-#if !DEBUG
-    Console.WriteLine("Not Debug");
+#if !MYTEST
+    Console.WriteLine("MYTEST is not defined");
 #endif
 ```
 

--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -69,11 +69,19 @@ You use four preprocessor directives to control conditional compilation:
 - `#else`: Closes the preceding conditional compilation and opens a new conditional compilation if the previous specified symbol isn't defined.
 - `#endif`: Closes the preceding conditional compilation.
 
-When the C# compiler finds an `#if` directive, followed eventually by an `#endif` directive, it compiles the code between the directives only if the specified symbol is defined. Unlike C and C++, you can't assign a numeric value to a symbol. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example:
+The C# compiler compiles the code between the `#if` directive and  `#endif` directive only if the specified symbol is defined, or not defined when the `!` not operator is used. Unlike C and C++,  a numeric value to a symbol can't be assigned. The `#if` statement in C# is Boolean and only tests whether the symbol has been defined or not. For example, the following code is compiled whe `DEBUG` is defined:
 
 ```csharp
 #if DEBUG
     Console.WriteLine("Debug version");
+#endif
+```
+
+The following code is compiled whe `DEBUG` is **not** defined:
+
+```csharp
+#if !DEBUG
+    Console.WriteLine("Not Debug");
 #endif
 ```
 


### PR DESCRIPTION
Fixes #26903

Quick fix, I'm sure you can improve my wording. `!` is used in the sample later in the doc, but I don't see it mentioned.