### PR TITLE
fix link to section "D.4.2 ID string format"

### DIFF
--- a/docs/fundamentals/code-analysis/suppress-warnings.md
+++ b/docs/fundamentals/code-analysis/suppress-warnings.md
@@ -79,7 +79,7 @@ If you add the attribute to the global suppressions file, you [scope](xref:Syste
 [assembly: SuppressMessage("Usage", "CA2200:Rethrow to preserve stack details", Justification = "Not production code.", Scope = "member", Target = "~M:MyApp.Program.IgnorableCharacters")]
 ```
 
-Use the *documentation ID* for the API you want to reference in the `Target` attribute. For information about documentation IDs, see [Documentation ID format](/dotnet/csharp/language-reference/language-specification/documentation-comments#id-string-format).
+Use the *documentation ID* for the API you want to reference in the `Target` attribute. For information about documentation IDs, see [Documentation ID format](/dotnet/csharp/language-reference/language-specification/documentation-comments#d42-id-string-format).
 
 To suppress warnings for compiler-generated code that doesn't map to explicitly provided user source, you must put the suppression attribute in a global suppressions file. For example, the following code suppresses a violation against a compiler-emitted constructor:
 


### PR DESCRIPTION
fix link to section "D.4.2 ID string format" on "Documentation comments" page 

## Summary
There's now a "d42-" prepended to the page anchor name.
