### PR TITLE
Use a consistent name for the variable

### DIFF
--- a/docs/fundamentals/networking/snippets/socket/socket-client/Program.cs
+++ b/docs/fundamentals/networking/snippets/socket/socket-client/Program.cs
@@ -2,15 +2,15 @@
 Console.OutputEncoding = Encoding.UTF8;
 Console.WriteLine("Socket client starting...");
 
-var endPoint = await NetworkDiscovery.GetSocketEndPointAsync();
+var ipEndPoint = await NetworkDiscovery.GetSocketEndPointAsync();
 
 // <socketclient>
 using Socket client = new(
-    endPoint.AddressFamily, 
+    ipEndPoint.AddressFamily, 
     SocketType.Stream, 
     ProtocolType.Tcp);
 
-await client.ConnectAsync(endPoint);
+await client.ConnectAsync(ipEndPoint);
 while (true)
 {
     // Send message.

--- a/docs/fundamentals/networking/snippets/socket/socket-server/Program.cs
+++ b/docs/fundamentals/networking/snippets/socket/socket-server/Program.cs
@@ -2,15 +2,15 @@
 Console.OutputEncoding = Encoding.UTF8;
 Console.WriteLine("Socket server starting...");
 
-var endPoint = await NetworkDiscovery.GetSocketEndPointAsync();
+var ipEndPoint = await NetworkDiscovery.GetSocketEndPointAsync();
 
 // <socketserver>
 using Socket listener = new(
-    endPoint.AddressFamily,
+    ipEndPoint.AddressFamily,
     SocketType.Stream,
     ProtocolType.Tcp);
 
-listener.Bind(endPoint);
+listener.Bind(ipEndPoint);
 listener.Listen(100);
 
 var handler = await listener.AcceptAsync();

--- a/docs/fundamentals/networking/snippets/tcp/tcp-client/Program.cs
+++ b/docs/fundamentals/networking/snippets/tcp/tcp-client/Program.cs
@@ -5,10 +5,10 @@ Console.WriteLine("TCP client starting...");
 var ipAddress = await NetworkDiscovery.GetLocalhostIPAddressAsync();
 
 // <tcpclient>
-var endPoint = new IPEndPoint(ipAddress, 13);
+var ipEndPoint = new IPEndPoint(ipAddress, 13);
 
 using TcpClient client = new();
-await client.ConnectAsync(endPoint);
+await client.ConnectAsync(ipEndPoint);
 await using NetworkStream stream = client.GetStream();
 
 var buffer = new byte[1_024];

--- a/docs/fundamentals/networking/snippets/tcp/tcp-listener/Program.cs
+++ b/docs/fundamentals/networking/snippets/tcp/tcp-listener/Program.cs
@@ -3,8 +3,8 @@ Console.OutputEncoding = Encoding.UTF8;
 Console.WriteLine("TCP listener starting...");
 
 // <tcplistener>
-var endPoint = new IPEndPoint(IPAddress.Any, 13);
-TcpListener listener = new(endPoint);
+var ipEndPoint = new IPEndPoint(IPAddress.Any, 13);
+TcpListener listener = new(ipEndPoint);
 
 try
 {    

--- a/docs/fundamentals/networking/sockets/socket-services.md
+++ b/docs/fundamentals/networking/sockets/socket-services.md
@@ -3,7 +3,7 @@ title: Use Sockets to send and receive data
 description: Learn how the Socket class exposes socket network communication functionality in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/24/2022
+ms.date: 09/15/2022
 helpviewer_keywords:
   - "application protocols, sockets"
   - "sending data, sockets"


### PR DESCRIPTION
## Summary

Use a consistent name for the variable and fixes #31178
