### PR TITLE
Standardise presentation of values with synonyms

### DIFF
--- a/docs/csharp/language-reference/includes/langversion-table.md
+++ b/docs/csharp/language-reference/includes/langversion-table.md
@@ -2,22 +2,22 @@
 ms.custom: "updateeachrelease"
 ---
 
-| Value                     | Meaning                                                                                                 |
-|---------------------------|---------------------------------------------------------------------------------------------------------|
-| `preview`                 | The compiler accepts all valid language syntax from the latest preview version.                         |
-| `latest`                  | The compiler accepts syntax from the latest released version of the compiler (including minor version). |
-| `latestMajor` (`default`) | The compiler accepts syntax from the latest released major version of the compiler.                     |
-| `11.0`                    | The compiler accepts only syntax that is included in C# 11 or lower.                                    |
-| `10.0`                    | The compiler accepts only syntax that is included in C# 10 or lower.                                    |
-| `9.0`                     | The compiler accepts only syntax that is included in C# 9 or lower.                                     |
-| `8.0`                     | The compiler accepts only syntax that is included in C# 8.0 or lower.                                   |
-| `7.3`                     | The compiler accepts only syntax that is included in C# 7.3 or lower.                                   |
-| `7.2`                     | The compiler accepts only syntax that is included in C# 7.2 or lower.                                   |
-| `7.1`                     | The compiler accepts only syntax that is included in C# 7.1 or lower.                                   |
-| `7`                       | The compiler accepts only syntax that is included in C# 7.0 or lower.                                   |
-| `6`                       | The compiler accepts only syntax that is included in C# 6.0 or lower.                                   |
-| `5`                       | The compiler accepts only syntax that is included in C# 5.0 or lower.                                   |
-| `4`                       | The compiler accepts only syntax that is included in C# 4.0 or lower.                                   |
-| `3`                       | The compiler accepts only syntax that is included in C# 3.0 or lower.                                   |
-| `ISO-2` (or `2`)          | The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0).                       |
-| `ISO-1` (or `1`)          | The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2).                   |
+| Value                         | Meaning                                                                                                 |
+|-------------------------------|---------------------------------------------------------------------------------------------------------|
+| `preview`                     | The compiler accepts all valid language syntax from the latest preview version.                         |
+| `latest`                      | The compiler accepts syntax from the latest released version of the compiler (including minor version). |
+| `latestMajor`<br>or `default` | The compiler accepts syntax from the latest released major version of the compiler.                     |
+| `11.0`                        | The compiler accepts only syntax that is included in C# 11 or lower.                                    |
+| `10.0`                        | The compiler accepts only syntax that is included in C# 10 or lower.                                    |
+| `9.0`                         | The compiler accepts only syntax that is included in C# 9 or lower.                                     |
+| `8.0`                         | The compiler accepts only syntax that is included in C# 8.0 or lower.                                   |
+| `7.3`                         | The compiler accepts only syntax that is included in C# 7.3 or lower.                                   |
+| `7.2`                         | The compiler accepts only syntax that is included in C# 7.2 or lower.                                   |
+| `7.1`                         | The compiler accepts only syntax that is included in C# 7.1 or lower.                                   |
+| `7`                           | The compiler accepts only syntax that is included in C# 7.0 or lower.                                   |
+| `6`                           | The compiler accepts only syntax that is included in C# 6.0 or lower.                                   |
+| `5`                           | The compiler accepts only syntax that is included in C# 5.0 or lower.                                   |
+| `4`                           | The compiler accepts only syntax that is included in C# 4.0 or lower.                                   |
+| `3`                           | The compiler accepts only syntax that is included in C# 3.0 or lower.                                   |
+| `ISO-2`<br>or `2`             | The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0).                       |
+| `ISO-1`<br>or `1`             | The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2).                   |


### PR DESCRIPTION
## Summary

Standardise presentation of option values when those values have synonyms.

Note that tables are `vertical-align: top` on learn.ms.com while GFM uses the default `middle`, so while the "Meaning" column will look wrong in the preview here, it will look correct on  https://learn.microsoft.com/dotnet/csharp/language-reference/configure-language-version (manual HTML edit of the latter for clarity):

![image](https://user-images.githubusercontent.com/1726434/203035739-c9b9d379-4fff-400e-a859-ffed3831648d.png)
