### PR TITLE
Add `dotnet publish` article for .NET 7 containerization support.

### DIFF
--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -36,7 +36,7 @@ If you have .NET installed, use the `dotnet --info` command to determine which S
 
 ## Create .NET app
 
-You need a .NET app that the Docker container will run. Open your terminal, create a working folder if you haven't already, and enter it. In the working folder, run the following command to create a new project in a subdirectory named *app*:
+You need a .NET app that the Docker container will run. Open your terminal, create a working folder if you haven't already, and enter it. In the working folder, run the following command to create a new project in a subdirectory named *App*:
 
 ```dotnetcli
 dotnet new console -o App -n DotNet.Docker

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -105,7 +105,8 @@ The preceding .NET CLI command, publishes the app as a container:
 > To build the container locally, you must have the Docker daemon running. If it isn't running when you attempt to publish the app as a container, you'll experience an error similar to the following:
 >
 > ```console
-> ..\.nuget\packages\microsoft.net.build.containers\0.1.8\build\Microsoft.NET.Build.Containers.targets(66,9): error MSB4018: The "CreateNewImage" task failed unexpectedly. [..\Worker\DotNet.ContainerImage.csproj]
+> ..\build\Microsoft.NET.Build.Containers.targets(66,9): error MSB4018:
+>    The "CreateNewImage" task failed unexpectedly. [..\Worker\DotNet.ContainerImage.csproj]
 > ```
 
 > [!TIP]

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -247,7 +247,7 @@ For more information, see [.NET environment variables](../tools/dotnet-environme
 
 ### `ContainerEntrypoint`
 
-The container entry point can be used to customize the `ENTRYPOINT` of the container, the binary that is run by default when the container is started. By default, for builds that create an executable binary that binary is set as the ContainerEntrypoint. For builds that do not create an executable binary `dotnet path/to/application.dll` is used as the `ContainerEntrypoint`.
+The container entry point can be used to customize the `ENTRYPOINT` of the container, which is the executable that is called when the container is started. By default, for builds that create an app host it is set as the `ContainerEntrypoint`. For builds that don't create an executable, the `dotnet path/to/application.dll` is used as the `ContainerEntrypoint`.
 
 The `ContainerEntrypoint` node has a single attribute:
 

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -152,7 +152,7 @@ If you set a value here, you should set the fully-qualified name of the image to
 
 ### `ContainerRegistry`
 
-The container registry property controls the destination registry, the place that the newly-created image will be pushed to. Be default, we push to the local Docker daemon (annotated by `docker://`), but for this release you can specify any _unauthenticated_ registry. For example, consider the following XML example:
+The container registry property controls the destination registry, the place that the newly-created image will be pushed to. Be default, we push to the local Docker daemon (`docker://`), but for this release you can specify any _unauthenticated_ registry. For example, consider the following XML example:
 
 ```xml
 <ContainerRegistry>registry.mycorp.com:1234</ContainerRegistry>

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -322,6 +322,7 @@ docker image rm 25aeb97a2e21
 
 ## Next steps
 
+- [Announcing built-in container support for the .NET SDK](https://devblogs.microsoft.com/dotnet/announcing-builtin-container-support-for-the-dotnet-sdk)
 - [Tutorial: Containerize a .NET app](build-container.md)
 - [Review the Azure services that support containers.](https://azure.microsoft.com/overview/containers/)
 - [Read about Dockerfile commands.](https://docs.docker.com/engine/reference/builder/)

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -13,10 +13,11 @@ Containers have many features and benefits, such as being an immutable infrastru
 
 Install the following prerequisites:
 
-- [.NET SDK](https://dotnet.microsoft.com/download)\
+- [.NET 7+ SDK](https://dotnet.microsoft.com/download/dotnet/7.0)\
 If you have .NET installed, use the `dotnet --info` command to determine which SDK you're using.
 - [Docker Community Edition](https://www.docker.com/products/docker-desktop)
-- Familiarity with [Worker Services in .NET](../extensions/workers.md)
+
+In addition these prerequisites, it's recommended to be familiar with [Worker Services in .NET](../extensions/workers.md).
 
 ## Create .NET app
 
@@ -44,7 +45,7 @@ Your folder tree will look like the following:
             └── project.nuget.cache
 ```
 
-The `dotnet new` command creates a new folder named *Worker- and generates a worker service that when ran will log a message every second. Change directories and navigate into the *Worker- folder, from your terminal session. Use the `dotnet run` command to start the app. The application will run, and print `Hello World!` below the command:
+The `dotnet new` command creates a new folder named _Worker_ and generates a worker service that when ran will log a message every second. Change directories and navigate into the *Worker- folder, from your terminal session. Use the `dotnet run` command to start the app. The application will run, and print `Hello World!` below the command:
 
 ```dotnetcli
 dotnet run

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -44,7 +44,7 @@ Your folder tree will look like the following:
             └── project.nuget.cache
 ```
 
-The `dotnet new` command creates a new folder named *Worker* and generates a worker service that when ran will log a message every second. Change directories and navigate into the *Worker* folder, from your terminal session. Use the `dotnet run` command to start the app. The application will run, and print `Hello World!` below the command:
+The `dotnet new` command creates a new folder named *Worker- and generates a worker service that when ran will log a message every second. Change directories and navigate into the *Worker- folder, from your terminal session. Use the `dotnet run` command to start the app. The application will run, and print `Hello World!` below the command:
 
 ```dotnetcli
 dotnet run
@@ -120,7 +120,7 @@ Determining projects to restore...
   Pushed container 'dotnet-worker-image:1.0.0' to registry 'docker://'
 ```
 
-This command compiles your worker app to the *publish* folder and pushes the container to your local docker registry.
+This command compiles your worker app to the *publish- folder and pushes the container to your local docker registry.
 
 ## Configure container image
 
@@ -130,17 +130,17 @@ You can control many aspects of the generated container through MSBuild properti
 > The only exception to this are `RUN` commands, due to the way containers are built, those cannot be emulated. If you need this functionality, you will need to use a _Dockerfile_ to build your container images.
 
 > [!IMPORTANT]
-> Only Linux containers are currently supported.
+> Currently, only Linux containers are supported.
 
 ### `ContainerBaseImage`
 
-This property controls the image used as the basis for your image. By default, we will infer the following values for you based on the properties of your project:
+The container base image property controls the image used as the basis for your image. By default, we will infer the following values for you based on the properties of your project:
 
-* if your project is self-contained, we use the `mcr.microsoft.com/dotnet/runtime-deps` image as the base image
-* if your project is an ASP.NET Core project, we use the `mcr.microsoft.com/dotnet/aspnet` image as the base image
-* otherwise we use the `mcr.microsoft.com/dotnet/runtime` image as the base image
+- If your project is self-contained, the `mcr.microsoft.com/dotnet/runtime-deps` image is used as the base image.
+- If your project is an ASP.NET Core project, the `mcr.microsoft.com/dotnet/aspnet` image is used as the base image.
+- Otherwise the `mcr.microsoft.com/dotnet/runtime` image is used as the base image.
 
-We infer the tag of the image to be the numeric component of your chosen `TargetFramework` - so a `.net6.0` project will use the `6.0` tag of the inferred base image, a `.net7.0-linux` project will use the `7.0` tag, and so on.
+The tag of the image is inferred to be the numeric component of your chosen `TargetFramework`. For example, a project targeting `.net6.0` will result in the `6.0` tag of the inferred base image, a `.net7.0-linux` project will use the `7.0` tag, and so on.
 
 If you set a value here, you should set the fully-qualified name of the image to use as the base, including any tag you prefer:
 
@@ -150,9 +150,7 @@ If you set a value here, you should set the fully-qualified name of the image to
 
 ### `ContainerRegistry`
 
-This property controls the destination registry - the place that the newly-created image will be pushed to.
-
-Be default, we push to the local Docker daemon (annotated by `docker://`), but for this release you can specify any _unauthenticated_ registry. For example:
+The container registry property controls the destination registry, the place that the newly-created image will be pushed to. Be default, we push to the local Docker daemon (annotated by `docker://`), but for this release you can specify any _unauthenticated_ registry. For example, consider the following XML example:
 
 ```xml
 <ContainerRegistry>registry.mycorp.com:1234</ContainerRegistry>
@@ -163,26 +161,23 @@ Be default, we push to the local Docker daemon (annotated by `docker://`), but f
 
 ### `ContainerImageName`
 
-This property controls the name of the image itself, e.g `dotnet/runtime` or `my-awesome-app`.
-
-By default, the value used will be the `AssemblyName` of the project.
+The container image name controls the name of the image itself, e.g `dotnet/runtime` or `my-app`. By default, the `AssemblyName` of the project is used.
 
 ```xml
-<ContainerImageName>my-super-awesome-app</ContainerImageName>
+<ContainerImageName>my-app</ContainerImageName>
 ```
 
-> [!CAUTION]
-> Image names can only contain lowercase alphanumeric characters, periods, underscores, and dashes, and must start with a letter or number, any other characters will result in an error being thrown.
+Image names can only contain lowercase alphanumeric characters, periods, underscores, and dashes, and must start with a letter or number, any other characters will result in an error being thrown.
 
-## `ContainerImageTag(s)`
+### `ContainerImageTag(s)`
 
-This property controls the tag that is generated for the image. Tags are often used to refer to different versions of an application, but they can also refer to different operating system distributions, or even just different baked-in configuration. This property also can be used to push multiple tags - simply use a semicolon-delimited set of tags in the `ContainerImageTags` property, similar to setting multiple `TargetFrameworks`.
-
-By default, the value used will be the `Version` of the project.
+The container image tag property controls the tags that are generated for the image. Tags are often used to refer to different versions of an application, but they can also refer to different operating system distributions, or even different configurations. By default, the `Version` of the project is used as the tag value. To override the default, specify either of the following:
 
 ```xml
 <ContainerImageTag>1.2.3-alpha2</ContainerImageTag>
 ```
+
+To specify multiple tags, use a semicolon-delimited set of tags in the `ContainerImageTags` property, similar to setting multiple `TargetFrameworks`:
 
 ```xml
 <ContainerImageTags>1.2.3-alpha2;latest</ContainerImageTags>
@@ -192,24 +187,22 @@ Tags can only contain up to 127 alphanumeric characters, periods, underscores, a
 
 ### `ContainerWorkingDirectory`
 
-This property controls the working directory of the container - the directory that commands are executed within if not other command is run.
+The container working directory node controls the working directory of the container, the directory that commands are executed within if not other command is run.
 
-By default, we use the `/app` directory as the working directory.
+By default, the `/app` directory value is used as the working directory.
 
 ```xml
 <ContainerWorkingDirectory>/bin</ContainerWorkingDirectory>
 ```
 
-## `ContainerPort`
+### `ContainerPort`
 
-This item adds TCP or UDP ports to the list of known ports for the container. This enables container runtimes like Docker to map these ports to the host machine automatically. This is often used as documentation for the container, but can also be used to enable automatic port mapping.
+The container port adds TCP or UDP ports to the list of known ports for the container. This enables container runtimes like Docker to map these ports to the host machine automatically. This is often used as documentation for the container, but can also be used to enable automatic port mapping.
 
-ContainerPort items have two properties:
+The `ContainerPort` node has two attributes:
 
-* Include
-  * The port number to expose
-* Type
-  * One of `tcp` or `udp` - the default is `tcp`
+- `Include`: The port number to expose.
+- `Type`: Defaults to `tcp`, valid values are either `tcp` or `udp`.
 
 ```xml
 <ItemGroup>
@@ -217,21 +210,14 @@ ContainerPort items have two properties:
 </ItemGroup>
 ```
 
-> **Note**
-> This item does nothing for the container by default and should be considered advisory at best.
-
 ### `ContainerLabel`
 
-This item adds a metadata label to the container. Labels have no impact on the container at runtime, but are often used to store version and authoring metadata for use by security scanners and other infrastructure tools.
+The container label adds a metadata label to the container. Labels have no impact on the container at runtime, but are often used to store version and authoring metadata for use by security scanners and other infrastructure tools. You can specify any number of container labels.
 
-ContainerLabel items have two properties:
+The `ContainerLabel` node has two attributes:
 
-* Include
-  * The key of the label
-* Value
-  * The value of the label - this may be empty
-
-See [default container labels](#default-container-labels) for a list of labels that are created by default.
+- `Include`: The key of the label.
+- `Value`: The value of the label (this may be empty).
 
 ```xml
 <ItemGroup>
@@ -239,16 +225,16 @@ See [default container labels](#default-container-labels) for a list of labels t
 <ItemGroup>
 ```
 
-## `ContainerEnvironmentVariable`
+For more information, see [default container labels](#default-container-labels) for a list of labels that are created by default.
 
-This item adds a new environment variable to the container. Environment variables will be accessible to the application running in the container immediately, and are often used to change the runtime behavior of the running application.
+### `ContainerEnvironmentVariable`
 
-ContainerEnvironmentVariable items have two properties:
+The container environment variable node allows you to add environment variables to the container. Environment variables will be accessible to the application running in the container immediately, and are often used to change the runtime behavior of the running application.
 
-* Include
-  * The name of the environment variable
-* Value
-  * The value of the environment variable
+The `ContainerEnvironmentVariable` node has two attributes:
+
+- `Include`:  The name of the environment variable.
+- `Value`: The value of the environment variable
 
 ```xml
 <ItemGroup>
@@ -256,16 +242,17 @@ ContainerEnvironmentVariable items have two properties:
 </ItemGroup>
 ```
 
-## `ContainerEntrypoint`
+For more information, see [.NET environment variables](../tools/dotnet-environment-variables.md).
 
-This item can be used to customize the entrypoint of the container - the binary that is run by default when the container is started.
+### `ContainerEntrypoint`
 
-By default, for builds that create an executable binary that binary is set as the ContainerEntrypoint. For builds that do not create an executable binary `dotnet path/to/application.dll` is used as the ContainerEntrypoint.
+The container entry point can be used to customize the `ENTRYPOINT` of the container, the binary that is run by default when the container is started. By default, for builds that create an executable binary that binary is set as the ContainerEntrypoint. For builds that do not create an executable binary `dotnet path/to/application.dll` is used as the `ContainerEntrypoint`.
 
-ContainerEntrypoint items have one property:
+The `ContainerEntrypoint` node has a single attribute:
 
-* Include
-  * The command, option, or argument to use in the entrypoint command
+- `Include`: The command, option, or argument to use in the entrypoint command.
+
+For example, consider the following sample .NET project item group:
 
 ```xml
 <ItemGroup Label="Entrypoint Assignment">
@@ -273,25 +260,27 @@ ContainerEntrypoint items have one property:
   <ContainerEntrypoint Include="dotnet" />
   <ContainerEntrypoint Include="ef" />
 
-  <!-- This shorthand syntax means the same thing - note the semicolon separating the tokens. -->
+  <!-- This shorthand syntax means the same thing.
+       Note the semicolon separating the tokens. -->
   <ContainerEntrypoint Include="dotnet;ef" />
 </ItemGroup>
 ```
 
-## `ContainerEntrypointArgs`
+### `ContainerEntrypointArgs`
 
-This item controls the default arguments provided to the `ContainerEntrypoint`. This should be used when the ContainerEntrypoint is a program that the user might want to use on its own.
+The container entry point args node controls the default arguments provided to the `ContainerEntrypoint`. This should be used when the `ContainerEntrypoint` is a program that the user might want to use on its own. By default, no `ContainerEntrypointArgs` are created on your behalf.
 
-By default, no ContainerEntrypointArgs are created on your behalf.
+The `ContainerEntrypointArg` node has a single attribute:
 
-ContainerEntrypointArg items have one property:
+- `Include`: The option or argument to apply to the `ContainerEntrypoint` command.
 
-* Include
-  * The option or argument to apply to the ContainerEntrypoint command
+Consider the following example .NET project item group:
 
 ```xml
 <ItemGroup>
-  <!-- Assuming the ContainerEntrypoint defined above, this would be the way to update the database by default, but let the user run a different EF command. -->
+  <!-- Assuming the ContainerEntrypoint defined above, 
+       this would be the way to update the database by 
+       default, but let the user run a different EF command. -->
   <ContainerEntrypointArgs Include="database" />
   <ContainerEntrypointArgs Include="update" />
 
@@ -304,46 +293,35 @@ ContainerEntrypointArg items have one property:
 
 Labels are often used to provide consistent metadata on container images. This package provides some default labels to encourage better maintainability of the generated images.
 
-* `org.opencontainers.image.created` is set to the ISO 8601 format of the current UTC DateTime
+- `org.opencontainers.image.created` is set to the ISO 8601 format of the current UTC `DateTime`.
 
 ## Clean up resources
 
-During this tutorial, you created containers and images. If you want, delete these resources. Use the following commands to
+In this article, you published a .NET worker as a container image. If you want, delete this resource. Use the `docker images` command to see a list of images installed.
 
-01. List all containers
-
-    ```console
-    docker ps -a
-    ```
-
-01. Stop containers that are running by their name.
-
-    ```console
-    docker stop counter-image
-    ```
-
-01. Delete the container
-
-    ```console
-    docker rm counter-image
-    ```
-
-Next, delete any images that you no longer want on your machine. Delete the image created by your _Dockerfile_ and then delete the .NET image the _Dockerfile_ was based on. You can use the **IMAGE ID** or the **REPOSITORY:TAG** formatted string.
-
-```console
-docker rmi counter-image:latest
-docker rmi mcr.microsoft.com/dotnet/aspnet:6.0
+```dockerfile
+docker images
 ```
 
-Use the `docker images` command to see a list of images installed.
+Consider the following example output:
+
+```console
+REPOSITORY            TAG       IMAGE ID       CREATED          SIZE
+dotnet-worker-image   1.0.0     25aeb97a2e21   12 seconds ago   191MB
+```
 
 > [!TIP]
 > Image files can be large. Typically, you would remove temporary containers you created while testing and developing your app. You usually keep the base images with the runtime installed if you plan on building other images based on that runtime.
 
+To delete the image, copy the image id and run the `docker image rm` command:
+
+```console
+docker image rm 25aeb97a2e21
+```
+
 ## Next steps
 
-- [Learn how to containerize an ASP.NET Core application.](/aspnet/core/host-and-deploy/docker/building-net-docker-images)
-- [Try the ASP.NET Core Microservice Tutorial.](https://dotnet.microsoft.com/learn/web/aspnet-microservice-tutorial/intro)
+- [Tutorial: Containerize a .NET app](build-container.md)
 - [Review the Azure services that support containers.](https://azure.microsoft.com/overview/containers/)
 - [Read about Dockerfile commands.](https://docs.docker.com/engine/reference/builder/)
 - [Explore the Container Tools for Visual Studio](/visualstudio/containers/overview)

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -296,6 +296,8 @@ Labels are often used to provide consistent metadata on container images. This p
 
 - `org.opencontainers.image.created` is set to the ISO 8601 format of the current UTC `DateTime`.
 
+For more information, see [Implement conventional labels on top of existing label infrastructure](https://github.com/dotnet/sdk-container-builds/issues/96).
+
 ## Clean up resources
 
 In this article, you published a .NET worker as a container image. If you want, delete this resource. Use the `docker images` command to see a list of images installed.

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -1,0 +1,457 @@
+---
+title: Containerize an app with dotnet publish
+description: In this tutorial, you'll learn how to containerize a .NET application with dotnet publish.
+ms.date: 10/17/2022
+ms.topic: tutorial
+ms.custom: "mvc"
+---
+
+# Containerize a .NET app with dotnet publish
+
+In this tutorial, you'll learn how to containerize a .NET application using the `dotnet publish` command. Containers have many features and benefits, such as being an immutable infrastructure, providing a portable architecture, and enabling scalability. The image can be used to create containers for your local development environment, private cloud, or public cloud.
+
+## Prerequisites
+
+Install the following prerequisites:
+
+- [.NET 7 SDK](https://dotnet.microsoft.com/download)\
+If you have .NET installed, use the `dotnet --info` command to determine which SDK you're using.
+- [Docker Community Edition](https://www.docker.com/products/docker-desktop)
+- A temporary working folder for the *Dockerfile* and .NET example app. In this tutorial, the name *docker-working* is used as the working folder.
+
+## Create .NET app
+
+You need a .NET app that the Docker container will run. Open your terminal, create a working folder if you haven't already, and enter it. In the working folder, run the following command to create a new project in a subdirectory named *app*:
+
+```dotnetcli
+dotnet new console -o App -n DotNet.Docker
+```
+
+Your folder tree will look like the following:
+
+```Directory
+📁 docker-working
+    └──📂 App
+        ├──DotNet.Docker.csproj
+        ├──Program.cs
+        └──📂 obj
+            ├── DotNet.Docker.csproj.nuget.dgspec.json
+            ├── DotNet.Docker.csproj.nuget.g.props
+            ├── DotNet.Docker.csproj.nuget.g.targets
+            ├── project.assets.json
+            └── project.nuget.cache
+```
+
+The `dotnet new` command creates a new folder named *App* and generates a "Hello World" console application. Change directories and navigate into the *App* folder, from your terminal session. Use the `dotnet run` command to start the app. The application will run, and print `Hello World!` below the command:
+
+```dotnetcli
+dotnet run
+Hello World!
+```
+
+The default template creates an app that prints to the terminal and then immediately terminates. For this tutorial, you'll use an app that loops indefinitely. Open the *Program.cs* file in a text editor.
+
+> [!TIP]
+> If you're using Visual Studio Code, from the previous terminal session type the following command:
+>
+> ```console
+> code .
+> ```
+>
+> This will open the *App* folder that contains the project in Visual Studio Code.
+
+The *Program.cs* should look like the following C# code:
+
+```csharp
+Console.WriteLine("Hello World!");
+```
+
+Replace the file with the following code that counts numbers every second:
+
+:::code source="snippets/App/Program.cs":::
+
+Save the file and test the program again with `dotnet run`. Remember that this app runs indefinitely. Use the cancel command <kbd>Ctrl+C</kbd> to stop it. The following is an example output:
+
+```dotnetcli
+dotnet run
+Counter: 1
+Counter: 2
+Counter: 3
+Counter: 4
+^C
+```
+
+If you pass a number on the command line to the app, it will only count up to that amount and then exit. Try it with `dotnet run -- 5` to count to five.
+
+> [!IMPORTANT]
+> Any parameters after `--` are not passed to the `dotnet run` command and instead are passed to your application.
+
+## Publish .NET app
+
+Before adding the .NET app to the Docker image, first it must be published. It is best to have the container run the published version of the app. To publish the app, run the following command:
+
+```dotnetcli
+dotnet publish -c Release
+```
+
+This command compiles your app to the *publish* folder. The path to the *publish* folder from the working folder should be `.\App\bin\Release\net6.0\publish\`
+
+#### [Windows](#tab/windows)
+
+From the *App* folder, get a directory listing of the publish folder to verify that the *DotNet.Docker.dll* file was created.
+
+```powershell
+dir .\bin\Release\net6.0\publish\
+
+    Directory: C:\Users\dapine\App\bin\Release\net6.0\publish
+
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+-a---            3/8/2022 10:43 AM            431 DotNet.Docker.deps.json
+-a---            3/8/2022 10:43 AM           6144 DotNet.Docker.dll
+-a---            3/8/2022 10:43 AM         149504 DotNet.Docker.exe
+-a---            3/8/2022 10:43 AM          10516 DotNet.Docker.pdb
+-a---            3/8/2022 10:43 AM            253 DotNet.Docker.runtimeconfig.json
+```
+
+#### [Linux](#tab/linux)
+
+Use the `ls` command to get a directory listing and verify that the *DotNet.Docker.dll* file was created.
+
+```bash
+me@DESKTOP:/docker-working/app$ ls bin/Release/net6.0/publish
+DotNet.Docker.deps.json  DotNet.Docker.dll  DotNet.Docker.exe  DotNet.Docker.pdb  DotNet.Docker.runtimeconfig.json
+```
+
+---
+
+## Create the Dockerfile
+
+The *Dockerfile* file is used by the `docker build` command to create a container image. This file is a text file named *Dockerfile* that doesn't have an extension.
+
+Create a file named *Dockerfile* in the directory containing the *.csproj* and open it in a text editor. This tutorial will use the ASP.NET Core runtime image (which contains the .NET runtime image) and corresponds with the .NET console application.
+
+:::code language="docker" source="snippets/App/Dockerfile":::
+
+> [!NOTE]
+> The ASP.NET Core runtime image is used intentionally here, although the `mcr.microsoft.com/dotnet/runtime:6.0` image could have been used.
+
+The `FROM` keyword requires a fully qualified Docker container image name. The Microsoft Container Registry (MCR, mcr.microsoft.com) is a syndicate of Docker Hub &mdash; which hosts publicly accessible containers. The `dotnet` segment is the container repository, whereas the `sdk` or `aspnet` segment is the container image name. The image is tagged with `6.0`, which is used for versioning. Thus, `mcr.microsoft.com/dotnet/aspnet:6.0` is the .NET 6.0 runtime. Make sure that you pull the runtime version that matches the runtime targeted by your SDK. For example, the app created in the previous section used the .NET 6.0 SDK and the base image referred to in the *Dockerfile* is tagged with **6.0**.
+
+Save the *Dockerfile* file. The directory structure of the working folder should look like the following. Some of the deeper-level files and folders have been omitted to save space in the article:
+
+```Directory
+📁 docker-working
+    └──📂 App
+        ├── Dockerfile
+        ├── DotNet.Docker.csproj
+        ├── Program.cs
+        ├──📂 bin
+        │   └──📂 Release
+        │       └──📂 net6.0
+        │           └──📂 publish
+        │               ├── DotNet.Docker.deps.json
+        │               ├── DotNet.Docker.exe
+        │               ├── DotNet.Docker.dll
+        │               ├── DotNet.Docker.pdb
+        │               └── DotNet.Docker.runtimeconfig.json
+        └──obj 📁
+            └──...
+```
+
+From your terminal, run the following command:
+
+```console
+docker build -t counter-image -f Dockerfile .
+```
+
+Docker will process each line in the *Dockerfile*. The `.` in the `docker build` command sets the build context of the image. The `-f` switch is the path to the _Dockerfile_. This command builds the image and creates a local repository named **counter-image** that points to that image. After this command finishes, run `docker images` to see a list of images installed:
+
+```console
+docker images
+REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
+counter-image                      latest    2f15637dc1f6   10 minutes ago   208MB
+```
+
+The `counter-image` repository is the name of the image. The `latest` tag is the tag that is used to identify the image. The `2f15637dc1f6` is the image ID. The `10 minutes ago` is the time the image was created. The `208MB` is the size of the image. The final steps of the _Dockerfile_ are to create a container from the image and run the app, copy the published app to the container, and define the entry point.
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
+WORKDIR /App
+COPY --from=build-env /App/out .
+ENTRYPOINT ["dotnet", "DotNet.Docker.dll"]
+```
+
+The `COPY` command tells Docker to copy the specified folder on your computer to a folder in the container. In this example, the *publish* folder is copied to a folder named *App* in the container.
+
+The `WORKDIR` command changes the **current directory** inside of the container to *App*.
+
+The next command, `ENTRYPOINT`, tells Docker to configure the container to run as an executable. When the container starts, the `ENTRYPOINT` command runs. When this command ends, the container will automatically stop.
+
+> [!TIP]
+> For added security, you can opt out of the diagnostic pipeline. When you opt-out this allows the container to run as read-only. To do this, specify a `DOTNET_EnableDiagnostics` environment variable as `0` (just before the `ENTRYPOINT` step):
+>
+> ```dockerfile
+> ENV DOTNET_EnableDiagnostics=0
+> ```
+>
+> For more information on various .NET environment variables, see [.NET environment variables](../tools/dotnet-environment-variables.md).
+
+[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
+
+From your terminal, run `docker build -t counter-image -f Dockerfile .` and when that command finishes, run `docker images`.
+
+```console
+docker build -t counter-image -f Dockerfile .
+[+] Building 3.1s (14/14) FINISHED
+ => [internal] load build definition from Dockerfile                              0.5s
+ => => transferring dockerfile: 32B                                               0.0s
+ => [internal] load .dockerignore                                                 0.6s
+ => => transferring context: 2B                                                   0.0s
+ => [internal] load metadata for mcr.microsoft.com/dotnet/aspnet:6.0              0.8s
+ => [internal] load metadata for mcr.microsoft.com/dotnet/sdk:6.0                 1.1s
+ => [stage-1 1/3] FROM mcr.microsoft.com/dotnet/aspnet:6.0@sha256:f1539d71        0.0s
+ => [internal] load build context                                                 0.4s
+ => => transferring context: 4.00kB                                               0.1s
+ => [build-env 1/5] FROM mcr.microsoft.com/dotnet/sdk:6.0@sha256:16e355af1        0.0s
+ => CACHED [stage-1 2/3] WORKDIR /App                                             0.0s
+ => CACHED [build-env 2/5] WORKDIR /App                                           0.0s
+ => CACHED [build-env 3/5] COPY . ./                                              0.0s
+ => CACHED [build-env 4/5] RUN dotnet restore                                     0.0s
+ => CACHED [build-env 5/5] RUN dotnet publish -c Release -o out                   0.0s
+ => CACHED [stage-1 3/3] COPY --from=build-env /App/out .                         0.0s
+ => exporting to image                                                            0.4s
+ => => exporting layers                                                           0.0s
+ => => writing image sha256:2f15637d                                              0.1s
+ => => naming to docker.io/library/counter-image
+
+docker images
+REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
+counter-image                      latest    2f15637dc1f6   10 minutes ago   208MB
+```
+
+Each command in the *Dockerfile* generated a layer and created an **IMAGE ID**. The final **IMAGE ID** (yours will be different) is **2f15637dc1f6** and next you'll create a container based on this image.
+
+## Create a container
+
+Now that you have an image that contains your app, you can create a container. You can create a container in two ways. First, create a new container that is stopped.
+
+```console
+docker create --name core-counter counter-image
+```
+
+The `docker create` command from above will create a container based on the **counter-image** image. The output of that command shows you the **CONTAINER ID** (yours will be different) of the created container:
+
+```console
+cf01364df4539812684c64277f5363a8fb354ef4c90785dc0845769a6c5b0f8e
+```
+
+To see a list of *all* containers, use the `docker ps -a` command:
+
+```console
+docker ps -a
+CONTAINER ID   IMAGE           COMMAND                  CREATED          STATUS    PORTS     NAMES
+cf01364df453   counter-image   "dotnet DotNet.Docke…"   18 seconds ago   Created             core-counter
+```
+
+### Manage the container
+
+The container was created with a specific name `core-counter`, this name is used to manage the container. The following example uses the `docker start` command to start the container, and then uses the `docker ps` command to only show containers that are running:
+
+```console
+docker start core-counter
+core-counter
+
+docker ps
+CONTAINER ID   IMAGE           COMMAND                  CREATED          STATUS          PORTS     NAMES
+cf01364df453   counter-image   "dotnet DotNet.Docke…"   53 seconds ago   Up 10 seconds             core-counter
+```
+
+Similarly, the `docker stop` command will stop the container. The following example uses the `docker stop` command to stop the container, and then uses the `docker ps` command to show that no containers are running:
+
+```console
+docker stop core-counter
+core-counter
+
+docker ps
+CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
+```
+
+### Connect to a container
+
+After a container is running, you can connect to it to see the output. Use the `docker start` and `docker attach` commands to start the container and peek at the output stream. In this example, the <kbd>Ctrl+C</kbd> keystroke is used to detach from the running container. This keystroke will end the process in the container unless otherwise specified, which would stop the container. The `--sig-proxy=false` parameter ensures that <kbd>Ctrl+C</kbd> will not stop the process in the container.
+
+After you detach from the container, reattach to verify that it's still running and counting.
+
+```console
+docker start core-counter
+core-counter
+
+docker attach --sig-proxy=false core-counter
+Counter: 7
+Counter: 8
+Counter: 9
+^C
+
+docker attach --sig-proxy=false core-counter
+Counter: 17
+Counter: 18
+Counter: 19
+^C
+```
+
+### Delete a container
+
+For this article, you don't want containers hanging around that don't do anything. Delete the container you previously created. If the container is running, stop it.
+
+```console
+docker stop core-counter
+```
+
+The following example lists all containers. It then uses the `docker rm` command to delete the container and then checks a second time for any running containers.
+
+```console
+docker ps -a
+CONTAINER ID    IMAGE            COMMAND                   CREATED          STATUS                        PORTS    NAMES
+2f6424a7ddce    counter-image    "dotnet DotNet.Dock…"    7 minutes ago    Exited (143) 20 seconds ago            core-counter
+
+docker rm core-counter
+core-counter
+
+docker ps -a
+CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
+```
+
+### Single run
+
+Docker provides the `docker run` command to create and run the container as a single command. This command eliminates the need to run `docker create` and then `docker start`. You can also set this command to automatically delete the container when the container stops. For example, use `docker run -it --rm` to do two things, first, automatically use the current terminal to connect to the container, and then when the container finishes, remove it:
+
+```console
+docker run -it --rm counter-image
+Counter: 1
+Counter: 2
+Counter: 3
+Counter: 4
+Counter: 5
+^C
+```
+
+The container also passes parameters into the execution of the .NET app. To instruct the .NET app to count only to 3 pass in 3.
+
+```console
+docker run -it --rm counter-image 3
+Counter: 1
+Counter: 2
+Counter: 3
+```
+
+With `docker run -it`, the <kbd>Ctrl+C</kbd> command will stop process that is running in the container, which in turn, stops the container. Since the `--rm` parameter was provided, the container is automatically deleted when the process is stopped. Verify that it doesn't exist:
+
+```console
+docker ps -a
+CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
+```
+
+### Change the ENTRYPOINT
+
+The `docker run` command also lets you modify the `ENTRYPOINT` command from the *Dockerfile* and run something else, but only for that container. For example, use the following command to run `bash` or `cmd.exe`. Edit the command as necessary.
+
+#### [Windows](#tab/windows)
+
+In this example, `ENTRYPOINT` is changed to `cmd.exe`. <kbd>Ctrl+C</kbd> is pressed to end the process and stop the container.
+
+```console
+docker run -it --rm --entrypoint "cmd.exe" counter-image
+
+Microsoft Windows [Version 10.0.17763.379]
+(c) 2018 Microsoft Corporation. All rights reserved.
+
+C:\>dir
+ Volume in drive C has no label.
+ Volume Serial Number is 3005-1E84
+
+ Directory of C:\
+
+04/09/2019  08:46 AM    <DIR>          app
+03/07/2019  10:25 AM             5,510 License.txt
+04/02/2019  01:35 PM    <DIR>          Program Files
+04/09/2019  01:06 PM    <DIR>          Users
+04/02/2019  01:35 PM    <DIR>          Windows
+               1 File(s)          5,510 bytes
+               4 Dir(s)  21,246,517,248 bytes free
+
+C:\>^C
+```
+
+#### [Linux](#tab/linux)
+
+In this example, `ENTRYPOINT` is changed to `bash`. The `exit` command is run which ends the process and stop the container.
+
+```bash
+docker run -it --rm --entrypoint "bash" counter-image
+root@9f8de8fbd4a8:/App# ls
+DotNet.Docker  DotNet.Docker.deps.json  DotNet.Docker.dll  DotNet.Docker.pdb  DotNet.Docker.runtimeconfig.json
+root@9f8de8fbd4a8:/App# dotnet DotNet.Docker.dll 7
+Counter: 1
+Counter: 2
+Counter: 3
+^C
+root@9f8de8fbd4a8:/App# exit
+exit
+```
+
+---
+
+## Essential commands
+
+Docker has many different commands that create, manage, and interact with containers and images. These Docker commands are essential to managing your containers:
+
+- [docker build](https://docs.docker.com/engine/reference/commandline/build/)
+- [docker run](https://docs.docker.com/engine/reference/commandline/run/)
+- [docker ps](https://docs.docker.com/engine/reference/commandline/ps/)
+- [docker stop](https://docs.docker.com/engine/reference/commandline/stop/)
+- [docker rm](https://docs.docker.com/engine/reference/commandline/rm/)
+- [docker rmi](https://docs.docker.com/engine/reference/commandline/rmi/)
+- [docker image](https://docs.docker.com/engine/reference/commandline/image/)
+
+## Clean up resources
+
+During this tutorial, you created containers and images. If you want, delete these resources. Use the following commands to
+
+01. List all containers
+
+    ```console
+    docker ps -a
+    ```
+
+02. Stop containers that are running by their name.
+
+    ```console
+    docker stop counter-image
+    ```
+
+03. Delete the container
+
+    ```console
+    docker rm counter-image
+    ```
+
+Next, delete any images that you no longer want on your machine. Delete the image created by your *Dockerfile* and then delete the .NET image the *Dockerfile* was based on. You can use the **IMAGE ID** or the **REPOSITORY:TAG** formatted string.
+
+```console
+docker rmi counter-image:latest
+docker rmi mcr.microsoft.com/dotnet/aspnet:6.0
+```
+
+Use the `docker images` command to see a list of images installed.
+
+> [!TIP]
+> Image files can be large. Typically, you would remove temporary containers you created while testing and developing your app. You usually keep the base images with the runtime installed if you plan on building other images based on that runtime.
+
+## Next steps
+
+- [Learn how to containerize an ASP.NET Core application.](/aspnet/core/host-and-deploy/docker/building-net-docker-images)
+- [Try the ASP.NET Core Microservice Tutorial.](https://dotnet.microsoft.com/learn/web/aspnet-microservice-tutorial/intro)
+- [Review the Azure services that support containers.](https://azure.microsoft.com/overview/containers/)
+- [Read about Dockerfile commands.](https://docs.docker.com/engine/reference/builder/)
+- [Explore the Container Tools for Visual Studio](/visualstudio/containers/overview)

--- a/docs/core/docker/snippets/Worker/DotNet.ContainerImage.csproj
+++ b/docs/core/docker/snippets/Worker/DotNet.ContainerImage.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-DotNet.ContainerImage-2e40c179-a00b-4cc9-9785-54266210b7eb</UserSecretsId>
+    <ContainerImageName>dotnet-worker-image</ContainerImageName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0-rc.1.22426.10" />
+    <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.1.8" />
+  </ItemGroup>
+</Project>

--- a/docs/core/docker/snippets/Worker/Program.cs
+++ b/docs/core/docker/snippets/Worker/Program.cs
@@ -1,0 +1,10 @@
+using DotNet.ContainerImage;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+host.Run();

--- a/docs/core/docker/snippets/Worker/Properties/launchSettings.json
+++ b/docs/core/docker/snippets/Worker/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "DotNet.ContainerImage": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/docs/core/docker/snippets/Worker/Worker.cs
+++ b/docs/core/docker/snippets/Worker/Worker.cs
@@ -1,0 +1,20 @@
+namespace DotNet.ContainerImage;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+            await Task.Delay(1000, stoppingToken);
+        }
+    }
+}

--- a/docs/core/docker/snippets/Worker/appsettings.Development.json
+++ b/docs/core/docker/snippets/Worker/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/docs/core/docker/snippets/Worker/appsettings.json
+++ b/docs/core/docker/snippets/Worker/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2014,6 +2014,8 @@ items:
       href: ../core/docker/introduction.md
     - name: Containerize a .NET app
       href: ../core/docker/build-container.md
+    - name: Publish app as container image
+      href: ../core/docker/publish-as-container.md
     - name: Container tools in Visual Studio
       href: /visualstudio/containers/overview
 - name: DevOps


### PR DESCRIPTION
## Summary

Adding `dotnet publish` article for .NET 7 containerization support.

Fixes https://github.com/dotnet/docs/issues/31761

## Preview

- [Containerize a .NET app with dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?branch=pr-en-us-31817)