### PR TITLE
Add contract customization article

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2344,6 +2344,8 @@ items:
           href: ../standard/serialization/system-text-json/source-generation.md
         - name: Write custom converters
           href: ../standard/serialization/system-text-json/converters-how-to.md
+        - name: Customize contracts
+          href: ../standard/serialization/custom-contracts.md
     - name: Binary serialization
       items:
       - name: Overview

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2345,7 +2345,7 @@ items:
         - name: Write custom converters
           href: ../standard/serialization/system-text-json/converters-how-to.md
         - name: Customize contracts
-          href: ../standard/serialization/custom-contracts.md
+          href: ../standard/serialization/system-text-json/custom-contracts.md
     - name: Binary serialization
       items:
       - name: Overview

--- a/docs/standard/serialization/system-text-json/converters-how-to.md
+++ b/docs/standard/serialization/system-text-json/converters-how-to.md
@@ -236,7 +236,6 @@ The following sections provide converter samples that address some common scenar
 ::: zone pivot="dotnet-7-0"
 
 * [Deserialize inferred types to object properties](#deserialize-inferred-types-to-object-properties).
-* [Support polymorphic deserialization](#support-polymorphic-deserialization).
 * [Support round-trip for Stack\<T>](#support-round-trip-for-stackt).
 * [Support enum string value deserialization](#support-enum-string-value-deserialization).
 * [Use default system converter](#use-default-system-converter).
@@ -353,7 +352,7 @@ The [unit tests folder](https://github.com/dotnet/runtime/blob/81bf79fd9aa75305e
 
 ### Support polymorphic deserialization
 
-Built-in features provide a limited range of [polymorphic serialization](polymorphism.md) but no support for deserialization at all. Deserialization requires a custom converter.
+.NET 7 provides support for both [polymorphic serialization and deserialization](polymorphism.md). However, in previous .NET versions, there was limited polymorphic serialization support and no support for deserialization. If you're using .NET 6 or an earlier version, deserialization requires a custom converter.
 
 Suppose, for example, you have a `Person` abstract base class, with `Employee` and `Customer` derived classes. Polymorphic deserialization means that at design time you can specify `Person` as the deserialization target, and `Customer` and `Employee` objects in the JSON are correctly deserialized at run time. During deserialization, you have to find clues that identify the required type in the JSON. The kinds of clues available vary with each scenario. For example, a discriminator property might be available or you might have to rely on the presence or absence of a particular property. The current release of `System.Text.Json` doesn't provide attributes to specify how to handle polymorphic deserialization scenarios, so custom converters are required.
 

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -1,0 +1,68 @@
+---
+title: Custom serialization and deserialization contracts
+description: "Learn how to write your own contract resolution logic to customize the JSON contract for a type."
+ms.date: 09/26/2022
+---
+# Customize a JSON contract
+
+The <xref:System.Text.Json?displayProperty=fullName> library constructs a JSON *contract* for each .NET type, which defines how the type should be serialized and deserialized. The contract is derived from the type's shape, which includes characteristics such as its properties and fields and whether it implements the <xref:System.Collections.IEnumerable> or <xref:System.Collections.IDictionary> interface. Types are mapped to contracts either at run time using reflection or at compile time using the source generator.
+
+Starting in .NET 7, you can customize these JSON contracts to provide more control over how types are converted into JSON and vice versa. The following list shows just some examples of the types of customizations you can make to serialization and deserialization:
+
+- Serialize private fields.
+- Support multiple names for a single property (for example, if a previous library version used a different name).
+- Construct new properties for serialization.
+- Ignore properties with a specific name, type, or value.
+- Replace `null` values with some other value.
+- Distinguish between explicit `null` values vs. lack of a value in the JSON payload.
+
+## Other ways to customize
+
+Besides customizing a contract, there are other ways to influence serialization and deserialization behavior, including the following:
+
+- The use of attributes derived from <xref:System.Text.Json.Serialization.JsonAttribute>, for example, <xref:System.Text.Json.Serialization.JsonIgnoreAttribute> and <xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute>.
+- Modifying <xref:System.Text.Json.JsonSerializerOptions>, for example, to set a naming policy or serialize enumeration values as strings instead of numbers.
+- Writing a custom converter that does the actual work of writing the JSON and, during deserialization, constructing an object.
+
+Contract customization is an improvement over these pre-existing customizations because you might not have access to the type to add attributes, and writing a custom converter is complex and hurts performance.
+
+## How to opt in
+
+There are two ways to plug into customization. Both involve obtaining a resolver, whose job is to provide a <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> instance for each type that needs to be serialized.
+
+- By calling the <xref:System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver.%23ctor> constructor to obtain the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver?displayProperty=nameWithType> and adding your custom actions to its <xref:System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver.Modifiers> property.
+
+  For example:
+
+  ```csharp
+  JsonSerializerOptions options = new()
+  {
+      TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+      {
+          Modifiers =
+          {
+              MyCustomModifier1,
+              MyCustomModifier2
+          }
+      }
+  };
+  ```
+
+  If you add multiple modifiers, they'll be called serially.
+
+- By writing a custom resolver that implements <xref:System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver>.
+
+  - If a type is not handled, <xref:System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver.GetTypeInfo%2A?displayProperty=nameWithType> should return `null` for that type.
+  - You can also combine your custom resolver with others, for example, the default resolver. The resolvers will be queried in order until a non-null <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> value is returned for the type.
+
+## Configurable aspects
+
+The <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Kind?displayProperty=nameWithType> property for a type indicates which aspects of its JSON contract are configurable. The `JsonTypeInfoKind.Object` kind ...
+
+
+
+## See also
+
+- [JSON contract customization blog post](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-6/#json-contract-customization)
+
+- Combine reflection-based resolver with source-generated resolver

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -50,10 +50,10 @@ The <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Kind?displayPrope
 
 | `JsonTypeInfo.Kind` | Description |
 | - | - |
-| [JsonTypeInfoKind.Object](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-object) | The converter will serialize the type into a JSON object and uses its properties. **This kind is used for most class and struct types and allows for the most flexibility.** |
-| [JsonTypeInfoKind.Enumerable](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-enumerable) | The converter will serialize the type into a JSON array. This kind is used for types like `List<T>` and array. |
-| [JsonTypeInfoKind.Dictionary](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-dictionary) | The converter will serialize the type into a JSON object. This kind is used for types like `Dictionary<K, V>`. |
-| [JsonTypeInfoKind.None](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-none) | The converter doesn't specify how it will serialize the type or what `JsonTypeInfo` properties it will use. This kind is used for types like <xref:System.Object?displayProperty=nameWithType>, `int`, and `string`, and for all types that use a custom converter. |
+| <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Object?displayProperty=nameWithType> | The converter will serialize the type into a JSON object and uses its properties. **This kind is used for most class and struct types and allows for the most flexibility.** |
+| <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Enumerable?displayProperty=nameWithType> | The converter will serialize the type into a JSON array. This kind is used for types like `List<T>` and array. |
+| <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Dictionary?displayProperty=nameWithType> | The converter will serialize the type into a JSON object. This kind is used for types like `Dictionary<K, V>`. |
+| <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.None?displayProperty=nameWithType> | The converter doesn't specify how it will serialize the type or what `JsonTypeInfo` properties it will use. This kind is used for types like <xref:System.Object?displayProperty=nameWithType>, `int`, and `string`, and for all types that use a custom converter. |
 
 ## Modifiers
 
@@ -64,7 +64,7 @@ The following table shows the modifications you can make and how to achieve them
 | Modification | Applicable `JsonTypeInfo.Kind` | How to achieve it | Example |
 | - | - | - | - |
 | Customize a property's value | `JsonTypeInfoKind.Object` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Get?displayProperty=nameWithType> delegate (for serialization) or <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Set?displayProperty=nameWithType> delegate (for deserialization) for the property. | [Increment a property's value](#example-increment-a-propertys-value) |
-| Add or remove properties | `JsonTypeInfoKind.Object` | [Serialize private fields](#example-serialize-private-fields) |
+| Add or remove properties | `JsonTypeInfoKind.Object` | Add or remove items from the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Properties?displayProperty=nameWithType> list. | [Serialize private fields](#example-serialize-private-fields) |
 | Conditionally serialize a property | `JsonTypeInfoKind.Object` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.ShouldSerialize?displayProperty=nameWithType> predicate for the property. | [Ignore properties with a specific type](#example-ignore-properties-with-a-specific-type) |
 | Customize number handling for a specific type | `JsonTypeInfoKind.None` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.NumberHandling?displayProperty=nameWithType> value for the type. | [Allow int values to be strings](#example-allow-int-values-to-be-strings) |
 
@@ -83,7 +83,7 @@ By default, `System.Text.Json` ignores private fields and properties. This examp
 :::code language="csharp" source="snippets/custom-contracts/PrivateFields.cs":::
 
 > [!TIP]
-> If your private field names start with underscores, consider adding a JSON naming policy to remove the underscore and capitalize the name.
+> If your private field names start with underscores, consider removing the underscores from the names when you add the fields as new JSON properties.
 
 ## Example: Ignore properties with a specific type
 

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -12,7 +12,7 @@ Starting in .NET 7, you can customize these JSON contracts to provide more contr
 - Serialize private fields and properties.
 - Support multiple names for a single property (for example, if a previous library version used a different name).
 - Ignore properties with a specific name, type, or value.
-- Distinguish between explicit `null` values vs. lack of a value in the JSON payload.
+- Distinguish between explicit `null` values and the lack of a value in the JSON payload.
 <!--Add links to blog post when published.-->
 
 ## How to opt in
@@ -26,7 +26,7 @@ There are two ways to plug into customization. Both involve obtaining a resolver
   ```csharp
   JsonSerializerOptions options = new()
   {
-      TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+      TypeInfoResolver = new DefaultJsonTypeInfoResolver
       {
           Modifiers =
           {
@@ -37,7 +37,7 @@ There are two ways to plug into customization. Both involve obtaining a resolver
   };
   ```
 
-  If you add multiple modifiers, they'll be called serially.
+  If you add multiple modifiers, they'll be called sequentially.
 
 - By writing a custom resolver that implements <xref:System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver>.
 
@@ -95,7 +95,7 @@ The following example shows how to filter out properties with a specific type, `
 
 ## Example: Allow int values to be strings
 
-Perhaps your input JSON can contain quotes around one of the numeric types but not on others. If you had control over the class, you could place <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> on the type to fix this, but you don't. Before .NET 7, you'd need to write a [custom converter](converters-how-to.md) to fix this behavior, which is hard. Using contract customization, you can customize the number handling behavior for any type.
+Perhaps your input JSON can contain quotes around one of the numeric types but not on others. If you had control over the class, you could place <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> on the type to fix this, but you don't. Before .NET 7, you'd need to write a [custom converter](converters-how-to.md) to fix this behavior, which is involved. Using contract customization, you can customize the number handling behavior for any type.
 
 The following example changes the behavior for all `int` values. The example can be easily adjusted to apply to any type or for a specific property of any type.
 

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -89,19 +89,19 @@ By default, `System.Text.Json` ignores private fields and properties. This examp
 
 Perhaps your model has properties with specific names or types that you don't want to expose to users. For example, you might have a property that stores credentials or some information that's useless to have in the payload.
 
-The following example shows how to filter out properties with a specific type, `SecretHolder`. It does this by first clearing the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Properties?displayProperty=nameWithType> list and then readding only those properties that don't have the specified type. The filtered properties will completely disappear from the contract, which means `System.Text.Json` won't look at them either during serialization or deserialization.
+The following example shows how to filter out properties with a specific type, `SecretHolder`. It does this by using an <xref:System.Collections.Generic.IList%601> extension method to remove any properties that have the specified type from the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Properties?displayProperty=nameWithType> list. The filtered properties completely disappear from the contract, which means `System.Text.Json` doesn't look at them either during serialization or deserialization.
 
 :::code language="csharp" source="snippets/custom-contracts/IgnoreType.cs":::
 
 ## Example: Allow int values to be strings
 
-Perhaps your input JSON can contain quotes around one of the numeric types but not on others. If you had control over the class, you could place <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> on the type to fix this, but you don't. Before .NET 7, you'd need to write a [custom converter](converters-how-to.md) to fix this behavior, which is involved. Using contract customization, you can customize the number handling behavior for any type.
+Perhaps your input JSON can contain quotes around one of the numeric types but not on others. If you had control over the class, you could place <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> on the type to fix this, but you don't. Before .NET 7, you'd need to write a [custom converter](converters-how-to.md) to fix this behavior, which requires righting a fair bit of code. Using contract customization, you can customize the number handling behavior for any type.
 
 The following example changes the behavior for all `int` values. The example can be easily adjusted to apply to any type or for a specific property of any type.
 
 :::code language="csharp" source="snippets/custom-contracts/ReadIntFromString.cs":::
 
-Without the modifier to allow reading `int` values from a string, the program would have ended with:
+Without the modifier to allow reading `int` values from a string, the program would have ended with an exception:
 
 > Unhandled exception. System.Text.Json.JsonException: The JSON value could not be converted to System.Int32. Path: $.X | LineNumber: 0 | BytePositionInLine: 9.
 

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -95,7 +95,7 @@ The following example shows how to filter out properties with a specific type, `
 
 ## Example: Allow int values to be strings
 
-Perhaps your input JSON can contain quotes around one of the numeric types but not on others. If you had control over the class, you could place <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> on the type to fix this, but you don't. Before .NET 7, you'd need to write a [custom converter](converters-how-to.md) to fix this behavior, which requires righting a fair bit of code. Using contract customization, you can customize the number handling behavior for any type.
+Perhaps your input JSON can contain quotes around one of the numeric types but not on others. If you had control over the class, you could place <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> on the type to fix this, but you don't. Before .NET 7, you'd need to write a [custom converter](converters-how-to.md) to fix this behavior, which requires writing a fair bit of code. Using contract customization, you can customize the number handling behavior for any type.
 
 The following example changes the behavior for all `int` values. The example can be easily adjusted to apply to any type or for a specific property of any type.
 

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -50,10 +50,10 @@ The <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Kind?displayPrope
 
 | `JsonTypeInfo.Kind` | Description |
 | - | - |
-| [JsonTypeInfoKind.Object](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind?view=net-7.0#system-text-json-serialization-metadata-jsontypeinfokind-object) | The converter will serialize the type into a JSON object and uses its properties. **This kind is used for most class and struct types and allows for the most flexibility.** |
-| [JsonTypeInfoKind.Enumerable](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind?view=net-7.0#system-text-json-serialization-metadata-jsontypeinfokind-enumerable) | The converter will serialize the type into a JSON array. This kind is used for types like `List<T>` and array. |
-| [JsonTypeInfoKind.Dictionary](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind?view=net-7.0#system-text-json-serialization-metadata-jsontypeinfokind-dictionary) | The converter will serialize the type into a JSON object. This kind is used for types like `Dictionary<K, V>`. |
-| [JsonTypeInfoKind.None](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind?view=net-7.0#system-text-json-serialization-metadata-jsontypeinfokind-none) | The converter doesn't specify how it will serialize the type or what `JsonTypeInfo` properties it will use. This kind is used for types like <xref:System.Object?displayProperty=nameWithType>, `int`, and `string`, and for all types that use a custom converter. |
+| [JsonTypeInfoKind.Object](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-object) | The converter will serialize the type into a JSON object and uses its properties. **This kind is used for most class and struct types and allows for the most flexibility.** |
+| [JsonTypeInfoKind.Enumerable](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-enumerable) | The converter will serialize the type into a JSON array. This kind is used for types like `List<T>` and array. |
+| [JsonTypeInfoKind.Dictionary](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-dictionary) | The converter will serialize the type into a JSON object. This kind is used for types like `Dictionary<K, V>`. |
+| [JsonTypeInfoKind.None](/dotnet/api/system.text.json.serialization.metadata.jsontypeinfokind#system-text-json-serialization-metadata-jsontypeinfokind-none) | The converter doesn't specify how it will serialize the type or what `JsonTypeInfo` properties it will use. This kind is used for types like <xref:System.Object?displayProperty=nameWithType>, `int`, and `string`, and for all types that use a custom converter. |
 
 ## Modifiers
 
@@ -63,7 +63,7 @@ The following table shows the modifications you can make and how to achieve them
 
 | Modification | Applicable `JsonTypeInfo.Kind` | How to achieve it | Example |
 | - | - | - | - |
-| Customize a property's value | `JsonTypeInfoKind.Object` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Get?displayProperty=nameWithType> delegate (for serialization) or <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Set?displayProperty=nameWithType> delegate (for deserialization) for the property. | [Increment a property's value](#example-customize-a-property) |
+| Customize a property's value | `JsonTypeInfoKind.Object` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Get?displayProperty=nameWithType> delegate (for serialization) or <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Set?displayProperty=nameWithType> delegate (for deserialization) for the property. | [Increment a property's value](#example-increment-a-propertys-value) |
 | Add or remove properties | `JsonTypeInfoKind.Object` | [Serialize private fields](#example-serialize-private-fields) |
 | Conditionally serialize a property | `JsonTypeInfoKind.Object` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.ShouldSerialize?displayProperty=nameWithType> predicate for the property. | [Ignore properties with a specific type](#example-ignore-properties-with-a-specific-type) |
 | Customize number handling for a specific type | `JsonTypeInfoKind.None` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.NumberHandling?displayProperty=nameWithType> value for the type. | [Allow int values to be strings](#example-allow-int-values-to-be-strings) |

--- a/docs/standard/serialization/system-text-json/preserve-references.md
+++ b/docs/standard/serialization/system-text-json/preserve-references.md
@@ -52,8 +52,8 @@ The <xref:System.Text.Json.Serialization.ReferenceResolver> class defines the be
 
 By default, reference data is only cached for each call to <xref:System.Text.Json.JsonSerializer.Serialize%2A> or <xref:System.Text.Json.JsonSerializer.Deserialize%2A>. To persist references from one `Serialize`/`Deserialize` call to another one, root the <xref:System.Text.Json.Serialization.ReferenceResolver> instance in the call site of `Serialize`/`Deserialize`. The following code shows an example for this scenario:
 
-* You have a list of `Employee`s and you have to serialize each one individually.
-* you want to take advantage of the references saved in the `ReferenceHandler`'s resolver.
+* You have a list of `Employee` objects and you have to serialize each one individually.
+* You want to take advantage of the references saved in the resolver for the `ReferenceHandler`.
 
 Here is the `Employee` class:
 

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/IgnoreType.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/IgnoreType.cs
@@ -16,7 +16,7 @@ namespace Serialization
 
     class IgnorePropertiesWithType
     {
-        private List<Type> _ignoredTypes = new List<Type>();
+        private List<Type> _ignoredTypes = new();
 
         public void IgnorePropertyWithType(Type type)
         {
@@ -28,7 +28,7 @@ namespace Serialization
             if (ti.Kind != JsonTypeInfoKind.Object)
                 return;
 
-            JsonPropertyInfo[] props = ti.Properties.Where((pi) => !_ignoredTypes.Contains(pi.PropertyType)).ToArray();
+            JsonPropertyInfo[] props = ti.Properties.Where(pi => !_ignoredTypes.Contains(pi.PropertyType)).ToArray();
             ti.Properties.Clear();
 
             foreach (var pi in props)
@@ -47,7 +47,7 @@ namespace Serialization
 
             JsonSerializerOptions options = new()
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
                 {
                     Modifiers = { modifier.ModifyTypeInfo }
                 }
@@ -56,7 +56,7 @@ namespace Serialization
             ExampleClass obj = new()
             {
                 Name = "Password",
-                Secret = new SecretHolder() { Value = "MySecret" }
+                Secret = new SecretHolder { Value = "MySecret" }
             };
 
             string output = JsonSerializer.Serialize(obj, options);

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/IgnoreType.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/IgnoreType.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Serialization
+{
+    class ExampleClass
+    {
+        public string Name { get; set; } = "";
+        public SecretHolder? Secret { get; set; }
+    }
+
+    class SecretHolder
+    {
+        public string Value { get; set; } = "";
+    }
+
+    class IgnorePropertiesWithType
+    {
+        private List<Type> _ignoredTypes = new List<Type>();
+
+        public void IgnorePropertyWithType(Type type)
+        {
+            _ignoredTypes.Add(type);
+        }
+
+        public void ModifyTypeInfo(JsonTypeInfo ti)
+        {
+            if (ti.Kind != JsonTypeInfoKind.Object)
+                return;
+
+            JsonPropertyInfo[] props = ti.Properties.Where((pi) => !_ignoredTypes.Contains(pi.PropertyType)).ToArray();
+            ti.Properties.Clear();
+
+            foreach (var pi in props)
+            {
+                ti.Properties.Add(pi);
+            }
+        }
+    }
+
+    public class IgnoreTypeExample
+    {
+        public static void RunIt()
+        {
+            var modifier = new IgnorePropertiesWithType();
+            modifier.IgnorePropertyWithType(typeof(SecretHolder));
+
+            JsonSerializerOptions options = new()
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                {
+                    Modifiers = { modifier.ModifyTypeInfo }
+                }
+            };
+
+            ExampleClass obj = new()
+            {
+                Name = "Password",
+                Secret = new SecretHolder() { Value = "MySecret" }
+            };
+
+            string output = JsonSerializer.Serialize(obj, options);
+            Console.WriteLine(output);
+            // {"Name":"Password"}
+        }
+    }
+}

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/PrivateFields.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/PrivateFields.cs
@@ -9,27 +9,27 @@ namespace Serialization
     public class JsonIncludePrivateFieldsAttribute : Attribute { }
 
     [JsonIncludePrivateFields]
-    public class TestClass
+    public class Human
     {
         private string _name;
         private int _age;
 
-        public TestClass()
+        public Human()
         {
             // This constructor should be used only by deserializers.
             _name = null!;
             _age = 0;
         }
 
-        public static TestClass Create(string name, int age)
+        public static Human Create(string name, int age)
         {
-            TestClass tc = new()
+            Human h = new()
             {
                 _name = name,
                 _age = age
             };
 
-            return tc;
+            return h;
         }
 
         [JsonIgnore]
@@ -77,13 +77,13 @@ namespace Serialization
                 }
             };
 
-            var value = TestClass.Create("Julius", 37);
-            string json = JsonSerializer.Serialize(value, options);
+            var human = Human.Create("Julius", 37);
+            string json = JsonSerializer.Serialize(human, options);
             Console.WriteLine(json);
             // {"_name":"Julius","_age":37}
 
-            TestClass result = JsonSerializer.Deserialize<TestClass>(json, options)!;
-            Console.WriteLine($"[Name={result.Name}; Age={result.Age}]");
+            Human deserializedHuman = JsonSerializer.Deserialize<Human>(json, options)!;
+            Console.WriteLine($"[Name={deserializedHuman.Name}; Age={deserializedHuman.Age}]");
             // [Name=Julius; Age=37]
         }
     }

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/PrivateFields.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/PrivateFields.cs
@@ -23,7 +23,7 @@ namespace Serialization
 
         public static TestClass Create(string name, int age)
         {
-            TestClass tc = new TestClass
+            TestClass tc = new()
             {
                 _name = name,
                 _age = age
@@ -71,7 +71,7 @@ namespace Serialization
         {
             var options = new JsonSerializerOptions
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
                 {
                     Modifiers = { AddPrivateFieldsModifier }
                 }

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/PrivateFields.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/PrivateFields.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Serialization
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public class JsonIncludePrivateFieldsAttribute : Attribute { }
+
+    [JsonIncludePrivateFields]
+    public class TestClass
+    {
+        private string _name;
+        private int _age;
+
+        public TestClass()
+        {
+            // This constructor should be used only by deserializers.
+            _name = null!;
+            _age = 0;
+        }
+
+        public static TestClass Create(string name, int age)
+        {
+            TestClass tc = new TestClass
+            {
+                _name = name,
+                _age = age
+            };
+
+            return tc;
+        }
+
+        [JsonIgnore]
+        public string Name
+        {
+            get => _name;
+            set => throw new NotSupportedException();
+        }
+
+        [JsonIgnore]
+        public int Age
+        {
+            get => _age;
+            set => throw new NotSupportedException();
+        }
+    }
+
+    public class PrivateFieldsExample
+    {
+        static void AddPrivateFieldsModifier(JsonTypeInfo jsonTypeInfo)
+        {
+            if (jsonTypeInfo.Kind != JsonTypeInfoKind.Object)
+                return;
+
+            if (!jsonTypeInfo.Type.IsDefined(typeof(JsonIncludePrivateFieldsAttribute), inherit: false))
+                return;
+
+            foreach (FieldInfo field in jsonTypeInfo.Type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                JsonPropertyInfo jsonPropertyInfo = jsonTypeInfo.CreateJsonPropertyInfo(field.FieldType, field.Name);
+                jsonPropertyInfo.Get = field.GetValue;
+                jsonPropertyInfo.Set = field.SetValue;
+
+                jsonTypeInfo.Properties.Add(jsonPropertyInfo);
+            }
+        }
+
+        public static void RunIt()
+        {
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                {
+                    Modifiers = { AddPrivateFieldsModifier }
+                }
+            };
+
+            var value = TestClass.Create("Julius", 37);
+            string json = JsonSerializer.Serialize(value, options);
+            Console.WriteLine(json);
+            // {"_name":"Julius","_age":37}
+
+            TestClass result = JsonSerializer.Deserialize<TestClass>(json, options)!;
+            Console.WriteLine($"[Name={result.Name}; Age={result.Age}]");
+            // [Name=Julius; Age=37]
+        }
+    }
+}

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/Program.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/Program.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Serialization
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            SerializationCountExample.RunIt();
+            Console.WriteLine();
+            PrivateFieldsExample.RunIt();
+            Console.WriteLine();
+            IgnoreTypeExample.RunIt();
+            Console.WriteLine();
+            AllowIntsAsStringsExample.RunIt();
+        }
+    }
+}

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/Project.csproj
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/Project.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/ReadIntFromString.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/ReadIntFromString.cs
@@ -24,7 +24,7 @@ namespace Serialization
         {
             JsonSerializerOptions options = new()
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
                 {
                     Modifiers = { SetNumberHandlingModifier }
                 }

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/ReadIntFromString.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/ReadIntFromString.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Serialization
+{
+    public class Point
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+    }
+
+    public class AllowIntsAsStringsExample
+    {
+        static void SetNumberHandlingModifier(JsonTypeInfo jsonTypeInfo)
+        {
+            if (jsonTypeInfo.Type == typeof(int))
+            {
+                jsonTypeInfo.NumberHandling = JsonNumberHandling.AllowReadingFromString;
+            }
+        }
+
+        public static void RunIt()
+        {
+            JsonSerializerOptions options = new()
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                {
+                    Modifiers = { SetNumberHandlingModifier }
+                }
+            };
+
+            // Triple-quote syntax is a C# 11 feature.
+            Point point = JsonSerializer.Deserialize<Point>("""{"X":"12","Y":"3"}""", options)!;
+            Console.WriteLine($"({point.X},{point.Y})");
+            // (12,3)
+        }
+    }
+}

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/SerializationCount.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/SerializationCount.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Serialization
+{
+    // Custom attribute to annotate the property
+    // we want to be incremented.
+    [AttributeUsage(AttributeTargets.Property)]
+    class SerializationCountAttribute : Attribute
+    {
+    }
+
+    // Example type to serialize and deserialize.
+    class Product
+    {
+        public string Name { get; set; } = "";
+        [SerializationCount]
+        public int RoundTrips { get; set; }
+    }
+
+    public class SerializationCountExample
+    {
+        // Custom modifier that increments the value
+        // of a specific property on deserialization.
+        static void IncrementCounterModifier(JsonTypeInfo typeInfo)
+        {
+            foreach (JsonPropertyInfo propertyInfo in typeInfo.Properties)
+            {
+                if (propertyInfo.PropertyType != typeof(int))
+                    continue;
+
+                object[] serializationCountAttributes = propertyInfo.AttributeProvider?.GetCustomAttributes(typeof(SerializationCountAttribute), true) ?? Array.Empty<object>();
+                SerializationCountAttribute? attribute = serializationCountAttributes.Length == 1 ? (SerializationCountAttribute)serializationCountAttributes[0] : null;
+
+                if (attribute != null)
+                {
+                    Action<object, object?>? set = propertyInfo.Set;
+
+                    if (set != null)
+                    {
+                        propertyInfo.Set = (obj, value) =>
+                        {
+                            if (value != null)
+                            {
+                                // Increment the value by 1.
+                                value = (int)value + 1;
+                            }
+
+                            set(obj, value);
+                        };
+                    }
+                }
+            }
+        }
+
+        public static void RunIt()
+        {
+            var product = new Product();
+            product.Name = "Aquafresh";
+
+            JsonSerializerOptions options = new()
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                {
+                    Modifiers = { IncrementCounterModifier }
+                }
+            };
+
+            // First serialization and deserialization.
+            string serialized = JsonSerializer.Serialize(product, options);
+            Console.WriteLine(serialized);
+            // {"Name":"Aquafresh","RoundTrips":0}
+
+            Product deserialized = JsonSerializer.Deserialize<Product>(serialized, options)!;
+            Console.WriteLine($"{deserialized.RoundTrips}");
+            // 1
+
+            // Second serialization and deserialization.
+            serialized = JsonSerializer.Serialize(deserialized, options);
+            Console.WriteLine(serialized);
+            // { "Name":"Aquafresh","RoundTrips":1}
+
+            deserialized = JsonSerializer.Deserialize<Product>(serialized, options)!;
+            Console.WriteLine($"{deserialized.RoundTrips}");
+            // 2
+        }
+    }
+}

--- a/docs/standard/serialization/system-text-json/snippets/custom-contracts/SerializationCount.cs
+++ b/docs/standard/serialization/system-text-json/snippets/custom-contracts/SerializationCount.cs
@@ -34,9 +34,8 @@ namespace Serialization
 
                 if (attribute != null)
                 {
-                    Action<object, object?>? set = propertyInfo.Set;
-
-                    if (set != null)
+                    Action<object, object?>? setProperty = propertyInfo.Set;
+                    if (setProperty is not null)
                     {
                         propertyInfo.Set = (obj, value) =>
                         {
@@ -46,7 +45,7 @@ namespace Serialization
                                 value = (int)value + 1;
                             }
 
-                            set(obj, value);
+                            setProperty (obj, value);
                         };
                     }
                 }
@@ -55,12 +54,14 @@ namespace Serialization
 
         public static void RunIt()
         {
-            var product = new Product();
-            product.Name = "Aquafresh";
+            var product = new Product
+            {
+                Name = "Aquafresh"
+            };
 
             JsonSerializerOptions options = new()
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
                 {
                     Modifiers = { IncrementCounterModifier }
                 }


### PR DESCRIPTION
Contributes to #30484.

- Add new article on contract customization - [preview](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/custom-contracts?branch=pr-en-us-31479).
- Refresh the "migrate from Newtonsoft" and "custom converters" articles to note that polymorphic deserialization and serializing private fields are now possible.