### PR TITLE
Breaking change for ASPNET-prefixed environment variables

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -19,7 +19,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ | Preview 2 |
-| [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ❌ | ✔️ | Preview 3 |
+| [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ✔️ | ✔️ | Preview 3 |
 | [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ | RC 1 |
 | [Authentication in WebAssembly apps](aspnet-core/7.0/wasm-app-authentication.md) | ❌ | ✔️ | RC 1 |
 | [Default authentication scheme](aspnet-core/7.0/default-authentication-scheme.md) | ❌ | ✔️ | Preview 7 |

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -19,6 +19,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ | Preview 2 |
+| [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ❌ | ✔️ | Preview 3 |
 | [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ | RC 1 |
 | [Authentication in WebAssembly apps](aspnet-core/7.0/wasm-app-authentication.md) | ❌ | ✔️ | RC 1 |
 | [Default authentication scheme](aspnet-core/7.0/default-authentication-scheme.md) | ❌ | ✔️ | Preview 7 |

--- a/docs/core/compatibility/aspnet-core/7.0/environment-variable-precedence.md
+++ b/docs/core/compatibility/aspnet-core/7.0/environment-variable-precedence.md
@@ -1,0 +1,42 @@
+---
+title: "Breaking change: ASPNET-prefixed environment variable precedence"
+description: Learn about the breaking change in ASP.NET Core 7.0 where ASPNET-prefixed environment variables now have the lowest precedence for WebApplicationBuilder.
+ms.date: 12/02/2022
+---
+# ASPNET-prefixed environment variable precedence
+
+Starting in .NET 7, and only when using the `WebApplicationBuilder` host, command-line arguments and `DOTNET_`-prefixed environment variables override `ASPNET_`-prefixed environment variables when reading from default host configuration sources. These sources are used to read host variables, such as the content root path and environment name, when the `WebApplicationBuilder` is constructed and serve as a base for app configuration.
+
+`ASPNET_`-prefixed environment variables now have the lowest precedence of all of the default host configuration sources for `WebApplicationBuilder`. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNET_`-prefixed environment variables still have the highest precedence.
+
+## Version introduced
+
+ASP.NET Core 7.0
+
+## Previous behavior
+
+`ASPNET_`-prefixed environment variables overrode command-line arguments and `DOTNET_`-prefixed environment variables.
+
+## New behavior
+
+Command-line arguments and `DOTNET_`-prefixed environment variables override `ASPNET_`-prefixed environment variables.
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change was made to prevent environment variables from overriding explicit command-line arguments when reading host variables. The new behavior is more consistent with application configuration, which has always given command-line arguments the highest precedence.
+
+## Recommended action
+
+If you were using `ASPNETCORE_`-prefixed environment variables to override command-line arguments or `DOTNET_`-prefixed environment variables, use something with a higher priority. This could mean using custom <xref:Microsoft.AspNetCore.Builder.WebApplicationOptions>, which overrides all default hosting configuration sources.
+
+## Affected APIs
+
+- <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder?displayProperty=fullName>
+
+## See also
+
+- [Default host configuration sources](/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#default-host-configuration-sources)

--- a/docs/core/compatibility/aspnet-core/7.0/environment-variable-precedence.md
+++ b/docs/core/compatibility/aspnet-core/7.0/environment-variable-precedence.md
@@ -15,7 +15,7 @@ ASP.NET Core 7.0
 
 ## Previous behavior
 
-`ASPNET_`-prefixed environment variables overrode command-line arguments and `DOTNET_`-prefixed environment variables.
+`ASPNET_`-prefixed environment variables overrode command-line arguments and `DOTNET_`-prefixed environment variables when reading `WebApplicationBuilder`'s [default host configuration](/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#default-host-configuration-sources).
 
 ## New behavior
 
@@ -23,7 +23,7 @@ Command-line arguments and `DOTNET_`-prefixed environment variables override `AS
 
 ## Type of breaking change
 
-This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+This is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -27,6 +27,8 @@ items:
         items:
         - name: API controller actions try to infer parameters from DI
           href: aspnet-core/7.0/api-controller-action-parameters-di.md
+        - name: ASPNET-prefixed environment variable precedence
+          href: aspnet-core/7.0/environment-variable-precedence.md
         - name: AuthenticateAsync for remote auth providers
           href: aspnet-core/7.0/authenticateasync-anonymous-request.md
         - name: Authentication in WebAssembly apps
@@ -673,6 +675,8 @@ items:
         items:
         - name: API controller actions try to infer parameters from DI
           href: aspnet-core/7.0/api-controller-action-parameters-di.md
+        - name: ASPNET-prefixed environment variable precedence
+          href: aspnet-core/7.0/environment-variable-precedence.md
         - name: AuthenticateAsync for remote auth providers
           href: aspnet-core/7.0/authenticateasync-anonymous-request.md
         - name: Authentication in WebAssembly apps


### PR DESCRIPTION
Related to https://github.com/aspnet/Announcements/issues/498.

[Preview link](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/environment-variable-precedence?branch=pr-en-us-32858).