### PR TITLE
Fix link anchor in CA2016 page

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -33,7 +33,7 @@ This rule locates method invocations that could accept a <xref:System.Threading.
 This rule analyzes method definitions that take a `CancellationToken` as their last parameter, then analyzes all methods invoked in its body. If any of the method invocations can either accept a `CancellationToken` as the last parameter, or have an overload that takes a `CancellationToken` as the last parameter, then the rule suggests using that option instead to ensure that the cancellation notification gets propagated to all operations that can listen to it.
 
 > [!NOTE]
-> Rule CA2016 is available in all .NET versions where the `CancellationToken` type is available. See [CancellationToken "Applies to" section](/dotnet/api/system.threading.cancellationtoken#moniker-applies-to)
+> Rule CA2016 is available in all .NET versions where the `CancellationToken` type is available. See [CancellationToken "Applies to" section](/dotnet/api/system.threading.cancellationtoken#applies-to).
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -33,7 +33,7 @@ This rule locates method invocations that could accept a <xref:System.Threading.
 This rule analyzes method definitions that take a `CancellationToken` as their last parameter, then analyzes all methods invoked in its body. If any of the method invocations can either accept a `CancellationToken` as the last parameter, or have an overload that takes a `CancellationToken` as the last parameter, then the rule suggests using that option instead to ensure that the cancellation notification gets propagated to all operations that can listen to it.
 
 > [!NOTE]
-> Rule CA2016 is available in all .NET versions where the `CancellationToken` type is available. See [CancellationToken "Applies to" section](/dotnet/api/system.threading.cancellationtoken#applies-to).
+> Rule CA2016 is available in all .NET versions where the `CancellationToken` type is available. For the applicable versions, see the [CancellationToken "Applies to" section](/dotnet/api/system.threading.cancellationtoken#applies-to).
 
 ## How to fix violations
 


### PR DESCRIPTION
* Fix the link anchor
* Add a full stop at the end