### PR TITLE
fixed "scaped" => "scoped" typo

### DIFF
--- a/docs/csharp/language-reference/statements/declarations.md
+++ b/docs/csharp/language-reference/statements/declarations.md
@@ -119,7 +119,7 @@ The `readonly ref` and `readonly ref readonly` declarations are valid only on `r
 
 The contextual keyword `scoped` restricts the lifetime of a value. The `scoped` modifier restricts the [*ref-safe-to-escape* or *safe-to-escape* lifetime](../keywords/method-parameters.md#scope-of-references-and-values), respectively, to the current method. Effectively, adding the `scoped` modifier asserts that your code won't extend the lifetime of the variable.
 
-You can apply `scaped` to a parameter or local variable. The `scoped` modifier may be applied to parameters and locals when the type is a [`ref struct`](../builtin-types/ref-struct.md). Otherwise, the `scoped` modifier may be applied only to local variables that are [ref types](#ref-locals). That includes local variables declared with the `ref` modifier and parameters declared with the `in`, `ref` or `out` modifiers.
+You can apply `scoped` to a parameter or local variable. The `scoped` modifier may be applied to parameters and locals when the type is a [`ref struct`](../builtin-types/ref-struct.md). Otherwise, the `scoped` modifier may be applied only to local variables that are [ref types](#ref-locals). That includes local variables declared with the `ref` modifier and parameters declared with the `in`, `ref` or `out` modifiers.
 
 The `scoped` modifier is implicitly added to `this` in methods declared in a `struct`, `out` parameters, and `ref` parameters when the type is a `ref struct`.
 


### PR DESCRIPTION
## Summary

There is no keyword "scaped".