### PR TITLE
Add note to cs0103

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0103.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0103.md
@@ -16,7 +16,8 @@ The name 'identifier' does not exist in the current context
 
  This error frequently occurs if you declare a variable in a loop or a `try` or `if` block and then attempt to access it from an enclosing code block or a separate code block, as shown in the following example:
 
-**Note:** This error may also be presented when missing the `greater than` symbol in the operator `=>` in an expression lambda.  For more information, see [expression lambdas](/csharp/language-reference/operators/lambda-expressions.md).
+> [!NOTE]
+> This error may also be presented when missing the `greater than` symbol in the operator `=>` in an expression lambda.  For more information, see [expression lambdas](/csharp/language-reference/operators/lambda-expressions.md).
 
 ```csharp
 using System;

--- a/docs/csharp/language-reference/compiler-messages/cs0103.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0103.md
@@ -16,6 +16,8 @@ The name 'identifier' does not exist in the current context
 
  This error frequently occurs if you declare a variable in a loop or a `try` or `if` block and then attempt to access it from an enclosing code block or a separate code block, as shown in the following example:
 
+**Note:** This error may also be presented when missing the `greater than` symbol in the operator `=>` in an expression lambda.  For more information, see [expression lambdas](/csharp/language-reference/operators/lambda-expressions.md).
+
 ```csharp
 using System;
 


### PR DESCRIPTION
Add note calling out that this error may be presented in an expression lambda.  Added a link to expression lambdas.

## Summary

Added note for error when missing operator in lambda.

Fixes #30468 
