### PR TITLE
Removed reference to `Microsoft.Extensions.Http`

### DIFF
--- a/docs/core/extensions/snippets/workers/windows-service/App.WindowsService.csproj
+++ b/docs/core/extensions/snippets/workers/windows-service/App.WindowsService.csproj
@@ -14,6 +14,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #30929, as well as makes https://docs.microsoft.com/en-us/dotnet/core/extensions/windows-service align with what dotnet new worker creates.


