### PR TITLE
Sql grain persistence changes

### DIFF
--- a/docs/orleans/host/configuration-guide/adonet-configuration.md
+++ b/docs/orleans/host/configuration-guide/adonet-configuration.md
@@ -35,7 +35,7 @@ The following sections contain links to SQL scripts to configure your database a
 | PostgreSQL | [PostgreSQL-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql) | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
 | Oracle | [Oracle-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Oracle-Persistence.sql) | [ODP.net](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) | `Oracle.DataAccess.Client` |
 
-\* If you are using MS Orleans v 3.X.X use this script template: https://github.com/dotnet/orleans/blob/3.x/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql
+\* If you're using Orleans v3.x use this script template: <https://github.com/dotnet/orleans/blob/3.x/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql>
 
 ## Reminders
 

--- a/docs/orleans/host/configuration-guide/adonet-configuration.md
+++ b/docs/orleans/host/configuration-guide/adonet-configuration.md
@@ -30,10 +30,12 @@ The following sections contain links to SQL scripts to configure your database a
 
 | Database | Script | NuGet package| ADO.NET invariant |
 |--|--|--|--|
-| SQL Server | [SQLServer-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql) | [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) | `System.Data.SqlClient` |
+| SQL Server* | [SQLServer-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql) | [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) | `System.Data.SqlClient` |
 | MySQL / MariaDB | [MySQL-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/MySQL-Persistence.sql) | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) | `MySql.Data.MySqlClient` |
 | PostgreSQL | [PostgreSQL-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql) | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
 | Oracle | [Oracle-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Oracle-Persistence.sql) | [ODP.net](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) | `Oracle.DataAccess.Client` |
+
+\* If you are using MS Orleans v 3.X.X use this script template: https://github.com/dotnet/orleans/blob/3.x/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql
 
 ## Reminders
 


### PR DESCRIPTION
Hello, the idea is to clarify that in Orleans 7.0.0+ the SQl Script for persistence changed removing the JsonPayload and XmlPayload columns, so if the devs are still using Orleans 3.x.x should apply the right sql script.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/host/configuration-guide/adonet-configuration.md](https://github.com/dotnet/docs/blob/d5527074ae60d07a78b46f8486975c6a05054cd2/docs/orleans/host/configuration-guide/adonet-configuration.md) | [docs/orleans/host/configuration-guide/adonet-configuration](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration?branch=pr-en-us-32532) |


<!-- PREVIEW-TABLE-END -->