### PR TITLE
Add Dotnet Workload command page.

### DIFF
--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -31,12 +31,11 @@ The `dotnet workload` command provides commands for working with .NET workloads.
 
 - **`--info`**
 
-  Prints out detailed information about installed workloads, including their installation source, manifest version, manifest path, and install type. 
+  Prints out detailed information about installed workloads, including their installation source, manifest version, manifest path, and install type.
 
 - **`-?|-h|--help`**
 
   Prints out a list of available commands.
- 
 
 ## See also
 

--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -5,7 +5,7 @@ ms.date: 10/24/2022
 ---
 # dotnet workload command
 
-**This article applies to:** ✔️ .NET Core 7.0 SDK and later versions
+**This article applies to:** ✔️ .NET 7 SDK and later versions
 
 ## Name
 

--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -21,9 +21,7 @@ dotnet workload -?|-h|--help
 
 ## Description
 
-The `dotnet workload` command provides commands for working with .NET workloads.
-
-  For example, [`dotnet workload install`](dotnet-workload-install.md) installs a particular workload. Each command defines its own options and arguments. All commands support the `--help` option for printing out brief documentation about how to use the command.
+The `dotnet workload` command provides commands for working with .NET workloads. For example, [`dotnet workload install`](dotnet-workload-install.md) installs a particular workload. Each command defines its own options and arguments. All commands support the `--help` option for printing out brief documentation about how to use the command.
 
 ## Options
 

--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -1,0 +1,44 @@
+---
+title: dotnet workload command
+description: Learn about the base dotnet workload command. Workloads allow you to manage and install optional components of .NET.
+ms.date: 10/24/2022
+---
+# dotnet workload command
+
+**This article applies to:** ✔️ .NET Core 7.0 SDK and later versions
+
+## Name
+
+`dotnet workload` - The generic driver for the .NET workloads experience.
+
+## Synopsis
+
+To get information about the available workload commands and or installed workloads:
+
+```dotnetcli
+dotnet workload [--info]
+
+dotnet workload -?|-h|--help
+```
+
+## Description
+
+The `dotnet workload` command provides commands for working with .NET workloads.
+
+  For example, [`dotnet workload install`](dotnet-workload-install.md) installs a particular workload. Each command defines its own options and arguments. All commands support the `--help` option for printing out brief documentation about how to use the command.
+
+## Options
+
+- **`--info`**
+
+  Prints out detailed information about installed workloads, including their installation source, manifest version, manifest path, and install type. 
+
+- **`-?|-h|--help`**
+
+  Prints out a list of available commands.
+ 
+
+## See also
+
+- [Installing a .NET Workload](dotnet-workload-install.md)
+- [Find the available workloads on your machine](dotnet-workload-search.md)

--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet workload command
-description: Learn about the base dotnet workload command. Workloads allow you to manage and install optional components of .NET.
+description: Learn about the base dotnet workload command. Workload commands manage and install optional components of .NET.
 ms.date: 10/24/2022
 ---
 # dotnet workload command

--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -9,11 +9,9 @@ ms.date: 10/24/2022
 
 ## Name
 
-`dotnet workload` - The generic driver for the .NET workloads experience.
+`dotnet workload` - Provides information about the available workload commands and installed workloads.
 
 ## Synopsis
-
-To get information about the available workload commands and or installed workloads:
 
 ```dotnetcli
 dotnet workload [--info]

--- a/docs/core/tools/dotnet-workload.md
+++ b/docs/core/tools/dotnet-workload.md
@@ -35,5 +35,6 @@ The `dotnet workload` command provides commands for working with .NET workloads.
 
 ## See also
 
-- [Installing a .NET Workload](dotnet-workload-install.md)
-- [Find the available workloads on your machine](dotnet-workload-search.md)
+- [Install a workload](dotnet-workload-install.md)
+- [List the installed workloads on your machine](dotnet-workload-list.md)
+- [Show workloads available to install](dotnet-workload-search.md)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -375,6 +375,8 @@ items:
       href: ../core/tools/dotnet-watch.md
     - name: dotnet workload
       items:
+      - name: dotnet workload
+        href: ../core/tools/dotnet-workload.md
       - name: dotnet workload install
         href: ../core/tools/dotnet-workload-install.md
       - name: dotnet workload list


### PR DESCRIPTION
I based this off of the `dotnet` command page. We support `dotnet workload --info` and needed to have this page to document it. It should show up as the primary header for workloads most likely, not sure how to make that change reflected in the main docs page. 

Since this may be the first thing people see searching up workloads, it should be well polished. Requesting a review from the SDK team to review.