### PR TITLE
fix: bad escape in .repoman.yml

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -311,7 +311,7 @@ pull_request:
             - path: "(?i).*docs\/fundamentals\/networking.*"
               run:
                 - labels-add: [ "dotnet-fundamentals/prod", "dotnet-networking/tech" ]
-            - path: "(?i).*docs\/core\/extensions/\http.*"
+            - path: "(?i).*docs\/core\/extensions\/http.*"
               run:
                 - labels-add: [ "dotnet-fundamentals/prod", "dotnet-networking/tech" ]
             - path: "(?i).*docs\/framework\/wcf.*"


### PR DESCRIPTION
## Summary

Was playing with Prettier formatting on some files, and this one it choked on because of the bad escaping. Didn't include the actual formatting to make it clearer
