### PR TITLE
Auto reply to dependabot PR

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -159,6 +159,17 @@
                       }
                     }
                   ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "isActivitySender",
+                      "parameters": {
+                        "user": "dependabot"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -200,6 +211,46 @@
         ]
       },
       "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "dependencies"
+              }
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": "dependabot"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Reply to dependabot PRs with automation command to squash and merge",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "@dependabot squash and merge"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
## Summary

- Add an ignore for `dependabot` in the existing condition on the `community-contribution` task.
- Create a new task to reply to dependabot PRs with:

```markdown
@dependabot squash and merge
```
