### PR TITLE
Changed event subscribe from C# 1.0/1.1 (2002 to 2004) era to C# 2.0 stye (2005)

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Data/XmlSchemaSetOverall Example/CS/xmlschemasetexample.cs
+++ b/samples/snippets/csharp/VS_Snippets_Data/XmlSchemaSetOverall Example/CS/xmlschemasetexample.cs
@@ -10,7 +10,7 @@ class XmlSchemaSetExample
         XmlReaderSettings booksSettings = new XmlReaderSettings();
         booksSettings.Schemas.Add("http://www.contoso.com/books", "books.xsd");
         booksSettings.ValidationType = ValidationType.Schema;
-        booksSettings.ValidationEventHandler += new ValidationEventHandler(booksSettingsValidationEventHandler);
+        booksSettings.ValidationEventHandler += booksSettingsValidationEventHandler;
 
         XmlReader books = XmlReader.Create("books.xml", booksSettings);
 


### PR DESCRIPTION
## Summary

The event subscribe was how things were done 17 years ago. C# 2.0 was release in 2005 so the code should reflect this.

Describe your changes here.

Here is the original code (C# 1.0-1.1)
booksSettings.ValidationEventHandler += new ValidationEventHandler(booksSettingsValidationEventHandler);

Here is the fix (C# 2.0 from 2005)
booksSettings.ValidationEventHandler += booksSettingsValidationEventHandler;

Fixes #Issue_Number (if available)
