### PR TITLE
Link the specific using article when possible

### DIFF
--- a/docs/csharp/misc/cs0104.md
+++ b/docs/csharp/misc/cs0104.md
@@ -12,7 +12,7 @@ ms.assetid: 1a7e9ae8-308b-441b-ba85-fac974222875
 
 'reference' is an ambiguous reference between 'identifier' and 'identifier'  
   
- Your program contains [using](../language-reference/keywords/using.md) directives for two namespaces and your code references a name that appears in both namespaces.  
+ Your program contains [using](../language-reference/keywords/using-directive.md) directives for two namespaces and your code references a name that appears in both namespaces.  
   
  The following sample generates CS0104:  
   

--- a/docs/csharp/misc/cs0138.md
+++ b/docs/csharp/misc/cs0138.md
@@ -12,7 +12,7 @@ ms.assetid: 970545f8-5ee5-428e-921a-3aa29f68d16d
 
 A using namespace directive can only be applied to namespaces; 'type' is a type not a namespace  
   
- A [using](../language-reference/keywords/using.md) directive can only take the name of a namespace as a parameter. For more information, see [Namespaces](../fundamentals/types/namespaces.md).  
+ A [using](../language-reference/keywords/using-directive.md) directive can only take the name of a namespace as a parameter. For more information, see [Namespaces](../fundamentals/types/namespaces.md).  
   
  The following sample generates CS0138:  
   

--- a/docs/csharp/misc/cs1529.md
+++ b/docs/csharp/misc/cs1529.md
@@ -12,7 +12,7 @@ ms.assetid: 672a6fd1-3a1f-422c-a29f-46f196d15211
 
 A using clause must precede all other elements defined in the namespace except extern alias declarations  
   
- A [using](../language-reference/keywords/using.md) clause must appear first in a namespace.  
+ A [using](../language-reference/keywords/using-directive.md) clause must appear first in a namespace.  
   
 ## Example  
 


### PR DESCRIPTION
I'm thinking about removing the [umbrella `using` article](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using), so updating some links to it before doing that.