### PR TITLE
Modify log scope to use keyvalue pairs

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -471,8 +471,12 @@ Use a scope by wrapping logger calls in a `using` block:
 public async Task<T> GetAsync<T>(string id)
 {
     T result;
+    var transactionId = Guid.NewGuid().ToString();
 
-    using (_logger.BeginScope("using block message"))
+    using (_logger.BeginScope(new List<KeyValuePair<string, object>>
+        {
+            new KeyValuePair<string, object>("TransactionId", transactionId),
+        }))
     {
         _logger.LogInformation(
             AppLogEvents.Read, "Reading value for {Id}", id);


### PR DESCRIPTION
## Summary

The scopes example currently uses a plain string. This PR proposes to replace that with a KVP collection, containing the key "TransactionId". This matches the example use case that was described right above the example code snippet.

While Scope can accept any `object` including `string`, most backends expect additional enrichments to come in the form of key-value pairs, so this is demonstrating a better practice of using Scopes.

Fixes #Issue_Number (if available)
