### PR TITLE
Fix cancellation by polling example (#31643)

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellation.csproj
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellation.csproj
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellation.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
@@ -41,23 +41,22 @@ class CancelByPolling
    static void NestedLoops(Rectangle rect, CancellationToken token)
    {
       for (int x = 0; x < rect.columns && !token.IsCancellationRequested; x++) {
+         // Assume that we know that the inner loop is very fast.
+         // Therefore, checking once per row in the outer loop is sufficient.
          for (int y = 0; y < rect.rows; y++) {
             // Simulating work.
             Thread.SpinWait(5000);
             Console.Write("{0},{1} ", x, y);
          }
+      }
 
-         // Assume that we know that the inner loop is very fast.
-         // Therefore, checking once per row is sufficient.
-         if (token.IsCancellationRequested) {
-            // Cleanup or undo here if necessary...
-            Console.WriteLine("\r\nCancelling after row {0}.", x);
-            Console.WriteLine("Press any key to exit.");
-            // then...
-            break;
-            // ...or, if using Task:
-            // token.ThrowIfCancellationRequested();
-         }
+      if (token.IsCancellationRequested) {
+         // Cleanup or undo here if necessary...
+         Console.WriteLine("\r\nCancelling after row {0}.", x);
+         Console.WriteLine("Press any key to exit.");
+
+         // If using Task:
+         // token.ThrowIfCancellationRequested();
       }
    }
    //</snippet3>

--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
@@ -40,14 +40,13 @@ class CancelByPolling
    //<snippet3>
    static void NestedLoops(Rectangle rect, CancellationToken token)
    {
-      int col = 0;
-      for (; col < rect.columns && !token.IsCancellationRequested; col++) {
+      for (int col = 0; col < rect.columns && !token.IsCancellationRequested; col++) {
          // Assume that we know that the inner loop is very fast.
          // Therefore, polling once per column in the outer loop condition
          // is sufficient.
          for (int row = 0; row < rect.rows; row++) {
             // Simulating work.
-            Thread.SpinWait(5000);
+            Thread.SpinWait(5_000);
             Console.Write("{0},{1} ", col, row);
          }
       }

--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
@@ -40,19 +40,21 @@ class CancelByPolling
    //<snippet3>
    static void NestedLoops(Rectangle rect, CancellationToken token)
    {
-      for (int x = 0; x < rect.columns && !token.IsCancellationRequested; x++) {
+      int col = 0;
+      for (; col < rect.columns && !token.IsCancellationRequested; col++) {
          // Assume that we know that the inner loop is very fast.
-         // Therefore, checking once per row in the outer loop is sufficient.
-         for (int y = 0; y < rect.rows; y++) {
+         // Therefore, polling once per column in the outer loop condition
+         // is sufficient.
+         for (int row = 0; row < rect.rows; row++) {
             // Simulating work.
             Thread.SpinWait(5000);
-            Console.Write("{0},{1} ", x, y);
+            Console.Write("{0},{1} ", col, row);
          }
       }
 
       if (token.IsCancellationRequested) {
          // Cleanup or undo here if necessary...
-         Console.WriteLine("\r\nCancelling after row {0}.", x);
+         Console.WriteLine("\r\nCancelling before column {0}.", col);
          Console.WriteLine("Press any key to exit.");
 
          // If using Task:

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellation.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellation.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellation.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellation.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex11.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex11.vb
@@ -41,19 +41,21 @@ Class CancelByPolling
 
     '<snippet3>
     Shared Sub NestedLoops(ByVal rect As Rectangle, ByVal token As CancellationToken)
-        For x As Integer = 0 To rect.columns
+        Dim col As Integer
+        For col = 0 To rect.columns - 1
             ' Assume that we know that the inner loop is very fast.
-            ' Therefore, checking once per row in the outer loop is sufficient.
-            For y As Integer = 0 To rect.rows
+            ' Therefore, polling once per column in the outer loop condition
+            ' is sufficient.
+            For col As Integer = 0 To rect.rows - 1
                 ' Simulating work.
                 Thread.SpinWait(5000)
-                Console.Write("0' end block,1' end block ", x, y)
+                Console.Write("0',1' ", x, y)
             Next
         Next
 
         If token.IsCancellationRequested = True Then
             ' Cleanup or undo here if necessary...
-            Console.WriteLine(vbCrLf + "Cancelling after row 0' end block.", x)
+            Console.WriteLine(vbCrLf + "Cancelling before column 0'.", col)
             Console.WriteLine("Press any key to exit.")
 
             ' If using Task:

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex11.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex11.vb
@@ -42,24 +42,23 @@ Class CancelByPolling
     '<snippet3>
     Shared Sub NestedLoops(ByVal rect As Rectangle, ByVal token As CancellationToken)
         For x As Integer = 0 To rect.columns
+            ' Assume that we know that the inner loop is very fast.
+            ' Therefore, checking once per row in the outer loop is sufficient.
             For y As Integer = 0 To rect.rows
                 ' Simulating work.
                 Thread.SpinWait(5000)
                 Console.Write("0' end block,1' end block ", x, y)
             Next
-
-            ' Assume that we know that the inner loop is very fast.
-            ' Therefore, checking once per row is sufficient.
-            If token.IsCancellationRequested = True Then
-                ' Cleanup or undo here if necessary...
-                Console.WriteLine(vbCrLf + "Cancelling after row 0' end block.", x)
-                Console.WriteLine("Press any key to exit.")
-                ' then...
-                Exit For
-                ' ...or, if using Task:
-                ' token.ThrowIfCancellationRequested()
-            End If
         Next
+
+        If token.IsCancellationRequested = True Then
+            ' Cleanup or undo here if necessary...
+            Console.WriteLine(vbCrLf + "Cancelling after row 0' end block.", x)
+            Console.WriteLine("Press any key to exit.")
+
+            ' If using Task:
+            ' token.ThrowIfCancellationRequested()
+        End If
     End Sub
     '</snippet3>
 End Class


### PR DESCRIPTION
## Summary

I moved the `token.IsCancellationRequested`-block out of the outer loop to ensure it is checked in all cases.

Fixes #31643 
