### PR TITLE
Add links for nullable contexts

### DIFF
--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -23,7 +23,7 @@ The following options control how the compiler interprets language features. The
 
 ## CheckForOverflowUnderflow
 
-The **CheckForOverflowUnderflow** option controls the default overflow-checking context that defines the program behavior in the case of integer arithmetic overflow.
+The **CheckForOverflowUnderflow** option controls the default overflow-checking context that defines the program behavior if integer arithmetic overflows.
 
 ```xml
 <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -37,7 +37,7 @@ For information about how the overflow-checking context affects operations and w
 
 ## AllowUnsafeBlocks
 
-The **AllowUnsafeBlocks** compiler option allows code that uses the [unsafe](../keywords/unsafe.md) keyword to compile. The default value for this option is `false`, meaning unsafe code is not allowed.
+The **AllowUnsafeBlocks** compiler option allows code that uses the [unsafe](../keywords/unsafe.md) keyword to compile. The default value for this option is `false`, meaning unsafe code isn't allowed.
 
 ```xml
 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -72,11 +72,13 @@ The following values are valid:
 
 The default language version depends on the target framework for your application and the version of the SDK or Visual Studio installed. Those rules are defined in [C# language versioning](../configure-language-version.md#defaults).
 
+> [!IMPORTANT] The `latest` value is generally not recommended. With it, the compiler enables the latest features, even if those features depend on updates not included in the configured target framework. Without this setting, your project uses the compiler version recommended for your target framework. You can update the target framework to access newer language features.
+
 Metadata referenced by your C# application isn't subject to the **LangVersion** compiler option.
 
 Because each version of the C# compiler contains extensions to the language specification, **LangVersion** doesn't give you the equivalent functionality of an earlier version of the compiler.
 
-Additionally, while C# version updates generally coincide with major .NET releases, the new syntax and features aren't necessarily tied to that specific framework version. While the new features definitely require a new compiler update that is also released alongside the C# revision, each specific feature has its own minimum .NET API or common language runtime requirements that may allow it to run on downlevel frameworks by including NuGet packages or other libraries.
+Additionally, while C# version updates generally coincide with major .NET releases, the new syntax and features aren't necessarily tied to that specific framework version. Each specific feature has its own minimum .NET API or common language runtime requirements that may allow it to run on downlevel frameworks by including NuGet packages or other libraries.
 
 Regardless of which **LangVersion** setting you use, use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [**ModuleAssemblyName**](advanced.md#moduleassemblyname), which work under **-langversion:ISO-1**.
 
@@ -133,7 +135,7 @@ The **Nullable** option lets you specify the nullable context. It can be set in 
 <Nullable>enable</Nullable>
 ```
 
-The argument must be one of `enable`, `disable`, `warnings`, or `annotations`. The `enable` argument enables the nullable context. Specifying `disable` will disable the nullable context. When providing the `warnings` argument the nullable warning context is enabled. When specifying the `annotations` argument, the nullable annotation context is enabled.
+The argument must be one of `enable`, `disable`, `warnings`, or `annotations`. The `enable` argument enables the nullable context. Specifying `disable` will disable the nullable context. When you specify the `warnings` argument, the nullable warning context is enabled. When you specify the `annotations` argument, the nullable annotation context is enabled. The values are described and explained in the article on [Nullable contexts](../../nullable-references.md#nullable-contexts). You can learn more about the tasks involved in enabling nullable reference types in an existing codebase in our article on [nullable migration strategies](../../nullable-migration-strategies.md).
 
 > [!NOTE]
 > When there's no value set, the default value `disable` is applied, however the .NET 6 templates are by default provided with the **Nullable** value set to `enable`.

--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -72,7 +72,8 @@ The following values are valid:
 
 The default language version depends on the target framework for your application and the version of the SDK or Visual Studio installed. Those rules are defined in [C# language versioning](../configure-language-version.md#defaults).
 
-> [!IMPORTANT] The `latest` value is generally not recommended. With it, the compiler enables the latest features, even if those features depend on updates not included in the configured target framework. Without this setting, your project uses the compiler version recommended for your target framework. You can update the target framework to access newer language features.
+> [!IMPORTANT]
+> The `latest` value is generally not recommended. With it, the compiler enables the latest features, even if those features depend on updates not included in the configured target framework. Without this setting, your project uses the compiler version recommended for your target framework. You can update the target framework to access newer language features.
 
 Metadata referenced by your C# application isn't subject to the **LangVersion** compiler option.
 


### PR DESCRIPTION
Fixes #30009
Fixes #27191
Fixes #32968

Add links to conceptual documentation that describes the nullable annotation and warning context. While editing this file, fix an unrelated issue regarding `LangVersion` setting `latest`.

Then, do a general edit pass.