### PR TITLE
Remove feature spec

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -9,6 +9,10 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals"
         },
         {
+            "source_path_from_root": "/_csharplang/proposals/csharp-7.2/private-protected.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes.md#1436-access-modifiers"
+        },
+        {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.3/leading-digit-separator.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals"
         },

--- a/docfx.json
+++ b/docfx.json
@@ -49,6 +49,7 @@
                     "csharp-7.2/readonly-struct.md",
                     "csharp-7.2/ref-extension-methods.md",
                     "csharp-7.2/ref-struct-and-span.md",
+                    "csharp-7.2/private-protected.md",
                     "csharp-7.3/enum-delegate-constraints.md",
                     "csharp-7.3/ref-loops.md",
                     "csharp-8.0/alternative-interpolated-verbatim.md",

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1374,8 +1374,6 @@ items:
         href: ../../_csharplang/proposals/csharp-7.2/span-safety.md
       - name: Non-trailing named arguments
         href: ../../_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md
-      - name: Private protected
-        href: ../../_csharplang/proposals/csharp-7.2/private-protected.md
       - name: Conditional ref
         href: ../../_csharplang/proposals/csharp-7.2/conditional-ref.md
     - name: C# 7.3 features


### PR DESCRIPTION
The PR for `private protected` has been merged into the C# Standard for V7.n. So, remove the private-protected feature spec and redirect traffic to the updated clause in the standard.

See dotnet/csharpstandard#215

