### PR TITLE
Update the documentation for PublishRelease and PackRelease

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -141,7 +141,7 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 
 ### PackRelease
 
-The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`.
+The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`. To use `PackRelease` in a solution's project, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Note that this will increase the time required to pack solutions with many projects. 
 
 ```xml
 <PropertyGroup>
@@ -317,7 +317,7 @@ For more information, see [Write reference assemblies to intermediate output](..
 
 ### PublishRelease
 
-The `PublishRelease` property informs `dotnet publish` to leverage the `Release` configuration instead of the `Debug` configuration. We recommend adding this property to a `Directory.Build.props` file instead of a project file so that it's evaluated early enough for the configuration change to propagate.
+The `PublishRelease` property informs `dotnet publish` to use the `Release` configuration by default instead of the `Debug` configuration.  To use `PublishRelease` in a solution's project, you must set the environment variable `DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Note that this will increase the time required to publish solutions with many projects. When publishing a solution with this enabled, the executable project's `PublishRelease` value will take precedence and flow the new default configuration to any other projects in its solution. If a solution contains multiple executable/top level projects with values of `PublishRelease` that differ, the solution will not successfully publish.
 
 ```xml
 <PropertyGroup>
@@ -326,7 +326,7 @@ The `PublishRelease` property informs `dotnet publish` to leverage the `Release`
 ```
 
 > [!NOTE]
-> This property does not affect the behavior of `dotnet build /t:Publish`.
+> This property does not affect the behavior of `dotnet build /t:Publish`, and changes the configuration only when publishing via the .NET SDK CLI.
 
 ### RollForward
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -141,7 +141,7 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 
 ### PackRelease
 
-The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`. To use `PackRelease` in a solution's project, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Note that this will increase the time required to pack solutions with many projects. 
+The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`. To use `PackRelease` in a solution's project, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Note that this will increase the time required to pack solutions with many projects.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -317,7 +317,10 @@ For more information, see [Write reference assemblies to intermediate output](..
 
 ### PublishRelease
 
-The `PublishRelease` property informs `dotnet publish` to use the `Release` configuration by default instead of the `Debug` configuration.  To use `PublishRelease` in a solution's project, you must set the environment variable `DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Note that this will increase the time required to publish solutions with many projects. When publishing a solution with this enabled, the executable project's `PublishRelease` value will take precedence and flow the new default configuration to any other projects in its solution. If a solution contains multiple executable/top level projects with values of `PublishRelease` that differ, the solution will not successfully publish.
+The `PublishRelease` property informs `dotnet publish` to use the `Release` configuration by default instead of the `Debug` configuration.
+
+> [!NOTE]
+> To use `PublishRelease` in a project that's part of a Visual Studio solution, you must set the environment variable `DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). This will increase the time required to publish solutions that have many projects. When publishing a solution with this variable enabled, the executable project's `PublishRelease` value takes precedence and flows the new default configuration to any other projects in the solution. If a solution contains multiple executable or top-level projects with differing values of `PublishRelease`, the solution won't successfully publish.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -127,6 +127,11 @@ The `GeneratedAssemblyInfoFile` property defines the relative or absolute path o
 
 ## Package properties
 
+- [Descriptive properties](#descriptive-properties)
+- [PackRelease](#packrelease)
+
+### Descriptive properties
+
 You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`, `Title`, and `Description` to describe the package that gets created from your project. For information about these and other properties, see [pack target](/nuget/reference/msbuild-targets#pack-target).
 
 ```xml
@@ -143,14 +148,14 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 
 The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`.
 
-> [!NOTE]
-> To use `PackRelease` in a project that's part of a Visual Studio solution, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Setting this variable will increase the time required to pack solutions that have many projects.
-
 ```xml
 <PropertyGroup>
   <PackRelease>true</PackRelease>
 </PropertyGroup>
 ```
+
+> [!NOTE]
+> To use `PackRelease` in a project that's part of a Visual Studio solution, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Setting this variable will increase the time required to pack solutions that have many projects.
 
 ## Publish-related properties
 
@@ -322,9 +327,6 @@ For more information, see [Write reference assemblies to intermediate output](..
 
 The `PublishRelease` property informs `dotnet publish` to use the `Release` configuration by default instead of the `Debug` configuration.
 
-> [!NOTE]
-> To use `PublishRelease` in a project that's part of a Visual Studio solution, you must set the environment variable `DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). This will increase the time required to publish solutions that have many projects. When publishing a solution with this variable enabled, the executable project's `PublishRelease` value takes precedence and flows the new default configuration to any other projects in the solution. If a solution contains multiple executable or top-level projects with differing values of `PublishRelease`, the solution won't successfully publish.
-
 ```xml
 <PropertyGroup>
   <PublishRelease>true</PublishRelease>
@@ -332,7 +334,9 @@ The `PublishRelease` property informs `dotnet publish` to use the `Release` conf
 ```
 
 > [!NOTE]
-> This property does not affect the behavior of `dotnet build /t:Publish` and changes the configuration only when publishing via the .NET CLI.
+>
+> - This property does not affect the behavior of `dotnet build /t:Publish` and changes the configuration only when publishing via the .NET CLI.
+> - To use `PublishRelease` in a project that's part of a Visual Studio solution, you must set the environment variable `DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). This will increase the time required to publish solutions that have many projects. When publishing a solution with this variable enabled, the executable project's `PublishRelease` value takes precedence and flows the new default configuration to any other projects in the solution. If a solution contains multiple executable or top-level projects with differing values of `PublishRelease`, the solution won't successfully publish.
 
 ### RollForward
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -141,7 +141,10 @@ You can specify properties such as `PackageId`, `PackageVersion`, `PackageIcon`,
 
 ### PackRelease
 
-The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`. To use `PackRelease` in a solution's project, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Note that this will increase the time required to pack solutions with many projects.
+The `PackRelease` property is similar to the [PublishRelease](#publishrelease) property, except that it changes the default behavior of `dotnet pack`.
+
+> [!NOTE]
+> To use `PackRelease` in a project that's part of a Visual Studio solution, you must set the environment variable `DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS` to `true` (or any other value). Setting this variable will increase the time required to pack solutions that have many projects.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -329,7 +329,7 @@ The `PublishRelease` property informs `dotnet publish` to use the `Release` conf
 ```
 
 > [!NOTE]
-> This property does not affect the behavior of `dotnet build /t:Publish`, and changes the configuration only when publishing via the .NET SDK CLI.
+> This property does not affect the behavior of `dotnet build /t:Publish` and changes the configuration only when publishing via the .NET CLI.
 
 ### RollForward
 


### PR DESCRIPTION
For .NET 7.0.100-rc1 we have enabled `PublishRelease` to work inside of a `.csproj` instead of forcing it to be put in `directory.build.props`. We've also introduced an environment variable to enable it for solutions. (The reason for the environment variable is so users can opt-in and or out of the performance cost of this new feature.)

See the relevant PR from the SDK here: https://github.com/dotnet/sdk/pull/26808
Old commit: https://github.com/dotnet/docs/pull/29996