### PR TITLE
Fix typos in docs/core/extensions and docs/core/testing

### DIFF
--- a/docs/core/extensions/channels.md
+++ b/docs/core/extensions/channels.md
@@ -140,7 +140,7 @@ An alternative producer might use the `WriteAsync` method:
 
 :::code language="csharp" source="snippets/channels/Program.Producer.cs" id="whilewrite":::
 
-Again, the `Channel<Coordinates>.Writer` is used within a `while` loop. But this time, the <xref:System.Threading.Channels.ChannelWriter%601.WriteAsync%2A> method is called. The method will continue only after the coordinates have been written. When the `while` loop exits, a call to <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A>is made, which signals that no more data will be written to the channel.
+Again, the `Channel<Coordinates>.Writer` is used within a `while` loop. But this time, the <xref:System.Threading.Channels.ChannelWriter%601.WriteAsync%2A> method is called. The method will continue only after the coordinates have been written. When the `while` loop exits, a call to <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A> is made, which signals that no more data will be written to the channel.
 
 Another producer pattern is to use the <xref:System.Threading.Channels.ChannelWriter%601.WaitToWriteAsync%2A> method, consider the following code:
 

--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -80,7 +80,7 @@ Update *Program.cs* with the following code:
 
 :::code language="csharp" source="snippets/configuration/console-di/Program.cs" id="Program" highlight="6-10":::
 
-Each `services.Add{LIFETIME}<{SERVICE}>` extension method adds (and potentially configures) services. We recommended that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
+Each `services.Add{LIFETIME}<{SERVICE}>` extension method adds (and potentially configures) services. We recommend that apps follow this convention. Place extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace to encapsulate groups of service registrations. Including the namespace portion `Microsoft.Extensions.DependencyInjection` for DI extension methods also:
 
 - Allows them to be displayed in [IntelliSense](/visualstudio/ide/using-intellisense) without adding additional `using` blocks.
 - Prevents excessive `using` statements in the `Program` or `Startup` classes where these extension methods are typically called.

--- a/docs/core/extensions/high-performance-logging.md
+++ b/docs/core/extensions/high-performance-logging.md
@@ -43,7 +43,7 @@ As work items are dequeued for processing the worker service app sets the:
 
 :::code language="csharp" source="snippets/logging/worker-service-options/Extensions/LoggerExtensions.cs" id="FailedProcessingAssignment":::
 
-The <xref:Microsoft.Extensions.Logging.LoggerMessage.Define%2A?displayProperty=nameWithType> method is used to configure and define a <xref:System.Action> delegate, that represents a log message.
+The <xref:Microsoft.Extensions.Logging.LoggerMessage.Define%2A?displayProperty=nameWithType> method is used to configure and define an <xref:System.Action> delegate, that represents a log message.
 
 Structured logging stores may use the event name when it's supplied with the event id to enrich logging. For example, [Serilog](https://github.com/serilog/serilog-extensions-logging) uses the event name.
 

--- a/docs/core/extensions/httpclient-http3.md
+++ b/docs/core/extensions/httpclient-http3.md
@@ -22,7 +22,7 @@ HTTP/3 and QUIC have a number of benefits compared to HTTP/1.1 and HTTP/2:
 >
 > For more information on preview features, see [**the preview features specification**](https://github.com/dotnet/designs/blob/main/accepted/2021/preview-features/preview-features.md#are-preview-features-supported).
 >
-> Apps configured to take advantage of HTTP/3 should be designed to also support HTTP/1.1 and HTTP/2. If issues are identified in HTTP/3, we recommended disabling HTTP/3 until the issues are resolved in a future release of .NET.
+> Apps configured to take advantage of HTTP/3 should be designed to also support HTTP/1.1 and HTTP/2. If issues are identified in HTTP/3, we recommend disabling HTTP/3 until the issues are resolved in a future release of .NET.
 
 ## HttpClient settings
 
@@ -45,7 +45,7 @@ The reason for requiring a configuration flag for HTTP/3 is to protect apps from
 
 ## Platform dependencies
 
-HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 uses [MsQuic](https://github.com/microsoft/msquic) to provide QUIC functionality. MsQuic is included in specific builds of windows and as a library for Linux. If the platform that HttpClient is running on doesn't have all the requirements for HTTP/3 then it's disabled.
+HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 uses [MsQuic](https://github.com/microsoft/msquic) to provide QUIC functionality. MsQuic is included in specific builds of Windows and as a library for Linux. If the platform that HttpClient is running on doesn't have all the requirements for HTTP/3 then it's disabled.
 
 ### Windows
 

--- a/docs/core/extensions/primitives.md
+++ b/docs/core/extensions/primitives.md
@@ -115,7 +115,7 @@ The <xref:Microsoft.Extensions.Primitives.StringValues> object is a `struct` typ
 
 :::code source="./snippets/primitives/string/Example.StringValues.cs" id="StringValues":::
 
-The preceding code instantiates a `StringValues` object given an array of string values. The <xref:Microsoft.Extensions.Primitives.StringValues.Count?displayProperty=nameWithType> is written the console.
+The preceding code instantiates a `StringValues` object given an array of string values. The <xref:Microsoft.Extensions.Primitives.StringValues.Count?displayProperty=nameWithType> is written to the console.
 
 The `StringValues` type is an implementation of the following collection types:
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -24,7 +24,7 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 With MSTest, tests are automatically ordered by their test name.
 
 > [!NOTE]
-> A test named `Test14` will run before `Test2` even though the number  `2` is less than `14`. This is because, test name ordering uses the text name of the test.
+> A test named `Test14` will run before `Test2` even though the number  `2` is less than `14`. This is because test name ordering uses the text name of the test.
 
 :::code language="csharp" source="snippets/order-unit-tests/csharp/MSTest.Project/ByAlphabeticalOrder.cs":::
 

--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -88,7 +88,7 @@ purchase.ValidateOrders();
 Assert.True(purchase.CanBeShipped);
 ```
 
-By renaming the class to `FakeOrder`, you've made the class a lot more generic, the class can be used as a mock or a stub. Whichever is better for the test case. In the above example, `FakeOrder` is used as a stub. You're not using the `FakeOrder` in any shape or form during the assert. `FakeOrder` was passed into the `Purchase` class to satisfy the requirements of the constructor.
+By renaming the class to `FakeOrder`, you've made the class a lot more generic. The class can be used as a mock or a stub, whichever is better for the test case. In the above example, `FakeOrder` is used as a stub. You're not using the `FakeOrder` in any shape or form during the assert. `FakeOrder` was passed into the `Purchase` class to satisfy the requirements of the constructor.
 
 To use it as a Mock, you could do something like this
 

--- a/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-dotnet-test.md
@@ -100,7 +100,7 @@ The following instructions provide the steps to create the test solution. See [C
 
 This section summarizes all the commands in the previous section. Skip this section if you've completed the steps in the previous section.
 
-The following commands create the test solution on a windows machine. For macOS and Unix, update the `ren` command to the OS version of `ren` to rename a file:
+The following commands create the test solution on a Windows machine. For macOS and Unix, update the `ren` command to the OS version of `ren` to rename a file:
 
 ```dotnetcli
 dotnet new sln -o unit-testing-using-dotnet-test

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -104,7 +104,7 @@ The following instructions provide the steps to create the test solution. See [C
 
 This section summarizes all the commands in the previous section. Skip this section if you've completed the steps in the previous section.
 
-The following commands create the test solution on a windows machine. For macOS and Unix, update the `ren` command to the OS version of `ren` to rename a file:
+The following commands create the test solution on a Windows machine. For macOS and Unix, update the `ren` command to the OS version of `ren` to rename a file:
 
 ```dotnetcli
 dotnet new sln -o unit-testing-using-dotnet-test


### PR DESCRIPTION
## Summary

Fix grammar, punctuation, wording, capitalization