### PR TITLE
Fix PoliChek hits: Scotch

### DIFF
--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
@@ -107,7 +107,7 @@ image106	borzoi
 image107	toy poodle
 image108	Kerry blue terrier
 image109	ox
-image110	Scotch terrier
+image110	Scottish terrier
 image111	Tibetan mastiff
 image112	spider monkey
 image113	Doberman

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
@@ -107,7 +107,7 @@ borzoi
 toy poodle
 Kerry blue terrier
 ox
-Scotch terrier
+Scottish terrier
 Tibetan mastiff
 spider monkey
 Doberman


### PR DESCRIPTION
Overall User Story: https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/2001296

## Summary

The term "Scotch" may be used if not referring to people. However, the correct name of the breed is apparently "Scottish terrier." We update the terms if possible even if not technically in error, so they won't get future hits.

Fixes the issue in the .tsv, .txt, and .zip. The issue was fixed in the .csv earlier in PR https://github.com/dotnet/docs/pull/31944.

Fixes #Issue_Number (if available) 
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14570
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14594
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14595


