### PR TITLE
chore: update Actions versions in docs and samples

### DIFF
--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -119,7 +119,7 @@ Notice the following things:
 1. The `on` object specifies when this workflow should run. This workflow has two events that trigger it: `push` to `main` and `pull_request` to `main`. Each time someone commits to `main` or creates a pull request (PR) to `main`, this workflow will execute.
 1. There's a single `job` called `build`. This build should run on a hosted agent. `ubuntu_latest` specifies the most recent Ubuntu hosted agent.
 1. There are five steps:
-    1. `actions/checkout@v2` is an action that checks out the code in the repository onto the runner.
+    1. `actions/checkout@v3` is an action that checks out the code in the repository onto the runner.
     1. `actions/setup-dotnet@v1` is an action that sets up the .NET CLI. This step also specifies a `name` attribute for the logs and the `dotnet-version` parameter within the `with` object.
     1. Three `run` steps that execute `dotnet restore`, `dotnet build`, and `dotnet test`. `name` attributes are also specified for these `run` steps to make the logs look pretty.
 
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:

--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -104,7 +104,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -197,7 +197,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -102,7 +102,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 5.0.x
     - name: Restore dependencies
@@ -120,7 +120,7 @@ Notice the following things:
 1. There's a single `job` called `build`. This build should run on a hosted agent. `ubuntu_latest` specifies the most recent Ubuntu hosted agent.
 1. There are five steps:
     1. `actions/checkout@v3` is an action that checks out the code in the repository onto the runner.
-    1. `actions/setup-dotnet@v1` is an action that sets up the .NET CLI. This step also specifies a `name` attribute for the logs and the `dotnet-version` parameter within the `with` object.
+    1. `actions/setup-dotnet@v3` is an action that sets up the .NET CLI. This step also specifies a `name` attribute for the logs and the `dotnet-version` parameter within the `with` object.
     1. Three `run` steps that execute `dotnet restore`, `dotnet build`, and `dotnet test`. `name` attributes are also specified for these `run` steps to make the logs look pretty.
 
 ## Publish the output
@@ -195,7 +195,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 5.0.x
     - name: Restore dependencies

--- a/docs/architecture/devops-for-aspnet-developers/actions-build.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-build.md
@@ -160,7 +160,7 @@ Now that you've successfully built and tested the code, add steps that publish t
 
     ```yml
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: website
           path: SimpleFeedReader/website/**
@@ -207,7 +207,7 @@ jobs:
     - name: Publish
       run: dotnet publish SimpleFeedReader/SimpleFeedReader.csproj -c Release -o website
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.2
+      uses: actions/upload-artifact@v3
       with:
         name: website
         path: SimpleFeedReader/website/**

--- a/docs/architecture/devops-for-aspnet-developers/actions-codeql.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-codeql.md
@@ -88,7 +88,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
@@ -421,7 +421,7 @@ jobs:
     - name: Publish
       run: dotnet publish SimpleFeedReader/SimpleFeedReader.csproj -c Release -o website
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.2
+      uses: actions/upload-artifact@v3
       with:
         name: website
         path: SimpleFeedReader/website/**

--- a/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
@@ -149,7 +149,7 @@ You can now add additional jobs to the workflow to deploy to the environments! Y
 
         steps:
         - name: Download a Build Artifact
-          uses: actions/download-artifact@v2.0.8
+          uses: actions/download-artifact@v3
           with:
             name: website
             path: website
@@ -437,7 +437,7 @@ jobs:
 
     steps:
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v2.0.8
+      uses: actions/download-artifact@v3
       with:
         name: website
         path: website

--- a/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
@@ -409,7 +409,7 @@ jobs:
       run: |
         echo 'Reason: ${{ github.event.inputs.reason }}'
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 2.1.x
     - name: Restore dependencies

--- a/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
+++ b/docs/architecture/devops-for-aspnet-developers/actions-deploy.md
@@ -403,7 +403,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 'Print manual run reason'
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |

--- a/docs/devops/dotnet-build-github-action.md
+++ b/docs/devops/dotnet-build-github-action.md
@@ -36,7 +36,7 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-build-github-action/build-validation.yml" range="11-12":::
 
-  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
+  - The environment variable `DOTNET_VERSION` is assigned the value `'6.0.401'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
 
 - The `jobs` node builds out the steps for the workflow to take.
 

--- a/docs/devops/dotnet-build-github-action.md
+++ b/docs/devops/dotnet-build-github-action.md
@@ -36,14 +36,14 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-build-github-action/build-validation.yml" range="11-12":::
 
-  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v1` GitHub Action.
+  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
 
 - The `jobs` node builds out the steps for the workflow to take.
 
   :::code language="yml" source="snippets/dotnet-build-github-action/build-validation.yml" range="14-34" highlight="2,4-8,13-15,18,21":::
 
   - There is a single job, named `build-<os>` where the `<os>` is the operating system name from the `strategy/matrix`. The `name` and `runs-on` elements are dynamic for each value in the `matrix/os`. This will run on the latest versions of Ubuntu, Windows, and macOS.
-  - The `actions/setup-dotnet@v1` GitHub Action is required to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
+  - The `actions/setup-dotnet@v3` GitHub Action is required to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
   - (Optionally) Additional steps may be required, depending on your .NET workload. They're omitted from this example, but you may need additional tools installed to build your apps.
     - For example, when building an ASP.NET Core Blazor WebAssembly application with Ahead-of-Time (AoT) compilation you'd install the corresponding workload before running restore/build/publish operations.
 

--- a/docs/devops/dotnet-publish-github-action.md
+++ b/docs/devops/dotnet-publish-github-action.md
@@ -59,14 +59,14 @@ In the preceding workflow composition:
 
   - The environment variable `AZURE_WEBAPP_NAME` is assigned the value `DotNetWeb`.
   - The environment variable `AZURE_WEBAPP_PACKAGE_PATH` is assigned the value `'.'`.
-  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v1` GitHub Action.
+  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
 
 - The `jobs` node builds out the steps for the workflow to take.
 
   :::code language="yml" source="snippets/dotnet-publish-github-action/publish-app.yml" range="12-42" highlight="2,4,9-11,14,19-20,24,26-31":::
 
   - There is a single job, named `publish` that will run on the latest version of Ubuntu.
-  - The `actions/setup-dotnet@v1` GitHub Action is used to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
+  - The `actions/setup-dotnet@v3` GitHub Action is used to set up the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
   - The [`dotnet restore`](../core/tools/dotnet-restore.md) command is called.
   - The [`dotnet build`](../core/tools/dotnet-build.md) command is called.
   - The [`dotnet publish`](../core/tools/dotnet-publish.md) command is called.

--- a/docs/devops/dotnet-publish-github-action.md
+++ b/docs/devops/dotnet-publish-github-action.md
@@ -59,7 +59,7 @@ In the preceding workflow composition:
 
   - The environment variable `AZURE_WEBAPP_NAME` is assigned the value `DotNetWeb`.
   - The environment variable `AZURE_WEBAPP_PACKAGE_PATH` is assigned the value `'.'`.
-  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
+  - The environment variable `DOTNET_VERSION` is assigned the value `'6.0.401'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
 
 - The `jobs` node builds out the steps for the workflow to take.
 

--- a/docs/devops/dotnet-test-github-action.md
+++ b/docs/devops/dotnet-test-github-action.md
@@ -36,7 +36,7 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-test-github-action/build-and-test.yml" range="11-12":::
 
-  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
+  - The environment variable `DOTNET_VERSION` is assigned the value `'6.0.401'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
 
 - The `jobs` node builds out the steps for the workflow to take.
 

--- a/docs/devops/dotnet-test-github-action.md
+++ b/docs/devops/dotnet-test-github-action.md
@@ -36,14 +36,14 @@ In the preceding workflow composition:
 
   :::code language="yml" source="snippets/dotnet-test-github-action/build-and-test.yml" range="11-12":::
 
-  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v1` GitHub Action.
+  - The environment variable `DOTNET_VERSION` is assigned the value `'5.0.301'`. The environment variable is later referenced to specify the `dotnet-version` of the `actions/setup-dotnet@v3` GitHub Action.
 
 - The `jobs` node builds out the steps for the workflow to take.
 
   :::code language="yml" source="snippets/dotnet-test-github-action/build-and-test.yml" range="14-37" highlight="2,4-8,13-15,18,21,24":::
 
   - There is a single job, named `build-<os>` where the `<os>` is the operating system name from the `strategy/matrix`. The `name` and `runs-on` elements are dynamic for each value in the `matrix/os`. This will run on the latest versions of Ubuntu, Windows, and macOS.
-  - The `actions/setup-dotnet@v1` GitHub Action is used to setup the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
+  - The `actions/setup-dotnet@v3` GitHub Action is used to setup the .NET SDK with the specified version from the `DOTNET_VERSION` environment variable.
   - The [`dotnet restore`](../core/tools/dotnet-restore.md) command is called.
   - The [`dotnet build`](../core/tools/dotnet-build.md) command is called.
   - The [`dotnet test`](../core/tools/dotnet-test.md) command is called.

--- a/docs/devops/snippets/create-dotnet-github-action/workflow.yml
+++ b/docs/devops/snippets/create-dotnet-github-action/workflow.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Print manual run reason'
       if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/docs/devops/snippets/create-dotnet-github-action/workflow.yml
+++ b/docs/devops/snippets/create-dotnet-github-action/workflow.yml
@@ -42,7 +42,7 @@ jobs:
         dir: ${{ './github-actions/DotNet.GitHubAction' }}
       
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v3.4.1
+      uses: peter-evans/create-pull-request@v4
       if: ${{ steps.dotnet-code-metrics.outputs.updated-metrics }} == 'true'
       with:
         title: '${{ steps.dotnet-code-metrics.outputs.summary-title }}'

--- a/docs/devops/snippets/dotnet-build-github-action/build-validation.yml
+++ b/docs/devops/snippets/dotnet-build-github-action/build-validation.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/docs/devops/snippets/dotnet-build-github-action/build-validation.yml
+++ b/docs/devops/snippets/dotnet-build-github-action/build-validation.yml
@@ -9,7 +9,7 @@ on:
     - '**.csproj'
 
 env:
-  DOTNET_VERSION: '5.0.301' # The .NET SDK version to use
+  DOTNET_VERSION: '6.0.401' # The .NET SDK version to use
 
 jobs:
   build:

--- a/docs/devops/snippets/dotnet-build-github-action/build-validation.yml
+++ b/docs/devops/snippets/dotnet-build-github-action/build-validation.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/docs/devops/snippets/dotnet-publish-github-action/publish-app.yml
+++ b/docs/devops/snippets/dotnet-publish-github-action/publish-app.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/docs/devops/snippets/dotnet-publish-github-action/publish-app.yml
+++ b/docs/devops/snippets/dotnet-publish-github-action/publish-app.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/docs/devops/snippets/dotnet-publish-github-action/publish-app.yml
+++ b/docs/devops/snippets/dotnet-publish-github-action/publish-app.yml
@@ -7,7 +7,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: DotNetWeb
   AZURE_WEBAPP_PACKAGE_PATH: '.' # Set this to the path to your web app project, defaults to the repository root:
-  DOTNET_VERSION: '5.0.301' # The .NET SDK version to use
+  DOTNET_VERSION: '6.0.401' # The .NET SDK version to use
 
 jobs:
   publish:

--- a/docs/devops/snippets/dotnet-secure-github-action/codeql-analysis.yml
+++ b/docs/devops/snippets/dotnet-secure-github-action/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
 

--- a/docs/devops/snippets/dotnet-test-github-action/build-and-test.yml
+++ b/docs/devops/snippets/dotnet-test-github-action/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/docs/devops/snippets/dotnet-test-github-action/build-and-test.yml
+++ b/docs/devops/snippets/dotnet-test-github-action/build-and-test.yml
@@ -9,7 +9,7 @@ on:
     - '**.csproj'
 
 env:
-  DOTNET_VERSION: '5.0.301' # The .NET SDK version to use
+  DOTNET_VERSION: '6.0.401' # The .NET SDK version to use
 
 jobs:
   build-and-test:

--- a/docs/devops/snippets/dotnet-test-github-action/build-and-test.yml
+++ b/docs/devops/snippets/dotnet-test-github-action/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/docs/orleans/deployment/deploy-to-azure-app-service.md
+++ b/docs/orleans/deployment/deploy-to-azure-app-service.md
@@ -157,7 +157,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 

--- a/docs/orleans/deployment/deploy-to-azure-app-service.md
+++ b/docs/orleans/deployment/deploy-to-azure-app-service.md
@@ -154,7 +154,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1

--- a/docs/orleans/deployment/deploy-to-azure-container-apps.md
+++ b/docs/orleans/deployment/deploy-to-azure-container-apps.md
@@ -92,7 +92,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1

--- a/docs/orleans/deployment/deploy-to-azure-container-apps.md
+++ b/docs/orleans/deployment/deploy-to-azure-container-apps.md
@@ -95,7 +95,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 


### PR DESCRIPTION
## Summary

Since the Dependabot updates on the nested copies don't appear to work, I manually updated the reference files and documents for the:
- `actions/*`
- `peter-evans/create-pull-request`

Didn't update the following, as I'm not familiar with how they pin major version or breakages:
- `azure/*`
- `github/codeql*`
- docker/*`
