### PR TITLE
Acrolinx and TOC touch-ups

### DIFF
--- a/docs/core/extensions/http-ratelimiter.md
+++ b/docs/core/extensions/http-ratelimiter.md
@@ -6,11 +6,11 @@ ms.author: dapine
 ms.date: 09/15/2022
 ---
 
-# Rate limiting an HTTP handler in .NET
+# Rate limit an HTTP handler in .NET
 
 [!INCLUDE [scl-preview](../../../includes/preview-content.md)]
 
-In this article, you'll learn how to create a client-side HTTP handler that rate limits the number of requests it sends. In this example, you'll see an <xref:System.Net.Http.HttpClient> that accesses the `"www.example.com"` resource. Resources are consumed by apps that rely on them, and when an app makes too many requests to a single resource this can lead to resource contention. Resource contention is when a resource is consumed by too many apps, and the resource is unable to serve all of the apps that are requesting it. This can lead to a poor user experience, and in some cases, it can even lead to a denial of service (DoS) attack. For more information on DoS, see [OWASP: Denial of Service](https://owasp.org/www-community/attacks/Denial_of_Service).
+In this article, you'll learn how to create a client-side HTTP handler that rate limits the number of requests it sends. You'll see an <xref:System.Net.Http.HttpClient> that accesses the `"www.example.com"` resource. Resources are consumed by apps that rely on them, and when an app makes too many requests to a single resource, it can lead to *resource contention*. Resource contention occurs when a resource is consumed by too many apps, and the resource is unable to serve all of the apps that are requesting it. This can result in a poor user experience, and in some cases, it can even lead to a denial of service (DoS) attack. For more information on DoS, see [OWASP: Denial of Service](https://owasp.org/www-community/attacks/Denial_of_Service).
 
 ## What is rate limiting?
 
@@ -20,7 +20,7 @@ To use rate limiting in .NET, you'll reference the [System.Threading.RateLimitin
 
 ## Implement a `DelegatingHandler` subclass
 
-To control the flow of requests, you implement a custom <xref:System.Net.Http.DelegatingHandler> subclass. This is a type of <xref:System.Net.Http.HttpMessageHandler> that allows you to intercept and handle requests before they are sent to the server. You can also intercept and handle responses before they are returned to the caller. In this example, you'll implement a custom `DelegatingHandler` subclass that limits the number of requests that can be sent to a single resource. Consider the following custom `ClientSideRateLimitedHandler` class:
+To control the flow of requests, you implement a custom <xref:System.Net.Http.DelegatingHandler> subclass. This is a type of <xref:System.Net.Http.HttpMessageHandler> that allows you to intercept and handle requests before they're sent to the server. You can also intercept and handle responses before they're returned to the caller. In this example, you'll implement a custom `DelegatingHandler` subclass that limits the number of requests that can be sent to a single resource. Consider the following custom `ClientSideRateLimitedHandler` class:
 
 :::code language="csharp" source="snippets/ratelimit/http/ClientSideRateLimitedHandler.cs":::
 
@@ -29,7 +29,7 @@ The preceding C# code:
 - Inherits the `DelegatingHandler` type.
 - Implements the <xref:System.IAsyncDisposable> interface.
 - Defines a `RateLimiter` field that is assigned from the constructor.
-- The `SendAsync` method is overridden to intercept and handle requests before they are sent to the server.
+- The `SendAsync` method is overridden to intercept and handle requests before they're sent to the server.
 - The <xref:System.IAsyncDisposable.DisposeAsync> method is overridden to dispose of the `RateLimiter` instance.
 
 Looking a bit closer at the `SendAsync` method, you'll see that it:
@@ -53,7 +53,7 @@ In the preceding console app:
 - The `HttpClient` is used to send a `GET` request to each URL, and the response is written to the console.
 - <xref:System.Threading.Tasks.Task.WhenAll%2A?displayProperty=nameWithType> waits for both tasks to complete.
 
-Since the `HttpClient` is configured with the `ClientSideRateLimitedHandler`, not all requests will make it to the server resource. You can test this by running the console app, and you'll see that only a fraction of the total number of requests are sent to the server, and the rest are rejected with an HTTP status code of `429`. Try altering the `options` object used to create the `TokenBucketRateLimiter` to see how the number of requests that are sent to the server changes.
+Since the `HttpClient` is configured with the `ClientSideRateLimitedHandler`, not all requests will make it to the server resource. You can test this assertion by running the console app. You'll see that only a fraction of the total number of requests are sent to the server, and the rest are rejected with an HTTP status code of `429`. Try altering the `options` object used to create the `TokenBucketRateLimiter` to see how the number of requests that are sent to the server changes.
 
 Consider the following example output:
 
@@ -159,9 +159,9 @@ URL: https://example.com?iteration=58, HTTP status code: OK (200)
 URL: https://example.com?iteration=50, HTTP status code: OK (200)
 ```
 
-You'll notice that the first logged entries are always the immediately returned 429s, and the last entries are always the 200s. This is because the rate limit is encountered client-side, and avoids making an HTTP call to a server. This is a good thing because it means that the server is not being flooded with requests, and it also means that the rate limit is enforced consistently across all clients.
+You'll notice that the first logged entries are always the immediately returned 429 responses, and the last entries are always the 200 responses. This is because the rate limit is encountered client-side and avoids making an HTTP call to a server. This is a good thing because it means that the server isn't flooded with requests. It also means that the rate limit is enforced consistently across all clients.
 
-You should also note that each URL's query string is unique, examine the `iteration` parameter to see that it is incremented by one for each request. This helps to illustrate that the 429 responses aren't from the first requests, but rather from the requests that are made after the rate limit is reached. The 200 responses finish later but were made earlier before the limit was reached.
+Note also that each URL's query string is unique: examine the `iteration` parameter to see that it's incremented by one for each request. This parameter helps to illustrate that the 429 responses aren't from the first requests, but rather from the requests that are made after the rate limit is reached. The 200 responses arrive later but these requests were made earlier&mdash;before the limit was reached.
 
 To have a better understanding of the various rate-limiting algorithms, try rewriting this code to accept a different `RateLimiter` implementation. In addition to the `TokenBucketRateLimiter` you could try:
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1670,7 +1670,7 @@ items:
     href: ../standard/clr.md
   - name: Managed execution process
     href: ../standard/managed-execution-process.md
-  - name: Assemblies in .NET
+  - name: Assemblies
     href: ../standard/assembly/
   - name: Metadata and self-describing components
     href: ../standard/metadata-and-self-describing-components.md
@@ -1697,7 +1697,7 @@ items:
       items:
       - name: Create a .NET application with plugins
         href: ../core/tutorials/creating-app-with-plugin-support.md
-      - name: How to use and debug assembly unloadability in .NET
+      - name: How to use and debug assembly unloadability
         href: ../core/../standard/assembly/unloadability.md
   - name: Versioning
     items:
@@ -2044,7 +2044,7 @@ items:
       href: ../standard/base-types/common-type-system.md
     - name: Language independence
       href: ../standard/language-independence.md
-    - name: Type conversion in .NET
+    - name: Type conversion
       href: ../standard/base-types/type-conversion.md
     - name: Type conversion tables
       href: ../standard/base-types/conversion-tables.md
@@ -2060,7 +2060,7 @@ items:
       href: ../standard/generics/index.md
     - name: Intro to generic types
       href: ../standard/generics.md
-    - name: Generic collections in .NET
+    - name: Generic collections
       href: ../standard/generics/collections.md
     - name: Generic delegates for manipulating arrays and lists
       href: ../standard/generics/delegates-for-manipulating-arrays-and-lists.md
@@ -2193,7 +2193,7 @@ items:
         href: ../standard/base-types/how-to-display-dates-in-non-gregorian-calendars.md
   - name: Work with strings
     items:
-    - name: Character encoding in .NET
+    - name: Character encoding
       href: ../standard/base-types/character-encoding-introduction.md
     - name: How to use character encoding classes
       href: ../standard/base-types/character-encoding.md
@@ -2559,7 +2559,7 @@ items:
     href: ../core/extensions/generic-host.md
   - name: Networking
     items:
-    - name: Network programming in .NET
+    - name: Network programming
       href: networking/overview.md
     - name: Network availability
       href: networking/network-info.md
@@ -2580,7 +2580,7 @@ items:
         href: ../core/extensions/httpclient-factory.md
       - name: HTTP/3 with .NET
         href: ../core/extensions/httpclient-http3.md
-      - name: Rate limiting an HTTP handler in .NET
+      - name: Rate limit an HTTP handler
         href: ../core/extensions/http-ratelimiter.md
     - name: Sockets
       items:
@@ -2594,9 +2594,9 @@ items:
         href: networking/tcp/tcp-overview.md
       - name: Use TcpClient and TcpListener
         href: networking/tcp/tcp-services.md
-  - name: File globbing in .NET
+  - name: File globbing
     href: ../core/extensions/file-globbing.md
-  - name: Primitives library in .NET
+  - name: Primitives library
     href: ../core/extensions/primitives.md
   - name: Globalization and localization
     items:

--- a/docs/standard/assembly/unloadability.md
+++ b/docs/standard/assembly/unloadability.md
@@ -1,22 +1,22 @@
 ---
-title: "How to use and debug assembly unloadability in .NET Core"
+title: "How to use and debug assembly unloadability in .NET"
 description: "Learn how to use collectible AssemblyLoadContext for loading and unloading managed assemblies and how to debug issues preventing the unloading success."
 author: "janvorli"
 ms.author: "janvorli"
-ms.date: "02/05/2019"
+ms.date: 09/16/2022
 ms.topic: how-to
 ---
-# How to use and debug assembly unloadability in .NET Core
+# How to use and debug assembly unloadability in .NET
 
-Starting with .NET Core 3.0, the ability to load and later unload a set of assemblies is supported. In .NET Framework, custom app domains were used for this purpose, but .NET Core only supports a single default app domain.
+.NET Core 3.0 introduced the ability to load and later unload a set of assemblies. In .NET Framework, custom app domains were used for this purpose, but .NET \[Core] only supports a single default app domain.
 
-.NET Core 3.0 and later versions support unloadability through <xref:System.Runtime.Loader.AssemblyLoadContext>. You can load a set of assemblies into a collectible `AssemblyLoadContext`, execute methods in them or just inspect them using reflection, and finally unload the `AssemblyLoadContext`. That unloads the assemblies loaded into the `AssemblyLoadContext`.
+Unloadability is supported through <xref:System.Runtime.Loader.AssemblyLoadContext>. You can load a set of assemblies into a collectible `AssemblyLoadContext`, execute methods in them or just inspect them using reflection, and finally unload the `AssemblyLoadContext`. That unloads the assemblies loaded into the `AssemblyLoadContext`.
 
 There's one noteworthy difference between the unloading using `AssemblyLoadContext` and using AppDomains. With AppDomains, the unloading is forced. At unload time, all threads running in the target AppDomain are aborted, managed COM objects created in the target AppDomain are destroyed, and so on. With `AssemblyLoadContext`, the unload is "cooperative". Calling the <xref:System.Runtime.Loader.AssemblyLoadContext.Unload%2A?displayProperty=nameWithType> method just initiates the unloading. The unloading finishes after:
 
 - No threads have methods from the assemblies loaded into the `AssemblyLoadContext` on their call stacks.
 - None of the types from the assemblies loaded into the `AssemblyLoadContext`, instances of those types, and the assemblies themselves are referenced by:
-  - References outside of the `AssemblyLoadContext`, except of weak references (<xref:System.WeakReference> or <xref:System.WeakReference%601>).
+  - References outside of the `AssemblyLoadContext`, except for weak references (<xref:System.WeakReference> or <xref:System.WeakReference%601>).
   - Strong garbage collector (GC) handles ([GCHandleType.Normal](xref:System.Runtime.InteropServices.GCHandleType.Normal) or [GCHandleType.Pinned](xref:System.Runtime.InteropServices.GCHandleType.Pinned)) from both inside and outside of the `AssemblyLoadContext`.
 
 ## Use collectible AssemblyLoadContext
@@ -25,7 +25,7 @@ This section contains a detailed step-by-step tutorial that shows a simple way t
 
 ### Create a collectible AssemblyLoadContext
 
-You need to derive your class from the <xref:System.Runtime.Loader.AssemblyLoadContext> and override its <xref:System.Runtime.Loader.AssemblyLoadContext.Load%2A?displayProperty=nameWithType> method. That method resolves references to all assemblies that are dependencies of assemblies loaded into that `AssemblyLoadContext`.
+Derive your class from the <xref:System.Runtime.Loader.AssemblyLoadContext> and override its <xref:System.Runtime.Loader.AssemblyLoadContext.Load%2A?displayProperty=nameWithType> method. That method resolves references to all assemblies that are dependencies of assemblies loaded into that `AssemblyLoadContext`.
 
 The following code is an example of the simplest custom `AssemblyLoadContext`:
 
@@ -242,7 +242,7 @@ The following code is used in the previous debugging example.
 
 [!code-csharp[Main testing program](~/samples/snippets/standard/assembly/unloading/unloadability_issues_example_main.cs)]
 
-## Program loaded into the TestAssemblyLoadContext
+### Program loaded into the TestAssemblyLoadContext
 
 The following code represents the *test.dll* passed to the `ExecuteAndUnload` method in the main testing program.
 


### PR DESCRIPTION
- Removed "in .NET" from TOC entries as it seemed redundant
- Acrolinx and other touch-ups in 2 articles