### PR TITLE
Correct the note about the .net 5 SDK EOL

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -38,7 +38,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.
 
-> <sup>1</sup> MSBuild/Visual Studio supported for longer.
+> <sup>1</sup> The .NET 5 SDK will be supported in Visual Studio scenarios until December 2022 when 3.1 goes out of support. MSBuild/Visual Studio supported for longer.
 >
 > [Visual Studio 2019 Lifecycle](/lifecycle/products/visual-studio-2019)
 >


### PR DESCRIPTION
## Summary

We're actually supporting 5.0.2xx until October and 5.0.4xx until December in VS only scenarios so updating the comment about that.

Fixes #Issue_Number (if available)
