### PR TITLE
Move `file` keyword into contextual keyword list

### DIFF
--- a/docs/csharp/language-reference/keywords/index.md
+++ b/docs/csharp/language-reference/keywords/index.md
@@ -45,7 +45,6 @@ The first table in this article lists keywords that are reserved identifiers in 
         [`explicit`](../operators/user-defined-conversion-operators.md)  
         [`extern`](extern.md)  
         [`false`](../builtin-types/bool.md)  
-        [`file`](file.md)  
         [`finally`](try-finally.md)  
         [`fixed`](../statements/fixed.md)  
         [`float`](../builtin-types/floating-point-numeric-types.md)  
@@ -123,6 +122,7 @@ A contextual keyword is used to provide a specific meaning in the code, but it i
         [`descending`](descending.md)  
         [`dynamic`](../builtin-types/reference-types.md)  
         [`equals`](equals.md)  
+        [`file`](file.md)  
         [`from`](from-clause.md)  
     :::column-end:::
     :::column:::


### PR DESCRIPTION
C# 11 declares a new feature using a new keyword `file` to restrict the accessibility. It should be a contextual keyword, not a predefined keyword.

Page: [C# Keywords](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/)

Content source: [docs/csharp/language-reference/keywords/index.md](https://github.com/dotnet/docs/blob/main/docs/csharp/language-reference/keywords/index.md)

---

This is my first PR. If there is something wrong with my operation or modification, please tell me :D