### PR TITLE
Remove superfluous output (#30419)

### DIFF
--- a/docs/fsharp/language-reference/arrays.md
+++ b/docs/fsharp/language-reference/arrays.md
@@ -138,13 +138,6 @@ The output of the preceding code is as follows.
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/arrays/snippet16.fs)]
 
-The output of the preceding code is as follows.
-
-```console
-[|(1, 1, 1); (1, 2, 2); (1, 3, 3); (2, 1, 2); (2, 2, 4); (2, 3, 6); (3, 1, 3);
-(3, 2, 6); (3, 3, 9)|]
-```
-
 [`Array.filter`](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-arraymodule.html#filter) takes a Boolean condition function and generates a new array that contains only those elements from the input array for which the condition is true. The following code demonstrates `Array.filter`.
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/arrays/snippet17.fs)]


### PR DESCRIPTION
## Summary

I removed the output that does not belong to the `Array.concat` example.

Fixes #30419