### PR TITLE
Ignore explicit porting bits for upgrade assistant content

### DIFF
--- a/dotnet-versionsweeper.json
+++ b/dotnet-versionsweeper.json
@@ -6,6 +6,7 @@
         "**/docs/csharp/programming-guide/concepts/async/snippets/multiple-tasks/MultipleTasks.csproj",
         "**/docs/framework/migration-guide/snippets/csharp/FrameworkVersions.csproj",
         "**/docs/framework/migration-guide/snippets/visual-basic/FrameworkVersions.vbproj",
-        "**/docs/framework/migration-guide/snippets/csharp/FrameworkVersions.csproj"
+        "**/docs/framework/migration-guide/snippets/csharp/FrameworkVersions.csproj",
+        "**/docs/core/porting/snippets/upgrade-assistant-wcf-framework/CalculatorSample/**/*.csproj"
     ]
 }


### PR DESCRIPTION
## Summary

Ignore explicit porting bits for upgrade assistant content

Fixes #31531 and checks off both task list items.
