### PR TITLE
Fix bad code in C# Programming Guide | Methods | Return values

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/methods.md
@@ -85,7 +85,7 @@ Using a local variable, in this case, `result`, to store a value is optional. It
 To use a value returned by reference from a method, you must declare a [ref local](../../language-reference/statements/declarations.md#ref-locals) variable if you intend to modify its value. For example, if the `Planet.GetEstimatedDistance` method returns a <xref:System.Double> value by reference, you can define it as a ref local variable with code like the following:
 
 ```csharp
-ref int distance = Planet.GetEstimatedDistance();
+ref double distance = ref Planet.GetEstimatedDistance();
 ```
 
 Returning a multi-dimensional array from a method, `M`, that modifies the array's contents is not necessary if the calling function passed the array into `M`.  You may return the resulting array from `M` for good style or functional flow of values, but it is not necessary because C# passes all reference types by value, and the value of an array reference is the pointer to the array. In the method `M`, any changes to the array's contents are observable by any code that has a reference to the array, as shown in the following example:


### PR DESCRIPTION
## Summary

1. The `ref` keyword on the right hand side was missing
2. The value should be a `double` instead of an `int` so as to be consistent with the wording above, which says:

    > ... the `Planet.GetEstimatedDistance` method returns a Double value by reference ...
