### PR TITLE
Correct the title on the C# language reference card

### DIFF
--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -155,7 +155,7 @@ landingContent:
             url: language-reference/index.md
           - text: "C# keywords"
             url: language-reference/keywords/index.md
-          - text: "C# operators"
+          - text: "C# operators and expressions"
             url: language-reference/operators/index.md
           - text: Configure language version
             url: language-reference/configure-language-version.md


### PR DESCRIPTION
The link goes to:
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/

that is titled as "C# operators and expressions"
