### PR TITLE
Improve reflection fallback breaking change doc.

### DIFF
--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -110,7 +110,6 @@ Starting in .NET 7 RC 2, you can re-enable reflection fallback globally using th
 </ItemGroup>
 ```
 
-Should re-enable reflection fallback for all source generated contexts in your app. See the article on [.NET runtime configuration settings](../../../runtime-config/index.md) for more details on using AppContext switches.
 ## Affected APIs
 
 - <xref:System.Text.Json.JsonSerializerOptions.GetConverter(System.Type)?displayProperty=fullName>

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -82,7 +82,7 @@ You might depend on the previous behavior, either intentionally or unintentional
 public partial class MyContext : JsonSerializerContext {}
 ```
 
-This will let your application take full advantage of the benefits of source generation, including trim safety. 
+This will let your application take full advantage of the benefits of source generation, including trim safety.
 
 In certain cases however, making such a change might not be practical or possible. Even though it is not recommended, there a couple of ways you can re-enable reflection fallback in your source generated serializer.
 

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -111,7 +111,6 @@ Starting in .NET 7 RC 2, you can re-enable reflection fallback globally using th
 ```
 
 Should re-enable reflection fallback for all source generated contexts in your app. See the article on [.NET runtime configuration settings](../../../runtime-config/index.md) for more details on using AppContext switches.
-
 ## Affected APIs
 
 - <xref:System.Text.Json.JsonSerializerOptions.GetConverter(System.Type)?displayProperty=fullName>

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -102,7 +102,7 @@ options.GetConverter(typeof(Poco2)); // Returns the reflection-based converter.
 
 ### Using the AppContext switch
 
-You can re-enable reflection fallback globally using the provided AppContext compatibility switch. Adding the following entry to your application's project file:
+Starting in .NET 7 RC 2, you can re-enable reflection fallback globally using the provided AppContext compatibility switch. Add the following entry to your application's project file to re-enable reflection fallback for all source-generated contexts in your app. For more information on using AppContext switches, see the article on [.NET runtime configuration settings](../../../runtime-config/index.md).
 
 ```xml
 <ItemGroup>

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -100,7 +100,7 @@ JsonSerializer.Serialize(new Poco2(), options); // Contract resolution falls bac
 options.GetConverter(typeof(Poco2)); // Returns the reflection-based converter.
 ```
 
-### Using the AppContext switch
+### Use an AppContext switch
 
 Starting in .NET 7 RC 2, you can re-enable reflection fallback globally using the provided AppContext compatibility switch. Add the following entry to your application's project file to re-enable reflection fallback for all source-generated contexts in your app. For more information on using AppContext switches, see the article on [.NET runtime configuration settings](../../../runtime-config/index.md).
 

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -86,7 +86,7 @@ This will let your application take full advantage of the benefits of source gen
 
 In certain cases, however, making such a change might not be practical or possible. Even though it's not recommended, there are a couple of ways you can re-enable reflection fallback in your source-generated serializer.
 
-### Using a custom contract resolver
+### Use a custom contract resolver
 
 You can use the new contract customization feature to build a custom contract resolver that falls back to reflection-based resolution where required:
 

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -74,7 +74,21 @@ The previous behavior violates the principle of least surprise and ultimately de
 
 ## Recommended action
 
-You might depend on the previous behavior, either intentionally or unintentionally. As such, you can use the following workaround to continue to fall back to reflection-based serialization when necessary:
+You might depend on the previous behavior, either intentionally or unintentionally. The recommended course of action is to update your <xref:System.Text.Json.Serialization.JsonSerializerContext> definition so that it includes all type dependencies:
+
+```csharp
+[JsonSerializable(typeof(Poco1))]
+[JsonSerializable(typeof(Poco2))]
+public partial class MyContext : JsonSerializerContext {}
+```
+
+This will let your application take full advantage of the benefits of source generation, including trim safety. 
+
+In certain cases however, making such a change might not be practical or possible. Even though it is not recommended, there a couple of ways you can re-enable reflection fallback in your source generated serializer.
+
+### Using a custom contract resolver
+
+You can use the new contract customization feature to build a custom contract resolver that falls back to reflection-based resolution where required:
 
 ```csharp
 var options = new JsonSerializerOptions
@@ -85,6 +99,18 @@ var options = new JsonSerializerOptions
 JsonSerializer.Serialize(new Poco2(), options); // Contract resolution falls back to the default reflection-based resolver.
 options.GetConverter(typeof(Poco2)); // Returns the reflection-based converter.
 ```
+
+### Using the AppContext switch
+
+You can re-enable reflection fallback globally using the provided AppContext compatibility switch. Adding the following entry to your application's project file:
+
+```xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.EnableSourceGenReflectionFallback" Value="true" />
+</ItemGroup>
+```
+
+Should re-enable reflection fallback for all source generated contexts in your app. See the article on [.NET runtime configuration settings](../../../runtime-config/index.md) for more details on using AppContext switches.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/serialization/7.0/reflection-fallback.md
+++ b/docs/core/compatibility/serialization/7.0/reflection-fallback.md
@@ -84,7 +84,7 @@ public partial class MyContext : JsonSerializerContext {}
 
 This will let your application take full advantage of the benefits of source generation, including trim safety.
 
-In certain cases however, making such a change might not be practical or possible. Even though it is not recommended, there a couple of ways you can re-enable reflection fallback in your source generated serializer.
+In certain cases, however, making such a change might not be practical or possible. Even though it's not recommended, there are a couple of ways you can re-enable reflection fallback in your source-generated serializer.
 
 ### Using a custom contract resolver
 


### PR DESCRIPTION
Improves the recommended actions section of the JSON source gen reflection fallback breaking change doc, and documents the newly added appcontext switch in https://github.com/dotnet/runtime/pull/75615