### PR TITLE
Fix PoliChek hit: Newfoundland

### DIFF
--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
@@ -58,7 +58,7 @@ image57,Lhasa
 image58,impala
 image59,coyote
 image60,Yorkshire terrier
-image61,Newfoundland
+image61,dresser
 image62,brown bear
 image63,red fox
 image64,Norwegian elkhound

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
@@ -58,7 +58,7 @@ image57	Lhasa
 image58	impala
 image59	coyote
 image60	Yorkshire terrier
-image61	Newfoundland
+image61	dresser
 image62	brown bear
 image63	red fox
 image64	Norwegian elkhound

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
@@ -58,7 +58,7 @@ Lhasa
 impala
 coyote
 Yorkshire terrier
-Newfoundland
+dresser
 brown bear
 red fox
 Norwegian elkhound


### PR DESCRIPTION
## Summary

User Story https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/2001296

The term is "Newfoundland". OK when referring to the island but not the province (Newfoundland and Labrador). This image could be a photo of the island, or of a map showing the province. I tracked down the image to Wikimedia Commons and it's actually a photo of an interior with a dresser. So I renamed the label to "dresser".

Fixes #Issue_Number (if available)
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14585
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14619
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14609
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14732
