### PR TITLE
Change "more information" link for CS0239

### DIFF
--- a/docs/csharp/misc/cs0239.md
+++ b/docs/csharp/misc/cs0239.md
@@ -12,7 +12,7 @@ ms.assetid: 2e07bbc2-03a9-44b2-b321-477ca95fff8c
 
 'member' : cannot override inherited member 'inherited member' because it is sealed  
   
- A member cannot [override](../language-reference/keywords/override.md) a [sealed](../language-reference/keywords/sealed.md) inherited member. For more information, see [Checked and Unchecked](../language-reference/keywords/checked-and-unchecked.md).  
+ A member cannot [override](../language-reference/keywords/override.md) a [sealed](../language-reference/keywords/sealed.md) inherited member. For more information, see [Inheritance](../fundamentals/object-oriented/inheritance.md).  
   
  The following sample generates CS0239:  
   


### PR DESCRIPTION
Since [CS0239][cs0239] is about `sealed` and `override` which is like [CS0238][cs0238],
it should link to "Inheritance" instead of "Checked and Unchecked", just like [CS0238][cs0238].

[cs0238]: https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0238
[cs0239]: https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0239