### PR TITLE
Update Linux perfcollect docs to disable Write-No-Execute

### DIFF
--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -37,7 +37,7 @@ The [`PerfCollect`](./trace-perfcollect-lttng.md) script is useful for collectin
   - `DOTNET_EnableEventLog=1`
 
 > [!NOTE]
-> When executing the app with .NET 7, please set `DOTNET_EnableWriteXorExecute=0` in addition to the above environment variables.
+> When executing the app with .NET 7, you must also set `DOTNET_EnableWriteXorExecute=0` in addition to the preceding environment variables.
 
   [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
 

--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -36,6 +36,9 @@ The [`PerfCollect`](./trace-perfcollect-lttng.md) script is useful for collectin
   - `DOTNET_PerfMapEnabled=1`
   - `DOTNET_EnableEventLog=1`
 
+> [!NOTE]
+> When executing the app with .NET 7, please set `DOTNET_EnableWriteXorExecute=0` in addition to the above environment variables.
+
   [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
 
 ### Using `PerfCollect` in a sidecar container

--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -71,6 +71,13 @@ For resolving method names of native runtime DLLs (such as libcoreclr.so), `perf
     > export DOTNET_EnableEventLog=1
     > ```
 
+    > [!NOTE]
+    > When executing the app with .NET 7, please set `DOTNET_EnableWriteXorExecute=0` in addition to the above environment variables.  For example:
+
+    > ```bash
+    > export DOTNET_EnableWriteXorExecute=0
+    > ```
+
    [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
 
 4. **[App]** Run the app - let it run as long as you need to in order to capture the performance problem. The exact length can be as short as you need as long as it sufficiently captures the window of time where the performance problem you want to investigate occurs.
@@ -158,6 +165,9 @@ For more information on how to interpret views in PerfView, see help links in th
 
 > [!NOTE]
 > Events written via <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> API (including the events from Framework) won't show up under their provider name. Instead, they are written as `EventSourceEvent` events under `Microsoft-Windows-DotNETRuntime` provider and their payloads are JSON serialized.
+
+> [!NOTE]
+> If you observe `[unknown] /memfd:doublemapper` frames in method names and callstacks, please set `DOTNET_EnableWriteXorExecute=0` before running the app being traced with perfcollect.
 
 ### Use TraceCompass to open the trace file
 

--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -72,8 +72,8 @@ For resolving method names of native runtime DLLs (such as libcoreclr.so), `perf
     > ```
 
     > [!NOTE]
-    > When executing the app with .NET 7, please set `DOTNET_EnableWriteXorExecute=0` in addition to the above environment variables.  For example:
-
+    > When executing the app with .NET 7, you must also set `DOTNET_EnableWriteXorExecute=0` in addition to the preceding environment variables.  For example:
+>
     > ```bash
     > export DOTNET_EnableWriteXorExecute=0
     > ```
@@ -167,7 +167,7 @@ For more information on how to interpret views in PerfView, see help links in th
 > Events written via <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> API (including the events from Framework) won't show up under their provider name. Instead, they are written as `EventSourceEvent` events under `Microsoft-Windows-DotNETRuntime` provider and their payloads are JSON serialized.
 
 > [!NOTE]
-> If you observe `[unknown] /memfd:doublemapper` frames in method names and callstacks, please set `DOTNET_EnableWriteXorExecute=0` before running the app being traced with perfcollect.
+> If you observe `[unknown] /memfd:doublemapper` frames in method names and callstacks, set `DOTNET_EnableWriteXorExecute=0` before running the app that you're tracing with perfcollect.
 
 ### Use TraceCompass to open the trace file
 

--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -73,7 +73,7 @@ For resolving method names of native runtime DLLs (such as libcoreclr.so), `perf
 
     > [!NOTE]
     > When executing the app with .NET 7, you must also set `DOTNET_EnableWriteXorExecute=0` in addition to the preceding environment variables.  For example:
->
+    >
     > ```bash
     > export DOTNET_EnableWriteXorExecute=0
     > ```


### PR DESCRIPTION
## Summary

Starting with .NET 7, there is an extra environment variable that needs to be set to collect a trace using the `perfcollect` script.  This PR updates the perfcollect docs to reflect the new requirement.

Related to https://github.com/dotnet/runtime/issues/71786