### PR TITLE
typo: Correct typo in Service section

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf-directive/servicehost.md
+++ b/docs/framework/configure-apps/file-schema/wcf-directive/servicehost.md
@@ -24,7 +24,7 @@ CodeBehind = "CodeBehind"
 
 ### Service
 
-The CLR type name of the service hosted. This should be a qualified name of a type that implements one or more of the service contacts.
+The CLR type name of the service hosted. This should be a qualified name of a type that implements one or more of the service contracts.
 
 ### Factory
 


### PR DESCRIPTION
## Summary

Minor typo in *Service* section:  ...should be "service cont***r***acts" and not "service contacts"