### PR TITLE
Environment variable prefix breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -71,6 +71,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [ContentRootPath for apps launched by Windows Shell](extensions/7.0/contentrootpath-hosted-app.md) | ❌ | ✔️ | Preview 6 |
+| [Environment variable prefixes](extensions/7.0/environment-variable-prefix.md) | ❌ | ✔️ | Preview 4 |
 
 ## Globalization
 

--- a/docs/core/compatibility/extensions/7.0/environment-variable-prefix.md
+++ b/docs/core/compatibility/extensions/7.0/environment-variable-prefix.md
@@ -47,6 +47,7 @@ var loadedValue = config.GetValue<string?>("ConfigKey", null);
 
 Console.WriteLine(String.Equals(myValue, loadedValue));
 // True
+```
 
 ## New behavior
 
@@ -74,7 +75,7 @@ This change can affect [binary compatibility](../../categories.md#binary-compati
 
 ## Reason for change
 
-This change was made to fix an unintentional behavior change for environment variable prefix delimiters in .NET 6. The new behavior matches the .NET 5 behavior.
+This change was made to fix an unintentional behavior change for normalizing environment variable prefix filters in .NET 6. The new behavior matches the .NET 5 behavior.
 
 ## Recommended action
 

--- a/docs/core/compatibility/extensions/7.0/environment-variable-prefix.md
+++ b/docs/core/compatibility/extensions/7.0/environment-variable-prefix.md
@@ -82,4 +82,8 @@ Most developers won't be affected by this change, since it corrects previously e
 
 ## Affected APIs
 
-- <xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Configuration.EnvironmentVariablesExtensions.AddEnvironmentVariables(Microsoft.Extensions.Configuration.IConfigurationBuilder,System.String)?displayProperty=fullName>
+
+## See also
+
+- [Configuration in .NET](../../../extensions/configuration.md)

--- a/docs/core/compatibility/extensions/7.0/environment-variable-prefix.md
+++ b/docs/core/compatibility/extensions/7.0/environment-variable-prefix.md
@@ -1,0 +1,85 @@
+---
+title: "Breaking change: Environment variable prefixes"
+description: Learn about the .NET 7 breaking change in .NET extensions where the comparison of normalized prefixes and environment variables has changed.
+ms.date: 10/12/2022
+---
+# Environment variable prefixes
+
+[Hierarchical data](../../../extensions/configuration.md#binding-hierarchies) is represented using `:` as the level delimiter. However, for environmental variables, the `:` character is normalized to `__`, because the latter is supported on all platforms. This change affects how normalized and non-normalized prefixes and keys are compared. Specifically, you can now add environment variables by specifying a prefix containing either `:` or `__` as the delimiter. Either syntax will match any environment variables with a matching prefix followed by either a `:` or `__`. Some environment variables that theoretically didn't match the filter previously may now match the filter.
+
+## Version introduced
+
+.NET 7 Preview 4
+
+## Previous behavior
+
+Previously, the following code printed `False`:
+
+```csharp
+using Microsoft.Extensions.Configuration;
+
+const string myValue = "value1";
+Environment.SetEnvironmentVariable("MY_PREFIX__ConfigKey", myValue);
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddEnvironmentVariables(prefix: "MY_PREFIX__")
+    .Build();
+
+var loadedValue = config.GetValue<string?>("ConfigKey", null);
+
+Console.WriteLine(String.Equals(myValue, loadedValue));
+// False
+```
+
+In order for the `MY_PREFIX__ConfigKey` environment variable to be added to the configuration, you had to add environment variables using a delimiter of `:` instead of `__`:
+
+```csharp
+using Microsoft.Extensions.Configuration;
+
+const string myValue = "value1";
+Environment.SetEnvironmentVariable("MY_PREFIX__ConfigKey", myValue);
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddEnvironmentVariables(prefix: "MY_PREFIX:")
+    .Build();
+
+var loadedValue = config.GetValue<string?>("ConfigKey", null);
+
+Console.WriteLine(String.Equals(myValue, loadedValue));
+// True
+
+## New behavior
+
+Starting in .NET 7, the following code prints `True`:
+
+```csharp
+using Microsoft.Extensions.Configuration;
+
+const string myValue = "value1";
+Environment.SetEnvironmentVariable("MY_PREFIX__ConfigKey", myValue);
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddEnvironmentVariables(prefix: "MY_PREFIX__")
+    .Build();
+
+var loadedValue = config.GetValue<string?>("ConfigKey", null);
+
+Console.WriteLine(String.Equals(myValue, loadedValue));
+// True
+```
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change was made to fix an unintentional behavior change for environment variable prefix delimiters in .NET 6. The new behavior matches the .NET 5 behavior.
+
+## Recommended action
+
+Most developers won't be affected by this change, since it corrects previously erroneous behavior. In the unlikely case that you relied on the fact that a prefix containing `__` didn't match an environment variable containing `__`, consider changing the prefixes of those variables.
+
+## Affected APIs
+
+- <xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -103,6 +103,8 @@ items:
         items:
         - name: ContentRootPath for apps launched by Windows Shell
           href: extensions/7.0/contentrootpath-hosted-app.md
+        - name: Environment variable prefixes
+          href: extensions/7.0/environment-variable-prefix.md
       - name: Interop
         items:
         - name: RuntimeInformation.OSArchitecture under emulation
@@ -1023,6 +1025,8 @@ items:
         items:
         - name: ContentRootPath for apps launched by Windows Shell
           href: extensions/7.0/contentrootpath-hosted-app.md
+        - name: Environment variable prefixes
+          href: extensions/7.0/environment-variable-prefix.md
       - name: .NET 6
         items:
         - name: AddProvider checks for non-null provider

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -3,7 +3,7 @@ title: Configuration providers
 description: Learn how the Configuration provider API is used to configure .NET applications.
 author: IEvangelist
 ms.author: dapine
-ms.date: 10/04/2022
+ms.date: 10/12/2022
 ms.topic: reference
 ---
 
@@ -150,27 +150,29 @@ The application would write the following sample output:
 
 Using the default configuration, the <xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider> loads configuration from environment variable key-value pairs after reading *appsettings.json*, *appsettings.*`Environment`*.json*, and Secret manager. Therefore, key values read from the environment override values read from *appsettings.json*, *appsettings.*`Environment`*.json*, and Secret manager.
 
-The `:` separator doesn't work with environment variable hierarchical keys on all platforms. The double underscore (`__`) is automatically replaced by a `:` and is supported by all platforms. For example, the `:` separator is not supported by [Bash](https://linuxhint.com/bash-environment-variables), but `__` is.
+The `:` delimiter doesn't work with environment variable hierarchical keys on all platforms. For example, the `:` delimiter is not supported by [Bash](https://linuxhint.com/bash-environment-variables). The double underscore (`__`), which is supported on all platforms, automatically replaces any `:` delimiters in environment variables.
 
-The following `set` commands:
+Consider the `TransientFaultHandlingOptions` class:
 
-- Set the environment keys and values of the preceding example on Windows.
-- Test the settings by changing them from their default values. The `dotnet run` command must be run in the project directory.
+```csharp
+public class TransientFaultHandlingOptions
+{
+    public bool Enabled { get; set; }
+    public TimeSpan AutoRetryDelay { get; set; }
+}
+```
+
+The following `set` commands set the environment keys and values of `SecretKey` and `TransientFaultHandlingOptions`.
 
 ```dotnetcli
 set SecretKey="Secret key from environment"
 set TransientFaultHandlingOptions__Enabled="true"
 set TransientFaultHandlingOptions__AutoRetryDelay="00:00:13"
-
-dotnet run
 ```
 
-The preceding environment settings:
+These environment settings are only set in processes launched from the command window they were set in. They aren't read by web apps launched with Visual Studio.
 
-- Are only set in processes launched from the command window they were set in.
-- Won't be read by web apps launched with Visual Studio.
-
-With Visual Studio 2019 version 16.10 preview 4 and later, you can specify environment variables using the **Launch Profiles** dialog.
+With Visual Studio 2019 and later, you can specify environment variables using the **Launch Profiles** dialog.
 
 :::image type="content" source="media/launch-profiles-env-vars.png" alt-text="Launch Profiles dialog showing environment variables" lightbox="media/launch-profiles-env-vars.png":::
 
@@ -180,16 +182,16 @@ The following [setx](/windows-server/administration/windows-commands/setx) comma
 setx SecretKey "Secret key from setx environment" /M
 setx TransientFaultHandlingOptions__Enabled "true" /M
 setx TransientFaultHandlingOptions__AutoRetryDelay "00:00:05" /M
-
-dotnet run
 ```
 
-To test that the preceding commands override *appsettings.json* and *appsettings.*`Environment`*.json*:
+To test that the preceding commands override any *appsettings.json* and *appsettings.*`Environment`*.json* settings:
 
 - With Visual Studio: Exit and restart Visual Studio.
 - With the CLI: Start a new command window and enter `dotnet run`.
 
-Call <xref:Microsoft.Extensions.Configuration.EnvironmentVariablesExtensions.AddEnvironmentVariables%2A> with a string to specify a prefix for environment variables:
+### Prefixes
+
+To specify a prefix for environment variables, call <xref:Microsoft.Extensions.Configuration.EnvironmentVariablesExtensions.AddEnvironmentVariables%2A> with a string:
 
 :::code language="csharp" source="snippets/configuration/console-env/Program.cs" highlight="6-7":::
 
@@ -200,24 +202,9 @@ In the preceding code:
 
 The prefix is stripped off when the configuration key-value pairs are read.
 
-The following commands test the custom prefix:
-
-```dotnetcli
-set CustomPrefix_SecretKey="Secret key with CustomPrefix_ environment"
-set CustomPrefix_TransientFaultHandlingOptions__Enabled=true
-set CustomPrefix_TransientFaultHandlingOptions__AutoRetryDelay=00:00:21
-
-dotnet run
-```
-
 The default configuration loads environment variables and command-line arguments prefixed with `DOTNET_`. The `DOTNET_` prefix is used by .NET for [host](generic-host.md#host-configuration) and [app configuration](generic-host.md#app-configuration), but not for user configuration.
 
 For more information on host and app configuration, see [.NET Generic Host](generic-host.md).
-
-On [Azure App Service](https://azure.microsoft.com/services/app-service), select **New application setting** on the **Settings > Configuration** page. Azure App Service application settings are:
-
-- Encrypted at rest and transmitted over an encrypted channel.
-- Exposed as environment variables.
 
 ### Connection string prefixes
 
@@ -246,6 +233,13 @@ When an environment variable is discovered and loaded into configuration with an
 
 Environment variables set in *launchSettings.json* override those set in the system environment.
 
+### Azure App Service settings
+
+On [Azure App Service](https://azure.microsoft.com/services/app-service), select **New application setting** on the **Settings** > **Configuration** page. Azure App Service application settings are:
+
+- Encrypted at rest and transmitted over an encrypted channel.
+- Exposed as environment variables.
+
 ## Command-line configuration provider
 
 Using the default configuration, the <xref:Microsoft.Extensions.Configuration.CommandLine.CommandLineConfigurationProvider> loads configuration from command-line argument key-value pairs after the following configuration sources:
@@ -256,7 +250,7 @@ Using the default configuration, the <xref:Microsoft.Extensions.Configuration.Co
 
 By default, configuration values set on the command line override configuration values set with all the other configuration providers.
 
-With Visual Studio 2019 version 16.10 preview 4 and later, you can specify command-line arguments using the **Launch Profiles** dialog.
+With Visual Studio 2019 and later, you can specify command-line arguments using the **Launch Profiles** dialog.
 
 :::image type="content" source="media/launch-profiles-cmd-line-args.png" alt-text="Launch Profiles dialog showing command-line arguments" lightbox="media/launch-profiles-cmd-line-args.png":::
 


### PR DESCRIPTION
[Breaking change preview link](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/7.0/environment-variable-prefix?branch=pr-en-us-31742).

Fixes #31490.

Also removes some confusing content from the environment variables config provider article.