### PR TITLE
Fix Standalone GC table format

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -557,6 +557,7 @@ Example:
 ## Standalone GC
 
 - Specifies the name of a standalone GC DLL that the runtime loads in place of the one it has in the main runtime DLL (coreclr.dll). This DLL needs to reside in the same directory as *coreclr.dll*
+
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | N/A | N/A | N/A |

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -556,7 +556,7 @@ Example:
 
 ## Standalone GC
 
-- Specifies the name of a standalone GC DLL that the runtime loads in place of the one it has in the main runtime DLL (coreclr.dll). This DLL needs to reside in the same directory as *coreclr.dll*
+- Specifies the name of a standalone GC DLL that the runtime loads in place of the one it has in the main runtime DLL (coreclr.dll). This DLL needs to reside in the same directory as *coreclr.dll*.
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |


### PR DESCRIPTION
## Summary

The table markdown is badly formatted and doesn't render as a table right now:
https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#standalone-gc

![image](https://user-images.githubusercontent.com/1165805/196823274-e8a70f9f-787c-4765-a994-286db53deed1.png)
