### PR TITLE
Rename `Interop guidance` to `Best practices`

### DIFF
--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -354,7 +354,7 @@ items:
       href: ../../standard/native-interop/custom-marshalling-source-generation.md
     - name: "Tutorial: Use custom marshallers in source generation"
       href: ../../standard/native-interop/tutorial-custom-marshaller.md
-  - name: Best practices
+  - name: Interop best practices
     href: ../../standard/native-interop/best-practices.md
   - name: Expose .NET components to COM
     href: ../../core/native-interop/expose-components-to-com.md

--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -354,7 +354,7 @@ items:
       href: ../../standard/native-interop/custom-marshalling-source-generation.md
     - name: "Tutorial: Use custom marshallers in source generation"
       href: ../../standard/native-interop/tutorial-custom-marshaller.md
-  - name: Interop guidance
+  - name: Best practices
     href: ../../standard/native-interop/best-practices.md
   - name: Expose .NET components to COM
     href: ../../core/native-interop/expose-components-to-com.md


### PR DESCRIPTION
This new name corresponds with the topic title.