### PR TITLE
Fix broken code snippet in source-generated logging docs

### DIFF
--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -77,7 +77,7 @@ using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
                 Indented = true
             }));
 
-ILogger<SampleObject> logger = LoggerFactory.CreateLogger<SampleObject>();
+ILogger<SampleObject> logger = loggerFactory.CreateLogger<SampleObject>();
 
 logger.CustomLogEvent(LogLevel.Information, "Liana", "Seattle");
 

--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -69,19 +69,21 @@ You can omit the logging message and <xref:System.String.Empty?displayProperty=n
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
-ILogger<SampleObject> logger = LoggerFactory.Create(
-    builder =>
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => 
     builder.AddJsonConsole(
         options =>
-        options.JsonWriterOptions = new JsonWriterOptions()
-        {
-            Indented = true
-        }))
-    .CreateLogger<SampleObject>();
+            options.JsonWriterOptions = new JsonWriterOptions 
+            {
+                Indented = true
+            }));
+
+ILogger<SampleObject> logger = LoggerFactory.CreateLogger<SampleObject>();
 
 logger.CustomLogEvent(LogLevel.Information, "Liana", "Seattle");
 
-public static partial class SampleObject
+public class SampleObject { }
+
+public static partial class Log
 {
     [LoggerMessage(EventId = 23)]
     public static partial void CustomLogEvent(
@@ -96,7 +98,7 @@ Consider the example logging output when using the `JsonConsole` formatter.
 {
   "EventId": 23,
   "LogLevel": "Information",
-  "Category": "ConsoleApp.SampleObject",
+  "Category": "SampleObject",
   "Message": "",
   "State": {
     "Message": "",


### PR DESCRIPTION
## Summary

- Implement 'using' statement to ensure logs are flushed. 
- Replace static generic type that doesn't compile.
- Fix broken code snippet in source-generated logging docs. 
- Correct output.

Fixes #32035
