### PR TITLE
Equivalent usages section in TCP

### DIFF
--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -84,7 +84,7 @@ The preceding C# code:
 
 ### Create a client `Socket`
 
-`TcpClient`'s default constructor tries to create a _dual-mode socket_, if it's not viable, it creates an IPv4 socket with the `new Socket(SocketType, ProtocolType)` constructor. Consider the following TCP client code:
+`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via `[new Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket)` constructor, if [IPv6 is supported (Socket.OSSupportsIPv6 == true)](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>). Otherwise, it fallbacks to IPv4 socket. Consider the following TCP client code:
 
 ```csharp
 var client = new TcpClient();
@@ -98,9 +98,9 @@ var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
 One of `TcpClient`'s constructor takes `AddressFamily` enum as a parameter. You can pass three different enum values to this constructor, otherwise, it throws an <xref:System.ArgumentException>. Valid enums are:
 
-- `AddressFamily.InterNetwork`: for IPv4 socket.
-- `AddressFamily.InterNetworkV6`: for IPv6 socket.
-- `AddressFamily.Unknown`: for dual-mode socket (by default, this enum value is used).
+- `[AddressFamily.InterNetwork](xref:System.Net.Sockets.AddressFamily.InterNetwork)`: for IPv4 socket.
+- `[AddressFamily.InterNetworkV6](xref:System.Net.Sockets.AddressFamily.InterNetworkV6)`: for IPv6 socket.
+- `[AddressFamily.Unknown](xref:System.Net.Sockets.AddressFamily.Unknown)`: for dual-stack socket (by default, this enum value is used).
 
 Consider the following TCP client code:
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -82,9 +82,11 @@ The preceding C# code:
 
 `TcpListener` and `TcpClient` classes internal implementation relies on the `Socket` class. This means you can do everything with `Socket` that you can do with `TcpClient` and `TcpListener`.
 
-### Create a client
+### Create a client socket
 
-`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via `[new Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket)` constructor, if [IPv6 is supported (Socket.OSSupportsIPv6 == true)](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>). Otherwise, it fallbacks to IPv4 socket. Consider the following TCP client code:
+`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via the `[new Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket)` constructor. This constructor creates a dual-stack socket if [IPv6 is supported](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise, it falls back to IPv4.
+
+Consider the following TCP client code:
 
 ```csharp
 var client = new TcpClient();
@@ -146,21 +148,23 @@ socket.Connect("www.example.com", 80);
 
 ### Connect to server
 
-Basically, every `Connect`, `ConnectAsync`, `BeginConnect` and `EndConnect` overload in `TcpClient` are functionally equivalent and their function signatures are same as well. Consider the following TCP client code:
+All `Connect`, `ConnectAsync`, `BeginConnect` and `EndConnect` overloads in `TcpClient` are functionally equivalent to the corresponding `Socket` methods.
+
+Consider the following TCP client code:
 
 ```csharp
 var client = new TcpClient();
 client.Connect("www.example.com", 80);
 ```
 
-The preceding TCP client code is functionally equivalent to the following socket code:
+The above `TcpClient` code is functionally equivalent to the following socket code:
 
 ```csharp
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 socket.Connect("www.example.com", 80);
 ```
 
-### Create a server
+### Create a server socket
 
 In `TcpListener` class, there are two constructors. Basically, both of them are initializes underlying socket. One of them is `TcpListener(IPAddress localaddr, int port)`. Consider the following TCP listener code:
 
@@ -202,9 +206,11 @@ var ep = new IPEndPoint(Socket.OSSupportsIPv6 ? IPAddress.IPv6Any : IPAddress.An
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-### Start listening on server
+### Start listening on the server
 
-In `Socket` class there are two steps to start listening on a server, but in `TcpClient` calling `Start` function is enough. Consider the following TCP listener code:
+The <xref:System.Net.Sockets.TcpClient.Start> method is a wrapper combining Socket's <xref:System.Net.Socket.Bind> and <xref:System.Net.Socket.Listen>.
+
+Consider the following TCP listener code:
 
 ```csharp
 var listener = new TcpListener(IPAddress.Loopback, 5000);
@@ -227,14 +233,9 @@ catch (SocketException)
 }
 ```
 
-### Accepting a connection on server
+### Accepting a connection on the server
 
-Basically, in `TcpListener` you can get two different type as return value on connection accept Those types are:
-
-- <xref:System.Net.Sockets.Socket>
-- <xref:System.Net.Sockets.TcpClient>
-
-You can get `TcpClient` from these functions: <xref:System.Net.Sockets.TcpListener.AcceptTcpClient> and <xref:System.Net.Sockets.TcpListener.AcceptTcpClientAsync>, and you can get `Socket` from these functions: <xref:System.Net.Sockets.TcpListener.AcceptSocket> and <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync>.
+`TcpListener` can accept both <xref:System.Net.Sockets.Socket> (via <xref:System.Net.Sockets.TcpListener.AcceptSocket> or <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync>) and <xref:System.Net.Sockets.TcpClient> (via <xref:System.Net.Sockets.TcpListener.AcceptTcpClient> and <xref:System.Net.Sockets.TcpListener.AcceptTcpClientAsync>).
 
 Consider the following TCP client code:
 
@@ -251,16 +252,18 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 var acceptSocket = socket.Accept(); // var acceptSocket = await socket.AcceptAsync();
 ```
 
-### Create a stream to send and receive data
+### Create a `NetworkStream` to send and receive data
 
-The difference in here is `TcpClient` class has a helper function for this if you want to create a `NetworkStream` which is called <xref:System.Net.Sockets.TcpClient.GetStream>, but in `Socket` class you should create it by yourself. Consider the following TCP client code:
+`TcpClient` class has a <xref:System.Net.Sockets.TcpClient.GetStream> helper method to instantiate a <xref:System.Net.Sockets.NetworkStream>. With `Socket`, you have to do it manually.
+
+Consider the following `TcpClient` code:
 
 ```csharp
 var client = new TcpClient();
 NetworkStream stream = client.GetStream();
 ```
 
-The preceding TCP client code is functionally equivalent to the following socket code:
+Which is equivalent to the following socket code:
 
 ```csharp
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -78,39 +78,43 @@ The preceding C# code:
 - Writes the sent message to the console.
 - Finally, calls the <xref:System.Net.Sockets.TcpListener.Stop%2A> method to stop listening on the port.
 
-## Equivalent usages of `TcpClient` and `TcpListener` classes in `Socket` class
+## Advanced TCP control with `Socket` class
 
-`TcpListener` and `TcpClient` classes directly uses `Socket` class in underlying implementation. It means you can do everything with `Socket` that you can do with `TcpClient` and `TcpListener`.
+`TcpListener` and `TcpClient` classes internal implementation relies on the `Socket` class. This means you can do everything with `Socket` that you can do with `TcpClient` and `TcpListener`.
 
 ### `TcpClient` Constructors
 
-`TcpClient's` default constructor basically tries to create a `dual mode socket`, if it's not viable, it creates IPv4 Socket via using `Socket(SocketType, ProtocolType)` constructor. It means following code snippets are equivalent:
+`TcpClient`'s default constructor tries to create a _dual-mode socket_, if it's not viable, it creates an IPv4 socket with the `new Socket(SocketType, ProtocolType)` constructor. Consider the following TCP client code:
 
 ```csharp
 TcpClient client = new TcpClient();
 ```
 
+The preceding TCP client code is functionally equivalent to the following socket code:
+
 ```csharp
 Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-One of `TcpClient's` constructor takes `AddressFamily` enum as parameter. You can pass three different enum value to this constructor, otherwise it throws an <xref:System.ArgumentException>. Valid enums are:
+One of `TcpClient`'s constructor takes `AddressFamily` enum as a parameter. You can pass three different enum values to this constructor, otherwise, it throws an <xref:System.ArgumentException>. Valid enums are:
 
-- `AddressFamily.InterNetwork` for IPv4 Socket
-- `AddressFamily.InterNetworkV6` for IPv6 Socket
-- `AddressFamily.Unknown` for Dual-Mode Socket (basically default constructor calls this constructor with this enum value)
+- `AddressFamily.InterNetwork`: for IPv4 socket.
+- `AddressFamily.InterNetworkV6`: for IPv6 socket.
+- `AddressFamily.Unknown`: for dual-mode socket (by default, this enum value is used).
 
-It means these code snippets are equivalent:
+Consider the following TCP client code:
 
 ```csharp
 TcpClient client = new TcpClient(AddressFamily.InterNetwork);
 ```
 
+The preceding TCP client code is functionally equivalent to the following socket code:
+
 ```csharp
 Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-Other `TcpClient's` constructor takes <xref:System.Net.IPEndPoint> class as parameter. This constructor basically gets `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates `Socket`, afterwards calls <xref:System.Net.Sockets.Socket.Bind%2A> on underlying `Socket` member with given <xref:System.Net.IPEndPoint> argument. Equivalent code snippets:
+Other `TcpClient`'s constructor takes an <xref:System.Net.IPEndPoint> class as a parameter. This constructor accepts an `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates a `Socket`. As part of this, it calls <xref:System.Net.Sockets.Socket.Bind%2A> on the underlying `Socket` member with the given <xref:System.Net.IPEndPoint> argument. Consider the following TCP client code:
 
 ```csharp
 // Example IPEndPoint object
@@ -118,6 +122,8 @@ IPEndPoint ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
 
 TcpClient client = new TcpClient(ep);
 ```
+
+The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
 // Example IPEndPoint object
@@ -127,11 +133,13 @@ Socket socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp
 socket.Bind(ep);
 ```
 
-Last but not least constructor overload of `TcpClient's` takes `hostname` and `port` as parameter, the difference from default constructor in here is; this constructor tries to connect given `hostname` and `port`. Equivalent code snippets:
+Another `TcpClient` constructor overload accepts a `hostname` and `port` as parameters, the difference from the default constructor is that this constructor tries to connect to the given `hostname` and `port`. Consider the following TCP client code:
 
 ```csharp
 TcpClient client = new TcpClient("www.example.com", 80);
 ```
+
+The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
 Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -89,13 +89,13 @@ Both `TcpClient` and `TcpListener` internally rely on the `Socket` class, meanin
 Consider the following TCP client code:
 
 ```csharp
-var client = new TcpClient();
+using var client = new TcpClient();
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
-var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
 #### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.Sockets.AddressFamily)> constructor
@@ -109,13 +109,13 @@ This constructor accepts only three `AddressFamily` values, otherwise it will th
 Consider the following TCP client code:
 
 ```csharp
-var client = new TcpClient(AddressFamily.InterNetwork);
+using var client = new TcpClient(AddressFamily.InterNetwork);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
-var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
 #### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)> constructor
@@ -126,7 +126,7 @@ Consider the following TCP client code:
 
 ```csharp
 var endPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
-var client = new TcpClient(endPoint);
+using var client = new TcpClient(endPoint);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
@@ -134,7 +134,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 ```csharp
 // Example IPEndPoint object
 var endPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
-var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(endPoint);
 ```
 
@@ -145,13 +145,13 @@ This constructor will attempt to create a dual-stack similar to the default cons
 Consider the following TCP client code:
 
 ```csharp
-var client = new TcpClient("www.example.com", 80);
+using var client = new TcpClient("www.example.com", 80);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
-var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 socket.Connect("www.example.com", 80);
 ```
 
@@ -162,14 +162,14 @@ All `Connect`, `ConnectAsync`, `BeginConnect` and `EndConnect` overloads in `Tcp
 Consider the following TCP client code:
 
 ```csharp
-var client = new TcpClient();
+using var client = new TcpClient();
 client.Connect("www.example.com", 80);
 ```
 
 The above `TcpClient` code is equivalent to the following socket code:
 
 ```csharp
-var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 socket.Connect("www.example.com", 80);
 ```
 
@@ -185,7 +185,7 @@ The preceding TCP listener code is functionally equivalent to the following sock
 
 ```csharp
 var ep = new IPEndPoint(IPAddress.Loopback, 5000);
-var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 ```
 
 ### Start listening on the server
@@ -203,7 +203,7 @@ The preceding TCP listener code is functionally equivalent to the following sock
 
 ```csharp
 var endPoint = new IPEndPoint(IPAddress.Loopback, 5000);
-var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(endPoint);
 try
 {
@@ -223,7 +223,7 @@ Consider the following `TcpListener` code:
 
 ```csharp
 var listener = new TcpListener(IPAddress.Loopback, 5000);
-var acceptedSocket = await listener.AcceptSocketAsync();
+using var acceptedSocket = await listener.AcceptSocketAsync();
 
 // Synchronous alternative.
 // var acceptedSocket = listener.AcceptSocket();
@@ -233,8 +233,8 @@ The preceding TCP listener code is functionally equivalent to the following sock
 
 ```csharp
 var endPoint = new IPEndPoint(IPAddress.Loopback, 5000);
-var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-var acceptedSocket = await socket.AcceptAsync();
+using var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+using var acceptedSocket = await socket.AcceptAsync();
 
 // Synchronous alternative
 // var acceptedSocket = socket.Accept();
@@ -247,17 +247,17 @@ With `TcpClient` you need to instantiate a <xref:System.Net.Sockets.NetworkStrea
 Consider the following `TcpClient` code:
 
 ```csharp
-var client = new TcpClient();
-NetworkStream stream = client.GetStream();
+using var client = new TcpClient();
+using NetworkStream stream = client.GetStream();
 ```
 
 Which is equivalent to the following socket code:
 
 ```csharp
-var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
 // Be aware that transfering the ownership means that closing/disposing the stream will also close the underlying socket.
-var stream = new NetworkStream(socket, ownsSocket: true);
+using var stream = new NetworkStream(socket, ownsSocket: true);
 ```
 
 > [!TIP]

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -170,7 +170,7 @@ socket.Connect("www.example.com", 80);
 
 ### Create a server socket
 
-In `TcpListener` class, there are two constructors. Basically, both of them are initializes underlying socket. One of them is `TcpListener(IPAddress localaddr, int port)`.
+In `TcpListener` class, basically, constructors initializes underlying socket. One of them is `TcpListener(IPAddress localaddr, int port)`.
 
 Consider the following TCP listener code:
 
@@ -185,40 +185,9 @@ var ep = new IPEndPoint(IPAddress.Loopback, 5000);
 var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-Other one is `TcpListener(IPEndPoint localEP)`, which does the same thing with the above constructor.
-
-Consider the following TCP listener code:
-
-```csharp
-var ep = new IPEndPoint(IPAddress.Loopback, 5000);
-var listener = new TcpListener(ep);
-```
-
-The preceding TCP listener code is functionally equivalent to the following socket code:
-
-```csharp
-var ep = new IPEndPoint(IPAddress.Loopback, 5000);
-var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-```
-
-Also, there is a `static` <xref:System.Net.Sockets.TcpListener.Create%2A> method as well. `Create` method creates _dual-stack_ socket if [IPv6 is supported (Socket.OSSupportsIPv6 == true)](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise creates IPv4 socket.
-
-Consider the following TCP listener code:
-
-```csharp
-var listener = TcpListener.Create(5000);
-```
-
-The preceding TCP listener code is functionally equivalent to the following socket code:
-
-```csharp
-var ep = new IPEndPoint(Socket.OSSupportsIPv6 ? IPAddress.IPv6Any : IPAddress.Any, 5000);
-var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-```
-
 ### Start listening on the server
 
-The <xref:System.Net.Sockets.TcpClient.Start> method is a wrapper combining Socket's <xref:System.Net.Socket.Bind> and <xref:System.Net.Socket.Listen>.
+The <xref:System.Net.Sockets.TcpListener.Start> method is a wrapper combining Socket's <xref:System.Net.Sockets.Socket.Bind%2A> and <xref:System.Net.Sockets.Socket.Listen>.
 
 Consider the following TCP listener code:
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -118,7 +118,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)?displayProperty=nameWithType> constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)> constructor
 
 Upon creating the socket, this constructor will also **bind** it to the provided **local** `IPEndPoint`. The <xref:System.Net.IPEndPoint.AddressFamily?displayProperty=nameWithType> property is used to determine the address family of the socket.
 
@@ -139,7 +139,7 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(ep);
 ```
 
-#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.String,System.Int32)?displayProperty=nameWithType> constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.String,System.Int32)> constructor
 
 This constructor will attempt to create a dual-stack similarly to the default constructor and **connect** it to the **remote** DNS endpoint defined by `hostname` and `port`.
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -87,13 +87,13 @@ The preceding C# code:
 `TcpClient`'s default constructor tries to create a _dual-mode socket_, if it's not viable, it creates an IPv4 socket with the `new Socket(SocketType, ProtocolType)` constructor. Consider the following TCP client code:
 
 ```csharp
-TcpClient client = new TcpClient();
+var client = new TcpClient();
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
-Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
 One of `TcpClient`'s constructor takes `AddressFamily` enum as a parameter. You can pass three different enum values to this constructor, otherwise, it throws an <xref:System.ArgumentException>. Valid enums are:
@@ -105,44 +105,42 @@ One of `TcpClient`'s constructor takes `AddressFamily` enum as a parameter. You 
 Consider the following TCP client code:
 
 ```csharp
-TcpClient client = new TcpClient(AddressFamily.InterNetwork);
+var client = new TcpClient(AddressFamily.InterNetwork);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
-Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
 Other `TcpClient`'s constructor takes an <xref:System.Net.IPEndPoint> class as a parameter. This constructor accepts an `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates a `Socket`. As part of this, it calls <xref:System.Net.Sockets.Socket.Bind%2A> on the underlying `Socket` member with the given <xref:System.Net.IPEndPoint> argument. Consider the following TCP client code:
 
 ```csharp
 // Example IPEndPoint object
-IPEndPoint ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
-
-TcpClient client = new TcpClient(ep);
+var ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
+var client = new TcpClient(ep);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
 // Example IPEndPoint object
-IPEndPoint ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
-
-Socket socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+var ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
+var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(ep);
 ```
 
 Another `TcpClient` constructor overload accepts a `hostname` and `port` as parameters, the difference from the default constructor is that this constructor tries to connect to the given `hostname` and `port`. Consider the following TCP client code:
 
 ```csharp
-TcpClient client = new TcpClient("www.example.com", 80);
+var client = new TcpClient("www.example.com", 80);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
-Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 socket.Connect("www.example.com", 80);
 ```
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -98,7 +98,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.Sockets.AddressFamily)?displayProperty=fullName> constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.Sockets.AddressFamily)?displayProperty=nameWithType> constructor
 
 This constructor accepts only three `AddressFamily` values, otherwise it will throw a <xref:System.ArgumentException>. Valid values are:
 
@@ -118,7 +118,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)?displayProperty=fullName> constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)?displayProperty=nameWithType> constructor
 
 Upon creating the socket, this constructor will also **bind** it to the provided **local** `IPEndPoint`. The <xref:System.Net.IPEndPoint.AddressFamily?displayProperty=nameWithType> property is used to determine the address family of the socket.
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -84,7 +84,7 @@ The preceding C# code:
 
 ### Create a client socket
 
-`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via the [new Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket) constructor. This constructor creates a dual-stack socket if [IPv6 is supported](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise, it falls back to IPv4.
+`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via the [Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket.%23ctor%2A) constructor. This constructor creates a dual-stack socket if [IPv6 is supported](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise, it falls back to IPv4.
 
 Consider the following TCP client code:
 
@@ -98,7 +98,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### TcpClient(AddressFamily) constructor
+#### The [TcpClient(AddressFamily)](xref:System.Net.Sockets.TcpClient.%23ctor%2A) constructor
 
 This constructor accepts only three `AddressFamily` values, otherwise it will throw a <xref:System.ArgumentException>. Valid values are:
 
@@ -118,7 +118,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### TcpClient(IPEndPoint) constructor
+#### The [TcpClient(IPEndPoint)](xref:System.Net.Sockets.TcpClient.%23ctor%2A) constructor
 
 Upon creating the socket, this constructor will also **bind** it to the provided **local** `IPEndPoint`. The <xref:System.Net.IPEndPoint.AddressFamily?displayProperty=nameWithType> property is used to determine the address family of the socket.
 
@@ -139,7 +139,7 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(ep);
 ```
 
-#### TcpClient(String, Int32) constructor
+#### The [TcpClient(String, Int32)](xref:System.Net.Sockets.TcpClient.%23ctor%2A) constructor
 
 This constructor will attempt to create a dual-stack similarly to the default constructor and **connect** it to the **remote** endpoint defined by `hostname` and `port`.
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -116,7 +116,9 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-Other `TcpClient`'s constructor takes an <xref:System.Net.IPEndPoint> class as a parameter. This constructor accepts an `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates a `Socket`. As part of this, it calls <xref:System.Net.Sockets.Socket.Bind%2A> on the underlying `Socket` member with the given <xref:System.Net.IPEndPoint> argument. Consider the following TCP client code:
+Other `TcpClient`'s constructor takes an <xref:System.Net.IPEndPoint> class as a parameter. This constructor accepts an `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates a `Socket`. As part of this, it calls <xref:System.Net.Sockets.Socket.Bind%2A> on the underlying `Socket` member with the given <xref:System.Net.IPEndPoint> argument.
+
+Consider the following TCP client code:
 
 ```csharp
 // Example IPEndPoint object
@@ -133,7 +135,9 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(ep);
 ```
 
-Another `TcpClient` constructor overload accepts a `hostname` and `port` as parameters, the difference from the default constructor is that this constructor tries to connect to the given `hostname` and `port`. Consider the following TCP client code:
+Another `TcpClient` constructor overload accepts a `hostname` and `port` as parameters, the difference from the default constructor is that this constructor tries to connect to the given `hostname` and `port`.
+
+Consider the following TCP client code:
 
 ```csharp
 var client = new TcpClient("www.example.com", 80);
@@ -166,7 +170,9 @@ socket.Connect("www.example.com", 80);
 
 ### Create a server socket
 
-In `TcpListener` class, there are two constructors. Basically, both of them are initializes underlying socket. One of them is `TcpListener(IPAddress localaddr, int port)`. Consider the following TCP listener code:
+In `TcpListener` class, there are two constructors. Basically, both of them are initializes underlying socket. One of them is `TcpListener(IPAddress localaddr, int port)`.
+
+Consider the following TCP listener code:
 
 ```csharp
 var listener = new TcpListener(IPAddress.Loopback, 5000);
@@ -179,7 +185,9 @@ var ep = new IPEndPoint(IPAddress.Loopback, 5000);
 var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-Other one is `TcpListener(IPEndPoint localEP)`, which does the same thing with the above constructor. Consider the following TCP listener code:
+Other one is `TcpListener(IPEndPoint localEP)`, which does the same thing with the above constructor.
+
+Consider the following TCP listener code:
 
 ```csharp
 var ep = new IPEndPoint(IPAddress.Loopback, 5000);
@@ -193,7 +201,9 @@ var ep = new IPEndPoint(IPAddress.Loopback, 5000);
 var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-Also, there is a `static` <xref:System.Net.Sockets.TcpListener.Create%2A> method as well. `Create` method creates _dual-stack_ socket if [IPv6 is supported (Socket.OSSupportsIPv6 == true)](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise creates IPv4 socket. Consider the following TCP listener code:
+Also, there is a `static` <xref:System.Net.Sockets.TcpListener.Create%2A> method as well. `Create` method creates _dual-stack_ socket if [IPv6 is supported (Socket.OSSupportsIPv6 == true)](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise creates IPv4 socket.
+
+Consider the following TCP listener code:
 
 ```csharp
 var listener = TcpListener.Create(5000);

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -78,10 +78,71 @@ The preceding C# code:
 - Writes the sent message to the console.
 - Finally, calls the <xref:System.Net.Sockets.TcpListener.Stop%2A> method to stop listening on the port.
 
+## Equivalent usages of `TcpClient` and `TcpListener` classes in `Socket` class
+
+`TcpListener` and `TcpClient` classes directly uses `Socket` class in underlying implementation. It means you can do everything with `Socket` that you can do with `TcpClient` and `TcpListener`.
+
+### `TcpClient` Constructors
+
+`TcpClient's` default constructor basically tries to create a `dual mode socket`, if it's not viable, it creates IPv4 Socket via using `Socket(SocketType, ProtocolType)` constructor. It means following code snippets are equivalent:
+
+```csharp
+TcpClient client = new TcpClient();
+```
+
+```csharp
+Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+```
+
+One of `TcpClient's` constructor takes `AddressFamily` enum as parameter. You can pass three different enum value to this constructor, otherwise it throws an <xref:System.ArgumentException>. Valid enums are:
+
+- `AddressFamily.InterNetwork` for IPv4 Socket
+- `AddressFamily.InterNetworkV6` for IPv6 Socket
+- `AddressFamily.Unknown` for Dual-Mode Socket (basically default constructor calls this constructor with this enum value)
+
+It means these code snippets are equivalent:
+
+```csharp
+TcpClient client = new TcpClient(AddressFamily.InterNetwork);
+```
+
+```csharp
+Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+```
+
+Other `TcpClient's` constructor takes <xref:System.Net.IPEndPoint> class as parameter. This constructor basically gets `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates `Socket`, afterwards calls <xref:System.Net.Sockets.Socket.Bind%2A> on underlying `Socket` member with given <xref:System.Net.IPEndPoint> argument. Equivalent code snippets:
+
+```csharp
+// Example IPEndPoint object
+IPEndPoint ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
+
+TcpClient client = new TcpClient(ep);
+```
+
+```csharp
+// Example IPEndPoint object
+IPEndPoint ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
+
+Socket socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+socket.Bind(ep);
+```
+
+Last but not least constructor overload of `TcpClient's` takes `hostname` and `port` as parameter, the difference from default constructor in here is; this constructor tries to connect given `hostname` and `port`. Equivalent code snippets:
+
+```csharp
+TcpClient client = new TcpClient("www.example.com", 80);
+```
+
+```csharp
+Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+socket.Connect("www.example.com", 80);
+```
+
 ## See also
 
 - [Use Sockets to send and receive data over TCP](socket-services.md)
 - [Networking in .NET](../overview.md)
+- <xref:System.Net.Sockets.Socket>
 - <xref:System.Net.Sockets.TcpClient>
 - <xref:System.Net.Sockets.TcpListener>
 - <xref:System.Net.Sockets.NetworkStream>

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -141,7 +141,7 @@ socket.Bind(ep);
 
 #### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.String,System.Int32)?displayProperty=nameWithType> constructor
 
-This constructor will attempt to create a dual-stack similarly to the default constructor and **connect** it to the **remote** endpoint defined by `hostname` and `port`.
+This constructor will attempt to create a dual-stack similarly to the default constructor and **connect** it to the **remote** DNS endpoint defined by `hostname` and `port`.
 
 Consider the following TCP client code:
 
@@ -227,6 +227,7 @@ Consider the following `TcpClient` code:
 ```csharp
 var listener = new TcpListener(IPAddress.Loopback, 5000);
 var acceptSocket = listener.AcceptSocket();
+
 // async code:
 // var acceptSocket = await listener.AcceptSocketAsync();
 ```
@@ -237,6 +238,7 @@ The preceding TCP listener code is functionally equivalent to the following sock
 var ep = new IPEndPoint(IPAddress.Loopback, 5000);
 var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 var acceptSocket = socket.Accept();
+
 // async code:
 // var acceptSocket = await socket.AcceptAsync();
 ```
@@ -256,6 +258,7 @@ Which is equivalent to the following socket code:
 
 ```csharp
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
 // Be aware that transfering the ownership means that closing/disposing the stream will also close the underlying socket.
 var stream = new NetworkStream(socket, ownsSocket: true);
 ```

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -98,7 +98,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.Sockets.AddressFamily)?displayProperty=nameWithType> constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.Sockets.AddressFamily)> constructor
 
 This constructor accepts only three `AddressFamily` values, otherwise it will throw a <xref:System.ArgumentException>. Valid values are:
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -82,7 +82,7 @@ The preceding C# code:
 
 `TcpListener` and `TcpClient` classes internal implementation relies on the `Socket` class. This means you can do everything with `Socket` that you can do with `TcpClient` and `TcpListener`.
 
-### `TcpClient` Constructors
+### Create a client `Socket`
 
 `TcpClient`'s default constructor tries to create a _dual-mode socket_, if it's not viable, it creates an IPv4 socket with the `new Socket(SocketType, ProtocolType)` constructor. Consider the following TCP client code:
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -78,9 +78,9 @@ The preceding C# code:
 - Writes the sent message to the console.
 - Finally, calls the <xref:System.Net.Sockets.TcpListener.Stop%2A> method to stop listening on the port.
 
-## Advanced TCP control with `Socket` class
+## Finite TCP control with the `Socket` class
 
-`TcpClient` and `TcpListener` relies on the `Socket` class internally, meaning you can achieve everything by using sockets directly. This guideline looks at several `TcpClient` and `TcpListener` use cases, presenting their `Socket` counterpart.
+Both `TcpClient` and `TcpListener` internally rely on the `Socket` class, meaning anything you can do with these classes can be achieved using sockets directly. This section demonstrates several `TcpClient` and `TcpListener` use cases, along with their `Socket` counterpart that is functionally equivalent.
 
 ### Create a client socket
 
@@ -120,28 +120,27 @@ var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolT
 
 #### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)> constructor
 
-Upon creating the socket, this constructor will also **bind** it to the provided **local** `IPEndPoint`. The <xref:System.Net.IPEndPoint.AddressFamily?displayProperty=nameWithType> property is used to determine the address family of the socket.
+Upon creating the socket, this constructor will also **bind** to the provided **local** `IPEndPoint`. The <xref:System.Net.IPEndPoint.AddressFamily?displayProperty=nameWithType> property is used to determine the address family of the socket.
 
 Consider the following TCP client code:
 
 ```csharp
-// Example IPEndPoint object
-var ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
-var client = new TcpClient(ep);
+var endPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
+var client = new TcpClient(endPoint);
 ```
 
 The preceding TCP client code is functionally equivalent to the following socket code:
 
 ```csharp
 // Example IPEndPoint object
-var ep = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
-var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-socket.Bind(ep);
+var endPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5001);
+var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+socket.Bind(endPoint);
 ```
 
 #### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.String,System.Int32)> constructor
 
-This constructor will attempt to create a dual-stack similarly to the default constructor and **connect** it to the **remote** DNS endpoint defined by `hostname` and `port`.
+This constructor will attempt to create a dual-stack similar to the default constructor and **connect** it to the **remote** DNS endpoint defined by the `hostname` and `port` pair.
 
 Consider the following TCP client code:
 
@@ -176,9 +175,7 @@ socket.Connect("www.example.com", 80);
 
 ### Create a server socket
 
-In `TcpListener` class, basically, constructors initializes underlying socket. One of them is `TcpListener(IPAddress localaddr, int port)`.
-
-Consider the following TCP listener code:
+Much like `TcpClient` instances having functional equivalency with their raw `Socket` counterparts, this section maps `TcpListener` constructors to their corresponding socket code. The first constructor to consider is the `TcpListener(IPAddress localaddr, int port)`.
 
 ```csharp
 var listener = new TcpListener(IPAddress.Loopback, 5000);
@@ -193,7 +190,7 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
 ### Start listening on the server
 
-The <xref:System.Net.Sockets.TcpListener.Start> method is a wrapper combining Socket's <xref:System.Net.Sockets.Socket.Bind%2A> and <xref:System.Net.Sockets.Socket.Listen>.
+The <xref:System.Net.Sockets.TcpListener.Start> method is a wrapper combining `Socket`'s <xref:System.Net.Sockets.Socket.Bind%2A> and <xref:System.Net.Sockets.Socket.Listen> functionality.
 
 Consider the following TCP listener code:
 
@@ -205,9 +202,9 @@ listener.Start(10);
 The preceding TCP listener code is functionally equivalent to the following socket code:
 
 ```csharp
-var ep = new IPEndPoint(IPAddress.Loopback, 5000);
-var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-socket.Bind(ep);
+var endPoint = new IPEndPoint(IPAddress.Loopback, 5000);
+var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+socket.Bind(endPoint);
 try
 {
     socket.Listen(10);
@@ -218,29 +215,29 @@ catch (SocketException)
 }
 ```
 
-### Accepting a connection on the server
+### Accept a server connection
 
 Under the hood, incoming TCP connections are always creating a new socket when accepted. `TcpListener` can accept a <xref:System.Net.Sockets.Socket> instance directly (via <xref:System.Net.Sockets.TcpListener.AcceptSocket> or <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync>) or it can accept a <xref:System.Net.Sockets.TcpClient> (via <xref:System.Net.Sockets.TcpListener.AcceptTcpClient> and <xref:System.Net.Sockets.TcpListener.AcceptTcpClientAsync>).
 
-Consider the following `TcpClient` code:
+Consider the following `TcpListener` code:
 
 ```csharp
 var listener = new TcpListener(IPAddress.Loopback, 5000);
-var acceptSocket = listener.AcceptSocket();
+var acceptedSocket = await listener.AcceptSocketAsync();
 
-// async code:
-// var acceptSocket = await listener.AcceptSocketAsync();
+// Synchronous alternative.
+// var acceptedSocket = listener.AcceptSocket();
 ```
 
 The preceding TCP listener code is functionally equivalent to the following socket code:
 
 ```csharp
-var ep = new IPEndPoint(IPAddress.Loopback, 5000);
-var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-var acceptSocket = socket.Accept();
+var endPoint = new IPEndPoint(IPAddress.Loopback, 5000);
+var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+var acceptedSocket = await socket.AcceptAsync();
 
-// async code:
-// var acceptSocket = await socket.AcceptAsync();
+// Synchronous alternative
+// var acceptedSocket = socket.Accept();
 ```
 
 ### Create a `NetworkStream` to send and receive data

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -84,7 +84,7 @@ The preceding C# code:
 
 ### Create a client socket
 
-`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via the `[new Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket)` constructor. This constructor creates a dual-stack socket if [IPv6 is supported](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise, it falls back to IPv4.
+`TcpClient`'s default constructor tries to create a [_dual-stack socket_](<xref:System.Net.Sockets.Socket.DualMode>) via the [new Socket(SocketType, ProtocolType)](xref:System.Net.Sockets.Socket) constructor. This constructor creates a dual-stack socket if [IPv6 is supported](<xref:System.Net.Sockets.Socket.OSSupportsIPv6>), otherwise, it falls back to IPv4.
 
 Consider the following TCP client code:
 
@@ -98,7 +98,9 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-One of `TcpClient`'s constructor takes `AddressFamily` enum as a parameter. You can pass three different enum values to this constructor, otherwise, it throws an <xref:System.ArgumentException>. Valid enums are:
+#### TcpClient(AddressFamily) constructor
+
+[One of `TcpClient`'s constructor](xref:System.Net.Sockets.TcpClient.%23ctor%2A) takes `AddressFamily` enum as a parameter. You can pass three different enum values to this constructor, otherwise, it throws an <xref:System.ArgumentException>. Valid enums are:
 
 - [AddressFamily.InterNetwork](xref:System.Net.Sockets.AddressFamily.InterNetwork): for IPv4 socket.
 - [AddressFamily.InterNetworkV6](xref:System.Net.Sockets.AddressFamily.InterNetworkV6): for IPv6 socket.
@@ -116,7 +118,9 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-Other `TcpClient`'s constructor takes an <xref:System.Net.IPEndPoint> class as a parameter. This constructor accepts an `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates a `Socket`. As part of this, it calls <xref:System.Net.Sockets.Socket.Bind%2A> on the underlying `Socket` member with the given <xref:System.Net.IPEndPoint> argument.
+#### TcpClient(IPEndPoint) constructor
+
+[Other `TcpClient`'s constructor](xref:System.Net.Sockets.TcpClient.%23ctor%2A) takes an <xref:System.Net.IPEndPoint> class as a parameter. This constructor accepts an `AddressFamily` from <xref:System.Net.IPEndPoint.AddressFamily> property and creates a `Socket`. As part of this, it calls <xref:System.Net.Sockets.Socket.Bind%2A> on the underlying `Socket` member with the given <xref:System.Net.IPEndPoint> argument.
 
 Consider the following TCP client code:
 
@@ -135,7 +139,9 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(ep);
 ```
 
-Another `TcpClient` constructor overload accepts a `hostname` and `port` as parameters, the difference from the default constructor is that this constructor tries to connect to the given `hostname` and `port`.
+#### TcpClient(String, Int32) constructor
+
+[Another `TcpClient` constructor overload](xref:System.Net.Sockets.TcpClient.%23ctor%2A) accepts a `hostname` and `port` as parameters, the difference from the default constructor is that this constructor tries to connect to the given `hostname` and `port`.
 
 Consider the following TCP client code:
 

--- a/docs/fundamentals/networking/sockets/tcp-classes.md
+++ b/docs/fundamentals/networking/sockets/tcp-classes.md
@@ -98,7 +98,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### The [TcpClient(AddressFamily)](xref:System.Net.Sockets.TcpClient.%23ctor%2A) constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.Sockets.AddressFamily)?displayProperty=fullName> constructor
 
 This constructor accepts only three `AddressFamily` values, otherwise it will throw a <xref:System.ArgumentException>. Valid values are:
 
@@ -118,7 +118,7 @@ The preceding TCP client code is functionally equivalent to the following socket
 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 ```
 
-#### The [TcpClient(IPEndPoint)](xref:System.Net.Sockets.TcpClient.%23ctor%2A) constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.Net.IPEndPoint)?displayProperty=fullName> constructor
 
 Upon creating the socket, this constructor will also **bind** it to the provided **local** `IPEndPoint`. The <xref:System.Net.IPEndPoint.AddressFamily?displayProperty=nameWithType> property is used to determine the address family of the socket.
 
@@ -139,7 +139,7 @@ var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 socket.Bind(ep);
 ```
 
-#### The [TcpClient(String, Int32)](xref:System.Net.Sockets.TcpClient.%23ctor%2A) constructor
+#### The <xref:System.Net.Sockets.TcpClient.%23ctor(System.String,System.Int32)?displayProperty=nameWithType> constructor
 
 This constructor will attempt to create a dual-stack similarly to the default constructor and **connect** it to the **remote** endpoint defined by `hostname` and `port`.
 


### PR DESCRIPTION
## Summary

Adding an article to show TcpClient usages equivalent to Socket under Use TcpClient and TcpListener.

Fixes one task from #31702 

## Preview

https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/sockets/tcp-classes?branch=pr-en-us-32106