### PR TITLE
Update nameof.md, Fix code example

### DIFF
--- a/docs/fsharp/language-reference/nameof.md
+++ b/docs/fsharp/language-reference/nameof.md
@@ -46,7 +46,7 @@ You can take a name of nearly every F# construct:
 module M =
     let f x = nameof x
 
-printfn $"{(M.f 12)]}"
+printfn $"{(M.f 12)}"
 printfn $"{(nameof M)}"
 printfn $"{(nameof M.f)}"
 ```


### PR DESCRIPTION
Issue: https://github.com/dotnet/docs/issues/30697
Documentation link : https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/nameof
## Summary
Fix: Remove additional brace in the code example in F#

Fixes #30697 
