### PR TITLE
Add two new SYSLIB warnings

### DIFF
--- a/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
@@ -2,7 +2,7 @@
 title: "Breaking change: .NET 7 obsoletions with non-default diagnostic IDs"
 titleSuffix: ""
 description: Learn about the .NET 7 breaking change in core .NET libraries where some APIs have been marked as obsolete with a custom diagnostic ID.
-ms.date: 04/08/2022
+ms.date: 11/07/2022
 ---
 # API obsoletions with non-default diagnostic IDs (.NET 7)
 
@@ -24,6 +24,7 @@ The following table lists the custom diagnostic IDs and their corresponding warn
 | [SYSLIB0041](../../../../fundamentals/syslib-diagnostics/syslib0041.md) | The default hash algorithm and iteration counts in <xref:System.Security.Cryptography.Rfc2898DeriveBytes> constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations. | Warning |
 | [SYSLIB0042](../../../../fundamentals/syslib-diagnostics/syslib0042.md) | `ToXmlString` and `FromXmlString` have no implementation for elliptic curve cryptography (ECC) types, and are obsolete. Use a standard import and export format such as `ExportSubjectPublicKeyInfo` or `ImportSubjectPublicKeyInfo` for public keys, and `ExportPkcs8PrivateKey` or `ImportPkcs8PrivateKey` for private keys. | Warning |
 | [SYSLIB0043](../../../../fundamentals/syslib-diagnostics/syslib0043.md) | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=nameWithType> and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo?displayProperty=nameWithType> instead. | Warning |
+| [SYSLIB0044](../../../../fundamentals/syslib-diagnostics/syslib0044.md) | <xref:System.Reflection.AssemblyName.CodeBase?displayProperty=nameWithType> and <xref:System.Reflection.AssemblyName.EscapedCodeBase?displayProperty=nameWithType> are obsolete. | Warning |
 | [SYSLIB0045](../../../../fundamentals/syslib-diagnostics/syslib0045.md) | Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless `Create` factory method on the algorithm type instead. | Warning |
 | [SYSLIB0047](../../../../fundamentals/syslib-diagnostics/syslib0047.md) | <xref:System.Xml.XmlSecureResolver> is obsolete. Use `XmlResolver.ThrowingResolver` instead to forbid resolution of external XML resources. | Warning |
 

--- a/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
@@ -2,7 +2,7 @@
 title: Obsolete features in .NET 5+
 titleSuffix: ""
 description: Learn about APIs that are marked as obsolete in .NET 5 and later versions that produce SYSLIB compiler warnings.
-ms.date: 01/13/2022
+ms.date: 11/07/2022
 ---
 
 # Obsolete features in .NET 5+
@@ -64,7 +64,9 @@ The following table provides an index to the `SYSLIB0XXX` obsoletions in .NET 5+
 | [SYSLIB0041](syslib0041.md) | Warning | The default hash algorithm and iteration counts in <xref:System.Security.Cryptography.Rfc2898DeriveBytes> constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations. |
 | [SYSLIB0042](syslib0042.md) | Warning | `ToXmlString` and `FromXmlString` have no implementation for elliptic curve cryptography (ECC) types, and are obsolete. Use a standard import and export format such as `ExportSubjectPublicKeyInfo` or `ImportSubjectPublicKeyInfo` for public keys, and `ExportPkcs8PrivateKey` or `ImportPkcs8PrivateKey` for private keys. |
 | [SYSLIB0043](syslib0043.md) | Warning | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=nameWithType> and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo?displayProperty=nameWithType> instead. |
+| [SYSLIB0044](syslib0044.md) | Warning | <xref:System.Reflection.AssemblyName.CodeBase?displayProperty=nameWithType> and <xref:System.Reflection.AssemblyName.EscapedCodeBase?displayProperty=nameWithType> are obsolete. Using them for loading an assembly is not supported. |
 | [SYSLIB0045](syslib0045.md) | Warning | Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless `Create` factory method on the algorithm type instead. |
+| [SYSLIB0046](syslib0046.md) | Warning | The <xref:System.Runtime.ControlledExecution.Run(System.Action,System.Threading.CancellationToken)?displayProperty=nameWithType> method might corrupt the process and should not be used in production code. |
 | [SYSLIB0047](syslib0047.md) | Warning | <xref:System.Xml.XmlSecureResolver> is obsolete. Use `XmlResolver.ThrowingResolver` instead when attempting to forbid XML external entity resolution. |
 
 ## Suppress warnings

--- a/docs/fundamentals/syslib-diagnostics/syslib0012.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0012.md
@@ -43,3 +43,7 @@ To suppress all the `SYSLIB0012` warnings in your project, add a `<NoWarn>` prop
 ```
 
 For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).
+
+## See also
+
+- [SYSLIB0044](syslib0044.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib0044.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0044.md
@@ -1,0 +1,49 @@
+---
+title: SYSLIB0044 warning - AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete
+description: Learn about the obsoletion of AssemblyName.CodeBase and AssemblyName.EscapedCodeBase that generates compile-time warning SYSLIB0044.
+ms.date: 11/07/2022
+---
+# SYSLIB0044: AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete
+
+The following properties are marked as obsolete, starting in .NET 7. Using them in code generates warning `SYSLIB0044` at compile time.
+
+- <xref:System.Reflection.AssemblyName.CodeBase?displayProperty=nameWithType>
+- <xref:System.Reflection.AssemblyName.EscapedCodeBase?displayProperty=nameWithType>
+
+## Workaround
+
+Use <xref:System.Reflection.Assembly.Location?displayProperty=nameWithType> instead.
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB0044
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB0044
+```
+
+To suppress all the `SYSLIB0044` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);SYSLIB0044</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).
+
+## See also
+
+- [SYSLIB0012: Assembly.CodeBase and Assembly.EscapedCodeBase are obsolete](syslib0012.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib0046.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0046.md
@@ -1,0 +1,46 @@
+---
+title: SYSLIB0046 warning - ControlledExecution.Run should not be used
+description: Learn about the obsoletion of ControlledExecution.Run that generates compile-time warning SYSLIB0046.
+ms.date: 11/07/2022
+---
+# SYSLIB0046: ControlledExecution.Run should not be used
+
+The <xref:System.Runtime.ControlledExecution.Run(System.Action,System.Threading.CancellationToken)?displayProperty=nameWithType> method might corrupt the process and should not be used in production code. This method runs code that can be aborted asynchronously. While this method is new for .NET 7, it's also marked as obsolete to discourage you from using it. For more information, see [Proposal for non-cooperative abortion of code execution](https://github.com/dotnet/runtime/discussions/66480).
+
+## Workaround
+
+N/A
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB0046
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB0046
+```
+
+To suppress all the `SYSLIB0046` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);SYSLIB0046</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).
+
+## See also
+
+- [Proposal for non-cooperative abortion of code execution](https://github.com/dotnet/runtime/discussions/66480)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -501,8 +501,12 @@ items:
         href: syslib-diagnostics/syslib0042.md
       - name: SYSLIB0043
         href: syslib-diagnostics/syslib0043.md
+      - name: SYSLIB0044
+        href: syslib-diagnostics/syslib0044.md
       - name: SYSLIB0045
         href: syslib-diagnostics/syslib0045.md
+      - name: SYSLIB0046
+        href: syslib-diagnostics/syslib0046.md
       - name: SYSLIB0047
         href: syslib-diagnostics/syslib0047.md
     - name: Source-generated code


### PR DESCRIPTION
SYSLIB0044 seems like it should also be doc'd as a breaking change.
SYSLIB0046 is not a breaking change because the API is new. - [preview link](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0046?branch=pr-en-us-32324)

Fixes #32302.
Related to https://github.com/dotnet/runtime/pull/71661 and https://github.com/dotnet/runtime/pull/70534.