### PR TITLE
Explain that the parameter of a Set is optional and defaults to `value` if not given.

### DIFF
--- a/docs/visual-basic/language-reference/statements/set-statement.md
+++ b/docs/visual-basic/language-reference/statements/set-statement.md
@@ -19,7 +19,7 @@ Declares a `Set` property procedure used to assign a value to a property.
 ## Syntax  
   
 ```vb  
-[ <attributelist> ] [ accessmodifier ] Set (ByVal value [ As datatype ])  
+[ <attributelist> ] [ accessmodifier ] Set [([ByVal value [ As datatype ]])]  
     [ statements ]  
 End Set  
 ```  
@@ -43,10 +43,10 @@ End Set
  See [Access levels in Visual Basic](../../programming-guide/language-features/declared-elements/access-levels.md).  
   
  `value`  
- Required. Parameter containing the new value for the property.  
+ Optional. Parameter containing the new value for the property. If not given (that is if parameter list is not present or is empty), an implicit parameter named `value` is defined. The data type of this implicit parameter is the data type of the property where this `Set` statement is declared.  
   
  `datatype`  
- Required if `Option Strict` is `On`. Data type of the `value` parameter. The data type specified must be the same as the data type of the property where this `Set` statement is declared.  
+ Required if `value` is present and `Option Strict` is `On`. Cannot be present if `value` is not given. Data type of the `value` parameter. The data type specified must be the same as the data type of the property where this `Set` statement is declared.  
   
  `statements`  
  Optional. One or more statements that run when the `Set` property procedure is called.  

--- a/docs/visual-basic/programming-guide/language-features/procedures/how-to-create-a-property.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/how-to-create-a-property.md
@@ -39,7 +39,7 @@ You enclose a property definition between a `Property` statement and an `End Pro
   
 1. Between the `Property` and `End Property` statements, write a [Set Statement](../../../language-reference/statements/set-statement.md), followed by an `End Set` statement.  
   
-2. In the `Set` statement, follow the `Set` keyword with a parameter list in parentheses. This parameter list must include at least a value parameter for the value passed by the calling code. The default name for this value parameter is `Value`, but you can use a different name if appropriate. The value parameter must have the same data type as the property itself.  
+2. In the `Set` statement, optionally follow the `Set` keyword with a parameter list in parentheses. If the parameter list is not present or is empty, an implicit parameter named `Value` is defined, whose type is the type of the property itself. If the parameter list is not empty, you can use a different name if appropriate, but the parameter must have the same data type as the property itself.  
   
 3. Place the code statements to store a value in the property between the `Set` and `End Set` statements. This code can include other calculations and data manipulations in addition to validating and storing the property's value.  
   


### PR DESCRIPTION
## Summary

Explain that the parameter of a Set is optional and defaults to `value` if not given, rather than saying it's required.

Fixes #31429
