### PR TITLE
Match condition from the snippet and the content. (#31377)

### DIFF
--- a/docs/fsharp/language-reference/match-expressions.md
+++ b/docs/fsharp/language-reference/match-expressions.md
@@ -57,7 +57,7 @@ Note that because values other than literals cannot be used in the pattern, you 
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-2/snippet4603.fs)]
 
-Note that when a union pattern is covered by a guard, the guard applies to **all** of the patterns, not just the last one. For example, given the following code, the guard `when a > 12` applies to both `A a` and `B a`:
+Note that when a union pattern is covered by a guard, the guard applies to **all** of the patterns, not just the last one. For example, given the following code, the guard `when a > 41` applies to both `A a` and `B a`:
 
 ```fsharp
 type Union =


### PR DESCRIPTION
## Summary

Content condition `a > 12` didn't march the code snippet having `a > 41`

Fixes #31377
