### PR TITLE
remove async main speclet

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -13,6 +13,10 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1264-local-function-declarations"
         },
         {
+            "source_path_from_root": "/_csharplang/proposals/csharp-7.1/async-main.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/basic-concepts#71-application-startup"
+        },
+        {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.0/throw-expression.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions.md#1115-the-throw-expression-operator"
         },

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -13,12 +13,12 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1264-local-function-declarations"
         },
         {
-            "source_path_from_root": "/_csharplang/proposals/csharp-7.1/async-main.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/basic-concepts#71-application-startup"
-        },
-        {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.0/throw-expression.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions.md#1115-the-throw-expression-operator"
+        },
+        {
+            "source_path_from_root": "/_csharplang/proposals/csharp-7.1/async-main.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/basic-concepts#71-application-startup"
         },
         {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.2/private-protected.md",

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -1014,7 +1014,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-7.1/index.md",
-            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-7.1/async-main"
+            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-7.1/target-typed-default"
         },
         {
             "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-7.2/index.md",

--- a/docfx.json
+++ b/docfx.json
@@ -57,6 +57,7 @@
                     "csharp-7.0/throw-expression.md",
                     "csharp-7.0/tuples.md",
                     "csharp-7.0/value-task.md",
+                    "csharp-7.1/async-main.md",
                     "csharp-7.2/leading-separator.md",
                     "csharp-7.2/readonly-struct.md",
                     "csharp-7.2/ref-extension-methods.md",
@@ -613,7 +614,6 @@
                 "_csharplang/proposals/csharp-7.0/digit-separators.md": "Digit separators",
                 "_csharplang/proposals/csharp-7.0/task-types.md": "Async task types",
 
-                "_csharplang/proposals/csharp-7.1/async-main.md": "Async main method",
                 "_csharplang/proposals/csharp-7.1/target-typed-default.md": "Default expressions",
                 "_csharplang/proposals/csharp-7.1/infer-tuple-names.md": "Infer tuple member names",
                 "_csharplang/proposals/csharp-7.1/generics-pattern-match.md": "Pattern matching with generics",
@@ -751,7 +751,6 @@
                 "_csharplang/proposals/csharp-7.0/digit-separators.md": "This feature specification describes the syntax to allow separators between groups of digits in numeric literals.",
                 "_csharplang/proposals/csharp-7.0/task-types.md": "This feature specification describes the syntax to support async return types that match a pattern, rather than restricting them to Task.",
 
-                "_csharplang/proposals/csharp-7.1/async-main.md": "This feature specification describes syntax enhancements to declare a Main method that is async and returns a Task type.",
                 "_csharplang/proposals/csharp-7.1/target-typed-default.md": "This feature specification describes the syntax to use the default keyword where the type of the expression can be inferred by the compiler.",
                 "_csharplang/proposals/csharp-7.1/infer-tuple-names.md": "This feature specification describes how the compiler interprets and infers the members names in a tuple.",
                 "_csharplang/proposals/csharp-7.1/generics-pattern-match.md": "This feature specification describes syntax enhancements to enable pattern matching with generic types.",

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1348,8 +1348,6 @@ items:
         href: ../../_csharplang/proposals/csharp-7.0/task-types.md
     - name: C# 7.1 features
       items:
-      - name: Async main method
-        href: ../../_csharplang/proposals/csharp-7.1/async-main.md
       - name: Default expressions
         href: ../../_csharplang/proposals/csharp-7.1/target-typed-default.md
       - name: Infer tuple names


### PR DESCRIPTION
This can be removed, as the updates were approved in the last C# standards meeting.

See dotnet/csharpstandard#70
