### PR TITLE
chore: Add job to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -1,0 +1,17 @@
+name: "PR Needs Rebase"
+
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  label-rebase-needed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "rebase needed :construction:"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.

--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -1,4 +1,4 @@
-name: "PR Needs Rebase"
+name: "rebase required"
 
 on:
   push:


### PR DESCRIPTION
## Summary

This is used over on the MDN repos through a shared workflow https://github.com/mdn/workflows/blob/main/.github/workflows/pr-rebase-needed.yml
Found this helpful, as it will notify authors when there PR gets merge conflicts so they know that they need to rebase to move a PR forward
