### PR TITLE
Fix broken link to voice and tone recommendations

### DIFF
--- a/styleguide/voice-tone.md
+++ b/styleguide/voice-tone.md
@@ -1,3 +1,3 @@
 # Voice and tone recommendations
 
-This content has been moved to the [Contributor guide](/contribute/dotnet-voice-tone).
+This content has been moved to the [Contributor guide](https://learn.microsoft.com/contribute/dotnet/dotnet-voice-tone).


### PR DESCRIPTION
Fix a broken link to the voice and tone recommendations for .NET documentation.

## Summary

The link to the [voice and tone recommendations for .NET documentation](https://learn.microsoft.com/contribute/dotnet/dotnet-voice-tone) in `styleguide/voice-tone.md` is broken. This PR fixes the link to point to the correct location.
