### PR TITLE
Update dotnet-nuget-push.md

### DIFF
--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -69,7 +69,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`--skip-duplicate`**
 
-  When pushing multiple packages to an HTTP(S) server, treats any 409 Conflict response as a warning so that the push can continue.
+  When pushing multiple packages to an HTTP(S) server, treats any 409 Conflict response as a warning so that the other push(s) can continue.
 
 - **`-sk|--symbol-api-key <API_KEY>`**
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -69,7 +69,7 @@ The command pushes an existing package. It doesn't create a package. To create a
 
 - **`--skip-duplicate`**
 
-  When pushing multiple packages to an HTTP(S) server, treats any 409 Conflict response as a warning so that the other push(s) can continue.
+  When pushing multiple packages to an HTTP(S) server, treats any 409 Conflict response as a warning so that other pushes can continue.
 
 - **`-sk|--symbol-api-key <API_KEY>`**
 


### PR DESCRIPTION
The description for the --skip-duplicate option was phrased in a way that makes it easy to misunderstand. "so that the push can continue" makes it sound like the flag will let you overwrite/replace a published nuget package when there is a conflict
