### PR TITLE
Fix grammar and wording

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1826.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1826.md
@@ -32,7 +32,7 @@ This rule analyzes the following collection types:
 
 - A type that implements <xref:System.Collections.Generic.IReadOnlyList%601>, but not <xref:System.Collections.Generic.IList%601>
 
-This rule flags calls to following methods on these collection types:
+This rule flags calls to the following methods on these collection types:
 
 - <xref:System.Linq.Enumerable.Count%2A?displayProperty=fullName> method
 - <xref:System.Linq.Enumerable.First%2A?displayProperty=fullName> method
@@ -40,7 +40,7 @@ This rule flags calls to following methods on these collection types:
 - <xref:System.Linq.Enumerable.Last%2A?displayProperty=fullName> method
 - <xref:System.Linq.Enumerable.LastOrDefault%2A?displayProperty=fullName> method
 
-The analyzed collection types and/or methods may be extended in future to cover more cases.
+The analyzed collection types and/or methods may be extended in the future to cover more cases.
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -22,7 +22,7 @@ ms.author: mavasani
 
 ## Cause
 
-The <xref:System.Linq.Enumerable.Count%2A> or <xref:System.Linq.Enumerable.LongCount%2A> method was used where <xref:System.Linq.Enumerable.Any%2A> method would be more efficient.
+The <xref:System.Linq.Enumerable.Count%2A> or <xref:System.Linq.Enumerable.LongCount%2A> method was used where the <xref:System.Linq.Enumerable.Any%2A> method would be more efficient.
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1828.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1828.md
@@ -22,7 +22,7 @@ ms.author: mavasani
 
 ## Cause
 
-<xref:Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.CountAsync%2A> or The <xref:Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.LongCountAsync%2A> method was used where the <xref:Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AnyAsync%2A> method would be more efficient.
+The <xref:Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.CountAsync%2A> or <xref:Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.LongCountAsync%2A> method was used where the <xref:Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AnyAsync%2A> method would be more efficient.
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1829.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1829.md
@@ -39,7 +39,7 @@ This rule flags <xref:System.Linq.Enumerable.Count%2A> calls on the following co
 - <xref:System.Collections.Generic.ICollection%601?displayProperty=fullName>
 - <xref:System.Collections.Generic.IReadOnlyCollection%601?displayProperty=fullName>
 
-The analyzed collection types may be extended in future to cover more cases.
+The analyzed collection types may be extended in the future to cover more cases.
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2244.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2244.md
@@ -26,7 +26,7 @@ An object initializer has more than one indexed element initializer with the sam
 
 [Object initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md#object-initializers) let you assign values to any accessible fields or properties of an object at creation time without having to invoke a constructor followed by lines of assignment statements.
 
-Indexed element initializers in objects initializers must initialize unique elements. A duplicate index will overwrite a previous element initialization.
+Indexed element initializers in object initializers must initialize unique elements. A duplicate index will overwrite a previous element initialization.
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2252.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2252.md
@@ -54,7 +54,7 @@ There are two ways to fix violations:
 
 ## When to suppress warnings
 
-Suppressing warnings from this rule is only recommended for advanced use cases where diagnostics on APIs need to explicitly disabled. In this case, you must be willing to take on the responsibility of marking preview APIs appropriately. For example, consider a case where an existing type implements a new preview interface. Since the entire type cannot be marked as preview (for backwards compatibility), the diagnostic around the type definition can be disabled locally. Further, you need to mark the preview interface implementations as preview. Now, the existing type can be used as before, but calls to the new interface methods will get diagnostics. *System.Private.CoreLib.csproj* uses this technique to expose generic math features on numeric types such as `Int32`, `Double`, and `Decimal`.
+Suppressing warnings from this rule is only recommended for advanced use cases where diagnostics on APIs need to be explicitly disabled. In this case, you must be willing to take on the responsibility of marking preview APIs appropriately. For example, consider a case where an existing type implements a new preview interface. Since the entire type cannot be marked as preview (for backwards compatibility), the diagnostic around the type definition can be disabled locally. Further, you need to mark the preview interface implementations as preview. Now, the existing type can be used as before, but calls to the new interface methods will get diagnostics. *System.Private.CoreLib.csproj* uses this technique to expose generic math features on numeric types such as `Int32`, `Double`, and `Decimal`.
 
 The following images show how to disable the CA2252 analyzer locally.
 


### PR DESCRIPTION
## Summary

Fix grammar and wording in /docs/fundamentals/code-analysis/quality-rules