### PR TITLE
Wrong variable in powershell cert cleanup examples

### DIFF
--- a/docs/core/additional-tools/self-signed-certificates-guide.md
+++ b/docs/core/additional-tools/self-signed-certificates-guide.md
@@ -245,7 +245,7 @@ Be sure that the host entries are updated for `contoso.com` to answer on the app
 
 ```powershell
 $cert | Remove-Item
-Get-ChildItem $certFilePath | Remove-Item
+Get-ChildItem $certKeyPath | Remove-Item
 $rootCert | Remove-item
 ```
 
@@ -305,7 +305,7 @@ Depending on the host os, the certificate will need to be trusted. On a Linux ho
 For the purposes of this guide, here's an example in Windows using PowerShell:
 
 ```powershell
-Import-Certificate -FilePath $certFilePath -CertStoreLocation 'Cert:\LocalMachine\Root'
+Import-Certificate -FilePath $certKeyPath -CertStoreLocation 'Cert:\LocalMachine\Root'
 ```
 
 For .NET Core 3.1, run the following command in WSL:
@@ -344,7 +344,7 @@ Be sure that the host entries are updated for `contoso.com` to answer on the app
 Be sure to clean up the self-signed certificates once done testing.
 
 ```powershell
-Get-ChildItem $certFilePath | Remove-Item
+Get-ChildItem $certKeyPath | Remove-Item
 ```
 
 ## See also


### PR DESCRIPTION
## Summary

I was following the powershell example to generate self-signed certificates. For this, the path where the pfx file is stored in a variable called $certKeyPath in all the examples, but in the step where it tells the reader to clean everything up after testing uses the variable $certFilePath that isn't used in any example.

##The problem

I got distracted and didn't notice the difference in the variables, so I executed this

```powershell
Get-ChildItem $certFilePath | Remove-Item
```

But as $certFilePath was never set, this resulted in the same as executing this

```powershell
Get-ChildItem | Remove-Item
```

And therefore powershell tried to remove everything at prompt level. Not happy with this I saw a warning saying it was going to delete "certs" folder, so I put "yes to all" option, and then prompted a second time that I didn´t read and half of my "D:\" drive was gone forever. I wasn't completely wipped out because I noticed what happend and press Ctrl+C.

## Proposal

I changed it so it matches the variable actually used in the examples just to prevent this from happening to someone else. I don't know which is the prefered solution of microsoft. I never proposed changes to docs before.
