### PR TITLE
remove no-loc directive in metadata

### DIFF
--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -1,5 +1,5 @@
 ---
-description: ":::no-loc text=interface::: (C# Reference)"
+description: "Use the `interface` keyword to define contracts that any implementing type must support. Interfaces provide the means to created common behavior among a set of unrelated types."
 title: "interface - C# Reference"
 ms.date: 07/08/2022
 f1_keywords: 

--- a/docs/csharp/language-reference/keywords/interface.md
+++ b/docs/csharp/language-reference/keywords/interface.md
@@ -1,5 +1,5 @@
 ---
-description: "Use the `interface` keyword to define contracts that any implementing type must support. Interfaces provide the means to created common behavior among a set of unrelated types."
+description: "Use the `interface` keyword to define contracts that any implementing type must support. Interfaces provide the means to create common behavior among a set of unrelated types."
 title: "interface - C# Reference"
 ms.date: 07/08/2022
 f1_keywords: 


### PR DESCRIPTION
It turns out the `no-loc` directive isn't allowed in the metadata values.

Provide a better description for this page.

I searched the current repo, and I didn't find any other pages with this issue.