### PR TITLE
Remove auto release labeling of breaking changes

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -43,19 +43,6 @@ issues:
       pass:
         - labels-add: ["source incompatible"]
 
-    # Checks breaking change version and adds a label
-    - check:
-        - type: query
-          value: "contains(Issue.body, '.NET 6 Preview') == `true` || contains(Issue.body, '.NET 6 RC') == `true` || contains(Issue.body, '.NET 6 GA') == `true`"
-      pass:
-        - labels-add: [":checkered_flag: Release: .NET 6"]
-        
-    - check:
-        - type: query
-          value: "contains(Issue.body, '.NET 7 Preview') == `true` || contains(Issue.body, '.NET 7 RC') == `true` || contains(Issue.body, '.NET 7 GA') == `true`"
-      pass:
-        - labels-add: [":checkered_flag: Release: .NET 7"]
-
     # Add to .NET 6 project if .NET 6 label added
     - check:
         - type: query


### PR DESCRIPTION
The labeling mechanism is too coarse-grained. For example, if it's a .NET 8 breaking change that talks about some functionality that was introduced in .NET 7, then the "Release: .NET 7" label gets added to the issue, and if you remove it, it gets readded.

E.g. https://github.com/dotnet/docs/issues/32225