### PR TITLE
Fix diamond problem example for `JsonPolymorphic`

### DIFF
--- a/docs/standard/serialization/system-text-json/polymorphism.md
+++ b/docs/standard/serialization/system-text-json/polymorphism.md
@@ -628,6 +628,7 @@ However, falling back to the nearest ancestor admits the possibility of "diamond
 [JsonPolymorphic(
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)]
 [JsonDerivedType(typeof(BasePoint))]
+[JsonDerivedType(typeof(IPointWithTimeSeries))]
 public interface IPoint { }
 
 public interface IPointWithTimeSeries : IPoint { }
@@ -641,6 +642,7 @@ public class BasePointWithTimeSeries : BasePoint, IPointWithTimeSeries { }
 <JsonPolymorphic(
     UnknownDerivedTypeHandling:=JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)>
 <JsonDerivedType(GetType(BasePoint))>
+<JsonDerivedType(GetType(IPointWithTimeSeries))>
 Public Interface IPoint
 End Interface
 


### PR DESCRIPTION
Seems like the diamond problem has not been reproducing due to missed `[JsonDerivedType(typeof(IPointWithTimeSeries))]` attribute for `IPoint` in the example.

I've tried current example [via sharplab.io](https://sharplab.io/#v2:C4LgTgrgdgPgAgJgAwFgBQiCM65IARyYB0AKgKYAewRAUgM4D2UA3DvoaZdfU0QMpkwASwCGAGyEAvEcCFNWaHJgCcACgCiUAG5CwTALZko1AGqC6cqAEoFhNeh5QBw8VMH9BoiZLIAeAJIACgxCxgB8qlBkAO54AEIidGTBocAA6kLAABYkQobOQmR0qlZW6HgVeDbo6ADajsFiAJ76DGAADllCAMaq5ZUAqlAA1lAM0VAAIp5aZAAmJE3tZAASIlBzElAA5ngAvHiOQ6PjUzPzi8trG1vbRABi4mIJ3cMkDAByZCJgRcAAglBun82lYALp1RzTYSzBZLMiqYDwhgAM1UCSSKWMpQhaAA9Hj6owzjCLvDEci0UEQsYMtlcvlPEUcTgAMx4VKCFEiYF4ampPAAbzwAF8ahh2ZywNzefzaZkcnkyAUingQHyscAhaLxXB2Yh4olkjSteq5VrhWLFBKCAhDZiTXTFYzhKr1RjjakADQax0KhnKpl0bUioA) and got no `NotSupportedException`.