### PR TITLE
Add deprecation-notice to rule CA2109

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -24,6 +24,11 @@ ms.author: gewarren
 
 A public or protected event-handling method was detected.
 
+> [!NOTE]
+> This rule last shipped with Microsoft.CodeAnalysis.Analyzers v3.3.0.
+> 
+> It was removed because the threat that the analyzer warned about (an untrusted intermediary hooking a privileged event handler to a privileged event invoker) did not exist since .NET 4.5.
+
 ## Rule description
 
 An externally visible event-handling method presents a security issue that requires review.

--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -27,7 +27,7 @@ A public or protected event-handling method was detected.
 > [!NOTE]
 > This rule has been deprecated. It last shipped with Microsoft.CodeAnalysis.Analyzers v3.3.0.
 > 
-> It was removed because the threat that the analyzer warned about (an untrusted intermediary hooking a privileged event handler to a privileged event invoker) did not exist since .NET 4.5.
+> The rule was removed because the threat that the analyzer warned about (an untrusted intermediary hooking a privileged event handler to a privileged event invoker) hasn't existed since .NET Framework 4.5.
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -25,7 +25,7 @@ ms.author: gewarren
 A public or protected event-handling method was detected.
 
 > [!NOTE]
-> This rule last shipped with Microsoft.CodeAnalysis.Analyzers v3.3.0.
+> This rule has been deprecated. It last shipped with Microsoft.CodeAnalysis.Analyzers v3.3.0.
 > 
 > It was removed because the threat that the analyzer warned about (an untrusted intermediary hooking a privileged event handler to a privileged event invoker) did not exist since .NET 4.5.
 


### PR DESCRIPTION
Adds a deprecation notice to rule CA2109 (similar to #21882)

Rule is removed by PR dotnet/roslyn-analyzers#6198.
Removal of the rule was discussed in dotnet/roslyn-analyzers#5974.