### PR TITLE
Add documentation for ide0130

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -39,7 +39,7 @@ Options specify the behavior that you want the rule to enforce. For information 
 | **Option name**          | dotnet_style_namespace_match_folder                  |                                                    |
 | **Option values**        | `true`                                               | Prefer namespace naming to match folder structure. |
 |                          | `false`                                              | Disables the rule.                                 |
-| **Default option value** | `false`                                              |                                                    |
+| **Default option value** | `true`                                               |                                                    |
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -45,7 +45,7 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 Assume that the following code snippets are from a file named `Data/Example.cs`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.
 
-### C\# 
+### C\#
 
 ```csharp
 // Code with violations
@@ -71,7 +71,7 @@ namespace Root.Data
 }
 ```
 
-### VB 
+### VB
 
 ```vb
 ' Code with violations

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -5,8 +5,10 @@ ms.date: 12/05/2022
 ms.topic: reference
 f1_keywords:
 - IDE0130
+- dotnet_style_namespace_match_folder
 helpviewer_keywords:
 - IDE0130
+- dotnet_style_namespace_match_folder
 author: gewarren
 ms.author: gewarren
 dev_langs:

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -43,9 +43,7 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 ## Example
 
-Assume that the following code snippets are from a file named `Data/Example.cs`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.
-
-### C\#
+Assume that the following code snippets are from a file named `Data/Example.cs` or `Data/Example.vb`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.
 
 ```csharp
 // Code with violations
@@ -70,8 +68,6 @@ namespace Root.Data
     }
 }
 ```
-
-### VB
 
 ```vb
 ' Code with violations

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -42,7 +42,8 @@ Options specify the behavior that you want the rule to enforce. For information 
 | **Default option value** | `true`                                               |                                                    |
 
 > [!NOTE]
-> `dotnet_style_namespace_match_folder` depends on knowing the current project and root namespace properties. This is provided by Visual Studio but not done in command line builds. For command line builds, such as `dotnet build` to work, you must add the following properties to your `.editorconfig`.
+> The `dotnet_style_namespace_match_folder` option depends on knowing the current project and root namespace properties. This information is provided by Visual Studio but is not available for command-line builds, such as `dotnet build`. For command-line builds to work, you must add the following properties to your *.editorconfig* file and replace the root directory and namespace placeholders with your values:
+
 > ```ini
 > is_global=true
 > build_property.ProjectDir = <root directory>

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -1,0 +1,101 @@
+---
+title: "IDE0130: Namespace does not match folder structure"
+description: "Learn about code analysis rule IDE0130: Namespace does not match folder structure"
+ms.date: 12/05/2021
+ms.topic: reference
+f1_keywords:
+- IDE0130
+helpviewer_keywords:
+- IDE0130
+author: gewarren
+ms.author: gewarren
+dev_langs:
+- CSharp
+- VB
+---
+# Namespace does not match folder structure (IDE0130)
+
+| Property                 | Value                                                  |
+| ------------------------ | ------------------------------------------------------ |
+| **Rule ID**              | IDE0130                                                |
+| **Title**                | Namespace does not match folder structure              |
+| **Category**             | Style                                                  |
+| **Subcategory**          | Naming  rules                                          |
+| **Applicable languages** | C# and Visual Basic                                    |
+| **Options**              | `dotnet_style_namespace_match_folder`                  |
+
+## Overview
+
+This style rule uses the folder structure of the project to enforce namespace naming requirements.
+
+## Options
+
+Options specify the behavior that you want the rule to enforce. For information about configuring options, see [Option format](language-rules.md#option-format).
+
+### dotnet_style_namespace_match_folder
+
+| Property                 | Value                                                | Description                                        |
+| ------------------------ | ---------------------------------------------------- | -------------------------------------------------- |
+| **Option name**          | dotnet_style_namespace_match_folder                  |                                                    |
+| **Option values**        | `true`                                               | Prefer namespace naming to match folder structure. |
+|                          | `false`                                              | Disables the rule.                                 |
+| **Default option value** | `false`                                              |                                                    |
+
+## Example
+
+Assume that the following file is `Data\Example.cs`, where `Data` represents the folder structure from the project file. Also note that the structure is added to the root namespace, which in this example will be `Root`.
+
+```csharp
+// Code with violations
+namespace Root.BadExample
+{
+    class Example
+    {
+        public void M()
+        {
+        }
+    }
+}
+
+// Fixed code
+namespace Root.Data
+{
+    class Example
+    {
+        public void M()
+        {
+        }
+    }
+}
+```
+
+## Suppress a warning
+
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0130
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0130
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0130.severity = none
+```
+
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
+## See also
+
+- [Naming rules](naming-rules.md)
+- [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -45,6 +45,8 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 Assume that the following code snippets are from a file named `Data/Example.cs`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.
 
+### C# 
+
 ```csharp
 // Code with violations
 namespace Root.BadExample
@@ -67,6 +69,26 @@ namespace Root.Data
         }
     }
 }
+```
+
+### VB 
+
+```vb
+' Code with violations
+Namespace Root.BadExample
+    Class Example
+        Public Sub M()
+        End Sub
+    End Class
+End Namespace
+
+' Fixed code
+Namespace Root.Data
+    Class Example
+        Public Sub M()
+        End Sub
+    End Class
+End Namespace
 ```
 
 ## Suppress a warning

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -45,7 +45,7 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 Assume that the following code snippets are from a file named `Data/Example.cs`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.
 
-### C# 
+### C\# 
 
 ```csharp
 // Code with violations

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0130: Namespace does not match folder structure"
 description: "Learn about code analysis rule IDE0130: Namespace does not match folder structure"
-ms.date: 12/05/2021
+ms.date: 12/05/2022
 ms.topic: reference
 f1_keywords:
 - IDE0130
@@ -43,7 +43,7 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 ## Example
 
-Assume that the following file is `Data\Example.cs`, where `Data` represents the folder structure from the project file. Also note that the structure is added to the root namespace, which in this example will be `Root`.
+Assume that the following code snippets are from a file named `Data/Example.cs`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.
 
 ```csharp
 // Code with violations

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -41,6 +41,14 @@ Options specify the behavior that you want the rule to enforce. For information 
 |                          | `false`                                              | Disables the rule.                                 |
 | **Default option value** | `true`                                               |                                                    |
 
+> [!NOTE]
+> `dotnet_style_namespace_match_folder` depends on knowing the current project and root namespace properties. This is provided by Visual Studio but not done in command line builds. For command line builds, such as `dotnet build` to work, you must add the following properties to your `.editorconfig`.
+> ```ini
+> is_global=true
+> build_property.ProjectDir = <root directory>
+> build_property.RootNamespace = <root namespace>
+> ```
+
 ## Example
 
 Assume that the following code snippets are from a file named `Data/Example.cs` or `Data/Example.vb`, where `Data` represents the folder structure from the project file. The folder structure naming is added to the root namespace, which in this example is `Root`.

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Rule ID**              | IDE0130                                                |
 | **Title**                | Namespace does not match folder structure              |
 | **Category**             | Style                                                  |
-| **Subcategory**          | Naming  rules                                          |
+| **Subcategory**          | Language rules (Namespace naming preferences)          |
 | **Applicable languages** | C# and Visual Basic                                    |
 | **Options**              | `dotnet_style_namespace_match_folder`                  |
 
@@ -97,5 +97,5 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Naming rules](naming-rules.md)
+- [Language rules](language-rules.md)
 - [Code style rules reference](index.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0130.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0130.md
@@ -45,7 +45,7 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 > [!NOTE]
 > The `dotnet_style_namespace_match_folder` option depends on knowing the current project and root namespace properties. This information is provided by Visual Studio but is not available for command-line builds, such as `dotnet build`. For command-line builds to work, you must add the following properties to your *.editorconfig* file and replace the root directory and namespace placeholders with your values:
-
+>
 > ```ini
 > is_global=true
 > build_property.ProjectDir = <root directory>

--- a/docs/fundamentals/code-analysis/style-rules/index.md
+++ b/docs/fundamentals/code-analysis/style-rules/index.md
@@ -119,6 +119,7 @@ The following table list all the code-style rules by ID and [options](../code-st
 > | [IDE0090](ide0090.md) | Simplify `new` expression | [csharp_style_implicit_object_creation_when_type_is_apparent](ide0090.md#csharp_style_implicit_object_creation_when_type_is_apparent) |
 > | [IDE0100](ide0100.md) | Remove unnecessary equality operator | |
 > | [IDE0110](ide0110.md) | Remove unnecessary discard | |
+> | [IDE0130](ide0130.md) | Namespace does not match folder structure | [dotnet_style_namespace_match_folder](ide0130.md#dotnet_style_namespace_match_folder) |
 > | [IDE0140](ide0140.md) | Simplify object creation | [visual_basic_style_prefer_simplified_object_creation](ide0140.md#visual_basic_style_prefer_simplified_object_creation) |
 > | [IDE0150](ide0150.md) | Prefer `null` check over type check | [csharp_style_prefer_null_check_over_type_check](ide0150.md#csharp_style_prefer_null_check_over_type_check) |
 > | [IDE0160](ide0160-ide0161.md) | Use block-scoped namespace | [csharp_style_namespace_declarations](ide0160-ide0161.md#csharp_style_namespace_declarations) |

--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -76,6 +76,7 @@ The style rules in this section are applicable to both C# and Visual Basic.
   - [Use null propagation (IDE0031)](ide0031.md)
   - [Use 'is null' check (IDE0041)](ide0041.md)
 - [File header preferences](ide0073.md)
+- [Namespace naming preferences](ide0130.md)
 
 ## C# style rules
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1676,6 +1676,10 @@ items:
             items:
             - name: IDE0073
               href: code-analysis/style-rules/ide0073.md
+          - name: Namespace naming preferences
+            items:
+            - name: IDE0130
+              href: code-analysis/style-rules/ide0130.md
         - name: Unnecessary code rules
           items:
           - name: Overview


### PR DESCRIPTION
## Summary

Add documentation for ide0130 (match namespace and folder structure).

Fixes https://github.com/dotnet/roslyn/issues/65759
