### PR TITLE
Document breaking changes in dotnet test for .NET 7

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -110,6 +110,8 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | - | :-: | :-: | - |
 | [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
 | [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
+| [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |
+| [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
 
 ## Serialization
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -83,8 +83,8 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 > [!WARNING]
 > Breaking changes in options:
 >
-> - switch `-a` to alias `--arch` instead of `--test-adapter-path`
-> - switch `-r` to alias `--runtime` instead of `--results-dir`
+> - Starting in .NET 7 Preview 1: switch `-a` to alias `--arch` instead of `--test-adapter-path`
+> - Starting in .NET 7 Preview 1: switch `-r` to alias `--runtime` instead of `--results-dir`
 
 - **`--test-adapter-path <ADAPTER_PATH>`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -83,8 +83,8 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 > [!WARNING]
 > Breaking changes in options:
 >
-> - Starting in .NET 7 Preview 1: switch `-a` to alias `--arch` instead of `--test-adapter-path`
-> - Starting in .NET 7 Preview 1: switch `-r` to alias `--runtime` instead of `--results-dir`
+> - Starting in .NET 7: switch `-a` to alias `--arch` instead of `--test-adapter-path`
+> - Starting in .NET 7: switch `-r` to alias `--runtime` instead of `--results-dir`
 
 - **`--test-adapter-path <ADAPTER_PATH>`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -15,8 +15,8 @@ ms.date: 03/17/2022
 
 ```dotnetcli
 dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL> | <EXE>]
-    [-a|--test-adapter-path <ADAPTER_PATH>] 
-    [--arch <ARCHITECTURE>]
+    [--test-adapter-path <ADAPTER_PATH>] 
+    [-a|--arch <ARCHITECTURE>]
     [--blame]
     [--blame-crash]
     [--blame-crash-dump-type <DUMP_TYPE>]
@@ -80,9 +80,17 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 ## Options
 
-- **`-a|--test-adapter-path <ADAPTER_PATH>`**
+> [!WARNING]
+> Breaking changes in options:
+>
+> - switch `-a` to alias `--arch` instead of `--test-adapter-path`
+> - switch `-r` to alias `--runtime` instead of `--results-dir`
+
+- **`--test-adapter-path <ADAPTER_PATH>`**
 
   Path to a directory to be searched for additional test adapters. Only *.dll* files with suffix `.TestAdapter.dll` are inspected. If not specified, the directory of the test *.dll* is searched.
+
+  Short form `-a` available in .NET SDK versions earlier than 7.
 
 [!INCLUDE [arch-no-a](../../../includes/cli-arch-no-a.md)]
 
@@ -183,11 +191,15 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 - **`--results-directory <RESULTS_DIR>`**
 
-  The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is `TestResults` in the directory that contains the project file. Short form `-r` available in .NET SDK versions earlier than 7.
+  The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is `TestResults` in the directory that contains the project file.
+
+  Short form `-r` available in .NET SDK versions earlier than 7.
 
 - **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 
-  The target runtime to test for. Short form `-r` available starting in .NET SDK 7.
+  The target runtime to test for.
+  
+  Short form `-r` available starting in .NET SDK 7.
 
 - **`-s|--settings <SETTINGS_FILE>`**
 


### PR DESCRIPTION
## Summary

Document the breaking changes in the options available for `dotnet test` both in the list of breaking changes of .NET 7 and in the documentation page of the `dotnet test`.

Relates to:

- https://github.com/dotnet/sdk/issues/21952
- https://github.com/dotnet/sdk/issues/21389
- https://github.com/dotnet/sdk/issues/28986
