### PR TITLE
Fix wrong method name

### DIFF
--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -209,7 +209,7 @@ public (string FName, string MName, string LName, int Age) GetPersonalInfo(strin
 }
 ```
 
-The previous call to the `GetPersonInfo` method can then be modified as follows:
+The previous call to the `GetPersonalInfo` method can then be modified as follows:
 
 ```csharp
 var person = GetPersonalInfo("111111111");


### PR DESCRIPTION
The method name should be `GetPersonalInfo` (not `GetPersonInfo`), to be consistent with the text and code samples around it.