### PR TITLE
improve SEO on statements

### DIFF
--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -1,7 +1,7 @@
 ---
-title: "+ and += operators - C# reference"
-description: "Learn about the C# addition operator and how it works with operands of numeric, string, or delegate types."
-ms.date: 06/30/2021
+title: "Addition operators - + and +="
+description: "The C# addition operators (`+`, and `+=`) work with operands of numeric, string, or delegate types."
+ms.date: 11/29/2022
 f1_keywords: 
   - "+_CSharpKeyword"
   - "+=_CSharpKeyword"
@@ -13,9 +13,8 @@ helpviewer_keywords:
   - "addition assignment operator [C#]"
   - "event subscription [C#]"
   - "+= operator [C#]"
-ms.assetid: 93e56486-bb42-43c1-bd43-60af11e64e67
 ---
-# + and += operators (C# reference)
+# Addition operators - `+` and `+=`
 
 The `+` and `+=` operators are supported by the built-in [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types, the [string](../builtin-types/reference-types.md#the-string-type) type, and [delegate](../builtin-types/reference-types.md#the-delegate-type) types.
 

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -1,7 +1,7 @@
 ---
-title: "Assignment operators - C# reference"
-description: "Learn about various C# assignment operators."
-ms.date: 09/14/2022
+title: "Assignment operators - assign an expression to a variable"
+description: "C# assignment operators assign an expression to a variable. Assignment sets the value of the expression. `ref` assignment sets the reference of a `ref` variable."
+ms.date: 11/29/2022
 f1_keywords:
   - "=_CSharpKeyword"
 helpviewer_keywords:

--- a/docs/csharp/language-reference/operators/await.md
+++ b/docs/csharp/language-reference/operators/await.md
@@ -1,15 +1,14 @@
 ---
-title: "await operator - C# reference"
-description: "Learn about the C# await operator that suspends evaluation of the enclosing async method."
-ms.date: 03/02/2022
+title: "await operator - asynchronously wait for a task to complete "
+description: "The C# `await` operator asynchronously suspends evaluation of the enclosing `async` method."
+ms.date: 11/29/2022
 f1_keywords: 
   - "await_CSharpKeyword"
 helpviewer_keywords: 
   - "await keyword [C#]"
   - "await [C#]"
-ms.assetid: 50725c24-ac76-4ca7-bca1-dd57642ffedb
 ---
-# await operator (C# reference)
+# await operator - asynchronously await for a task to complete
 
 The `await` operator suspends evaluation of the enclosing [async](../keywords/async.md) method until the asynchronous operation represented by its operand completes. When the asynchronous operation completes, the `await` operator returns the result of the operation, if any. When the `await` operator is applied to the operand that represents an already completed operation, it returns the result of the operation immediately without suspension of the enclosing method. The `await` operator doesn't block the thread that evaluates the async method. When the `await` operator suspends the enclosing async method, the control returns to the caller of the method.
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -38,7 +38,11 @@ helpviewer_keywords:
 ---
 # Bitwise and shift operators (C# reference)
 
-The bitwise and shift operators take operands of the [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../builtin-types/char.md) type. They include unary [`~` (bitwise complement)](#bitwise-complement-operator-), binary [`<<` (left shift)](#left-shift-operator-), [`>>` (right shift)](#right-shift-operator-), and [`>>>` (unsigned right shift)](#unsigned-right-shift-operator-) operators, and the binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators.
+The bitwise and shift operators include unary bitwise complement, binary left and right shift, unsigned right shift, amd the binary logical AND, OR, and exclusive OR operators. These operands take operands of the [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../builtin-types/char.md) type.
+
+- Unary [`~` (bitwise complement)](#bitwise-complement-operator-) operator
+- Binary [`<<` (left shift)](#left-shift-operator-), [`>>` (right shift)](#right-shift-operator-), and [`>>>` (unsigned right shift)](#unsigned-right-shift-operator-) operators
+- Binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators
 
 Those operators are defined for the `int`, `uint`, `long`, and `ulong` types. When both operands are of other integral types (`sbyte`, `byte`, `short`, `ushort`, or `char`), their values are converted to the `int` type, which is also the result type of an operation. When operands are of different integral types, their values are converted to the closest containing integral type. For more information, see the [Numeric promotions](~/_csharpstandard/standard/expressions.md#1147-numeric-promotions) section of the [C# language specification](~/_csharpstandard/standard/README.md). The compound operators (such as `>>=`) don't convert their arguments to `int` or have the result type as `int`.
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -1,7 +1,7 @@
 ---
-title: "Bitwise and shift operators - C# reference"
-description: "Learn about C# operators that perform bitwise logical or shift operations with operands of integral types."
-ms.date: 06/10/2022
+title: "Bitwise and shift operators - perform boolean (AND, NOT, OR, XOR) and shift operations on individual bits in integral types"
+description: "Learn about C# operators that perform bitwise logical (AND - `&`, NOT - `~`, OR - `|`, XOR - `^`) or shift operations( `<<`, and `>>`) with operands of integral types. "
+ms.date: 11/29/2022
 author: pkulikov
 f1_keywords: 
   - "~_CSharpKeyword"
@@ -38,11 +38,7 @@ helpviewer_keywords:
 ---
 # Bitwise and shift operators (C# reference)
 
-The following operators perform bitwise or shift operations with operands of the [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../builtin-types/char.md) type:
-
-- Unary [`~` (bitwise complement)](#bitwise-complement-operator-) operator
-- Binary [`<<` (left shift)](#left-shift-operator-), [`>>` (right shift)](#right-shift-operator-), and [`>>>` (unsigned right shift)](#unsigned-right-shift-operator-) operators
-- Binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators
+The bitwise and shift operators take operands of the [integral numeric types](../builtin-types/integral-numeric-types.md) or the [char](../builtin-types/char.md) type. They include unary [`~` (bitwise complement)](#bitwise-complement-operator-), binary [`<<` (left shift)](#left-shift-operator-), [`>>` (right shift)](#right-shift-operator-), and [`>>>` (unsigned right shift)](#unsigned-right-shift-operator-) operators, and the binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators.
 
 Those operators are defined for the `int`, `uint`, `long`, and `ulong` types. When both operands are of other integral types (`sbyte`, `byte`, `short`, `ushort`, or `char`), their values are converted to the `int` type, which is also the result type of an operation. When operands are of different integral types, their values are converted to the closest containing integral type. For more information, see the [Numeric promotions](~/_csharpstandard/standard/expressions.md#1147-numeric-promotions) section of the [C# language specification](~/_csharpstandard/standard/README.md). The compound operators (such as `>>=`) don't convert their arguments to `int` or have the result type as `int`.
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -1,7 +1,7 @@
 ---
-title: "Boolean logical operators - C# reference"
-description: "Learn about C# operators that perform logical negation, conjunction (AND), and inclusive and exclusive disjunction (OR) operations with Boolean operands."
-ms.date: 06/29/2020
+title: "Boolean logical operators - the boolean and, or, not, and xor operators"
+description: "C# logical operators perform logical negation (`!`), conjunction (AND - `&`, `&&`), and inclusive and exclusive disjunction (OR - `|`, `||`, `^`) operations with Boolean operands."
+ms.date: 11/29/2022
 author: pkulikov
 f1_keywords: 
   - "!_CSharpKeyword"
@@ -36,13 +36,9 @@ helpviewer_keywords:
   - "short-circuiting OR operator [C#]"
   - "|| operator [C#]"
 ---
-# Boolean logical operators (C# reference)
+# Boolean logical operators - AND, OR, NOT, XOR
 
-The following operators perform logical operations with [bool](../builtin-types/bool.md) operands:
-
-- Unary [`!` (logical negation)](#logical-negation-operator-) operator.
-- Binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators. Those operators always evaluate both operands.
-- Binary [`&&` (conditional logical AND)](#conditional-logical-and-operator-) and [`||` (conditional logical OR)](#conditional-logical-or-operator-) operators. Those operators evaluate the right-hand operand only if it's necessary.
+The logical Boolean operators perform logical operations with [bool](../builtin-types/bool.md) operands. The unary [`!` (logical negation)](#logical-negation-operator-) operator reverses `true` and `false`. The binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators always evaluate both operands. The binary [`&&` (conditional logical AND)](#conditional-logical-and-operator-) and [`||` (conditional logical OR)](#conditional-logical-or-operator-) operators evaluate the right-hand operand only if it's necessary.
 
 For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `&`, `|`, and `^` operators perform bitwise logical operations. For more information, see [Bitwise and shift operators](bitwise-and-shift-operators.md).
 
@@ -92,7 +88,7 @@ For operands of the [integral numeric types](../builtin-types/integral-numeric-t
 
 ## <a name="conditional-logical-and-operator-"></a> Conditional logical AND operator &amp;&amp;
 
-The conditional logical AND operator `&&`, also known as the "short-circuiting" logical AND operator, computes the logical AND of its operands. The result of `x && y` is `true` if both `x` and `y` evaluate to `true`. Otherwise, the result is `false`. If `x` evaluates to `false`, `y` is not evaluated.
+The conditional logical AND operator `&&`, also known as the "short-circuiting" logical AND operator, computes the logical AND of its operands. The result of `x && y` is `true` if both `x` and `y` evaluate to `true`. Otherwise, the result is `false`. If `x` evaluates to `false`, `y` isn't evaluated.
 
 In the following example, the right-hand operand of the `&&` operator is a method call, which isn't performed if the left-hand operand evaluates to `false`:
 
@@ -102,7 +98,7 @@ The [logical AND operator](#logical-and-operator-) `&` also computes the logical
 
 ## Conditional logical OR operator ||
 
-The conditional logical OR operator `||`, also known as the "short-circuiting" logical OR operator, computes the logical OR of its operands. The result of `x || y` is `true` if either `x` or `y` evaluates to `true`. Otherwise, the result is `false`. If `x` evaluates to `true`, `y` is not evaluated.
+The conditional logical OR operator `||`, also known as the "short-circuiting" logical OR operator, computes the logical OR of its operands. The result of `x || y` is `true` if either `x` or `y` evaluates to `true`. Otherwise, the result is `false`. If `x` evaluates to `true`, `y` isn't evaluated.
 
 In the following example, the right-hand operand of the `||` operator is a method call, which isn't performed if the left-hand operand evaluates to `true`:
 
@@ -132,7 +128,7 @@ The following table presents that semantics:
 |null|false|false|null|  
 |null|null|null|null|  
 
-The behavior of those operators differs from the typical operator behavior with nullable value types. Typically, an operator which is defined for operands of a value type can be also used with operands of the corresponding nullable value type. Such an operator produces `null` if any of its operands evaluates to `null`. However, the `&` and `|` operators can produce non-null even if one of the operands evaluates to `null`. For more information about the operator behavior with nullable value types, see the [Lifted operators](../builtin-types/nullable-value-types.md#lifted-operators) section of the [Nullable value types](../builtin-types/nullable-value-types.md) article.
+The behavior of those operators differs from the typical operator behavior with nullable value types. Typically, an operator that is defined for operands of a value type can be also used with operands of the corresponding nullable value type. Such an operator produces `null` if any of its operands evaluates to `null`. However, the `&` and `|` operators can produce non-null even if one of the operands evaluates to `null`. For more information about the operator behavior with nullable value types, see the [Lifted operators](../builtin-types/nullable-value-types.md#lifted-operators) section of the [Nullable value types](../builtin-types/nullable-value-types.md) article.
 
 You can also use the `!` and `^` operators with `bool?` operands, as the following example shows:
 
@@ -182,9 +178,9 @@ For the complete list of C# operators ordered by precedence level, see the [Oper
 
 ## Operator overloadability
 
-A user-defined type can [overload](operator-overloading.md) the `!`, `&`, `|`, and `^` operators. When a binary operator is overloaded, the corresponding compound assignment operator is also implicitly overloaded. A user-defined type cannot explicitly overload a compound assignment operator.
+A user-defined type can [overload](operator-overloading.md) the `!`, `&`, `|`, and `^` operators. When a binary operator is overloaded, the corresponding compound assignment operator is also implicitly overloaded. A user-defined type can't explicitly overload a compound assignment operator.
 
-A user-defined type cannot overload the conditional logical operators `&&` and `||`. However, if a user-defined type overloads the [true and false operators](true-false-operators.md) and the `&` or `|` operator in a certain way, the `&&` or `||` operation, respectively, can be evaluated for the operands of that type. For more information, see the [User-defined conditional logical operators](~/_csharpstandard/standard/expressions.md#11133-user-defined-conditional-logical-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
+A user-defined type can't overload the conditional logical operators `&&` and `||`. However, if a user-defined type overloads the [true and false operators](true-false-operators.md) and the `&` or `|` operator in a certain way, the `&&` or `||` operation, respectively, can be evaluated for the operands of that type. For more information, see the [User-defined conditional logical operators](~/_csharpstandard/standard/expressions.md#11133-user-defined-conditional-logical-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -38,7 +38,11 @@ helpviewer_keywords:
 ---
 # Boolean logical operators - AND, OR, NOT, XOR
 
-The logical Boolean operators perform logical operations with [bool](../builtin-types/bool.md) operands. The unary [`!` (logical negation)](#logical-negation-operator-) operator reverses `true` and `false`. The binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators always evaluate both operands. The binary [`&&` (conditional logical AND)](#conditional-logical-and-operator-) and [`||` (conditional logical OR)](#conditional-logical-or-operator-) operators evaluate the right-hand operand only if it's necessary.
+The logical Boolean operators perform logical operations with [bool](../builtin-types/bool.md) operands. The operators include the unary logical negation (`!`), binary logical AND (`&`), OR (`|`), and exclusive OR (`^`), and the binary conditional logical AND (`&&`) and OR (`||`).
+
+- Unary [`!` (logical negation)](#logical-negation-operator-) operator.
+- Binary [`&` (logical AND)](#logical-and-operator-), [`|` (logical OR)](#logical-or-operator-), and [`^` (logical exclusive OR)](#logical-exclusive-or-operator-) operators. Those operators always evaluate both operands.
+- Binary [`&&` (conditional logical AND)](#conditional-logical-and-operator-) and [`||` (conditional logical OR)](#conditional-logical-or-operator-) operators. Those operators evaluate the right-hand operand only if it's necessary.
 
 For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `&`, `|`, and `^` operators perform bitwise logical operations. For more information, see [Bitwise and shift operators](bitwise-and-shift-operators.md).
 

--- a/docs/csharp/language-reference/operators/comparison-operators.md
+++ b/docs/csharp/language-reference/operators/comparison-operators.md
@@ -1,7 +1,7 @@
 ---
-title: "Comparison operators - C# reference"
-description: "Learn about C# comparison operators that you can use to check the order of numeric values."
-ms.date: 05/11/2020
+title: "Comparison operators - order items using the greater than and less than operators"
+description: "C# comparison operators check the order of values. The operators `>`, `<`, `>=`, `<=` compare the order of values. They determine if a value or greater than or less than another value."
+ms.date: 11/29/2022
 author: pkulikov
 f1_keywords: 
   - "<_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -1,7 +1,7 @@
 ---
-title: "?: operator - C# reference"
-description: "Learn about the C# ternary conditional operator that returns the result of one of the two expressions based on a Boolean expression's result."
-ms.date: "09/17/2020"
+title: "?: operator - the ternary conditional operator"
+description: "Learn about the C# ternary conditional operator, (`?:`), that returns the result of one of the two expressions based on a Boolean expression's result."
+ms.date: "11/29/2022"
 f1_keywords:
   - "?:_CSharpKeyword"
   - "?_CSharpKeyword"
@@ -9,9 +9,8 @@ f1_keywords:
 helpviewer_keywords:
   - "?: operator [C#]"
   - "conditional operator (?:) [C#]"
-ms.assetid: e83a17f1-7500-48ba-8bee-2fbc4c847af4
 ---
-# ?: operator (C# reference)
+# ?: operator - the ternary conditional operator
 
 The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`, as the following example shows:
 
@@ -64,7 +63,7 @@ condition ? ref consequent : ref alternative
 
 Like the original conditional operator, a conditional ref expression evaluates only one of the two expressions: either `consequent` or `alternative`.
 
-In the case of a conditional ref expression, the type of `consequent` and `alternative` must be the same. Conditional ref expressions are not target-typed.
+In a conditional ref expression, the type of `consequent` and `alternative` must be the same. Conditional ref expressions aren't target-typed.
 
 The following example demonstrates the usage of a conditional ref expression:
 
@@ -78,7 +77,7 @@ Use of the conditional operator instead of an [`if` statement](../statements/sel
 
 ## Operator overloadability
 
-A user-defined type cannot overload the conditional operator.
+A user-defined type can't overload the conditional operator.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -1,13 +1,13 @@
 ---
-title: "default value expressions - C# reference"
-description: "Use the default value expressions to obtain the default value of a type."
-ms.date: 03/13/2020
+title: "default value expressions - produce the default value for any type"
+description: "Use the default value expressions to obtain the default, uninitialized value of a type. The default value expression can be used with generic type parameters in addition to other types."
+ms.date: 11/29/2022
 f1_keywords:
   - "default_CSharpKeyword"
 helpviewer_keywords:
   - "default keyword [C#]"
 ---
-# default value expressions (C# reference)
+# default value expressions - produce the default value
 
 A default value expression produces the [default value](../builtin-types/default-values.md) of a type. There are two kinds of default value expressions: the [default operator](#default-operator) call and a [default literal](#default-literal).
 

--- a/docs/csharp/language-reference/operators/delegate-operator.md
+++ b/docs/csharp/language-reference/operators/delegate-operator.md
@@ -1,14 +1,14 @@
 ---
-title: "delegate operator - C# reference"
-description: "Learn about the C# delegate operator that is used to create anonymous methods."
-ms.date: 09/25/2020
+title: "delegate operator - Create an anonymous method that can be converted to a delegate type."
+description: "The C# delegate operator that is used to create anonymous methods. These types can be used for `Func<>` and `Action<>` parameters in many .NET APIs."
+ms.date: 11/29/2022
 helpviewer_keywords:
   - "delegate [C#]"
   - "anonymous method [C#]"
 ---
-# delegate operator (C# reference)
+# delegate operator
 
-The `delegate` operator creates an anonymous method that can be converted to a delegate type:
+The `delegate` operator creates an anonymous method that can be converted to a delegate type. An anonymous method can be converted to types such as <xref:System.Action?displayProperty=nameWithType> and <xref:System.Func%601?displayProperty=nameWithType> types used as arguments to many methods.
 
 [!code-csharp-interactive[anonymous method](snippets/shared/DelegateOperator.cs#AnonymousMethod)]
 
@@ -23,7 +23,7 @@ When you use the `delegate` operator, you might omit the parameter list. If you 
 
 [!code-csharp-interactive[no parameter list](snippets/shared/DelegateOperator.cs#WithoutParameterList)]
 
-That's the only functionality of anonymous methods that is not supported by lambda expressions. In all other cases, a lambda expression is a preferred way to write inline code.
+That's the only functionality of anonymous methods that isn't supported by lambda expressions. In all other cases, a lambda expression is a preferred way to write inline code.
 
 Beginning with C# 9.0, you can use [discards](../../fundamentals/functional/discards.md) to specify two or more input parameters of an anonymous method that aren't used by the method:
 

--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -1,7 +1,7 @@
 ---
-title: "Equality operators - C# reference"
-description: "Learn about C# equality comparison operators and C# type equality."
-ms.date: 10/30/2020
+title: "Equality operators - test if two objects are equal or not equal"
+description: "C# equality operators test if two objects are equal or not equal. You can define equality operators for your types for custom comparisons for equality"
+ms.date: 11/29/2022
 author: pkulikov
 f1_keywords: 
   - "==_CSharpKeyword"
@@ -16,9 +16,9 @@ helpviewer_keywords:
   - "not equals operator [C#]"
   - "!= operator [C#]"
 ---
-# Equality operators (C# reference)
+# Equality operators - test if two objects are equal or not
 
-The [`==` (equality)](#equality-operator-) and [`!=` (inequality)](#inequality-operator-) operators check if their operands are equal or not.
+The [`==` (equality)](#equality-operator-) and [`!=` (inequality)](#inequality-operator-) operators check if their operands are equal or not. Value types are equal when their contents are equal. Reference types are equal when the two variables refer to the same storage.
 
 ## Equality operator ==
 
@@ -53,7 +53,7 @@ Available in C# 9.0 and later, [record types](../builtin-types/record.md) suppor
 
 :::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="RecordTypesEquality":::
 
-As the preceding example shows, in case of non-record reference-type members their reference values are compared, not the referenced instances.
+As the preceding example shows, for non-record reference-type members their reference values are compared, not the referenced instances.
 
 ### String equality
 
@@ -61,7 +61,7 @@ Two [string](../builtin-types/reference-types.md#the-string-type) operands are e
 
 [!code-csharp-interactive[string equality](snippets/shared/EqualityOperators.cs#StringEquality)]
 
-That is a case-sensitive ordinal comparison. For more information about string comparison, see [How to compare strings in C#](../../how-to/compare-strings.md).
+String equality comparisons are case-sensitive ordinal comparisons. For more information about string comparison, see [How to compare strings in C#](../../how-to/compare-strings.md).
 
 ### Delegate equality
 
@@ -71,13 +71,13 @@ Two [delegate](../../programming-guide/delegates/index.md) operands of the same 
 
 For more information, see the [Delegate equality operators](~/_csharpstandard/standard/expressions.md#11119-delegate-equality-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
-Delegates that are produced from evaluation of semantically identical [lambda expressions](lambda-expressions.md) are not equal, as the following example shows:
+Delegates that are produced from evaluation of semantically identical [lambda expressions](lambda-expressions.md) aren't equal, as the following example shows:
 
 [!code-csharp-interactive[from identical lambdas](snippets/shared/EqualityOperators.cs#IdenticalLambdas)]
 
 ## Inequality operator !=
 
-The inequality operator `!=` returns `true` if its operands are not equal, `false` otherwise. For the operands of the [built-in types](../builtin-types/built-in-types.md), the expression `x != y` produces the same result as the expression `!(x == y)`. For more information about type equality, see the [Equality operator](#equality-operator-) section.
+The inequality operator `!=` returns `true` if its operands aren't equal, `false` otherwise. For the operands of the [built-in types](../builtin-types/built-in-types.md), the expression `x != y` produces the same result as the expression `!(x == y)`. For more information about type equality, see the [Equality operator](#equality-operator-) section.
 
 The following example demonstrates the usage of the `!=` operator:
 
@@ -87,7 +87,7 @@ The following example demonstrates the usage of the `!=` operator:
 
 A user-defined type can [overload](operator-overloading.md) the `==` and `!=` operators. If a type overloads one of the two operators, it must also overload the other one.
 
-A record type cannot explicitly overload the `==` and `!=` operators. If you need to change the behavior of the `==` and `!=` operators for record type `T`, implement the <xref:System.IEquatable%601.Equals%2A?displayProperty=nameWithType> method with the following signature:
+A record type can't explicitly overload the `==` and `!=` operators. If you need to change the behavior of the `==` and `!=` operators for record type `T`, implement the <xref:System.IEquatable%601.Equals%2A?displayProperty=nameWithType> method with the following signature:
 
 ```csharp
 public virtual bool Equals(T? other);

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -1,7 +1,7 @@
 ---
-title: "C# operators and expressions - C# reference"
-description: "Learn about C# operators and expressions, operator precedence, and operator associativity."
-ms.date: 08/04/2020
+title: "C# operators and expressions - List all C# operators and expression"
+description: "Learn the C# operators and expressions, operator precedence, and operator associativity."
+ms.date: 11/28/2022
 f1_keywords: 
   - "cs.operators"
 helpviewer_keywords: 
@@ -9,9 +9,8 @@ helpviewer_keywords:
   - "operator precedence [C#]"
   - "operator associativity [C#]"
   - "expressions [C#]"
-ms.assetid: 0301e31f-22ad-49af-ac3c-d5eae7f0ac43
 ---
-# C# operators and expressions (C# reference)
+# C# operators and expressions
 
 C# provides a number of operators. Many of them are supported by the [built-in types](../builtin-types/built-in-types.md) and allow you to perform basic operations with values of those types. Those operators include the following groups:
 
@@ -95,6 +94,9 @@ When operators have the same precedence, associativity of the operators determin
 
 - *Left-associative* operators are evaluated in order from left to right. Except for the [assignment operators](assignment-operator.md) and the [null-coalescing operators](null-coalescing-operator.md), all binary operators are left-associative. For example, `a + b - c` is evaluated as `(a + b) - c`.
 - *Right-associative* operators are evaluated in order from right to left. The assignment operators, the null-coalescing operators, lambdas, and the [conditional operator `?:`](conditional-operator.md) are right-associative. For example, `x = y = z` is evaluated as `x = (y = z)`.
+
+> [!IMPORTANT]
+> In an expression of the form `P?.A0?.A1`, if `P` is `null`, neither `A0` nor `A1` are evaluated. Similarly, in an expression of the form `P?.A0.A1`, because `A0` isn't evaluated when `P` is null, neither is `A0.A1`. See the [C# language specification](~/_csharpstandard/standard/expressions#1177-null-conditional-member-access) for more details.
 
 Use parentheses to change the order of evaluation imposed by operator associativity:
 

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -96,7 +96,7 @@ When operators have the same precedence, associativity of the operators determin
 - *Right-associative* operators are evaluated in order from right to left. The assignment operators, the null-coalescing operators, lambdas, and the [conditional operator `?:`](conditional-operator.md) are right-associative. For example, `x = y = z` is evaluated as `x = (y = z)`.
 
 > [!IMPORTANT]
-> In an expression of the form `P?.A0?.A1`, if `P` is `null`, neither `A0` nor `A1` are evaluated. Similarly, in an expression of the form `P?.A0.A1`, because `A0` isn't evaluated when `P` is null, neither is `A0.A1`. See the [C# language specification](~/_csharpstandard/standard/expressions#1177-null-conditional-member-access) for more details.
+> In an expression of the form `P?.A0?.A1`, if `P` is `null`, neither `A0` nor `A1` are evaluated. Similarly, in an expression of the form `P?.A0.A1`, because `A0` isn't evaluated when `P` is null, neither is `A0.A1`. See the [C# language specification](~/_csharpstandard/standard/expressions.md#1177-null-conditional-member-access) for more details.
 
 Use parentheses to change the order of evaluation imposed by operator associativity:
 

--- a/docs/csharp/language-reference/operators/is.md
+++ b/docs/csharp/language-reference/operators/is.md
@@ -1,19 +1,16 @@
 ---
-title: "is operator - C# reference"
-description: "Learn about the C# is operator that matches an expression against a pattern."
-ms.date: 04/23/2021
+title: "The `is` operator - Match an expression against a type or constant pattern"
+description: "Learn about the C# `is` operator that matches an expression against a pattern. The `is` operator returns true when the expression matches the pattern."
+ms.date: 11/28/2022
 f1_keywords: 
   - "is_CSharpKeyword"
   - "is"
 helpviewer_keywords: 
   - "is keyword [C#]"
-ms.assetid: bc62316a-d41f-4f90-8300-c6f4f0556e43
 ---
 # is operator (C# reference)
 
-The `is` operator checks if the result of an expression is compatible with a given type. For information about the type-testing `is` operator, see the [is operator](type-testing-and-cast.md#is-operator) section of the [Type-testing and cast operators](type-testing-and-cast.md) article.
-
-You can also use the `is` operator to match an expression against a pattern, as the following example shows:
+The `is` operator checks if the result of an expression is compatible with a given type. For information about the type-testing `is` operator, see the [is operator](type-testing-and-cast.md#is-operator) section of the [Type-testing and cast operators](type-testing-and-cast.md) article. You can also use the `is` operator to match an expression against a pattern, as the following example shows:
 
 :::code language="csharp" source="snippets/shared/IsOperator.cs" id="IntroExample":::
 

--- a/docs/csharp/language-reference/operators/lambda-expressions.md
+++ b/docs/csharp/language-reference/operators/lambda-expressions.md
@@ -1,16 +1,15 @@
 ---
-title: "Lambda expressions - C# reference"
-description: Learn about C# lambda expressions that are used to create anonymous functions.
-ms.date: 11/08/2021
+title: "Lambda expressions - Lambda expressions and anonymous functions"
+description: C# lambda expressions that are used to create anonymous functions and expression bodied members.
+ms.date: 11/28/2022
 helpviewer_keywords:
   - "lambda expressions [C#]"
   - "outer variables [C#]"
   - "statement lambda [C#]"
   - "expression lambda [C#]"
   - "expressions [C#], lambda"
-ms.assetid: 57e3ba27-9a82-4067-aca7-5ca446b7bf93
 ---
-# Lambda expressions (C# reference)
+# Lambda expressions and anonymous functions
 
 You use a *lambda expression* to create an anonymous function. Use the [lambda declaration operator `=>`](lambda-operator.md) to separate the lambda's parameter list from its body. A lambda expression can be of any of the following two forms:
 
@@ -163,7 +162,7 @@ For more information about C# tuples, see [Tuple types](../../language-reference
 
 ## Lambdas with the standard query operators
 
-LINQ to Objects, among other implementations, have an input parameter whose type is one of the <xref:System.Func%601> family of generic delegates. These delegates use type parameters to define the number and type of input parameters, and the return type of the delegate. `Func` delegates are useful for encapsulating user-defined expressions that are applied to each element in a set of source data. For example, consider the <xref:System.Func%602> delegate type:
+LINQ to Objects, among other implementations, has an input parameter whose type is one of the <xref:System.Func%601> family of generic delegates. These delegates use type parameters to define the number and type of input parameters, and the return type of the delegate. `Func` delegates are useful for encapsulating user-defined expressions that are applied to each element in a set of source data. For example, consider the <xref:System.Func%602> delegate type:
 
 ```csharp
 public delegate TResult Func<in T, out TResult>(T arg)
@@ -252,7 +251,7 @@ Func<string, int> parse = s => int.Parse(s);
 
 ## Explicit return type
 
-Typically, the return type of a lambda expression is obvious and inferred. For some expressions, that doesn't work:
+Typically, the return type of a lambda expression is obvious and inferred. For some expressions that doesn't work:
 
 ```csharp
 var choose = (bool b) => b ? 1 : "two"; // ERROR: Can't infer return type
@@ -269,15 +268,14 @@ var choose = object (bool b) => b ? 1 : "two"; // Func<bool, object>
 Beginning with C# 10, you can add attributes to a lambda expression and its parameters. The following example shows how to add attributes to a lambda expression:
 
 ```csharp
-Func<string, int> parse = [Example(1)] (s) => int.Parse(s);
-var choose = [Example(2)][Example(3)] object (bool b) => b ? 1 : "two";
+Func<string?, int?> parse = [ProvidesNullCheck] (s) => (s is not null) ? int.Parse(s) : null;
 ```
 
 You can also add attributes to the input parameters or return value, as the following example shows:
 
 ```csharp
-var sum = ([Example(1)] int a, [Example(2), Example(3)] int b) => a + b;
-var inc = [return: Example(1)] (int s) => s++;
+var concat = ([DisallowNull] string a, [DisallowNull] string b) => a + b;
+var inc = [return: NotNullifNotNull(nameof(s))] (int? s) => s.HasValue ? s++ : null;
 ```
 
 As the preceding examples show, you must parenthesize the input parameters when you add attributes to a lambda expression or its parameters.
@@ -287,7 +285,7 @@ As the preceding examples show, you must parenthesize the input parameters when 
 
 ## Capture of outer variables and variable scope in lambda expressions
 
-Lambdas can refer to *outer variables*. These are the variables that are in scope in the method that defines the lambda expression, or in scope in the type that contains the lambda expression. Variables that are captured in this manner are stored for use in the lambda expression even if the variables would otherwise go out of scope and be garbage collected. An outer variable must be definitely assigned before it can be consumed in a lambda expression. The following example demonstrates these rules:
+Lambdas can refer to *outer variables*. These *outer variables* are the variables that are in scope in the method that defines the lambda expression, or in scope in the type that contains the lambda expression. Variables that are captured in this manner are stored for use in the lambda expression even if the variables would otherwise go out of scope and be garbage collected. An outer variable must be definitely assigned before it can be consumed in a lambda expression. The following example demonstrates these rules:
 
 [!code-csharp[variable scope](snippets/lambda-expressions/VariableScopeWithLambdas.cs#VariableScope)]
 

--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -1,7 +1,7 @@
 ---
-title: "=> operator - C# reference"
-description: "Learn about the C# => operator that is used in lambda expressions and expression body definitions."
-ms.date: 11/08/2021
+title: "The lambda operator - The `=>` operator is used to define a lambda expression in C#"
+description: "The C# => operator defines lambda expressions and expression bodied members. Lambda expressions define a block of code used as data."
+ms.date: 11/28/2022
 f1_keywords: 
   - "=>_CSharpKeyword"
 helpviewer_keywords: 
@@ -9,7 +9,7 @@ helpviewer_keywords:
   - "=> operator [C#]"
   - "lambda expressions [C#], => operator"
 ---
-# => operator (C# reference)
+# Lambda expression (`=>`) operator defines a lambda expression
 
 The `=>` token is supported in two forms: as the [lambda operator](#lambda-operator) and as a separator of a member name and the member implementation in an [expression body definition](#expression-body-definition).
 
@@ -68,7 +68,7 @@ You can create expression body definitions for methods, operators, read-only pro
 
 ## Operator overloadability
 
-The `=>` operator cannot be overloaded.
+The `=>` operator can't be overloaded.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -1,7 +1,7 @@
 ---
-title: "Member access operators and expressions - C# reference"
-description: "Learn about C# operators that you can use to access type members."
-ms.date: 09/16/2022
+title: "Member access operators and expressions"
+description: "C# operators that you use to access type members. These operators include the dot operator - `.`, indexers - `[`, `]`, `^` and `..`, and invocation - `(`, `)`."
+ms.date: 11/28/2022
 author: pkulikov
 f1_keywords:
   - "._CSharpKeyword"
@@ -33,18 +33,11 @@ helpviewer_keywords:
   - ".. operator [C#]"
   - "range operator [C#]"
 ---
-# Member access operators and expressions (C# reference)
+# Member access operators and expressions - the dot, indexer, and invocation operators.
 
-You can use the following operators and expressions when you access a type member:
+You use several operators and expressions to access a type member. The [`.` (member access)](#member-access-expression-) accesses a member of a namespace or a type. The [`[]` (array element or indexer access)](#indexer-operator-) accesses an array element or a type indexer. The [`?.` and `?[]` (null-conditional operators)](#null-conditional-operators--and-) perform a member or element access operation only if an operand is non-null. The [`()` (invocation)](#invocation-expression-) calls an accessed method or invokes a delegate. The [`^` (index from end)](#index-from-end-operator-) indicates that the element position is from the end of a sequence. The [`..` (range)](#range-operator-) specifies a range of indices that you can use to obtain a range of sequence elements.
 
-- [`.` (member access)](#member-access-expression-): to access a member of a namespace or a type
-- [`[]` (array element or indexer access)](#indexer-operator-): to access an array element or a type indexer
-- [`?.` and `?[]` (null-conditional operators)](#null-conditional-operators--and-): to perform a member or element access operation only if an operand is non-null
-- [`()` (invocation)](#invocation-expression-): to call an accessed method or invoke a delegate
-- [`^` (index from end)](#index-from-end-operator-): to indicate that the element position is from the end of a sequence
-- [`..` (range)](#range-operator-): to specify a range of indices that you can use to obtain a range of sequence elements
-
-## Member access expression .
+## Member access expression `.`
 
 You use the `.` token to access a member of a namespace or a type, as the following examples demonstrate:
 
@@ -101,7 +94,7 @@ You also use square brackets to specify [attributes](../../programming-guide/con
 void TraceMethod() {}
 ```
 
-## Null-conditional operators ?. and ?[]
+## Null-conditional operators `?.` and `?[]`
 
 A null-conditional operator applies a [member access](#member-access-expression-), `?.`, or [element access](#indexer-operator-), `?[]`, operation to its operand only if that operand evaluates to non-null; otherwise, it returns `null`. That is,
 
@@ -111,20 +104,20 @@ A null-conditional operator applies a [member access](#member-access-expression-
   > [!NOTE]
   > If `a.x` or `a[x]` throws an exception, `a?.x` or `a?[x]` would throw the same exception for non-null `a`. For example, if `a` is a non-null array instance and `x` is outside the bounds of `a`, `a?[x]` would throw an <xref:System.IndexOutOfRangeException>.
 
-The null-conditional operators are short-circuiting. That is, if one operation in a chain of conditional member or element access operations returns `null`, the rest of the chain doesn't execute. In the following example, `B` is not evaluated if `A` evaluates to `null` and `C` is not evaluated if `A` or `B` evaluates to `null`:
+The null-conditional operators are short-circuiting. That is, if one operation in a chain of conditional member or element access operations returns `null`, the rest of the chain doesn't execute. In the following example, `B` isn't evaluated if `A` evaluates to `null` and `C` isn't evaluated if `A` or `B` evaluates to `null`:
 
 ```csharp
 A?.B?.Do(C);
 A?.B?[C];
 ```
 
-If `A` might be null but `B` and `C` would not be null if A is not null, you only need to apply the null-conditional operator to `A`:
+If `A` might be null but `B` and `C` wouldn't be null if A isn't null, you only need to apply the null-conditional operator to `A`:
 
 ```csharp
 A?.B.C();
 ```
 
-In the preceding example, `B` is not evaluated and `C()` is not called if `A` is null. However, if the chained member access is interrupted, for example by parentheses as in `(A?.B).C()`, short-circuiting doesn't happen.
+In the preceding example, `B` isn't evaluated and `C()` isn't called if `A` is null. However, if the chained member access is interrupted, for example by parentheses as in `(A?.B).C()`, short-circuiting doesn't happen.
 
 The following examples demonstrate the usage of the `?.` and `?[]` operators:
 
@@ -162,7 +155,7 @@ if (handler != null)
 }
 ```
 
-That is a thread-safe way to ensure that only a non-null `handler` is invoked. Because delegate instances are immutable, no thread can change the object referenced by the `handler` local variable. In particular, if the code executed by another thread unsubscribes from the `PropertyChanged` event and `PropertyChanged` becomes `null` before `handler` is invoked, the object referenced by `handler` remains unaffected.
+The preceding example is a thread-safe way to ensure that only a non-null `handler` is invoked. Because delegate instances are immutable, no thread can change the object referenced by the `handler` local variable. In particular, if the code executed by another thread unsubscribes from the `PropertyChanged` event and `PropertyChanged` becomes `null` before `handler` is invoked, the object referenced by `handler` remains unaffected.
 
 ## Invocation expression ()
 
@@ -190,7 +183,7 @@ As the preceding example shows, expression `^e` is of the <xref:System.Index?dis
 
 You can also use the `^` operator with the [range operator](#range-operator-) to create a range of indices. For more information, see [Indices and ranges](../../tutorials/ranges-indexes.md).
 
-## Range operator ..
+## Range operator `..`
 
 The `..` operator specifies the start and end of a range of indices as its operands. The left-hand operand is an *inclusive* start of a range. The right-hand operand is an *exclusive* end of a range. Either of operands can be an index from the start or from the end of a sequence, as the following example shows:
 
@@ -230,7 +223,7 @@ For more information, see [Indices and ranges](../../tutorials/ranges-indexes.md
 
 ## Operator overloadability
 
-The `.`, `()`, `^`, and `..` operators cannot be overloaded. The `[]` operator is also considered a non-overloadable operator. Use [indexers](../../programming-guide/indexers/index.md) to support indexing with user-defined types.
+The `.`, `()`, `^`, and `..` operators can't be overloaded. The `[]` operator is also considered a non-overloadable operator. Use [indexers](../../programming-guide/indexers/index.md) to support indexing with user-defined types.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -35,7 +35,14 @@ helpviewer_keywords:
 ---
 # Member access operators and expressions - the dot, indexer, and invocation operators.
 
-You use several operators and expressions to access a type member. The [`.` (member access)](#member-access-expression-) accesses a member of a namespace or a type. The [`[]` (array element or indexer access)](#indexer-operator-) accesses an array element or a type indexer. The [`?.` and `?[]` (null-conditional operators)](#null-conditional-operators--and-) perform a member or element access operation only if an operand is non-null. The [`()` (invocation)](#invocation-expression-) calls an accessed method or invokes a delegate. The [`^` (index from end)](#index-from-end-operator-) indicates that the element position is from the end of a sequence. The [`..` (range)](#range-operator-) specifies a range of indices that you can use to obtain a range of sequence elements.
+You use several operators and expressions to access a type member. These operators include member access (`.`), array element or indexer access (`[]`), index-from-end (`^`), range (`..`), null-conditional operators (`?.` and `?[]`), and method invocation (`()`).
+
+- [`.` (member access)](#member-access-expression-): to access a member of a namespace or a type
+- [`[]` (array element or indexer access)](#indexer-operator-): to access an array element or a type indexer
+- [`?.` and `?[]` (null-conditional operators)](#null-conditional-operators--and-): to perform a member or element access operation only if an operand is non-null
+- [`()` (invocation)](#invocation-expression-): to call an accessed method or invoke a delegate
+- [`^` (index from end)](#index-from-end-operator-): to indicate that the element position is from the end of a sequence
+- [`..` (range)](#range-operator-): to specify a range of indices that you can use to obtain a range of sequence elements
 
 ## Member access expression `.`
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -1,7 +1,7 @@
 ---
-title: "nameof expression - C# reference"
-description: "Learn about the C# nameof expression that produces the name of its operand."
-ms.date: 05/20/2022
+title: "The nameof expression - evaluate the text name of a symbol"
+description: "The C# `nameof` expression produces the name of its operand. You use it whenever you need to use the nam of a symbol as text"
+ms.date: 11/28/2022
 f1_keywords:
   - "nameof_CSharpKeyword"
   - "nameof"
@@ -10,17 +10,15 @@ helpviewer_keywords:
 ---
 # nameof expression (C# reference)
 
-A `nameof` expression produces the name of a variable, type, or member as the string constant:
+<!-- Note that all remaining acrolinx issues are because acrolinx things "nameof" is mis-spelled. -->
+
+A `nameof` expression produces the name of a variable, type, or member as the string constant. A `nameof` expression is evaluated at compile time and has no effect at run time. When the operand is a type or a namespace, the produced name isn't [fully qualified](~/_csharpstandard/standard/basic-concepts.md#783-fully-qualified-names). The following example shows the use of a `nameof` expression:
 
 [!code-csharp-interactive[nameof expression](snippets/shared/NameOfOperator.cs#Examples)]
 
-As the preceding example shows, in the case of a type and a namespace, the produced name is not [fully qualified](~/_csharpstandard/standard/basic-concepts.md#783-fully-qualified-names).
-
-In the case of [verbatim identifiers](../tokens/verbatim.md), the `@` character is not the part of a name, as the following example shows:
+When the operand is a [verbatim identifier](../tokens/verbatim.md), the `@` character isn't the part of a name, as the following example shows:
 
 [!code-csharp-interactive[nameof verbatim](snippets/shared/NameOfOperator.cs#Verbatim)]
-
-A `nameof` expression is evaluated at compile time and has no effect at run time.
 
 You can use a `nameof` expression to make the argument-checking code more maintainable:
 

--- a/docs/csharp/language-reference/operators/namespace-alias-qualifier.md
+++ b/docs/csharp/language-reference/operators/namespace-alias-qualifier.md
@@ -1,7 +1,7 @@
 ---
-title: ":: operator - C# reference"
-description: "Learn about the C# namespace alias qualifier :: that is used to access a member of an aliased namespace."
-ms.date: 08/09/2019
+title: "Namespace alias operator - the `::` is used to access a member of an aliased namespace."
+description: "The C# namespace alias qualifier `::` is used to access a member of an aliased namespace. The `::` operator is often used with the `global` alias, an alias for the global namespace"
+ms.date: 11/28/2022
 f1_keywords: 
   - "::_CSharpKeyword"
   - "global_CSharpKeyword"
@@ -11,11 +11,10 @@ helpviewer_keywords:
   - "namespace alias qualifier [C#]"
   - "namespace [C#]"
   - "global keyword [C#]"
-ms.assetid: 698b5a73-85cf-4e0e-9e8e-6496887f8527
 ---
-# :: operator (C# reference)
+# :: operator - the namespace alias operator
 
-Use the namespace alias qualifier `::` to access a member of an aliased namespace. You can use the `::` qualifier only between two identifiers. The left-hand identifier can be any of the following aliases:
+Use the namespace alias qualifier `::` to access a member of an aliased namespace. You can use the `::` qualifier only between two identifiers. The left-hand identifier can be one of a namespace alias, an extern alias, or the `global` alias. For example:
 
 - A namespace alias created with a [using alias directive](../keywords/using-directive.md):
 
@@ -30,7 +29,7 @@ Use the namespace alias qualifier `::` to access a member of an aliased namespac
   ```
 
 - An [extern alias](../keywords/extern-alias.md).
-- The `global` alias, which is the global namespace alias. The global namespace is the namespace that contains namespaces and types that are not declared inside a named namespace. When used with the `::` qualifier, the `global` alias always references the global namespace, even if there is the user-defined `global` namespace alias.
+- The `global` alias, which is the global namespace alias. The global namespace is the namespace that contains namespaces and types that aren't declared inside a named namespace. When used with the `::` qualifier, the `global` alias always references the global namespace, even if there's the user-defined `global` namespace alias.
 
   The following example uses the `global` alias to access the .NET <xref:System> namespace, which is a member of the global namespace. Without the `global` alias, the user-defined `System` namespace, which is a member of the `MyCompany.MyProduct` namespace, would be accessed:
 

--- a/docs/csharp/language-reference/operators/new-operator.md
+++ b/docs/csharp/language-reference/operators/new-operator.md
@@ -1,18 +1,16 @@
 ---
-title: "new operator - C# reference"
-description: "Learn about the C# new operator that is used to create a new instance of a type."
-ms.date: 10/02/2020
+title: "new operator - Create and initialize a new instance of a type"
+description: "The C# new operator is used to create a optionally initialize a new instance of a type."
+ms.date: 11/28/2022
 f1_keywords:
  - new_CSharpKeyword
 helpviewer_keywords: 
   - "new operator keyword [C#]"
 ms.assetid: a212b697-a79b-4105-9923-1f7b108036e8
 ---
-# new operator (C# reference)
+# new operator - The `new` operator creates a new instance of a type
 
-The `new` operator creates a new instance of a type.
-
-You can also use the `new` keyword as a [member declaration modifier](../keywords/new-modifier.md) or a [generic type constraint](../keywords/new-constraint.md).
+The `new` operator creates a new instance of a type. You can also use the `new` keyword as a [member declaration modifier](../keywords/new-modifier.md) or a [generic type constraint](../keywords/new-constraint.md).
 
 ## Constructor invocation
 
@@ -58,7 +56,7 @@ For type instances that contain unmanaged resources, for example, a file handle,
 
 ## Operator overloadability
 
-A user-defined type cannot overload the `new` operator.
+A user-defined type can't overload the `new` operator.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/null-coalescing-operator.md
+++ b/docs/csharp/language-reference/operators/null-coalescing-operator.md
@@ -1,7 +1,7 @@
 ---
-title: "?? and ??= operators - C# reference"
-description: "Learn about ?? and ??= which are the C# null-coalescing operators."
-ms.date: 09/10/2019
+title: "?? and ??= operators - null-coalescing operators"
+description: "The `??` and `??=` operators are the C# null-coalescing operators. They return the value of the left-hand operand if it isn't null. Otherwise, they return the value of the right-hand operand"
+ms.date: 11/28/2022
 f1_keywords:
   - "??_CSharpKeyword"
   - "??=_CSharpKeyword"
@@ -12,17 +12,19 @@ helpviewer_keywords:
   - "??= operator [C#]"
 ms.assetid: 088b1f0d-c1af-4fe1-b4b8-196fd5ea9132
 ---
-# ?? and ??= operators (C# reference)
+# ?? and ??= operators - the null-coalescing operators
 
-The null-coalescing operator `??` returns the value of its left-hand operand if it isn't `null`; otherwise, it evaluates the right-hand operand and returns its result. The `??` operator doesn't evaluate its right-hand operand if the left-hand operand evaluates to non-null.
+<!-- 
+  Note: All the remaining acrolinx issues in this article are because of the `??` and `??=` operator. Acrolinx believes it's a mispelling of the ? mark.
+-->
 
-The null-coalescing assignment operator `??=` assigns the value of its right-hand operand to its left-hand operand only if the left-hand operand evaluates to `null`. The `??=` operator doesn't evaluate its right-hand operand if the left-hand operand evaluates to non-null.
+The null-coalescing operator `??` returns the value of its left-hand operand if it isn't `null`; otherwise, it evaluates the right-hand operand and returns its result. The `??` operator doesn't evaluate its right-hand operand if the left-hand operand evaluates to non-null. The null-coalescing assignment operator `??=` assigns the value of its right-hand operand to its left-hand operand only if the left-hand operand evaluates to `null`. The `??=` operator doesn't evaluate its right-hand operand if the left-hand operand evaluates to non-null.
 
 [!code-csharp[null-coalescing assignment](snippets/shared/NullCoalescingOperator.cs#Assignment)]
 
 The left-hand operand of the `??=` operator must be a variable, a [property](../../programming-guide/classes-and-structs/properties.md), or an [indexer](../../programming-guide/indexers/index.md) element.
 
-The type of the left-hand operand of the `??` and `??=` operators cannot be a non-nullable value type. In particular, you can use the null-coalescing operators with unconstrained type parameters:
+The type of the left-hand operand of the `??` and `??=` operators can't be a non-nullable value type. In particular, you can use the null-coalescing operators with unconstrained type parameters:
 
 [!code-csharp[unconstrained type parameter](snippets/shared/NullCoalescingOperator.cs#UnconstrainedType)]
 
@@ -44,7 +46,7 @@ d ??= (e ??= f)
 
 The `??` and `??=` operators can be useful in the following scenarios:
 
-- In expressions with the [null-conditional operators ?. and ?[]](member-access-operators.md#null-conditional-operators--and-), you can use the `??` operator to provide an alternative expression to evaluate in case the result of the expression with null-conditional operations is `null`:
+- In expressions with the [null-conditional operators `?.` and `?[]`](member-access-operators.md#null-conditional-operators--and-), you can use the `??` operator to provide an alternative expression to evaluate in case the result of the expression with null-conditional operations is `null`:
 
   [!code-csharp-interactive[with null-conditional](snippets/shared/NullCoalescingOperator.cs#WithNullConditional)]
 
@@ -77,7 +79,7 @@ The `??` and `??=` operators can be useful in the following scenarios:
 
 ## Operator overloadability
 
-The operators `??` and `??=` cannot be overloaded.
+The operators `??` and `??=` can't be overloaded.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/null-forgiving.md
+++ b/docs/csharp/language-reference/operators/null-forgiving.md
@@ -1,7 +1,7 @@
 ---
 title: "! (null-forgiving) operator - C# reference"
 description: "Learn about the C# null-forgiving, or null-suppression, operator that is used to declare that an expression of a reference type isn't null."
-ms.date: 11/13/2020
+ms.date: 11/28/2022
 f1_keywords:
   - "nullForgiving_CSharpKeyword"
 helpviewer_keywords:
@@ -10,9 +10,7 @@ helpviewer_keywords:
 ---
 # ! (null-forgiving) operator (C# reference)
 
-The unary postfix `!` operator is the null-forgiving, or null-suppression, operator. In an enabled [nullable annotation context](../../nullable-references.md#nullable-contexts), you use the null-forgiving operator to declare that expression `x` of a reference type isn't `null`: `x!`. The unary prefix `!` operator is the [logical negation operator](boolean-logical-operators.md#logical-negation-operator-).
-
-The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
+The unary postfix `!` operator is the null-forgiving, or null-suppression, operator. In an enabled [nullable annotation context](../../nullable-references.md#nullable-contexts), you use the null-forgiving operator to suppress all nullable warnings for the preceding expression. The unary prefix `!` operator is the [logical negation operator](boolean-logical-operators.md#logical-negation-operator-). The null-forgiving operator has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression. At run time, expression `x!` evaluates to the result of the underlying expression `x`.
 
 For more information about the nullable reference types feature, see [Nullable reference types](../builtin-types/nullable-reference-types.md).
 
@@ -28,17 +26,17 @@ Using the [MSTest test framework](../../../core/testing/unit-testing-with-mstest
 
 Without the null-forgiving operator, the compiler generates the following warning for the preceding code: `Warning CS8625: Cannot convert null literal to non-nullable reference type`. By using the null-forgiving operator, you inform the compiler that passing `null` is expected and shouldn't be warned about.
 
-You can also use the null-forgiving operator when you definitely know that an expression cannot be `null` but the compiler doesn't manage to recognize that. In the following example, if the `IsValid` method returns `true`, its argument is not `null` and you can safely dereference it:
+You can also use the null-forgiving operator when you definitely know that an expression can't be `null` but the compiler doesn't manage to recognize that. In the following example, if the `IsValid` method returns `true`, its argument isn't `null` and you can safely dereference it:
 
 [!code-csharp[Use null-forgiving operator](snippets/shared/NullForgivingOperator.cs#UseNullForgiving)]
 
 Without the null-forgiving operator, the compiler generates the following warning for the `p.Name` code: `Warning CS8602: Dereference of a possibly null reference`.
 
-If you can modify the `IsValid` method, you can use the [NotNullWhen](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute to inform the compiler that an argument of the `IsValid` method cannot be `null` when the method returns `true`:
+If you can modify the `IsValid` method, you can use the [NotNullWhen](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute to inform the compiler that an argument of the `IsValid` method can't be `null` when the method returns `true`:
 
 [!code-csharp[Use an attribute](snippets/shared/NullForgivingOperator.cs#UseAttribute)]
 
-In the preceding example, you don't need to use the null-forgiving operator because the compiler has enough information to find out that `p` cannot be `null` inside the `if` statement. For more information about the attributes that allow you to provide additional information about the null state of a variable, see [Upgrade APIs with attributes to define null expectations](../attributes/nullable-analysis.md).
+In the preceding example, you don't need to use the null-forgiving operator because the compiler has enough information to find out that `p` can't be `null` inside the `if` statement. For more information about the attributes that allow you to provide additional information about the null state of a variable, see [Upgrade APIs with attributes to define null expectations](../attributes/nullable-analysis.md).
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/operator-overloading.md
+++ b/docs/csharp/language-reference/operators/operator-overloading.md
@@ -1,7 +1,7 @@
 ---
-title: "Operator overloading - C# reference"
-description: "Learn how to overload a C# operator and which C# operators are overloadable."
-ms.date: 07/05/2019
+title: "Operator overloading - Define unary, arithmetic, equality, and comparison operators."
+description: "Learn how to overload a C# operator and which C# operators are overloadable. In general, the unary, arithmetic, equality and comparison operators are overloadable."
+ms.date: 11/28/2022
 f1_keywords: 
   - "operator_CSharpKeyword"
   - operator
@@ -9,7 +9,7 @@ helpviewer_keywords:
   - "operator keyword [C#]"
   - "operator overloading [C#]"
 ---
-# Operator overloading (C# reference)
+# Operator overloading - predefined unary, arithmetic, equality and comparison operators
 
 A user-defined type can overload a predefined C# operator. That is, a type can provide the custom implementation of an operation in case one or both of the operands are of that type. The [Overloadable operators](#overloadable-operators) section shows which C# operators can be overloaded.
 
@@ -38,7 +38,7 @@ The following table shows the operators that can be overloaded:
 
 ## Non overloadable operators
 
-The following table shows the operators that cannot be overloaded:
+The following table shows the operators that can't be overloaded:
 
 | Operators | Alternatives |
 | :---------: | --------------- |

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -1,7 +1,7 @@
 ---
-title: "Patterns - C# reference"
-description: "Learn about the patterns supported by C# pattern matching expressions and statements."
-ms.date: 10/21/2022
+title: "Patterns - Pattern matching using the is and switch expressions."
+description: "Learn about the patterns supported by the `is` and `switch` expressions. Combine multiple patterns using the `and`, `or`, and `not` operators."
+ms.date: 11/28/2022
 f1_keywords: 
   - "and_CSharpKeyword"
   - "or_CSharpKeyword"
@@ -12,28 +12,9 @@ helpviewer_keywords:
   - "or keyword [C#]"
   - "not keyword [C#]"
 ---
-# Patterns (C# reference)
+# Pattern matching - the `is` and `switch` expressions, and operators `and`, `or` and `not` in patterns
 
-The following C# expressions and statements support pattern matching:
-
-- [`is` expression](is.md)
-- [switch statement](../statements/selection-statements.md#the-switch-statement)
-- [switch expression](switch-expression.md)
-
-In those constructs, you can match an input expression against any of the following patterns:
-
-- [Declaration pattern](#declaration-and-type-patterns): to check the run-time type of an expression and, if a match succeeds, assign an expression result to a declared variable.
-- [Type pattern](#declaration-and-type-patterns): to check the run-time type of an expression. Introduced in C# 9.0.
-- [Constant pattern](#constant-pattern): to test if an expression result equals a specified constant.
-- [Relational patterns](#relational-patterns): to compare an expression result with a specified constant. Introduced in C# 9.0.
-- [Logical patterns](#logical-patterns): to test if an expression matches a logical combination of patterns. Introduced in C# 9.0.
-- [Property pattern](#property-pattern): to test if an expression's properties or fields match nested patterns.
-- [Positional pattern](#positional-pattern): to deconstruct an expression result and test if the resulting values match nested patterns.
-- [`var` pattern](#var-pattern): to match any expression and assign its result to a declared variable.
-- [Discard pattern](#discard-pattern): to match any expression.
-- [List patterns](#list-patterns): to test if sequence elements match corresponding nested patterns. Introduced in C# 11.
-
-[Logical](#logical-patterns), [property](#property-pattern), [positional](#positional-pattern), and [list](#list-patterns) patterns are *recursive* patterns. That is, they can contain *nested* patterns.
+The following C# expressions and statements support pattern matching. The [`is` expression](is.md), the [switch statement](../statements/selection-statements.md#the-switch-statement) and the [switch expression](switch-expression.md). In those constructs, you can match an input expression against many patterns. The [declaration pattern](#declaration-and-type-patterns) checks the run-time type of an expression and, if a match succeeds, assign an expression result to a declared variable. The [type pattern](#declaration-and-type-patterns) checks the run-time type of an expression (introduced in C# 9.0). The [constant pattern](#constant-pattern) tests if an expression result equals a specified constant. The [relational patterns](#relational-patterns) compares an expression result with a specified constant (introduced in C# 9.0). [Logical patterns](#logical-patterns) test if an expression matches a logical combination of patterns (introduced in C# 9.0). The [Property pattern](#property-pattern) tests if an expression's properties or fields match nested patterns. [Positional patterns](#positional-pattern)deconstruct an expression result and test if the resulting values match nested patterns. The [List patterns](#list-patterns) tests if a sequence's elements match corresponding nested patterns (introduced in C# 11). The [`var` pattern](#var-pattern): to match any expression and assign its result to a declared variable. The [Discard pattern](#discard-pattern) matches any expression. [Logical](#logical-patterns), [property](#property-pattern), [positional](#positional-pattern), and [list](#list-patterns) patterns are *recursive* patterns. That is, they can contain *nested* patterns.
 
 For the example of how to use those patterns to build a data-driven algorithm, see [Tutorial: Use pattern matching to build type-driven and data-driven algorithms](../../fundamentals/tutorials/pattern-matching.md).
 
@@ -176,7 +157,7 @@ A property pattern is a recursive pattern. That is, you can use any pattern as a
 
 The preceding example uses two features available in C# 9.0 and later: `or` [pattern combinator](#logical-patterns) and [record types](../builtin-types/record.md).
 
-Beginning with C# 10, you can reference nested properties or fields within a property pattern. This is known as an *extended property pattern*. For example, you can refactor the method from the preceding example into the following equivalent code:
+Beginning with C# 10, you can reference nested properties or fields within a property pattern. This capability is known as an *extended property pattern*. For example, you can refactor the method from the preceding example into the following equivalent code:
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="ExtendedPropertyPattern":::
 
@@ -227,7 +208,7 @@ You use a *`var` pattern* to match any expression, including `null`, and assign 
 
 :::code language="csharp" source="snippets/patterns/VarPattern.cs" id="KeepInterimResult":::
 
-A `var` pattern is useful when you need a temporary variable within a Boolean expression to hold the result of intermediate calculations. You can also use a `var` pattern when you need to perform additional checks in `when` case guards of a `switch` expression or statement, as the following example shows:
+A `var` pattern is useful when you need a temporary variable within a Boolean expression to hold the result of intermediate calculations. You can also use a `var` pattern when you need to perform more checks in `when` case guards of a `switch` expression or statement, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/VarPattern.cs" id="WithCaseGuards":::
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -14,7 +14,28 @@ helpviewer_keywords:
 ---
 # Pattern matching - the `is` and `switch` expressions, and operators `and`, `or` and `not` in patterns
 
-The following C# expressions and statements support pattern matching. The [`is` expression](is.md), the [switch statement](../statements/selection-statements.md#the-switch-statement) and the [switch expression](switch-expression.md). In those constructs, you can match an input expression against many patterns. The [declaration pattern](#declaration-and-type-patterns) checks the run-time type of an expression and, if a match succeeds, assign an expression result to a declared variable. The [type pattern](#declaration-and-type-patterns) checks the run-time type of an expression (introduced in C# 9.0). The [constant pattern](#constant-pattern) tests if an expression result equals a specified constant. The [relational patterns](#relational-patterns) compares an expression result with a specified constant (introduced in C# 9.0). [Logical patterns](#logical-patterns) test if an expression matches a logical combination of patterns (introduced in C# 9.0). The [Property pattern](#property-pattern) tests if an expression's properties or fields match nested patterns. [Positional patterns](#positional-pattern)deconstruct an expression result and test if the resulting values match nested patterns. The [List patterns](#list-patterns) tests if a sequence's elements match corresponding nested patterns (introduced in C# 11). The [`var` pattern](#var-pattern): to match any expression and assign its result to a declared variable. The [Discard pattern](#discard-pattern) matches any expression. [Logical](#logical-patterns), [property](#property-pattern), [positional](#positional-pattern), and [list](#list-patterns) patterns are *recursive* patterns. That is, they can contain *nested* patterns.
+You use the [`is` expression](is.md), the [switch statement](../statements/selection-statements.md#the-switch-statement) and the [switch expression](switch-expression.md) to match an input expression against any number of characteristics. C# supports multiple patterns, including declaration, type, constant, relational, property, list, var, and discard. Patterns can be combined using boolean logic keywords `and`, `or`, and `not`.
+
+The following C# expressions and statements support pattern matching:
+
+- [`is` expression](is.md)
+- [switch statement](../statements/selection-statements.md#the-switch-statement)
+- [switch expression](switch-expression.md)
+
+In those constructs, you can match an input expression against any of the following patterns:
+
+- [Declaration pattern](#declaration-and-type-patterns): to check the run-time type of an expression and, if a match succeeds, assign an expression result to a declared variable.
+- [Type pattern](#declaration-and-type-patterns): to check the run-time type of an expression. Introduced in C# 9.0.
+- [Constant pattern](#constant-pattern): to test if an expression result equals a specified constant.
+- [Relational patterns](#relational-patterns): to compare an expression result with a specified constant. Introduced in C# 9.0.
+- [Logical patterns](#logical-patterns): to test if an expression matches a logical combination of patterns. Introduced in C# 9.0.
+- [Property pattern](#property-pattern): to test if an expression's properties or fields match nested patterns.
+- [Positional pattern](#positional-pattern): to deconstruct an expression result and test if the resulting values match nested patterns.
+- [`var` pattern](#var-pattern): to match any expression and assign its result to a declared variable.
+- [Discard pattern](#discard-pattern): to match any expression.
+- [List patterns](#list-patterns): to test if sequence elements match corresponding nested patterns. Introduced in C# 11.
+
+[Logical](#logical-patterns), [property](#property-pattern), [positional](#positional-pattern), and [list](#list-patterns) patterns are *recursive* patterns. That is, they can contain *nested* patterns.
 
 For the example of how to use those patterns to build a data-driven algorithm, see [Tutorial: Use pattern matching to build type-driven and data-driven algorithms](../../fundamentals/tutorials/pattern-matching.md).
 

--- a/docs/csharp/language-reference/operators/pointer-related-operators.md
+++ b/docs/csharp/language-reference/operators/pointer-related-operators.md
@@ -1,7 +1,7 @@
 ---
-title: "Pointer related operators - C# reference"
-description: "Learn about C# operators that you can use when working with pointers."
-ms.date: 05/20/2019
+title: "Pointer related operators - access memory and dereference memory locations"
+description: "Learn about C# operators that you can use when working with pointers. You use these operators to access memory, index memory locations and dereference the storage at a memory location"
+ms.date: 11/28/2022
 author: pkulikov
 f1_keywords: 
   - "->_CSharpKeyword"
@@ -21,15 +21,9 @@ helpviewer_keywords:
   - "pointer decrement [C#]"
   - "pointer comparison [C#]"
 ---
-# Pointer related operators (C# reference)
+# Pointer related operators - take the address of variables, dereference storage locations, and access memory locations
 
-You can use the following operators to work with pointers:
-
-- Unary [`&` (address-of)](#address-of-operator-) operator: to get the address of a variable
-- Unary [`*` (pointer indirection)](#pointer-indirection-operator-) operator: to obtain the variable pointed by a pointer
-- The [`->` (member access)](#pointer-member-access-operator--) and [`[]` (element access)](#pointer-element-access-operator-) operators
-- Arithmetic operators [`+`, `-`, `++`, and `--`](#pointer-arithmetic-operators)
-- Comparison operators [`==`, `!=`, `<`, `>`, `<=`, and `>=`](#pointer-comparison-operators)
+You can use operators to work with pointers. The unary [`&` (address-of)](#address-of-operator-) operator gets the address of a variable. The unary [`*` (pointer indirection)](#pointer-indirection-operator-) operator obtains the variable pointed by a pointer. The [`->` (member access)](#pointer-member-access-operator--) and [`[]` (element access)](#pointer-element-access-operator-) operators access the variable referred to at a memory location. Arithmetic operators [`+`, `-`, `++`, and `--`](#pointer-arithmetic-operators) traverse memory locations based on the size of the objects stored at that memory location. Comparison operators [`==`, `!=`, `<`, `>`, `<=`, and `>=`](#pointer-comparison-operators) test equality for pointer values.
 
 For information about pointer types, see [Pointer types](../unsafe-code.md#pointer-types).
 
@@ -58,7 +52,7 @@ The unary pointer indirection operator `*` obtains the variable to which its ope
 
 [!code-csharp[pointer indirection](snippets/shared/PointerOperators.cs#PointerIndirection)]
 
-You cannot apply the `*` operator to an expression of type `void*`.
+You can't apply the `*` operator to an expression of type `void*`.
 
 The binary `*` operator computes the [product](arithmetic-operators.md#multiplication-operator-) of its numeric operands.
 
@@ -80,7 +74,7 @@ The following example demonstrates the usage of the `->` operator:
 
 [!code-csharp[pointer member access](snippets/shared/PointerOperators.cs#MemberAccess)]
 
-You cannot apply the `->` operator to an expression of type `void*`.
+You can't apply the `->` operator to an expression of type `void*`.
 
 ## Pointer element access operator []
 
@@ -95,7 +89,7 @@ In the preceding example, a [`stackalloc` expression](stackalloc.md) allocates a
 > [!NOTE]
 > The pointer element access operator doesn't check for out-of-bounds errors.
 
-You cannot use `[]` for pointer element access with an expression of type `void*`.
+You can't use `[]` for pointer element access with an expression of type `void*`.
 
 You can also use the `[]` operator for [array element or indexer access](member-access-operators.md#indexer-operator-).
 
@@ -107,7 +101,7 @@ You can perform the following arithmetic operations with pointers:
 - Subtract two pointers
 - Increment or decrement a pointer
 
-You cannot perform those operations with pointers of type `void*`.
+You can't perform those operations with pointers of type `void*`.
 
 For information about supported arithmetic operations with numeric types, see [Arithmetic operators](arithmetic-operators.md).
 
@@ -144,7 +138,7 @@ The following example demonstrates the behavior of both postfix and prefix incre
 
 ## Pointer comparison operators
 
-You can use the `==`, `!=`, `<`, `>`, `<=`, and `>=` operators to compare operands of any pointer type, including `void*`. Those operators compare the addresses given by the two operands as if they were unsigned integers.
+You can use the `==`, `!=`, `<`, `>`, `<=`, and `>=` operators to compare operands of any pointer type, including `void*`. Those operators compare the addresses given by the two operands as if they're unsigned integers.
 
 For information about the behavior of those operators for operands of other types, see the [Equality operators](equality-operators.md) and [Comparison operators](comparison-operators.md) articles.
 
@@ -164,7 +158,7 @@ For the complete list of C# operators ordered by precedence level, see the [Oper
 
 ## Operator overloadability
 
-A user-defined type cannot overload the pointer related operators `&`, `*`, `->`, and `[]`.
+A user-defined type can't overload the pointer related operators `&`, `*`, `->`, and `[]`.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/pointer-related-operators.md
+++ b/docs/csharp/language-reference/operators/pointer-related-operators.md
@@ -23,7 +23,15 @@ helpviewer_keywords:
 ---
 # Pointer related operators - take the address of variables, dereference storage locations, and access memory locations
 
-You can use operators to work with pointers. The unary [`&` (address-of)](#address-of-operator-) operator gets the address of a variable. The unary [`*` (pointer indirection)](#pointer-indirection-operator-) operator obtains the variable pointed by a pointer. The [`->` (member access)](#pointer-member-access-operator--) and [`[]` (element access)](#pointer-element-access-operator-) operators access the variable referred to at a memory location. Arithmetic operators [`+`, `-`, `++`, and `--`](#pointer-arithmetic-operators) traverse memory locations based on the size of the objects stored at that memory location. Comparison operators [`==`, `!=`, `<`, `>`, `<=`, and `>=`](#pointer-comparison-operators) test equality for pointer values.
+The pointer operators enable you to take the address of a variable (`&`), dereference a pointer (`*`), compare pointer values, and add or subtract pointers and integers.
+
+You use the following operators to work with pointers:
+
+- Unary [`&` (address-of)](#address-of-operator-) operator: to get the address of a variable
+- Unary [`*` (pointer indirection)](#pointer-indirection-operator-) operator: to obtain the variable pointed by a pointer
+- The [`->` (member access)](#pointer-member-access-operator--) and [`[]` (element access)](#pointer-element-access-operator-) operators
+- Arithmetic operators [`+`, `-`, `++`, and `--`](#pointer-arithmetic-operators)
+- Comparison operators [`==`, `!=`, `<`, `>`, `<=`, and `>=`](#pointer-comparison-operators)
 
 For information about pointer types, see [Pointer types](../unsafe-code.md#pointer-types).
 

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -1,15 +1,14 @@
 ---
-title: "sizeof operator - C# reference"
-description: "Learn about the C# sizeof operator that returns the memory amount occupied by a variable of a given type."
-ms.date: 07/25/2019
+title: "sizeof operator - determine the storage needs for a type"
+description: "Learn about the C# `sizeof` operator that returns the memory amount occupied by a variable of a given type."
+ms.date: 11/28/2022
 f1_keywords: 
   - "sizeof_CSharpKeyword"
   - "sizeof"
 helpviewer_keywords: 
   - "sizeof keyword [C#]"
-ms.assetid: c548592c-677c-4f40-a4ce-e613f7529141
 ---
-# sizeof operator (C# reference)
+# sizeof operator - determine the memory needs for a given type
 
 The `sizeof` operator returns the number of bytes occupied by a variable of a given type. The argument to the `sizeof` operator must be the name of an [unmanaged type](../builtin-types/unmanaged-types.md) or a type parameter that is [constrained](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to be an unmanaged type.
 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -1,7 +1,7 @@
 ---
 title: "stackalloc expression - Allocate variable storage on the stack instead of the heap"
 description: "The C# stackalloc expression allocates a block of memory on the stack. Stackalloc memory is automatically discarded when that method returns."
-ms.date: 11/28/2028
+ms.date: 11/28/2022
 f1_keywords: 
   - "stackalloc_CSharpKeyword"
 helpviewer_keywords: 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -1,7 +1,7 @@
 ---
-title: "stackalloc expression - C# reference"
-description: "Learn about the C# stackalloc expression that allocates a block of memory on the stack."
-ms.date: 03/13/2020
+title: "stackalloc expression - Allocate variable storage on the stack instead of the heap"
+description: "The C# stackalloc expression allocates a block of memory on the stack. Stackalloc memory is automatically discarded when that method returns."
+ms.date: 11/28/2028
 f1_keywords: 
   - "stackalloc_CSharpKeyword"
 helpviewer_keywords: 
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # stackalloc expression (C# reference)
 
-A `stackalloc` expression allocates a block of memory on the stack. A stack allocated memory block created during the method execution is automatically discarded when that method returns. You cannot explicitly free the memory allocated with `stackalloc`. A stack allocated memory block is not subject to [garbage collection](../../../standard/garbage-collection/index.md) and doesn't have to be pinned with a [`fixed` statement](../statements/fixed.md).
+A `stackalloc` expression allocates a block of memory on the stack. A stack allocated memory block created during the method execution is automatically discarded when that method returns. You can't explicitly free the memory allocated with `stackalloc`. A stack allocated memory block isn't subject to [garbage collection](../../../standard/garbage-collection/index.md) and doesn't have to be pinned with a [`fixed` statement](../statements/fixed.md).
 
 You can assign the result of a `stackalloc` expression to a variable of one of the following types:
 

--- a/docs/csharp/language-reference/operators/subtraction-operator.md
+++ b/docs/csharp/language-reference/operators/subtraction-operator.md
@@ -1,7 +1,7 @@
 ---
-title: "- and -= operators - C# reference"
-description: "Learn about the C# subtraction operator and how it works with operands of numeric or delegate types."
-ms.date: 05/27/2019
+title: "- and -= operators - subtraction (minus) operators"
+description: "Learn about the C# subtraction (minus) operator and how it works with operands of numeric or delegate types."
+ms.date: 11/28/2022
 f1_keywords: 
   - "-_CSharpKeyword"
   - "-=_CSharpKeyword"
@@ -12,9 +12,8 @@ helpviewer_keywords:
   - "subtraction assignment operator [C#]"
   - "event unsubscription [C#]"
   - "-= operator [C#]"
-ms.assetid: 4de7a4fa-c69d-48e6-aff1-3130af970b2d
 ---
-# - and -= operators (C# reference)
+# - and -= operators - subtraction (minus)
 
 The `-` and `-=` operators are supported by the built-in [integral](../builtin-types/integral-numeric-types.md) and [floating-point](../builtin-types/floating-point-numeric-types.md) numeric types and [delegate](../builtin-types/reference-types.md#the-delegate-type) types.
 
@@ -28,11 +27,11 @@ For operands of the same [delegate](../builtin-types/reference-types.md#the-dele
 
   [!code-csharp-interactive[delegate removal](snippets/shared/SubtractionOperator.cs#DelegateRemoval)]
 
-- If the invocation list of the right-hand operand is not a proper contiguous sublist of the invocation list of the left-hand operand, the result of the operation is the left-hand operand. For example, removing a delegate that is not part of the multicast delegate does nothing and results in the unchanged multicast delegate.
+- If the invocation list of the right-hand operand isn't a proper contiguous sublist of the invocation list of the left-hand operand, the result of the operation is the left-hand operand. For example, removing a delegate that isn't part of the multicast delegate does nothing and results in the unchanged multicast delegate.
 
   [!code-csharp-interactive[delegate removal with no effect](snippets/shared/SubtractionOperator.cs#DelegateRemovalNoChange)]
 
-  The preceding example also demonstrates that during delegate removal delegate instances are compared. For example, delegates that are produced from evaluation of identical [lambda expressions](lambda-expressions.md) are not equal. For more information about delegate equality, see the [Delegate equality operators](~/_csharpstandard/standard/expressions.md#11119-delegate-equality-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
+  The preceding example also demonstrates that during delegate removal delegate instances are compared. For example, delegates that are produced from evaluation of identical [lambda expressions](lambda-expressions.md) aren't equal. For more information about delegate equality, see the [Delegate equality operators](~/_csharpstandard/standard/expressions.md#11119-delegate-equality-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
 - If the left-hand operand is `null`, the result of the operation is `null`. If the right-hand operand is `null`, the result of the operation is the left-hand operand.
 
@@ -66,7 +65,7 @@ You also use the `-=` operator to specify an event handler method to remove when
 
 ## Operator overloadability
 
-A user-defined type can [overload](operator-overloading.md) the `-` operator. When a binary `-` operator is overloaded, the `-=` operator is also implicitly overloaded. A user-defined type cannot explicitly overload the `-=` operator.
+A user-defined type can [overload](operator-overloading.md) the `-` operator. When a binary `-` operator is overloaded, the `-=` operator is also implicitly overloaded. A user-defined type can't explicitly overload the `-=` operator.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/switch-expression.md
+++ b/docs/csharp/language-reference/operators/switch-expression.md
@@ -1,14 +1,14 @@
 ---
-title: "switch expression - C# reference"
-description: Learn about the C# switch expression that provides switch-like semantics based on pattern matching.
-ms.date: 04/16/2021
+title: "switch expression - Evaluate a pattern match expression using the `switch` expression"
+description: Learn about the C# `switch` expression that provides switch-like semantics based on pattern matching. You can compute a value based on which pattern an input variable matches.
+ms.date: 11/28/2022
 f1_keywords:
   - "switch-expression_CSharpKeyword"
 helpviewer_keywords:
   - "switch expression [C#]"
   - "pattern matching [C#]"
 ---
-# switch expression (C# reference)
+# switch expression - pattern matching expressions using the `switch` keyword
 
 You use the `switch` expression to evaluate a single expression from a list of candidate expressions based on a pattern match with an input expression. For information about the `switch` statement that supports `switch`-like semantics in a statement context, see the [`switch` statement](../statements/selection-statements.md#the-switch-statement) section of the [Selection statements](../statements/selection-statements.md) article.
 
@@ -35,7 +35,7 @@ The compiler generates an error when a lower `switch` expression arm can't be ch
 
 ## Case guards
 
-A pattern may be not expressive enough to specify the condition for the evaluation of an arm's expression. In such a case, you can use a case guard. That is an additional condition that must be satisfied together with a matched pattern. A case guard must be a Boolean expression. You specify a case guard after the `when` keyword that follows a pattern, as the following example shows:
+A pattern may be not expressive enough to specify the condition for the evaluation of an arm's expression. In such a case, you can use a *case guard*. A *case guard* is another condition that must be satisfied together with a matched pattern. A case guard must be a Boolean expression. You specify a case guard after the `when` keyword that follows a pattern, as the following example shows:
 
 :::code language="csharp" source="snippets/shared/SwitchExpressions.cs" id="CaseGuardExample":::
 
@@ -43,7 +43,7 @@ The preceding example uses [property patterns](patterns.md#property-pattern) wit
 
 ## Non-exhaustive switch expressions
 
-If none of a `switch` expression's patterns matches an input value, the runtime throws an exception. In .NET Core 3.0 and later versions, the exception is a <xref:System.Runtime.CompilerServices.SwitchExpressionException?displayProperty=nameWithType>. In .NET Framework, the exception is an <xref:System.InvalidOperationException>. In most cases, the compiler generates a warning if a `switch` expression doesn't handle all possible input values. [List patterns](patterns.md#list-patterns) do not generate a warning when all possible inputs aren't handled.
+If none of a `switch` expression's patterns matches an input value, the runtime throws an exception. In .NET Core 3.0 and later versions, the exception is a <xref:System.Runtime.CompilerServices.SwitchExpressionException?displayProperty=nameWithType>. In .NET Framework, the exception is an <xref:System.InvalidOperationException>. In most cases, the compiler generates a warning if a `switch` expression doesn't handle all possible input values. [List patterns](patterns.md#list-patterns) don't generate a warning when all possible inputs aren't handled.
 
 > [!TIP]
 > To guarantee that a `switch` expression handles all possible input values, provide a `switch` expression arm with a [discard pattern](patterns.md#discard-pattern).

--- a/docs/csharp/language-reference/operators/true-false-operators.md
+++ b/docs/csharp/language-reference/operators/true-false-operators.md
@@ -1,15 +1,14 @@
 ---
-title: "true and false operators - C# reference"
-description: "Learn about the C# true and false operators."
-ms.date: 12/10/2018
+title: "true and false operators - treat objects as Boolean values"
+description: "Learn about the C# `true` and `false` operators. Overload these operators to treat your type as a Boolean value"
+ms.date: 11/28/2022
 helpviewer_keywords: 
   - "false operator [C#]"
   - "true operator [C#]"
-ms.assetid: 81a888fd-011e-4589-b242-6c261fea505e
 ---
-# true and false operators (C# reference)
+# true and false operators - treat your objects as a Boolean value
 
-The `true` operator returns the [bool](../builtin-types/bool.md) value `true` to indicate that its operand is definitely true. The `false` operator returns the `bool` value `true` to indicate that its operand is definitely false. The `true` and `false` operators are not guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
+The `true` operator returns the [bool](../builtin-types/bool.md) value `true` to indicate that its operand is definitely true. The `false` operator returns the `bool` value `true` to indicate that its operand is definitely false. The `true` and `false` operators aren't guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
 
 > [!TIP]
 > Use the `bool?` type, if you need to support the three-valued logic (for example, when you work with databases that support a three-valued Boolean type). C# provides the `&` and `|` operators that support the three-valued logic with the `bool?` operands. For more information, see the [Nullable Boolean logical operators](boolean-logical-operators.md#nullable-boolean-logical-operators) section of the [Boolean logical operators](boolean-logical-operators.md) article.
@@ -28,7 +27,7 @@ The following example presents the type that defines both `true` and `false` ope
 
 [!code-csharp[true and false operators example](snippets/shared/TrueFalseOperators.cs)]
 
-Notice the short-circuiting behavior of the `&&` operator. When the `GetFuelLaunchStatus` method returns `LaunchStatus.Red`, the right-hand operand of the `&&` operator is not evaluated. That is because `LaunchStatus.Red` is definitely false. Then the result of the logical AND doesn't depend on the value of the right-hand operand. The output of the example is as follows:
+Notice the short-circuiting behavior of the `&&` operator. When the `GetFuelLaunchStatus` method returns `LaunchStatus.Red`, the right-hand operand of the `&&` operator isn't evaluated. That is because `LaunchStatus.Red` is definitely false. Then the result of the logical AND doesn't depend on the value of the right-hand operand. The output of the example is as follows:
 
 ```console
 Getting fuel launch status...

--- a/docs/csharp/language-reference/operators/type-testing-and-cast.md
+++ b/docs/csharp/language-reference/operators/type-testing-and-cast.md
@@ -23,7 +23,7 @@ helpviewer_keywords:
 ---
 # Type-testing operators and cast expressions - `is`, `as`, `typeof` and casts
 
-These operators and expressions perform type checking or type conversion. The[is operator](#is-operator) checks if the run-time type of an expression is compatible with a given type. The [as operator](#as-operator) explicitly converts an expression to a given type if its run-time type is compatible with that type. [Cast expressions](#cast-expression) perform an explicit conversion to a target type. The [typeof operator](#typeof-operator) obtains the <xref:System.Type?displayProperty=nameWithType> instance for a type.
+These operators and expressions perform type checking or type conversion. The `is` [operator](#is-operator) checks if the run-time type of an expression is compatible with a given type. The `as` [operator](#as-operator) explicitly converts an expression to a given type if its run-time type is compatible with that type. [Cast expressions](#cast-expression) perform an explicit conversion to a target type. The `typeof` [operator](#typeof-operator) obtains the <xref:System.Type?displayProperty=nameWithType> instance for a type.
 
 ## is operator
 

--- a/docs/csharp/language-reference/operators/type-testing-and-cast.md
+++ b/docs/csharp/language-reference/operators/type-testing-and-cast.md
@@ -1,7 +1,7 @@
 ---
-title: "Type-testing operators and cast expression - C# reference"
-description: "Learn about C# operators that you can use to check the type of an expression result and convert it to another type if necessary."
-ms.date: 11/08/2021
+title: "Type-testing operators and cast expressions test the runtime type of an object"
+description: "The `is` and `as` operators test the type of an object. The `typeof` keyword returns the type of a variable. Casts try to convert an object to a variable of a different type."
+ms.date: 11/28/2022
 author: pkulikov
 f1_keywords: 
   - "is_CSharpKeyword"
@@ -21,14 +21,9 @@ helpviewer_keywords:
   - "() operator [C#]"
   - "typeof operator [C#]"
 ---
-# Type-testing operators and cast expression (C# reference)
+# Type-testing operators and cast expressions - `is`, `as`, `typeof` and casts
 
-You can use the following operators and expressions to perform type checking or type conversion:
-
-- [is operator](#is-operator): Check if the run-time type of an expression is compatible with a given type
-- [as operator](#as-operator): Explicitly convert an expression to a given type if its run-time type is compatible with that type
-- [cast expression](#cast-expression): Perform an explicit conversion
-- [typeof operator](#typeof-operator): Obtain the <xref:System.Type?displayProperty=nameWithType> instance for a type
+These operators and expressions perform type checking or type conversion. The[is operator](#is-operator) checks if the run-time type of an expression is compatible with a given type. The [as operator](#as-operator) explicitly converts an expression to a given type if its run-time type is compatible with that type. [Cast expressions](#cast-expression) perform an explicit conversion to a target type. The [typeof operator](#typeof-operator) obtains the <xref:System.Type?displayProperty=nameWithType> instance for a type.
 
 ## is operator
 
@@ -142,7 +137,7 @@ Use the `typeof` operator to check if the run-time type of the expression result
 
 ## Operator overloadability
 
-The `is`, `as`, and `typeof` operators cannot be overloaded.
+The `is`, `as`, and `typeof` operators can't be overloaded.
 
 A user-defined type can't overload the `()` operator, but can define custom type conversions that can be performed by a cast expression. For more information, see [User-defined conversion operators](user-defined-conversion-operators.md).
 

--- a/docs/csharp/language-reference/operators/user-defined-conversion-operators.md
+++ b/docs/csharp/language-reference/operators/user-defined-conversion-operators.md
@@ -1,25 +1,23 @@
 ---
-title: "User-defined conversion operators - C# reference"
-description: "Learn how to define custom implicit and explicit type conversions in C#."
-ms.date: 07/25/2022
-f1_keywords: 
+title: "User-defined explicit and implicit conversion operators - provide conversions to different types"
+description: "Learn how to define custom implicit and explicit type conversions in C#. The operators provide the functionality for casting an object to a new type."
+ms.date: 11/28/2022
+f1_keywords:
   - "explicit_CSharpKeyword"
   - "implicit_CSharpKeyword"
   - "explicit"
   - "implicit"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "explicit keyword [C#]"
   - "implicit keyword [C#]"
   - "conversion operator [C#]"
   - "user-defined conversion [C#]"
 ---
-# User-defined conversion operators (C# reference)
+# User-defined explicit and implicit conversion operators
 
-A user-defined type can define a custom implicit or explicit conversion from or to another type.
+A user-defined type can define a custom implicit or explicit conversion from or to another type. Implicit conversions don't require special syntax to be invoked and can occur in various situations, for example, in assignments and methods invocations. Predefined C# implicit conversions always succeed and never throw an exception. User-defined implicit conversions should behave in that way as well. If a custom conversion can throw an exception or lose information, define it as an explicit conversion.
 
-Implicit conversions don't require special syntax to be invoked and can occur in a variety of situations, for example, in assignments and methods invocations. Predefined C# implicit conversions always succeed and never throw an exception. User-defined implicit conversions should behave in that way as well. If a custom conversion can throw an exception or lose information, define it as an explicit conversion.
-
-User-defined conversions are not considered by the [is](type-testing-and-cast.md#is-operator) and [as](type-testing-and-cast.md#as-operator) operators. Use a [cast expression](type-testing-and-cast.md#cast-expression) to invoke a user-defined explicit conversion.
+User-defined conversions aren't considered by the [is](type-testing-and-cast.md#is-operator) and [as](type-testing-and-cast.md#as-operator) operators. Use a [cast expression](type-testing-and-cast.md#cast-expression) to invoke a user-defined explicit conversion.
 
 Use the `operator` and `implicit` or `explicit` keywords to define an implicit or explicit conversion, respectively. The type that defines a conversion must be either a source type or a target type of that conversion. A conversion between two user-defined types can be defined in either of the two types.
 

--- a/docs/csharp/language-reference/operators/with-expression.md
+++ b/docs/csharp/language-reference/operators/with-expression.md
@@ -1,20 +1,18 @@
 ---
-title: "with expression - C# reference"
-description: "Learn about a with expression that performs nondestructive mutation of C# records and structures"
-ms.date: 09/15/2021
+title: "with expression - create new objects that are modified copies of existing objects"
+description: "Learn about a with expression that performs nondestructive mutation of C# records and structures. The `with` keyword provides the means to modify one or more properties in the new object."
+ms.date: 11/28/2022
 f1_keywords:
   - "with_CSharpKeyword"
 helpviewer_keywords:
   - "with expression [C#]"
   - "with operator [C#]"
 ---
-# with expression (C# reference)
+# with expression - Nondestructive mutation creates a new object with modified properties
 
-Available in C# 9.0 and later, a `with` expression produces a copy of its operand with the specified properties and fields modified:
+Available in C# 9.0 and later, a `with` expression produces a copy of its operand with the specified properties and fields modified. you use [object initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md) syntax to specify what members to modify and their new values:
 
 :::code language="csharp" source="snippets/with-expression/BasicExample.cs" :::
-
-As the preceding example shows, you use [object initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md) syntax to specify what members to modify and their new values.
 
 In C# 9.0, a left-hand operand of a `with` expression must be of a [record type](../builtin-types/record.md). Beginning with C# 10, a left-hand operand of a `with` expression can also be of a [structure type](../builtin-types/struct.md) or an [anonymous type](../../fundamentals/types/anonymous-types.md).
 
@@ -28,11 +26,11 @@ In the case of a reference-type member, only the reference to a member instance 
 
 ## Custom copy semantics
 
-Any record class type has the *copy constructor*. That is a constructor with a single parameter of the containing record type. It copies the state of its argument to a new record instance. At evaluation of a `with` expression, the copy constructor gets called to instantiate a new record instance based on an original record. After that, the new instance gets updated according to the specified modifications. By default, the copy constructor is implicit, that is, compiler-generated. If you need to customize the record copy semantics, explicitly declare a copy constructor with the desired behavior. The following example updates the preceding example with an explicit copy constructor. The new copy behavior is to copy list items instead of a list reference when a record is copied:
+Any record class type has the *copy constructor*. A *copy constructor* is a constructor with a single parameter of the containing record type. It copies the state of its argument to a new record instance. At evaluation of a `with` expression, the copy constructor gets called to instantiate a new record instance based on an original record. After that, the new instance gets updated according to the specified modifications. By default, the copy constructor is implicit, that is, compiler-generated. If you need to customize the record copy semantics, explicitly declare a copy constructor with the desired behavior. The following example updates the preceding example with an explicit copy constructor. The new copy behavior is to copy list items instead of a list reference when a record is copied:
 
 :::code language="csharp" source="snippets/with-expression/UserDefinedCopyConstructor.cs" :::
 
-You cannot customize the copy semantics for structure types.
+You can't customize the copy semantics for structure types.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/statements/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/statements/checked-and-unchecked.md
@@ -1,7 +1,7 @@
 ---
-title: "checked and unchecked statements - C# reference"
-description: "Learn about the statements that control the overflow-checking context."
-ms.date: 08/24/2022
+title: "checked and unchecked statements - control the overflow-checking context"
+description: "The `checked` and `unchecked` statements control the overflow-checking context. In a check context, overflow causes an exception to be thrown. In an unchecked context, the result is truncated."
+ms.date: 11/22/2022
 f1_keywords: 
   - "checked_CSharpKeyword"
   - "unchecked_CSharpKeyword"
@@ -13,14 +13,9 @@ helpviewer_keywords:
 ---
 # checked and unchecked statements (C# reference)
 
-The `checked` and `unchecked` statements specify the overflow-checking context for integral-type arithmetic operations and conversions, as the following example shows:
+The `checked` and `unchecked` statements specify the overflow-checking context for integral-type arithmetic operations and conversions. When integer arithmetic overflow occurs, the overflow-checking context defines what happens. In a checked context, a <xref:System.OverflowException?displayProperty=nameWithType> is thrown; if overflow happens in a constant expression, a compile-time error occurs. In an unchecked context, the operation result is truncated by discarding any high-order bits that don't fit in the destination type. For example, in the case of addition it wraps from the maximum value to the minimum value. The following example shows both the same operation in both a `checked` and `unchecked` context:
 
 :::code language="csharp" interactive="try-dotnet-method" source="snippets/checked-and-unchecked/Program.cs" id="MainExample":::
-
-When integer arithmetic overflow occurs, the overflow-checking context defines what happens as follows:
-
-- In a checked context, a <xref:System.OverflowException?displayProperty=nameWithType> is thrown; if overflow happens in a constant expression, a compile-time error occurs.
-- In an unchecked context, the operation result is truncated by discarding any high-order bits that don't fit in the destination type. For example, in the case of addition it wraps from the maximum value to the minimum value, as the preceding example shows.
 
 > [!NOTE]
 > The behavior of user-defined operators and conversions in the case of the overflow of the corresponding result type can differ from the one described in the previous paragraph. In particular, [user-defined checked operators](../operators/arithmetic-operators.md#user-defined-checked-operators) might not throw an exception in a checked context.

--- a/docs/csharp/language-reference/statements/declarations.md
+++ b/docs/csharp/language-reference/statements/declarations.md
@@ -1,7 +1,7 @@
 ---
-title: "Declaration statements - C# reference"
-description: "Declaration statements, including `var`, `ref` locals, and `ref` fields - C# reference"
-ms.date: 09/15/2022
+title: "Declaration statements - var, ref local variables, and ref fields"
+description: "Declarations introduce a new variable. These statements include `var`, `ref` locals, and `ref` fields. In addition to declaring a new variable, these statements can initialize that variable's value."
+ms.date: 11/22/2022
 f1_keywords: 
   - "var"
   - "var_CSharpKeyword"
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # Declaration statements
 
-A *declaration statement* declares a new variable, and optionally, initializes it. All variables have declared type. You can learn more about types in the article on the [.NET type system](../../../standard/base-types/common-type-system.md).
+A *declaration statement* declares a new variable, and optionally, initializes it. All variables have declared type. You can learn more about types in the article on the [.NET type system](../../../standard/base-types/common-type-system.md). Typically, a declaration includes a type and a variable name. It can also include an initialization: the `=` operator followed by an expression. The type may be replaced with `var`. The declaration or the expression may include the `ref` modifier to declare that the new variable refers to an existing storage location.
 
 ## Implicitly typed local variables
 

--- a/docs/csharp/language-reference/statements/fixed.md
+++ b/docs/csharp/language-reference/statements/fixed.md
@@ -1,7 +1,7 @@
 ---
-title: "fixed statement - C# reference"
-description: "Use the C# fixed statement to pin a moveable variable for the duration of the statement."
-ms.date: 09/09/2022
+title: "fixed statement - pin a moveable variable"
+description: "Use the C# fixed statement to pin a moveable variable for a block. Use the `fixed` statement to safely access the memory for a variable knowing that the memory location won't change."
+ms.date: 11/22/2022
 f1_keywords: 
   - "fixed_CSharpKeyword"
   - "fixed"
@@ -9,13 +9,11 @@ helpviewer_keywords:
   - "fixed statement [C#]"
   - "fixed keyword [C#]"
 ---
-# fixed statement (C# reference)
+# fixed statement - safely access memory underlying a variable
 
-The `fixed` statement prevents the [garbage collector](../../../standard/garbage-collection/index.md) from relocating a moveable variable and declares a pointer to that variable:
+The `fixed` statement prevents the [garbage collector](../../../standard/garbage-collection/index.md) from relocating a moveable variable and declares a pointer to that variable. The address of a fixed, or pinned, variable doesn't change during execution of the statement. You can use the declared pointer only inside the corresponding `fixed` statement. The declared pointer is readonly and can't be modified:
 
 :::code language="csharp" source="snippets/fixed/Program.cs" id="PinnedArray":::
-
-The address of a fixed, or pinned, variable doesn't change for the duration of the statement. You can use the declared pointer only inside the corresponding `fixed` statement. The declared pointer is readonly and cannot be modified.
 
 > [!NOTE]
 > You can use the `fixed` statement only in an [unsafe](../keywords/unsafe.md) context. The code that contains unsafe blocks must be compiled with the [**AllowUnsafeBlocks**](../compiler-options/language.md#allowunsafeblocks) compiler option.

--- a/docs/csharp/language-reference/statements/iteration-statements.md
+++ b/docs/csharp/language-reference/statements/iteration-statements.md
@@ -1,7 +1,7 @@
 ---
-title: "Iteration statements - C# reference"
-description: "Learn about C# iteration statements that repeatedly execute the code: for, foreach, do, and while."
-ms.date: 05/24/2021
+title: "Iteration statements -for, foreach, do, and while"
+description: "C# iteration statements (for, foreach, do, and while) repeatedly execute a block of code. You repeat a block of code with different values for one or more variables."
+ms.date: 11/22/2022
 f1_keywords:
   - "for_CSharpKeyword"
   - "foreach_CSharpKeyword"
@@ -18,16 +18,11 @@ helpviewer_keywords:
   - "while keyword [C#]"
   - "while statement [C#]"
 ---
-# Iteration statements (C# reference)
+# Iteration statements - `for`, `foreach`, `do`, and `while`
 
-The following statements repeatedly execute a statement or a block of statements:
+The iteration statements repeatedly execute a statement or a block of statements. The [`for` statement](#the-for-statement): executes its body while a specified Boolean expression evaluates to `true`. The [`foreach` statement](#the-foreach-statement): enumerates the elements of a collection and executes its body for each element of the collection. The [`do` statement](#the-do-statement): conditionally executes its body one or more times. The [`while` statement](#the-while-statement): conditionally executes its body zero or more times.
 
-- The [`for` statement](#the-for-statement): executes its body while a specified Boolean expression evaluates to `true`.
-- The [`foreach` statement](#the-foreach-statement): enumerates the elements of a collection and executes its body for each element of the collection.
-- The [`do` statement](#the-do-statement): conditionally executes its body one or more times.
-- The [`while` statement](#the-while-statement): conditionally executes its body zero or more times.
-
-At any point within the body of an iteration statement, you can break out of the loop by using the [break](jump-statements.md#the-break-statement) statement, or step to the next iteration in the loop by using the [continue](jump-statements.md#the-continue-statement) statement.
+At any point within the body of an iteration statement, you can break out of the loop using the [break](jump-statements.md#the-break-statement) statement. You can step to the next iteration in the loop using the [continue](jump-statements.md#the-continue-statement) statement.
 
 ## The `for` statement
 
@@ -45,7 +40,7 @@ The preceding example shows the elements of the `for` statement:
   int i = 0
   ```
 
-- The *condition* section that determines if the next iteration in the loop should be executed. If it evaluates to `true` or is not present, the next iteration is executed; otherwise, the loop is exited. The *condition* section must be a Boolean expression.
+- The *condition* section that determines if the next iteration in the loop should be executed. If it evaluates to `true` or isn't present, the next iteration is executed; otherwise, the loop is exited. The *condition* section must be a Boolean expression.
 
   The *condition* section in the preceding example checks if a counter value is less than three:
 
@@ -133,7 +128,7 @@ In the preceding form, type `T` of a collection element must be implicitly or ex
 
 ## The `do` statement
 
-The `do` statement executes a statement or a block of statements while a specified Boolean expression evaluates to `true`. Because that expression is evaluated after each execution of the loop, a `do` loop executes one or more times. This differs from a [while](#the-while-statement) loop, which executes zero or more times.
+The `do` statement executes a statement or a block of statements while a specified Boolean expression evaluates to `true`. Because that expression is evaluated after each execution of the loop, a `do` loop executes one or more times. The `do` statement differs from a [while](#the-while-statement) loop, which executes zero or more times.
 
 The following example shows the usage of the `do` statement:
 
@@ -141,7 +136,7 @@ The following example shows the usage of the `do` statement:
 
 ## The `while` statement
 
-The `while` statement executes a statement or a block of statements while a specified Boolean expression evaluates to `true`. Because that expression is evaluated before each execution of the loop, a `while` loop executes zero or more times. This differs from a [do](#the-do-statement) loop, which executes one or more times.
+The `while` statement executes a statement or a block of statements while a specified Boolean expression evaluates to `true`. Because that expression is evaluated before each execution of the loop, a `while` loop executes zero or more times. The `while` statement differs from a [do](#the-do-statement) loop, which executes one or more times.
 
 The following example shows the usage of the `while` statement:
 

--- a/docs/csharp/language-reference/statements/jump-statements.md
+++ b/docs/csharp/language-reference/statements/jump-statements.md
@@ -1,7 +1,7 @@
 ---
-title: "Jump statements - C# reference"
-description: "Learn about C# jump statements: break, continue, return, and goto."
-ms.date: 09/15/2022
+title: "Jump statements - break, continue, return, and goto"
+description: "C# jump statements (break, continue, return, and goto), unconditionally transfer control from the current location to a different statement. These locations jump to a new location."
+ms.date: 11/22/2022
 f1_keywords:
   - "break_CSharpKeyword"
   - "continue_CSharpKeyword"
@@ -17,14 +17,9 @@ helpviewer_keywords:
   - "goto statement [C#]"
   - "goto keyword [C#]"
 ---
-# Jump statements (C# reference)
+# Jump statements - `break`, `continue`, `return` and `goto`
 
-The following statements unconditionally transfer control:
-
-- The [`break` statement](#the-break-statement): terminates the closest enclosing [iteration statement](iteration-statements.md) or [`switch` statement](selection-statements.md#the-switch-statement).
-- The [`continue` statement](#the-continue-statement): starts a new iteration of the closest enclosing [iteration statement](iteration-statements.md).
-- The [`return` statement](#the-return-statement): terminates execution of the function in which it appears and returns control to the caller. The `ref` modifier on a `return` statement indicates the returned expression is returned *by reference*, not *by value*.
-- The [`goto` statement](#the-goto-statement): transfers control to a statement that is marked by a label.
+Four C# statements unconditionally transfer control. The [`break` statement](#the-break-statement), terminates the closest enclosing [iteration statement](iteration-statements.md) or [`switch` statement](selection-statements.md#the-switch-statement). The [`continue` statement](#the-continue-statement): starts a new iteration of the closest enclosing [iteration statement](iteration-statements.md). The [`return` statement](#the-return-statement): terminates execution of the function in which it appears and returns control to the caller. The `ref` modifier on a `return` statement indicates the returned expression is returned *by reference*, not *by value*. The [`goto` statement](#the-goto-statement): transfers control to a statement that is marked by a label.
 
 For information about the `throw` statement that throws an exception and unconditionally transfers control as well, see [throw](../keywords/throw.md).
 

--- a/docs/csharp/language-reference/statements/jump-statements.md
+++ b/docs/csharp/language-reference/statements/jump-statements.md
@@ -19,7 +19,7 @@ helpviewer_keywords:
 ---
 # Jump statements - `break`, `continue`, `return` and `goto`
 
-Four C# statements unconditionally transfer control. The [`break` statement](#the-break-statement), terminates the closest enclosing [iteration statement](iteration-statements.md) or [`switch` statement](selection-statements.md#the-switch-statement). The [`continue` statement](#the-continue-statement): starts a new iteration of the closest enclosing [iteration statement](iteration-statements.md). The [`return` statement](#the-return-statement): terminates execution of the function in which it appears and returns control to the caller. The `ref` modifier on a `return` statement indicates the returned expression is returned *by reference*, not *by value*. The [`goto` statement](#the-goto-statement): transfers control to a statement that is marked by a label.
+Four C# statements unconditionally transfer control. The `break` [statement](#the-break-statement), terminates the closest enclosing [iteration statement](iteration-statements.md) or `switch` [statement](selection-statements.md#the-switch-statement). The `continue` [statement](#the-continue-statement) starts a new iteration of the closest enclosing [iteration statement](iteration-statements.md). The `return` [statement](#the-return-statement): terminates execution of the function in which it appears and returns control to the caller. The `ref` modifier on a `return` statement indicates the returned expression is returned *by reference*, not *by value*. The `goto` [statement](#the-goto-statement): transfers control to a statement that is marked by a label.
 
 For information about the `throw` statement that throws an exception and unconditionally transfers control as well, see [throw](../keywords/throw.md).
 

--- a/docs/csharp/language-reference/statements/lock.md
+++ b/docs/csharp/language-reference/statements/lock.md
@@ -1,17 +1,16 @@
 ---
-title: "lock statement - C# reference"
-description: "Use the C# lock statement to synchronize thread access to a shared resource"
-ms.date: 04/02/2020
+title: "lock statement - synchronize thread access to a shared resource"
+description: "Use the C# lock statement to ensure that only a single thread exclusively reads or writes a shared resource, blocking all other threads until it completes."
+ms.date: 11/22/2022
 f1_keywords: 
   - "lock_CSharpKeyword"
   - "lock"
 helpviewer_keywords: 
   - "lock keyword [C#]"
-ms.assetid: 656da1a4-707e-4ef6-9c6e-6d13b646af42
 ---
-# lock statement (C# reference)
+# lock statement - ensure exclusive access to a shared resource.
 
-The `lock` statement acquires the mutual-exclusion lock for a given object, executes a statement block, and then releases the lock. While a lock is held, the thread that holds the lock can again acquire and release the lock. Any other thread is blocked from acquiring the lock and waits until the lock is released.
+The `lock` statement acquires the mutual-exclusion lock for a given object, executes a statement block, and then releases the lock. While a lock is held, the thread that holds the lock can again acquire and release the lock. Any other thread is blocked from acquiring the lock and waits until the lock is released. The `lock` statement ensures that a single thread has exclusive access to that object.
 
 The `lock` statement is of the form
 
@@ -44,17 +43,17 @@ You can't use the [await operator](../operators/await.md) in the body of a `lock
 
 ## Guidelines
 
-When you synchronize thread access to a shared resource, lock on a dedicated object instance (for example, `private readonly object balanceLock = new object();`) or another instance that is unlikely to be used as a lock object by unrelated parts of the code. Avoid using the same lock object instance for different shared resources, as it might result in deadlock or lock contention. In particular, avoid using the following as lock objects:
+When you synchronize thread access to a shared resource, lock on a dedicated object instance (for example, `private readonly object balanceLock = new object();`) or another instance that is unlikely to be used as a lock object by unrelated parts of the code. Avoid using the same lock object instance for different shared resources, as it might result in deadlock or lock contention. In particular, avoid using the following types as lock objects:
 
 - `this`, as it might be used by the callers as a lock.
-- <xref:System.Type> instances, as those might be obtained by the [typeof](../operators/type-testing-and-cast.md#typeof-operator) operator or reflection.
-- string instances, including string literals, as those might be [interned](/dotnet/api/system.string.intern#remarks).
+- <xref:System.Type> instances, as those objects might be obtained by the [typeof](../operators/type-testing-and-cast.md#typeof-operator) operator or reflection.
+- string instances, including string literals, as string literals might be [interned](/dotnet/api/system.string.intern#remarks).
 
 Hold a lock for as short time as possible to reduce lock contention.
 
 ## Example
 
-The following example defines an `Account` class that synchronizes access to its private `balance` field by locking on a dedicated `balanceLock` instance. Using the same instance for locking ensures that the `balance` field cannot be updated simultaneously by two threads attempting to call the `Debit` or `Credit` methods simultaneously.
+The following example defines an `Account` class that synchronizes access to its private `balance` field by locking on a dedicated `balanceLock` instance. Using the same instance for locking ensures that the `balance` field can't be updated simultaneously by two threads attempting to call the `Debit` or `Credit` methods simultaneously.
 
 :::code language="csharp" source="snippets/lock/Program.cs":::
 

--- a/docs/csharp/language-reference/statements/selection-statements.md
+++ b/docs/csharp/language-reference/statements/selection-statements.md
@@ -19,7 +19,7 @@ helpviewer_keywords:
 ---
 # Selection statements - `if`, `else` and `switch`
 
-The `if`, `else` and `switch` statements select statements to execute from many possible paths based on the value of an expression. The [`if` statement](#the-if-statement) selects a statement to execute based on the value of a Boolean expression. An `if` statement can be combined with `else` to choose two distinct paths based on the Boolean expression. The [`switch` statement](#the-switch-statement) selects a statement list to execute based on a pattern match with an expression.
+The `if`, `else` and `switch` statements select statements to execute from many possible paths based on the value of an expression. The `if` [statement](#the-if-statement) selects a statement to execute based on the value of a Boolean expression. An `if` statement can be combined with `else` to choose two distinct paths based on the Boolean expression. The `switch` [statement](#the-switch-statement) selects a statement list to execute based on a pattern match with an expression.
 
 ## The `if` statement
 

--- a/docs/csharp/language-reference/statements/selection-statements.md
+++ b/docs/csharp/language-reference/statements/selection-statements.md
@@ -1,7 +1,7 @@
 ---
-title: "Selection statements - C# reference"
-description: "Learn about C# selection statements: if and switch."
-ms.date: 08/09/2021
+title: "if and switch statements - select execution path among branches."
+description: "The `if` and `switch` statements provide branching logic in C#. You use `if, `else` and `switch` to choose the path your program follows."
+ms.date: 11/22/2022
 f1_keywords:
   - "if_CSharpKeyword"
   - "else_CSharpKeyword"
@@ -17,12 +17,9 @@ helpviewer_keywords:
   - "case keyword [C#]"
   - "default keyword [C#]"
 ---
-# Selection statements (C# reference)
+# Selection statements - `if`, `else` and `switch`
 
-The following statements select statements to execute from a number of possible statements based on the value of an expression:
-
-- The [`if` statement](#the-if-statement): selects a statement to execute based on the value of a Boolean expression.
-- The [`switch` statement](#the-switch-statement): selects a statement list to execute based on a pattern match with an expression.
+The `if`, `else` and `switch` statements select statements to execute from many possible paths based on the value of an expression. The [`if` statement](#the-if-statement) selects a statement to execute based on the value of a Boolean expression. An `if` statement can be combined with `else` to choose two distinct paths based on the Boolean expression. The [`switch` statement](#the-switch-statement) selects a statement list to execute based on a pattern match with an expression.
 
 ## The `if` statement
 
@@ -51,12 +48,12 @@ The `switch` statement selects a statement list to execute based on a pattern ma
 At the preceding example, the `switch` statement uses the following patterns:
 
 - A [relational pattern](../operators/patterns.md#relational-patterns) (available in C# 9.0 and later): to compare an expression result with a constant.
-- A [constant pattern](../operators/patterns.md#constant-pattern): to test if an expression result equals a constant.
+- A [constant pattern](../operators/patterns.md#constant-pattern): test if an expression result equals a constant.
 
 > [!IMPORTANT]
 > For information about the patterns supported by the `switch` statement, see [Patterns](../operators/patterns.md).
 
-The preceding example also demonstrates the `default` case. The `default` case specifies statements to execute when a match expression doesn't match any other case pattern. If a match expression doesn't match any case pattern and there is no `default` case, control falls through a `switch` statement.
+The preceding example also demonstrates the `default` case. The `default` case specifies statements to execute when a match expression doesn't match any other case pattern. If a match expression doesn't match any case pattern and there's no `default` case, control falls through a `switch` statement.
 
 A `switch` statement executes the *statement list* in the first *switch section* whose *case pattern* matches a match expression and whose [case guard](#case-guards), if present, evaluates to `true`. A `switch` statement evaluates case patterns in text order from top to bottom. The compiler generates an error when a `switch` statement contains an unreachable case. That is a case that is already handled by an upper case or whose pattern is impossible to match.
 
@@ -67,7 +64,7 @@ You can specify multiple case patterns for one section of a `switch` statement, 
 
 :::code language="csharp" source="snippets/selection-statements/SwitchStatement.cs" id="MultipleCases":::
 
-Within a `switch` statement, control cannot fall through from one switch section to the next. As the examples in this section show, typically you use the `break` statement at the end of each switch section to pass control out of a `switch` statement. You can also use the [return](jump-statements.md#the-return-statement) and [throw](../keywords/throw.md) statements to pass control out of a `switch` statement. To imitate the fall-through behavior and pass control to other switch section, you can use the [`goto` statement](jump-statements.md#the-goto-statement).
+Within a `switch` statement, control can't fall through from one switch section to the next. As the examples in this section show, typically you use the `break` statement at the end of each switch section to pass control out of a `switch` statement. You can also use the [return](jump-statements.md#the-return-statement) and [throw](../keywords/throw.md) statements to pass control out of a `switch` statement. To imitate the fall-through behavior and pass control to other switch section, you can use the [`goto` statement](jump-statements.md#the-goto-statement).
 
 In an expression context, you can use the [`switch` expression](../operators/switch-expression.md) to evaluate a single expression from a list of candidate expressions based on a pattern match with an expression.
 

--- a/docs/csharp/language-reference/statements/yield.md
+++ b/docs/csharp/language-reference/statements/yield.md
@@ -1,16 +1,16 @@
 ---
-title: "yield statement - C# reference"
-description: "Use the yield statement in iterators to provide the next value or signal the end of iteration"
-ms.date: 09/27/2022
+title: "yield statement - provide the next element in an iterator"
+description: "Use the yield statement in iterators to provide the next value or signal the end of an iteration"
+ms.date: 11/22/2022
 f1_keywords: 
   - "yield"
   - "yield_CSharpKeyword"
 helpviewer_keywords: 
   - "yield keyword [C#]"
 ---
-# yield statement (C# reference)
+# yield statement - provide the next element
 
-You use the `yield` statement in an [iterator](../../iterators.md) in two following forms:
+You use the `yield` statement in an [iterator](../../iterators.md) to provide the next value from a sequence when iterating the sequence. The `yield` statement has the two following forms:
 
 - `yield return`: to provide the next value in iteration, as the following example shows:
 
@@ -33,7 +33,7 @@ In the preceding examples, the return type of iterators is <xref:System.Collecti
 
   :::code language="csharp" source="snippets/yield/GetEnumeratorExample.cs" id="GetEnumeratorExample":::
 
-You cannot use the `yield` statements in:
+You can't use the `yield` statements in:
 
 - methods with [in](../keywords/in-parameter-modifier.md), [ref](../keywords/ref.md), or [out](../keywords/out-parameter-modifier.md) parameters
 - [lambda expressions](../operators/lambda-expressions.md) and [anonymous methods](../operators/delegate-operator.md)

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -1,7 +1,7 @@
 ---
-title: "$ - string interpolation - C# reference"
-description: String interpolation provides a more readable and convenient syntax to format string output than traditional string composite formatting.
-ms.date: 04/15/2022
+title: "$ - string interpolation - format string output"
+description: String interpolation using the `$` token provides a more readable and convenient syntax to format string output than traditional string composite formatting.
+ms.date: 11/29/2022
 f1_keywords:
     - "$_CSharpKeyword"
     - "$"
@@ -12,7 +12,7 @@ helpviewer_keywords:
 author: pkulikov
 ---
 
-# $ - string interpolation (C# reference)
+# String interpolation using `$`
 
 The `$` special character identifies a string literal as an _interpolated string_. An interpolated string is a string literal that might contain _interpolation expressions_. When an interpolated string is resolved to a result string, items with interpolation expressions are replaced by the string representations of the expression results.
 

--- a/docs/csharp/language-reference/tokens/verbatim.md
+++ b/docs/csharp/language-reference/tokens/verbatim.md
@@ -1,16 +1,15 @@
 ---
-description: "@ - C# Reference"
-title: "@ - C# Reference"
-ms.date: 02/09/2017
+description: "Verbatim text using the `@` enables C# keywords to be used as identifiers, or indicates that a string literal should be interpreted verbatim, or to distinguish attribute names"
+title: "Verbatim text and strings - @"
+ms.date: 11/29/2022
 f1_keywords: 
   - "@_CSharpKeyword"
   - "@"
 helpviewer_keywords: 
   - "@ special character [C#]"
   - "@ language element [C#]"
-ms.assetid: 89bc7e53-85f5-478a-866d-1cca003c4e8c
 ---
-# @ (C# Reference)
+# Verbatim text - `@` in variables, attributes, and string literals
 
 The `@` special character serves as a verbatim identifier. It can be used in the following ways:
 
@@ -18,7 +17,7 @@ The `@` special character serves as a verbatim identifier. It can be used in the
 
    [!code-csharp[verbatim1](../../../../samples/snippets/csharp/language-reference/keywords/verbatim1.cs#1)]
 
-1. To indicate that a string literal is to be interpreted verbatim. The `@` character in this instance defines a *verbatim string literal*. Simple escape sequences (such as `"\\"` for a backslash), hexadecimal escape sequences (such as `"\x0041"` for an uppercase A), and Unicode escape sequences (such as `"\u0041"` for an uppercase A) are interpreted literally. Only a quote escape sequence (`""`) is not interpreted literally; it produces one double quotation mark. Additionally, in case of a verbatim [interpolated string](interpolated.md) brace escape sequences (`{{` and `}}`) are not interpreted literally; they produce single brace characters. The following example defines two identical file paths, one by using a regular string literal and the other by using a verbatim string literal. This is one of the more common uses of verbatim string literals.
+1. To indicate that a string literal is to be interpreted verbatim. The `@` character in this instance defines a *verbatim string literal*. Simple escape sequences (such as `"\\"` for a backslash), hexadecimal escape sequences (such as `"\x0041"` for an uppercase A), and Unicode escape sequences (such as `"\u0041"` for an uppercase A) are interpreted literally. Only a quote escape sequence (`""`) isn't interpreted literally; it produces one double quotation mark. Additionally, in case of a verbatim [interpolated string](interpolated.md) brace escape sequences (`{{` and `}}`) aren't interpreted literally; they produce single brace characters. The following example defines two identical file paths, one by using a regular string literal and the other by using a verbatim string literal. This is one of the more common uses of verbatim string literals.
 
    [!code-csharp[verbatim2](../../../../samples/snippets/csharp/language-reference/keywords/verbatim1.cs#2)]
 
@@ -26,7 +25,7 @@ The `@` special character serves as a verbatim identifier. It can be used in the
 
    [!code-csharp[verbatim3](../../../../samples/snippets/csharp/language-reference/keywords/verbatim1.cs#3)]
 
-1. To enable the compiler to distinguish between attributes in cases of a naming conflict. An attribute is a class that derives from <xref:System.Attribute>. Its type name typically includes the suffix **Attribute**, although the compiler does not enforce this convention. The attribute can then be referenced in code either by its full type name (for example, `[InfoAttribute]` or its shortened name (for example, `[Info]`). However, a naming conflict occurs if two shortened attribute type names are identical, and one type name includes the **Attribute** suffix but the other does not. For example, the following code fails to compile because the compiler cannot determine whether the `Info` or `InfoAttribute` attribute is applied to the `Example` class. See [CS1614](../compiler-messages/cs1614.md) for more information.
+1. To enable the compiler to distinguish between attributes in cases of a naming conflict. An attribute is a class that derives from <xref:System.Attribute>. Its type name typically includes the suffix **Attribute**, although the compiler doesn't enforce this convention. The attribute can then be referenced in code either by its full type name (for example, `[InfoAttribute]` or its shortened name (for example, `[Info]`). However, a naming conflict occurs if two shortened attribute type names are identical, and one type name includes the **Attribute** suffix but the other doesn't. For example, the following code fails to compile because the compiler can't determine whether the `Info` or `InfoAttribute` attribute is applied to the `Example` class. For more information, see [CS1614](../compiler-messages/cs1614.md).
 
    [!code-csharp[verbatim4](../../../../samples/snippets/csharp/language-reference/keywords/verbatim2.cs#1)]
 


### PR DESCRIPTION
In all the statements, operators, and tokens pages, edit the title, description, and opening paragraph to increase SEO on the statement keywords.

First commit - edit all statements pages.
Second commit - edit all the operator pages.

Fixes #32497

For this issue, update the title, description, and opening paragraph to include the keyword, name of operators, the symbols, and the term used for each operator. Where the opening was a list of the operators, convert that to a paragraph so it shows in search results. Also, do a general edit pass.

For review, checking the opening two paragraphs should be sufficient. 

Also check modified pages for open issues. Fix the following:

#32630 - see Language reference [lambda expressions attributes](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions?branch=pr-en-us-32704#attributes).
#26112 - see Language reference operators See [operator associativity](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/?branch=pr-en-us-32704#operator-associativity).
