### PR TITLE
Fix PoliChek hit: Scotch

### DIFF
--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
@@ -107,7 +107,7 @@ image106,borzoi
 image107,toy poodle
 image108,Kerry blue terrier
 image109,ox
-image110,Scotch terrier
+image110,Scottish terrier
 image111,Tibetan mastiff
 image112,spider monkey
 image113,Doberman


### PR DESCRIPTION
User Story https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1977854.

## Summary

The term "Scotch" may be used if not referring to people. However, the correct name of the breed is apparently "Scottish terrier."
Fixes #Issue_Number (if available) https://dev.azure.com/msft-skilling/Content/_queries/edit/14703/?triage=true
