### PR TITLE
ci: cleanup actions usings

### DIFF
--- a/.github/workflows/bcnotify.yaml
+++ b/.github/workflows/bcnotify.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'breaking-change'
     steps:
-    - uses: actions/checkout@v3 #@v2
+    - uses: actions/checkout@v3
     - uses: timheuer/issue-notifier@v1
       env:
         SENDGRID_API_KEY: ${{ secrets.SENDGRID_API }}

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -32,7 +32,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3 #@v2
+    - uses: actions/checkout@v3
 
     # Get the latest preview SDK (or sdk not installed by the runner)
     - name: Setup .NET SDK

--- a/.github/workflows/docs-verifier-tryfix.yml
+++ b/.github/workflows/docs-verifier-tryfix.yml
@@ -30,7 +30,7 @@ jobs:
             core.setFailed(`Request failed with error ${err}`)
           }
     - name: Checkout the repository
-      uses: actions/checkout@v3 #@v2
+      uses: actions/checkout@v3
 
     - name: Checkout Pull Request
       run: |

--- a/.github/workflows/docs-verifier.yml
+++ b/.github/workflows/docs-verifier.yml
@@ -12,7 +12,7 @@ jobs:
         statuses: write
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3 #@v2
+      uses: actions/checkout@v3
 
     - name: Validate
       uses: dotnet/docs-actions/actions/docs-verifier@main

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -24,7 +24,7 @@ jobs:
         statuses: write
 
     steps:
-    - uses: actions/checkout@v3 #@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js
       uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d #@v1
       with:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js
-      uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d #@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
     - name: Run Markdownlint

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
+      - uses: lee-dohm/no-response@v0.5.0
         with:
           token: ${{ github.token }}
           responseRequiredLabel: needs-more-info


### PR DESCRIPTION
## Summary

Dependabot has now unpinned the `usings` to the major versions. This left behind some out of date comments that were helpful for the old git-has versions.
The setup-node might not have been updated in this round, but would likely be bumped in the next dependabot run.
The last job was the remain git-has reference, so just changed it back to the tag name, since it doesn't look like it has a floating major version tag like the others
