### PR TITLE
Update high-performance-logging.md with note

### DIFF
--- a/docs/core/extensions/high-performance-logging.md
+++ b/docs/core/extensions/high-performance-logging.md
@@ -15,6 +15,9 @@ The <xref:Microsoft.Extensions.Logging.LoggerMessage> class exposes functionalit
 - Logger extension methods require "boxing" (converting) value types, such as `int`, into `object`. The <xref:Microsoft.Extensions.Logging.LoggerMessage> pattern avoids boxing by using static <xref:System.Action> fields and extension methods with strongly typed parameters.
 - Logger extension methods must parse the message template (named format string) every time a log message is written. <xref:Microsoft.Extensions.Logging.LoggerMessage> only requires parsing a template once when the message is defined.
 
+> [!IMPORTANT]
+> Instead of using the [LoggerMessage class](xref:Microsoft.Extensions.Logging.LoggerMessage) to create high-performance logs, you can use the [LoggerMessage attribute](xref:Microsoft.Extensions.Logging.LoggerMessageAttribute) in .NET 6.0. The `LoggerMessageAttribute` provides source-generation logging support designed to deliver a highly usable and highly performant logging solution for modern .NET applications. For more information, see [Compile-time logging source generation (.NET Fundamentals)](./logger-message-generator.md).
+
 The sample app demonstrates <xref:Microsoft.Extensions.Logging.LoggerMessage> features with a priority queue processing worker service. The app processes work items in priority order. As these operations occur, log messages are generated using the <xref:Microsoft.Extensions.Logging.LoggerMessage> pattern.
 
 [!INCLUDE [logging-samples-browser](includes/logging-samples-browser.md)]


### PR DESCRIPTION
## Summary

Adds a note informing people to use the compile-time logging source generation available in .NET 6 instead of the `LoggerMessage.Define` API previously required.

The `Important` note is similar to the note found on https://learn.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting.

I figured this should be added here because it seems like the `LoggerMessageAttribute` replaces the `LoggerMessage` class almost entirely per the summary available here https://learn.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator#summary.

Fixes #Issue_Number (if available)
