### PR TITLE
Fix incorrect uppercase character

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/properties.md
@@ -40,7 +40,7 @@ Beginning with C# 6, read-only properties can implement the `get` accessor as an
 
 :::code language="csharp" source="./snippets/properties/Person.cs" id="ExpressionBodiedProperty":::
 
-BEginning with C# 7.0, both the `get` and the `set` accessor can be implemented as expression-bodied members. In this case, the `get` and `set` keywords must be present. The following example illustrates the use of expression body definitions for both accessors. The `return` keyword isn't used with the `get` accessor.
+Beginning with C# 7.0, both the `get` and the `set` accessor can be implemented as expression-bodied members. In this case, the `get` and `set` keywords must be present. The following example illustrates the use of expression body definitions for both accessors. The `return` keyword isn't used with the `get` accessor.
 
 :::code language="csharp" source="./snippets/properties/SaleItem.cs" id="SaleItemV1":::
 


### PR DESCRIPTION
## Summary
Resolves a minor capitalization mistake on the "Properties (C# Programming Guide)" page.
