### PR TITLE
fix: adding `paste` shortcut tip to the start of each tutorial

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
@@ -8,6 +8,8 @@ ms.date: 03/23/2022
 
 This tutorial teaches you how to write C# code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
+> Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+
 ## Prerequisites
 
 The tutorial expects that you have a machine set up for local development. See [Set up your local environment](local-environment.md) for installation instructions and an overview of application development in .NET.

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
@@ -8,7 +8,8 @@ ms.date: 03/23/2022
 
 This tutorial teaches you how to write C# code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
-> Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+> [!TIP]
+> To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 
 ## Prerequisites
 

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
@@ -17,7 +17,8 @@ items:
   content: |
     This tutorial teaches you how to write code that examines variables and changes execution path based on those variables. You'll use your browser to write C# interactively and see the results of compiling and running your code. This tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
-    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+    > [!TIP]
+    > To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 - title: Make decisions using the if statement
   durationInMinutes: 4
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
@@ -16,6 +16,8 @@ items:
 - durationInMinutes: 1
   content: |
     This tutorial teaches you how to write code that examines variables and changes execution path based on those variables. You'll use your browser to write C# interactively and see the results of compiling and running your code. This tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
+
+    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
 - title: Make decisions using the if statement
   durationInMinutes: 4
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -17,7 +17,8 @@ items:
   content: |
     This tutorial teaches you C# interactively, using your browser to write C# and see the results of compiling and running your code. It contains a series of lessons that begin with a "Hello World" program. These lessons teach you the fundamentals of the C# language.
     
-    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+    > [!TIP]
+    > To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 - title: Run your first C# program
   durationInMinutes: 2
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -16,6 +16,8 @@ items:
 - durationInMinutes: 1
   content: |
     This tutorial teaches you C# interactively, using your browser to write C# and see the results of compiling and running your code. It contains a series of lessons that begin with a "Hello World" program. These lessons teach you the fundamentals of the C# language.
+    
+    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
 - title: Run your first C# program
   durationInMinutes: 2
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
@@ -14,6 +14,8 @@ items:
 - durationInMinutes: 1
   content: |
     This tutorial teaches you C# interactively, using your browser to write C# code and see the results of compiling and running your code. It contains a series of lessons that create, modify, and explore collections and arrays.
+    
+    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
 - title: Create lists
   durationInMinutes: 2
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
@@ -16,7 +16,7 @@ items:
     This tutorial teaches you C# interactively, using your browser to write C# code and see the results of compiling and running your code. It contains a series of lessons that create, modify, and explore collections and arrays.
     
     > [!TIP]
-> To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
+    > To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 - title: Create lists
   durationInMinutes: 2
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
@@ -15,7 +15,8 @@ items:
   content: |
     This tutorial teaches you C# interactively, using your browser to write C# code and see the results of compiling and running your code. It contains a series of lessons that create, modify, and explore collections and arrays.
     
-    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+    > [!TIP]
+> To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 - title: Create lists
   durationInMinutes: 2
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -8,6 +8,8 @@ ms.date: 03/23/2022
 
 This tutorial teaches you about the numeric types in C#. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
+> Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+
 ## Prerequisites
 
 The tutorial expects that you have a machine set up for local development. See [Set up your local environment](local-environment.md) for installation instructions and an overview of application development in .NET.

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp-local.md
@@ -8,7 +8,8 @@ ms.date: 03/23/2022
 
 This tutorial teaches you about the numeric types in C#. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
-> Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+> [!TIP]
+> To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 
 ## Prerequisites
 

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
@@ -17,7 +17,8 @@ items:
   content: |
     This tutorial teaches you about the numeric types in C# interactively, using your browser. You'll write C# and see the results of compiling and running your code. It contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
     
-    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
+    > [!TIP]
+    > To paste a code snippet inside the **focus mode** you should use your keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>v</kbd>, or <kbd>cmd</kbd> + <kbd>v</kbd>).
 - title: Explore integer math
   durationInMinutes: 4
   content: |

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.yml
@@ -16,6 +16,8 @@ items:
 - durationInMinutes: 1
   content: |
     This tutorial teaches you about the numeric types in C# interactively, using your browser. You'll write C# and see the results of compiling and running your code. It contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
+    
+    > Note: To paste a code snippet inside the `focus mode` you should use your keyboard shortcut (ctrl+v, or cmd+v).
 - title: Explore integer math
   durationInMinutes: 4
   content: |


### PR DESCRIPTION
## Summary

Adding the `paste` shortcut tip to the start of each tutorial.

Fixes #30453
