### PR TITLE
Simplify linux doc

### DIFF
--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -38,7 +38,7 @@ You may need to install [.NET dependencies](https://github.com/dotnet/core/blob/
 - [Snap](linux-snap.md)
 - [Ubuntu](linux-ubuntu.md)
 
-.NET is [supported by Microsoft](https://github.com/dotnet/core/blob/main/microsoft-support.md) when downloaded from a Microsoft source. Best effort support is offered from Microsoft when downloaded from elsewhere. You can  open issues at [dotnet/core](https://github.com/dotnet/core) if you run into problems.
+.NET is [supported by Microsoft](https://github.com/dotnet/core/blob/main/microsoft-support.md) when downloaded from a Microsoft source. Best effort support is offered from Microsoft when downloaded from elsewhere. You can open issues at [dotnet/core](https://github.com/dotnet/core) if you run into problems.
 
 ## Next steps
 

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -14,55 +14,31 @@ ms.date: 11/08/2022
 > - [Install on macOS](macos.md)
 > - [Install on Linux](linux.md)
 
-This article details how to install .NET on various Linux distributions, manually and via a package manager. Typically, stable .NET versions are available in a package manager, and Preview versions are not.
-
-The latest version of .NET is 7.
+This article details how to install .NET on various Linux distributions, manually, via a package manager, or [containers](../docker/introduction.md#net-core-images).
 
 ## Manual installation
 
 You can install .NET manually in the following ways:
 
-- [Download tarballs](https://dotnet.microsoft.com/download/dotnet)
+- [Manual install](linux-scripted-manual.md#manual-install)
 - [Scripted install](linux-scripted-manual.md#scripted-install)
-- [Manual binary extraction](linux-scripted-manual.md#manual-install)
 
 You may need to install [.NET dependencies](https://github.com/dotnet/core/blob/main/release-notes/7.0/linux-packages.md) if you install .NET manually.
 
-## Official package archives
+## Packages
 
-.NET is available in the [official package archives](https://pkgs.org/search/?q=dotnet) for various Linux distributions, including the following ones:
+.NET is available in [official package archives](https://github.com/dotnet/core/blob/main/linux.md) for various Linux distributions and [packages.microsoft.com](https://packages.microsoft.com/).
 
-- [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=dotnet*)
-- [Arch Linux](https://archlinux.org/packages/?q=dotnet)
-- [Arch Linux User Repository](https://aur.archlinux.org/packages?K=dotnet)
-- [Fedora](https://packages.fedoraproject.org/search?query=dotnet)
-- [Red Hat Enterprise Linux](https://access.redhat.com/documentation/en-us/net/6.0)
-- [Ubuntu](https://packages.ubuntu.com/search?keywords=dotnet6)
-
-Microsoft collaborates with partners to ensure .NET works well on their Linux distributions. Support is provided by those distributions. You can still [open issues at dotnet/core](https://github.com/dotnet/core/issues) if you run into problems.
-
-## Microsoft packages
-
-.NET is also available via [packages.microsoft.com](https://packages.microsoft.com/).
-
+- [Alpine](linux-alpine.md)
 - [CentOS](linux-centos.md)
 - [Debian](linux-debian.md)
 - [Fedora](linux-fedora.md)
 - [openSUSE](linux-opensuse.md)
 - [SLES](linux-sles.md)
+- [Snap](linux-snap.md)
 - [Ubuntu](linux-ubuntu.md)
 
-These packages are [supported by Microsoft](https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md).
-
-You're encouraged to install .NET from the official archive for your distribution if it's available there, even if it's also available at packages.microsoft.com.
-
-## Other distributions
-
-Installation information is also provided for other distributions.
-
-- [Alpine](linux-alpine.md)
-- [Containers](../docker/introduction.md#net-core-images)
-- [Snap](linux-snap.md)
+.NET is [supported by Microsoft](https://github.com/dotnet/core/blob/main/microsoft-support.md) when downloaded from a Microsoft source. Best effort support is offered from Microsoft when downloaded from elsewhere. You can  open issues at [dotnet/core](https://github.com/dotnet/core) if you run into problems.
 
 ## Next steps
 

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -14,7 +14,7 @@ ms.date: 11/08/2022
 > - [Install on macOS](macos.md)
 > - [Install on Linux](linux.md)
 
-This article details how to install .NET on various Linux distributions, manually, via a package manager, or [containers](../docker/introduction.md#net-core-images).
+This article details how to install .NET on various Linux distributions either manually, via a package manager, or via a [container](../docker/introduction.md#net-core-images).
 
 ## Manual installation
 


### PR DESCRIPTION
Simplify the document. After this, we need to update some of the distro docs. For example, the Alpine doc doesn't describe how to install from the Alpine package manager.

Related to: https://github.com/dotnet/core/pull/7971