### PR TITLE
Clean up C# breadcrumbs

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -1009,8 +1009,16 @@
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-8.0/nullable-reference-types"
         },
         {
-            "source_path_from_root": "/docs/csharp/language-reference/proposals/index.md",
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-9.0/index.md",
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-9.0/records"
+        },
+        {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-10.0/index.md",
+            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs"
+        },
+        {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-11.0/index.md",
+            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-11.0/static-abstracts-in-interfaces"
         },
         {
             "source_path_from_root": "/docs/csharp/local-functions-vs-lambdas.md",

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -338,9 +338,6 @@ items:
         tocHref: /dotnet/csharp/programming-guide/
         topicHref: /dotnet/csharp/programming-guide/index
         items:
-        - name: Inside a C# program
-          tocHref: /dotnet/csharp/programming-guide/inside-a-program/
-          topicHref: /dotnet/csharp/programming-guide/inside-a-program/index
         - name: Arrays
           tocHref: /dotnet/csharp/programming-guide/arrays/
           topicHref: /dotnet/csharp/programming-guide/arrays/index
@@ -353,9 +350,6 @@ items:
         - name: Events
           tocHref: /dotnet/csharp/programming-guide/events/
           topicHref: /dotnet/csharp/programming-guide/events/index
-        - name: Exceptions and exception handling
-          tocHref: /dotnet/csharp/programming-guide/exceptions/
-          topicHref: /dotnet/csharp/programming-guide/exceptions/index
         - name: File system and the registry
           tocHref: /dotnet/csharp/programming-guide/file-system/
           topicHref: /dotnet/csharp/programming-guide/file-system/index
@@ -371,12 +365,6 @@ items:
         - name: Interoperability
           tocHref: /dotnet/csharp/programming-guide/interop/
           topicHref: /dotnet/csharp/programming-guide/interop/index
-        - name: Main() and command-line arguments
-          tocHref: /dotnet/csharp/programming-guide/main-and-command-args/
-          topicHref: /dotnet/csharp/programming-guide/main-and-command-args/index
-        - name: Namespaces
-          tocHref: /dotnet/csharp/programming-guide/namespaces/
-          topicHref: /dotnet/csharp/programming-guide/namespaces/index
         - name: Programming concepts
           tocHref: /dotnet/csharp/programming-guide/concepts/
           topicHref: /dotnet/csharp/programming-guide/concepts/index
@@ -411,12 +399,6 @@ items:
         - name: Types
           tocHref: /dotnet/csharp/programming-guide/types/
           topicHref: /dotnet/csharp/programming-guide/types/index
-        - name: Unsafe code and pointers
-          tocHref: /dotnet/csharp/programming-guide/unsafe-code-pointers/
-          topicHref: /dotnet/csharp/programming-guide/unsafe-code-pointers/index
-        - name: XML documentation
-          tocHref: /dotnet/csharp/programming-guide/xmldoc/
-          topicHref: /dotnet/csharp/programming-guide/xmldoc/xml-documentation-comments
       - name: Language reference
         tocHref: /dotnet/csharp/language-reference/
         topicHref: /dotnet/csharp/language-reference/index
@@ -424,7 +406,7 @@ items:
         - name: Keywords
           tocHref: /dotnet/csharp/language-reference/keywords/
           topicHref: /dotnet/csharp/language-reference/keywords/index
-        - name: Operators
+        - name: Operators and expressions
           tocHref: /dotnet/csharp/language-reference/operators/
           topicHref: /dotnet/csharp/language-reference/operators/index
         - name: Special characters
@@ -464,7 +446,13 @@ items:
           topicHref: /dotnet/csharp/language-reference/proposals/csharp-8.0/index
         - name: C# 9.0 feature specifications
           tocHref: /dotnet/csharp/language-reference/proposals/csharp-9.0/
-          topicHref: /dotnet/csharp/language-reference/proposals/csharp-9.0/records
+          topicHref: /dotnet/csharp/language-reference/proposals/csharp-9.0/index
+        - name: C# 10 feature specifications
+          tocHref: /dotnet/csharp/language-reference/proposals/csharp-10.0/
+          topicHref: /dotnet/csharp/language-reference/proposals/csharp-10.0/index
+        - name: C# 11 feature specifications
+          tocHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/
+          topicHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/index
     - name: F# guide
       tocHref: /dotnet/fsharp/
       topicHref: /dotnet/fsharp/index


### PR DESCRIPTION
- Add/fix the breadcrumbs for the latest C# feature proposals
- Remove breadcrumbs for deleted programming-guide folders
