### PR TITLE
chore: Add Dependabot for GitHub Actions  snippets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,36 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions" # Create dotnet GitHub Actions snippet
+    directory: "/docs/devops/snippets/create-dotnet-github-action"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions" # Build dotnet GitHub Actions snippet
+    directory: "/docs/devops/snippets/dotnet-build-github-action"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions" # Publish dotnet GitHub Actions snippet
+    directory: "/docs/devops/snippets/dotnet-publish-github-action"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions" # Secure dotnet GitHub Actions snippet
+    directory: "/docs/devops/snippets/dotnet-secure-github-action"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions" # Test dotnet GitHub Actions snippet
+    directory: "/docs/devops/snippets/dotnet-test-github-action"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
   - package-ecosystem: "nuget"
     directory: "/samples/snippets/csharp/pipelines" #Pipes.csproj
     schedule:


### PR DESCRIPTION
## Summary

Think this should work the same as the other subfolder updates config, but I wasn't sure if the `directory` parameter was any different because of the existing special handling for GitHub Actions
