### PR TITLE
ci: Allow Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,12 @@
 # https://github.com/dotnet/core/tree/master/samples/dependadotnet
 version: 2
 updates:
+  - package-ecosystem: "github-actions" # Core GitHub Actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
   - package-ecosystem: "nuget"
     directory: "/samples/snippets/csharp/pipelines" #Pipes.csproj
     schedule:


### PR DESCRIPTION
## Summary

Looking through the action files, some of the ones that were pinned to hashes are several major versions behind at this point. This will allow dependabot to create PRs to keep them in sync
