### PR TITLE
Document NET 7 breaking changes for workloads and RID inference

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -123,7 +123,8 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
 | [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |
 | [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
-
+| [Preview .NET 7 SDK installation workloads can interfere with RTM workloads](https://github.com/dotnet/core/blob/main/release-notes/7.0/known-issues.md#70-projects-using-certain-workloads-dont-load-build-and-or-run-if-net-7-preview-sdk-workloads-are-installed) |✔️ | ✔️ | Preview 3 |
+| [Runtime Identifiers are now automatically inferred and added for `SelfContained`, `PublishSingleFile`, `PublishReadyToRun`, `PublishAot`](https://github.com/dotnet/sdk/issues/26028) | ❌ | ✔️ | RC 1 |
 ## Serialization
 
 | Title | Binary compatible | Source compatible | Introduced |

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -125,6 +125,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
 | [Preview .NET 7 SDK installation workloads can interfere with RTM workloads](https://github.com/dotnet/core/blob/main/release-notes/7.0/known-issues.md#70-projects-using-certain-workloads-dont-load-build-and-or-run-if-net-7-preview-sdk-workloads-are-installed) |✔️ | ✔️ | Preview 3 |
 | [Runtime Identifiers are now automatically inferred and added for `SelfContained`, `PublishSingleFile`, `PublishReadyToRun`, `PublishAot`](https://github.com/dotnet/sdk/issues/26028) | ❌ | ✔️ | RC 1 |
+
 ## Serialization
 
 | Title | Binary compatible | Source compatible | Introduced |


### PR DESCRIPTION
The additional information for the changes is included in the doc change itself. We didn't expect RID Inference to be a breaking change but there were after-effects, like here: https://github.com/dotnet/sdk/issues/29164 or here https://github.com/dotnet/sdk/issues/29177

