### PR TITLE
Rename result to quotient (#30705)

### DIFF
--- a/docs/csharp/tour-of-csharp/snippets/shared/ClassesObjects.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/ClassesObjects.cs
@@ -290,16 +290,16 @@ namespace TourOfCsharp
         // </RefExample>
 
         // <OutExample>
-        static void Divide(int x, int y, out int result, out int remainder)
+        static void Divide(int x, int y, out int quotient, out int remainder)
         {
-            result = x / y;
+            quotient = x / y;
             remainder = x % y;
         }
         
         public static void OutUsage()
         {
-            Divide(10, 3, out int res, out int rem);
-            Console.WriteLine($"{res} {rem}");	// "3 1"
+            Divide(10, 3, out int quo, out int rem);
+            Console.WriteLine($"{quo} {rem}");	// "3 1"
         }
         // </OutExample>
 


### PR DESCRIPTION
## Summary

I renamed the `result`/`res` variable to `quotient`/`quo` (not sure about the abbrivation though).

Fixes #30705
