### PR TITLE
logger-message-generator: change example param names to avoid confusion

### DIFF
--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -79,14 +79,14 @@ ILogger<SampleObject> logger = LoggerFactory.Create(
         }))
     .CreateLogger<SampleObject>();
 
-logger.CustomLogEvent(LogLevel.Information, "Liana", "California");
+logger.CustomLogEvent(LogLevel.Information, "Liana", "Seattle");
 
 public static partial class SampleObject
 {
     [LoggerMessage(EventId = 23)]
     public static partial void CustomLogEvent(
         this ILogger logger, LogLevel logLevel,
-        string name, string state);
+        string name, string city);
 }
 ```
 
@@ -101,7 +101,7 @@ Consider the example logging output when using the `JsonConsole` formatter.
   "State": {
     "Message": "",
     "name": "Liana",
-    "state": "California",
+    "city": "Seattle",
     "{OriginalFormat}": ""
   }
 }


### PR DESCRIPTION
## Summary

The original example was using `state` as a parameter name, which led to unnecessary confusion with the ILogger's `TState` and `state` mentioned elsewhere in the same doc. Modified the example to use `city` so as not to confuse future readers.
