### PR TITLE
Fix var keyword redirection link

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -737,7 +737,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/language-reference/keywords/var.md",
-            "redirect_url": "/dotnet/csharp/language-reference/statements/declarations#var"
+            "redirect_url": "/dotnet/csharp/language-reference/statements/declarations#implicitly-typed-local-variables"
         },
         {
             "source_path_from_root": "/docs/csharp/language-reference/keywords/void.md",


### PR DESCRIPTION
There is no "var" section, it's called differently:
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/declarations#implicitly-typed-local-variables
