### PR TITLE
Fixed OrleansAdventure.sln broken link to github

### DIFF
--- a/docs/orleans/tutorials-and-samples/adventure.md
+++ b/docs/orleans/tutorials-and-samples/adventure.md
@@ -10,7 +10,7 @@ This sample is a simple multiplayer text adventure game inspired by old-fashione
 
 ## Instructions
 
-1. Open [_OrleansAdventure.sln_](https://github.com/dotnet/orleans/tree/main/samples/Adventure) in Visual Studio.
+1. Open [_OrleansAdventure.sln_](https://github.com/dotnet/samples/tree/main/orleans/Adventure) in Visual Studio.
 2. Start the 'AdventureSetup' project.
 3. Once AdventureSetup is running, start the 'AdventureClient' project.
 4. You will then be prompted to enter your name on the command line. Enter it and begin the game.


### PR DESCRIPTION
## Summary
The instruction's link for OrleansAdventure.sln was invalid and was directing to the github 404. 

Old link was https://github.com/dotnet/orleans/tree/main/samples/Adventure, new link is https://github.com/dotnet/samples/tree/main/orleans/Adventure

Fixes #Issue_Number (if available)
