### PR TITLE
XmlSecureResolver breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -80,8 +80,6 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
 | [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
-| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ | RC 1 |
-| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ | Preview 2 |
 
 ## Cryptography
 
@@ -173,3 +171,10 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 | [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing 6.0.101 |
 | [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1-4 |
 | [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ | Preview 1 |
+
+## XML and XSLT
+
+| Title | Binary compatible | Source compatible | Introduced |
+| - | :-: | :-: | - |
+| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ | RC 1 |
+| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ | Preview 2 |

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -97,3 +97,9 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [Some APIs throw ArgumentNullException](windows-forms/7.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1 |
+
+## XML and XSLT
+
+| Title | Binary compatible | Source compatible | Introduced |
+| - | :-: | :-: | - |
+| [XmlSecureResolver is obsolete](xml/7.0/xmlsecureresolver-obsolete.md) | ❌ | ❌ | RC 1 |

--- a/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
@@ -24,6 +24,7 @@ The following table lists the custom diagnostic IDs and their corresponding warn
 | [SYSLIB0041](../../../../fundamentals/syslib-diagnostics/syslib0041.md) | The default hash algorithm and iteration counts in <xref:System.Security.Cryptography.Rfc2898DeriveBytes> constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations. | Warning |
 | [SYSLIB0042](../../../../fundamentals/syslib-diagnostics/syslib0042.md) | `ToXmlString` and `FromXmlString` have no implementation for elliptic curve cryptography (ECC) types, and are obsolete. Use a standard import and export format such as `ExportSubjectPublicKeyInfo` or `ImportSubjectPublicKeyInfo` for public keys, and `ExportPkcs8PrivateKey` or `ImportPkcs8PrivateKey` for private keys. | Warning |
 | [SYSLIB0043](../../../../fundamentals/syslib-diagnostics/syslib0043.md) | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=nameWithType> and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo?displayProperty=nameWithType> instead. | Warning |
+| [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) | <xref:System.Xml.XmlSecureResolver> is obsolete. Use `XmlResolver.ThrowingResolver` instead when attempting to forbid XML external entity resolution. | Warning |
 
 ## Version introduced
 
@@ -87,6 +88,10 @@ These obsoletions can affect [source compatibility](../../categories.md#source-c
 
 - <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=fullName>
 - <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.%23ctor(System.Byte[])>
+
+### SYSLIB0047
+
+- <xref:System.Xml.XmlSecureResolver?displayProperty=fullName>
 
 ## See also
 

--- a/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
@@ -24,7 +24,7 @@ The following table lists the custom diagnostic IDs and their corresponding warn
 | [SYSLIB0041](../../../../fundamentals/syslib-diagnostics/syslib0041.md) | The default hash algorithm and iteration counts in <xref:System.Security.Cryptography.Rfc2898DeriveBytes> constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations. | Warning |
 | [SYSLIB0042](../../../../fundamentals/syslib-diagnostics/syslib0042.md) | `ToXmlString` and `FromXmlString` have no implementation for elliptic curve cryptography (ECC) types, and are obsolete. Use a standard import and export format such as `ExportSubjectPublicKeyInfo` or `ImportSubjectPublicKeyInfo` for public keys, and `ExportPkcs8PrivateKey` or `ImportPkcs8PrivateKey` for private keys. | Warning |
 | [SYSLIB0043](../../../../fundamentals/syslib-diagnostics/syslib0043.md) | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=nameWithType> and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo?displayProperty=nameWithType> instead. | Warning |
-| [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) | <xref:System.Xml.XmlSecureResolver> is obsolete. Use `XmlResolver.ThrowingResolver` instead when attempting to forbid XML external entity resolution. | Warning |
+| [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) | <xref:System.Xml.XmlSecureResolver> is obsolete. Use `XmlResolver.ThrowingResolver` instead to forbid resolution of external XML resources. | Warning |
 
 ## Version introduced
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -107,6 +107,10 @@ items:
         items:
         - name: Deserialize Version type with leading or trailing whitespace
           href: serialization/7.0/deserialize-version-with-whitespace.md
+      - name: XML and XSLT
+        items:
+        - name: XmlSecureResolver is obsolete
+          href: xml/7.0/xmlsecureresolver-obsolete.md
       - name: Windows Forms
         items:
         - name: APIs throw ArgumentNullException
@@ -223,10 +227,6 @@ items:
           href: core-libraries/6.0/task-fromresult-returns-singleton.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
-        - name: XmlDocument.XmlResolver nullability change
-          href: core-libraries/6.0/xmlresolver-nullable.md
-        - name: XNodeReader.GetAttribute behavior for invalid index
-          href: core-libraries/6.0/xnodereader-getattribute.md
       - name: Cryptography
         items:
         - name: CreateEncryptor methods throw exception for incorrect feedback size
@@ -323,6 +323,12 @@ items:
           href: windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md
         - name: TreeNodeCollection.Item throws exception if node is assigned elsewhere
           href: windows-forms/6.0/treenodecollection-item-throws-argumentexception.md
+      - name: XML and XSLT
+        items:
+        - name: XmlDocument.XmlResolver nullability change
+          href: core-libraries/6.0/xmlresolver-nullable.md
+        - name: XNodeReader.GetAttribute behavior for invalid index
+          href: core-libraries/6.0/xnodereader-getattribute.md
     - name: .NET 5
       items:
       - name: Overview
@@ -851,10 +857,6 @@ items:
           href: core-libraries/6.0/task-fromresult-returns-singleton.md
         - name: Unhandled exceptions from a BackgroundService
           href: core-libraries/6.0/hosting-exception-handling.md
-        - name: XmlDocument.XmlResolver nullability change
-          href: core-libraries/6.0/xmlresolver-nullable.md
-        - name: XNodeReader.GetAttribute behavior for invalid index
-          href: core-libraries/6.0/xnodereader-getattribute.md
       - name: .NET 5
         items:
         - name: Assembly-related API changes for single-file publishing
@@ -1213,3 +1215,15 @@ items:
           href: sdk/5.0/automatically-infer-winexe-output-type.md
         - name: WPF apps use Microsoft.NET.Sdk
           href: sdk/5.0/sdk-and-target-framework-change.md
+    - name: XML and XSLT
+      items:
+      - name: .NET 7
+        items:
+        - name: XmlSecureResolver is obsolete
+          href: xml/7.0/xmlsecureresolver-obsolete.md
+      - name: .NET 6
+        items:
+        - name: XmlDocument.XmlResolver nullability change
+          href: core-libraries/6.0/xmlresolver-nullable.md
+        - name: XNodeReader.GetAttribute behavior for invalid index
+          href: core-libraries/6.0/xnodereader-getattribute.md

--- a/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
+++ b/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
@@ -7,7 +7,7 @@ ms.date: 09/08/2022
 
 The method <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=fullName> unconditionally throws an <xref:System.Xml.XmlException> at run time. If your application utilizes <xref:System.Xml.XmlSecureResolver> and you attempt to resolve an entity through it, entity resolution will fail with an exception.
 
-Additionally, the entirety of the type <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> is obsolete as warning. All references to this type will result in a [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) warning at build time. If you've enabled warnings as errors, this will cause a build break if your application references <xref:System.Xml.XmlSecureResolver>.
+Additionally, the entire <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> type is obsolete. All references to this type will result in a [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) warning at build time. If you've enabled warnings as errors, this will cause a build break if your application references <xref:System.Xml.XmlSecureResolver>.
 
 ```csharp
 using System.Xml;

--- a/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
+++ b/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
@@ -5,7 +5,7 @@ ms.date: 09/08/2022
 ---
 # XmlSecureResolver is obsolete
 
-The method <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=fullName> unconditionally throws an <xref:System.Xml.XmlException> at run time. If your application utilizes <xref:System.Xml.XmlSecureResolver> and you attempt to resolve an entity through it, entity resolution will fail with an exception.
+The method <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=fullName> unconditionally throws an <xref:System.Xml.XmlException> at run time. If your application utilizes <xref:System.Xml.XmlSecureResolver> and you attempt to resolve an XML resource through it, resolution will fail with an exception.
 
 Additionally, the entire <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> type is obsolete. All references to this type will result in a [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) warning at build time. If you've enabled warnings as errors, this will cause a build break if your application references <xref:System.Xml.XmlSecureResolver>.
 
@@ -26,13 +26,13 @@ object entity = resolver.GetEntity(
 
 ## Previous behavior
 
-In .NET Framework, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> constructs a Code Access Security (CAS) sandbox to restrict the external entity resolution process. If policy is violated, a <xref:System.Security.SecurityException> is thrown.
+In .NET Framework, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> constructs a Code Access Security (CAS) sandbox to restrict the external XML resource resolution process. If policy is violated, a <xref:System.Security.SecurityException> is thrown.
 
-In .NET Core 3.1, and .NET 6, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> doesn't restrict external entity resolution at all. External entity resolution is allowed to proceed with no limitations.
+In .NET Core 3.1, and .NET 6, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> doesn't restrict external XML resource resolution at all. External resource resolution is allowed to proceed with no limitations.
 
 ## New behavior
 
-Starting in .NET 7, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> unconditionally throws an <xref:System.Xml.XmlException>. It does not construct a CAS sandbox and does not attempt to resolve the external entity.
+Starting in .NET 7, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> unconditionally throws an <xref:System.Xml.XmlException>. It does not construct a CAS sandbox and does not attempt to resolve the external resource.
 
 ## Version introduced
 
@@ -48,7 +48,7 @@ This change improves the security of the .NET ecosystem. This obsoletion moves t
 
 ## Recommended action
 
-Consider instead using the newly introduced static property `XmlResolver.ThrowingResolver`. This property provides an <xref:System.Xml.XmlResolver> instance that forbids external entity resolution.
+Consider instead using the newly introduced static property `XmlResolver.ThrowingResolver`. This property provides an <xref:System.Xml.XmlResolver> instance that forbids external resource resolution.
 
 ```csharp
 using System.Xml;

--- a/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
+++ b/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
@@ -1,0 +1,68 @@
+---
+title: ".NET 7 breaking change: XmlSecureResolver is obsolete"
+description: Learn about the .NET 7 breaking change in XML/XSLT where XmlSecureResolver was obsoleted and XmlSecureResolver.GetEntity unconditionally throws a run-time exception.
+ms.date: 09/08/2022
+---
+# XmlSecureResolver is obsolete
+
+The method <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=fullName> unconditionally throws an <xref:System.Xml.XmlException> at run time. If your application utilizes <xref:System.Xml.XmlSecureResolver> and you attempt to resolve an entity through it, entity resolution will fail with an exception.
+
+Additionally, the entirety of the type <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> is obsolete as warning. All references to this type will result in a `SYSLIB0047` warning at build time. If you've enabled warnings as errors, this will cause a build break if your application references <xref:System.Xml.XmlSecureResolver>.
+
+```csharp
+using System.Xml;
+
+// Compiler warning SYSLIB0047: XmlSecureResolver type is obsolete.
+XmlResolver resolver = new XmlSecureResolver(
+    resolver: new XmlUrlResolver(),
+    securityUrl: "https://www.example.com/");
+
+// Call to XmlSecureResolver.GetEntity below throws XmlException at run time.
+object entity = resolver.GetEntity(
+    absoluteUri: new Uri("https://www.example.com/some-entity"),
+    role: null,
+    ofObjectToReturn: null);
+```
+
+## Previous behavior
+
+In .NET Framework, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> constructs a Code Access Security (CAS) sandbox to restrict the external entity resolution process. If policy is violated, a <xref:System.Security.SecurityException> is thrown.
+
+In .NET Core 3.1, and .NET 6, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> doesn't restrict external entity resolution at all. External entity resolution is allowed to proceed with no limitations.
+
+## New behavior
+
+Starting in .NET 7, <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=nameWithType> unconditionally throws an <xref:System.Xml.XmlException>. It does not construct a CAS sandbox and does not attempt to resolve the external entity.
+
+## Version introduced
+
+.NET 7 RC 1
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility) and [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change improves the security of the .NET ecosystem. This obsoletion moves the behavior of <xref:System.Xml.XmlSecureResolver> from fail-dangerous (always perform resolution) to fail-safe (never perform resolution) when running on .NET 7 or later.
+
+## Recommended action
+
+Consider instead using the newly introduced static property `XmlResolver.ThrowingResolver`. This property provides an <xref:System.Xml.XmlResolver> instance that forbids external entity resolution.
+
+```csharp
+using System.Xml;
+
+// BAD: Do not use XmlSecureResolver.
+// XmlResolver resolver = new XmlSecureResolver(
+//     resolver: new XmlUrlResolver(),
+//     securityUrl: "https://www.example.com/");
+
+// GOOD: Use XmlResolver.ThrowingResolver instead.
+XmlResolver resolver = XmlResolver.ThrowingResolver;
+```
+
+## Affected APIs
+
+- <xref:System.Xml.XmlSecureResolver?displayProperty=fullName>
+- <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=fullName>

--- a/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
+++ b/docs/core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md
@@ -7,7 +7,7 @@ ms.date: 09/08/2022
 
 The method <xref:System.Xml.XmlSecureResolver.GetEntity(System.Uri,System.String,System.Type)?displayProperty=fullName> unconditionally throws an <xref:System.Xml.XmlException> at run time. If your application utilizes <xref:System.Xml.XmlSecureResolver> and you attempt to resolve an entity through it, entity resolution will fail with an exception.
 
-Additionally, the entirety of the type <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> is obsolete as warning. All references to this type will result in a `SYSLIB0047` warning at build time. If you've enabled warnings as errors, this will cause a build break if your application references <xref:System.Xml.XmlSecureResolver>.
+Additionally, the entirety of the type <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> is obsolete as warning. All references to this type will result in a [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) warning at build time. If you've enabled warnings as errors, this will cause a build break if your application references <xref:System.Xml.XmlSecureResolver>.
 
 ```csharp
 using System.Xml;

--- a/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
@@ -64,6 +64,7 @@ The following table provides an index to the `SYSLIB0XXX` obsoletions in .NET 5+
 | [SYSLIB0041](syslib0041.md) | Warning | The default hash algorithm and iteration counts in <xref:System.Security.Cryptography.Rfc2898DeriveBytes> constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations. |
 | [SYSLIB0042](syslib0042.md) | Warning | `ToXmlString` and `FromXmlString` have no implementation for elliptic curve cryptography (ECC) types, and are obsolete. Use a standard import and export format such as `ExportSubjectPublicKeyInfo` or `ImportSubjectPublicKeyInfo` for public keys, and `ExportPkcs8PrivateKey` or `ImportPkcs8PrivateKey` for private keys. |
 | [SYSLIB0043](syslib0043.md) | Warning | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=nameWithType> and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo?displayProperty=nameWithType> instead. |
+| [SYSLIB0047](syslib0047.md) | Warning | <xref:System.Xml.XmlSecureResolver> is obsolete. Use `XmlResolver.ThrowingResolver` instead when attempting to forbid XML external entity resolution. |
 
 ## Suppress warnings
 

--- a/docs/fundamentals/syslib-diagnostics/syslib0043.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0043.md
@@ -1,6 +1,6 @@
 ---
 title: SYSLIB0043 warning - ECDiffieHellmanPublicKey.ToByteArray is obsolete
-description: Learn about the obsoletion of ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor that generates compile-time warning SYSLIB0042.
+description: Learn about the obsoletion of ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor that generates compile-time warning SYSLIB0043.
 ms.date: 04/08/2022
 ---
 # SYSLIB0043: ECDiffieHellmanPublicKey.ToByteArray is obsolete

--- a/docs/fundamentals/syslib-diagnostics/syslib0047.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0047.md
@@ -9,7 +9,7 @@ The <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> type is obsolet
 
 ## Workaround
 
-Consider using the static property `XmlResolver.ThrowingResolver` instead. This property provides an <xref:System.Xml.XmlResolver> instance that forbids external entity resolution.
+Consider using the static property `XmlResolver.ThrowingResolver` instead. This property provides an <xref:System.Xml.XmlResolver> instance that forbids resolution of external XML resources.
 
 ```csharp
 using System.Xml;

--- a/docs/fundamentals/syslib-diagnostics/syslib0047.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0047.md
@@ -1,0 +1,48 @@
+---
+title: SYSLIB0047 warning - XmlSecureResolver is obsolete
+description: Learn about the obsoletion of XmlSecureResolver that generates compile-time warning SYSLIB0047.
+ms.date: 04/08/2022
+---
+# SYSLIB0047: XmlSecureResolver is obsolete
+
+The <xref:System.Xml.XmlSecureResolver?displayProperty=fullName> type is obsolete, starting in .NET 7. Using it in code generates warning `SYSLIB0047` at compile time.
+
+## Workaround
+
+Consider using the static property `XmlResolver.ThrowingResolver` instead. This property provides an <xref:System.Xml.XmlResolver> instance that forbids external entity resolution.
+
+```csharp
+using System.Xml;
+
+XmlResolver resolver = XmlResolver.ThrowingResolver;
+```
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB0047
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB0047
+```
+
+To suppress all the `SYSLIB0047` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);SYSLIB0047</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).

--- a/docs/fundamentals/syslib-diagnostics/syslib0047.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0047.md
@@ -46,3 +46,7 @@ To suppress all the `SYSLIB0047` warnings in your project, add a `<NoWarn>` prop
 ```
 
 For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).
+
+## See also
+
+- [XmlSecureResolver is obsolete](../../core/compatibility/xml/7.0/xmlsecureresolver-obsolete.md)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -499,6 +499,8 @@ items:
         href: syslib-diagnostics/syslib0042.md
       - name: SYSLIB0043
         href: syslib-diagnostics/syslib0043.md
+      - name: SYSLIB0047
+        href: syslib-diagnostics/syslib0047.md
     - name: Source-generated code
       items:
       - name: Overview


### PR DESCRIPTION
Fixes #30550.

Previews:

- [Breaking change](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/xml/7.0/xmlsecureresolver-obsolete?branch=pr-en-us-31076)
- [SYSLIB0047](https://review.docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0047?branch=pr-en-us-31076)