### PR TITLE
Updated sample code writing output parameters

### DIFF
--- a/docs/devops/snippets/create-dotnet-github-action/DotNet.GitHubAction/Program.cs
+++ b/docs/devops/snippets/create-dotnet-github-action/DotNet.GitHubAction/Program.cs
@@ -26,7 +26,7 @@ parser.WithNotParsed(
             .LogError(
                 string.Join(
                     Environment.NewLine, errors.Select(error => error.ToString())));
-        
+
         Environment.Exit(2);
     });
 
@@ -47,9 +47,13 @@ static async Task StartAnalysisAsync(ActionInputs inputs, IHost host)
 
     // Do the work here...
 
-    Console.WriteLine($"::set-output name=updated-metrics::{updatedMetrics}");
-    Console.WriteLine($"::set-output name=summary-title::{title}");
-    Console.WriteLine($"::set-output name=summary-details::{summary}");
+    var githubOutputFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT", EnvironmentVariableTarget.Process);
+    using (var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8))
+    {
+        textWriter.WriteLine($"updated-metrics={updatedMetrics}");
+        textWriter.WriteLine($"summary-title={title}");
+        textWriter.WriteLine($"summary-details={summary}");
+    }
 
     await Task.CompletedTask;
 


### PR DESCRIPTION
## Summary

Changed the code that sets the output parameters as to be done after GitHub deprecation of `::set-output` command.

Fixes #32600
