### PR TITLE
Enable stale Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Close stale issues
 
 on:
-  schedule: # Run 5 minutes after the hour every hour.
+  schedule: # Run 5 minutes after midnight daily.
   - cron: '5 0 * * *'
 
 jobs:
@@ -14,13 +14,14 @@ jobs:
     steps:
     - uses: actions/stale@v4.1.0
       with:
+        start-date: '2022-03-01T00:00:00Z' # ISO 8601 or RFC 2822
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 180
-        days-before-close: 7
+        days-before-close: 14
         stale-issue-label: stale
         close-issue-message: >
             This issue has been automatically closed due to lack of activity.
             If you feel this issue is still important, please reopen it and leave a comment.
-        exempt-issue-labels: breaking-change,Pri0
+        exempt-issue-labels: 'breaking-change,Pri0,:watch: Not Triaged,:checkered_flag: Release: .NET 7,:checkered_flag: Release: .NET 8'
         operations-per-run: 50
         debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
         stale-issue-label: stale
         close-issue-message: >
             This issue has been automatically closed due to lack of activity.
-            If you feel this issue is still important, please comment and we will reopen it.
+            If you feel this issue is still important, please reopen it and leave a comment.
         exempt-issue-labels: breaking-change,Pri0
         operations-per-run: 50
         debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,12 +15,12 @@ jobs:
     - uses: actions/stale@v4.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 120
-        days-before-close: 14
-        stale-issue-label: needs-more-info
+        days-before-stale: 180
+        days-before-close: 7
+        stale-issue-label: stale
         close-issue-message: >
-            This issue has been automatically closed due to no response from the original author.
-            Please feel free to reopen it if you have more information that can help us investigate the issue further.
+            This issue has been automatically closed due to lack of activity.
+            If you feel this issue is still important, please comment and we will reopen it.
         exempt-issue-labels: breaking-change,Pri0
         operations-per-run: 50
         debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-- name: Close stale issues
+name: Close stale issues
 
 on:
   schedule: # Run 5 minutes after the hour every hour.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+- name: Close stale issues
+
+on:
+  schedule: # Run 5 minutes after the hour every hour.
+  - cron: '5 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v4.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 120
+        days-before-close: 14
+        stale-issue-label: needs-more-info
+        close-issue-message: >
+            This issue has been automatically closed due to no response from the original author.
+            Please feel free to reopen it if you have more information that can help us investigate the issue further.
+        exempt-issue-labels: breaking-change,Pri0
+        operations-per-run: 50
+        debug-only: true


### PR DESCRIPTION
Adds stale label after 6 months of no activity and closes after 7 days of adding the label.
Excludes issues with labels `breaking-change` and `Pri1`. Any others?
This should not act on PRs because we're not explicitly giving write permissions to PRs.
Also, this initial configuration sets `debug-only` to true, so it will just do dry runs until that line is deleted/changed to false.