### PR TITLE
Correct link to not be self-referencing

### DIFF
--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -12,7 +12,7 @@ ms.date: 03/14/2021
 .NET applications can be instrumented using the <xref:System.Diagnostics.Activity?displayProperty=nameWithType> API to produce
 distributed tracing telemetry. Some instrumentation is built into standard .NET libraries, but you may want to add more to make
 your code more easily diagnosable. In this tutorial, you will add new custom distributed tracing instrumentation. See
-[the collection tutorial](distributed-tracing-instrumentation-walkthroughs.md) to learn more about recording the telemetry
+[the collection tutorial](distributed-tracing-collection-walkthroughs.md) to learn more about recording the telemetry
 produced by this instrumentation.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

Was pointing to `distributed-tracing-instrumentation-walkthroughs` instead of intended `distributed-tracing-collection-walkthroughs`.
