### PR TITLE
Renamed the config/options

### DIFF
--- a/docs/core/extensions/custom-logging-provider.md
+++ b/docs/core/extensions/custom-logging-provider.md
@@ -3,7 +3,7 @@ title: Implement a custom logging provider
 description: Learn how to implement a custom logging provider in your .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/20/2022
+ms.date: 09/15/2022
 ms.topic: how-to
 ---
 
@@ -31,7 +31,7 @@ The `ILogger` implementation category name is typically the logging source. For 
 The preceding code:
 
 - Creates a logger instance per category name.
-- Checks `_getCurrentConfig().LogLevels.ContainsKey(logLevel)` in `IsEnabled`, so each `logLevel` has a unique logger. In this implementation, each log level requires an explicit configuration entry in order to log.
+- Checks `_getCurrentConfig().LogLevelToColorMap.ContainsKey(logLevel)` in `IsEnabled`, so each `logLevel` has a unique logger. In this implementation, each log level requires an explicit configuration entry in order to log.
 
 :::code language="csharp" source="snippets/configuration/console-custom-logging/ColorConsoleLogger.cs" range="15-16":::
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
@@ -13,7 +13,7 @@ public sealed class ColorConsoleLogger : ILogger
     public IDisposable BeginScope<TState>(TState state) => default!;
 
     public bool IsEnabled(LogLevel logLevel) =>
-        _getCurrentConfig().LogLevels.ContainsKey(logLevel);
+        _getCurrentConfig().LogLevelToColorMap.ContainsKey(logLevel);
 
     public void Log<TState>(
         LogLevel logLevel,

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLogger.cs
@@ -32,13 +32,13 @@ public sealed class ColorConsoleLogger : ILogger
         {
             ConsoleColor originalColor = Console.ForegroundColor;
 
-            Console.ForegroundColor = config.LogLevels[logLevel];
+            Console.ForegroundColor = config.LogLevelToColorMap[logLevel];
             Console.WriteLine($"[{eventId.Id,2}: {logLevel,-12}]");
             
             Console.ForegroundColor = originalColor;
             Console.Write($"     {_name} - ");
 
-            Console.ForegroundColor = config.LogLevels[logLevel];
+            Console.ForegroundColor = config.LogLevelToColorMap[logLevel];
             Console.Write($"{formatter(state, exception)}");
             
             Console.ForegroundColor = originalColor;

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerConfiguration.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/ColorConsoleLoggerConfiguration.cs
@@ -4,7 +4,7 @@ public class ColorConsoleLoggerConfiguration
 {
     public int EventId { get; set; }
 
-    public Dictionary<LogLevel, ConsoleColor> LogLevels { get; set; } = new()
+    public Dictionary<LogLevel, ConsoleColor> LogLevelToColorMap { get; set; } = new()
     {
         [LogLevel.Information] = ConsoleColor.Green
     };

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/Program.cs
@@ -8,9 +8,9 @@ using IHost host = Host.CreateDefaultBuilder(args)
             .AddColorConsoleLogger(configuration =>
             {
                 // Replace warning value from appsettings.json of "Cyan"
-                configuration.LogLevels[LogLevel.Warning] = ConsoleColor.DarkCyan;
+                configuration.LogLevelToColorMap[LogLevel.Warning] = ConsoleColor.DarkCyan;
                 // Replace warning value from appsettings.json of "Red"
-                configuration.LogLevels[LogLevel.Error] = ConsoleColor.DarkRed;
+                configuration.LogLevelToColorMap[LogLevel.Error] = ConsoleColor.DarkRed;
             }))
             .Build();
 

--- a/docs/core/extensions/snippets/configuration/console-custom-logging/appsettings.json
+++ b/docs/core/extensions/snippets/configuration/console-custom-logging/appsettings.json
@@ -1,7 +1,7 @@
 {
     "Logging": {
         "ColorConsole": {
-            "LogLevels": {
+            "LogLevelToColorMap": {
                 "Information": "DarkGreen",
                 "Warning": "Cyan",
                 "Error": "Red"


### PR DESCRIPTION
## Summary

Renamed the `LogLevels` option member to something more meaningful, and less confusing. Fixes #31025.
