### PR TITLE
Added a table to help more quickly mentally model range operators

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -211,16 +211,16 @@ You can omit any of the operands of the `..` operator to obtain an open-ended ra
 
 The following table shows various ways to express collection ranges:
 
-| Range operator expression | Description                                                                          |
-|---------------------------|--------------------------------------------------------------------------------------|
-| `..`                      | All values in the collection.                                                        |
-| `..{end}`                 | Values from the start to the `{end}` exclusively.                                    |
-| `{start}..`               | Values from the `{start}` inclusively to the end.                                    |
-| `{start}..{end}`          | Values from the `{start}` inclusively to the `{end}` exclusively.                    |
-| `^{start}..`              | Values from the `{start}` inclusively to the end counting from the end.              |
-| `..^{end}`                | Values from the start to the `{end}` exclusively counting from the end.              |
-| `{start}..^{end}`         | Values from `{start}` inclusively to `{end}` exclusively counting from the end.      |
-| `^{start}..^{end}`        | Values from `{start}` inclusively to `{end}` exclusively both counting from the end. |
+| Range operator expression | Description                                                                      |
+|---------------------------|----------------------------------------------------------------------------------|
+| `..`                      | All values in the collection.                                                    |
+| `..end`                   | Values from the start to the `end` exclusively.                                  |
+| `start..`                 | Values from the `start` inclusively to the end.                                  |
+| `start..end`              | Values from the `start` inclusively to the `end` exclusively.                    |
+| `^start..`                | Values from the `start` inclusively to the end counting from the end.            |
+| `..^end`                  | Values from the start to the `end` exclusively counting from the end.            |
+| `start..^end`             | Values from `start` inclusively to `end` exclusively counting from the end.      |
+| `^start..^end`            | Values from `start` inclusively to `end` exclusively both counting from the end. |
 
 The following example demonstrates the effect of using all the ranges presented in the preceding table:
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -1,7 +1,7 @@
 ---
 title: "Member access operators and expressions - C# reference"
 description: "Learn about C# operators that you can use to access type members."
-ms.date: 08/16/2021
+ms.date: 09/16/2022
 author: pkulikov
 f1_keywords:
   - "._CSharpKeyword"
@@ -204,7 +204,25 @@ You can omit any of the operands of the `..` operator to obtain an open-ended ra
 - `..b` is equivalent to `0..b`
 - `..` is equivalent to `0..^0`
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesOptional":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesOptional" interactive="try-dotnet-method":::
+
+There are several ways to express a range, as the following table describes:
+
+| Range operator expression | Description |
+|--|--|
+| `..` | All values in the collection. |
+| `..{n}` | All values in the collection up to `{n}` exclusively. |
+| `{n}..` | All values in the collection after `{n}` inclusively. |
+| `{n1}..{n2}` | All values in the collection between `{n1}` inclusively and `{n2}` exclusively. |
+| `^{n}..` | All values in the collection after `{n}` starting from the end inclusively. |
+| `..^{n}` | All values in the collection up to `{n}` starting from the end exclusively. |
+| `{n1}..^{n2}` | All values in the collection between `{n1}` inclusively and `{n2}` starting from the end exclusively. |
+| `^{n1}..^{n2}` | All values in the collection between `{n1}` starting from the end inclusively and `{n2}` starting from the end exclusively. |
+
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible" interactive="try-dotnet-method":::
+
+> [!IMPORTANT]
+> Implicit conversions from `int` to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.
 
 For more information, see [Indices and ranges](../../whats-new/tutorials/ranges-indexes.md).
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -219,10 +219,12 @@ There are several ways to express a range, as the following table describes:
 | `{n1}..^{n2}` | All values in the collection between `{n1}` inclusively and `{n2}` starting from the end exclusively. |
 | `^{n1}..^{n2}` | All values in the collection between `{n1}` starting from the end inclusively and `{n2}` starting from the end exclusively. |
 
+To help visualize these various expressions, the following code uses an array with values one through ten, and performs the following operations:
+
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible":::
 
 > [!IMPORTANT]
-> Implicit conversions from `int` to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.
+> Implicit conversions from <xref:System.Int32> to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.
 
 For more information, see [Indices and ranges](../../whats-new/tutorials/ranges-indexes.md).
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -209,20 +209,20 @@ You can omit any of the operands of the `..` operator to obtain an open-ended ra
 
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesOptional":::
 
-There are several ways to express a range, as the following table describes:
+There are several ways to express range operators. Please consider the descriptions from the following table:
 
-| Range operator expression | Description |
-|--|--|
-| `..` | All values in the collection. |
-| `..{n}` | All values in the collection up to `{n}` exclusively. |
-| `{n}..` | All values in the collection after `{n}` inclusively. |
-| `{n1}..{n2}` | All values in the collection between `{n1}` inclusively and `{n2}` exclusively. |
-| `^{n}..` | All values in the collection after `{n}` starting from the end inclusively. |
-| `..^{n}` | All values in the collection up to `{n}` starting from the end exclusively. |
-| `{n1}..^{n2}` | All values in the collection between `{n1}` inclusively and `{n2}` starting from the end exclusively. |
-| `^{n1}..^{n2}` | All values in the collection between `{n1}` starting from the end inclusively and `{n2}` starting from the end exclusively. |
+| Range operator expression | Description                                                                          |
+|---------------------------|--------------------------------------------------------------------------------------|
+| `..`                      | All values in the collection.                                                        |
+| `..{end}`                 | Values from the start to the `{end}` exclusively.                                    |
+| `{start}..`               | Values from the `{start}` inclusively to the end.                                    |
+| `{start}..{end}`          | Values from the `{start}` inclusively to the `{end}` exclusively.                    |
+| `^{start}..`              | Values from the `{start}` inclusively to the end starting from the end.              |
+| `..^{end}`                | Values from the start to the `{end}` exclusively starting from the end.              |
+| `{start}..^{end}`         | Values from `{start}` inclusively to `{end}` exclusively starting from the end.      |
+| `^{start}..^{end}`        | Values from `{start}` inclusively to `{end}` exclusively both starting from the end. |
 
-To help visualize these various expressions, the following code uses an array with values one through ten, and performs the following operations:
+To help visualize the various ways to express these, the following code uses an array with values one through ten, performs all of the possible range operator expressions, and shows their corresponding result:
 
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible":::
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -204,7 +204,7 @@ You can omit any of the operands of the `..` operator to obtain an open-ended ra
 - `..b` is equivalent to `0..b`
 - `..` is equivalent to `0..^0`
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesOptional" interactive="try-dotnet-method":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesOptional":::
 
 There are several ways to express a range, as the following table describes:
 
@@ -219,7 +219,7 @@ There are several ways to express a range, as the following table describes:
 | `{n1}..^{n2}` | All values in the collection between `{n1}` inclusively and `{n2}` starting from the end exclusively. |
 | `^{n1}..^{n2}` | All values in the collection between `{n1}` starting from the end inclusively and `{n2}` starting from the end exclusively. |
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible" interactive="try-dotnet-method":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible":::
 
 > [!IMPORTANT]
 > Implicit conversions from `int` to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -217,10 +217,10 @@ The following table shows various ways to express collection ranges:
 | `..{end}`                 | Values from the start to the `{end}` exclusively.                                    |
 | `{start}..`               | Values from the `{start}` inclusively to the end.                                    |
 | `{start}..{end}`          | Values from the `{start}` inclusively to the `{end}` exclusively.                    |
-| `^{start}..`              | Values from the `{start}` inclusively to the end starting from the end.              |
-| `..^{end}`                | Values from the start to the `{end}` exclusively starting from the end.              |
-| `{start}..^{end}`         | Values from `{start}` inclusively to `{end}` exclusively starting from the end.      |
-| `^{start}..^{end}`        | Values from `{start}` inclusively to `{end}` exclusively both starting from the end. |
+| `^{start}..`              | Values from the `{start}` inclusively to the end counting from the end.              |
+| `..^{end}`                | Values from the start to the `{end}` exclusively counting from the end.              |
+| `{start}..^{end}`         | Values from `{start}` inclusively to `{end}` exclusively counting from the end.      |
+| `^{start}..^{end}`        | Values from `{start}` inclusively to `{end}` exclusively both counting from the end. |
 
 The following example demonstrates the effect of using all the ranges presented in the preceding table:
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -199,7 +199,7 @@ Available in C# 8.0 and later, the `..` operator specifies the start and end of 
 As the preceding example shows, expression `a..b` is of the <xref:System.Range?displayProperty=nameWithType> type. In expression `a..b`, the results of `a` and `b` must be implicitly convertible to <xref:System.Int32> or <xref:System.Index>.
 
 > [!IMPORTANT]
-> Implicit conversions from `int` to `Index` will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.
+> Implicit conversions from `int` to `Index` throw an <xref:System.ArgumentOutOfRangeException> when the value is negative.
 
 You can omit any of the operands of the `..` operator to obtain an open-ended range:
 
@@ -209,7 +209,7 @@ You can omit any of the operands of the `..` operator to obtain an open-ended ra
 
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesOptional":::
 
-There are several ways to express range operators. Please consider the descriptions from the following table:
+The following table shows various ways to express collection ranges:
 
 | Range operator expression | Description                                                                          |
 |---------------------------|--------------------------------------------------------------------------------------|
@@ -222,7 +222,7 @@ There are several ways to express range operators. Please consider the descripti
 | `{start}..^{end}`         | Values from `{start}` inclusively to `{end}` exclusively starting from the end.      |
 | `^{start}..^{end}`        | Values from `{start}` inclusively to `{end}` exclusively both starting from the end. |
 
-To help visualize the various ways to express these, the following code uses an array with values one through ten, performs all of the possible range operator expressions, and shows their corresponding result:
+The following example demonstrates the effect of using all the ranges presented in the preceding table:
 
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible":::
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -196,7 +196,10 @@ Available in C# 8.0 and later, the `..` operator specifies the start and end of 
 
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Ranges":::
 
-As the preceding example shows, expression `a..b` is of the <xref:System.Range?displayProperty=nameWithType> type. In expression `a..b`, the results of `a` and `b` must be implicitly convertible to `int` or <xref:System.Index>.
+As the preceding example shows, expression `a..b` is of the <xref:System.Range?displayProperty=nameWithType> type. In expression `a..b`, the results of `a` and `b` must be implicitly convertible to <xref:System.Int32> or <xref:System.Index>.
+
+> [!IMPORTANT]
+> Implicit conversions from `int` to `Index` will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.
 
 You can omit any of the operands of the `..` operator to obtain an open-ended range:
 
@@ -222,9 +225,6 @@ There are several ways to express a range, as the following table describes:
 To help visualize these various expressions, the following code uses an array with values one through ten, and performs the following operations:
 
 :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="RangesAllPossible":::
-
-> [!IMPORTANT]
-> Implicit conversions from <xref:System.Int32> to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative.
 
 For more information, see [Indices and ranges](../../whats-new/tutorials/ranges-indexes.md).
 

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -17,6 +17,7 @@ public static class MemberAccessOperators
         IndexFromEnd();
         Ranges();
         RangesOptional();
+        RangesAllPossible();
     }
 
     private static void QualifiedName()
@@ -73,7 +74,7 @@ public static class MemberAccessOperators
     private static void NullConditional()
     {
         // <SnippetNullConditional>
-        double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
+        static double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
         {
             return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
         }
@@ -98,7 +99,7 @@ public static class MemberAccessOperators
     private static void NullConditionalWithNullCoalescing()
     {
         // <SnippetNullConditionalWithNullCoalescing>
-        int GetSumOfFirstTwoOrDefault(int[] numbers)
+        static int GetSumOfFirstTwoOrDefault(int[] numbers)
         {
             if ((numbers?.Length ?? 0) < 2)
             {
@@ -165,7 +166,7 @@ public static class MemberAccessOperators
         string end = line[endIndices];
         Console.WriteLine(end);  // output: three
 
-        void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
+        static void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
         // </SnippetRanges>
     }
 
@@ -184,7 +185,29 @@ public static class MemberAccessOperators
         int[] all = numbers[..];
         Display(all);  // output: 0 10 20 30 40 50
 
-        void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
+        static void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
         // </SnippetRangesOptional>
+    }
+
+    private static void RangesAllPossible()
+    {
+        // <RangesAllPossible>
+        var oneThroughTen = new[]
+        {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        };
+
+        Write(oneThroughTen, ..);      // 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        Write(oneThroughTen, ..2);     // 1, 2
+        Write(oneThroughTen, 2..);     //       3, 4, 5, 6, 7, 8, 9, 10
+        Write(oneThroughTen, 3..5);    //          4, 5
+        Write(oneThroughTen, ^5..);    //                6, 7, 8, 9, 10
+        Write(oneThroughTen, ..^4);    // 1, 2, 3, 4, 5, 6
+        Write(oneThroughTen, 3..^4);   //          4, 5, 6
+        Write(oneThroughTen, ^4..^1);  //                   7, 8, 9
+
+        static void Write(int[] vals, Range range) =>
+            Console.WriteLine(string.Join(", ", vals[range]));
+        // </RangesAllPossible>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -198,13 +198,13 @@ public static class MemberAccessOperators
         };
 
         Write(oneThroughTen, ..);      // 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        Write(oneThroughTen, ..2);     // 1, 2
+        Write(oneThroughTen, ..3);     // 1, 2, 3,
         Write(oneThroughTen, 2..);     //       3, 4, 5, 6, 7, 8, 9, 10
         Write(oneThroughTen, 3..5);    //          4, 5
-        Write(oneThroughTen, ^5..);    //                6, 7, 8, 9, 10
-        Write(oneThroughTen, ..^4);    // 1, 2, 3, 4, 5, 6
+        Write(oneThroughTen, ^2..);    //                         9, 10
+        Write(oneThroughTen, ..^3);    // 1, 2, 3, 4, 5, 6, 7
         Write(oneThroughTen, 3..^4);   //          4, 5, 6
-        Write(oneThroughTen, ^4..^1);  //                   7, 8, 9
+        Write(oneThroughTen, ^4..^2);  //                   7, 8, 9
 
         void Write(int[] values, Range range) =>
             Console.WriteLine(string.Join(", ", values[range]));

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -197,17 +197,26 @@ public static class MemberAccessOperators
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10
         };
 
-        Write(oneThroughTen, ..);      // 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        Write(oneThroughTen, ..3);     // 1, 2, 3,
-        Write(oneThroughTen, 2..);     //       3, 4, 5, 6, 7, 8, 9, 10
-        Write(oneThroughTen, 3..5);    //          4, 5
-        Write(oneThroughTen, ^2..);    //                         9, 10
-        Write(oneThroughTen, ..^3);    // 1, 2, 3, 4, 5, 6, 7
-        Write(oneThroughTen, 3..^4);   //          4, 5, 6
-        Write(oneThroughTen, ^4..^2);  //                   7, 8, 9
+        Write(oneThroughTen, ..);
+        Write(oneThroughTen, ..3);
+        Write(oneThroughTen, 2..);
+        Write(oneThroughTen, 3..5);
+        Write(oneThroughTen, ^2..);
+        Write(oneThroughTen, ..^3);
+        Write(oneThroughTen, 3..^4);
+        Write(oneThroughTen, ^4..^2);
 
         void Write(int[] values, Range range) =>
-            Console.WriteLine(string.Join(", ", values[range]));
+            Console.WriteLine($"{range}:\tstring.Join(", ", values[range])");
+        // Sample output:
+        //      0..^0:      1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        //      0..3:       1, 2, 3
+        //      2..^0:      3, 4, 5, 6, 7, 8, 9, 10
+        //      3..5:       4, 5
+        //      ^2..^0:     9, 10
+        //      0..^3:      1, 2, 3, 4, 5, 6, 7
+        //      3..^4:      4, 5, 6
+        //      ^4..^2:     7, 8
         // </RangesAllPossible>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -192,7 +192,7 @@ public static class MemberAccessOperators
     private static void RangesAllPossible()
     {
         // <RangesAllPossible>
-        int[] oneThroughTen = new[]
+        int[] oneThroughTen =
         {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10
         };

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -192,7 +192,7 @@ public static class MemberAccessOperators
     private static void RangesAllPossible()
     {
         // <RangesAllPossible>
-        var oneThroughTen = new[]
+        int[] oneThroughTen = new[]
         {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10
         };
@@ -206,8 +206,8 @@ public static class MemberAccessOperators
         Write(oneThroughTen, 3..^4);   //          4, 5, 6
         Write(oneThroughTen, ^4..^1);  //                   7, 8, 9
 
-        void Write(int[] vals, Range range) =>
-            Console.WriteLine(string.Join(", ", vals[range]));
+        void Write(int[] values, Range range) =>
+            Console.WriteLine(string.Join(", ", values[range]));
         // </RangesAllPossible>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -74,7 +74,7 @@ public static class MemberAccessOperators
     private static void NullConditional()
     {
         // <SnippetNullConditional>
-        static double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
+        double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
         {
             return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
         }
@@ -99,7 +99,7 @@ public static class MemberAccessOperators
     private static void NullConditionalWithNullCoalescing()
     {
         // <SnippetNullConditionalWithNullCoalescing>
-        static int GetSumOfFirstTwoOrDefault(int[] numbers)
+        int GetSumOfFirstTwoOrDefault(int[] numbers)
         {
             if ((numbers?.Length ?? 0) < 2)
             {
@@ -166,7 +166,7 @@ public static class MemberAccessOperators
         string end = line[endIndices];
         Console.WriteLine(end);  // output: three
 
-        static void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
+        void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
         // </SnippetRanges>
     }
 
@@ -185,7 +185,7 @@ public static class MemberAccessOperators
         int[] all = numbers[..];
         Display(all);  // output: 0 10 20 30 40 50
 
-        static void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
+        void Display<T>(IEnumerable<T> xs) => Console.WriteLine(string.Join(" ", xs));
         // </SnippetRangesOptional>
     }
 
@@ -206,7 +206,7 @@ public static class MemberAccessOperators
         Write(oneThroughTen, 3..^4);   //          4, 5, 6
         Write(oneThroughTen, ^4..^1);  //                   7, 8, 9
 
-        static void Write(int[] vals, Range range) =>
+        void Write(int[] vals, Range range) =>
             Console.WriteLine(string.Join(", ", vals[range]));
         // </RangesAllPossible>
     }

--- a/docs/csharp/whats-new/tutorials/ranges-indexes.md
+++ b/docs/csharp/whats-new/tutorials/ranges-indexes.md
@@ -1,7 +1,7 @@
 ---
 title: Explore ranges of data using indices and ranges
 description: This advanced tutorial teaches you to explore data using indices and ranges to examine a continuous range of a sequential data set.
-ms.date: 09/11/2020
+ms.date: 09/16/2022
 ms.technology: csharp-fundamentals
 ms.custom: mvc
 ---
@@ -14,6 +14,7 @@ In this tutorial, you'll learn how to:
 > [!div class="checklist"]
 >
 > - Use the syntax for ranges in a sequence.
+> - Implicitly define a <xref:System.Range>.
 > - Understand the design decisions for the start and end of each sequence.
 > - Learn scenarios for the <xref:System.Index> and <xref:System.Range> types.
 
@@ -69,6 +70,15 @@ You can also declare ranges or indices as variables. The variable can then be us
 The following sample shows many of the reasons for those choices. Modify `x`, `y`, and `z` to try different combinations. When you experiment, use values where `x` is less than `y`, and `y` is less than `z` for valid combinations. Add the following code in a new method. Try different combinations:
 
 [!code-csharp[SemanticsExamples](~/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs#IndicesAndRanges_Semantics)]
+
+### Implicit range operator expression conversions
+
+When using the range operator expression syntax, the compiler implicitly converts the start and end values to an <xref:System.Index> and from them, creates a new <xref:System.Range> instance. The following code shows an example implicit conversion from the range operator expression syntax, and its corresponding explicit alternative:
+
+:::code language="csharp" source="../../../../samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs" id="ImplicitRangeOperatorConversion":::
+
+> [!IMPORTANT]
+> Implicit conversions from <xref:System.Int32> to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative. Likewise, the `Index` constructor will throw `ArgumentOutOfRangeException` when the `value` parameter is negative.
 
 ## Type support for indices and ranges
 

--- a/docs/csharp/whats-new/tutorials/ranges-indexes.md
+++ b/docs/csharp/whats-new/tutorials/ranges-indexes.md
@@ -78,7 +78,7 @@ When using the range operator expression syntax, the compiler implicitly convert
 :::code language="csharp" source="../../../../samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs" id="ImplicitRangeOperatorConversion":::
 
 > [!IMPORTANT]
-> Implicit conversions from <xref:System.Int32> to <xref:System.Index> will throw the <xref:System.ArgumentOutOfRangeException> when the value is negative. Likewise, the `Index` constructor will throw `ArgumentOutOfRangeException` when the `value` parameter is negative.
+> Implicit conversions from <xref:System.Int32> to <xref:System.Index> throw an <xref:System.ArgumentOutOfRangeException> when the value is negative. Likewise, the `Index` constructor throws an `ArgumentOutOfRangeException` when the `value` parameter is negative.
 
 ## Type support for indices and ranges
 

--- a/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
+++ b/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
@@ -189,8 +189,13 @@ namespace RangesIndexes
                 start: new Index(value: 3, fromEnd: false),
                 end: new Index(value: 5, fromEnd: true));
 
-            // Prints "True"
-            Console.WriteLine(implicitRange.Equals(explicitRange));
+            if (implicitRange.Equals(explicitRange))
+            {
+                Console.WriteLine(
+                    $"The implicit range '{implicitRange}' equals the explicit range '{explicitRange}'");
+            }
+            // Sample output:
+            //     The implicit range '3..^5' equals the explicit range '3..^5'
             // </ImplicitRangeOperatorConversion>
         }
     }

--- a/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
+++ b/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
@@ -183,9 +183,9 @@ namespace RangesIndexes
         internal void ImplicitRangeOperatorConversion()
         {
             // <ImplicitRangeOperatorConversion>
-            var implicitRange = 3..^5;
+            Range implicitRange = 3..^5;
 
-            var explicitRange = new Range(
+            Range explicitRange = new(
                 start: new Index(value: 3, fromEnd: false),
                 end: new Index(value: 5, fromEnd: true));
 

--- a/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
+++ b/samples/snippets/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
@@ -153,16 +153,16 @@ namespace RangesIndexes
             // <SnippetIndicesAndRanges_JaggedArrays>
             var jagged = new int[10][]
             {
-               new int[10] { 0,  1, 2, 3, 4, 5, 6, 7, 8, 9},
-               new int[10] { 10,11,12,13,14,15,16,17,18,19},
-               new int[10] { 20,21,22,23,24,25,26,27,28,29},
-               new int[10] { 30,31,32,33,34,35,36,37,38,39},
-               new int[10] { 40,41,42,43,44,45,46,47,48,49},
-               new int[10] { 50,51,52,53,54,55,56,57,58,59},
-               new int[10] { 60,61,62,63,64,65,66,67,68,69},
-               new int[10] { 70,71,72,73,74,75,76,77,78,79},
-               new int[10] { 80,81,82,83,84,85,86,87,88,89},
-               new int[10] { 90,91,92,93,94,95,96,97,98,99},
+               new int[10] {  0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+               new int[10] { 10,11,12,13,14,15,16,17,18,19 },
+               new int[10] { 20,21,22,23,24,25,26,27,28,29 },
+               new int[10] { 30,31,32,33,34,35,36,37,38,39 },
+               new int[10] { 40,41,42,43,44,45,46,47,48,49 },
+               new int[10] { 50,51,52,53,54,55,56,57,58,59 },
+               new int[10] { 60,61,62,63,64,65,66,67,68,69 },
+               new int[10] { 70,71,72,73,74,75,76,77,78,79 },
+               new int[10] { 80,81,82,83,84,85,86,87,88,89 },
+               new int[10] { 90,91,92,93,94,95,96,97,98,99 },
             };
 
             var selectedRows = jagged[3..^3];
@@ -178,6 +178,20 @@ namespace RangesIndexes
             }
             // </SnippetIndicesAndRanges_JaggedArrays>
             return 0;
+        }
+
+        internal void ImplicitRangeOperatorConversion()
+        {
+            // <ImplicitRangeOperatorConversion>
+            var implicitRange = 3..^5;
+
+            var explicitRange = new Range(
+                start: new Index(value: 3, fromEnd: false),
+                end: new Index(value: 5, fromEnd: true));
+
+            // Prints "True"
+            Console.WriteLine(implicitRange.Equals(explicitRange));
+            // </ImplicitRangeOperatorConversion>
         }
     }
 }

--- a/samples/snippets/csharp/tutorials/RangesIndexes/Program.cs
+++ b/samples/snippets/csharp/tutorials/RangesIndexes/Program.cs
@@ -24,6 +24,8 @@ namespace RangesIndexes
             indexSamples.ComputeMovingAverages();
             Console.WriteLine("          ==========          Jageged arrays.        ==========");
             indexSamples.JaggedArrays();
+            Console.WriteLine("          ==========          Implicit range operator expression conversions.        ==========");
+            indexSamples.ImplicitRangeOperatorConversion();
         }
     }
 }

--- a/samples/snippets/csharp/tutorials/RangesIndexes/RangesIndexes.csproj
+++ b/samples/snippets/csharp/tutorials/RangesIndexes/RangesIndexes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Added a table to help more quickly mentally model range operators.

- [🔗 SharpLab.io link](https://sharplab.io/#v2:EYLgtghglgdgNAFxAJwK7wCYgNQB8ACATAIwCwAUBbAgNoC6ABAPYwCmAKgBbJOoDmndqxgMAvAzYB3ehQDeFBoobE4DQqoDMqgCyqArKoBsqgOyqAHKoCcq4gAYKAXwDcFCgHVkUBKwAULDm5eASF4BgA6cIBKZyUlAHp45VV1Bi0GXQYDBmMGMwZLBhtlB3JPbz8Arh5+QWFVSMIYuIZE5LUPLx9/NmrgurDCSOa4tpa0nX0jUwtrW1Ly7qqg2tDNSL0RxTHxxUy9ToqewJqQ+oYAPRNh2ISk3b2pnJmCuZLDpd6Vs7DIi+0tq0kio1JpJlkjB9Kl9TgN1uF/lsdrt9pCyl1oSd+mtLto/sQRsiHrt8oUrG5yPhiIYGPhtAxFn5qPQGAA3CAAGwAzqoAEoQGB8VgMZACoVRMQAPgUSipVl8VLs4QAUkxYL4AESqLVszlcmiiwWsOhRGIyxQUIA)
- [🔗 Preview - Range operator `..`](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-31223#range-operator-)
- [🔗 Preview - Implicit range operator expression conversions](https://review.docs.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/ranges-indexes?branch=pr-en-us-31223#implicit-range-operator-expression-conversions)

Fixes #31224