### PR TITLE
Update pre-requisites for native aot publishing

### DIFF
--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -24,7 +24,7 @@ The following prerequisites need to be installed before publishing .NET projects
 
 On Windows, install [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), including Desktop development with C++ workload.
 
-On Linux, install clang and developer packages for libraries that .NET runtime depends on.
+On Linux, install compiler toolchain and developer packages for libraries that .NET runtime depends on.
 
 - Ubuntu (18.04+)
 

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -35,7 +35,7 @@ On Linux, install clang and developer packages for libraries that .NET runtime d
 - Alpine (3.15+)
 
     ```sh
-    sudo apk add clang gcc lld musl-dev build-base zlib-dev
+    sudo apk add build-base zlib-dev
     ```
 
 ## Publish Native AOT - CLI

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -35,7 +35,7 @@ On Linux, install compiler toolchain and developer packages for libraries that .
 - Alpine (3.15+)
 
     ```sh
-    sudo apk add build-base zlib-dev
+    sudo apk add clang build-base zlib-dev
     ```
 
 ## Publish Native AOT - CLI


### PR DESCRIPTION
## Summary

Trim to list pre-requisites for native aot publishing to just what is actually required.

Addressed feedback from https://github.com/dotnet/runtime/issues/69739#issuecomment-1264133462
