### PR TITLE
Fixed Missing closing of output segment

### DIFF
--- a/docs/standard/linq/find-descendants-specific-element-name.md
+++ b/docs/standard/linq/find-descendants-specific-element-name.md
@@ -79,6 +79,7 @@ This example produces the following output:
 
 ```output
 Some text that's broken up into multiple segments.
+```
 
 ## Example: Find when the XML is in a namespace
 


### PR DESCRIPTION
## Summary

Describe your changes here.

There is a missing Closing tag for an output segment on this page

Fixes #Issue_Number (if available)
