### PR TITLE
Use "HTTP method" instead of "HTTP verb"

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca3005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3005.md
@@ -43,7 +43,7 @@ For the user-controlled portion of LDAP statements, consider one o:
 - Disallow special character
 - Escape special characters.
 
-See [OWASP's LDAP Injection Prevention Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md) for more guidance.
+See [OWASP's LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html) for more guidance.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/networking/http/http-overview.md
+++ b/docs/fundamentals/networking/http/http-overview.md
@@ -27,17 +27,17 @@ The request methods are differentiated via several factors, first by their _verb
 - A request method is **_cacheable_** when its corresponding response can be stored for reuse. For more information, see [RFC 7231: Section 4.2.3 Cacheable Methods](https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.3).
 - A request method is considered a **_safe method_** if it doesn't modify the state of a resource. All _safe methods_ are also _idempotent_, but not all _idempotent_ methods are considered _safe_. For more information, see [RFC 7231: Section 4.2.1 Safe Methods](https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1).
 
-| HTTP verb | Is idempotent | Is cacheable         | Is safe |
-|-----------|---------------|----------------------|---------|
-| `GET`     | ✔️ Yes       | ✔️ Yes               | ✔️ Yes |
-| `POST`    | ❌ No         | ⚠️ <sup>†</sup>Rarely | ❌ No   |
-| `PUT`     | ✔️ Yes       | ❌ No                 | ❌ No   |
-| `PATCH`   | ❌ No         | ❌ No                 | ❌ No   |
-| `DELETE`  | ✔️ Yes       | ❌ No                 | ❌ No   |
-| `HEAD`    | ✔️ Yes       | ✔️ Yes               | ✔️ Yes |
-| `OPTIONS` | ✔️ Yes       | ❌ No                 | ✔️ Yes |
-| `TRACE`   | ✔️ Yes       | ❌ No                 | ✔️ Yes |
-| `CONNECT` | ❌ No         | ❌ No                 | ❌ No   |
+| HTTP method | Is idempotent | Is cacheable         | Is safe |
+|-------------|---------------|----------------------|---------|
+| `GET`       | ✔️ Yes       | ✔️ Yes               | ✔️ Yes |
+| `POST`      | ❌ No         | ⚠️ <sup>†</sup>Rarely | ❌ No   |
+| `PUT`       | ✔️ Yes       | ❌ No                 | ❌ No   |
+| `PATCH`     | ❌ No         | ❌ No                 | ❌ No   |
+| `DELETE`    | ✔️ Yes       | ❌ No                 | ❌ No   |
+| `HEAD`      | ✔️ Yes       | ✔️ Yes               | ✔️ Yes |
+| `OPTIONS`   | ✔️ Yes       | ❌ No                 | ✔️ Yes |
+| `TRACE`     | ✔️ Yes       | ❌ No                 | ✔️ Yes |
+| `CONNECT`   | ❌ No         | ❌ No                 | ❌ No   |
 
 > <sup>†</sup>The `POST` method is only cacheable when the appropriate `Cache-Control` or `Expires` response headers are present. This is very uncommon in practice.
 

--- a/docs/fundamentals/networking/http/httpclient.md
+++ b/docs/fundamentals/networking/http/httpclient.md
@@ -45,7 +45,7 @@ This `HttpClient` instance will always use the base address when making subseque
 
 To make an HTTP request, you call any of the following APIs:
 
-| HTTP verb                    | API                                                                                 |
+| HTTP method                  | API                                                                                 |
 |------------------------------|-------------------------------------------------------------------------------------|
 | `GET`                        | <xref:System.Net.Http.HttpClient.GetAsync%2A?displayProperty=nameWithType>          |
 | `GET`                        | <xref:System.Net.Http.HttpClient.GetByteArrayAsync%2A?displayProperty=nameWithType> |
@@ -64,7 +64,7 @@ To make an HTTP request, you call any of the following APIs:
 
 ### HTTP content
 
-The <xref:System.Net.Http.HttpContent> type is used to represent an HTTP entity body and corresponding content headers. For HTTP verbs (or request methods) that require a body, `POST`, `PUT`, and `PATCH`, you use the <xref:System.Net.Http.HttpContent> class to specify the body of the request. Most examples show how to prepare the  <xref:System.Net.Http.StringContent> subclass with a JSON payload, but additional subclasses exist for different [content (MIME) types](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/MIME_types).
+The <xref:System.Net.Http.HttpContent> type is used to represent an HTTP entity body and corresponding content headers. For HTTP methods (or request methods) that require a body, `POST`, `PUT`, and `PATCH`, you use the <xref:System.Net.Http.HttpContent> class to specify the body of the request. Most examples show how to prepare the  <xref:System.Net.Http.StringContent> subclass with a JSON payload, but additional subclasses exist for different [content (MIME) types](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/MIME_types).
 
 - <xref:System.Net.Http.ByteArrayContent>: Provides HTTP content based on a byte array.
 - <xref:System.Net.Http.FormUrlEncodedContent>: Provides HTTP content for name/value tuples encoded using `"application/x-www-form-urlencoded"` MIME type.
@@ -79,7 +79,7 @@ The `HttpContent` class is also used to represent the response body of the <xref
 
 ### HTTP Get
 
-A `GET` request shouldn't send a body and is used (as the verb indicates) to retrieve (or get) data from a resource. To make an HTTP `GET` request, given an `HttpClient` and a URI, use the <xref:System.Net.Http.HttpClient.GetAsync%2A?displayProperty=nameWithType> method:
+A `GET` request shouldn't send a body and is used (as the method name indicates) to retrieve (or get) data from a resource. To make an HTTP `GET` request, given an `HttpClient` and a URI, use the <xref:System.Net.Http.HttpClient.GetAsync%2A?displayProperty=nameWithType> method:
 
 :::code language="csharp" source="../snippets/httpclient/Program.Get.cs" id="get":::
 
@@ -239,7 +239,7 @@ The `TRACE` request can be useful for debugging as it provides application-level
 :::code language="csharp" source="../snippets/httpclient/Program.Trace.cs" id="trace":::
 
 > [!CAUTION]
-> The `TRACE` HTTP verb is not supported by all HTTP servers. It can expose a security vulnerability if used unwisely. For more information, see [Open Web Application Security Project (OWASP): Cross Site Tracing](https://owasp.org/www-community/attacks/Cross_Site_Tracing).
+> The `TRACE` HTTP method is not supported by all HTTP servers. It can expose a security vulnerability if used unwisely. For more information, see [Open Web Application Security Project (OWASP): Cross Site Tracing](https://owasp.org/www-community/attacks/Cross_Site_Tracing).
 
 ## Handle an HTTP response
 

--- a/docs/standard/serialization/binaryformatter-security-guide.md
+++ b/docs/standard/serialization/binaryformatter-security-guide.md
@@ -83,5 +83,5 @@ Another scenario is where the data file is stored in cloud storage and automatic
 
 * [YSoSerial.Net](https://github.com/pwntester/ysoserial.net) for research into how adversaries attack apps that utilize `BinaryFormatter`.
 * General background on deserialization vulnerabilities:
-  * [OWASP Top 10 - A8:2017-Insecure Deserialization](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A8-Insecure_Deserialization)
+  * [OWASP: Deserialization of Untrusted Data](https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data)
   * [CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)


### PR DESCRIPTION
## Summary

Changes wording ("method" instead of "verb")

Fixes #32056 
