### PR TITLE
Update netsdk1100.md

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1100.md
+++ b/docs/core/tools/sdk-errors/netsdk1100.md
@@ -12,7 +12,7 @@ NETSDK1100 indicates that you're building a project that targets Windows on Linu
 
 > To build a project targeting Windows on this operating system, set the `EnableWindowsTargeting` property to true.
 
-To resolve this error, set the `EnableWindowsTargeting` property to true. You can set it in the project file or by passing `/p:EnableWindowsTargeting=false` to a .NET CLI command, such as `dotnet build`. Here's an example project file:
+To resolve this error, set the `EnableWindowsTargeting` property to true. You can set it in the project file or by passing `/p:EnableWindowsTargeting=true` to a .NET CLI command, such as `dotnet build`. Here's an example project file:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">


### PR DESCRIPTION
Update the command line property to enable windows targeting instead of disabling it.

## Summary
The page tells you to set the `EnableWindowsTargeting` property to true, but then gives a snippet that sets `EnableWindowsTargeting` to false. 
