### PR TITLE
Removed: await finishedTask;

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/index.md
+++ b/docs/csharp/programming-guide/concepts/async/index.md
@@ -241,7 +241,6 @@ while (breakfastTasks.Count > 0)
     {
         Console.WriteLine("Toast is ready");
     }
-    await finishedTask;    
     breakfastTasks.Remove(finishedTask);
 }
 ```


### PR DESCRIPTION
## Summary

I've removed the `await finishedTask;` from line 244 because the task was awaited on line 231.