### PR TITLE
Fix typos in /docs/core/deploying/trimming

### DIFF
--- a/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
+++ b/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
@@ -25,7 +25,7 @@ Consider doing both. Project-specific trimming is convenient and shows trim warn
 ### Enable project-specific trimming
 
 > [!TIP]
-> To use the latest version of the analyzer with the most coverage, consider using the [.Net 7 preview SDK.](https://dotnet.microsoft.com/en-us/download/dotnet). Note this will only update the tooling used to build your app, this does not require you to target the .Net 7 runtime.
+> To use the latest version of the analyzer with the most coverage, consider using the [.NET 7 preview SDK](https://dotnet.microsoft.com/en-us/download/dotnet). Note this will only update the tooling used to build your app, this does not require you to target the .NET 7 runtime.
 
 Set `<IsTrimmable>true</IsTrimmable>` in a `<PropertyGroup>` tag in your library project file. This will mark your assembly as "trimmable" and enable trim warnings for that project. Being "trimmable" means your library is considered compatible with trimming and should have no trim warnings when building the library. When used in a trimmed application, the assembly will have its unused members trimmed in the final output.
 

--- a/docs/core/deploying/trimming/trim-warnings/il2030.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2030.md
@@ -23,7 +23,7 @@ the trimmer behavior, all other attributes will be ignored. Attributes added via
 attribute annotations only influence the trimmer behavior and they are never added to the
 output assembly.
 
-The value of the `assembly` argument in a `attribute` element does not match any of the
+The value of the `assembly` argument in an `attribute` element does not match any of the
 assemblies seen by the trimmer.
 
 ## Example

--- a/docs/core/deploying/trimming/trim-warnings/il2046.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2046.md
@@ -1,5 +1,5 @@
 ---
-title: "IL2046: All interface implementations and method overrides must have annotations matching the interface or overriden virtual method 'RequiresUnreferencedCodeAttribute' annotations"
+title: "IL2046: All interface implementations and method overrides must have annotations matching the interface or overridden virtual method 'RequiresUnreferencedCodeAttribute' annotations"
 description: "Learn about trim warning IL2046: RequiresUnreferencedCodeAttributeMismatchMessage"
 ms.date: 08/27/2021
 ms.topic: reference
@@ -7,7 +7,7 @@ author: mateoatr
 f1_keywords:
   - "IL2046"
 ---
-# IL2046: All interface implementations and method overrides must have annotations matching the interface or overriden virtual method 'RequiresUnreferencedCodeAttribute' annotations
+# IL2046: All interface implementations and method overrides must have annotations matching the interface or overridden virtual method 'RequiresUnreferencedCodeAttribute' annotations
 
 ## Cause
 
@@ -33,7 +33,7 @@ public class Derived : Base
 }
 ```
 
-A derived member has the attribute but the overriden base member does not have the
+A derived member has the attribute but the overridden base member does not have the
 attribute.
 
 ```csharp


### PR DESCRIPTION
Fix spelling, grammar, capitalization, punctuation