### PR TITLE
Remove not supported example for workload update command

### DIFF
--- a/docs/core/tools/dotnet-workload-update.md
+++ b/docs/core/tools/dotnet-workload-update.md
@@ -70,10 +70,3 @@ For more information about the `dotnet workload` commands, see the [dotnet workl
   ```dotnetcli
   dotnet workload update
   ```
-
-- Download the assets needed for updating installed workloads to a cache located in the *workload-cache* directory under the current directory. Then update installed workloads from that cache location:
-
-  ```dotnetcli
-  dotnet workload update --download-to-cache ./workload-cache
-  dotnet workload update --from-cache ./workload-cache
-  ```


### PR DESCRIPTION
## Summary

Removes not supported example for `workload update` command

Fixes #30844
