### PR TITLE
remove feature specs

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -19,6 +19,10 @@
         {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.1/async-main.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/basic-concepts#71-application-startup"
+        }, 
+        {
+            "source_path_from_root": "/_csharplang/proposals/csharp-7.1/target-typed-default.md.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11719-default-value-expressions"
         },
         {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.2/private-protected.md",
@@ -27,6 +31,10 @@
         {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.2/readonly-struct.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs.md#1524-struct-interfaces"
+        },
+        {
+            "source_path_from_root": "/_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11621-general"
         },
         {
             "source_path_from_root": "/_csharplang/proposals/csharp-7.3/leading-digit-separator.md",

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -21,7 +21,7 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/basic-concepts#71-application-startup"
         }, 
         {
-            "source_path_from_root": "/_csharplang/proposals/csharp-7.1/target-typed-default.md.md",
+            "source_path_from_root": "/_csharplang/proposals/csharp-7.1/target-typed-default.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11719-default-value-expressions"
         },
         {

--- a/docfx.json
+++ b/docfx.json
@@ -61,6 +61,7 @@
                     "csharp-7.1/target-typed-default.md",
                     "csharp-7.2/leading-separator.md",
                     "csharp-7.2/readonly-struct.md",
+                    "csharp-7.2/ref-struct-and-span.md",
                     "csharp-7.2/ref-extension-methods.md",
                     "csharp-7.2/non-trailing-named-arguments.md",
                     "csharp-7.2/private-protected.md",

--- a/docfx.json
+++ b/docfx.json
@@ -58,10 +58,12 @@
                     "csharp-7.0/tuples.md",
                     "csharp-7.0/value-task.md",
                     "csharp-7.1/async-main.md",
+                    "csharp-7.1/target-typed-default.md",
                     "csharp-7.2/leading-separator.md",
                     "csharp-7.2/readonly-struct.md",
                     "csharp-7.2/ref-extension-methods.md",
-                    "csharp-7.2/ref-struct-and-span.md",
+                    "csharp-7.2/non-trailing-named-arguments.md",
+                    "csharp-7.2/private-protected.md",
                     "csharp-7.2/private-protected.md",
                     "csharp-7.3/enum-delegate-constraints.md",
                     "csharp-7.3/ref-loops.md",
@@ -115,8 +117,10 @@
                 "exclude": [
                     "_csharplang/proposals/csharp-7.0/local-functions.md",
                     "_csharplang/proposals/csharp-7.0/throw-expression.md",
-                    "_csharplang/proposals/csharp-7.2/private-protected.md",
+                    "_csharplang/proposals/csharp-7.0/throw-expression.md",
+                    "_csharplang/proposals/csharp-7.1/target-typed-default.md",
                     "_csharplang/proposals/csharp-7.2/readonly-struct.md",
+                    "_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md",
                     "_csharplang/proposals/csharp-7.3/blittable.md"
                 ]
             }

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1348,8 +1348,6 @@ items:
         href: ../../_csharplang/proposals/csharp-7.0/task-types.md
     - name: C# 7.1 features
       items:
-      - name: Default expressions
-        href: ../../_csharplang/proposals/csharp-7.1/target-typed-default.md
       - name: Infer tuple names
         href: ../../_csharplang/proposals/csharp-7.1/infer-tuple-names.md
       - name: Pattern matching with generics
@@ -1360,8 +1358,6 @@ items:
         href: ../../_csharplang/proposals/csharp-7.2/readonly-ref.md
       - name: Compile-time safety for ref-like types
         href: ../../_csharplang/proposals/csharp-7.2/span-safety.md
-      - name: Non-trailing named arguments
-        href: ../../_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md
       - name: Conditional ref
         href: ../../_csharplang/proposals/csharp-7.2/conditional-ref.md
     - name: C# 7.3 features


### PR DESCRIPTION
The standard committe has merged the updates to the standard for the following features:

- dotnet/csharpstandard#216 - non-trailing named arguments
- dotnet/csharpstandard#236 - default literals

Remove the feature speclets from the publishing list, and fix any related links.
