### PR TITLE
Warn against installing dotnet tools on snap installations

### DIFF
--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -16,7 +16,7 @@ A snap is a bundle of an app and its dependencies that works without modificatio
 > Snap packages aren't supported in WSL2 on Windows 10. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
 
 > [!CAUTION]
-> Snap installations of .NET may have problems running [.NET tools](dotnet/core/tools/global-tools.md). If you wish to use .NET tools, it's recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
+> Snap installations of .NET may have problems running [.NET tools](../tools/global-tools.md). If you wish to use .NET tools, it's recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
 
 ## .NET releases
 

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -12,11 +12,15 @@ Use a Snap package to install the .NET SDK or .NET Runtime. Snaps are a great al
 
 A snap is a bundle of an app and its dependencies that works without modification across many different Linux distributions. Snaps are discoverable and installable from the Snap Store. For more information about Snap, see [Getting started with Snap](https://snapcraft.io/docs/getting-started).
 
-> [!CAUTION]
-> Snap packages aren't supported in WSL2 on Windows 10. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
+> [!IMPORTANT]
+> Snap packages aren't supported in WSL2 on Windows. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
 
 > [!CAUTION]
 > Snap installations of .NET may have problems running [.NET tools](../tools/global-tools.md). If you wish to use .NET tools, we recommend that you install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
+>
+> It's a known issue that the `dotnet watch` command doesn't work when .NET is installed via Snap.
+>
+> If you're going to use .NET tools or the `dotnet watch` command, we recommend that you install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install).
 
 ## .NET releases
 

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -16,7 +16,7 @@ A snap is a bundle of an app and its dependencies that works without modificatio
 > Snap packages aren't supported in WSL2 on Windows 10. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
 
 > [!CAUTION]
-> Snap installations of .NET may have problems running [.NET tools](dotnet/core/tools/global-tools). If you wish to use .NET tools It is recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
+> Snap installations of .NET may have problems running [.NET tools](dotnet/core/tools/global-tools). If you wish to use .NET tools, it's recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
 
 ## .NET releases
 

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -15,6 +15,9 @@ A snap is a bundle of an app and its dependencies that works without modificatio
 > [!CAUTION]
 > Snap packages aren't supported in WSL2 on Windows 10. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
 
+> [!CAUTION]
+> Snap installations of .NET may have problems running [.NET tools](dotnet/core/tools/global-tools). If you wish to use .NET tools It is recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
+
 ## .NET releases
 
 Only ✔️ supported versions of .NET SDK are available through Snap. All versions of the .NET Runtime are available through snap starting with version 2.1. The following table lists the .NET (and .NET Core) releases:

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -16,7 +16,7 @@ A snap is a bundle of an app and its dependencies that works without modificatio
 > Snap packages aren't supported in WSL2 on Windows 10. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
 
 > [!CAUTION]
-> Snap installations of .NET may have problems running [.NET tools](../tools/global-tools.md). If you wish to use .NET tools, it's recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
+> Snap installations of .NET may have problems running [.NET tools](../tools/global-tools.md). If you wish to use .NET tools, we recommend that you install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
 
 ## .NET releases
 

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -16,7 +16,7 @@ A snap is a bundle of an app and its dependencies that works without modificatio
 > Snap packages aren't supported in WSL2 on Windows 10. As an alternative, use the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular WSL2 distribution. It's not recommended but you can try to enable snap with an [unsupported workaround from the snapcraft forums](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033).
 
 > [!CAUTION]
-> Snap installations of .NET may have problems running [.NET tools](dotnet/core/tools/global-tools). If you wish to use .NET tools, it's recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
+> Snap installations of .NET may have problems running [.NET tools](dotnet/core/tools/global-tools.md). If you wish to use .NET tools, it's recommended to install .NET using the [`dotnet-install` script](linux-scripted-manual.md#scripted-install) or the package manager for the particular Linux distribution.
 
 ## .NET releases
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -27,10 +27,8 @@ A .NET tool is a special NuGet package that contains a console application. You 
   The .NET CLI uses manifest files to keep track of tools that are installed as local to a directory. When the manifest file is saved in the root directory of a source code repository, a contributor can clone the repository and invoke a single .NET CLI command to install all of the tools listed in the manifest files.
 
 > [!IMPORTANT]
-> .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
-
-> [!CAUTION]
-> If .NET was [installed via Snap](../install/linux-snap.md), installed .NET tools may not work correctly.
+> * .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
+> * If .NET was [installed via Snap](../install/linux-snap.md), installed .NET tools might not work correctly.
 
 ## Find a tool
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -30,7 +30,7 @@ A .NET tool is a special NuGet package that contains a console application. You 
 > .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
 
 > [!CAUTION]
-> If .NET was [installed via Snap](dotnet/core/install/linux-snap), installed .NET tools may not work correctly.
+> If .NET was [installed via Snap](dotnet/core/install/linux-snap.md), installed .NET tools may not work correctly.
 
 ## Find a tool
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -30,7 +30,7 @@ A .NET tool is a special NuGet package that contains a console application. You 
 > .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
 
 > [!CAUTION]
-> If .NET was [installed via Snap](dotnet/core/install/linux-snap.md), installed .NET tools may not work correctly.
+> If .NET was [installed via Snap](../install/linux-snap.md), installed .NET tools may not work correctly.
 
 ## Find a tool
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -27,8 +27,9 @@ A .NET tool is a special NuGet package that contains a console application. You 
   The .NET CLI uses manifest files to keep track of tools that are installed as local to a directory. When the manifest file is saved in the root directory of a source code repository, a contributor can clone the repository and invoke a single .NET CLI command to install all of the tools listed in the manifest files.
 
 > [!IMPORTANT]
-> * .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
-> * If .NET was [installed via Snap](../install/linux-snap.md), installed .NET tools might not work correctly.
+> .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
+>
+> .NET tools might not work correctly if .NET was [installed via Snap](../install/linux-snap.md).
 
 ## Find a tool
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -29,6 +29,9 @@ A .NET tool is a special NuGet package that contains a console application. You 
 > [!IMPORTANT]
 > .NET tools run in full trust. Don't install a .NET tool unless you trust the author.
 
+> [!CAUTION]
+> If .NET was [installed via Snap](dotnet/core/install/linux-snap), installed .NET tools may not work correctly.
+
 ## Find a tool
 
 Here are some ways to find tools:


### PR DESCRIPTION
## Summary

if .NET was installed using Snap, running tools mostly results in a tool crash.

Related issues:
- https://github.com/dotnet/runtime/issues/60441
- https://github.com/dotnet/core/issues/7776