### PR TITLE
simplify example of lambda function

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0039.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0039.md
@@ -50,8 +50,7 @@ int fibonacci(int n)
 }
 
 // csharp_style_prefer_local_over_anonymous_function = false
-Func<int, int> fibonacci = null;
-fibonacci = (int n) =>
+Func<int, int> fibonacci = (int n) =>
 {
     return n <= 1 ? 1 : fibonacci(n - 1) + fibonacci(n - 2);
 };


### PR DESCRIPTION
## Summary

Very minor code clarity improvement, but not sure why it's important to assign to null first and then re-assign the actual value of the lambda.  Type is already spelled out for clarity, so it's not being used to clarify type.  Main reason to update is to make easier the visual comparison between a local function and lambda function with adding extra steps to one, but not the other.
