### PR TITLE
Add a note regarding supressing CS0282

### DIFF
--- a/docs/csharp/misc/cs0282.md
+++ b/docs/csharp/misc/cs0282.md
@@ -42,3 +42,6 @@ partial struct A
     int j;
 }
 ```
+
+> [!NOTE]
+> If the struct layout does not matter, decorating the struct with `[StructLayout(LayoutKind.Auto)]` will express it,and suppress the warning


### PR DESCRIPTION
## Summary

Just added a note, incase anyone else stumbles on this The alternative was to disable it with a directive, which is less expressive, and no hint in the anylzer/quick actions showed this attribute as a possible solution

Dotnet provides the means to inhibit this warning message, but it was not clear from the documentation how to properly suppress the warning and express intent that the layout of the struct was not significant