### PR TITLE
Remove 2 third-party commercial links in the TOC.

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -7,8 +7,8 @@ items:
     href: ../core/get-started.md
   - name: Get started tutorials
     href: ../standard/get-started.md
-  - name: .NET 101 videos
-    href: https://www.youtube.com/playlist?list=PLdo4fOcmZ0oWoazjhXQzBKMrFuArxpW80
+  - name: .NET Live TV
+    href: https://dotnet.microsoft.com/live
   - name: How to install
     items:
     - name: Overview

--- a/docs/spark/toc.yml
+++ b/docs/spark/toc.yml
@@ -78,5 +78,3 @@
     href: resources/index.md
   - name: .NET for Apache Spark GitHub
     href: https://github.com/dotnet/spark
-  - name: Stack Overflow
-    href: https://stackoverflow.com/questions/tagged/.net-spark


### PR DESCRIPTION
## Summary

I searched 12,329 TOC hrefs, in 123 toc.yml files, and found ten total. Of the ten, two links were 3rd-party commercial sites.
