### PR TITLE
Automatic RID breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -119,9 +119,10 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ | |
-| [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
+| [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ | 7.0.100 |
 | [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
+| [Side-by-side SDK installations](sdk/7.0/side-by-side-install.md) | ❌ | ❌ | 7.0.100 |
+| [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
 | [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |
 | [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
 

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -119,6 +119,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 | Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
+| [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ | |
 | [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
 | [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
 | [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |

--- a/docs/core/compatibility/sdk/7.0/automatic-runtimeidentifier.md
+++ b/docs/core/compatibility/sdk/7.0/automatic-runtimeidentifier.md
@@ -1,0 +1,59 @@
+---
+title: "Breaking change: Automatic RuntimeIdentifier"
+description: Learn about a breaking change in the .NET 7 SDK where a RuntimeIdentifier is automatically added to projects that use certain publish properties.
+ms.date: 12/05/2022
+---
+# Automatic RuntimeIdentifier for certain projects
+
+Projects that specify any of the following properties now get a [runtime identifier (RID)](../../../rid-catalog.md) automatically. An RID enables publishing a self-contained deployment.
+
+- `SelfContained`
+- `PublishAot`
+- `PublishReadyToRun`
+- `PublishSingleFile`
+- `PublishSelfContained` (.NET SDK 7.0.200 and later versions only)
+
+The following projects might be affected by this change:
+
+- Old projects that circumvented the missing runtime identifier error.
+- Projects that have `RuntimeIdentifiers` but not `RuntimeIdentifier`.
+- Projects that use hard-coded paths without RIDs.
+- Projects that had these properties but used a build instead of a publish and accepted publish being in a broken state.
+
+There are other potential nuances that could break individual situations that we're not yet aware of.
+
+## Version introduced
+
+.NET 7
+
+## Previous behavior
+
+Previously, these projects failed to publish with errors such as:
+
+> It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.
+
+OR
+
+> error NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.
+
+In some cases, such as `PublishSingleFile` or with special `RuntimeIdentifiers` logic, projects might have built successfully without a `RuntimeIdentifier`.
+
+## New behavior
+
+Projects that specify any of the properties listed at the beginning of this article get a `RuntimeIdentifier` automatically. This new behavior can cause build failures on projects that rely on `RuntimeIdentifiers` but not `RuntimeIdentifier`, because `RuntimeIdentifier` can affect the output path distinctly from `RuntimeIdentifiers`. It can also cause failures on `AnyCPU` projects that rely on `PublishSingleFile` but don't always give a `RuntimeIdentifier` when taking other actions. These failures can appear as follows:
+
+> The target process exited without raising a CoreCLR started event. Ensure that the target process is configured to use .NET Core.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+A majority of .NET projects fail to publish using the mentioned properties without `RuntimeIdentifier` set. This change reduces the need to add the RID manually every time you use the mentioned properties.
+
+## Recommended action
+
+If your project is impacted, you can disable the automatic `RuntimeIdentifier` by adding `<UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>` to your project file.
+
+If you encounter a break due to the output path changing, add `<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>` to your project file.

--- a/docs/core/compatibility/sdk/7.0/side-by-side-install.md
+++ b/docs/core/compatibility/sdk/7.0/side-by-side-install.md
@@ -1,0 +1,41 @@
+---
+title: "Breaking change: Side-by-side SDK installations"
+description: Learn about a breaking change in the .NET 7 SDK where having a preview version of the SDK installed alongside the GA version causes projects with certain workloads to fail to build, load, or run.
+ms.date: 12/05/2022
+---
+# Side-by-side SDK installations
+
+If a preview .NET 7 SDK is installed alongside the general availability (GA) version of the .NET 7 SDK, projects with workload dependencies such as `microsoft.net.workload.mono.toolchain` may fail to build, load, or run. The error is similar to:
+
+> The SDK resolver "Microsoft.DotNet.MSBuildSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.Sdk". Exception: "Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadManifestCompositionException: Workload definition 'wasm-tools' in manifest 'microsoft.net.workload.mono.toolchain'.
+
+> [!NOTE]
+> This behavior will be fixed in .NET SDK 7.2.00.
+
+## Version introduced
+
+.NET 7
+
+## Previous behavior
+
+Building, loading, or running an affected project worked fine.
+
+## New behavior
+
+Building, loading, or running an affected project fails.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility) and [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+.NET 7 preview SDKs are incompatible with the GA version because the mono.toolchain workload was renamed.
+
+## Recommended action
+
+Choose one of the following actions:
+
+- Uninstall any .NET 7 preview SDKs. For detailed instructions, see [How to remove the .NET Runtime and SDK](../../../install/remove-runtime-sdk-versions.md). For example, on Windows, you can uninstall .NET preview SDKs using **Add or remove programs** in Control panel. You can also use the [`dotnet-core-uninstall` tool](https://github.com/dotnet/cli-lab/releases) to uninstall preview SDKs.
+
+- For file-based installs, you can delete the folder *%ProgramFiles%/dotnet/sdk-manifests/7.0.100/microsoft.net.workload.mono.toolchain*.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -153,6 +153,8 @@ items:
           href: sdk/7.0/vs-msbuild-version.md
         - name: Serialization of custom types in .NET 7
           href: sdk/7.0/custom-serialization.md
+        - name: Side-by-side SDK installations
+          href: sdk/7.0/side-by-side-install.md
       - name: Serialization
         items:
         - name: DataContractSerializer retains sign when deserializing -0
@@ -1185,6 +1187,8 @@ items:
           href: sdk/7.0/vs-msbuild-version.md
         - name: Serialization of custom types in .NET 7
           href: sdk/7.0/custom-serialization.md
+        - name: Side-by-side SDK installations
+          href: sdk/7.0/side-by-side-install.md
       - name: .NET 6
         items:
         - name: -p option for `dotnet run` is deprecated

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -147,6 +147,8 @@ items:
           href: networking/7.0/socket-end-closed-sockets.md
       - name: SDK and MSBuild
         items:
+        - name: Automatic RuntimeIdentifier for certain projects
+          href: sdk/7.0/automatic-runtimeidentifier.md
         - name: Version requirements for .NET 7 SDK
           href: sdk/7.0/vs-msbuild-version.md
         - name: Serialization of custom types in .NET 7
@@ -1177,6 +1179,8 @@ items:
       items:
       - name: .NET 7
         items:
+        - name: Automatic RuntimeIdentifier for certain projects
+          href: sdk/7.0/automatic-runtimeidentifier.md
         - name: Version requirements for .NET 7 SDK
           href: sdk/7.0/vs-msbuild-version.md
         - name: Serialization of custom types in .NET 7


### PR DESCRIPTION
Fixes #32816.
Fixes #32814.

[Internal preview link](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/automatic-runtimeidentifier?branch=pr-en-us-32892).