### PR TITLE
Add SYSLIB diagnostics for .NET 7 source generators

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -8,7 +8,7 @@ ms.date: 05/11/2021
 
 If your .NET 6+ project references a package that enables source generation of code, for example, a logging solution, then the analyzers that are specific to source generation will run at compile time. This article lists the compiler diagnostics related to source-generated code.
 
-If you encounter one of these build warnings or errors, follow the specific guidance provided for the diagnostic ID listed in the [Reference](#reference) section. Warnings can also be suppressed using the specific `SYSLIB1XXX` diagnostic ID value. For more information, see [Suppress warnings](#suppress-warnings).
+If you encounter one of these build warnings or errors, follow the specific guidance provided for the diagnostic ID listed in the [Reference](#reference) section. You can also suppress warnings using the specific `SYSLIB1XXX` diagnostic ID value. For more information, see [Suppress warnings](#suppress-warnings).
 
 ## Analyzer warnings
 

--- a/docs/fundamentals/syslib-diagnostics/syslib1040-1049.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1040-1049.md
@@ -1,0 +1,25 @@
+---
+title: SYSLIB warnings for regex source generation
+description: Learn about the SYSLIB diagnostics that generate compile-time warnings SYSLIB1040, SYSLIB1041, SYSLIB1042, SYSLIB1043, SYSLIB1044, and SYSLIB1045.
+ms.date: 11/07/2022
+---
+# SYSLIB warnings for regex source generation
+
+The following table shows the diagnostic IDs for regex source-generation analyzers in .NET 7 and later versions. `SYSLIB1045` automatically alerts you to places that you can use source generation to generate the regular expression engine implementation at compile time. The remaining diagnostics alert you to errors related to usage of the source generator.
+
+| Diagnostic ID | Description |
+| - | - |
+| `SYSLIB1040` | Invalid <xref:System.Text.RegularExpressions.GeneratedRegexAttribute> usage. |
+| `SYSLIB1041` | Multiple <xref:System.Text.RegularExpressions.GeneratedRegexAttribute> attributes were applied to the same method, but only one is allowed. |
+| `SYSLIB1042` | The specified regular expression is invalid. |
+| `SYSLIB1043` | A <xref:System.Text.RegularExpressions.GeneratedRegexAttribute> method must be partial, parameterless, non-generic, and non-abstract, and return <xref:System.Text.RegularExpressions.Regex>. |
+| `SYSLIB1044` | The regex generator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details. |
+| `SYSLIB1045` | Use <xref:System.Text.RegularExpressions.GeneratedRegexAttribute> to generate the regular expression implementation at compile time. |
+
+For more information about source generation for regular expressions, see [.NET regular expression source generators](../../standard/base-types/regular-expression-source-generators.md).
+
+[!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]
+
+## See also
+
+- [.NET regular expression source generators](../../standard/base-types/regular-expression-source-generators.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib1040-1049.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1040-1049.md
@@ -1,9 +1,9 @@
 ---
-title: SYSLIB warnings for regex source generation
-description: Learn about the SYSLIB diagnostics that generate compile-time warnings SYSLIB1040, SYSLIB1041, SYSLIB1042, SYSLIB1043, SYSLIB1044, and SYSLIB1045.
+title: SYSLIB diagnostics for regex source generation
+description: Learn about the regular expression source-generation analyzers that generate compile-time suggestions SYSLIB1040, SYSLIB1041, SYSLIB1042, SYSLIB1043, SYSLIB1044, and SYSLIB1045.
 ms.date: 11/07/2022
 ---
-# SYSLIB warnings for regex source generation
+# SYSLIB diagnostics for regex source generation
 
 The following table shows the diagnostic IDs for regex source-generation analyzers in .NET 7 and later versions. `SYSLIB1045` automatically alerts you to places that you can use source generation to generate the regular expression engine implementation at compile time. The remaining diagnostics alert you to errors related to usage of the source generator.
 

--- a/docs/fundamentals/syslib-diagnostics/syslib1050-1069.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1050-1069.md
@@ -23,6 +23,8 @@ The following table shows the diagnostic IDs for platform-invoke (p/invoke) sour
 | `SYSLIB1061` | The marshaller type has incompatible method signatures. |
 | `SYSLIB1062` | The project must be updated with `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>`. |
 
+For more information about source generation for p/invoke, see [Source generation for platform invokes](../../standard/native-interop/pinvoke-source-generation.md) and [Tutorial: Use custom marshallers in source-generated P/Invokes](../../standard/native-interop/tutorial-custom-marshaller.md).
+
 ## See also
 
 - [Source generation for platform invokes](../../standard/native-interop/pinvoke-source-generation.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib1050-1069.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1050-1069.md
@@ -1,0 +1,28 @@
+---
+title: SYSLIB diagnostics for Microsoft.Interop.LibraryImportGenerator
+description: Learn about the p/invoke source-generation analyzers that generate compile-time suggestions SYSLIB1050, SYSLIB1051, SYSLIB1052, SYSLIB1053, SYSLIB1054, SYSLIB1055, SYSLIB1056, SYSLIB1057, SYSLIB1058, SYSLIB1059, SYSLIB1060, SYSLIB1061, and SYSLIB1062.
+ms.date: 11/07/2022
+---
+# SYSLIB diagnostics for p/invoke source generation
+
+The following table shows the diagnostic IDs for platform-invoke (p/invoke) source-generation analyzers in .NET 7 and later versions. `SYSLIB1054` automatically alerts you to places that you can use source generation to generate p/invoke marshalling code at compile time. The remaining diagnostics alert you to errors related to usage of the source generator.
+
+| Diagnostic ID | Description |
+| - | - |
+| `SYSLIB1050` | Invalid <xref:System.Runtime.InteropServices.LibraryImportAttribute> usage. |
+| `SYSLIB1051` | The specified type is not supported by source-generated p/invokes. |
+| `SYSLIB1052` | The specified configuration is not supported by source-generated p/invokes. |
+| `SYSLIB1053` | The specified <xref:System.Runtime.InteropServices.LibraryImportAttribute> arguments cannot be forwarded to <xref:System.Runtime.InteropServices.DllImportAttribute>. |
+| `SYSLIB1054` | Use <xref:System.Runtime.InteropServices.LibraryImportAttribute> instead of <xref:System.Runtime.InteropServices.DllImportAttribute> to generate p/invoke marshalling code at compile time.  |
+| `SYSLIB1055` | Invalid <xref:System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute> usage. |
+| `SYSLIB1056` | The specified native type is invalid. |
+| `SYSLIB1057` | The marshaller type does not have the required shape. |
+| `SYSLIB1058` | Invalid <xref:System.Runtime.InteropServices.Marshalling.NativeMarshallingAttribute> usage |
+| `SYSLIB1059` | The marshaller type does not support an allocating constructor. |
+| `SYSLIB1060` | The specified marshaller type is invalid. |
+| `SYSLIB1061` | The marshaller type has incompatible method signatures. |
+| `SYSLIB1062` | The project must be updated with `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>`. |
+
+## See also
+
+- [Source generation for platform invokes](../../standard/native-interop/pinvoke-source-generation.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib1070-1089.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1070-1089.md
@@ -1,0 +1,21 @@
+---
+title: SYSLIB diagnostics for System.Runtime.InteropServices.JavaScript.JSImportGenerator
+description: Learn about the JavaScript interop source-generation analyzers that generate compile-time suggestions SYSLIB1050, SYSLIB1051, SYSLIB1052, SYSLIB1053, SYSLIB1054, SYSLIB1055, SYSLIB1056, SYSLIB1057, SYSLIB1058, SYSLIB1059, SYSLIB1060, SYSLIB1061, and SYSLIB1062.
+ms.date: 11/07/2022
+---
+# SYSLIB diagnostics for JavaScript interop source generation
+
+The following table shows the diagnostic IDs for JavaScript interop source-generation analyzers in .NET 7 and later versions.
+
+| Diagnostic ID | Description |
+| - | - |
+| `SYSLIB1070` | Invalid <xref:System.Runtime.InteropServices.JavaScript.JSImportAttribute> usage. |
+| `SYSLIB1071` | Invalid <xref:System.Runtime.InteropServices.JavaScript.JSExportAttribute> usage. |
+| `SYSLIB1072` | The specified type is not supported by source-generated JavaScript interop. |
+| `SYSLIB1073` | The specified configuration is not supported by source-generated JavaScript interop. |
+| `SYSLIB1074` | <xref:System.Runtime.InteropServices.JavaScript.JSImportAttribute> requires unsafe code.  |
+| `SYSLIB1075` | <xref:System.Runtime.InteropServices.JavaScript.JSExportAttribute> requires unsafe code. |
+
+## See also
+
+- <xref:System.Runtime.InteropServices.JavaScript?displayProperty=fullName> namespace

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -574,6 +574,18 @@ items:
         href: syslib-diagnostics/syslib1037.md
       - name: SYSLIB1038
         href: syslib-diagnostics/syslib1038.md
+      - name: SYSLIB1040
+        href: syslib-diagnostics/syslib1040-1049.md
+      - name: SYSLIB1041
+        href: syslib-diagnostics/syslib1040-1049.md
+      - name: SYSLIB1042
+        href: syslib-diagnostics/syslib1040-1049.md
+      - name: SYSLIB1043
+        href: syslib-diagnostics/syslib1040-1049.md
+      - name: SYSLIB1044
+        href: syslib-diagnostics/syslib1040-1049.md
+      - name: SYSLIB1045
+        href: syslib-diagnostics/syslib1040-1049.md
   - name: Integrated development environments (IDEs)
     items:
     - name: Visual Studio

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -612,6 +612,18 @@ items:
         href: syslib-diagnostics/syslib1050-1069.md
       - name: SYSLIB1062
         href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1070
+        href: syslib-diagnostics/syslib1070-1089.md
+      - name: SYSLIB1071
+        href: syslib-diagnostics/syslib1070-1089.md
+      - name: SYSLIB1072
+        href: syslib-diagnostics/syslib1070-1089.md
+      - name: SYSLIB1073
+        href: syslib-diagnostics/syslib1070-1089.md
+      - name: SYSLIB1074
+        href: syslib-diagnostics/syslib1070-1089.md
+      - name: SYSLIB1075
+        href: syslib-diagnostics/syslib1070-1089.md
   - name: Integrated development environments (IDEs)
     items:
     - name: Visual Studio

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -586,6 +586,32 @@ items:
         href: syslib-diagnostics/syslib1040-1049.md
       - name: SYSLIB1045
         href: syslib-diagnostics/syslib1040-1049.md
+      - name: SYSLIB1050
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1051
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1052
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1053
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1054
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1055
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1056
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1057
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1058
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1059
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1060
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1061
+        href: syslib-diagnostics/syslib1050-1069.md
+      - name: SYSLIB1062
+        href: syslib-diagnostics/syslib1050-1069.md
   - name: Integrated development environments (IDEs)
     items:
     - name: Visual Studio

--- a/docs/standard/base-types/regular-expression-source-generators.md
+++ b/docs/standard/base-types/regular-expression-source-generators.md
@@ -381,15 +381,15 @@ The general guidance is if you can use the source generator, use it. If you're u
 When used with an option like `RegexOptions.NonBacktracking` for which the source generator can't generate a custom implementation, it will still emit caching and XML comments that describe the implementation, making it valuable. The main downside of the source generator is that it emits additional code into your assembly, so there's the potential for increased size. The more regexes in your app and the larger they are, the more code will be emitted for them. In some situations, just as `RegexOptions.Compiled` may be unnecessary, so too may be the source generator. For example, if you have a regex that's needed only rarely and for which throughput doesn't matter, it could be more beneficial to just rely on the interpreter for that sporadic usage.
 
 > [!IMPORTANT]
-> .NET 7 includes an analyzer that identifies the use of `Regex` that could be converted to the source generator, and a fixer that does the conversion for you:
+> .NET 7 includes an [analyzer](../../fundamentals/syslib-diagnostics/syslib1040-1049.md) that identifies the use of `Regex` that could be converted to the source generator, and a fixer that does the conversion for you:
 >
 > :::image type="content" source="media/regular-expression-source-generators/convert-to-regexgenerator.png" lightbox="media/regular-expression-source-generators/convert-to-regexgenerator.png" alt-text="RegexGenerator analyzer and fixer":::
 
 ## See also
 
+- [SYSLIB warnings for regex source generation](../../fundamentals/syslib-diagnostics/syslib1040-1049.md)
 - [.NET regular expressions](regular-expressions.md)
-- [Backtracking in Regular Expressions](backtracking-in-regular-expressions.md)
-- [Compilation and Reuse in Regular Expressions](compilation-and-reuse-in-regular-expressions.md)
-- [Source Generators](../../csharp/roslyn-sdk/source-generators-overview.md)
-- [Tutorial: Debug a .NET console application using Visual Studio](../../core/tutorials/debugging-with-visual-studio.md)
+- [Backtracking in regular expressions](backtracking-in-regular-expressions.md)
+- [Compilation and reuse in regular expressions](compilation-and-reuse-in-regular-expressions.md)
+- [Source generators](../../csharp/roslyn-sdk/source-generators-overview.md)
 - [.NET Blog: Regular Expression improvements in .NET 7](https://devblogs.microsoft.com/dotnet/regular-expression-improvements-in-dotnet-7)

--- a/docs/standard/base-types/regular-expression-source-generators.md
+++ b/docs/standard/base-types/regular-expression-source-generators.md
@@ -387,7 +387,7 @@ When used with an option like `RegexOptions.NonBacktracking` for which the sourc
 
 ## See also
 
-- [SYSLIB warnings for regex source generation](../../fundamentals/syslib-diagnostics/syslib1040-1049.md)
+- [SYSLIB diagnostics for regex source generation](../../fundamentals/syslib-diagnostics/syslib1040-1049.md)
 - [.NET regular expressions](regular-expressions.md)
 - [Backtracking in regular expressions](backtracking-in-regular-expressions.md)
 - [Compilation and reuse in regular expressions](compilation-and-reuse-in-regular-expressions.md)

--- a/docs/standard/native-interop/pinvoke-source-generation.md
+++ b/docs/standard/native-interop/pinvoke-source-generation.md
@@ -6,9 +6,9 @@ ms.date: 07/25/2022
 
 # Source generation for platform invokes
 
-.NET 7 introduces a [source generator](../../csharp/roslyn-sdk/source-generators-overview.md) for P/Invokes in C# which recognizes the <xref:System.Runtime.InteropServices.LibraryImportAttribute>.
+.NET 7 introduces a [source generator](../../csharp/roslyn-sdk/source-generators-overview.md) for P/Invokes that recognizes the <xref:System.Runtime.InteropServices.LibraryImportAttribute> in C# code.
 
-When a P/Invoke is defined and called as shown in the following code, the built-in interop system in the .NET runtime generates an IL stub&mdash;a stream of IL instructions that is JIT-ed&mdash;at run time to facilitate the transition from managed to unmanaged.
+When not using source generation, the built-in interop system in the .NET runtime generates an IL stub&mdash;a stream of IL instructions that is JIT-ed&mdash;at run time to facilitate the transition from managed to unmanaged. The following code shows defining and then calling a P/Invoke that uses this mechanism:
 
 ```csharp
 [DllImport(
@@ -22,7 +22,7 @@ internal static extern string ToLower(string str);
 
 The IL stub handles [marshalling](type-marshalling.md) of parameters and return values and calling the unmanaged code while respecting settings on <xref:System.Runtime.InteropServices.DllImportAttribute> that affect how the unmanaged code should be invoked (for example, <xref:System.Runtime.InteropServices.DllImportAttribute.SetLastError>). Since this IL stub is generated at run time, it is not available for ahead-of-time (AOT) compiler or IL trimming scenarios. Generation of the IL represents an important cost to consider for marshalling. This cost can be measured in terms of application performance and support for potential target platforms that may not permit dynamic code generation. The NativeAOT application model addresses issues with dynamic code generation by precompiling all code ahead of time directly into native code. Using `DllImport` is not an option for platforms that require full NativeAOT scenarios and therefore using other approaches (for example, source generation) is more appropriate. Debugging the marshalling logic in `DllImport` scenarios is also a non-trivial exercise.
 
-The P/Invoke source generator, included with the .NET 7 SDK and enabled by default, looks for <xref:System.Runtime.InteropServices.LibraryImportAttribute> on a `static` and `partial` method to trigger compile-time source generation of marshalling code, removing the need for the generation of an IL stub at run time and allowing the P/Invoke to be inlined. Analyzers and code fixers are also included to help with migration from the built-in system to the source generator and with usage in general.
+The P/Invoke source generator, included with the .NET 7 SDK and enabled by default, looks for <xref:System.Runtime.InteropServices.LibraryImportAttribute> on a `static` and `partial` method to trigger compile-time source generation of marshalling code, removing the need for the generation of an IL stub at run time and allowing the P/Invoke to be inlined. [Analyzers](../../fundamentals/syslib-diagnostics/syslib1050-1069.md) and code fixers are also included to help with migration from the built-in system to the source generator and with usage in general.
 
 ## Basic usage
 
@@ -69,7 +69,7 @@ internal static partial string ToLower(string str);
 
 ## Differences from `DllImport`
 
-<xref:System.Runtime.InteropServices.LibraryImportAttribute> is intended to be a straight-forward conversion from <xref:System.Runtime.InteropServices.DllImportAttribute> in most cases, but there are some intentional changes.
+<xref:System.Runtime.InteropServices.LibraryImportAttribute> is intended to be a straightforward conversion from <xref:System.Runtime.InteropServices.DllImportAttribute> in most cases, but there are some intentional changes:
 
 - <xref:System.Runtime.InteropServices.DllImportAttribute.CallingConvention> has no equivalent on <xref:System.Runtime.InteropServices.LibraryImportAttribute>. <xref:System.Runtime.InteropServices.UnmanagedCallConvAttribute> should be used instead.
 - <xref:System.Runtime.InteropServices.CharSet> (for <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet>) has been replaced with <xref:System.Runtime.InteropServices.StringMarshalling> (for <xref:System.Runtime.InteropServices.LibraryImportAttribute.StringMarshalling>). ANSI has been removed and UTF-8 is now available as a first-class option.
@@ -83,3 +83,4 @@ There are also differences in support for some settings on <xref:System.Runtime.
 
 - [P/Invoke](pinvoke.md)
 - <xref:System.Runtime.InteropServices.LibraryImportAttribute>
+- [SYSLIB diagnostics for P/Invoke source generation](../../fundamentals/syslib-diagnostics/syslib1050-1069.md)


### PR DESCRIPTION
Fixes #32084.

I grouped the diagnostics into 3 files:

- regex source gen - [preview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1040-1049?branch=pr-en-us-32331)
- p/invoke source gen - [preview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1050-1069?branch=pr-en-us-32331)
- JavaScript interop source gen - [preview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1070-1089?branch=pr-en-us-32331)

The docs I added don't add much over the diagnostic message except to link to related information. If you have any suggestions on what else I should add, please leave a suggestion. 