### PR TITLE
docs: fix grammar in numbers-in-csharp

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
@@ -173,7 +173,7 @@ items:
     useful to represent non-integral numbers that may be very large or small
     in magnitude. **Double-precision** is a relative term that describes the 
     numbers of binary digits used to store the value. **Double precision**
-    number have twice the number of binary digits as **single-precision**. On modern computers,
+    numbers have twice the number of binary digits as **single-precision**. On modern computers,
     it is more common to use double precision than single precision numbers. **Single precision** numbers are declared using the `float` keyword.
     Let's explore. Try the following code in the interactive window and see the result:
 


### PR DESCRIPTION
## Summary

The sentence "Double precision number have twice the number of binary digits as single-precision" seems to be missing an "s" in the word "numbers". 

It could also be rephrased as "A double precision number has twice the number of binary digits as single-precision".

I also noticed that "double-precision" and "double precision" are used interchangeably within the same paragraph, the same for "single-precision" and "single precision". Perhaps one should be enforced, but no change is introduced regarding this.

Thank you for a great tutorial :)