### PR TITLE
Socket.End* breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -85,6 +85,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | - | :-: | :-: | - |
 | [AllowRenegotiation default is false](networking/7.0/allowrenegotiation-default.md) | ❌ | ❌ | Preview 3 |
 | [Custom ping payloads on Linux](networking/7.0/ping-custom-payload-linux.md) | ❌ | ✔️ | Preview 2 |
+| [Socket.End methods don't throw ObjectDisposedException](networking/7.0/socket-end-closed-sockets.md) | ❌ | ✔️ | Preview 7 |
 
 ## SDK and MSBuild
 

--- a/docs/core/compatibility/networking/7.0/socket-end-closed-sockets.md
+++ b/docs/core/compatibility/networking/7.0/socket-end-closed-sockets.md
@@ -25,7 +25,7 @@ This change can affect [binary compatibility](../../categories.md#binary-compati
 
 ## Reason for change
 
-Starting with .NET 6, the legacy Socket APM (`Begin*` and `End*`) APIs are backed with a `Task`-based implementation as part of an effort to consolidate and simplify the `Socket` codebase. Unfortunately, the 6.0 implementation leaked unobserved `SocketException` exceptions. This happened even when the APIS were used correctly, meaning that the user code always invokes the `End*` methods, including when the socket is closed).
+The [asynchronous programming model (APM)](../../../../standard/asynchronous-programming-patterns/asynchronous-programming-model-apm.md) APIs are those named `Begin*` and `End*`. Starting with .NET 6, these legacy APIs are backed with a `Task`-based implementation as part of an effort to consolidate and simplify the `Socket` codebase. Unfortunately, the 6.0 implementation leaked unobserved `SocketException` exceptions. This happened even when the APIS were used correctly, meaning that the user code always invokes the `End*` methods, including when the socket is closed).
 
 The change to throw a <xref:System.Net.Sockets.SocketException> was made to ensure that no unobserved exceptions are leaked in such cases.
 
@@ -34,7 +34,7 @@ The change to throw a <xref:System.Net.Sockets.SocketException> was made to ensu
 If your code catches an <xref:System.ObjectDisposedException> from any of the `Socket.End*` methods, change it to catch <xref:System.Net.Sockets.SocketException> and refer to <xref:System.Net.Sockets.SocketException.SocketErrorCode?displayProperty=nameWithType> to query the underlying reason.
 
 > [!NOTE]
-> APM code should always make sure that `End` methods are invoked after the corresponding `Begin` methods, even if the socket is closed.
+> APM code should always make sure that `End*` methods are invoked after the corresponding `Begin*` methods, even if the socket is closed.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/networking/7.0/socket-end-closed-sockets.md
+++ b/docs/core/compatibility/networking/7.0/socket-end-closed-sockets.md
@@ -1,0 +1,47 @@
+---
+title: "Breaking change: Socket.End methods don't throw ObjectDisposedException"
+description: Learn about the .NET 7 breaking change in networking where Socket.End methods no longer throw ObjectDisposedException when the socket is closed.
+ms.date: 09/14/2022
+---
+# Socket.End methods don't throw ObjectDisposedException
+
+`System.Net.Sockets.Socket.End*` methods (for example, <xref:System.Net.Sockets.Socket.EndSend%2A>) throw a <xref:System.Net.Sockets.SocketException> instead of an <xref:System.ObjectDisposedException> if the socket is closed.
+
+## Previous behavior
+
+Previously, the [affected methods](#affected-apis) threw an <xref:System.ObjectDisposedException> for closed sockets.
+
+## New behavior
+
+Starting in .NET 7, the [affected methods](#affected-apis) throw a <xref:System.Net.Sockets.SocketException> with <xref:System.Net.Sockets.SocketException.SocketErrorCode> set to <xref:System.Net.Sockets.SocketError.OperationAborted?displayProperty=nameWithType> for closed sockets.
+
+## Version introduced
+
+.NET 7 Preview 7
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+Starting with .NET 6, the legacy Socket APM (`Begin*` and `End*`) APIs are backed with a `Task`-based implementation as part of an effort to consolidate and simplify the `Socket` codebase. Unfortunately, the 6.0 implementation leaked unobserved `SocketException` exceptions. This happened even when the APIS were used correctly, meaning that the user code always invokes the `End*` methods, including when the socket is closed).
+
+The change to throw a <xref:System.Net.Sockets.SocketException> was made to ensure that no unobserved exceptions are leaked in such cases.
+
+## Recommended action
+
+If your code catches an <xref:System.ObjectDisposedException> from any of the `Socket.End*` methods, change it to catch <xref:System.Net.Sockets.SocketException> and refer to <xref:System.Net.Sockets.SocketException.SocketErrorCode?displayProperty=nameWithType> to query the underlying reason.
+
+> [!NOTE]
+> APM code should always make sure that `End` methods are invoked after the corresponding `Begin` methods, even if the socket is closed.
+
+## Affected APIs
+
+- <xref:System.Net.Sockets.Socket.EndConnect(System.IAsyncResult)?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndDisconnect(System.IAsyncResult)?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndSend%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndSendFile(System.IAsyncResult)?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndSendTo(System.IAsyncResult)?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndReceive%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndAccept%2A?displayProperty=fullName>

--- a/docs/core/compatibility/networking/7.0/socket-end-closed-sockets.md
+++ b/docs/core/compatibility/networking/7.0/socket-end-closed-sockets.md
@@ -25,7 +25,7 @@ This change can affect [binary compatibility](../../categories.md#binary-compati
 
 ## Reason for change
 
-The [asynchronous programming model (APM)](../../../../standard/asynchronous-programming-patterns/asynchronous-programming-model-apm.md) APIs are those named `Begin*` and `End*`. Starting with .NET 6, these legacy APIs are backed with a `Task`-based implementation as part of an effort to consolidate and simplify the `Socket` codebase. Unfortunately, the 6.0 implementation leaked unobserved `SocketException` exceptions. This happened even when the APIS were used correctly, meaning that the user code always invokes the `End*` methods, including when the socket is closed).
+The [asynchronous programming model (APM)](../../../../standard/asynchronous-programming-patterns/asynchronous-programming-model-apm.md) APIs are those named `Begin*` and `End*`. Starting with .NET 6, these legacy APIs are backed with a `Task`-based implementation as part of an effort to consolidate and simplify the `Socket` codebase. Unfortunately, the 6.0 implementation leaked unobserved `SocketException` exceptions. This happened even when the APIS were used correctly, meaning that the calling code always invoked the `End*` methods, including when the socket was closed).
 
 The change to throw a <xref:System.Net.Sockets.SocketException> was made to ensure that no unobserved exceptions are leaked in such cases.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -103,6 +103,8 @@ items:
           href: networking/7.0/allowrenegotiation-default.md
         - name: Custom ping payloads on Linux
           href: networking/7.0/ping-custom-payload-linux.md
+        - name: Socket.End methods don't throw ObjectDisposedException
+          href: networking/7.0/socket-end-closed-sockets.md
       - name: SDK and MSBuild
         items:
         - name: Version requirements for .NET 7 SDK
@@ -1057,6 +1059,8 @@ items:
           href: networking/7.0/allowrenegotiation-default.md
         - name: Custom ping payloads on Linux
           href: networking/7.0/ping-custom-payload-linux.md
+        - name: Socket.End methods don't throw ObjectDisposedException
+          href: networking/7.0/socket-end-closed-sockets.md
       - name: .NET 6
         items:
         - name: Port removed from SPN


### PR DESCRIPTION
Fixes #30977 

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/core/compatibility/networking/7.0/socket-end-closed-sockets?branch=pr-en-us-31190).