### PR TITLE
Fix Policheck hits: Eskimo, Newfoundland, cock

### DIFF
--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
@@ -58,7 +58,7 @@ image57,Lhasa
 image58,impala
 image59,coyote
 image60,Yorkshire terrier
-image61,dresser
+image61,dog
 image62,brown bear
 image63,red fox
 image64,Norwegian elkhound
@@ -147,7 +147,7 @@ image146,Norwich terrier
 image147,flat-coated retriever
 image148,hog
 image149,keeshond
-image150,American Eskimo dog
+image150,American dog
 image151,spaniel
 image152,standard poodle
 image153,Lakeland terrier

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.csv
@@ -381,7 +381,7 @@ image380,screwdriver
 image381,shovel
 image382,plow
 image383,chain saw
-image384,cock
+image384,rooster
 image385,hen
 image386,ostrich
 image387,brambling

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
@@ -58,7 +58,7 @@ image57	Lhasa
 image58	impala
 image59	coyote
 image60	Yorkshire terrier
-image61	dresser
+image61	dog
 image62	brown bear
 image63	red fox
 image64	Norwegian elkhound
@@ -147,7 +147,7 @@ image146	Norwich terrier
 image147	flat-coated retriever
 image148	hog
 image149	keeshond
-image150	Eskimo dog
+image150	American dog
 image151	Brittany spaniel
 image152	standard poodle
 image153	Lakeland terrier

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet.tsv
@@ -381,7 +381,7 @@ image380	screwdriver
 image381	shovel
 image382	plow
 image383	chain saw
-image384	cock
+image384	rooster
 image385	hen
 image386	ostrich
 image387	brambling

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
@@ -381,7 +381,7 @@ screwdriver
 shovel
 plow
 chain saw
-cock
+rooster
 hen
 ostrich
 brambling

--- a/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
+++ b/docs/machine-learning/tutorials/snippets/image-classification/csharp/assets/inception/imagenet_comp_graph_label_strings.txt
@@ -58,7 +58,7 @@ Lhasa
 impala
 coyote
 Yorkshire terrier
-dresser
+dog
 brown bear
 red fox
 Norwegian elkhound
@@ -147,7 +147,7 @@ Norwich terrier
 flat-coated retriever
 hog
 keeshond
-American Eskimo dog
+American dog
 spaniel
 standard poodle
 Lakeland terrier


### PR DESCRIPTION
## Summary

More Policheck hits in this image list. @gewarren and I discussed previously that these particular list items don't actually link to any images in the tutorial. 

Also updates an item ("Newfoundland") that I had renamed to "dresser" (based on a wikimedia photo) previously, probably inappropriately. @gewarren pointed out that this was probably a dog based on its place in the list. I have re-renamed it to "dog". 

For Eskimo dog, "Eskimo" is offensive in all contexts, but "Inuit" isn't accurate. Some places called this an "American Eskimo dog," so I have renamed it to "American dog."

11/7/22: Added term "rooster" to replace "cock".

These names are probably arbitrary. The offensive terms still occur in the publicly-available Tensorflow list. We are removing the terms from MS docs if possible to avoid any future hits. https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/2001296

Fixes #Issue_Number (if available)
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14660
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14695
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14677
https://dev.azure.com/msft-skilling/Content/_workitems/edit/14641
[14716](https://dev.azure.com/msft-skilling/Content/_workitems/edit/14716)
[14755](https://dev.azure.com/msft-skilling/Content/_workitems/edit/14755)
[14746](https://dev.azure.com/msft-skilling/Content/_workitems/edit/14746)
[14573](https://dev.azure.com/msft-skilling/Content/_workitems/edit/14573)

