### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,19 +39,7 @@ updates:
       day: "wednesday"
     open-pull-requests-limit: 10
   - package-ecosystem: "nuget"
-    directory: "/samples/snippets/csharp/pipelines" #Pipes.csproj
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "nuget"
     directory: "/samples/snippets/csharp/xunit-test" #xunit-test.csproj
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "nuget"
-    directory: "/samples/snippets/csharp/new-in-6" #new-in-6.csproj
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -226,18 +214,6 @@ updates:
     open-pull-requests-limit: 5
   - package-ecosystem: "nuget"
     directory: "/docs/core/extensions/snippets/logging/console-formatter-systemd" #console-formatter-systemd.csproj
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "nuget"
-    directory: "/docs/csharp/tutorials/snippets/generate-consume-asynchronous-streams/finished" #IssuePRreport.csproj
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "nuget"
-    directory: "/docs/csharp/tutorials/snippets/generate-consume-asynchronous-streams/start" #IssuePRreport.csproj
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
These directories don't exist, and thus it fails with an error similar to the following:

> ⚠️ Dependabot couldn't find a <anything>.(cs|vb|fs)proj
Dependabot couldn't find a .(cs|vb|fs)proj.
> 
> Dependabot requires a .(cs|vb|fs)proj to evaluate your .NET dependencies. It had expected to find one at the path: /samples/snippets/csharp/pipelines/<anything>.(cs|vb|fs)proj.
> 
> If this isn't a .NET project, you may wish to disable updates for it in the .github/dependabot.yml config file in this repo.
