### PR TITLE
Add preview SDK table

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -79,7 +79,7 @@ To ensure consistent tooling, you should use `dotnet build` rather than `msbuild
 
 Major versions of the .NET SDK are typically released within a few days of a Visual Studio preview version. While there may be other combinations that work, only the latest preview released is tested and officially supported. The following table shows which version of Visual Studio each .NET 7 preview version was tested with prior to release.
 
-| SDK preview | Visual Studio Release |
+| SDK preview version | Visual Studio version |
 |-|-|
 | Preview 1 | 17.2-preview1 |
 | Preview 2 | 17.2-preview2 |

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -75,6 +75,22 @@ Starting with .NET SDK 7.0.100 and .NET SDK 6.0.300, a policy has been put into 
 
 To ensure consistent tooling, you should use `dotnet build` rather than `msbuild` to build your application when possible.
 
+## Preview Versioning
+For .NET SDK major versions, we typically release within a few days of a Visual Studio preview version. While there may be other combinations that work, only the latest preview released is tested and officially supported. Below is the alignment of .NET 7 previews and which versions of Visual Studio they were tested with prior to release.
+
+| SDK preview | Visual Studio Release |
+|-|-|
+| Preview 1 | 17.2-preview1 |
+| Preview 2 | 17.2-preview2 |
+| Preview 3 | 17.2-preview3 |
+| Preview 4 | 17.3-preview1 |
+| Preview 5 | 17.3-preview2 |
+| Preview 6 | 17.3-preview3 |
+| Preview 7 | 17.4-preview1 |
+| RC 1 | 17.4-preview2 |
+| RC 2 | 17.4-preview3 |
+| 7.0.100 | 17.4.0 |
+
 ## Reference
 
 - [Overview of how .NET is versioned](../versions/index.md)

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -81,7 +81,7 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 
 | SDK preview version | Visual Studio version |
 |-|-|
-| Preview 1 | 17.2-preview1 |
+| Preview 1 | 17.2 Preview 1 |
 | Preview 2 | 17.2-preview2 |
 | Preview 3 | 17.2-preview3 |
 | Preview 4 | 17.3-preview1 |

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -75,7 +75,8 @@ Starting with .NET SDK 7.0.100 and .NET SDK 6.0.300, a policy has been put into 
 
 To ensure consistent tooling, you should use `dotnet build` rather than `msbuild` to build your application when possible.
 
-## Preview Versioning
+## Preview versioning
+
 For .NET SDK major versions, we typically release within a few days of a Visual Studio preview version. While there may be other combinations that work, only the latest preview released is tested and officially supported. Below is the alignment of .NET 7 previews and which versions of Visual Studio they were tested with prior to release.
 
 | SDK preview | Visual Studio Release |

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -77,7 +77,7 @@ To ensure consistent tooling, you should use `dotnet build` rather than `msbuild
 
 ## Preview versioning
 
-For .NET SDK major versions, we typically release within a few days of a Visual Studio preview version. While there may be other combinations that work, only the latest preview released is tested and officially supported. Below is the alignment of .NET 7 previews and which versions of Visual Studio they were tested with prior to release.
+Major versions of the .NET SDK are typically released within a few days of a Visual Studio preview version. While there may be other combinations that work, only the latest preview released is tested and officially supported. The following table shows which version of Visual Studio each .NET 7 preview version was tested with prior to release.
 
 | SDK preview | Visual Studio Release |
 |-|-|

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -82,14 +82,14 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 | SDK preview version | Visual Studio version |
 |-|-|
 | Preview 1 | 17.2 Preview 1 |
-| Preview 2 | 17.2-preview2 |
-| Preview 3 | 17.2-preview3 |
-| Preview 4 | 17.3-preview1 |
-| Preview 5 | 17.3-preview2 |
-| Preview 6 | 17.3-preview3 |
-| Preview 7 | 17.4-preview1 |
-| RC 1 | 17.4-preview2 |
-| RC 2 | 17.4-preview3 |
+| Preview 2 | 17.2 Preview 2 |
+| Preview 3 | 17.2 Preview 3 |
+| Preview 4 | 17.3 Preview 1 |
+| Preview 5 | 17.3 Preview 2 |
+| Preview 6 | 17.3 Preview 3 |
+| Preview 7 | 17.4 Preview 1 |
+| RC 1 | 17.4 Preview 2 |
+| RC 2 | 17.4 Preview 3 |
 | 7.0.100 | 17.4.0 |
 
 ## Reference


### PR DESCRIPTION
## Summary

We've gotten lots of questions for customers who want to know which Visual Studio version is supported for a particular .NET preview. We only test with a single preview Visual Studio so adding that as a table in this document.
