### PR TITLE
Revised list patterns reference

### DIFF
--- a/docs/csharp/fundamentals/functional/pattern-matching.md
+++ b/docs/csharp/fundamentals/functional/pattern-matching.md
@@ -80,9 +80,30 @@ The preceding code demonstrates the [*positional pattern*](../../language-refere
 
 ## List patterns
 
-You can check elements in a list or an array using a *list pattern*. A list pattern provides a means to apply a pattern to any element of a sequence. In addition, you can apply the *discard pattern* (`_`) to match any element, or apply a *slice pattern* to match zero or more elements. The following example determines if an array matches the binary digits, or the start of a Fibonacci sequence:
+You can check elements in a list or an array using a *list pattern*. A [list pattern](../../language-reference/operators/patterns.md#list-patterns) provides a means to apply a pattern to any element of a sequence. In addition, you can apply the *discard pattern* (`_`) to match any element, or apply a *slice pattern* to match zero or more elements.
 
-:::code language="csharp" source="snippets/patterns/OrderProcessor.cs" id="ListPattern":::
+List patterns are a valuable tool when data doesn't follow a regular structure. You can use pattern matching to test the shape and values of the data instead of transforming it into a set of objects.
+
+Consider the following excerpt from a text file containing bank transactions:
+
+```output
+04-01-2020, DEPOSIT,    Initial deposit,            2250.00
+04-15-2020, DEPOSIT,    Refund,                      125.65
+04-18-2020, DEPOSIT,    Paycheck,                    825.65
+04-22-2020, WITHDRAWAL, Debit,           Groceries,  255.73
+05-01-2020, WITHDRAWAL, #1102,           Rent, apt, 2100.00
+05-02-2020, INTEREST,                                  0.65
+05-07-2020, WITHDRAWAL, Debit,           Movies,      12.57
+04-15-2020, FEE,                                       5.55
+```
+
+It's a CSV format, but some of the rows have more columns than others. Even worse for processing, one column in the `WITHDRAWAL` type has user-generated text and can contain a comma in the text. A *list pattern* that includes the *discard* pattern, *constant* pattern and *var* pattern to capture the value processes data in this format:
+
+:::code language="csharp" source="snippets/patterns/ListPattern.cs" id="ListPattern":::
+
+The preceding example takes a string array, where each element is one field in the row. The `switch` expression keys on the second field, which determines the kind of transaction, and the number of remaining columns. Each row ensures the data is in the correct format. The discard pattern (`_`) skips the first field, with the date of the transaction. The second field matches the type of transaction. Remaining element matches skip to the field with the amount. The final match uses the *var* pattern to capture the string representation of the amount. The expression calculates the amount to add or subtract from the balance.
+
+*List patterns* enable you to match on the shape of a sequence of data elements. You use the *discard* and *slice* patterns to match the location of elements. You use other patterns to match characteristics about individual elements.
 
 This article provided a tour of the kinds of code you can write with pattern matching in C#. The following articles show more examples of using patterns in scenarios, and the full vocabulary of patterns available to use.
 

--- a/docs/csharp/fundamentals/functional/snippets/patterns/ListPattern.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/ListPattern.cs
@@ -35,7 +35,7 @@ static class ListPattern
 
         IEnumerable<string[]> ReadRecords()
         {
-            foreach (var record in records)
+            foreach (var record in s_records)
                 yield return record.Split(',', StringSplitOptions.TrimEntries);
         }
     }

--- a/docs/csharp/fundamentals/functional/snippets/patterns/ListPattern.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/ListPattern.cs
@@ -2,7 +2,7 @@ namespace patterns;
 
 static class ListPattern
 {
-    static string[] records =
+    static string[] s_records =
     {
         "04-01-2020, DEPOSIT, Initial deposit, 2250.00",
         "04-15-2020, DEPOSIT, Refund, 125.65",

--- a/docs/csharp/fundamentals/functional/snippets/patterns/ListPattern.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/ListPattern.cs
@@ -1,0 +1,42 @@
+namespace patterns;
+
+static class ListPattern
+{
+    static string[] records =
+    {
+        "04-01-2020, DEPOSIT, Initial deposit, 2250.00",
+        "04-15-2020, DEPOSIT, Refund, 125.65",
+        "04-18-2020, DEPOSIT, Paycheck, 125.65",
+        "04-22-2020, WITHDRAWAL, Debit, Groceries, 255.73",
+        "05-01-2020, WITHDRAWAL, #1102, Rent, apt, 2100.00",
+        "05-02-2020, INTEREST,  0.65",
+        "05-07-2020, WITHDRAWAL, Debit, Movies, 12.57",
+        "04-15-2020, FEE, 5.55",
+    };
+
+    
+    public static void Example()
+    {
+        // <ListPattern>
+        decimal balance = 0m;
+        foreach (string[] transaction in ReadRecords())
+        {
+            balance += transaction switch
+            {
+                [_, "DEPOSIT", _, var amount]     => decimal.Parse(amount),
+                [_, "WITHDRAWAL", .., var amount] => -decimal.Parse(amount),
+                [_, "INTEREST", var amount]       => decimal.Parse(amount),
+                [_, "FEE", var fee]               => -decimal.Parse(fee),
+                _                                 => throw new InvalidOperationException($"Record {string.Join(", ", transaction)} is not in the expected format!"),
+            };
+            Console.WriteLine($"Record: {string.Join(", ", transaction)}, New balance: {balance:C}");
+        }
+        // </ListPattern>
+
+        IEnumerable<string[]> ReadRecords()
+        {
+            foreach (var record in records)
+                yield return record.Split(',', StringSplitOptions.TrimEntries);
+        }
+    }
+}

--- a/docs/csharp/fundamentals/functional/snippets/patterns/OrderProcessor.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/OrderProcessor.cs
@@ -33,24 +33,3 @@ class OrderProcessing
         };
     // </DeconstructPattern>
 }
-
-class ListPattern
-{
-    // <ListPattern>
-    public void MatchElements(int[] array)
-    {
-        if (array is [0,1])
-        {
-            Console.WriteLine("Binary Digits");
-        }
-        else if (array is [1,1,2,3,5,8, ..])
-        {
-            Console.WriteLine("array looks like a Fibonacci sequence");
-        }
-        else
-        {
-            Console.WriteLine("Array shape not recognized");
-        }
-    }
-    // </ListPattern>
-}

--- a/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
@@ -11,6 +11,8 @@ class Program
         var sequence = new List<int> {1,2,3,4,5,6,7};
         var middle = MidPoint(sequence);
         Console.WriteLine(middle);
+
+        ListPattern.Example();
     }
 
     // <MidPoint>

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -17,8 +17,8 @@ helpviewer_keywords:
 The following C# expressions and statements support pattern matching:
 
 - [`is` expression](is.md)
-- [`switch` statement](../statements/selection-statements.md#the-switch-statement)
-- [`switch` expression](switch-expression.md)
+- [switch statement](../statements/selection-statements.md#the-switch-statement)
+- [switch expression](switch-expression.md)
 
 In those constructs, you can match an input expression against any of the following patterns:
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -1,7 +1,7 @@
 ---
 title: "Patterns - C# reference"
 description: "Learn about the patterns supported by C# pattern matching expressions and statements."
-ms.date: 06/02/2022
+ms.date: 10/21/2022
 f1_keywords: 
   - "and_CSharpKeyword"
   - "or_CSharpKeyword"
@@ -17,8 +17,8 @@ helpviewer_keywords:
 The following C# expressions and statements support pattern matching:
 
 - [`is` expression](is.md)
-- `switch` [statement](../statements/selection-statements.md#the-switch-statement)
-- `switch` [expression](switch-expression.md)
+- [`switch` statement](../statements/selection-statements.md#the-switch-statement)
+- [`switch` expression](switch-expression.md)
 
 In those constructs, you can match an input expression against any of the following patterns:
 
@@ -31,8 +31,9 @@ In those constructs, you can match an input expression against any of the follow
 - [Positional pattern](#positional-pattern): to deconstruct an expression result and test if the resulting values match nested patterns.
 - [`var` pattern](#var-pattern): to match any expression and assign its result to a declared variable.
 - [Discard pattern](#discard-pattern): to match any expression.
+- [List patterns](#list-patterns): to test if sequence elements match corresponding nested patterns. Introduced in C# 11.
 
-[Logical](#logical-patterns), [property](#property-pattern), and [positional](#positional-pattern) patterns are *recursive* patterns. That is, they can contain *nested* patterns.
+[Logical](#logical-patterns), [property](#property-pattern), [positional](#positional-pattern), and [list](#list-patterns) patterns are *recursive* patterns. That is, they can contain *nested* patterns.
 
 For the example of how to use those patterns to build a data-driven algorithm, see [Tutorial: Use pattern matching to build type-driven and data-driven algorithms](../../fundamentals/tutorials/pattern-matching.md).
 
@@ -70,9 +71,9 @@ Beginning with C# 9.0, for that purpose you can use a *type pattern*, as the fol
 
 Like a declaration pattern, a type pattern matches an expression when an expression result is non-null and its run-time type satisfies any of the conditions listed above.
 
-You can also use this pattern for a clear, concise `null` check:
+To check for non-null, you can use a [negated](#logical-patterns) `null` [constant pattern](#constant-pattern), as the following example shows:
 
-:::code language="csharp" source="snippets/patterns/DeclarationAndTypePatterns.cs" id="NotNull":::
+:::code language="csharp" source="snippets/patterns/DeclarationAndTypePatterns.cs" id="NonNullCheck":::
 
 For more information, see the [Declaration pattern](~/_csharplang/proposals/csharp-8.0/patterns.md#declaration-pattern) and [Type pattern](~/_csharplang/proposals/csharp-9.0/patterns3.md#type-patterns) sections of the feature proposal notes.
 
@@ -256,55 +257,25 @@ Beginning with C# 9.0, you can put parentheses around any pattern. Typically, yo
 
 ## List patterns
 
-Beginning with C# 11, you can match an array or a list to a *sequence* of patterns that match elements. You can apply any of the following patterns:
+Beginning with C# 11, you can match an array or a list against a *sequence* of patterns, as the following example shows:
 
-- Any pattern can be applied to any element to check that an individual element matches certain characteristics.
-- The discard pattern (`_`) matches a single element.
-- The *range pattern* (`..`) can match zero or more elements in the sequence. At most one range pattern is allowed in a list pattern.
-- The `var` pattern can capture a single element, or a range of elements.
+:::code language="csharp" source="snippets/patterns/ListPattern.cs" id="BasicExample":::
 
-These rules are demonstrated using the following array declarations:
+As the preceding example shows, a list pattern is matched when each nested pattern is matched by the corresponding element of an input sequence. You can use any pattern within a list pattern. To match any element, use the [discard pattern](#discard-pattern) or, if you also want to capture the element, the [var pattern](#var-pattern), as the following example shows:
 
-:::code language="csharp" source="./snippets/patterns/ListPattern.cs" id="DeclareArrays":::
+:::code language="csharp" source="snippets/patterns/ListPattern.cs" id="MatchAnyElement":::
 
-You can match the entire sequence by specifying all the elements and using values:
+The preceding examples match a whole input sequence against a list pattern. To match elements only at the start or/and the end of an input sequence, use the *slice pattern* `..` within a list pattern, as the following example shows:
 
-:::code language="csharp" source="./snippets/patterns/ListPattern.cs" id="MatchEntireArray":::
+:::code language="csharp" source="snippets/patterns/ListPattern.cs" id="UseSlice":::
 
-You can match some elements in a sequence of a known length using the discard pattern (`_`) as a placeholder:
+A slice pattern matches zero or more elements. You can use at most one slice pattern in a list pattern.
 
-:::code language="csharp" source="./snippets/patterns/ListPattern.cs" id="MatchElements":::
+You can also nest a subpattern within a slice pattern, as the following example shows:
 
-You can supply any number of values or placeholders anywhere in the sequence. If you aren't concerned with the length, you can use the *range* pattern to match zero or more elements:
+:::code language="csharp" source="snippets/patterns/ListPattern.cs" id="SliceWithPattern":::
 
-:::code language="csharp" source="./snippets/patterns/ListPattern.cs" id="MatchRange":::
-
-The previous examples used the *constant pattern* to determine if an element is a given number. Any of those patterns could be replaced by a different pattern, such as a relational pattern:
-
-:::code language="csharp" source="./snippets/patterns/ListPattern.cs" id="RelationalMatch":::
-
-List patterns are a valuable tool when data doesn't follow a regular structure. You can use pattern matching to test the shape and values of the data instead of transforming it into a set of objects.
-
-Consider the following excerpt from a text file containing bank transactions:
-
-```output
-04-01-2020, DEPOSIT,    Initial deposit,            2250.00
-04-15-2020, DEPOSIT,    Refund,                      125.65
-04-18-2020, DEPOSIT,    Paycheck,                    825.65
-04-22-2020, WITHDRAWAL, Debit,           Groceries,  255.73
-05-01-2020, WITHDRAWAL, #1102,           Rent, apt, 2100.00
-05-02-2020, INTEREST,                                  0.65
-05-07-2020, WITHDRAWAL, Debit,           Movies,      12.57
-04-15-2020, FEE,                                       5.55
-```
-
-It's a CSV format, but some of the rows have more columns than others. Even worse for processing, one column in the `WITHDRAWAL` type has user-generated text and can contain a comma in the text. A *list pattern* that includes the *discard* pattern, *constant* pattern and *var* pattern to capture the value processes data in this format:
-
-:::code language="csharp" source="./snippets/patterns/ListPattern.cs" id="DataRecordExample":::
-
-The preceding example takes a string array, where each element is one field in the row. The switch expression keys on the second field, which determines the kind of transaction, and the number of remaining columns. Each row ensures the data is in the correct format. The discard pattern (`_`) skips the first field, with the date of the transaction. The second field matches the type of transaction. Remaining element matches skip to the field with the amount. The final match uses the *var* pattern to capture the string representation of the amount. The expression calculates the amount to add or subtract from the balance.
-
-*List patterns* enable you to match on the shape of a sequence of data elements. You use the *discard* and *range* patterns to match the location of elements. You use other patterns to match characteristics about individual elements.
+For more information, see the [List patterns](~/_csharplang/proposals/csharp-11.0/list-patterns.md) feature proposal note.
 
 ## C# language specification
 
@@ -321,4 +292,5 @@ For more information, see the following feature proposal notes:
 
 - [C# reference](../index.md)
 - [C# operators and expressions](index.md)
+- [Pattern matching overview](../../fundamentals/functional/pattern-matching.md)
 - [Tutorial: Use pattern matching to build type-driven and data-driven algorithms](../../fundamentals/tutorials/pattern-matching.md)

--- a/docs/csharp/language-reference/operators/snippets/patterns/DeclarationAndTypePatterns.cs
+++ b/docs/csharp/language-reference/operators/snippets/patterns/DeclarationAndTypePatterns.cs
@@ -12,17 +12,15 @@
 
         private static void NotNullPattern()
         {
-            object input = default;
-            // <NotNull>
+            object input = new object();
+            // <NonNullCheck>
             if (input is not null)
             {
-                Console.WriteLine(input);
-            } else
-            {
-                throw new ArgumentNullException(paramName: nameof(input), message: "Input should not be null");
+                // ...
             }
-            // </NotNull>
+            // </NonNullCheck>
         }
+        
         private static void BasicExample()
         {
             // <BasicExample>

--- a/docs/csharp/language-reference/operators/snippets/patterns/DeclarationAndTypePatterns.cs
+++ b/docs/csharp/language-reference/operators/snippets/patterns/DeclarationAndTypePatterns.cs
@@ -12,7 +12,7 @@
 
         private static void NotNullPattern()
         {
-            object input = new object();
+            object input = new();
             // <NonNullCheck>
             if (input is not null)
             {

--- a/docs/csharp/language-reference/operators/snippets/patterns/ListPattern.cs
+++ b/docs/csharp/language-reference/operators/snippets/patterns/ListPattern.cs
@@ -2,78 +2,80 @@
 
 public static class ListPattern
 {
-    static string[] records =
-    {
-        "04-01-2020, DEPOSIT, Initial deposit, 2250.00",
-        "04-15-2020, DEPOSIT, Refund, 125.65",
-        "04-18-2020, DEPOSIT, Paycheck, 125.65",
-        "04-22-2020, WITHDRAWAL, Debit, Groceries, 255.73",
-        "05-01-2020, WITHDRAWAL, #1102, Rent, apt, 2100.00",
-        "05-02-2020, INTEREST,  0.65",
-        "05-07-2020, WITHDRAWAL, Debit, Movies, 12.57",
-        "04-15-2020, FEE, 5.55",
-    };
-
-
     public static void Examples()
     {
-        // <DeclareArrays>
-        int[] one = { 1 };
-        int[] odd = { 1, 3, 5 };
-        int[] even = { 2, 4, 6 };
-        int[] fib = { 1, 1, 2, 3, 5 };
-        // </DeclareArrays>
+        BasicExample();
+        MatchAnyElement();
+        UseSlice();
+        SliceWithPattern();
+    }
 
-        Console.WriteLine("Match entire array");
-        // <MatchEntireArray>
-        Console.WriteLine(odd is [1, 3, 5]); // true
-        Console.WriteLine(even is [1, 3, 5]); // false (values)
-        Console.WriteLine(one is [1, 3, 5]); // false (length)
-        // </MatchEntireArray>
+    private static void BasicExample()
+    {
+        // <BasicExample>
+        int[] numbers = { 1, 2, 3 };
 
-        Console.WriteLine("Match elements");
-        // <MatchElements>
-        Console.WriteLine(odd is [1, _, _]); // true
-        Console.WriteLine(odd is [_, 3, _]); // true
-        Console.WriteLine(even is [_, _, 5]); // false (last value)
-        // </MatchElements>
+        Console.WriteLine(numbers is [1, 2, 3]);  // True
+        Console.WriteLine(numbers is [1, 2, 4]);  // False
+        Console.WriteLine(numbers is [1, 2, 3, 4]);  // False
+        Console.WriteLine(numbers is [0 or 1, <= 2, >= 3]);  // True
+        // </BasicExample>
+    }
 
-        Console.WriteLine("Match range");
-        // <MatchRange>
-        Console.WriteLine(odd is [1, .., 3, _]); // true
-        Console.WriteLine(fib is [1, .., 3, _]); // true
+    private static void MatchAnyElement()
+    {
+        // <MatchAnyElement>
+        List<int> numbers = new() { 1, 2, 3 };
 
-        Console.WriteLine(odd is [1, _, 5, ..]); // true
-        Console.WriteLine(fib is [1, _, 5, ..]); // false
-        // </MatchRange>
-
-        Console.WriteLine("Relational pattern");
-        // <RelationalMatch>
-        Console.WriteLine(odd is [_, >1, ..]); // true
-        Console.WriteLine(even is [_, >1, ..]); // true
-        Console.WriteLine(fib is [_, > 1, ..]); // false
-        // </RelationalMatch>
-
-        // <DataRecordExample>
-        decimal balance = 0m;
-        foreach (var transaction in ReadRecords())
+        if (numbers is [var first, _, _])
         {
-            balance += transaction switch
-            {
-                [_, "DEPOSIT", _, var amount]     => decimal.Parse(amount),
-                [_, "WITHDRAWAL", .., var amount] => -decimal.Parse(amount),
-                [_, "INTEREST", var amount]       => decimal.Parse(amount),
-                [_, "FEE", var fee]               => -decimal.Parse(fee),
-                _                                 => throw new InvalidOperationException($"Record {transaction} is not in the expected format!"),
-            };
-            Console.WriteLine($"Record: {transaction}, New balance: {balance:C}");
+            Console.WriteLine($"The first element of a three-item list is {first}.");
         }
-        // </DataRecordExample>
+        // Output:
+        // The first element of a three-item list is 1.
+        // </MatchAnyElement>
+    }
 
-        IEnumerable<string[]> ReadRecords()
+    private static void UseSlice()
+    {
+        // <UseSlice>
+        Console.WriteLine(new[] { 1, 2, 3, 4, 5 } is [> 0, > 0, ..]);  // True
+        Console.WriteLine(new[] { 1, 1 } is [_, _, ..]);  // True
+        Console.WriteLine(new[] { 0, 1, 2, 3, 4 } is [> 0, > 0, ..]);  // False
+        Console.WriteLine(new[] { 1 } is [1, 2, ..]);  // False
+
+        Console.WriteLine(new[] { 1, 2, 3, 4 } is [.., > 0, > 0]);  // True
+        Console.WriteLine(new[] { 2, 4 } is [.., > 0, 2, 4]);  // False
+        Console.WriteLine(new[] { 2, 4 } is [.., 2, 4]);  // True
+
+        Console.WriteLine(new[] { 1, 2, 3, 4 } is [>= 0, .., 2 or 4]);  // True
+        Console.WriteLine(new[] { 1, 0, 0, 1 } is [1, 0, .., 0, 1]);  // True
+        Console.WriteLine(new[] { 1, 0, 1 } is [1, 0, .., 0, 1]);  // False
+        // </UseSlice>
+    }
+
+    private static void SliceWithPattern()
+    {
+        // <SliceWithPattern>
+        void MatchMessage(string message)
         {
-            foreach (var record in records)
-                yield return record.Split(',', StringSplitOptions.TrimEntries); ;
+            var result = message is ['a' or 'A', .. var s, 'a' or 'A']
+                ? $"Message {message} matches; inner part is {s}."
+                : $"Message {message} doesn't match.";
+            Console.WriteLine(result);
         }
+
+        MatchMessage("aBBA");  // output: Message aBBA matches; inner part is BB.
+        MatchMessage("apron");  // output: Message apron doesn't match.
+
+        void Validate(int[] numbers)
+        {
+            var result = numbers is [< 0, .. { Length: 2 or 4 }, > 0] ? "valid" : "not valid";
+            Console.WriteLine(result);
+        }
+
+        Validate(new[] { -1, 0, 1 });  // output: not valid
+        Validate(new[] { -1, 0, 0, 1 });  // output: valid
+        // </SliceWithPattern>
     }
 }


### PR DESCRIPTION
Moved the conceptual-like part to the overview article. Added more examples (matching a string, using a subpattern with `..`)
