### PR TITLE
24 hour format

### DIFF
--- a/docs/core/extensions/snippets/logging/console-formatter-json/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-json/Program.cs
@@ -7,7 +7,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         builder.AddJsonConsole(options =>
         {
             options.IncludeScopes = false;
-            options.TimestampFormat = "hh:mm:ss ";
+            options.TimestampFormat = "HH:mm:ss ";
             options.JsonWriterOptions = new JsonWriterOptions
             {
                 Indented = true

--- a/docs/core/extensions/snippets/logging/console-formatter-simple/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-simple/Program.cs
@@ -12,7 +12,7 @@ class Program
                 {
                     options.IncludeScopes = true;
                     options.SingleLine = true;
-                    options.TimestampFormat = "hh:mm:ss ";
+                    options.TimestampFormat = "HH:mm:ss ";
                 }));
 
         ILogger<Program> logger = loggerFactory.CreateLogger<Program>();

--- a/docs/core/extensions/snippets/logging/console-formatter-systemd/Program.cs
+++ b/docs/core/extensions/snippets/logging/console-formatter-systemd/Program.cs
@@ -11,7 +11,7 @@ class Program
                 builder.AddSystemdConsole(options =>
                 {
                     options.IncludeScopes = true;
-                    options.TimestampFormat = "hh:mm:ss ";
+                    options.TimestampFormat = "HH:mm:ss ";
                 }));
 
         ILogger<Program> logger = loggerFactory.CreateLogger<Program>();


### PR DESCRIPTION
## Summary

Update the [samples](https://learn.microsoft.com/en-us/dotnet/core/extensions/console-log-formatter) to display output in 24 hour format, eg in the afternoon it will display `16:45:56` instead of `04:45:56`.
