### PR TITLE
Do not use smart quotes in code examples

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/constructing-types-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/constructing-types-entity-sql.md
@@ -46,7 +46,7 @@ Entity SQL allows type constructors (initializers) to create instances of named 
 
 The following expression creates an instance of a complex type.
 
-`MyModel.ZipCode(‘98118’, ‘4567’)`
+`MyModel.ZipCode('98118', '4567')`
 
 The following expression creates an instance of a nested complex type.
 
@@ -56,7 +56,7 @@ The following expression creates an instance of an entity with a nested complex 
 
 `MyModel.Person("Bill", MyModel.AddressInfo('My street address', 'Seattle', 'WA', MyModel.ZipCode('98118', '4567')))`
 
-The following example shows how to initialize a property of a complex type to null. `MyModel.ZipCode(‘98118’, null)`
+The following example shows how to initialize a property of a complex type to null. `MyModel.ZipCode('98118', null)`
 
 The arguments to the constructor are assumed to be in the same order as the declaration of the attributes of the type.
 

--- a/docs/framework/data/adonet/ef/language-reference/entity-sql-quick-reference.md
+++ b/docs/framework/data/adonet/ef/language-reference/entity-sql-quick-reference.md
@@ -73,7 +73,7 @@ DATETIME '2006-12-25 01:01'
 
 ### ROW
 
- [ROW](row-entity-sql.md) constructs an anonymous, structurally-typed (record) value as in: `ROW(1 AS myNumber, ‘Name’ AS myName).`
+ [ROW](row-entity-sql.md) constructs an anonymous, structurally-typed (record) value as in: `ROW(1 AS myNumber, 'Name' AS myName).`
 
  Example:
 

--- a/docs/framework/data/adonet/ef/language-reference/literals-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/literals-entity-sql.md
@@ -66,8 +66,8 @@ DATETIME'2006-12-25 01:01:00.0000000' -- same as DATETIME'2006-12-25 01:01'
  There can be any number of spaces between the TIME symbol and the literal payload, but no new lines.
 
 ```sql
-TIME‘23:11’
-TIME‘01:01:00.1234567’
+TIME'23:11'
+TIME'01:01:00.1234567'
 ```
 
 ## DateTimeOffset
@@ -77,8 +77,8 @@ TIME‘01:01:00.1234567’
  There can be any number of spaces between the DATETIMEOFFSET symbol and the literal payload, but no new lines.
 
 ```sql
-DATETIMEOFFSET‘2006-10-1 23:11 +02:00’
-DATETIMEOFFSET‘2006-12-25 01:01:00.0000000 -08:30’
+DATETIMEOFFSET'2006-10-1 23:11 +02:00'
+DATETIMEOFFSET'2006-12-25 01:01:00.0000000 -08:30'
 ```
 
 > [!NOTE]

--- a/docs/framework/data/adonet/ef/language-reference/named-type-constructor-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/named-type-constructor-entity-sql.md
@@ -36,7 +36,7 @@ Used to create instances of conceptual model nominal types such as Entity or Com
   
  The expression below creates an instance of a complex type:  
   
- `MyModel.ZipCode(‘98118’, ‘4567’)`  
+ `MyModel.ZipCode('98118', '4567')`  
   
  The expression below creates an instance of a nested complex type:  
   
@@ -46,7 +46,7 @@ Used to create instances of conceptual model nominal types such as Entity or Com
   
  `MyModel.Person("Bill", MyModel.AddressInfo('My street address', 'Seattle', 'WA', MyModel.ZipCode('98118', '4567')))`  
   
- The following example shows how to initialize a property of a complex type to null:`MyModel.ZipCode(‘98118’, null)`  
+ The following example shows how to initialize a property of a complex type to null:`MyModel.ZipCode('98118', null)`  
   
 ## Example  
 

--- a/docs/framework/data/adonet/sql/linq/sql-clr-type-mismatches.md
+++ b/docs/framework/data/adonet/sql/linq/sql-clr-type-mismatches.md
@@ -198,9 +198,9 @@ Operators and functions that are essentially comparable have subtly different se
     create table T4 (
         Col1      nvarchar (256)
     )
-    insert into T4 values (‘Food’)
-    insert into T4 values (‘FOOD’)
-    select * from T4 where Col1 = ‘food’
+    insert into T4 values ('Food')
+    insert into T4 values ('FOOD')
+    select * from T4 where Col1 = 'food'
     -- Both the rows are returned because of case-insensitive matching.
     ```
 
@@ -249,7 +249,7 @@ create table T5 (
     Col1      nvarchar(10),
     Col2      nvarchar(10)
 )
-Insert into T5(col1, col2) values (‘3’, ‘2’);
+Insert into T5(col1, col2) values ('3', '2');
 ```
 
 [!code-csharp[DLinqMismatch#8](../../../../../../samples/snippets/csharp/VS_Snippets_Data/DLinqMismatch/cs/Program.cs#8)]

--- a/docs/framework/whats-new/whats-new-in-accessibility.md
+++ b/docs/framework/whats-new/whats-new-in-accessibility.md
@@ -161,7 +161,7 @@ public Form1()
 }
 
 …
-Label1.Text = “Ready!”;
+Label1.Text = "Ready!";
 ```
 
 Narrator announces “Ready” regardless of where the user is interacting with the application.

--- a/docs/fsharp/what-is-fsharp.md
+++ b/docs/fsharp/what-is-fsharp.md
@@ -97,8 +97,8 @@ type Set<'T when 'T: comparison>(elements: seq<'T>) =
     // ...
     // Further Implementation elided
     // ...
-    interface IEnumerable<‘T>
-    interface IReadOnlyCollection<‘T>
+    interface IEnumerable<'T>
+    interface IReadOnlyCollection<'T>
 
 module Set =
     let isEmpty (set: Set<'T>) = set.IsEmpty

--- a/docs/fsharp/whats-new/fsharp-6.md
+++ b/docs/fsharp/whats-new/fsharp-6.md
@@ -475,7 +475,7 @@ For example, consider the following F# 5 code:
 let r = ref 0
 
 let doSomething() =
-    printfn "doing something”
+    printfn "doing something"
     r := !r + 1
 ```
 
@@ -485,7 +485,7 @@ First, reference cells are rarely needed in modern F# coding, as `let mutable` c
 let mutable r = 0
 
 let doSomething() =
-    printfn "doing something”
+    printfn "doing something"
     r <- r + 1
 ```
 
@@ -495,7 +495,7 @@ If you use reference cells, F# 6 emits an informational warning asking you to ch
 let r = ref 0
 
 let doSomething() =
-    printfn "doing something”
+    printfn "doing something"
     r.Value <- r.Value + 1
 ```
 


### PR DESCRIPTION
## Summary

Small changes to code samples that use smart quotes instead of regular quotes.
This fixes some samples and should allow for a better copy & paste experience.
