### PR TITLE
Revert "Revert "Tool list package id feature doc update""

### DIFF
--- a/docs/core/tools/dotnet-tool-list.md
+++ b/docs/core/tools/dotnet-tool-list.md
@@ -20,6 +20,8 @@ dotnet tool list --tool-path <PATH>
 
 dotnet tool list --local
 
+dotnet tool list [<PACKAGE_ID>]
+
 dotnet tool list
 
 dotnet tool list -h|--help
@@ -27,11 +29,18 @@ dotnet tool list -h|--help
 
 ## Description
 
-The `dotnet tool list` command provides a way for you to list all .NET global, tool-path, or local tools installed on your machine. The command lists the package name, version installed, and the tool command.  To use the command, you specify one of the following:
+The `dotnet tool list` command provides a way for you to list .NET global, tool-path, or local tools installed on your machine. The command lists the package name, version installed, and the tool command.  To use the command, you specify one of the following:
 
 * To list global tools installed in the default location, use the `--global` option
 * To list global tools installed in a custom location, use the `--tool-path` option.
 * To list local tools, use the `--local` option or omit the `--global`, `--tool-path`, and `--local` options.
+* To list a specific tool, use the optional `PACKAGE_ID` argument.
+
+## Arguments
+
+- **`PACKAGE_ID`**
+
+  Lists the tool that has the supplied package ID if the tool is installed. Can be used in conjunction with options. Provides a way to check if a specific tool was installed. The command returns 1 if no tool with the specified package ID is found; returns 0 otherwise.
 
 ## Options
 
@@ -66,6 +75,14 @@ The `dotnet tool list` command provides a way for you to list all .NET global, t
 - **`dotnet tool list`** or **`dotnet tool list --local`**
 
   Lists all local tools available in the current directory.
+
+- **`dotnet tool list -g dotnetsay`**
+
+  Lists the global tool with the package id [dotnetsay](https://www.nuget.org/packages/dotnetsay/)
+
+- **`dotnet tool list dotnetsay`**
+
+  Lists the local tool with the package id [dotnetsay](https://www.nuget.org/packages/dotnetsay/)
 
 ## See also
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -195,7 +195,7 @@ To list a specific tool, use the [dotnet tool list <PACKAGE_ID>](dotnet-tool-lis
 dotnet tool list dotnetsay
 ```
 
-The output will be only contain information of that tool if it is installed, similar to the following example:
+The output will only list that tool if it's installed, similar to the following example:
 
 ```console
 Package Id      Version      Commands       Manifest

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -189,6 +189,20 @@ dotnetsay       2.1.3        dotnetsay      /home/name/repository/.config/dotnet
 
 As shown in the preceding example, the list shows local tools. To see global tools, use the `--global` option. To see tool-path tools, use the `--tool-path` option.
 
+To list a specific tool, use the [dotnet tool list <PACKAGE_ID>](dotnet-tool-list.md) command:
+
+```dotnetcli
+dotnet tool list dotnetsay
+```
+
+The output will be only contain information of that tool if it is installed, similar to the following example:
+
+```console
+Package Id      Version      Commands       Manifest
+-------------------------------------------------------------------------------------------
+dotnetsay       2.1.3        dotnetsay      /home/name/repository/.config/dotnet-tools.json
+```
+
 ### Invoke a global tool
 
 For global tools, use the tool command by itself. For example, if the command is `dotnetsay` or `dotnet-doc`, that's what you use to invoke the global tool:


### PR DESCRIPTION
Reverts dotnet/docs#32002, coming full circle—getting back to the desired state of having this PR not yet merged, but approved.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-list.md](https://github.com/dotnet/docs/blob/0dd63a3c3895b97548a37d4cfbda6ba4fbdd6696/docs/core/tools/dotnet-tool-list.md) | [dotnet tool list](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list?branch=pr-en-us-32003) |
| [docs/core/tools/global-tools.md](https://github.com/dotnet/docs/blob/0dd63a3c3895b97548a37d4cfbda6ba4fbdd6696/docs/core/tools/global-tools.md) | [How to manage .NET tools](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-tools?branch=pr-en-us-32003) |

<!-- PREVIEW-TABLE-END -->