### PR TITLE
C# breaking change metadata

### DIFF
--- a/docs/csharp/whats-new/breaking-changes.md
+++ b/docs/csharp/whats-new/breaking-changes.md
@@ -2,7 +2,6 @@
 title: Breaking changes in the C# compiler
 description: Find any breaking changes in the C# compiler that you're using.
 ms.topic: troubleshooting
-ms.custom: updateeachrelease
 ms.date: 03/21/2022
 ---
 


### PR DESCRIPTION
Remove "updateeachrelease" since newer breaking changes are documented elsewhere.