### PR TITLE
Document UseCurrentRuntime

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -19,7 +19,7 @@ dotnet build [<PROJECT>|<SOLUTION>] [-a|--arch <ARCHITECTURE>]
     [--force] [--interactive] [--no-dependencies] [--no-incremental]
     [--no-restore] [--nologo] [--no-self-contained] [--os <OS>]
     [-o|--output <OUTPUT_DIRECTORY>] [-r|--runtime <RUNTIME_IDENTIFIER>]
-    [--self-contained [true|false]] [--source <SOURCE>]
+    [--self-contained [true|false]] [--source <SOURCE>] [--use-current-runtime, --ucr [true|false]]
     [-v|--verbosity <LEVEL>] [--version-suffix <VERSION_SUFFIX>]
 
 dotnet build -h|--help
@@ -133,6 +133,10 @@ The project or solution file to build. If a project or solution file isn't speci
   The URI of the NuGet package source to use during the restore operation.
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
+
+- **`--use-current-runtime, --ucr [true|false]`**
+
+  Sets the `RuntimeIdentifier` to a platform portable `RuntimeIdentifier` based on the one of your machine. This happens implicitly with properties that require a `RuntimeIdentifier`, such as `SelfContained`, `PublishAot`, `PublishSelfContained`, `PublishSingleFile`, and `PublishReadyToRun`. If the property is set to false, that implicit resolution will no longer occur.
 
 - **`--version-suffix <VERSION_SUFFIX>`**
 


### PR DESCRIPTION
Initial Feature was added in 2020 but not documented here: https://github.com/dotnet/sdk/issues/10449
We've added implicit RIDs here: https://github.com/dotnet/sdk/pull/26143 
And we've added interaction to toggle implicit RIDs off with UCR here: https://github.com/dotnet/sdk/pull/28628
And we added the shorthand for ucr here: https://github.com/dotnet/sdk/pull/27971 

Needs to be duplicated for `dotnet publish` as well.

FYI `PublishSelfContained` wont be available until net 7.0.200 most likely. 

cc @am11 @marcpopMSFT 
