### PR TITLE
Fix PoliChek hit: Scotch

### DIFF
--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
@@ -107,7 +107,7 @@ borzoi
 toy poodle
 Kerry blue terrier
 ox
-Scotch terrier
+Scottish terrier
 Tibetan mastiff
 spider monkey
 Doberman


### PR DESCRIPTION
User Story https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/2001296

## Summary

The term "Scotch" may be used if not referring to people. However, the correct name of the breed is apparently "Scottish terrier."

Fixes #Issue_Number (if available) https://dev.azure.com/msft-skilling/Content/_workitems/edit/14570
