### PR TITLE
Fix typo in ca5364.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5364.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5364.md
@@ -21,7 +21,7 @@ f1_keywords:
 
 ## Cause
 
-This rule fires when either of the following conditions are me:
+This rule fires when either of the following conditions are met:
 
 - A deprecated <xref:System.Net.SecurityProtocolType?displayProperty=nameWithType> value was referenced.
 - An integer value representing a deprecated value was assigned to a <xref:System.Net.SecurityProtocolType> variable.


### PR DESCRIPTION
Replace "following conditions are **me**" with "following conditions are **met**"