### PR TITLE
Three ASP.NET Core breaking changes

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -21,13 +21,16 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ | Preview 2 |
 | [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ | RC 1 |
 | [Default authentication scheme](aspnet-core/7.0/default-authentication-scheme.md) | ❌ | ✔️ | Preview 7 |
+| [Endpoint metadata provider interface changes](aspnet-core/7.0/iendpointmetadataprovider-changes.md) | ❌ | ❌ | RC 2 |
 | [Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed](aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md) | ❌ | ✔️ | Preview 3 |
+| [Fallback file endpoints](aspnet-core/7.0/fallback-file-endpoints.md) | ❌ | ✔️ | RC 2 |
 | [IHubClients and IHubCallerClients hide members](aspnet-core/7.0/ihubclients-ihubcallerclients.md) | ✔️ | ❌ | |
 | [Kestrel: Default HTTPS binding removed](aspnet-core/7.0/https-binding-kestrel.md) | ❌ | ✔️ | Preview 6 |
 | [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed](aspnet-core/7.0/libuv-transport-dll-removed.md) | ❌ | ❌ | Preview 1 |
 | [Microsoft.Data.SqlClient updated to 4.0.1](aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md) | ✔️ | ❌ | Preview 2 |
 | [Middleware no longer defers to endpoint with null request delegate](aspnet-core/7.0/middleware-null-requestdelegate.md) | ❌ | ✔️ | Preview 7 |
 | [MVC's detection of an empty body in model binding changed](aspnet-core/7.0/mvc-empty-body-model-binding.md) | ❌ | ✔️ | Preview 3 |
+| [Output caching API changes](aspnet-core/7.0/output-caching-renames.md) | ❌ | ❌ | RC 2 |
 | [SignalR Hub methods try to resolve parameters from DI](aspnet-core/7.0/signalr-hub-method-parameters-di.md) | ✔️ | ❌ | Preview 2 |
 
 ## Core .NET libraries

--- a/docs/core/compatibility/aspnet-core/7.0/fallback-file-endpoints.md
+++ b/docs/core/compatibility/aspnet-core/7.0/fallback-file-endpoints.md
@@ -1,0 +1,41 @@
+---
+title: "Breaking change: Fallback file endpoints"
+description: Learn about the breaking change in ASP.NET Core 7.0 where endpoints configured with 'MapFallbackToFile()' now only match 'HEAD' and 'GET' requests.
+ms.date: 10/10/2022
+---
+# Fallback file endpoints
+
+The <xref:Microsoft.AspNetCore.Mvc.ConsumesAttribute> attribute allows controller actions to specify their supported content types. Starting in .NET 6, if a fallback file endpoint was configured, it could match routes that were discarded because the request had a different content type than what was specified in an action's <xref:Microsoft.AspNetCore.Mvc.ConsumesAttribute>. The .NET 6 behavior was an undesirable change from the .NET 5 behavior. This breaking change partially addresses the issue by making fallback file endpoints only match `GET` and `HEAD` requests.
+
+## Version introduced
+
+ASP.NET Core 7.0 RC 2
+
+## Previous behavior
+
+Endpoints configured with <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=nameWithType> matched requests made with any request method.
+
+## New behavior
+
+Endpoints configured with <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=nameWithType> only match `HEAD` and `GET` requests.
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change partially reverts a larger breaking change accidentally introduced in .NET 6. Since it's highly unusual to expect a fallback file response when making a request with a method other than `HEAD` or `GET`, the impact of this breaking change should be minimal.
+
+## Recommended action
+
+If you want fallback file endpoints to match requests with methods other than HEAD or GET, you can specify additional HTTP request methods using `WithMetadata()`. For example:
+
+```csharp
+endpoints.MapFallbackToFile("index.html")
+    .WithMetadata(new HttpMethodMetadata(new[] { /* List supported methods here */ }));
+```
+
+## Affected APIs
+
+- All overloads of <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=fullName>.

--- a/docs/core/compatibility/aspnet-core/7.0/fallback-file-endpoints.md
+++ b/docs/core/compatibility/aspnet-core/7.0/fallback-file-endpoints.md
@@ -38,4 +38,4 @@ endpoints.MapFallbackToFile("index.html")
 
 ## Affected APIs
 
-- All overloads of <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=fullName>.
+- <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=fullName>

--- a/docs/core/compatibility/aspnet-core/7.0/iendpointmetadataprovider-changes.md
+++ b/docs/core/compatibility/aspnet-core/7.0/iendpointmetadataprovider-changes.md
@@ -1,0 +1,50 @@
+---
+title: "Breaking change: Endpoint metadata provider interface changes"
+description: Learn about the breaking change in ASP.NET Core 7.0 where changes were made to the IEndpointMetadataProvider and IEndpointParameterMetadataProvider interfaces.
+ms.date: 10/10/2022
+---
+# Endpoint metadata provider interface changes
+
+The <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> and <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider> interfaces introduced in .NET 7 Preview 4 have been updated to take an <xref:Microsoft.AspNetCore.Builder.EndpointBuilder> rather than an <xref:Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext> or <xref:Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext>.
+
+## Version introduced
+
+ASP.NET Core 7.0 RC 2
+
+## Previous behavior
+
+The `PopulateMetadata()` methods on both the <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> and <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider> interfaces took their respective context arguments as a single parameter. Both contexts included services (<xref:System.IServiceProvider>) and endpoint metadata (`IList<object>`).
+
+<xref:Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext> included the <xref:System.Reflection.MethodInfo> for the minimal route handler MVC action that took the implementing type as a parameter or returned it. <xref:Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext> provided <xref:System.Reflection.ParameterInfo> and could only be used on parameter types.
+
+## New behavior
+
+The `PopulateMetadata()` methods on both the <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> and <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider> interfaces take an <xref:Microsoft.AspNetCore.Builder.EndpointBuilder> as their second parameter. The `EndpointBuilder` provides access to the application services (<xref:System.IServiceProvider>) and endpoint metadata (`IList<object>`) previously provided by <xref:Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext> and <xref:Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext>.
+
+<xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> takes a <xref:System.Reflection.MethodInfo> and <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider> takes a <xref:System.Reflection.ParameterInfo> as the first parameter.
+
+<xref:Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext> and <xref:Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext> have been removed.
+
+## Type of breaking change
+
+This change affects [binary compatibility](../../categories.md#binary-compatibility) and [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+The metadata providers now get access to more metadata like the `RoutePattern` (with a downcast) and `DisplayName` via the `EndpointBuilder`, and this allowed us to delete unnecessary context types.
+
+## Recommended action
+
+Update implementations of <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> and <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider> to access the necessary information from the new parameters. Everything that was previously available via the contexts is now available via the new parameters of `PopulateMetadata()`.
+
+## Affected APIs
+
+The parameters on the following two methods changed:
+
+- <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider.PopulateMetadata(Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext)?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider.PopulateMetadata(Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext)?displayProperty=fullName>
+
+The following two types were removed:
+
+- <xref:Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext?displayProperty=fullName>

--- a/docs/core/compatibility/aspnet-core/7.0/output-caching-renames.md
+++ b/docs/core/compatibility/aspnet-core/7.0/output-caching-renames.md
@@ -1,0 +1,64 @@
+---
+title: "Breaking change: Output caching API changes"
+description: Learn about the breaking change in ASP.NET Core 7.0 where changes were made to some output caching APIs.
+ms.date: 10/10/2022
+---
+# Output caching API changes
+
+Some APIs in the <xref:Microsoft.AspNetCore.OutputCaching?displayProperty=fullName> namespace have changed to better represent their intent.
+
+The following APIs were removed:
+
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.%23ctor> constructor
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.Clear?displayProperty=nameWithType>
+
+The following APIs were renamed:
+
+| Previous name | New name |
+| - | - |
+| <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.AllowLocking(System.Boolean)?displayProperty=nameWithType> | `SetLocking()` |
+| <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByRouteValue(System.String[])?displayProperty=nameWithType> | `SetVaryByRouteValue()` |
+| <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByQuery(System.String[])?displayProperty=nameWithType> | `SetVaryByQuery` |
+| <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByHeader(System.String[])?displayProperty=nameWithType> | `SetVaryByHeader` |
+
+The following APIs were added:
+
+- `CacheVaryByRules.VaryByHost`
+- `OutputCacheOptions.AddPolicy(string name, Action<OutputCachePolicyBuilder> build, bool excludeDefaultPolicy)`
+- `OutputCacheOptions.AddBasePolicy(Action<OutputCachePolicyBuilder> build, bool excludeDefaultPolicy)`
+- `Microsoft.Extensions.DependencyInjection.OutputCacheConventionBuilderExtensions.CacheOutput<TBuilder>(this TBuilder builder, Action<OutputCachePolicyBuilder> policy, bool excludeDefaultPolicy)`
+
+## Version introduced
+
+ASP.NET Core 7.0 RC 2
+
+## Previous behavior
+
+<xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByQuery(System.String[])?displayProperty=nameWithType> was additive: every call added more query string keys.
+
+## New behavior
+
+The <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByQuery(System.String[])?displayProperty=nameWithType> method is now named `OutputCachePolicyBuilder.SetVaryByQuery`, and each call replaces existing query string keys.
+
+For other changes, see the first section of this article.
+
+## Type of breaking change
+
+This change affects [source compatibility](../../categories.md#source-compatibility) and [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change was made to improve the consistency of method names and to remove ambiguity in their behavior.
+
+## Recommended action
+
+Recompile any projects built with an earlier SDK. If you referenced any of these method names directly, update the source to reflect the new names.
+
+## Affected APIs
+
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.%23ctor> constructor
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.Clear?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.AllowLocking(System.Boolean)?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByRouteValue(System.String[])?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByQuery(System.String[])?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByHeader(System.String[])?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -31,8 +31,12 @@ items:
           href: aspnet-core/7.0/authenticateasync-anonymous-request.md
         - name: Default authentication scheme
           href: aspnet-core/7.0/default-authentication-scheme.md
+        - name: Endpoint metadata provider interface changes
+          href: aspnet-core/7.0/iendpointmetadataprovider-changes.md
         - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed
           href: aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
+        - name: Fallback file endpoints
+          href: aspnet-core/7.0/fallback-file-endpoints.md
         - name: IHubClients and IHubCallerClients hide members
           href: aspnet-core/7.0/ihubclients-ihubcallerclients.md
         - name: "Kestrel: Default HTTPS binding removed"
@@ -45,6 +49,8 @@ items:
           href: aspnet-core/7.0/middleware-null-requestdelegate.md
         - name: MVC's detection of an empty body in model binding changed
           href: aspnet-core/7.0/mvc-empty-body-model-binding.md
+        - name: Output caching API changes
+          href: aspnet-core/7.0/output-caching-renames.md
         - name: SignalR Hub methods try to resolve parameters from DI
           href: aspnet-core/7.0/signalr-hub-method-parameters-di.md
       - name: Core .NET libraries
@@ -641,8 +647,12 @@ items:
           href: aspnet-core/7.0/authenticateasync-anonymous-request.md
         - name: Default authentication scheme
           href: aspnet-core/7.0/default-authentication-scheme.md
+        - name: Endpoint metadata provider interface changes
+          href: aspnet-core/7.0/iendpointmetadataprovider-changes.md
         - name: Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed
           href: aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
+        - name: Fallback file endpoints
+          href: aspnet-core/7.0/fallback-file-endpoints.md
         - name: IHubClients and IHubCallerClients hide members
           href: aspnet-core/7.0/ihubclients-ihubcallerclients.md
         - name: "Kestrel: Default HTTPS binding removed"
@@ -655,6 +665,8 @@ items:
           href: aspnet-core/7.0/middleware-null-requestdelegate.md
         - name: MVC's detection of an empty body in model binding changed
           href: aspnet-core/7.0/mvc-empty-body-model-binding.md
+        - name: Output caching API changes
+          href: aspnet-core/7.0/output-caching-renames.md
         - name: SignalR Hub methods try to resolve parameters from DI
           href: aspnet-core/7.0/signalr-hub-method-parameters-di.md
       - name: .NET 6


### PR DESCRIPTION
Related to:

https://github.com/aspnet/Announcements/issues/496 - [preview link](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/iendpointmetadataprovider-changes?branch=pr-en-us-31688)
https://github.com/aspnet/Announcements/issues/495 - [preview link](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/fallback-file-endpoints?branch=pr-en-us-31688)
https://github.com/aspnet/Announcements/issues/492 - [preview link](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/output-caching-renames?branch=pr-en-us-31688)