### PR TITLE
Removed arrow brackets

### DIFF
--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -139,8 +139,8 @@ The compiler verifies the syntax of the elements followed by a single \* in the 
 - [Generate links and references](#generate-links-and-references) - These tags generate links to other documentation.
   - [`<see>`](#see) \*
   - [`<seealso>`](#seealso) \*
-  - [`<cref>`](#cref-attribute)
-  - [`<href>`](#href-attribute)
+  - [`cref`](#cref-attribute)
+  - [`href`](#href-attribute)
 - [Tags for generic types and methods](#generic-types-and-methods) - These tags are used only on generic types and methods
   - [`<typeparam>`](#typeparam) \*: The value of this element is displayed in IntelliSense in Visual Studio.
   - [`<typeparamref>`](#typeparamref)


### PR DESCRIPTION
Removed incorrect arrow brackets from a href and cref attribute, since they're not tags.
Fixes #30385
