### PR TITLE
Fix formatting on keywords list

### DIFF
--- a/docs/csharp/language-reference/keywords/index.md
+++ b/docs/csharp/language-reference/keywords/index.md
@@ -45,7 +45,7 @@ The first table in this article lists keywords that are reserved identifiers in 
         [`explicit`](../operators/user-defined-conversion-operators.md)  
         [`extern`](extern.md)  
         [`false`](../builtin-types/bool.md)  
-        [`file`](file.md)
+        [`file`](file.md)  
         [`finally`](try-finally.md)  
         [`fixed`](../statements/fixed.md)  
         [`float`](../builtin-types/floating-point-numeric-types.md)  


### PR DESCRIPTION
## Summary

fixes space in between "file" and "finally"
