### PR TITLE
[Tiny] Fix one single Event ID

### DIFF
--- a/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md
+++ b/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md
@@ -199,7 +199,7 @@ The following table shows the event information:
 
 |Event|Event ID|Raised when|
 |-----------|--------------|-----------------|
-|`GCSuspendEEBegin_V1`|8|Start of suspension of the execution engine for garbage collection.|
+|`GCSuspendEEBegin_V1`|9|Start of suspension of the execution engine for garbage collection.|
 
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|


### PR DESCRIPTION
See https://github.com/dotnet/runtime/blob/4719135a5fd6c9f22ce429ad8a211d696eae0426/src/coreclr/nativeaot/Runtime/EtwEvents.h#L344 for the correct ID.

## Summary

Just fixed the event ID - I didn't check the others, noticed this one reviewing a [PR](https://github.com/signalfx/signalfx-dotnet-tracing/pull/643#discussion_r997324739) that was using id 9 that I didn't see in the docs.
