### PR TITLE
Fix programs in "specify-era"

### DIFF
--- a/samples/snippets/standard/datetime/calendars/specify-era/cs/Program.cs
+++ b/samples/snippets/standard/datetime/calendars/specify-era/cs/Program.cs
@@ -16,11 +16,11 @@ public class Example
            if (jaJp.DateTimeFormat.GetEraName(ctr) == "明治")
               eraIndex = ctr;
         var date1 = japaneseCal.ToDateTime(23, 9, 8, 0, 0, 0, 0, eraIndex);
-        Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d}");
+        Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d})");
 
         try {
             var date2 = DateTime.Parse("明治23/9/8", jaJp);
-            Console.WriteLine($"{date2.ToString("d", jaJp)} (Gregorian {date2:d}");
+            Console.WriteLine($"{date2.ToString("d", jaJp)} (Gregorian {date2:d})");
         }
         catch (FormatException)
         {
@@ -29,7 +29,7 @@ public class Example
 
         try {
             var date3 = DateTime.ParseExact("明治23/9/8", "gyy/M/d", jaJp);
-            Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d}");
+            Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d})");
         }
         catch (FormatException)
         {
@@ -38,6 +38,6 @@ public class Example
     }
 }
 // The example displays the following output:
-//   明治23/9/8 (Gregorian 9/8/1890
-//   明治23/9/8 (Gregorian 9/8/1890
-//   明治23/9/8 (Gregorian 9/8/1890
+//   明治23/9/8 (Gregorian 9/8/1890)
+//   明治23/9/8 (Gregorian 9/8/1890)
+//   明治23/9/8 (Gregorian 9/8/1890)

--- a/samples/snippets/standard/datetime/calendars/specify-era/cs/Program.cs
+++ b/samples/snippets/standard/datetime/calendars/specify-era/cs/Program.cs
@@ -28,7 +28,7 @@ public class Example
         }
 
         try {
-            var date3 = DateTime.ParseExact("明治23/9/8", "gyy/m/d", jaJp);
+            var date3 = DateTime.ParseExact("明治23/9/8", "gyy/M/d", jaJp);
             Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d}");
         }
         catch (FormatException)

--- a/samples/snippets/standard/datetime/calendars/specify-era/cs/Program.cs
+++ b/samples/snippets/standard/datetime/calendars/specify-era/cs/Program.cs
@@ -20,7 +20,7 @@ public class Example
 
         try {
             var date2 = DateTime.Parse("明治23/9/8", jaJp);
-            Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d}");
+            Console.WriteLine($"{date2.ToString("d", jaJp)} (Gregorian {date2:d}");
         }
         catch (FormatException)
         {
@@ -29,7 +29,7 @@ public class Example
 
         try {
             var date3 = DateTime.ParseExact("明治23/9/8", "gyy/m/d", jaJp);
-            Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d}");
+            Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d}");
         }
         catch (FormatException)
         {

--- a/samples/snippets/standard/datetime/calendars/specify-era/vb/Program.vb
+++ b/samples/snippets/standard/datetime/calendars/specify-era/vb/Program.vb
@@ -23,7 +23,7 @@ Public Module Example
         End Try
 
         Try
-            Dim date3 = DateTime.ParseExact("明治23/9/8", "gyy/m/d", jaJp)
+            Dim date3 = DateTime.ParseExact("明治23/9/8", "gyy/M/d", jaJp)
             Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d}")
         Catch e As FormatException
             Console.WriteLine("The parsing operation failed.")

--- a/samples/snippets/standard/datetime/calendars/specify-era/vb/Program.vb
+++ b/samples/snippets/standard/datetime/calendars/specify-era/vb/Program.vb
@@ -17,14 +17,14 @@ Public Module Example
 
         Try
             Dim date2 = DateTime.Parse("明治23/9/8", jaJp)
-            Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d}")
+            Console.WriteLine($"{date2.ToString("d", jaJp)} (Gregorian {date2:d}")
         Catch e As FormatException
             Console.WriteLine("The parsing operation failed.")
         End Try
 
         Try
             Dim date3 = DateTime.ParseExact("明治23/9/8", "gyy/m/d", jaJp)
-            Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d}")
+            Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d}")
         Catch e As FormatException
             Console.WriteLine("The parsing operation failed.")
         End Try

--- a/samples/snippets/standard/datetime/calendars/specify-era/vb/Program.vb
+++ b/samples/snippets/standard/datetime/calendars/specify-era/vb/Program.vb
@@ -13,24 +13,24 @@ Public Module Example
             If jaJp.DateTimeFormat.GetEraName(ctr) = "明治" Then eraIndex = ctr
         Next
         Dim date1 = japaneseCal.ToDateTime(23, 9, 8, 0, 0, 0, 0, eraIndex)
-        Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d}")
+        Console.WriteLine($"{date1.ToString("d", jaJp)} (Gregorian {date1:d})")
 
         Try
             Dim date2 = DateTime.Parse("明治23/9/8", jaJp)
-            Console.WriteLine($"{date2.ToString("d", jaJp)} (Gregorian {date2:d}")
+            Console.WriteLine($"{date2.ToString("d", jaJp)} (Gregorian {date2:d})")
         Catch e As FormatException
             Console.WriteLine("The parsing operation failed.")
         End Try
 
         Try
             Dim date3 = DateTime.ParseExact("明治23/9/8", "gyy/M/d", jaJp)
-            Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d}")
+            Console.WriteLine($"{date3.ToString("d", jaJp)} (Gregorian {date3:d})")
         Catch e As FormatException
             Console.WriteLine("The parsing operation failed.")
         End Try
     End Sub
 End Module
 ' The example displays the following output:
-'   明治23/9/8 (Gregorian 9/8/1890
-'   明治23/9/8 (Gregorian 9/8/1890
-'   明治23/9/8 (Gregorian 9/8/1890
+'   明治23/9/8 (Gregorian 9/8/1890)
+'   明治23/9/8 (Gregorian 9/8/1890)
+'   明治23/9/8 (Gregorian 9/8/1890)


### PR DESCRIPTION
## Summary

Fix the *third* program in the ["Instantiate a date with an era" section of the "Work with calendars" page](https://docs.microsoft.com/en-us/dotnet/standard/datetime/working-with-calendars#instantiate-a-date-with-an-era).

1. Use the variables `date2` and `date3`, which were defined but unused.
2. Use `M` instead of `m` for month, since `m` is for minute and `M` is for month for *custom date and time formats*, according to [the doc](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings).
3. Add closing parentheses in the output.