### PR TITLE
Typo "cloud explorer"→"Cloud Explorer"

### DIFF
--- a/docs/orleans/deployment/troubleshooting-azure-cloud-services-deployments.md
+++ b/docs/orleans/deployment/troubleshooting-azure-cloud-services-deployments.md
@@ -50,7 +50,7 @@ role recycling. Check the logs for more information. Visual Studio provides some
 
 ## How to check logs
 
-- Use the cloud explorer in Visual Studio to navigate to the appropriate storage table or blob in the storage account. The WADLogsTable is a good starting point for looking at the logs.
+- Use the Cloud Explorer in Visual Studio to navigate to the appropriate storage table or blob in the storage account. The WADLogsTable is a good starting point for looking at the logs.
 - You might only be logging errors. If you want informational logs as well, you will need to modify the configuration to set the logging severity level.
 
 Programmatic configuration:


### PR DESCRIPTION
## Summary

Describe your changes here.
Typo "cloud explorer"→"Cloud Explorer"
https://docs.microsoft.com/en-us/dotnet/orleans/deployment/troubleshooting-azure-cloud-services-deployments
https://github.com/dotnet/docs/blob/main/docs/orleans/deployment/troubleshooting-azure-cloud-services-deployments.md
#PingMSFTDocs

Fixes #Issue_Number (if available)
