### PR TITLE
Remove redirect hops

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2,7 +2,7 @@
     "redirections": [
     {
         "source_path_from_root": "/docs/about/index.md",
-        "redirect_url": "/dotnet/standard/index"
+        "redirect_url": "/dotnet/fundamentals/"
     },
     {
         "source_path_from_root": "/docs/about/products.md",
@@ -66,7 +66,7 @@
     },
     {
         "source_path_from_root": "/docs/standard/about.md",
-        "redirect_url": "/dotnet/standard/index"
+        "redirect_url": "/dotnet/fundamentals/"
     },
     {
         "source_path_from_root": "/docs/tutorials/getting-started-with-csharp/microservices.md",

--- a/.openpublishing.redirection.standard.json
+++ b/.openpublishing.redirection.standard.json
@@ -11,7 +11,7 @@
         },
         {
             "source_path_from_root": "/docs/standard/application-essentials.md",
-            "redirect_url": "/dotnet/standard/index"
+            "redirect_url": "/dotnet/fundamentals/"
         },
         {
             "source_path_from_root": "/docs/standard/assembly-format.md",


### PR DESCRIPTION
/dotnet/standard/index redirects to /dotnet/fundamentals, so remove these hops.