### PR TITLE
Fixed typo in Indexers (C# Programming Guide)

### DIFF
--- a/docs/csharp/programming-guide/indexers/index.md
+++ b/docs/csharp/programming-guide/indexers/index.md
@@ -28,7 +28,7 @@ It is common for an indexer's get or set accessor to consist of a single stateme
 
 Note that `=>` introduces the expression body, and that the `get` keyword is not used.
 
-Starting with C# 7.0, both the get and set accessor can be an implemented as expression-bodied members. In this case, both `get` and `set` keywords must be used. For example:
+Starting with C# 7.0, both the get and set accessor can be implemented as expression-bodied members. In this case, both `get` and `set` keywords must be used. For example:
 
 [!code-csharp[indexers#3](../../../../samples/snippets/csharp/programming-guide/indexers/indexer-3.cs)]  
   


### PR DESCRIPTION
## Summary

Removed redundant `an` in Indexers (C# Programming Guide)
