### PR TITLE
Publish C# 11 speclets

### DIFF
--- a/.openpublishing.redirection.core.json
+++ b/.openpublishing.redirection.core.json
@@ -1105,7 +1105,7 @@
         },
         {
             "source_path_from_root": "/docs/core/whats-new/index.md",
-            "redirect_url": "/dotnet/core/whats-new/dotnet-core-3-1",
+            "redirect_url": "/dotnet/core/whats-new/dotnet-6",
             "ms.custom": "updateeachrelease"
         },
         {

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -2835,7 +2835,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new/index.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-10",
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-11",
             "ms.custom": "updateeachrelease"
         },
         {

--- a/docfx.json
+++ b/docfx.json
@@ -30,7 +30,8 @@
                     "csharp-7.3/*.md",
                     "csharp-8.0/*.md",
                     "csharp-9.0/*.md",
-                    "csharp-10.0/*.md"
+                    "csharp-10.0/*.md",
+                    "csharp-11.0/*.md"
                 ],
                 "src": "_csharplang/proposals",
                 "dest": "csharp/language-reference/proposals",
@@ -450,7 +451,8 @@
                 "_csharplang/proposals/csharp-8.0/*.md": "09/10/2019",
                 "_csharplang/proposals/csharp-9.0/*.md": "07/29/2020",
                 "_csharplang/proposals/csharp-10.0/*.md": "08/07/2021",
-                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "03/21/2022",
+                "_csharplang/proposals/csharp-11.0/*.md": "09/30/2022",
+                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "09/30/2022",
                 "_vblang/spec/*.md": "07/21/2017"
             },
             "ms.technology": {
@@ -665,6 +667,21 @@
                 "_csharplang/proposals/csharp-10.0/improved-definite-assignment.md": "Improved definite assignment analysis",
                 "_csharplang/proposals/csharp-10.0/async-method-builders.md": "AsyncMethodBuilder override",
 
+                "_csharplang/proposals/csharp-11.0/auto-default-structs.md": "Auto-default struct",
+                "_csharplang/proposals/csharp-11.0/checked-user-defined-operators.md": "Checked user defined operators",
+                "_csharplang/proposals/csharp-11.0/extended-nameof-scope.md": "Extended nameof parameter scope",
+                "_csharplang/proposals/csharp-11.0/file-local-types.md": "File local types",
+                "_csharplang/proposals/csharp-11.0/list-patterns.md": "List patterns",
+                "_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md": "Interpolated string expression newline",
+                "_csharplang/proposals/csharp-11.0/numeric-intptr.md": "Numeric IntPtr",
+                "_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md": "Pattern match Span<char>",
+                "_csharplang/proposals/csharp-11.0/raw-string-literal.md": "Raw string literal",
+                "_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md": "Relaxed right shift requirement",
+                "_csharplang/proposals/csharp-11.0/required-members.md": "Required members",
+                "_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md": "Static abstract methods in interfaces",
+                "_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md": "Unsigned right shift operator",
+                "_csharplang/proposals/csharp-11.0/utf8-string-literals.md": "UTF-8 string literals",
+
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "C# compiler breaking changes since C# 10",
 
                 "_vblang/spec/introduction.md": "Introduction",
@@ -789,6 +806,21 @@
                 "_csharplang/proposals/csharp-10.0/improved-definite-assignment.md": "This feature specification describes updates to the rules for definite assignment analysis. The result is more accurate warnings for when a variable may not be definitely assigned, or may not be null.",
                 "_csharplang/proposals/csharp-10.0/async-method-builders.md": "This feature specification describes new rules to enable types to override the default AsyncMethodBuilder. This will be used by the runtime for performance improvements.",
 
+                "_csharplang/proposals/csharp-11.0/auto-default-structs.md": "This feature updates the rules for struct initialization and default values. This feature standardizes the behavior for default struct values and newly initialized structs.",
+                "_csharplang/proposals/csharp-11.0/checked-user-defined-operators.md": "This feature enables checked and unchecked alternatives for some operators.",
+                "_csharplang/proposals/csharp-11.0/extended-nameof-scope.md": "This feature enables the nameof expression to be used with parameter names in a method declaration.",
+                "_csharplang/proposals/csharp-11.0/file-local-types.md": "This feature allows you to create types (either structs or classes) that are visibile only in the file in which they are declared. This is primarily useful for source generators.",
+                "_csharplang/proposals/csharp-11.0/list-patterns.md": "This feature describes enhancements to pattern matching to support patterns in lists of elements.",
+                "_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md": "This feature describes changes to allow newlines in the interpolation expressions in an interpolated string expression.",
+                "_csharplang/proposals/csharp-11.0/numeric-intptr.md": "This feature enables the IntPtr and UIntPtr to be treated as the numeric types nint and nuint, respectively.",
+                "_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md": "This feature enables a Span<char> to pattern match a literal string value.",
+                "_csharplang/proposals/csharp-11.0/raw-string-literal.md": "This feature describes raw string literals. Raw string literals enable string literals to avoid almost all escape sequences.",
+                "_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md": "This feature removes the restriction that the right operand of a right shift must be an integer.",
+                "_csharplang/proposals/csharp-11.0/required-members.md": "This feature defines the required modifier. The required modifier instructs the compiler that a field or property must be initialized during the construction of a new object.",
+                "_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md": "This feature enables an interface to define static members. This enables interfaces to define operators that must be provided by implementing types.",
+                "_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md": "This feature defines a logical right-shift operator, `>>>`. The logical right shift operator always shifts in 0 values in the left-most bits during a shift.",
+                "_csharplang/proposals/csharp-11.0/utf8-string-literals.md": "This feature enables the `u8` suffix on a string literal. The `u8` suffix instructs the compiler to convert the UTF-8 string literal to a `ReadOnlySpan<byte>`.",
+
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "Learn about any breaking changes since the initial release of C# 10",
 
                 "_vblang/spec/introduction.md": "This chapter provides and introduction to the Visual Basic language.",
@@ -814,6 +846,7 @@
                 "_csharplang/proposals/csharp-8.0/*.md": "C# 8.0 draft specifications",
                 "_csharplang/proposals/csharp-9.0/*.md": "C# 9.0 draft specifications",
                 "_csharplang/proposals/csharp-10.0/*.md": "C# 10.0 draft specifications",
+                "_csharplang/proposals/csharp-11.0/*.md": "C# 11.0 draft specifications",
                 "docs/framework/**/**.md": ".NET Framework",
                 "docs/framework/data/adonet/**/**.md": "ADO.NET",
                 "docs/framework/wcf/**/**.md": "WCF",

--- a/docs/core/compatibility/core-libraries/6.0/static-abstract-interface-methods.md
+++ b/docs/core/compatibility/core-libraries/6.0/static-abstract-interface-methods.md
@@ -3,7 +3,7 @@ title: "Breaking change: Static abstract members in interfaces"
 description: Learn about the .NET 6 breaking change where `static` interface members can now be marked `abstract`.
 ms.date: 09/08/2021
 ---
-# Static abstract members in interfaces
+# Static abstract members declared in interfaces
 
 .NET 6 previews a new feature where `static` interface members can be marked as `abstract`. This feature involves several changes to the ECMA 335 spec to allow intermediate language (IL) metadata patterns that were previously considered illegal. For more information, see [dotnet/runtime#49558](https://github.com/dotnet/runtime/issues/49558).
 

--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -54,7 +54,9 @@ At run time, if the <xref:System.Type?displayProperty=nameWithType> instance rep
 For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
 
 - [Default values](~/_csharpstandard/standard/variables.md#93-default-values)
-- [Default constructors](~/_csharpstandard/standard/types.md#833-default-constructors)
+- [Default constructors](~/_csharpstandard/standard/types.md#833-default-constructors)\
+- [C# 10 - Parameterless struct constructors](~_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
+- [C# 11 - Auto default structs](~/_csharplang/proposals/csharp-11.0/auto-default-structs.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -55,7 +55,7 @@ For more information, see the following sections of the [C# language specificati
 
 - [Default values](~/_csharpstandard/standard/variables.md#93-default-values)
 - [Default constructors](~/_csharpstandard/standard/types.md#833-default-constructors)\
-- [C# 10 - Parameterless struct constructors](~_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
+- [C# 10 - Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
 - [C# 11 - Auto default structs](~/_csharplang/proposals/csharp-11.0/auto-default-structs.md)
 
 ## See also

--- a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
@@ -152,7 +152,7 @@ For more information, see the following sections of the [C# language specificati
 
 - [Integral types](~/_csharpstandard/standard/types.md#836-integral-types)
 - [Integer literals](~/_csharpstandard/standard/lexical-structure.md#6453-integer-literals)
-- [C# 9 - Natural sized integral types](_csharplang/proposals/csharp-9.0/native-integers.md)
+- [C# 9 - Natural sized integral types](~/_csharplang/proposals/csharp-9.0/native-integers.md)
 - [C# 11 - Numeric `IntPtr` and `UIntPtr](~/_csharplang/proposals/csharp-11.0/numeric-intptr.md)
 
 ## See also

--- a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
@@ -152,7 +152,7 @@ For more information, see the following sections of the [C# language specificati
 
 - [Integral types](~/_csharpstandard/standard/types.md#836-integral-types)
 - [Integer literals](~/_csharpstandard/standard/lexical-structure.md#6453-integer-literals)
-- [C# 9 - Natural sized integral types](~/_csharplang/proposals/csharp-9.0/native-integers.md)
+- [C# 9 - Native sized integral types](~/_csharplang/proposals/csharp-9.0/native-integers.md)
 - [C# 11 - Numeric `IntPtr` and `UIntPtr](~/_csharplang/proposals/csharp-11.0/numeric-intptr.md)
 
 ## See also

--- a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
@@ -152,6 +152,8 @@ For more information, see the following sections of the [C# language specificati
 
 - [Integral types](~/_csharpstandard/standard/types.md#836-integral-types)
 - [Integer literals](~/_csharpstandard/standard/lexical-structure.md#6453-integer-literals)
+- [C# 9 - Natural sized integral types](_csharplang/proposals/csharp-9.0/native-integers.md)
+- [C# 11 - Numeric `IntPtr` and `UIntPtr](~/_csharplang/proposals/csharp-11.0/numeric-intptr.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -272,6 +272,17 @@ The following example uses `dynamic` in several declarations. The `Main` method 
 
 [!code-csharp[csrefKeywordsTypes#25](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsTypes/CS/dynamic2.cs#25)]
 
+### C# language specification
+
+For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
+
+- [§8.2.3 The object type](~/_csharpstandard/standard/types#823-the-object-type)
+- [§8.2.4 The dynamic type](~/_csharpstandard/standard/types#824-the-dynamic-type)
+- [§8.2.5 The string type](~/_csharpstandard/standard/types#825-the-string-type)
+- [§8.2.8 Delegate types](~/_csharpstandard/standard/types#828-delegate-types)
+- [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/raw-string-literal.md)
+- [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/utf8-string-literals.md)
+
 ### See also
 
 - [C# Reference](../index.md)

--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -276,10 +276,10 @@ The following example uses `dynamic` in several declarations. The `Main` method 
 
 For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
 
-- [§8.2.3 The object type](~/_csharpstandard/standard/types#823-the-object-type)
-- [§8.2.4 The dynamic type](~/_csharpstandard/standard/types#824-the-dynamic-type)
-- [§8.2.5 The string type](~/_csharpstandard/standard/types#825-the-string-type)
-- [§8.2.8 Delegate types](~/_csharpstandard/standard/types#828-delegate-types)
+- [§8.2.3 The object type](~/_csharpstandard/standard/types.md#823-the-object-type)
+- [§8.2.4 The dynamic type](~/_csharpstandard/standard/types.md#824-the-dynamic-type)
+- [§8.2.5 The string type](~/_csharpstandard/standard/types.md#825-the-string-type)
+- [§8.2.8 Delegate types](~/_csharpstandard/standard/types.md#828-delegate-types)
 - [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/raw-string-literal.md)
 - [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/utf8-string-literals.md)
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -143,11 +143,12 @@ For more information, see the [Structs](~/_csharpstandard/standard/structs.md) s
 
 For more information about `struct` features, see the following feature proposal notes:
 
-- [Readonly structs](~/_csharplang/proposals/csharp-7.2/readonly-ref.md#readonly-structs)
-- [Readonly instance members](~/_csharplang/proposals/csharp-8.0/readonly-instance-members.md)
-- [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
-- [Allow `with` expression on structs](~/_csharplang/proposals/csharp-10.0/record-structs.md#allow-with-expression-on-structs)
-- [Record structs](~/_csharplang/proposals/csharp-10.0/record-structs.md)
+- [C# 7.2 - Readonly structs](~/_csharplang/proposals/csharp-7.2/readonly-ref.md#readonly-structs)
+- [C# 8 - Readonly instance members](~/_csharplang/proposals/csharp-8.0/readonly-instance-members.md)
+- [C# 10 - Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
+- [C# 10 - Allow `with` expression on structs](~/_csharplang/proposals/csharp-10.0/record-structs.md#allow-with-expression-on-structs)
+- [C# 10 - Record structs](~/_csharplang/proposals/csharp-10.0/record-structs.md)
+- [C# 11 - Auto default structs](~/_csharplang/proposals/csharp-11.0/auto-default-structs.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/file.md
+++ b/docs/csharp/language-reference/keywords/file.md
@@ -37,7 +37,7 @@ In another source file, you can declare types that have the same names as the fi
 
 ## C# language specification  
 
-For more information, see [Declared accessibility](~/_csharpstandard/standard/basic-concepts.md#752-declared-accessibility) in the [C# Language Specification](~/_csharpstandard/standard/README.md), and the [C# 11 - File local types](_csharplang/proposals/csharp-11.0/file-local-types.md) feature specification.
+For more information, see [Declared accessibility](~/_csharpstandard/standard/basic-concepts.md#752-declared-accessibility) in the [C# Language Specification](~/_csharpstandard/standard/README.md), and the [C# 11 - File local types](~/_csharplang/proposals/csharp-11.0/file-local-types.md) feature specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/file.md
+++ b/docs/csharp/language-reference/keywords/file.md
@@ -37,7 +37,7 @@ In another source file, you can declare types that have the same names as the fi
 
 ## C# language specification  
 
-For more information, see [Declared accessibility](~/_csharpstandard/standard/basic-concepts.md#752-declared-accessibility) in the [C# Language Specification](~/_csharpstandard/standard/README.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Declared accessibility](~/_csharpstandard/standard/basic-concepts.md#752-declared-accessibility) in the [C# Language Specification](~/_csharpstandard/standard/README.md), and the [C# 11 - File local types](_csharplang/proposals/csharp-11.0/file-local-types.md) feature specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -74,7 +74,7 @@ The following example demonstrates interface implementation. In this example, th
 
 ## C# language specification
 
-For more information, see the [Interfaces](~/_csharpstandard/standard/interfaces.md) section of the [C# language specification](~/_csharpstandard/standard/README.md) and the feature specification for [Default interface members - C# 8.0](~/_csharplang/proposals/csharp-8.0/default-interface-methods.md)
+For more information, see the [Interfaces](~/_csharpstandard/standard/interfaces.md) section of the [C# language specification](~/_csharpstandard/standard/README.md), the feature specification for [C# 8 - Default interface members](~/_csharplang/proposals/csharp-8.0/default-interface-methods.md), and the feature spec for [C# 11 - static abstract members in interfaces](~/_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/required.md
+++ b/docs/csharp/language-reference/keywords/required.md
@@ -30,3 +30,5 @@ Some types, such as [positional records](../builtin-types/record.md#positional-s
 The following code shows a class hierarchy that uses the `required` modifier for the `FirstName` and `LastName` properties:
 
 :::code language="csharp" source="./snippets/RequiredExample.cs" id="SnippetRequired":::
+
+For more information on required members, see the [C#11 - Required members](~/_csharplang/proposals/csharp-11.0/required-members.md) feature specification.

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -201,6 +201,8 @@ For more information, see the following sections of the [C# language specificati
 - [Logical operators](~/_csharpstandard/standard/expressions.md#1112-logical-operators)
 - [Compound assignment](~/_csharpstandard/standard/expressions.md#11183-compound-assignment)
 - [Numeric promotions](~/_csharpstandard/standard/expressions.md#1147-numeric-promotions)
+- [C# 11 - Relaxed shift requirements](~/_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md)
+- [C# 11 - Logical right-shift operator](~/_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -34,7 +34,7 @@ A `nameof` expression with a parameter is useful when you use the [nullable anal
 
 ## C# language specification
 
-For more information, see the [Nameof expressions](~/_csharpstandard/standard/expressions.md#11720-nameof-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md).
+For more information, see the [Nameof expressions](~/_csharpstandard/standard/expressions.md#11720-nameof-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), and the [C# 11 - Extended `nameof` scope](_csharplang/proposals/csharp-11.0/extended-nameof-scope.md) feature specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -34,7 +34,7 @@ A `nameof` expression with a parameter is useful when you use the [nullable anal
 
 ## C# language specification
 
-For more information, see the [Nameof expressions](~/_csharpstandard/standard/expressions.md#11720-nameof-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), and the [C# 11 - Extended `nameof` scope](_csharplang/proposals/csharp-11.0/extended-nameof-scope.md) feature specification.
+For more information, see the [Nameof expressions](~/_csharpstandard/standard/expressions.md#11720-nameof-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), and the [C# 11 - Extended `nameof` scope](~/_csharplang/proposals/csharp-11.0/extended-nameof-scope.md) feature specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -310,10 +310,12 @@ The preceding example takes a string array, where each element is one field in t
 
 For more information, see the following feature proposal notes:
 
-- [Pattern matching](~/_csharplang/proposals/csharp-7.0/pattern-matching.md)
-- [Recursive pattern matching](~/_csharplang/proposals/csharp-8.0/patterns.md)
-- [Pattern-matching changes for C# 9.0](~/_csharplang/proposals/csharp-9.0/patterns3.md)
-- [Extended property patterns (C# 10)](~/_csharplang/proposals/csharp-10.0/extended-property-patterns.md)
+- [C# 7 - Pattern matching](~/_csharplang/proposals/csharp-7.0/pattern-matching.md)
+- [C# 8 - Recursive pattern matching](~/_csharplang/proposals/csharp-8.0/patterns.md)
+- [C# 9 - Pattern-matching updates](~/_csharplang/proposals/csharp-9.0/patterns3.md)
+- [C# 10 - Extended property patterns](~/_csharplang/proposals/csharp-10.0/extended-property-patterns.md)
+- [C# 11 - List patterns](~/_csharplang/proposals/csharp-10.0/list-patterns.md)
+- [C# 11 - Pattern match `Span<char>` on string literal](~/_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -314,7 +314,7 @@ For more information, see the following feature proposal notes:
 - [C# 8 - Recursive pattern matching](~/_csharplang/proposals/csharp-8.0/patterns.md)
 - [C# 9 - Pattern-matching updates](~/_csharplang/proposals/csharp-9.0/patterns3.md)
 - [C# 10 - Extended property patterns](~/_csharplang/proposals/csharp-10.0/extended-property-patterns.md)
-- [C# 11 - List patterns](~/_csharplang/proposals/csharp-10.0/list-patterns.md)
+- [C# 11 - List patterns](~/_csharplang/proposals/csharp-11.0/list-patterns.md)
 - [C# 11 - Pattern match `Span<char>` on string literal](~/_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md)
 
 ## See also

--- a/docs/csharp/language-reference/statements/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/statements/checked-and-unchecked.md
@@ -61,6 +61,7 @@ For more information, see the following sections of the [C# language specificati
 
 - [The checked and unchecked statements](~/_csharpstandard/standard/statements.md#1212-the-checked-and-unchecked-statements)
 - [The checked and unchecked operators](~/_csharpstandard/standard/expressions.md#11718-the-checked-and-unchecked-operators)
+- [User defined checked and unchecked operators - C# 11](~/_csharplang/proposals/csharp-11.0/checked-user-defined-operators.md)
 
 ## See also
 

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -109,7 +109,7 @@ Beginning with C# 10, when an interpolated string is used, the compiler checks i
 
 ## C# language specification
 
-For more information, see the [Interpolated strings](~/_csharpstandard/standard/expressions.md#1173-interpolated-string-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), the [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/raw-string-literal.md) feature specification and the [C# 11 - Newlines in string interpolations](~/_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md).
+For more information, see the [Interpolated strings](~/_csharpstandard/standard/expressions.md#1173-interpolated-string-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), the [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/raw-string-literal.md) feature specification and the [C# 11 - Newlines in string interpolations](~/_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md) feature specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -109,7 +109,7 @@ Beginning with C# 10, when an interpolated string is used, the compiler checks i
 
 ## C# language specification
 
-For more information, see the [Interpolated strings](~/_csharpstandard/standard/expressions.md#1173-interpolated-string-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md).
+For more information, see the [Interpolated strings](~/_csharpstandard/standard/expressions.md#1173-interpolated-string-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), the [C# 11 - Raw string literals](~/_csharplang/proposals/csharp-11.0/raw-string-literal.md) feature specification and the [C# 11 - Newlines in string interpolations](~/_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md).
 
 ## See also
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1482,31 +1482,31 @@ items:
         href: ../../_csharplang/proposals/csharp-10.0/async-method-builders.md
     - name: C# 11 features
       items:
-      - name: Auto-default struct
-        href: ../../_csharplang/proposals/csharp-11.0/auto-default-structs.md
+      - name: Static abstracts in interfaces
+        href: ../../_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md
       - name: Checked user-defined operators
         href: ../../_csharplang/proposals/csharp-11.0/checked-user-defined-operators.md
+      - name: Unsigned right-shift operator
+        href: ../../_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md
+      - name: Relaxing shift operator
+        href: ../../_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md
+      - name: Numeric IntPtr
+        href: ../../_csharplang/proposals/csharp-11.0/numeric-intptr.md
+      - name: Raw string literals
+        href: ../../_csharplang/proposals/csharp-11.0/raw-string-literal.md
+      - name: Interpolated string newline
+        href: ../../_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md
+      - name: UTF-8 string literals
+        href: ../../_csharplang/proposals/csharp-11.0/utf8-string-literals.md
+      - name: Pattern match span
+        href: ../../_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
+      - name: List patterns
+        href: ../../_csharplang/proposals/csharp-11.0/list-patterns.md
+      - name: Required members
+        href: ../../_csharplang/proposals/csharp-11.0/required-members.md
+      - name: Auto-default struct
+        href: ../../_csharplang/proposals/csharp-11.0/auto-default-structs.md
       - name: Extended nameof scope
         href: ../../_csharplang/proposals/csharp-11.0/extended-nameof-scope.md
       - name: File local types
         href: ../../_csharplang/proposals/csharp-11.0/file-local-types.md
-      - name: List patterns
-        href: ../../_csharplang/proposals/csharp-11.0/list-patterns.md
-      - name: Interpolated string newline
-        href: ../../_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md
-      - name: Numeric IntPtr
-        href: ../../_csharplang/proposals/csharp-11.0/numeric-intptr.md
-      - name: Pattern match span
-        href: ../../_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
-      - name: Raw string literals
-        href: ../../_csharplang/proposals/csharp-11.0/raw-string-literal.md
-      - name: Relaxing shift operator
-        href: ../../_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md
-      - name: Required members
-        href: ../../_csharplang/proposals/csharp-11.0/required-members.md
-      - name: Static abstracts in interfaces
-        href: ../../_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md
-      - name: Unsigned right-shift operator
-        href: ../../_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md
-      - name: UTF-8 string literals
-        href: ../../_csharplang/proposals/csharp-11.0/utf8-string-literals.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1338,7 +1338,7 @@ items:
       href: ../../_csharpstandard/standard/documentation-comments.md
     - name: Bibliography
       href: ../../_csharpstandard/standard/bibliography.md
-  - name: C# 7.0 - 10.0 features
+  - name: C# 7.0 - 11.0 features
     items:
     - name: C# 7.0 features
       items:
@@ -1480,3 +1480,33 @@ items:
         href: ../../_csharplang/proposals/csharp-10.0/improved-definite-assignment.md
       - name: AsyncMethodBuilder override
         href: ../../_csharplang/proposals/csharp-10.0/async-method-builders.md
+    - name: C# 11 features
+      items:
+      - name: Auto-default struct
+        href: ../../_csharplang/proposals/csharp-11.0/auto-default-structs.md
+      - name: Checked user-defined operators
+        href: ../../_csharplang/proposals/csharp-11.0/checked-user-defined-operators.md
+      - name: Extended nameof scope
+        href: ../../_csharplang/proposals/csharp-11.0/extended-nameof-scope.md
+      - name: File local types
+        href: ../../_csharplang/proposals/csharp-11.0/file-local-types.md
+      - name: List patterns
+        href: ../../_csharplang/proposals/csharp-11.0/list-patterns.md
+      - name: Interpolated string newline
+        href: ../../_csharplang/proposals/csharp-11.0/new-line-in-interpolation.md
+      - name: Numeric IntPtr
+        href: ../../_csharplang/proposals/csharp-11.0/numeric-intptr.md
+      - name: Pattern match span
+        href: ../../_csharplang/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
+      - name: Raw string literals
+        href: ../../_csharplang/proposals/csharp-11.0/raw-string-literal.md
+      - name: Relaxing shift operator
+        href: ../../_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md
+      - name: Required members
+        href: ../../_csharplang/proposals/csharp-11.0/required-members.md
+      - name: Static abstracts in interfaces
+        href: ../../_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md
+      - name: Unsigned right-shift operator
+        href: ../../_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md
+      - name: UTF-8 string literals
+        href: ../../_csharplang/proposals/csharp-11.0/utf8-string-literals.md


### PR DESCRIPTION
Add the C# 11 speclets to the C# TOC and the list of published specifications.

Fixes #31408 
Fixes #31458 

