### PR TITLE
Fix "Global IPv6 unicast addresses"

### DIFF
--- a/docs/fundamentals/networking/ipv6-overview.md
+++ b/docs/fundamentals/networking/ipv6-overview.md
@@ -109,7 +109,7 @@ IPv6 defines the following address types:
 
   - **Global IPv6 unicast addresses:**
 
-  These addresses can be used across the Internet and have the following format: `010(FP, 3 bits) TLA ID (13 bits) Reserved (8 bits) NLA ID (24 bits) SLA ID (16 bits) *InterfaceID* (64 bits)`.
+  These addresses can be used across the Internet and have the following format: `*GlobalRoutingPrefix*::*SubnetID*:*InterfaceID*`.
 
 - **Multicast address:**
 


### PR DESCRIPTION
## Summary

Fixes #26677. The old description with TLA / NLA was based on [rfc2374](https://datatracker.ietf.org/doc/html/rfc2374) which is now replaced by [rfc3587](https://datatracker.ietf.org/doc/html/rfc3587) defining Global Unicast Address as following:

```
    |         n bits          |   m bits  |       128-n-m bits         |
    +-------------------------+-----------+----------------------------+
    | global routing prefix   | subnet ID |       interface ID         |
    +-------------------------+-----------+----------------------------+
```
