### PR TITLE
Add double-dash to install/uninstall options.

### DIFF
--- a/docs/core/tutorials/cli-templates-create-project-template.md
+++ b/docs/core/tutorials/cli-templates-create-project-template.md
@@ -123,10 +123,10 @@ This config file contains all of the settings for your template. You can see the
 
 The `classifications` item represents the **tags** column you see when you run `dotnet new` and get a list of templates. Users can also search based on classification tags. Don't confuse the `tags` property in the json file with the `classifications` tags list. They're two different things unfortunately named similarly. The full schema for the *template.json* file is found at the [JSON Schema Store](http://json.schemastore.org/template). For more information about the *template.json* file, see the [dotnet templating wiki](https://github.com/dotnet/templating/wiki).
 
-Now that you have a valid _.template.config/template.json_ file, your template is ready to be installed. Before you install the template, make sure that you delete any extra folders and files you don't want included in your template, like the _bin_ or _obj_ folders. In your terminal, navigate to the _consoleasync_ folder and run `dotnet new install .\` to install the template located at the current folder. If you're using a Linux or macOS operating system, use a forward slash: `dotnet new install ./`.
+Now that you have a valid _.template.config/template.json_ file, your template is ready to be installed. Before you install the template, make sure that you delete any extra folders and files you don't want included in your template, like the _bin_ or _obj_ folders. In your terminal, navigate to the _consoleasync_ folder and run `dotnet new --install .\` to install the template located at the current folder. If you're using a Linux or macOS operating system, use a forward slash: `dotnet new --install ./`.
 
 ```dotnetcli
-dotnet new install .\
+dotnet new --install .\
 ```
 
 This command outputs a list of the installed templates, which should include yours.
@@ -177,8 +177,8 @@ Congratulations! You created and deployed a project template with .NET. In prepa
 
 In your terminal, navigate to the  _consoleasync_ folder and run the following command to uninstall the template located in the current folder:
 
-* **On Windows**: `dotnet new uninstall .\`
-* **On Linux or macOS**: `dotnet new uninstall ./`
+* **On Windows**: `dotnet new --uninstall .\`
+* **On Linux or macOS**: `dotnet new --uninstall ./`
 
 This command outputs a list of the templates that were uninstalled, which should include yours.
 


### PR DESCRIPTION
Examples for install/uninstall produce the following error:
```console
Error: Invalid option(s):
  ./
```

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
