### PR TITLE
Add latest OS version in system requirements

### DIFF
--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -46,7 +46,8 @@ For information on the support lifecycle of .NET Framework versions, see [Micros
 
 | Operating system | Supported editions | Preinstalled with the OS | Installable separately |
 | ---------------- | ------------------ | ------------------------ | ---------------------- |
-| Windows 11<br/> (version 21H2) | 64-bit | .NET Framework 4.8 | .NET Framework 4.8.1 |
+| Windows 11 | 64-bit | .NET Framework 4.8 | .NET Framework 4.8.1 |
+| Windows 10 2022 Update<br/> (version 22H2) | 32-bit and 64-bit | .NET Framework 4.8 | .NET Framework 4.8.1 |
 | Windows 10 November 2021 Update<br/> (version 21H2) | 32-bit and 64-bit | .NET Framework 4.8 | .NET Framework 4.8.1 |
 | Windows 10 May 2021 Update<br/> (version 21H1) | 32-bit and 64-bit | .NET Framework 4.8 | .NET Framework 4.8.1 |
 | Windows 10 October 2020 Update<br/> (version 20H2) | 32-bit and 64-bit | .NET Framework 4.8 | .NET Framework 4.8.1 |


### PR DESCRIPTION
## Summary

Added Windows 10 22H2.
Remove Windows 11 version. (This means including 22H2.)

Windows 11 is written without a version number in the following document.
This will reduce maintenance costs, but feel free to change it if it is better to note the version as well.
https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies
![image](https://user-images.githubusercontent.com/12545287/201909016-c85c4d60-3e0f-4d55-8e2c-c7ef9dbfa463.png)

