### PR TITLE
Fix typo in the .NET globalization and ICU documentation

### DIFF
--- a/docs/core/extensions/globalization-icu.md
+++ b/docs/core/extensions/globalization-icu.md
@@ -155,7 +155,7 @@ This must be done for all the ICU binaries for the supported runtimes. Also, the
 
 ### macOS behavior
 
-`macOS` has a different behavior for resolving dependent dynamic libraries from the load commands specified in the `match-o` file than the Linux loader. In the Linux loader, .NET can try `libicudata`, `libicuuc`, and `libicui18n` (in that order) to satisfy ICU dependency graph. However, on macOS, this doesn't work. When building ICU on macOS, you, by default, get a dynamic library with these load commands in `libicuuc`. The following snippet shows an example.
+`macOS` has a different behavior for resolving dependent dynamic libraries from the load commands specified in the `Mach-O` file than the Linux loader. In the Linux loader, .NET can try `libicudata`, `libicuuc`, and `libicui18n` (in that order) to satisfy ICU dependency graph. However, on macOS, this doesn't work. When building ICU on macOS, you, by default, get a dynamic library with these load commands in `libicuuc`. The following snippet shows an example.
 
 ```sh
 ~/ % otool -L /Users/santifdezm/repos/icu-build/icu/install/lib/libicuuc.67.1.dylib


### PR DESCRIPTION
## Summary

`match-o` → `Mach-O`