### PR TITLE
Update API ref views on hub pages for .NET 7

### DIFF
--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -52,7 +52,7 @@ landingContent:
           - text: "F# library reference"
             url: https://fsharp.github.io/fsharp-core-docs
           - text: ".NET library reference"
-            url: ../../api/index.md?view=net-6.0
+            url: ../../api/index.md?view=net-7.0
 
   - title: "F# fundamentals"
     linkLists:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -307,7 +307,7 @@ additionalContent:
       # Card
       - title: ".NET API reference"
         summary: API reference documentation for .NET
-        url: ../api/index.md?view=net-6.0
+        url: ../api/index.md?view=net-7.0
       # Card
       - title: ".NET Framework API reference"
         summary: API reference documentation for .NET Framework

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -42,11 +42,11 @@ groups:
   title: .NET version
   prompt: Choose a .NET version
   pivots:
+    - id: dotnet-7-0
+      title: .NET 7
     - id: dotnet-6-0
       title: .NET 6
     - id: dotnet-5-0
       title: .NET 5
     - id: dotnet-core-3-1
       title: .NET Core 3.1
-    - id: dotnet-7-0
-      title: .NET 7 Preview


### PR DESCRIPTION
Contributes to #29176.

Base branch is release-dotnet-7.