### PR TITLE
Fixed the naming inconsistencies of the WORKDIR

### DIFF
--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -192,14 +192,14 @@ The `counter-image` repository is the name of the image. The `latest` tag is the
 
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
-WORKDIR /app
-COPY --from=build-env /app/out .
+WORKDIR /App
+COPY --from=build-env /App/out .
 ENTRYPOINT ["dotnet", "DotNet.Docker.dll"]
 ```
 
-The `COPY` command tells Docker to copy the specified folder on your computer to a folder in the container. In this example, the *publish* folder is copied to a folder named *app* in the container.
+The `COPY` command tells Docker to copy the specified folder on your computer to a folder in the container. In this example, the *publish* folder is copied to a folder named *App* in the container.
 
-The `WORKDIR` command changes the **current directory** inside of the container to *app*.
+The `WORKDIR` command changes the **current directory** inside of the container to *App*.
 
 The next command, `ENTRYPOINT`, tells Docker to configure the container to run as an executable. When the container starts, the `ENTRYPOINT` command runs. When this command ends, the container will automatically stop.
 


### PR DESCRIPTION
## Summary

The article mentions the `WORKDIR` as /App in all of the snippets but it changes later on. The logs building the Dockerfile don't reflect the directory as `app` either, but as `App`.

Fixes #31793
