### PR TITLE
Avoid using one-shot HttpClient in code sample

### DIFF
--- a/docs/fundamentals/networking/http/httpclient.md
+++ b/docs/fundamentals/networking/http/httpclient.md
@@ -29,7 +29,7 @@ Most of the following examples reuse the same `HttpClient` instance, and therefo
 
 The preceding code:
 
-- Instantiates a new `HttpClient` instance as a `static` variable. As per the guidelines referenced above, it's strongly recommended to reuse `HttpClient` instance(s) during the application's lifecycle.
+- Instantiates a new `HttpClient` instance as a `static` variable. As per the [guidelines](httpclient-guidelines.md), it's strongly recommended to reuse `HttpClient` instances during the application's lifecycle.
 - Sets the <xref:System.Net.Http.HttpClient.BaseAddress?displayProperty=nameWithType> to `"https://jsonplaceholder.typicode.com"`.
 
 This `HttpClient` instance will always use the base address when making subsequent requests. To apply additional configuration consider:

--- a/docs/fundamentals/networking/http/httpclient.md
+++ b/docs/fundamentals/networking/http/httpclient.md
@@ -25,11 +25,11 @@ HTTP endpoints commonly return JavaScript Object Notation (JSON) data, but not a
 
 Most of the following examples reuse the same `HttpClient` instance, and therefore only need to be configured once. To create an `HttpClient`, use the `HttpClient` class constructor. For more information, see [Guidelines for using HttpClient](httpclient-guidelines.md).
 
-:::code language="csharp" source="../snippets/httpclient/Program.cs" id="todoclient":::
+:::code language="csharp" source="../snippets/httpclient/Program.cs" id="sharedclient":::
 
 The preceding code:
 
-- Instantiates a new `HttpClient` instance with the object initializer syntax, and as a [using declaration](../../../csharp/whats-new/csharp-8.md#using-declarations).
+- Instantiates a new `HttpClient` instance as a `static` variable.
 - Sets the <xref:System.Net.Http.HttpClient.BaseAddress?displayProperty=nameWithType> to `"https://jsonplaceholder.typicode.com"`.
 
 This `HttpClient` instance will always use the base address when making subsequent requests. To apply additional configuration consider:

--- a/docs/fundamentals/networking/http/httpclient.md
+++ b/docs/fundamentals/networking/http/httpclient.md
@@ -29,7 +29,7 @@ Most of the following examples reuse the same `HttpClient` instance, and therefo
 
 The preceding code:
 
-- Instantiates a new `HttpClient` instance as a `static` variable.
+- Instantiates a new `HttpClient` instance as a `static` variable. As per the guidelines referenced above, it's strongly recommended to reuse `HttpClient` instance(s) during the application's lifecycle.
 - Sets the <xref:System.Net.Http.HttpClient.BaseAddress?displayProperty=nameWithType> to `"https://jsonplaceholder.typicode.com"`.
 
 This `HttpClient` instance will always use the base address when making subsequent requests. To apply additional configuration consider:

--- a/docs/fundamentals/networking/snippets/httpclient/Program.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.cs
@@ -2,7 +2,7 @@
 {
     // <sharedclient>
     // HttpClient lifecycle management best practices:
-    // https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use
+    // https://learn.microsoft.com/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use
     private static HttpClient sharedClient = new()
     {
         BaseAddress = new Uri("https://jsonplaceholder.typicode.com"),

--- a/docs/fundamentals/networking/snippets/httpclient/Program.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.cs
@@ -1,22 +1,29 @@
-﻿// <todoclient>
-using HttpClient todoClient = new()
+﻿static partial class Program
 {
-    BaseAddress = new Uri("https://jsonplaceholder.typicode.com")
-};
-// </todoclient>
+    // <sharedclient>
+    // HttpClient lifecycle management best practices:
+    // https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use
+    private static HttpClient sharedClient = new()
+    {
+        BaseAddress = new Uri("https://jsonplaceholder.typicode.com"),
+    };
+    // </sharedclient>
+    public static async Task Main(string[] args)
+    {
+        await GetAsync(sharedClient);
+        await GetFromJsonAsync(sharedClient);
+        await PostAsync(sharedClient);
+        await PostAsJsonAsync(sharedClient);
+        await PutAsync(sharedClient);
+        await PutAsJsonAsync(sharedClient);
+        await PatchAsync(sharedClient);
+        await DeleteAsync(sharedClient);
 
-await GetAsync(todoClient);
-await GetFromJsonAsync(todoClient);
-await PostAsync(todoClient);
-await PostAsJsonAsync(todoClient);
-await PutAsync(todoClient);
-await PutAsJsonAsync(todoClient);
-await PatchAsync(todoClient);
-await DeleteAsync(todoClient);
+        // <client>
+        using HttpClient client = new();
+        // </client>
 
-// <client>
-using HttpClient client = new();
-// </client>
-
-await HeadAsync(client);
-await OptionsAsync(client);
+        await HeadAsync(client);
+        await OptionsAsync(client);
+    }
+}


### PR DESCRIPTION
## Summary

`using HttpClient client = new()` is a common antipattern people copy-paste into their production code from our basic examples, going against the [best practices](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use) we promote in the same doc. It's worth to be very didactic about this from the beginning.