### PR TITLE
Add C# 11 to version table

### DIFF
--- a/docs/csharp/language-reference/includes/langversion-table.md
+++ b/docs/csharp/language-reference/includes/langversion-table.md
@@ -7,6 +7,7 @@ ms.custom: "updateeachrelease"
 | `preview`                 | The compiler accepts all valid language syntax from the latest preview version.                         |
 | `latest`                  | The compiler accepts syntax from the latest released version of the compiler (including minor version). |
 | `latestMajor` (`default`) | The compiler accepts syntax from the latest released major version of the compiler.                     |
+| `11.0`                    | The compiler accepts only syntax that is included in C# 11 or lower.                                    |
 | `10.0`                    | The compiler accepts only syntax that is included in C# 10 or lower.                                    |
 | `9.0`                     | The compiler accepts only syntax that is included in C# 9 or lower.                                     |
 | `8.0`                     | The compiler accepts only syntax that is included in C# 8.0 or lower.                                   |


### PR DESCRIPTION
Fixes #32353
